### PR TITLE
refactor(platform): use canonical connector catalog items

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -221,7 +221,7 @@ original URL. Its signals combine several reactive reads and an action:
 
 ```ts
 interface ConnectorSignals extends ConnectorActionDescriptor {
-  displayMetadata$: Computed<Promise<ConnectorCatalogDisplayMetadata | null>>;
+  catalogItem$: Computed<Promise<PublicConnectorCatalogStatusItem | null>>;
   available$: Computed<Promise<boolean>>;
   connected$: Computed<Promise<boolean>>;
   authorized$: Computed<Promise<boolean>>;

--- a/turbo/apps/platform/src/signals/__tests__/connector-form-signals.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/connector-form-signals.test.ts
@@ -41,7 +41,7 @@ describe("connector form signals", () => {
     ).toStrictEqual({});
 
     context.store.set(setConnectorOAuthDeviceAuthStartOptionValue$, {
-      type: "connector-a",
+      connectorRef: "connector-a",
       authMethod: "device-auth-a",
       name: "region",
       value: "us-west",

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -195,7 +195,7 @@ export const waitForGoogleDriveAuthorization$ = command(
           get(
             isAgentConnectorAuthorized({
               agentId: params.agentId,
-              connectorType: "google-drive",
+              connectorRef: "google-drive",
             }),
           ),
         ]);

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -4,22 +4,18 @@ import {
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { customConnectorProposalSchema } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogStatusByRef$ } from "../external/connectors.ts";
 import {
-  connectorCatalogDisplayMetadataByRef$,
-  connectorCatalogStatusByRef$,
-  type ConnectorCatalogDisplayMetadata,
-} from "../external/connectors.ts";
-import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   connectConnectorNoAuth$,
   connectConnectorOAuthAuthCode$,
   getConnectorStatusConnectLaunchMode,
   getOnlyAvailableStatusBrowserAuthMethodDetail,
   getOnlyAvailableStatusNoAuthMethod,
-  setSelectedConnectorType$,
-  type ConnectorTypeWithStatus,
+  setSelectedConnectorRef$,
 } from "../zero-page/settings/connectors.ts";
-import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-type.ts";
+import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-ref.ts";
 import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authorizations.ts";
 import { jsonParseBase64UrlOr } from "../utils.ts";
 import {
@@ -41,7 +37,7 @@ export interface ConnectorActionDescriptor {
 }
 
 export interface ConnectorSignals extends ConnectorActionDescriptor {
-  displayMetadata$: Computed<Promise<ConnectorCatalogDisplayMetadata | null>>;
+  catalogItem$: Computed<Promise<PublicConnectorCatalogStatusItem | null>>;
   available$: Computed<Promise<boolean>>;
   connected$: Computed<Promise<boolean>>;
   authorized$: Computed<Promise<boolean>>;
@@ -77,7 +73,7 @@ export const activeChatConnectorAction$ = computed((get) => {
 
 export const closeChatConnectorActionConnectDialog$ = command(({ set }) => {
   set(activeChatConnectorActionState$, null);
-  set(setSelectedConnectorType$, null);
+  set(setSelectedConnectorRef$, null);
 });
 
 const CONNECTOR_AUTHORIZE_BASE_URL = "https://app.vm0.ai";
@@ -146,7 +142,7 @@ export function createCustomConnectorSignals(
   return descriptor;
 }
 
-function getDirectConnectMethod(connector: ConnectorTypeWithStatus) {
+function getDirectConnectMethod(connector: PublicConnectorCatalogStatusItem) {
   const launchMode = getConnectorStatusConnectLaunchMode(connector);
   if (launchMode === "browser-auth") {
     const authMethod = getOnlyAvailableStatusBrowserAuthMethodDetail(connector);
@@ -162,14 +158,14 @@ function getDirectConnectMethod(connector: ConnectorTypeWithStatus) {
 export function createConnectorSignals(
   descriptor: ConnectorActionDescriptor,
 ): ConnectorSignals {
-  const displayMetadata$ = computed(async (get) => {
-    const metadataByRef = await get(connectorCatalogDisplayMetadataByRef$);
-    return metadataByRef.get(descriptor.connectorRef) ?? null;
+  const catalogItem$ = computed(async (get) => {
+    const statusByRef = await get(connectorCatalogStatusByRef$);
+    return statusByRef.get(descriptor.connectorRef) ?? null;
   });
 
   const available$ = computed(async (get): Promise<boolean> => {
-    const displayMetadata = await get(displayMetadata$);
-    return displayMetadata !== null;
+    const catalogItem = await get(catalogItem$);
+    return catalogItem !== null;
   });
 
   const connected$ = computed(async (get): Promise<boolean> => {
@@ -181,7 +177,7 @@ export function createConnectorSignals(
     return await get(
       isAgentConnectorAuthorized({
         agentId: descriptor.agentId,
-        connectorType: descriptor.connectorRef,
+        connectorRef: descriptor.connectorRef,
       }),
     );
   });
@@ -229,10 +225,10 @@ export function createConnectorSignals(
       return;
     }
 
-    const connectorTypes = await get(allConnectorTypes$);
+    const connectorCatalogItems = await get(allConnectorCatalogItems$);
     signal.throwIfAborted();
-    const connector = connectorTypes.find((item) => {
-      return item.type === descriptor.connectorRef;
+    const connector = connectorCatalogItems.find((item) => {
+      return item.connectorRef === descriptor.connectorRef;
     });
     if (!connector) {
       return;
@@ -241,7 +237,7 @@ export function createConnectorSignals(
     const directConnectMethod = getDirectConnectMethod(connector);
     if (!directConnectMethod) {
       set(activeChatConnectorActionState$, descriptor);
-      set(setSelectedConnectorType$, descriptor.connectorRef);
+      set(setSelectedConnectorRef$, descriptor.connectorRef);
       return;
     }
 
@@ -261,7 +257,7 @@ export function createConnectorSignals(
         : await set(
             connectConnectorNoAuth$,
             {
-              type: descriptor.connectorRef,
+              connectorRef: descriptor.connectorRef,
               authMethod: directConnectMethod.authMethod,
               options: connectOptions,
             },
@@ -286,7 +282,7 @@ export function createConnectorSignals(
 
   return {
     ...descriptor,
-    displayMetadata$,
+    catalogItem$,
     available$,
     connected$,
     authorized$,

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-ref.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-ref.ts
@@ -15,13 +15,13 @@ import {
 } from "../zero-page/agent-connector-authorizations.ts";
 
 /**
- * Connector type extracted from `/connectors/:type/authorize` route params.
+ * Connector ref extracted from `/connectors/:type/authorize` route params.
  */
-export const directedAuthorizeType$ = computed((get): string | null => {
+export const directedAuthorizeRef$ = computed((get): ConnectorRef | null => {
   const params = get(pathParams$);
-  const type = params?.type;
+  const routeType = params?.type;
   const parsed = connectorRefSchema.safeParse(
-    typeof type === "string" ? type.toLowerCase() : null,
+    typeof routeType === "string" ? routeType.toLowerCase() : null,
   );
   return parsed.success ? parsed.data : null;
 });
@@ -57,7 +57,7 @@ export const agentEnabledTypes$ = computed(async (get) => {
 });
 
 export type DirectedAuthorizeConnectModalKey = {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string;
   readonly signal: AbortSignal;
 };
@@ -74,10 +74,10 @@ export const setDirectedAuthorizeConnectModalKey$ = command(
 );
 
 function connectorAgentAuthorizationKey(args: {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string;
 }): string {
-  return `${args.agentId}:${args.connectorType}`;
+  return `${args.agentId}:${args.connectorRef}`;
 }
 
 const internalAuthorized$ = state<Set<string>>(new Set());
@@ -91,7 +91,7 @@ export const justAuthorizedConnectorAgentKeys$ = computed((get) => {
 export const authorizeConnector$ = command(
   async (
     { get, set },
-    connectorType: ConnectorRef,
+    connectorRef: ConnectorRef,
     agentId: string,
     signal: AbortSignal,
   ) => {
@@ -102,7 +102,7 @@ export const authorizeConnector$ = command(
       accept(
         client.update({
           params: { id: agentId },
-          body: { enabledTypes: [connectorType], operation: "add" },
+          body: { enabledTypes: [connectorRef], operation: "add" },
           fetchOptions: { signal },
         }),
         [200],
@@ -117,7 +117,7 @@ export const authorizeConnector$ = command(
     set(internalAuthorized$, (prev) => {
       return new Set([
         ...prev,
-        connectorAgentAuthorizationKey({ connectorType, agentId }),
+        connectorAgentAuthorizationKey({ connectorRef, agentId }),
       ]);
     });
   },
@@ -126,7 +126,7 @@ export const authorizeConnector$ = command(
 export function isJustAuthorizedConnectorAgent(
   justAuthorizedKeys: ReadonlySet<string>,
   args: {
-    readonly connectorType: ConnectorRef;
+    readonly connectorRef: ConnectorRef;
     readonly agentId: string;
   },
 ): boolean {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-ref.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-ref.ts
@@ -7,13 +7,13 @@ import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
 
 /**
- * Connector type extracted from `/connectors/:type/connect` route params.
+ * Connector ref extracted from `/connectors/:type/connect` route params.
  */
-export const directedConnectType$ = computed((get): string | null => {
+export const directedConnectRef$ = computed((get): ConnectorRef | null => {
   const params = get(pathParams$);
-  const type = params?.type;
+  const routeType = params?.type;
   const parsed = connectorRefSchema.safeParse(
-    typeof type === "string" ? type.toLowerCase() : null,
+    typeof routeType === "string" ? routeType.toLowerCase() : null,
   );
   return parsed.success ? parsed.data : null;
 });
@@ -40,13 +40,13 @@ export const directedConnectAgentName$ = computed(async (get) => {
 });
 
 export type DirectedConnectManualGrantDialogKey = {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string | null;
   readonly signal: AbortSignal;
 };
 
 export type DirectedConnectModalKey = {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string | null;
   readonly signal: AbortSignal;
 };

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -5,8 +5,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
-  type PublicConnectorCatalogIcon,
-  type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
@@ -14,13 +12,6 @@ import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connect
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
 import { featureSwitch$ } from "./feature-switch.ts";
-
-export interface ConnectorCatalogDisplayMetadata {
-  readonly connectorRef: ConnectorRef;
-  readonly label: string;
-  readonly helpText: string;
-  readonly icon: PublicConnectorCatalogIcon;
-}
 
 /**
  * Reload trigger for connector signals.
@@ -67,29 +58,6 @@ export const connectorCatalogStatusByRef$ = computed(async (get) => {
   );
 });
 
-function connectorCatalogDisplayMetadata(
-  connector: PublicConnectorCatalogStatusItem,
-): ConnectorCatalogDisplayMetadata {
-  return {
-    connectorRef: connector.connectorRef,
-    label: connector.label,
-    helpText: connector.description,
-    icon: connector.icon,
-  };
-}
-
-export const connectorCatalogDisplayMetadataByRef$ = computed(async (get) => {
-  const connectorsByRef = await get(connectorCatalogStatusByRef$);
-  return new Map(
-    [...connectorsByRef.values()].map((connector) => {
-      return [
-        connector.connectorRef,
-        connectorCatalogDisplayMetadata(connector),
-      ];
-    }),
-  );
-});
-
 /**
  * Trigger a reload of connectors data.
  */
@@ -100,19 +68,20 @@ export const reloadConnectors$ = command(({ set }) => {
 });
 
 /**
- * Delete a connector by type.
+ * Delete a connector by ref.
  */
 export const deleteConnector$ = command(
-  async ({ get, set }, type: ConnectorRef, _signal: AbortSignal) => {
+  async ({ get, set }, connectorRef: ConnectorRef, signal: AbortSignal) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroConnectorsByTypeContract);
     await accept(
       client.delete({
-        params: { type },
-        fetchOptions: { signal: _signal },
+        params: { type: connectorRef },
+        fetchOptions: { signal },
       }),
       [204],
     );
+    signal.throwIfAborted();
 
     set(internalReloadConnectors$, (x) => {
       return x + 1;

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -68,12 +68,12 @@ export function agentConnectorAuthorizations(params: {
 
 export function isAgentConnectorAuthorized(params: {
   readonly agentId: string;
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
 }): Computed<Promise<boolean>> {
   return computed(async (get): Promise<boolean> => {
     const authorizations = await get(
       agentConnectorAuthorizations({ agentId: params.agentId }),
     );
-    return authorizations.enabledTypes.includes(params.connectorType);
+    return authorizations.enabledTypes.includes(params.connectorRef);
   });
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -27,19 +27,19 @@ interface ConnectorAgentAuthorizationRow {
 
 interface SetConnectorAgentAuthorizationParams {
   readonly agentId: string;
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authorized: boolean;
 }
 
-const managedConnectorAccessTypeState$ = state<ConnectorRef | null>(null);
+const managedConnectorAccessRefState$ = state<ConnectorRef | null>(null);
 const connectorAccessManagementSearchState$ = state("");
 const connectorAccessManagementSavingAgentIdState$ = state<string | null>(null);
 const connectorAccessManagementPermissionAgentIdState$ = state<string | null>(
   null,
 );
 
-export const managedConnectorAccessType$ = computed((get) => {
-  return get(managedConnectorAccessTypeState$);
+export const managedConnectorAccessRef$ = computed((get) => {
+  return get(managedConnectorAccessRefState$);
 });
 
 export const connectorAccessManagementSearch$ = computed((get) => {
@@ -54,14 +54,14 @@ export const connectorAccessManagementPermissionAgentId$ = computed((get) => {
   return get(connectorAccessManagementPermissionAgentIdState$);
 });
 
-export const setManagedConnectorAccessType$ = command(
-  ({ set }, connectorType: ConnectorRef | null) => {
-    set(managedConnectorAccessTypeState$, connectorType);
+export const setManagedConnectorAccessRef$ = command(
+  ({ set }, connectorRef: ConnectorRef | null) => {
+    set(managedConnectorAccessRefState$, connectorRef);
   },
 );
 
 export const closeConnectorAccessManagement$ = command(({ set }) => {
-  set(managedConnectorAccessTypeState$, null);
+  set(managedConnectorAccessRefState$, null);
   set(connectorAccessManagementSearchState$, "");
   set(connectorAccessManagementSavingAgentIdState$, null);
   set(connectorAccessManagementPermissionAgentIdState$, null);
@@ -113,27 +113,27 @@ export const connectorAgentAuthorizations$ = computed(
   },
 );
 
-export const connectorAuthorizedAgentsByType$ = computed(
+export const connectorAuthorizedAgentsByRef$ = computed(
   async (
     get,
   ): Promise<ReadonlyMap<ConnectorRef, readonly TeamComposeItem[]>> => {
     const authorizations = await get(connectorAgentAuthorizations$);
-    const agentsByType = new Map<ConnectorRef, TeamComposeItem[]>();
+    const agentsByRef = new Map<ConnectorRef, TeamComposeItem[]>();
     for (const row of authorizations) {
-      for (const connectorType of row.enabledTypes) {
-        const agents = agentsByType.get(connectorType) ?? [];
+      for (const connectorRef of row.enabledTypes) {
+        const agents = agentsByRef.get(connectorRef) ?? [];
         agents.push(row.agent);
-        agentsByType.set(connectorType, agents);
+        agentsByRef.set(connectorRef, agents);
       }
     }
-    return agentsByType;
+    return agentsByRef;
   },
 );
 
 export const managedConnectorAgentAccessRows$ = computed(
   async (get): Promise<readonly ConnectorAgentAccessRow[]> => {
-    const connectorType = get(managedConnectorAccessType$);
-    if (!connectorType) {
+    const connectorRef = get(managedConnectorAccessRef$);
+    if (!connectorRef) {
       return [];
     }
     const authorizations = await get(connectorAgentAuthorizations$);
@@ -143,7 +143,7 @@ export const managedConnectorAgentAccessRows$ = computed(
           agent,
           enabledTypes,
         }): Promise<ConnectorAgentAccessRow | null> => {
-          const authorized = enabledTypes.includes(connectorType);
+          const authorized = enabledTypes.includes(connectorRef);
           let grants: readonly UserPermissionGrantResponse[] = [];
           if (authorized) {
             const loadedGrants = await get(
@@ -170,13 +170,11 @@ export const managedConnectorAgentAccessRows$ = computed(
 
 export const managedConnectorFirewallPermissionMetadata$ = computed(
   async (get) => {
-    const connectorType = get(managedConnectorAccessType$);
-    if (!connectorType) {
+    const connectorRef = get(managedConnectorAccessRef$);
+    if (!connectorRef) {
       return null;
     }
-    return await get(
-      firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
-    );
+    return await get(firewallPermissionMetadataByConnector({ connectorRef }));
   },
 );
 
@@ -192,7 +190,7 @@ export const setConnectorAgentAuthorization$ = command(
         client.update({
           params: { id: params.agentId },
           body: {
-            enabledTypes: [params.connectorType],
+            enabledTypes: [params.connectorRef],
             operation: params.authorized ? "add" : "remove",
           },
           fetchOptions: { signal },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -33,9 +33,7 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
   PublicConnectorCatalogAuthMethodDetail,
-  PublicConnectorCatalogConnection,
-  PublicConnectorCatalogIcon,
-  PublicConnectorCatalogPermissionSummary,
+  PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
@@ -67,57 +65,15 @@ import { connectorRedirectingPath } from "../../connectors-page/connector-redire
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 
-const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
+const { get$: hiddenConnectorRefsRaw$, set$: setHiddenConnectorRefs$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
 type PostConnectOptions = {
   readonly connectorLabel?: string;
   readonly agentId?: string;
 };
-export type ConnectorConnectionStatus =
-  | "not-connected"
-  | "connected"
-  | "scope-mismatch"
-  | "reconnect-required";
-
 // ---------------------------------------------------------------------------
 // Derived state
 // ---------------------------------------------------------------------------
-
-/**
- * All connector types with their connection status.
- * Uses server-authored public catalog/status data.
- */
-export interface ConnectorTypeWithStatus {
-  type: ConnectorRef;
-  label: string;
-  helpText: string;
-  icon: PublicConnectorCatalogIcon;
-  category: string;
-  /** Lowercase aliases/keywords used by connector search. */
-  tags: readonly string[];
-  connected: boolean;
-  connector: PublicConnectorCatalogConnection | null;
-  /** Public auth method metadata available after server-side filtering. */
-  authMethods: readonly PublicConnectorCatalogAuthMethodDetail[];
-  /** Auth methods available for this connector after availability filtering. */
-  availableAuthMethods: ConnectorAuthMethodId[];
-  /** Single available auth-code method if direct OAuth can be considered. */
-  singleAuthCodeAuthMethodId: ConnectorAuthMethodId | null;
-  /** Public notice shown before direct connect flows. */
-  connectNotice: "google-security-warning" | null;
-  /** True if at least one agent references this connector (env mapping). */
-  usedByAgent?: boolean;
-  /** True if stored grant scopes don't cover all currently required scopes. */
-  scopeMismatch: boolean;
-  /** User-facing connection state derived from API state and scope coverage. */
-  connectionStatus: ConnectorConnectionStatus;
-  /** Stored credential expiry returned by the API. */
-  tokenExpiresAt: string | null;
-  /** True when the selected auth method can refresh runtime access. */
-  authMethodSupportsRefresh: boolean;
-  /** Public permission summary returned by the catalog status API. */
-  permissionSummary: PublicConnectorCatalogPermissionSummary;
-}
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -130,15 +86,8 @@ export type ConnectorCatalogBrowserAuthMethodDetail =
     readonly grantKind: BrowserAuthGrantKind;
   };
 
-export type ConnectorStatusAuthMethodDetail = Omit<
-  PublicConnectorCatalogAuthMethodDetail,
-  "id"
-> & {
-  readonly id: ConnectorAuthMethodId;
-};
-
 export function manualGrantInputValuesForMethod(
-  method: Pick<ConnectorStatusAuthMethodDetail, "manualFields">,
+  method: Pick<PublicConnectorCatalogAuthMethodDetail, "manualFields">,
   values: Readonly<Record<string, string>>,
 ): Record<string, string> {
   return Object.fromEntries(
@@ -189,69 +138,49 @@ function isNoAuthGrantKind(grantKind: ConnectorStatusGrantKind): boolean {
   return grantKind === "none";
 }
 
-function parseConnectorStatusAuthMethodDetail(
-  connector: ConnectorTypeWithStatus,
-  method: PublicConnectorCatalogAuthMethodDetail,
-): ConnectorStatusAuthMethodDetail | null {
-  if (!connector.availableAuthMethods.includes(method.id)) {
-    return null;
-  }
-  return method;
-}
-
 export function getConnectorStatusAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   authMethod: ConnectorAuthMethodId,
-): ConnectorStatusAuthMethodDetail | null {
-  for (const method of connector.authMethods) {
-    if (method.id !== authMethod) {
-      continue;
-    }
-    return parseConnectorStatusAuthMethodDetail(connector, method);
-  }
-  return null;
+): PublicConnectorCatalogAuthMethodDetail | null {
+  return (
+    connector.authMethods.find((method) => {
+      return method.id === authMethod;
+    }) ?? null
+  );
 }
 
 export function getConnectorStatusAuthMethodsByGrantKind(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   grantKind: ConnectorStatusGrantKind,
-): ConnectorStatusAuthMethodDetail[] {
-  return connector.authMethods.flatMap((method) => {
-    if (method.grantKind !== grantKind) {
-      return [];
-    }
-    const parsed = parseConnectorStatusAuthMethodDetail(connector, method);
-    return parsed ? [parsed] : [];
+): PublicConnectorCatalogAuthMethodDetail[] {
+  return connector.authMethods.filter((method) => {
+    return method.grantKind === grantKind;
   });
 }
 
 export function getOnlyManualConnectorStatusAuthMethod(
-  connector: ConnectorTypeWithStatus,
-): ConnectorStatusAuthMethodDetail | null {
+  connector: PublicConnectorCatalogStatusItem,
+): PublicConnectorCatalogAuthMethodDetail | null {
   const methods = getConnectorStatusAuthMethodsByGrantKind(connector, "manual");
   return methods.length === 1 ? (methods[0] ?? null) : null;
 }
 
 export function hasConnectorStatusProviderDrivenConnectMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): boolean {
   return connector.authMethods.some((method) => {
-    const parsed = parseConnectorStatusAuthMethodDetail(connector, method);
-    if (!parsed) {
-      return false;
-    }
     return (
-      parsed.grantKind === "auth-code" ||
-      parsed.grantKind === "openid-auth" ||
-      parsed.grantKind === "device-auth" ||
-      parsed.grantKind === "external-code" ||
-      parsed.grantKind === "managed"
+      method.grantKind === "auth-code" ||
+      method.grantKind === "openid-auth" ||
+      method.grantKind === "device-auth" ||
+      method.grantKind === "external-code" ||
+      method.grantKind === "managed"
     );
   });
 }
 
 export function hasConnectorStatusAuthCodeGrant(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): boolean {
   return getConnectorStatusAuthMethodsByGrantKind(connector, "auth-code").some(
     () => {
@@ -261,16 +190,15 @@ export function hasConnectorStatusAuthCodeGrant(
 }
 
 export function hasConnectorStatusBrowserAuthGrant(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): boolean {
   return connector.authMethods.some((method) => {
-    const parsed = parseConnectorStatusAuthMethodDetail(connector, method);
-    return parsed ? isBrowserAuthGrantKind(parsed.grantKind) : false;
+    return isBrowserAuthGrantKind(method.grantKind);
   });
 }
 
 export function getConnectorStatusConnectLaunchMode(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): ConnectorConnectLaunchMode {
   if (getOnlyAvailableStatusBrowserAuthMethod(connector)) {
     return "browser-auth";
@@ -282,7 +210,7 @@ export function getConnectorStatusConnectLaunchMode(
 }
 
 export function getAvailableStatusAuthCodeAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
   const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
@@ -297,13 +225,14 @@ export function getAvailableStatusAuthCodeAuthMethod(
 }
 
 export function getOnlyAvailableStatusAuthCodeAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): ConnectorAuthMethodId | null {
   const authMethod = connector.singleAuthCodeAuthMethodId;
+  const [method] = connector.authMethods;
   if (
-    connector.availableAuthMethods.length !== 1 ||
+    connector.authMethods.length !== 1 ||
     !authMethod ||
-    connector.availableAuthMethods[0] !== authMethod
+    method?.id !== authMethod
   ) {
     return null;
   }
@@ -311,7 +240,7 @@ export function getOnlyAvailableStatusAuthCodeAuthMethod(
 }
 
 export function getAvailableStatusBrowserAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
   const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
@@ -326,22 +255,21 @@ export function getAvailableStatusBrowserAuthMethod(
 }
 
 export function getOnlyAvailableStatusBrowserAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): ConnectorAuthMethodId | null {
-  const [authMethod] = connector.availableAuthMethods;
-  if (connector.availableAuthMethods.length !== 1 || !authMethod) {
+  const [method] = connector.authMethods;
+  if (connector.authMethods.length !== 1 || !method) {
     return null;
   }
-  const method = getConnectorStatusAuthMethod(connector, authMethod);
   if (method?.grantKind === "auth-code") {
     return getOnlyAvailableStatusAuthCodeAuthMethod(connector);
   }
-  return method?.grantKind === "openid-auth" ? authMethod : null;
+  return method.grantKind === "openid-auth" ? method.id : null;
 }
 
 export function getOnlyAvailableStatusBrowserAuthMethodDetail(
-  connector: ConnectorTypeWithStatus,
-): ConnectorStatusAuthMethodDetail | null {
+  connector: PublicConnectorCatalogStatusItem,
+): PublicConnectorCatalogAuthMethodDetail | null {
   const authMethod = getOnlyAvailableStatusBrowserAuthMethod(connector);
   return authMethod
     ? getConnectorStatusAuthMethod(connector, authMethod)
@@ -349,7 +277,7 @@ export function getOnlyAvailableStatusBrowserAuthMethodDetail(
 }
 
 export function getAvailableStatusNoAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
   const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
@@ -364,17 +292,17 @@ export function getAvailableStatusNoAuthMethod(
 }
 
 export function getOnlyAvailableStatusNoAuthMethod(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): ConnectorAuthMethodId | null {
-  const [authMethod] = connector.availableAuthMethods;
-  if (connector.availableAuthMethods.length !== 1 || !authMethod) {
+  const [method] = connector.authMethods;
+  if (connector.authMethods.length !== 1 || !method) {
     return null;
   }
-  return getAvailableStatusNoAuthMethod(connector, authMethod);
+  return getAvailableStatusNoAuthMethod(connector, method.id);
 }
 
 function connectorTokenExpiresAtMs(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): number | null {
   if (!connector.tokenExpiresAt) {
     return null;
@@ -384,9 +312,9 @@ function connectorTokenExpiresAtMs(
 }
 
 export function connectorCurrentConnectionStatus(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   nowMs = now(),
-): ConnectorConnectionStatus {
+): PublicConnectorCatalogConnectionStatus {
   if (connector.connectionStatus === "not-connected") {
     return "not-connected";
   }
@@ -404,7 +332,7 @@ function formatExpiryCountdown(value: number, unit: "day" | "hour"): string {
 }
 
 export function connectorExpiryCountdownText(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
   nowMs = now(),
 ): string | null {
   if (
@@ -436,50 +364,22 @@ const reconnectReasonTooltipText = {
 } satisfies Record<ConnectorReconnectReason, string>;
 
 export function connectorReconnectReasonTooltipText(
-  connector: ConnectorTypeWithStatus,
+  connector: PublicConnectorCatalogStatusItem,
 ): string | null {
-  const reason = connector.connector?.reconnectReason;
+  const reason = connector.connection?.reconnectReason;
   return reason ? reconnectReasonTooltipText[reason] : null;
 }
 
-function connectorCatalogStatusItemToConnectorType(
-  item: PublicConnectorCatalogStatusItem,
-): ConnectorTypeWithStatus {
-  return {
-    type: item.connectorRef,
-    label: item.label,
-    helpText: item.description,
-    icon: item.icon,
-    category: item.category,
-    tags: item.tags,
-    connected: item.connected,
-    connector: item.connection,
-    authMethods: item.authMethods,
-    availableAuthMethods: item.authMethods.map((authMethod) => {
-      return authMethod.id;
-    }),
-    singleAuthCodeAuthMethodId: item.singleAuthCodeAuthMethodId,
-    connectNotice: item.connectNotice,
-    scopeMismatch: item.scopeMismatch,
-    connectionStatus: item.connectionStatus,
-    tokenExpiresAt: item.tokenExpiresAt,
-    authMethodSupportsRefresh: item.authMethodSupportsRefresh,
-    permissionSummary: item.permissionSummary,
-  };
-}
-
 /**
- * Case-insensitive substring match across label, type, helpText, and tags.
+ * Case-insensitive substring match across label, ref, description, and tags.
  * Returns true when `search` is empty, so callers can use it directly as a filter.
  */
 export function matchesConnectorSearch(
   search: string,
-  connector: {
-    label: string;
-    type: string;
-    helpText?: string;
-    tags?: readonly string[];
-  },
+  connector: Pick<
+    PublicConnectorCatalogStatusItem,
+    "connectorRef" | "description" | "label" | "tags"
+  >,
 ): boolean {
   const needle = search.trim().toLowerCase();
   if (!needle) {
@@ -488,10 +388,10 @@ export function matchesConnectorSearch(
   if (connector.label.toLowerCase().includes(needle)) {
     return true;
   }
-  if (connector.type.toLowerCase().includes(needle)) {
+  if (connector.connectorRef.toLowerCase().includes(needle)) {
     return true;
   }
-  if (connector.helpText?.toLowerCase().includes(needle)) {
+  if (connector.description.toLowerCase().includes(needle)) {
     return true;
   }
   if (
@@ -504,9 +404,9 @@ export function matchesConnectorSearch(
   return false;
 }
 
-export const allConnectorTypes$ = computed(async (get) => {
+export const allConnectorCatalogItems$ = computed(async (get) => {
   const { connectors } = await get(connectorCatalogStatus$);
-  const items = connectors.map(connectorCatalogStatusItemToConnectorType);
+  const items = [...connectors];
 
   // Sort connected connectors to the top of the list
   items.sort((a, b) => {
@@ -520,11 +420,11 @@ export const allConnectorTypes$ = computed(async (get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Hidden connector types (removed from list by user; persisted in localStorage)
+// Hidden connector refs (removed from list by user; persisted in localStorage)
 // ---------------------------------------------------------------------------
 
-const hiddenConnectorTypes$ = computed((get): Set<ConnectorRef> => {
-  const raw = get(hiddenConnectorTypesRaw$);
+const hiddenConnectorRefs$ = computed((get): Set<ConnectorRef> => {
+  const raw = get(hiddenConnectorRefsRaw$);
   if (!raw) {
     return new Set();
   }
@@ -570,11 +470,11 @@ export const connectorsSearch$ = computed((get) => {
   return get(searchParams$).get(CONNECTORS_SEARCH_PARAM) ?? "";
 });
 
-export const filteredConnectorTypes$ = computed(async (get) => {
+export const filteredConnectorCatalogItems$ = computed(async (get) => {
   const keyword = get(connectorsSearch$);
   const effectiveFilter = get(connectorsConnectionFilter$);
 
-  const agentEnabledTypes =
+  const agentEnabledRefs =
     effectiveFilter.kind === "agent"
       ? new Set(
           (await get(connectorAgentAuthorizations$)).find((row) => {
@@ -583,8 +483,8 @@ export const filteredConnectorTypes$ = computed(async (get) => {
         )
       : null;
 
-  const allConnectorTypes = await get(allConnectorTypes$);
-  return allConnectorTypes.filter((connector) => {
+  const allConnectorCatalogItems = await get(allConnectorCatalogItems$);
+  return allConnectorCatalogItems.filter((connector) => {
     if (!matchesConnectorSearch(keyword, connector)) {
       return false;
     }
@@ -595,7 +495,7 @@ export const filteredConnectorTypes$ = computed(async (get) => {
       return !connector.connected;
     }
     if (effectiveFilter.kind === "agent") {
-      return agentEnabledTypes?.has(connector.type) ?? false;
+      return agentEnabledRefs?.has(connector.connectorRef) ?? false;
     }
     return true;
   });
@@ -632,10 +532,10 @@ export const setConnectorsConnectionFilter$ = command(
 // Selected connector for connect modal
 // ---------------------------------------------------------------------------
 
-const internalSelectedConnectorType$ = state<ConnectorRef | null>(null);
+const internalSelectedConnectorRef$ = state<ConnectorRef | null>(null);
 
 type ActiveConnectorOAuthDeviceAuthState = {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly sessionId: string;
@@ -650,7 +550,7 @@ type ActiveConnectorOAuthDeviceAuthState = {
 };
 
 type ActiveConnectorExternalCodeState = {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly sessionId: string;
@@ -664,11 +564,11 @@ type ActiveConnectorExternalCodeState = {
 export type ConnectorOAuthDeviceAuthState =
   | {
       readonly status: "idle";
-      readonly connectorType: ConnectorRef | null;
+      readonly connectorRef: ConnectorRef | null;
     }
   | {
       readonly status: "starting";
-      readonly connectorType: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly requestId: string;
     }
@@ -677,7 +577,7 @@ export type ConnectorOAuthDeviceAuthState =
     })
   | {
       readonly status: "denied" | "expired" | "error";
-      readonly connectorType: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly message: string;
     };
@@ -685,11 +585,11 @@ export type ConnectorOAuthDeviceAuthState =
 export type ConnectorExternalCodeState =
   | {
       readonly status: "idle";
-      readonly connectorType: ConnectorRef | null;
+      readonly connectorRef: ConnectorRef | null;
     }
   | {
       readonly status: "starting";
-      readonly connectorType: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly requestId: string;
     }
@@ -698,20 +598,20 @@ export type ConnectorExternalCodeState =
     })
   | {
       readonly status: "expired" | "error";
-      readonly connectorType: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly message: string;
     };
 
 type ConnectorConnectFlowState = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly id: string;
 };
 
 function createIdleConnectorOAuthDeviceAuthState(
-  connectorType: ConnectorRef | null = null,
+  connectorRef: ConnectorRef | null = null,
 ): ConnectorOAuthDeviceAuthState {
-  return { status: "idle", connectorType };
+  return { status: "idle", connectorRef };
 }
 
 const internalConnectorOAuthDeviceAuthState$ =
@@ -720,9 +620,9 @@ const internalConnectorOAuthDeviceAuthState$ =
   );
 
 function createIdleConnectorExternalCodeState(
-  connectorType: ConnectorRef | null = null,
+  connectorRef: ConnectorRef | null = null,
 ): ConnectorExternalCodeState {
-  return { status: "idle", connectorType };
+  return { status: "idle", connectorRef };
 }
 
 const internalConnectorExternalCodeState$ = state<ConnectorExternalCodeState>(
@@ -734,26 +634,26 @@ const connectorOAuthDeviceAuthStartOptionValues$ = state<
   Record<string, Record<string, string>>
 >({});
 
-export const selectedConnectorType$ = computed((get) => {
-  return get(internalSelectedConnectorType$);
+export const selectedConnectorRef$ = computed((get) => {
+  return get(internalSelectedConnectorRef$);
 });
-export const setSelectedConnectorType$ = command(
-  ({ get, set }, type: ConnectorRef | null) => {
-    set(internalSelectedConnectorType$, type);
+export const setSelectedConnectorRef$ = command(
+  ({ get, set }, connectorRef: ConnectorRef | null) => {
+    set(internalSelectedConnectorRef$, connectorRef);
     const deviceAuthCurrent = get(internalConnectorOAuthDeviceAuthState$);
-    if (type !== deviceAuthCurrent.connectorType) {
+    if (connectorRef !== deviceAuthCurrent.connectorRef) {
       set(resetConnectorOAuthDeviceAuthFlowSignal$);
       set(
         internalConnectorOAuthDeviceAuthState$,
-        createIdleConnectorOAuthDeviceAuthState(type),
+        createIdleConnectorOAuthDeviceAuthState(connectorRef),
       );
     }
     const externalCodeCurrent = get(internalConnectorExternalCodeState$);
-    if (type !== externalCodeCurrent.connectorType) {
+    if (connectorRef !== externalCodeCurrent.connectorRef) {
       set(resetConnectorExternalCodeFlowSignal$);
       set(
         internalConnectorExternalCodeState$,
-        createIdleConnectorExternalCodeState(type),
+        createIdleConnectorExternalCodeState(connectorRef),
       );
     }
   },
@@ -784,18 +684,18 @@ function connectorExternalCodeStateIsActive(
 }
 
 function connectorConnectOperationIsActive({
-  authCodeConnectorType,
+  authCodeConnectorRef,
   connectFlow,
   deviceAuthState,
   externalCodeState,
 }: {
-  readonly authCodeConnectorType: ConnectorRef | null;
+  readonly authCodeConnectorRef: ConnectorRef | null;
   readonly connectFlow: ConnectorConnectFlowState | null;
   readonly deviceAuthState: ConnectorOAuthDeviceAuthState;
   readonly externalCodeState: ConnectorExternalCodeState;
 }): boolean {
   return (
-    authCodeConnectorType !== null ||
+    authCodeConnectorRef !== null ||
     connectFlow !== null ||
     connectorOAuthDeviceAuthStateIsActive(deviceAuthState) ||
     connectorExternalCodeStateIsActive(externalCodeState)
@@ -803,17 +703,19 @@ function connectorConnectOperationIsActive({
 }
 
 function connectorOAuthDeviceAuthStartOptionsKey(
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): string {
-  return `${type}:${authMethod}`;
+  return `${connectorRef}:${authMethod}`;
 }
 
 export const connectorOAuthDeviceAuthStartOptionValuesFor$ = computed((get) => {
   const values = get(connectorOAuthDeviceAuthStartOptionValues$);
-  return (type: ConnectorRef, authMethod: ConnectorAuthMethodId) => {
+  return (connectorRef: ConnectorRef, authMethod: ConnectorAuthMethodId) => {
     return (
-      values[connectorOAuthDeviceAuthStartOptionsKey(type, authMethod)] ?? {}
+      values[
+        connectorOAuthDeviceAuthStartOptionsKey(connectorRef, authMethod)
+      ] ?? {}
     );
   };
 });
@@ -822,14 +724,14 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
   (
     { get, set },
     args: {
-      readonly type: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly name: string;
       readonly value: string;
     },
   ) => {
     const key = connectorOAuthDeviceAuthStartOptionsKey(
-      args.type,
+      args.connectorRef,
       args.authMethod,
     );
     const current = get(connectorOAuthDeviceAuthStartOptionValues$);
@@ -847,25 +749,28 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
-const internalScopeReviewType$ = state<ConnectorRef | null>(null);
-export const scopeReviewType$ = computed((get) => {
-  return get(internalScopeReviewType$);
+const internalScopeReviewConnectorRef$ = state<ConnectorRef | null>(null);
+export const scopeReviewConnectorRef$ = computed((get) => {
+  return get(internalScopeReviewConnectorRef$);
 });
 
 export const scopeDiff$ = computed(async (get) => {
-  const type = get(internalScopeReviewType$);
-  if (!type) {
+  const connectorRef = get(internalScopeReviewConnectorRef$);
+  if (!connectorRef) {
     return null;
   }
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorScopeDiffContract);
-  const result = await accept(client.getScopeDiff({ params: { type } }), [200]);
+  const result = await accept(
+    client.getScopeDiff({ params: { type: connectorRef } }),
+    [200],
+  );
   return result.body;
 });
 
-export const setScopeReviewType$ = command(
-  ({ set }, type: ConnectorRef | null) => {
-    set(internalScopeReviewType$, type);
+export const setScopeReviewConnectorRef$ = command(
+  ({ set }, connectorRef: ConnectorRef | null) => {
+    set(internalScopeReviewConnectorRef$, connectorRef);
   },
 );
 
@@ -882,26 +787,28 @@ export const manualGrantFormSubmitting$ = computed((get) => {
 const internalManualGrantFormSubmitting$ = state<string | null>(null);
 
 export const setManualGrantFormValue$ = command(
-  ({ get, set }, type: string, name: string, value: string) => {
+  ({ get, set }, connectorRef: ConnectorRef, name: string, value: string) => {
     const current = get(manualGrantFormValues$);
     set(manualGrantFormValues$, {
       ...current,
-      [type]: { ...current[type], [name]: value },
+      [connectorRef]: { ...current[connectorRef], [name]: value },
     });
   },
 );
 
-export const clearManualGrantForm$ = command(({ get, set }, type: string) => {
-  const current = get(manualGrantFormValues$);
-  const updated = { ...current };
-  delete updated[type];
-  set(manualGrantFormValues$, updated);
-});
+export const clearManualGrantForm$ = command(
+  ({ get, set }, connectorRef: ConnectorRef) => {
+    const current = get(manualGrantFormValues$);
+    const updated = { ...current };
+    delete updated[connectorRef];
+    set(manualGrantFormValues$, updated);
+  },
+);
 
 export const manualGrantFormValuesFor$ = computed((get) => {
   const values = get(manualGrantFormValues$);
-  return (type: string) => {
-    return values[type] ?? {};
+  return (connectorRef: ConnectorRef) => {
+    return values[connectorRef] ?? {};
   };
 });
 
@@ -920,11 +827,11 @@ type FinishConnectorConnectionOptions = PostConnectOptions & {
 const finishConnectorConnection$ = command(
   (
     { get, set },
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     options: FinishConnectorConnectionOptions = {},
   ): boolean => {
-    set(internalJustConnectedTypes$, (prev) => {
-      return new Set([...prev, type]);
+    set(internalJustConnectedRefs$, (prev) => {
+      return new Set([...prev, connectorRef]);
     });
     if (options.reloadConnectors !== false) {
       set(reloadConnectors$);
@@ -933,20 +840,21 @@ const finishConnectorConnection$ = command(
       set(reloadAgentConnectorAuthorizations$);
     }
 
-    const hidden = new Set(get(hiddenConnectorTypes$));
-    hidden.delete(type);
-    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
+    const hidden = new Set(get(hiddenConnectorRefs$));
+    hidden.delete(connectorRef);
+    set(setHiddenConnectorRefs$, JSON.stringify([...hidden]));
 
     if (options.toastMessage !== null) {
       toast.success(
-        options.toastMessage ?? `${options.connectorLabel ?? type} connected`,
+        options.toastMessage ??
+          `${options.connectorLabel ?? connectorRef} connected`,
         {
-          id: `connector-connected-${type}`,
+          id: `connector-connected-${connectorRef}`,
         },
       );
     }
     if (options.clearSelectedConnector) {
-      set(internalSelectedConnectorType$, null);
+      set(internalSelectedConnectorRef$, null);
     }
     return true;
   },
@@ -957,7 +865,7 @@ const finishConnectorConnection$ = command(
 // ---------------------------------------------------------------------------
 
 type SubmitManualGrantParams = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly inputValues: Record<string, string>;
   readonly options: PostConnectOptions;
@@ -966,12 +874,12 @@ type SubmitManualGrantParams = {
 export const submitManualGrant$ = command(
   async (
     { get, set },
-    { type, authMethod, inputValues, options }: SubmitManualGrantParams,
+    { connectorRef, authMethod, inputValues, options }: SubmitManualGrantParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
     if (
       connectorConnectOperationIsActive({
-        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        authCodeConnectorRef: get(internalPollingOAuthAuthCodeConnectorRef$),
         connectFlow: get(internalConnectFlowState$),
         deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
         externalCodeState: get(internalConnectorExternalCodeState$),
@@ -980,7 +888,7 @@ export const submitManualGrant$ = command(
       return false;
     }
 
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
     let connectorStateChanged = false;
     return await withCleanup(
@@ -989,7 +897,7 @@ export const submitManualGrant$ = command(
         const connectorClient = createClient(zeroConnectorManualGrantContract);
         await accept(
           connectorClient.connect({
-            params: { type },
+            params: { type: connectorRef },
             body: {
               authMethod,
               authorizeAgent: true,
@@ -1002,10 +910,10 @@ export const submitManualGrant$ = command(
         );
         connectorStateChanged = true;
         signal.throwIfAborted();
-        set(finishConnectorConnection$, type, {
+        set(finishConnectorConnection$, connectorRef, {
           ...options,
           reloadConnectors: false,
-          toastMessage: `${options.connectorLabel ?? type} connected successfully`,
+          toastMessage: `${options.connectorLabel ?? connectorRef} connected successfully`,
         });
         return true;
       })(),
@@ -1026,7 +934,7 @@ export const submitManualGrant$ = command(
 // ---------------------------------------------------------------------------
 
 type ConnectNoAuthParams = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
 };
@@ -1034,12 +942,12 @@ type ConnectNoAuthParams = {
 export const connectConnectorNoAuth$ = command(
   async (
     { get, set },
-    { type, authMethod, options }: ConnectNoAuthParams,
+    { connectorRef, authMethod, options }: ConnectNoAuthParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
     if (
       connectorConnectOperationIsActive({
-        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        authCodeConnectorRef: get(internalPollingOAuthAuthCodeConnectorRef$),
         connectFlow: get(internalConnectFlowState$),
         deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
         externalCodeState: get(internalConnectorExternalCodeState$),
@@ -1048,7 +956,7 @@ export const connectConnectorNoAuth$ = command(
       return false;
     }
 
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
     let connectorStateChanged = false;
     return await withCleanup(
@@ -1057,7 +965,7 @@ export const connectConnectorNoAuth$ = command(
         const connectorClient = createClient(zeroConnectorNoAuthGrantContract);
         await accept(
           connectorClient.connect({
-            params: { type },
+            params: { type: connectorRef },
             body: {
               authMethod,
               authorizeAgent: true,
@@ -1069,10 +977,10 @@ export const connectConnectorNoAuth$ = command(
         );
         connectorStateChanged = true;
         signal.throwIfAborted();
-        set(finishConnectorConnection$, type, {
+        set(finishConnectorConnection$, connectorRef, {
           ...options,
           reloadConnectors: false,
-          toastMessage: `${options.connectorLabel ?? type} enabled successfully`,
+          toastMessage: `${options.connectorLabel ?? connectorRef} enabled successfully`,
         });
         return true;
       })(),
@@ -1108,34 +1016,34 @@ export const connectConnectorNoAuthAndSettle$ = command(
 // Polling state (for connect flow)
 // ---------------------------------------------------------------------------
 
-const internalPollingOAuthAuthCodeConnectorType$ = state<ConnectorRef | null>(
+const internalPollingOAuthAuthCodeConnectorRef$ = state<ConnectorRef | null>(
   null,
 );
 const internalConnectFlowState$ = state<ConnectorConnectFlowState | null>(null);
 
-export const pollingOAuthAuthCodeConnectorType$ = computed((get) => {
-  return get(internalPollingOAuthAuthCodeConnectorType$);
+export const pollingOAuthAuthCodeConnectorRef$ = computed((get) => {
+  return get(internalPollingOAuthAuthCodeConnectorRef$);
 });
 
-export const pollingOAuthDeviceAuthConnectorType$ = computed((get) => {
+export const pollingOAuthDeviceAuthConnectorRef$ = computed((get) => {
   const current = get(internalConnectorOAuthDeviceAuthState$);
   return current.status === "pending" || current.status === "polling"
-    ? current.connectorType
+    ? current.connectorRef
     : null;
 });
 
-export const connectFlowType$ = computed((get) => {
-  return get(internalConnectFlowState$)?.type ?? null;
+export const connectFlowConnectorRef$ = computed((get) => {
+  return get(internalConnectFlowState$)?.connectorRef ?? null;
 });
 
 export const runConnectorConnectSuccess$ = command(
   async (
     { set },
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     onSuccess: () => void | Promise<void>,
     signal: AbortSignal,
   ): Promise<void> => {
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
     return await withCleanup(
       (async () => {
@@ -1154,14 +1062,14 @@ export const runConnectorConnectSuccess$ = command(
 
 // ---------------------------------------------------------------------------
 // Optimistic connected state — bridges the gap between connect success and
-// allConnectorTypes$ recomputation so the UI doesn't flash.
+// allConnectorCatalogItems$ recomputation so the UI doesn't flash.
 // ---------------------------------------------------------------------------
 
-const internalJustConnectedTypes$ = state<Set<string>>(new Set());
+const internalJustConnectedRefs$ = state<Set<ConnectorRef>>(new Set());
 
-/** Types that were just connected but may not yet be reflected in allConnectorTypes$. */
-export const justConnectedTypes$ = computed((get) => {
-  return get(internalJustConnectedTypes$);
+/** Refs that were just connected but may not yet be reflected in allConnectorCatalogItems$. */
+export const justConnectedRefs$ = computed((get) => {
+  return get(internalJustConnectedRefs$);
 });
 
 /**
@@ -1169,38 +1077,38 @@ export const justConnectedTypes$ = computed((get) => {
  *
  * Without this cleanup, a connector that was connected earlier in the session
  * stays in the Connected section of /connectors after disconnect because the
- * optimistic override in allConnectorTypes$ wins over the fresh
+ * optimistic override in allConnectorCatalogItems$ wins over the fresh
  * `connected = false` from the API (regression #10272).
  */
 export const disconnectConnector$ = command(
   async (
     { set },
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     connectorLabel: string,
     signal: AbortSignal,
   ): Promise<void> => {
-    await set(deleteConnector$, type, signal);
+    await set(deleteConnector$, connectorRef, signal);
     signal.throwIfAborted();
-    set(internalJustConnectedTypes$, (prev) => {
-      if (!prev.has(type)) {
+    set(internalJustConnectedRefs$, (prev) => {
+      if (!prev.has(connectorRef)) {
         return prev;
       }
       const next = new Set(prev);
-      next.delete(type);
+      next.delete(connectorRef);
       return next;
     });
     toast.success(`${connectorLabel} disconnected`, {
-      id: `connector-disconnected-${type}`,
+      id: `connector-disconnected-${connectorRef}`,
     });
   },
 );
 
 function createConnectorConnectFlowState(
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
 ): ConnectorConnectFlowState {
   return {
-    type,
-    id: `${type}-connect-${now()}-${Math.random().toString(36).slice(2)}`,
+    connectorRef,
+    id: `${connectorRef}-connect-${now()}-${Math.random().toString(36).slice(2)}`,
   };
 }
 
@@ -1215,7 +1123,7 @@ function secondsToMilliseconds(value: number): number {
 const OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS = IN_VITEST ? 10 : 1000;
 
 type PollConnectorOAuthDeviceAuthArgs = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly createClient: ZeroClientFactory;
@@ -1223,7 +1131,7 @@ type PollConnectorOAuthDeviceAuthArgs = {
 };
 
 type ConnectConnectorOAuthDeviceAuthParams = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
   readonly startOptions?: ConnectorDeviceAuthStartOptions;
@@ -1261,8 +1169,10 @@ type PollConnectorOAuthDeviceAuthIterationOutcome = {
   readonly expired?: true;
 };
 
-function createConnectorOAuthDeviceAuthRequestId(type: ConnectorRef): string {
-  return `${type}-oauth-device-${now()}-${Math.random().toString(36).slice(2)}`;
+function createConnectorOAuthDeviceAuthRequestId(
+  connectorRef: ConnectorRef,
+): string {
+  return `${connectorRef}-oauth-device-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function getOAuthDeviceAuthTerminalMessage(
@@ -1289,7 +1199,7 @@ function getOAuthDeviceAuthTerminalMessage(
 
 function isCurrentConnectorOAuthDeviceAuthRequest(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   requestId: string,
 ): state is ActiveConnectorOAuthDeviceAuthState & {
@@ -1297,7 +1207,7 @@ function isCurrentConnectorOAuthDeviceAuthRequest(
 } {
   return (
     (state.status === "pending" || state.status === "polling") &&
-    state.connectorType === type &&
+    state.connectorRef === connectorRef &&
     state.authMethod === authMethod &&
     state.requestId === requestId
   );
@@ -1314,13 +1224,13 @@ export const clearConnectorOAuthDeviceAuth$ = command(({ set }) => {
 export const openConnectorOAuthDeviceAuthVerificationPage$ = command(
   (
     { get, set },
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     authMethod: ConnectorAuthMethodId,
   ): boolean => {
     const current = get(internalConnectorOAuthDeviceAuthState$);
     if (
       (current.status !== "pending" && current.status !== "polling") ||
-      current.connectorType !== type ||
+      current.connectorRef !== connectorRef ||
       current.authMethod !== authMethod
     ) {
       return false;
@@ -1353,7 +1263,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
     { get, set },
     {
       client,
-      type,
+      connectorRef,
       authMethod,
       requestId,
       options,
@@ -1367,7 +1277,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
         if (
           !isCurrentConnectorOAuthDeviceAuthRequest(
             current,
-            type,
+            connectorRef,
             authMethod,
             requestId,
           )
@@ -1396,7 +1306,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
 
         const pollResponse = await accept(
           client.poll({
-            params: { type, sessionId: current.sessionId },
+            params: { type: connectorRef, sessionId: current.sessionId },
             body: { sessionToken: current.sessionToken },
             fetchOptions: { signal },
           }),
@@ -1411,7 +1321,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
         if (
           !isCurrentConnectorOAuthDeviceAuthRequest(
             latest,
-            type,
+            connectorRef,
             authMethod,
             requestId,
           )
@@ -1421,7 +1331,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
 
         if (pollResult.status === "complete") {
           signal.throwIfAborted();
-          set(finishConnectorConnection$, type, {
+          set(finishConnectorConnection$, connectorRef, {
             ...options,
             clearSelectedConnector: true,
             reloadConnectors: false,
@@ -1438,7 +1348,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
         if (pollResult.status !== "pending") {
           set(internalConnectorOAuthDeviceAuthState$, {
             status: pollResult.status,
-            connectorType: type,
+            connectorRef,
             authMethod,
             message: getOAuthDeviceAuthTerminalMessage(pollResult),
           });
@@ -1477,7 +1387,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
   async (
     { get, set },
     {
-      type,
+      connectorRef,
       authMethod,
       requestId,
       createClient,
@@ -1491,7 +1401,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
     const isCurrentRequest = (state: ConnectorOAuthDeviceAuthState) => {
       return isCurrentConnectorOAuthDeviceAuthRequest(
         state,
-        type,
+        connectorRef,
         authMethod,
         requestId,
       );
@@ -1503,7 +1413,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
       async (sig) => {
         const outcome = await set(
           pollConnectorOAuthDeviceAuthOnce$,
-          { client, type, authMethod, requestId, options },
+          { client, connectorRef, authMethod, requestId, options },
           sig,
         );
         sig.throwIfAborted();
@@ -1525,7 +1435,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
     if (expired && isCurrentRequest(latest)) {
       set(internalConnectorOAuthDeviceAuthState$, {
         status: "expired",
-        connectorType: type,
+        connectorRef,
         authMethod,
         message: "Connection session expired. Start again to retry.",
       });
@@ -1540,10 +1450,10 @@ const connectConnectorOAuthDeviceAuth$ = command(
     args: ConnectConnectorOAuthDeviceAuthParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const { type, authMethod, options } = args;
+    const { connectorRef, authMethod, options } = args;
     if (
       connectorConnectOperationIsActive({
-        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        authCodeConnectorRef: get(internalPollingOAuthAuthCodeConnectorRef$),
         connectFlow: get(internalConnectFlowState$),
         deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
         externalCodeState: get(internalConnectorExternalCodeState$),
@@ -1552,19 +1462,19 @@ const connectConnectorOAuthDeviceAuth$ = command(
       return false;
     }
 
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
     return await withCleanup(
       (async () => {
-        requestId = createConnectorOAuthDeviceAuthRequestId(type);
+        requestId = createConnectorOAuthDeviceAuthRequestId(connectorRef);
         const flowSignal = set(
           resetConnectorOAuthDeviceAuthFlowSignal$,
           signal,
         );
         set(internalConnectorOAuthDeviceAuthState$, {
           status: "starting",
-          connectorType: type,
+          connectorRef,
           authMethod,
           requestId,
         });
@@ -1577,7 +1487,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
         const startResponse = await tapError(
           accept(
             client.create({
-              params: { type },
+              params: { type: connectorRef },
               body: connectorOAuthDeviceAuthStartBody(args),
               fetchOptions: { signal: flowSignal },
             }),
@@ -1592,7 +1502,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
           }
           set(internalConnectorOAuthDeviceAuthState$, {
             status: "error",
-            connectorType: type,
+            connectorRef,
             authMethod,
             message: "Connection failed. Start again to retry.",
           });
@@ -1604,7 +1514,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
 
         set(internalConnectorOAuthDeviceAuthState$, {
           status: "pending",
-          connectorType: type,
+          connectorRef,
           authMethod,
           requestId,
           sessionId: startResult.sessionId,
@@ -1624,7 +1534,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
         return await set(
           pollConnectorOAuthDeviceAuth$,
           {
-            type,
+            connectorRef,
             authMethod,
             requestId,
             createClient,
@@ -1640,7 +1550,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
         set(internalConnectorOAuthDeviceAuthState$, (current) => {
           if (
             requestId === null ||
-            current.connectorType !== type ||
+            current.connectorRef !== connectorRef ||
             (current.status !== "starting" &&
               current.status !== "pending" &&
               current.status !== "polling") ||
@@ -1649,7 +1559,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
           ) {
             return current;
           }
-          return createIdleConnectorOAuthDeviceAuthState(type);
+          return createIdleConnectorOAuthDeviceAuthState(connectorRef);
         });
       },
     );
@@ -1660,7 +1570,7 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
   async (
     { set },
     args: {
-      readonly type: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly onSuccess: () => void | Promise<void>;
       readonly options: PostConnectOptions;
@@ -1671,7 +1581,7 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
     const connected = await set(
       connectConnectorOAuthDeviceAuth$,
       {
-        type: args.type,
+        connectorRef: args.connectorRef,
         authMethod: args.authMethod,
         options: args.options,
         startOptions: args.startOptions,
@@ -1690,24 +1600,26 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
 // ---------------------------------------------------------------------------
 
 type ConnectConnectorExternalCodeParams = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly agentId?: string;
 };
 
 type CompleteConnectorExternalCodeParams = {
-  readonly type: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
 };
 
-function createConnectorExternalCodeRequestId(type: ConnectorRef): string {
-  return `${type}-external-code-${now()}-${Math.random().toString(36).slice(2)}`;
+function createConnectorExternalCodeRequestId(
+  connectorRef: ConnectorRef,
+): string {
+  return `${connectorRef}-external-code-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function isCurrentConnectorExternalCodeRequest(
   state: ConnectorExternalCodeState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   requestId: string,
 ): state is ActiveConnectorExternalCodeState & {
@@ -1715,7 +1627,7 @@ function isCurrentConnectorExternalCodeRequest(
 } {
   return (
     state.status === "pending" &&
-    state.connectorType === type &&
+    state.connectorRef === connectorRef &&
     state.authMethod === authMethod &&
     state.requestId === requestId
   );
@@ -1733,7 +1645,7 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
   (
     { get, set },
     args: {
-      readonly type: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly code: string;
     },
@@ -1741,7 +1653,7 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
     const current = get(internalConnectorExternalCodeState$);
     if (
       current.status !== "pending" ||
-      current.connectorType !== args.type ||
+      current.connectorRef !== args.connectorRef ||
       current.authMethod !== args.authMethod
     ) {
       return false;
@@ -1758,13 +1670,13 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
 export const openConnectorExternalCodeAuthorizationPage$ = command(
   (
     { get, set },
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     authMethod: ConnectorAuthMethodId,
   ): boolean => {
     const current = get(internalConnectorExternalCodeState$);
     if (
       current.status !== "pending" ||
-      current.connectorType !== type ||
+      current.connectorRef !== connectorRef ||
       current.authMethod !== authMethod
     ) {
       return false;
@@ -1793,10 +1705,10 @@ export const connectConnectorExternalCode$ = command(
     args: ConnectConnectorExternalCodeParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const { type, authMethod } = args;
+    const { connectorRef, authMethod } = args;
     if (
       connectorConnectOperationIsActive({
-        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        authCodeConnectorRef: get(internalPollingOAuthAuthCodeConnectorRef$),
         connectFlow: get(internalConnectFlowState$),
         deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
         externalCodeState: get(internalConnectorExternalCodeState$),
@@ -1805,16 +1717,16 @@ export const connectConnectorExternalCode$ = command(
       return false;
     }
 
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
     return await withCleanup(
       (async () => {
-        requestId = createConnectorExternalCodeRequestId(type);
+        requestId = createConnectorExternalCodeRequestId(connectorRef);
         const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
         set(internalConnectorExternalCodeState$, {
           status: "starting",
-          connectorType: type,
+          connectorRef,
           authMethod,
           requestId,
         });
@@ -1826,7 +1738,7 @@ export const connectConnectorExternalCode$ = command(
         const startResponse = await tapError(
           accept(
             client.create({
-              params: { type },
+              params: { type: connectorRef },
               body: {
                 authMethod,
                 authorizeAgent: true,
@@ -1845,7 +1757,7 @@ export const connectConnectorExternalCode$ = command(
           }
           set(internalConnectorExternalCodeState$, {
             status: "error",
-            connectorType: type,
+            connectorRef,
             authMethod,
             message: "Connection failed. Start again to retry.",
           });
@@ -1857,7 +1769,7 @@ export const connectConnectorExternalCode$ = command(
 
         set(internalConnectorExternalCodeState$, {
           status: "pending",
-          connectorType: type,
+          connectorRef,
           authMethod,
           requestId,
           sessionId: startResult.sessionId,
@@ -1877,14 +1789,14 @@ export const connectConnectorExternalCode$ = command(
           if (
             !signal.aborted ||
             requestId === null ||
-            current.connectorType !== type ||
+            current.connectorRef !== connectorRef ||
             (current.status !== "starting" && current.status !== "pending") ||
             current.authMethod !== authMethod ||
             current.requestId !== requestId
           ) {
             return current;
           }
-          return createIdleConnectorExternalCodeState(type);
+          return createIdleConnectorExternalCodeState(connectorRef);
         });
       },
     );
@@ -1897,11 +1809,11 @@ const completeConnectorExternalCode$ = command(
     args: CompleteConnectorExternalCodeParams,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const { type, authMethod, options } = args;
+    const { connectorRef, authMethod, options } = args;
     const current = get(internalConnectorExternalCodeState$);
     if (
       current.status !== "pending" ||
-      current.connectorType !== type ||
+      current.connectorRef !== connectorRef ||
       current.authMethod !== authMethod
     ) {
       return false;
@@ -1909,7 +1821,7 @@ const completeConnectorExternalCode$ = command(
     if (now() > current.expiresAtMs) {
       set(internalConnectorExternalCodeState$, {
         status: "expired",
-        connectorType: type,
+        connectorRef,
         authMethod,
         message: "Connection session expired. Start again to retry.",
       });
@@ -1920,7 +1832,7 @@ const completeConnectorExternalCode$ = command(
     if (!code) {
       set(internalConnectorExternalCodeState$, {
         ...current,
-        errorMessage: `Enter the code from ${options.connectorLabel ?? type}.`,
+        errorMessage: `Enter the code from ${options.connectorLabel ?? connectorRef}.`,
       });
       return false;
     }
@@ -1941,7 +1853,7 @@ const completeConnectorExternalCode$ = command(
         });
         const completeResult = await accept(
           client.complete({
-            params: { type, sessionId: current.sessionId },
+            params: { type: connectorRef, sessionId: current.sessionId },
             body: {
               sessionToken: current.sessionToken,
               code,
@@ -1959,7 +1871,7 @@ const completeConnectorExternalCode$ = command(
         if (
           !isCurrentConnectorExternalCodeRequest(
             latest,
-            type,
+            connectorRef,
             authMethod,
             current.requestId,
           )
@@ -1975,7 +1887,7 @@ const completeConnectorExternalCode$ = command(
           return false;
         }
 
-        set(finishConnectorConnection$, type, {
+        set(finishConnectorConnection$, connectorRef, {
           ...options,
           clearSelectedConnector: true,
           reloadConnectors: false,
@@ -2006,7 +1918,7 @@ export const completeConnectorExternalCodeAndSettle$ = command(
     const connected = await set(
       completeConnectorExternalCode$,
       {
-        type: args.type,
+        connectorRef: args.connectorRef,
         authMethod: args.authMethod,
         options: args.options,
       },
@@ -2068,14 +1980,14 @@ const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 
 function connectorMatchesAuthMethod(
   connector: ConnectorResponse,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): boolean {
-  return connector.type === type && connector.authMethod === authMethod;
+  return connector.type === connectorRef && connector.authMethod === authMethod;
 }
 
 function createConnectorOAuthAuthCodeChangedCommand(
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   agentId: string | undefined,
 ) {
@@ -2093,7 +2005,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
     );
     const polled = (result.body as ConnectorListResponse).connectors;
     const current = polled.find((c) => {
-      return connectorMatchesAuthMethod(c, type, authMethod);
+      return connectorMatchesAuthMethod(c, connectorRef, authMethod);
     });
 
     if (initialUpdatedAt === undefined) {
@@ -2117,7 +2029,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
       );
       return (
         authorization.status === 200 &&
-        authorization.body.enabledTypes.includes(type)
+        authorization.body.enabledTypes.includes(connectorRef)
       );
     }
     return false;
@@ -2128,8 +2040,8 @@ const openConnectorOAuthAuthCodeWindow$ = command(
   async (
     { get },
     args: {
-      readonly type: ConnectorRef;
-      readonly method: ConnectorStatusAuthMethodDetail;
+      readonly connectorRef: ConnectorRef;
+      readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly connectorLabel: string;
       readonly agentId: string | undefined;
       readonly beforeStart: (signal: AbortSignal) => Promise<void>;
@@ -2142,7 +2054,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     // URL in the external browser instead of blocking it as a popup.
     const popupFeatures = standalone ? undefined : "width=600,height=700";
     const redirectingPath = connectorRedirectingPath({
-      type: args.type,
+      type: args.connectorRef,
       label: args.connectorLabel,
     });
     const authWindow = window.open(redirectingPath, "_blank", popupFeatures);
@@ -2159,7 +2071,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       (async () => {
         if (!isBrowserAuthGrantKind(args.method.grantKind)) {
           throw new Error(
-            `${args.type}/${args.method.id} does not support browser authorization`,
+            `${args.connectorRef}/${args.method.id} does not support browser authorization`,
           );
         }
 
@@ -2172,7 +2084,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 get(zeroClient$)(zeroConnectorOpenIdStartContract, {
                   apiBase: "api",
                 }).start({
-                  params: { type: args.type },
+                  params: { type: args.connectorRef },
                   body: {
                     authMethod: args.method.id,
                     authorizeAgent: true,
@@ -2186,7 +2098,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 get(zeroClient$)(zeroConnectorOauthStartContract, {
                   apiBase: OAUTH_WEB_API_BASE,
                 }).start({
-                  params: { type: args.type },
+                  params: { type: args.connectorRef },
                   body: {
                     authMethod: args.method.id,
                     authorizeAgent: true,
@@ -2211,7 +2123,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
             authWindow.close();
           } else {
             authWindow.location.href = connectorRedirectingPath({
-              type: args.type,
+              type: args.connectorRef,
               label: args.connectorLabel,
               status: "error",
             });
@@ -2228,15 +2140,15 @@ const openConnectorOAuthAuthCodeWindow$ = command(
 export const connectConnectorOAuthAuthCode$ = command(
   async (
     { get, set },
-    type: ConnectorRef,
-    method: ConnectorStatusAuthMethodDetail,
+    connectorRef: ConnectorRef,
+    method: PublicConnectorCatalogAuthMethodDetail,
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
     signal.throwIfAborted();
     if (
       connectorConnectOperationIsActive({
-        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        authCodeConnectorRef: get(internalPollingOAuthAuthCodeConnectorRef$),
         connectFlow: get(internalConnectFlowState$),
         deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
         externalCodeState: get(internalConnectorExternalCodeState$),
@@ -2245,9 +2157,9 @@ export const connectConnectorOAuthAuthCode$ = command(
       return false;
     }
 
-    const flow = createConnectorConnectFlowState(type);
+    const flow = createConnectorConnectFlowState(connectorRef);
     set(internalConnectFlowState$, flow);
-    set(internalPollingOAuthAuthCodeConnectorType$, type);
+    set(internalPollingOAuthAuthCodeConnectorRef$, connectorRef);
 
     return await withCleanup(
       (async () => {
@@ -2256,16 +2168,16 @@ export const connectConnectorOAuthAuthCode$ = command(
         // while avoiding a race where a very fast callback completes before the
         // first poll baseline is captured.
         const onConnectorChanged$ = createConnectorOAuthAuthCodeChangedCommand(
-          type,
+          connectorRef,
           method.id,
           options.agentId,
         );
         const authWindow = await set(
           openConnectorOAuthAuthCodeWindow$,
           {
-            type,
+            connectorRef,
             method,
-            connectorLabel: options.connectorLabel ?? type,
+            connectorLabel: options.connectorLabel ?? connectorRef,
             agentId: options.agentId,
             beforeStart: async (sig) => {
               await set(onConnectorChanged$, sig);
@@ -2338,10 +2250,10 @@ export const connectConnectorOAuthAuthCode$ = command(
         // Mark as optimistically connected before clearing polling so the UI
         // transitions directly from "Connecting…" to "Connected" without flash.
         const isConnected = connectors.some((c) => {
-          return connectorMatchesAuthMethod(c, type, method.id);
+          return connectorMatchesAuthMethod(c, connectorRef, method.id);
         });
         if (isConnected) {
-          set(finishConnectorConnection$, type, {
+          set(finishConnectorConnection$, connectorRef, {
             ...options,
             clearSelectedConnector: true,
             reloadConnectors: false,
@@ -2351,8 +2263,8 @@ export const connectConnectorOAuthAuthCode$ = command(
         return isConnected;
       })(),
       () => {
-        set(internalPollingOAuthAuthCodeConnectorType$, (current) => {
-          return current === type ? null : current;
+        set(internalPollingOAuthAuthCodeConnectorRef$, (current) => {
+          return current === connectorRef ? null : current;
         });
         set(internalConnectFlowState$, (current) => {
           return current?.id === flow.id ? null : current;
@@ -2370,8 +2282,8 @@ export const connectConnectorOAuthAuthCodeAndSettle$ = command(
   async (
     { set },
     args: {
-      readonly type: ConnectorRef;
-      readonly method: ConnectorStatusAuthMethodDetail;
+      readonly connectorRef: ConnectorRef;
+      readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly onSuccess: () => void | Promise<void>;
       readonly options: PostConnectOptions;
     },
@@ -2379,7 +2291,7 @@ export const connectConnectorOAuthAuthCodeAndSettle$ = command(
   ): Promise<void> => {
     const connected = await set(
       connectConnectorOAuthAuthCode$,
-      args.type,
+      args.connectorRef,
       args.method,
       args.options,
       signal,

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -27,12 +27,12 @@ export interface ComposerConnectorSignals {
   >;
   readonly showAddDialog$: Computed<boolean>;
   readonly setShowAddDialog$: Command<void, [boolean]>;
-  readonly pendingConnectType$: Computed<ConnectorRef | null>;
-  readonly setPendingConnectType$: Command<void, [ConnectorRef | null]>;
-  readonly selectedConnectType$: Computed<ConnectorRef | null>;
-  readonly setSelectedConnectType$: Command<void, [ConnectorRef | null]>;
-  readonly savingType$: Computed<ConnectorRef | null>;
-  readonly setSavingType$: Command<void, [ConnectorRef | null]>;
+  readonly pendingConnectorRef$: Computed<ConnectorRef | null>;
+  readonly setPendingConnectorRef$: Command<void, [ConnectorRef | null]>;
+  readonly selectedConnectorRef$: Computed<ConnectorRef | null>;
+  readonly setSelectedConnectorRef$: Command<void, [ConnectorRef | null]>;
+  readonly savingConnectorRef$: Computed<ConnectorRef | null>;
+  readonly setSavingConnectorRef$: Command<void, [ConnectorRef | null]>;
   readonly addDialogSearch$: Computed<string>;
   readonly setAddDialogSearch$: Command<void, [string]>;
   readonly popoverSearch$: Computed<string>;
@@ -44,8 +44,8 @@ export interface ComposerConnectorSignals {
   >;
   readonly computerUseDownloadDialogOpen$: Computed<boolean>;
   readonly setComputerUseDownloadDialogOpen$: Command<void, [boolean]>;
-  readonly permissionConnector$: Computed<ConnectorRef | null>;
-  readonly setPermissionConnector$: Command<void, [ConnectorRef | null]>;
+  readonly permissionConnectorRef$: Computed<ConnectorRef | null>;
+  readonly setPermissionConnectorRef$: Command<void, [ConnectorRef | null]>;
   readonly permissionMetadata$: Computed<
     Promise<PublicConnectorCatalogPermissionDetail | null>
   >;
@@ -68,27 +68,27 @@ function createStateBinding<T>(initialValue: T) {
 
 interface ComposerConnectorUiState {
   readonly showAddDialog: boolean;
-  readonly pendingConnectType: ConnectorRef | null;
-  readonly selectedConnectType: ConnectorRef | null;
-  readonly savingType: ConnectorRef | null;
+  readonly pendingConnectorRef: ConnectorRef | null;
+  readonly selectedConnectorRef: ConnectorRef | null;
+  readonly savingConnectorRef: ConnectorRef | null;
   readonly addDialogSearch: string;
   readonly popoverSearch: string;
   readonly popoverSortOrder: readonly ConnectorRef[] | null;
   readonly computerUseDownloadDialogOpen: boolean;
-  readonly permissionConnector: ConnectorRef | null;
+  readonly permissionConnectorRef: ConnectorRef | null;
 }
 
 function initialComposerConnectorUiState(): ComposerConnectorUiState {
   return {
     showAddDialog: false,
-    pendingConnectType: null,
-    selectedConnectType: null,
-    savingType: null,
+    pendingConnectorRef: null,
+    selectedConnectorRef: null,
+    savingConnectorRef: null,
     addDialogSearch: "",
     popoverSearch: "",
     popoverSortOrder: null,
     computerUseDownloadDialogOpen: false,
-    permissionConnector: null,
+    permissionConnectorRef: null,
   };
 }
 
@@ -117,7 +117,7 @@ function createConnectorAuthorizationSignals(
     async (
       { get, set },
       operation: "add" | "remove",
-      connectorType: ConnectorRef,
+      connectorRef: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
       const agentId = await get(agentId$);
@@ -131,7 +131,7 @@ function createConnectorAuthorizationSignals(
         accept(
           client.update({
             params: { id: agentId },
-            body: { enabledTypes: [connectorType], operation },
+            body: { enabledTypes: [connectorRef], operation },
             fetchOptions: { signal },
           }),
           [200],
@@ -150,20 +150,20 @@ function createConnectorAuthorizationSignals(
   const authorizeConnector$ = command(
     async (
       { set },
-      connectorType: ConnectorRef,
+      connectorRef: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
-      await set(updateAuthorizedConnectors$, "add", connectorType, signal);
+      await set(updateAuthorizedConnectors$, "add", connectorRef, signal);
     },
   );
 
   const deauthorizeConnector$ = command(
     async (
       { set },
-      connectorType: ConnectorRef,
+      connectorRef: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
-      await set(updateAuthorizedConnectors$, "remove", connectorType, signal);
+      await set(updateAuthorizedConnectors$, "remove", connectorRef, signal);
     },
   );
 
@@ -180,25 +180,25 @@ export function createComposerConnectorSignals(
   const authorization = createConnectorAuthorizationSignals(agentId$);
   const initial = initialComposerConnectorUiState();
   const showAddDialog = createStateBinding(initial.showAddDialog);
-  const pendingConnectType = createStateBinding(initial.pendingConnectType);
-  const selectedConnectType = createStateBinding(initial.selectedConnectType);
-  const savingType = createStateBinding(initial.savingType);
+  const pendingConnectorRef = createStateBinding(initial.pendingConnectorRef);
+  const selectedConnectorRef = createStateBinding(initial.selectedConnectorRef);
+  const savingConnectorRef = createStateBinding(initial.savingConnectorRef);
   const addDialogSearch = createStateBinding(initial.addDialogSearch);
   const popoverSearch = createStateBinding(initial.popoverSearch);
   const popoverSortOrder = createStateBinding(initial.popoverSortOrder);
   const computerUseDownloadDialogOpen = createStateBinding(
     initial.computerUseDownloadDialogOpen,
   );
-  const permissionConnector = createStateBinding(initial.permissionConnector);
+  const permissionConnectorRef = createStateBinding(
+    initial.permissionConnectorRef,
+  );
 
   const permissionMetadata$ = computed(async (get) => {
-    const connectorType = get(permissionConnector.value$);
-    if (!connectorType) {
+    const connectorRef = get(permissionConnectorRef.value$);
+    if (!connectorRef) {
       return null;
     }
-    return await get(
-      firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
-    );
+    return await get(firewallPermissionMetadataByConnector({ connectorRef }));
   });
   const permissionGrants$ = computed(
     async (get): Promise<readonly UserPermissionGrantResponse[]> => {
@@ -215,12 +215,12 @@ export function createComposerConnectorSignals(
     ...authorization,
     showAddDialog$: showAddDialog.value$,
     setShowAddDialog$: showAddDialog.set$,
-    pendingConnectType$: pendingConnectType.value$,
-    setPendingConnectType$: pendingConnectType.set$,
-    selectedConnectType$: selectedConnectType.value$,
-    setSelectedConnectType$: selectedConnectType.set$,
-    savingType$: savingType.value$,
-    setSavingType$: savingType.set$,
+    pendingConnectorRef$: pendingConnectorRef.value$,
+    setPendingConnectorRef$: pendingConnectorRef.set$,
+    selectedConnectorRef$: selectedConnectorRef.value$,
+    setSelectedConnectorRef$: selectedConnectorRef.set$,
+    savingConnectorRef$: savingConnectorRef.value$,
+    setSavingConnectorRef$: savingConnectorRef.set$,
     addDialogSearch$: addDialogSearch.value$,
     setAddDialogSearch$: addDialogSearch.set$,
     popoverSearch$: popoverSearch.value$,
@@ -229,8 +229,8 @@ export function createComposerConnectorSignals(
     setPopoverSortOrder$: popoverSortOrder.set$,
     computerUseDownloadDialogOpen$: computerUseDownloadDialogOpen.value$,
     setComputerUseDownloadDialogOpen$: computerUseDownloadDialogOpen.set$,
-    permissionConnector$: permissionConnector.value$,
-    setPermissionConnector$: permissionConnector.set$,
+    permissionConnectorRef$: permissionConnectorRef.value$,
+    setPermissionConnectorRef$: permissionConnectorRef.set$,
     permissionMetadata$,
     permissionGrants$,
   };

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
@@ -6,24 +6,22 @@ import { firewallPermissionMetadataByConnector } from "../firewall-permission-me
 // JobPermissionsTab UI state
 // ---------------------------------------------------------------------------
 
-const internalConnectorType$ = state<ConnectorRef | null>(null);
-export const permConnectorType$ = computed((get) => {
-  return get(internalConnectorType$);
+const internalConnectorRef$ = state<ConnectorRef | null>(null);
+export const permConnectorRef$ = computed((get) => {
+  return get(internalConnectorRef$);
 });
-export const setPermConnectorType$ = command(
-  ({ set }, type: ConnectorRef | null) => {
-    set(internalConnectorType$, type);
+export const setPermConnectorRef$ = command(
+  ({ set }, connectorRef: ConnectorRef | null) => {
+    set(internalConnectorRef$, connectorRef);
   },
 );
 
 export const agentPermissionMetadata$ = computed(async (get) => {
-  const connectorType = get(permConnectorType$);
-  if (!connectorType) {
+  const connectorRef = get(permConnectorRef$);
+  if (!connectorRef) {
     return null;
   }
-  return await get(
-    firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
-  );
+  return await get(firewallPermissionMetadataByConnector({ connectorRef }));
 });
 
 const internalPermSearch$ = state("");
@@ -42,10 +40,12 @@ export const setPermSearchActive$ = command(({ set }, active: boolean) => {
   set(internalPermSearchActive$, active);
 });
 
-const internalPermSavingType$ = state<string | null>(null);
-export const permSavingType$ = computed((get) => {
-  return get(internalPermSavingType$);
+const internalPermSavingRef$ = state<ConnectorRef | null>(null);
+export const permSavingRef$ = computed((get) => {
+  return get(internalPermSavingRef$);
 });
-export const setPermSavingType$ = command(({ set }, type: string | null) => {
-  set(internalPermSavingType$, type);
-});
+export const setPermSavingRef$ = command(
+  ({ set }, connectorRef: ConnectorRef | null) => {
+    set(internalPermSavingRef$, connectorRef);
+  },
+);

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -48,16 +48,14 @@ import {
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
-import {
-  connectorCatalogDisplayMetadataByRef$,
-  type ConnectorCatalogDisplayMetadata,
-} from "../../signals/external/connectors.ts";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import { formatCredits } from "../../lib/format-credits.ts";
 import { getCardPalette } from "../../lib/card-palette.ts";
 
-type ConnectorDisplayMetadataByRef = ReadonlyMap<
+type ConnectorCatalogStatusByRef = ReadonlyMap<
   string,
-  ConnectorCatalogDisplayMetadata
+  PublicConnectorCatalogStatusItem
 >;
 
 // ---------------------------------------------------------------------------
@@ -752,31 +750,31 @@ function fallbackConnectorLabel(ref: string): string {
 
 function connectorLabel(
   type: string,
-  metadataByRef: ConnectorDisplayMetadataByRef | null,
+  statusByRef: ConnectorCatalogStatusByRef | null,
 ): string {
-  return metadataByRef?.get(type)?.label ?? fallbackConnectorLabel(type);
+  return statusByRef?.get(type)?.label ?? fallbackConnectorLabel(type);
 }
 
 function permissionLabel(
   p: { label: string; connectorType?: string },
-  metadataByRef: ConnectorDisplayMetadataByRef | null,
+  statusByRef: ConnectorCatalogStatusByRef | null,
 ): string {
   if (!p.connectorType || p.label === p.connectorType) {
-    return connectorLabel(p.label, metadataByRef);
+    return connectorLabel(p.label, statusByRef);
   }
-  return `${connectorLabel(p.connectorType, metadataByRef)}(${p.label})`;
+  return `${connectorLabel(p.connectorType, statusByRef)}(${p.label})`;
 }
 
 function ServicesCard({
   day,
   colorIndex,
   hoveredAgent,
-  metadataByRef,
+  statusByRef,
 }: {
   day: DayInsight;
   colorIndex: number;
   hoveredAgent: string | null;
-  metadataByRef: ConnectorDisplayMetadataByRef | null;
+  statusByRef: ConnectorCatalogStatusByRef | null;
 }) {
   const maxCalls = Math.max(
     1,
@@ -818,7 +816,7 @@ function ServicesCard({
               className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <span className="text-sm font-medium w-20 truncate shrink-0">
-                {connectorLabel(s.domain, metadataByRef)}
+                {connectorLabel(s.domain, statusByRef)}
               </span>
               <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
                 <div
@@ -847,12 +845,12 @@ function PermissionsAllowedCard({
   day,
   colorIndex,
   hoveredAgent,
-  metadataByRef,
+  statusByRef,
 }: {
   day: DayInsight;
   colorIndex: number;
   hoveredAgent: string | null;
-  metadataByRef: ConnectorDisplayMetadataByRef | null;
+  statusByRef: ConnectorCatalogStatusByRef | null;
 }) {
   const expandedDays = useGet(expandedAllowedDays$);
   const toggleExpanded = useSet(toggleExpandedAllowed$);
@@ -900,7 +898,7 @@ function PermissionsAllowedCard({
             >
               <div className="flex items-center justify-between gap-2">
                 <span className="text-sm font-medium">
-                  {connectorLabel(p.connectorType ?? p.label, metadataByRef)}
+                  {connectorLabel(p.connectorType ?? p.label, statusByRef)}
                 </span>
                 <span className="text-xs opacity-60 tabular-nums shrink-0">
                   {p.allowed} {p.allowed === 1 ? "call" : "calls"}
@@ -934,11 +932,11 @@ function PermissionsAllowedCard({
 function PermissionsBlockedCard({
   day,
   hoveredAgent,
-  metadataByRef,
+  statusByRef,
 }: {
   day: DayInsight;
   hoveredAgent: string | null;
-  metadataByRef: ConnectorDisplayMetadataByRef | null;
+  statusByRef: ConnectorCatalogStatusByRef | null;
 }) {
   const blocked = day.permissions.filter((p) => {
     return p.denied > 0;
@@ -980,7 +978,7 @@ function PermissionsBlockedCard({
               className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <span className="text-sm font-medium">
-                {permissionLabel(p, metadataByRef)}
+                {permissionLabel(p, statusByRef)}
               </span>
               <span className="text-xs tabular-nums shrink-0 opacity-70">
                 {fullyBlocked
@@ -1262,12 +1260,12 @@ function DaySection({
   day,
   isAdmin,
   userId,
-  metadataByRef,
+  statusByRef,
 }: {
   day: DayInsight;
   isAdmin: boolean;
   userId: string | null;
-  metadataByRef: ConnectorDisplayMetadataByRef | null;
+  statusByRef: ConnectorCatalogStatusByRef | null;
 }) {
   const hoveredAgent = useGet(insightsHoveredAgent$);
   const setHoveredAgent = useSet(setInsightsHoveredAgent$);
@@ -1306,7 +1304,7 @@ function DaySection({
           day={day}
           colorIndex={2}
           hoveredAgent={hoveredAgent}
-          metadataByRef={metadataByRef}
+          statusByRef={statusByRef}
         />
         <DayAutomationsCard dayDate={day.date} automations={day.automations} />
         <DayChatsCard dayDate={day.date} chats={day.chats} />
@@ -1314,12 +1312,12 @@ function DaySection({
           day={day}
           colorIndex={5}
           hoveredAgent={hoveredAgent}
-          metadataByRef={metadataByRef}
+          statusByRef={statusByRef}
         />
         <PermissionsBlockedCard
           day={day}
           hoveredAgent={hoveredAgent}
-          metadataByRef={metadataByRef}
+          statusByRef={statusByRef}
         />
       </div>
     </section>
@@ -1350,8 +1348,8 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const prefsLoadable = useLastLoadable(userPreferences$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);
   const userLoadable = useLastLoadable(user$);
-  const connectorMetadataLoadable = useLastLoadable(
-    connectorCatalogDisplayMetadataByRef$,
+  const connectorCatalogStatusLoadable = useLastLoadable(
+    connectorCatalogStatusByRef$,
   );
   const timezone =
     prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
@@ -1363,9 +1361,9 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
     adminLoadable.state === "hasData" ? adminLoadable.data : false;
   const userId =
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? null) : null;
-  const connectorMetadataByRef =
-    connectorMetadataLoadable.state === "hasData"
-      ? connectorMetadataLoadable.data
+  const connectorCatalogStatusByRef =
+    connectorCatalogStatusLoadable.state === "hasData"
+      ? connectorCatalogStatusLoadable.data
       : null;
 
   return (
@@ -1423,7 +1421,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
                 day={day}
                 isAdmin={isAdmin}
                 userId={userId}
-                metadataByRef={connectorMetadataByRef}
+                statusByRef={connectorCatalogStatusByRef}
               />
             );
           })

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -91,9 +91,8 @@ import {
   currentAgentUserPermissionGrants$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   matchesConnectorSearch,
-  type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
   currentAgentVisibleWorkflows$,
@@ -101,18 +100,21 @@ import {
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
-  permConnectorType$,
+  permConnectorRef$,
   agentPermissionMetadata$,
-  setPermConnectorType$,
+  setPermConnectorRef$,
   permSearch$,
   setPermSearch$,
   permSearchActive$,
   setPermSearchActive$,
-  permSavingType$,
-  setPermSavingType$,
+  permSavingRef$,
+  setPermSavingRef$,
 } from "../../signals/zero-page/zero-job-detail-page.ts";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
-import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type {
+  PublicConnectorCatalogPermissionDetail,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission-grants.ts";
 import {
@@ -322,7 +324,7 @@ function PermissionRow({
   onManage,
   isLast,
 }: {
-  connector: ConnectorTypeWithStatus;
+  connector: PublicConnectorCatalogStatusItem;
   enabled: boolean;
   onToggle: (checked: boolean) => void;
   loading?: boolean;
@@ -339,15 +341,15 @@ function PermissionRow({
             <span className="text-sm font-medium text-foreground">
               {connector.label}
             </span>
-            {connector.connector?.externalUsername && (
+            {connector.connection?.externalUsername && (
               <span className="text-xs text-muted-foreground">
-                @{connector.connector.externalUsername}
+                @{connector.connection.externalUsername}
               </span>
             )}
           </div>
-          {connector.helpText && (
+          {connector.description && (
             <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-              {connector.helpText
+              {connector.description
                 .replace(/^Connect your \w+ account to /i, "")
                 .replace(/^access /i, "")
                 .replace(/^create /i, "Create ")
@@ -470,21 +472,21 @@ export function ConnectedConnectorPermissions({
   setSearch,
   searchActive,
   setSearchActive,
-  savingType,
+  savingConnectorRef,
   canManagePermissions,
   onToggle,
   onManage,
 }: {
-  filteredConnectors: readonly ConnectorTypeWithStatus[];
+  filteredConnectors: readonly PublicConnectorCatalogStatusItem[];
   authorizedSet: ReadonlySet<string>;
   search: string;
   setSearch: (value: string) => void;
   searchActive: boolean;
   setSearchActive: (active: boolean) => void;
-  savingType: string | null;
+  savingConnectorRef: ConnectorRef | null;
   canManagePermissions: boolean;
-  onToggle: (type: ConnectorRef, checked: boolean) => Promise<void>;
-  onManage: (type: ConnectorRef) => void;
+  onToggle: (connectorRef: ConnectorRef, checked: boolean) => Promise<void>;
+  onManage: (connectorRef: ConnectorRef) => void;
 }) {
   return (
     <>
@@ -555,18 +557,18 @@ export function ConnectedConnectorPermissions({
           filteredConnectors.map((c, i) => {
             return (
               <PermissionRow
-                key={c.type}
+                key={c.connectorRef}
                 connector={c}
-                enabled={authorizedSet.has(c.type)}
+                enabled={authorizedSet.has(c.connectorRef)}
                 onToggle={onDomEventFn(async (checked) => {
-                  await onToggle(c.type, checked);
+                  await onToggle(c.connectorRef, checked);
                 })}
-                loading={savingType === c.type}
+                loading={savingConnectorRef === c.connectorRef}
                 showManage={
                   canManagePermissions && c.permissionSummary.hasPermissions
                 }
                 onManage={() => {
-                  return onManage(c.type);
+                  return onManage(c.connectorRef);
                 }}
                 isLast={i === filteredConnectors.length - 1}
               />
@@ -587,7 +589,7 @@ export function ConnectedConnectorPermissions({
 export function AgentPermissionsDrawer({
   targetId,
   targetKind = "agent",
-  connectorType,
+  connectorRef,
   connectorLabel,
   displayName,
   initialPolicies,
@@ -602,7 +604,7 @@ export function AgentPermissionsDrawer({
 }: {
   targetId: string;
   targetKind?: "agent" | "workflow";
-  connectorType: ConnectorRef | null;
+  connectorRef: ConnectorRef | null;
   connectorLabel: string;
   displayName: string;
   initialPolicies: FirewallPolicies;
@@ -620,14 +622,14 @@ export function AgentPermissionsDrawer({
   ) => Promise<void>;
   onClose: () => void;
 }) {
-  if (!connectorType) {
+  if (!connectorRef) {
     return null;
   }
   return (
     <PermissionsDrawer
       agentId={targetId}
       targetKind={targetKind}
-      connectorType={connectorType}
+      connectorRef={connectorRef}
       connectorLabel={connectorLabel}
       metadata$={agentPermissionMetadata$}
       displayName={displayName}
@@ -676,55 +678,62 @@ function JobPermissionsTab({
       : null;
   const drawerInitialPolicies = userGrantPolicies ?? {};
   const [, applyGrantPolicies] = useLoadableSet(applyUserPermissionGrants$);
-  const connectorType = useGet(permConnectorType$);
-  const setConnectorType = useSet(setPermConnectorType$);
+  const connectorRef = useGet(permConnectorRef$);
+  const setConnectorRef = useSet(setPermConnectorRef$);
   const search = useGet(permSearch$);
   const setSearch = useSet(setPermSearch$);
   const searchActive = useGet(permSearchActive$);
   const setSearchActive = useSet(setPermSearchActive$);
-  const savingType = useGet(permSavingType$);
-  const setSavingType = useSet(setPermSavingType$);
+  const savingRef = useGet(permSavingRef$);
+  const setSavingRef = useSet(setPermSavingRef$);
 
   const connectorsLoading = connectorsLoadable.state === "loading";
 
-  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
+  const catalogItemsLoadable = useLastLoadable(allConnectorCatalogItems$);
   const allConnectors =
-    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+    catalogItemsLoadable.state === "hasData" ? catalogItemsLoadable.data : [];
   const canManagePermissions = true;
 
   const connectedConnectors = allConnectors.filter((c) => {
     return c.connected;
   });
-  const connectorLabel = connectorType
+  const connectorLabel = connectorRef
     ? (allConnectors.find((connector) => {
-        return connector.type === connectorType;
-      })?.label ?? connectorType)
+        return connector.connectorRef === connectorRef;
+      })?.label ?? connectorRef)
     : "";
   const filteredConnectors = connectedConnectors.filter((c) => {
     return matchesConnectorSearch(search, c);
   });
   const authorizedSet = new Set(authorizedConnectors);
 
-  const handleToggle = async (type: ConnectorRef, checked: boolean) => {
-    if (savingType !== null) {
+  const handleToggle = async (
+    targetConnectorRef: ConnectorRef,
+    checked: boolean,
+  ) => {
+    if (savingRef !== null) {
       return;
     }
     const modify = checked
-      ? authorizeFn(type, pageSignal)
-      : deauthorizeFn(type, pageSignal);
-    setSavingType(type);
+      ? authorizeFn(targetConnectorRef, pageSignal)
+      : deauthorizeFn(targetConnectorRef, pageSignal);
+    setSavingRef(targetConnectorRef);
     await bestEffort(
       (async () => {
         await modify;
-        await saveConnectors(type, checked ? "add" : "remove", pageSignal);
+        await saveConnectors(
+          targetConnectorRef,
+          checked ? "add" : "remove",
+          pageSignal,
+        );
         toast.success("Connectors saved");
       })(),
     );
-    setSavingType(null);
+    setSavingRef(null);
   };
 
   if (
-    allTypesLoadable.state !== "hasData" ||
+    catalogItemsLoadable.state !== "hasData" ||
     connectorsLoading ||
     userGrantsLoadable.state === "loading"
   ) {
@@ -748,14 +757,14 @@ function JobPermissionsTab({
             setSearch={setSearch}
             searchActive={searchActive}
             setSearchActive={setSearchActive}
-            savingType={savingType}
+            savingConnectorRef={savingRef}
             canManagePermissions={canManagePermissions}
             onToggle={handleToggle}
-            onManage={setConnectorType}
+            onManage={setConnectorRef}
           />
           <AgentPermissionsDrawer
             targetId={agentId}
-            connectorType={connectorType}
+            connectorRef={connectorRef}
             connectorLabel={connectorLabel}
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
@@ -763,12 +772,12 @@ function JobPermissionsTab({
             resetEnabled
             readOnly={!canManagePermissions}
             onApply={async (intent, { metadata }) => {
-              if (connectorType === null) {
+              if (connectorRef === null) {
                 throw new Error("Cannot save permissions without a connector");
               }
               await savePermissionDraftPolicies({
                 scope: { agentId },
-                connectorRef: connectorType,
+                connectorRef,
                 metadata,
                 initialPolicies: drawerInitialPolicies,
                 initialGrants: activeUserGrantSnapshot.grants,
@@ -779,7 +788,7 @@ function JobPermissionsTab({
               toast.success("Permissions updated");
             }}
             onClose={() => {
-              return setConnectorType(null);
+              return setConnectorRef(null);
             }}
           />
         </>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -2267,7 +2267,7 @@ describe("connectors page", () => {
       context.store.set(
         submitManualGrant$,
         {
-          type: "axiom",
+          connectorRef: "axiom",
           authMethod: "api-token",
           inputValues: { apiToken: "xaat-test" },
           options: { connectorLabel: "Public Axiom" },

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -22,11 +22,15 @@ import type {
   ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { FormEvent, ReactElement } from "react";
-import type { PublicConnectorCatalogStartOption } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogStartOption,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
-  allConnectorTypes$,
-  connectFlowType$,
-  pollingOAuthAuthCodeConnectorType$,
+  allConnectorCatalogItems$,
+  connectFlowConnectorRef$,
+  pollingOAuthAuthCodeConnectorRef$,
   connectorExternalCodeState$,
   connectorOAuthDeviceAuthState$,
   connectConnectorOAuthAuthCodeAndSettle$,
@@ -46,17 +50,14 @@ import {
   setManualGrantFormValue$,
   clearManualGrantForm$,
   manualGrantFormValuesFor$,
-  selectedConnectorType$,
+  selectedConnectorRef$,
   isStandaloneMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
-  getConnectorStatusAuthMethod,
   hasConnectorStatusBrowserAuthGrant,
   manualGrantInputValuesForMethod,
-  type ConnectorStatusAuthMethodDetail,
   type ConnectorExternalCodeState,
   type ConnectorOAuthDeviceAuthState,
-  type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -68,7 +69,7 @@ import { ConnectorHelpText } from "./connector-help-text.tsx";
 // Connected status text helper
 // ---------------------------------------------------------------------------
 
-function connectedStatusText(item: ConnectorTypeWithStatus): string {
+function connectedStatusText(item: PublicConnectorCatalogStatusItem): string {
   const connectionStatus = connectorCurrentConnectionStatus(item);
   if (connectionStatus === "reconnect-required") {
     return "Connection expired";
@@ -80,11 +81,11 @@ function connectedStatusText(item: ConnectorTypeWithStatus): string {
   if (expiryText) {
     return expiryText;
   }
-  if (item.connector?.externalUsername) {
-    if (item.connector.externalUsername.startsWith("arn:")) {
-      return `Connected as ${item.connector.externalUsername}`;
+  if (item.connection?.externalUsername) {
+    if (item.connection.externalUsername.startsWith("arn:")) {
+      return `Connected as ${item.connection.externalUsername}`;
     }
-    return `Connected as @${item.connector.externalUsername}`;
+    return `Connected as @${item.connection.externalUsername}`;
   }
   return "Connected";
 }
@@ -95,7 +96,7 @@ type PostConnectOptions = {
 };
 
 type SubmitManualGrantFn = (
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   inputValues: Record<string, string>,
   options: PostConnectOptions,
@@ -103,8 +104,8 @@ type SubmitManualGrantFn = (
 ) => Promise<boolean>;
 
 type ConnectOAuthAuthCodeAndSettleFn = (
-  type: ConnectorRef,
-  method: ConnectorStatusAuthMethodDetail,
+  connectorRef: ConnectorRef,
+  method: PublicConnectorCatalogAuthMethodDetail,
   onSuccess: () => void | Promise<void>,
   options: PostConnectOptions,
   signal: AbortSignal,
@@ -112,7 +113,7 @@ type ConnectOAuthAuthCodeAndSettleFn = (
 
 type ConnectOAuthDeviceAuthAndSettleFn = (
   args: {
-    readonly type: ConnectorRef;
+    readonly connectorRef: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -123,7 +124,7 @@ type ConnectOAuthDeviceAuthAndSettleFn = (
 
 type ConnectExternalCodeFn = (
   args: {
-    readonly type: ConnectorRef;
+    readonly connectorRef: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly agentId?: string;
   },
@@ -132,7 +133,7 @@ type ConnectExternalCodeFn = (
 
 type CompleteExternalCodeAndSettleFn = (
   args: {
-    readonly type: ConnectorRef;
+    readonly connectorRef: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -142,7 +143,7 @@ type CompleteExternalCodeAndSettleFn = (
 
 type ConnectNoAuthAndSettleFn = (
   args: {
-    readonly type: ConnectorRef;
+    readonly connectorRef: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -151,14 +152,14 @@ type ConnectNoAuthAndSettleFn = (
 ) => Promise<void>;
 
 type ConnectModalContentProps = {
-  item: ConnectorTypeWithStatus;
+  item: PublicConnectorCatalogStatusItem;
   agentId?: string;
   onSuccess: () => void | Promise<void>;
 };
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
   connectExternalCode: ConnectExternalCodeFn;
@@ -182,16 +183,16 @@ type ConnectMethodContentComponent = (
 
 type ConnectMethodContentEntry = {
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   Content: ConnectMethodContentComponent;
 };
 
 function connectorOAuthDeviceAuthFlowIsActive(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
 ): boolean {
   return (
-    state.connectorType === type &&
+    state.connectorRef === connectorRef &&
     (state.status === "starting" ||
       state.status === "pending" ||
       state.status === "polling")
@@ -200,20 +201,20 @@ function connectorOAuthDeviceAuthFlowIsActive(
 
 function connectorExternalCodeFlowIsActive(
   state: ConnectorExternalCodeState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
 ): boolean {
   return (
-    state.connectorType === type &&
+    state.connectorRef === connectorRef &&
     (state.status === "starting" || state.status === "pending")
   );
 }
 
 function connectorOAuthDeviceAuthStateForMethod(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorOAuthDeviceAuthState | null {
-  if (state.connectorType !== type || state.status === "idle") {
+  if (state.connectorRef !== connectorRef || state.status === "idle") {
     return null;
   }
   return state.authMethod === authMethod ? state : null;
@@ -221,10 +222,10 @@ function connectorOAuthDeviceAuthStateForMethod(
 
 function connectorExternalCodeStateForMethod(
   state: ConnectorExternalCodeState,
-  type: ConnectorRef,
+  connectorRef: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorExternalCodeState | null {
-  if (state.connectorType !== type || state.status === "idle") {
+  if (state.connectorRef !== connectorRef || state.status === "idle") {
     return null;
   }
   return state.authMethod === authMethod ? state : null;
@@ -235,7 +236,7 @@ function connectorExternalCodeStateForMethod(
 // ---------------------------------------------------------------------------
 
 function ManualGrantForm({
-  type,
+  connectorRef,
   connectorLabel,
   authMethod,
   method,
@@ -244,10 +245,10 @@ function ManualGrantForm({
   submit,
   submitting,
 }: {
-  type: ConnectorRef;
+  connectorRef: ConnectorRef;
   connectorLabel: string;
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   onSuccess: () => void | Promise<void>;
   agentId?: string;
   submit: SubmitManualGrantFn;
@@ -257,7 +258,7 @@ function ManualGrantForm({
   const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
   const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
-  const fieldValues = manualGrantFormValuesFor(type);
+  const fieldValues = manualGrantFormValuesFor(connectorRef);
 
   const allFilled = method.manualFields.every((field) => {
     return !field.required || hasTokenInputValue(fieldValues[field.id]);
@@ -270,7 +271,7 @@ function ManualGrantForm({
         return;
       }
       const connected = await submit(
-        type,
+        connectorRef,
         authMethod,
         manualGrantInputValuesForMethod(method, fieldValues),
         {
@@ -282,7 +283,7 @@ function ManualGrantForm({
       if (!connected) {
         return;
       }
-      clearForm(type);
+      clearForm(connectorRef);
       await onSuccess();
     },
   );
@@ -301,7 +302,11 @@ function ManualGrantForm({
               placeholder={fieldConfig.placeholder ?? undefined}
               value={fieldValues[fieldConfig.id] ?? ""}
               onChange={(e) => {
-                return setFormValue(type, fieldConfig.id, e.target.value);
+                return setFormValue(
+                  connectorRef,
+                  fieldConfig.id,
+                  e.target.value,
+                );
               }}
             />
           </div>
@@ -366,7 +371,7 @@ function OAuthAuthCodeConnectButton({
   connectOAuthAuthCodeAndSettle,
   signal,
 }: ConnectModalContentProps & {
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   signal: AbortSignal;
 }) {
@@ -376,7 +381,7 @@ function OAuthAuthCodeConnectButton({
       onClick={() => {
         return detach(
           connectOAuthAuthCodeAndSettle(
-            item.type,
+            item.connectorRef,
             method,
             onSuccess,
             {
@@ -530,13 +535,13 @@ function deviceAuthStartOptionsFilled(
 }
 
 function OAuthDeviceAuthStartOptionsForm({
-  type,
+  connectorRef,
   authMethod,
   startOptions,
   values,
   setValue,
 }: {
-  type: ConnectorRef;
+  connectorRef: ConnectorRef;
   authMethod: ConnectorAuthMethodId;
   startOptions: readonly PublicConnectorCatalogStartOption[];
   values: Record<string, string>;
@@ -549,7 +554,7 @@ function OAuthDeviceAuthStartOptionsForm({
   return (
     <>
       {startOptions.map((option) => {
-        const inputId = `connector-device-auth-option-${type}-${authMethod}-${option.id}`;
+        const inputId = `connector-device-auth-option-${connectorRef}-${authMethod}-${option.id}`;
         return (
           <div key={option.id} className="flex flex-col gap-1.5">
             <label
@@ -602,7 +607,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
     connectorOAuthDeviceAuthStartOptionValuesFor$,
   );
   const startOptionValues = connectorOAuthDeviceAuthStartOptionValuesFor(
-    props.item.type,
+    props.item.connectorRef,
     props.authMethod,
   );
   const effectiveStartOptionValues = {
@@ -615,7 +620,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   );
   const setStartOptionValue = (name: string, value: string) => {
     setStartOptionValueCommand({
-      type: props.item.type,
+      connectorRef: props.item.connectorRef,
       authMethod: props.authMethod,
       name,
       value,
@@ -623,7 +628,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   };
   const current = connectorOAuthDeviceAuthStateForMethod(
     state,
-    props.item.type,
+    props.item.connectorRef,
     props.authMethod,
   );
   const starting = current?.status === "starting";
@@ -631,7 +636,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   const start = onDomEventFn(async () => {
     await props.connectOAuthDeviceAuthAndSettle(
       {
-        type: props.item.type,
+        connectorRef: props.item.connectorRef,
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
@@ -658,7 +663,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
       <OAuthDeviceAuthCodePanel
         state={current}
         onOpenVerificationPage={() => {
-          openVerificationPage(props.item.type, props.authMethod);
+          openVerificationPage(props.item.connectorRef, props.authMethod);
         }}
       />
     );
@@ -672,7 +677,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
     return (
       <div className="flex flex-col gap-3">
         <OAuthDeviceAuthStartOptionsForm
-          type={props.item.type}
+          connectorRef={props.item.connectorRef}
           authMethod={props.authMethod}
           startOptions={startOptions}
           values={effectiveStartOptionValues}
@@ -701,7 +706,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
         verification page to approve access.
       </p>
       <OAuthDeviceAuthStartOptionsForm
-        type={props.item.type}
+        connectorRef={props.item.connectorRef}
         authMethod={props.authMethod}
         startOptions={startOptions}
         values={effectiveStartOptionValues}
@@ -735,7 +740,7 @@ function ExternalCodeStartContent({
   onStart,
 }: {
   connectorLabel: string;
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   current: ConnectorExternalCodeState | null;
   starting: boolean;
   onStart: ExternalCodeButtonHandler;
@@ -775,7 +780,7 @@ function ExternalCodePendingContent({
   onComplete,
 }: {
   connectorLabel: string;
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   current: PendingConnectorExternalCodeState;
   completing: boolean;
   onOpen: ExternalCodeButtonHandler;
@@ -844,7 +849,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
   );
   const current = connectorExternalCodeStateForMethod(
     state,
-    props.item.type,
+    props.item.connectorRef,
     props.authMethod,
   );
   const starting = current?.status === "starting";
@@ -852,7 +857,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
   const start = onDomEventFn(async () => {
     await props.connectExternalCode(
       {
-        type: props.item.type,
+        connectorRef: props.item.connectorRef,
         authMethod: props.authMethod,
         ...(props.agentId ? { agentId: props.agentId } : {}),
       },
@@ -864,7 +869,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
     event.preventDefault();
     await props.completeExternalCodeAndSettle(
       {
-        type: props.item.type,
+        connectorRef: props.item.connectorRef,
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
@@ -890,11 +895,11 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
         current={current}
         completing={props.externalCodeCompleting}
         onOpen={() => {
-          openAuthorizationPage(props.item.type, props.authMethod);
+          openAuthorizationPage(props.item.connectorRef, props.authMethod);
         }}
         onCodeChange={(code) => {
           setCode({
-            type: props.item.type,
+            connectorRef: props.item.connectorRef,
             authMethod: props.authMethod,
             code,
           });
@@ -921,7 +926,7 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
   }
   return (
     <ManualGrantForm
-      type={props.item.type}
+      connectorRef={props.item.connectorRef}
       connectorLabel={props.item.label}
       authMethod={props.authMethod}
       method={props.method}
@@ -937,7 +942,7 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
   const enable = onDomEventFn(async () => {
     await props.connectNoAuthAndSettle(
       {
-        type: props.item.type,
+        connectorRef: props.item.connectorRef,
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
@@ -968,7 +973,7 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
 }
 
 function getConnectMethodContentComponent(
-  method: ConnectorStatusAuthMethodDetail,
+  method: PublicConnectorCatalogAuthMethodDetail,
 ): ConnectMethodContentComponent | null {
   switch (method.grantKind) {
     case "auth-code": {
@@ -996,13 +1001,10 @@ function getConnectMethodContentComponent(
 }
 
 function getConnectMethodContentEntries(
-  item: ConnectorTypeWithStatus,
+  item: PublicConnectorCatalogStatusItem,
 ): ConnectMethodContentEntry[] {
-  return item.availableAuthMethods.flatMap((authMethod) => {
-    const method = getConnectorStatusAuthMethod(item, authMethod);
-    if (!method) {
-      return [];
-    }
+  return item.authMethods.flatMap((method) => {
+    const authMethod = method.id;
     const Content = getConnectMethodContentComponent(method);
     return Content ? [{ authMethod, method, Content }] : [];
   });
@@ -1025,7 +1027,7 @@ function ConnectMethodHeading({
   method,
   show,
 }: {
-  method: ConnectorStatusAuthMethodDetail;
+  method: PublicConnectorCatalogAuthMethodDetail;
   show: boolean;
 }) {
   if (!show) {
@@ -1064,7 +1066,7 @@ function ConnectMethodsContent({
       {entries.map(({ authMethod, method, Content }, index) => {
         return (
           <div
-            key={`${props.item.type}:${authMethod}`}
+            key={`${props.item.connectorRef}:${authMethod}`}
             className="flex flex-col gap-3"
           >
             {index > 0 && <AuthMethodDivider />}
@@ -1109,7 +1111,7 @@ function StandardConnectMethodsContent({
     <div className="flex flex-col gap-4">
       <ConnectMethodsContent
         entries={entries}
-        availableAuthMethodCount={item.availableAuthMethods.length}
+        availableAuthMethodCount={item.authMethods.length}
         props={{
           item,
           agentId,
@@ -1152,32 +1154,32 @@ function ConnectModalContent({
     connectConnectorNoAuthAndSettle$,
   );
   const submitManualGrant: SubmitManualGrantFn = async (
-    type,
+    connectorRef,
     authMethod,
     inputValues,
     options,
     signal,
   ) => {
     return await submitManualGrantCommand(
-      { type, authMethod, inputValues, options },
+      { connectorRef, authMethod, inputValues, options },
       signal,
     );
   };
   const [, runConnectSuccess] = useLoadableSet(runConnectorConnectSuccess$);
   const pageSignal = useGet(pageSignal$);
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingConnectorRef = useGet(pollingOAuthAuthCodeConnectorRef$);
   const settling = settleLoadable.state === "loading";
   const externalCodeCompleting =
     completeExternalCodeLoadable.state === "loading";
   const manualGrantSubmitting = manualGrantLoadable.state === "loading";
   const noAuthSubmitting = noAuthLoadable.state === "loading";
-  const isPolling = pollingType === item.type;
+  const isPolling = pollingConnectorRef === item.connectorRef;
   const entries = getConnectMethodContentEntries(item);
   const onConnectSuccess = async () => {
-    await runConnectSuccess(item.type, onSuccess, pageSignal);
+    await runConnectSuccess(item.connectorRef, onSuccess, pageSignal);
   };
   const connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn = async (
-    type,
+    connectorRef,
     method,
     connectSuccess,
     options,
@@ -1185,7 +1187,7 @@ function ConnectModalContent({
   ) => {
     await connectOAuthAuthCodeAndSettleCommand(
       {
-        type,
+        connectorRef,
         method,
         onSuccess: connectSuccess,
         options,
@@ -1197,7 +1199,7 @@ function ConnectModalContent({
     async (args, signal) => {
       await connectOAuthDeviceAuthAndSettle(
         {
-          type: args.type,
+          connectorRef: args.connectorRef,
           authMethod: args.authMethod,
           onSuccess: args.onSuccess,
           options: args.options,
@@ -1259,43 +1261,46 @@ function ConnectModalContent({
 export function ConnectModal({
   onClose,
   onSuccess,
-  selectedType: selectedTypeOverride,
+  selectedConnectorRef: selectedConnectorRefOverride,
   agentId,
 }: {
   onClose: () => void;
   onSuccess?: () => void | Promise<void>;
-  selectedType?: ConnectorRef | null;
+  selectedConnectorRef?: ConnectorRef | null;
   agentId?: string;
 }) {
-  const globalSelectedType = useGet(selectedConnectorType$);
-  const selectedType =
-    selectedTypeOverride === undefined
-      ? globalSelectedType
-      : selectedTypeOverride;
-  const connectorTypes = useLastResolved(allConnectorTypes$);
+  const globalSelectedConnectorRef = useGet(selectedConnectorRef$);
+  const selectedConnectorRef =
+    selectedConnectorRefOverride === undefined
+      ? globalSelectedConnectorRef
+      : selectedConnectorRefOverride;
+  const connectorCatalogItems = useLastResolved(allConnectorCatalogItems$);
   const clearConnectorOAuthDeviceAuth = useSet(clearConnectorOAuthDeviceAuth$);
   const clearConnectorExternalCode = useSet(clearConnectorExternalCode$);
-  const connectFlowType = useGet(connectFlowType$);
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const connectFlowConnectorRef = useGet(connectFlowConnectorRef$);
+  const pollingConnectorRef = useGet(pollingOAuthAuthCodeConnectorRef$);
   const connectorOAuthDeviceAuthState = useGet(connectorOAuthDeviceAuthState$);
   const connectorExternalCodeState = useGet(connectorExternalCodeState$);
 
-  const item = connectorTypes?.find((c) => {
-    return c.type === selectedType;
+  const item = connectorCatalogItems?.find((catalogItem) => {
+    return catalogItem.connectorRef === selectedConnectorRef;
   });
 
-  if (!selectedType || !item) {
+  if (!selectedConnectorRef || !item) {
     return null;
   }
 
   const connectFlowActive =
-    connectFlowType === selectedType ||
-    pollingType === selectedType ||
+    connectFlowConnectorRef === selectedConnectorRef ||
+    pollingConnectorRef === selectedConnectorRef ||
     connectorOAuthDeviceAuthFlowIsActive(
       connectorOAuthDeviceAuthState,
-      selectedType,
+      selectedConnectorRef,
     ) ||
-    connectorExternalCodeFlowIsActive(connectorExternalCodeState, selectedType);
+    connectorExternalCodeFlowIsActive(
+      connectorExternalCodeState,
+      selectedConnectorRef,
+    );
 
   return (
     <Dialog

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -48,7 +48,7 @@ import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
 
 interface ConnectorAccessManagementDialogProps {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly connectorLabel: string;
   readonly onClose: () => void;
 }
@@ -312,7 +312,7 @@ function ConnectorAccessDialog({
 function AgentPermissionDialog({
   row,
   metadata,
-  connectorType,
+  connectorRef,
   connectorLabel,
   pageSignal,
   applyGrantPolicies,
@@ -320,7 +320,7 @@ function AgentPermissionDialog({
 }: {
   readonly row: ConnectorAgentAccessRow | undefined;
   readonly metadata: PublicConnectorCatalogPermissionDetail | null;
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly connectorLabel: string;
   readonly pageSignal: AbortSignal;
   readonly applyGrantPolicies: ApplyUserPermissionGrants;
@@ -336,7 +336,7 @@ function AgentPermissionDialog({
   return (
     <PermissionsDialog
       agentId={row.agent.id}
-      connectorType={connectorType}
+      connectorRef={connectorRef}
       connectorLabel={connectorLabel}
       metadata$={managedConnectorFirewallPermissionMetadata$}
       displayName={agentName(row.agent)}
@@ -347,7 +347,7 @@ function AgentPermissionDialog({
       onApply={async (intent, { metadata: appliedMetadata }) => {
         await savePermissionDraftPolicies({
           scope: { agentId: row.agent.id },
-          connectorRef: connectorType,
+          connectorRef,
           metadata: appliedMetadata,
           initialPolicies,
           initialGrants: activeSnapshot.grants,
@@ -363,7 +363,7 @@ function AgentPermissionDialog({
 }
 
 export function ConnectorAccessManagementDialog({
-  connectorType,
+  connectorRef,
   connectorLabel,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
@@ -404,7 +404,7 @@ export function ConnectorAccessManagementDialog({
       withCleanup(
         (async () => {
           await setAuthorization(
-            { agentId: row.agent.id, connectorType, authorized },
+            { agentId: row.agent.id, connectorRef, authorized },
             pageSignal,
           );
           toast.success(`${connectorLabel} access updated`);
@@ -436,7 +436,7 @@ export function ConnectorAccessManagementDialog({
       <AgentPermissionDialog
         row={selectedPermissionRow}
         metadata={metadata}
-        connectorType={connectorType}
+        connectorRef={connectorRef}
         connectorLabel={connectorLabel}
         pageSignal={pageSignal}
         applyGrantPolicies={applyGrantPolicies}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -104,7 +104,7 @@ interface ConnectorPermission {
 interface PermissionsDrawerProps {
   agentId: string;
   targetKind?: "agent" | "workflow";
-  connectorType: ConnectorRef;
+  connectorRef: ConnectorRef;
   connectorLabel: string;
   metadata$: Computed<Promise<PublicConnectorCatalogPermissionDetail | null>>;
   displayName: string;
@@ -165,24 +165,24 @@ type LoadedPermissionsDrawerContentProps = Pick<
 
 function buildInitialPermissionDrawerState({
   agentId,
-  connectorType,
+  connectorRef,
   metadata,
   initialPolicies,
   initialGrants,
 }: Pick<
   PermissionsDrawerProps,
-  "agentId" | "connectorType" | "initialPolicies" | "initialGrants"
+  "agentId" | "connectorRef" | "initialPolicies" | "initialGrants"
 > & {
   readonly metadata: PublicConnectorCatalogPermissionDetail;
 }): InitialPermissionDrawerState {
-  const explicitGrants = buildExplicitGrantMap(connectorType, initialGrants);
+  const explicitGrants = buildExplicitGrantMap(connectorRef, initialGrants);
   const grantStateKey = explicitGrantStateKey(explicitGrants);
   const context = createPermissionDraftContext({ metadata, initialPolicies });
   const initialPolicyStateKey = permissionDraftInitialPolicyKey(context);
   return {
-    ref: connectorType,
+    ref: connectorRef,
     explicitGrants,
-    initialPolicyKey: `${agentId}\u0000${connectorType}\u0000${permissionDraftMetadataKey(metadata)}\u0000${initialPolicyStateKey}\u0000${grantStateKey}`,
+    initialPolicyKey: `${agentId}\u0000${connectorRef}\u0000${permissionDraftMetadataKey(metadata)}\u0000${initialPolicyStateKey}\u0000${grantStateKey}`,
   };
 }
 
@@ -1551,7 +1551,7 @@ function PermissionsContent({
   const loadedInitialState = loadedMetadata
     ? buildInitialPermissionDrawerState({
         agentId: props.agentId,
-        connectorType: props.connectorType,
+        connectorRef: props.connectorRef,
         metadata: loadedMetadata,
         initialPolicies: props.initialPolicies,
         initialGrants: props.initialGrants,
@@ -1561,7 +1561,7 @@ function PermissionsContent({
   const message =
     metadataLoadable.state === "hasError"
       ? "Failed to load permission metadata"
-      : `No permission metadata found for ${props.connectorType}`;
+      : `No permission metadata found for ${props.connectorRef}`;
 
   return (
     <>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -8,35 +8,35 @@ import {
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   scopeDiff$,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ScopeReviewModalProps {
-  connectorType: ConnectorRef | null;
+  connectorRef: ConnectorRef | null;
   onClose: () => void;
-  onReconnect: (type: ConnectorRef) => void;
+  onReconnect: (connectorRef: ConnectorRef) => void;
 }
 
 export function ScopeReviewModal({
-  connectorType,
+  connectorRef,
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
   const scopeDiffLoadable = useLoadable(scopeDiff$);
-  const connectorTypes = useLastResolved(allConnectorTypes$);
+  const connectorCatalogItems = useLastResolved(allConnectorCatalogItems$);
   const loading = scopeDiffLoadable.state === "loading";
   const scopeDiff =
     scopeDiffLoadable.state === "hasData" ? scopeDiffLoadable.data : null;
 
-  if (!connectorType) {
+  if (!connectorRef) {
     return null;
   }
 
-  const connector = connectorTypes?.find((candidate) => {
-    return candidate.type === connectorType;
+  const connector = connectorCatalogItems?.find((candidate) => {
+    return candidate.connectorRef === connectorRef;
   });
-  const connectorLabel = connector?.label ?? connectorType;
+  const connectorLabel = connector?.label ?? connectorRef;
 
   return (
     <Dialog
@@ -116,7 +116,7 @@ export function ScopeReviewModal({
               <button
                 type="button"
                 onClick={() => {
-                  return onReconnect(connectorType);
+                  return onReconnect(connectorRef);
                 }}
                 className="flex-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
               >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -142,6 +142,7 @@ import {
 } from "@vm0/core";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
@@ -151,11 +152,10 @@ import {
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   matchesConnectorSearch,
-  justConnectedTypes$,
-  pollingOAuthAuthCodeConnectorType$,
-  type ConnectorTypeWithStatus,
+  justConnectedRefs$,
+  pollingOAuthAuthCodeConnectorRef$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -414,18 +414,9 @@ type TemplatePreviewImageSize = Parameters<typeof r2ImageTransformUrl>[1];
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface ComposerConnectorItem {
-  type: ConnectorRef;
-  label: string;
-  helpText: string;
-  icon: ConnectorTypeWithStatus["icon"];
-  tags: readonly string[];
-  connected: boolean;
-  authorized: boolean;
-  available: boolean;
-  /** True when this connector exposes configurable firewall permissions. */
-  hasPermissions: boolean;
-}
+type ComposerConnectorItem = PublicConnectorCatalogStatusItem & {
+  readonly authorized: boolean;
+};
 
 function resolveComposerModelForSelection(
   modelPicker: ComposerModelPicker | undefined,
@@ -1376,10 +1367,10 @@ function WorkflowTemplateConnectorIcons({
   limit?: number;
   withDivider?: boolean;
 }) {
-  const catalogConnectors = useLastResolved(allConnectorTypes$);
+  const catalogConnectors = useLastResolved(allConnectorCatalogItems$);
   const visibleConnectors = connectors.flatMap((connectorRef) => {
     const connector = catalogConnectors?.find((candidate) => {
-      return candidate.type === connectorRef;
+      return candidate.connectorRef === connectorRef;
     });
     return connector ? [connector] : [];
   });
@@ -1403,7 +1394,7 @@ function WorkflowTemplateConnectorIcons({
         {displayedConnectors.map((connector) => {
           return (
             <span
-              key={connector.type}
+              key={connector.connectorRef}
               className={cn(
                 "flex shrink-0 items-center justify-center border border-border/60 bg-background",
                 compact ? "h-5 w-5 rounded" : "h-7 w-7 rounded-md",
@@ -5507,7 +5498,7 @@ function ConnectorTriggerIcons({
     <span className="flex items-center -space-x-2 sm:-space-x-1.5">
       {enabled.map((c) => {
         return (
-          <span key={c.type} className="relative shrink-0">
+          <span key={c.connectorRef} className="relative shrink-0">
             <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background zero-border sm:h-7 sm:w-7">
               <ConnectorIcon icon={c.icon} size={16} />
             </span>
@@ -5528,15 +5519,15 @@ function ConnectorTriggerIcons({
 function AddConnectorsDialog({
   signals,
   unconnected,
-  pollingType,
+  pollingConnectorRef,
   onClose,
   onSelect,
 }: {
   signals: ComposerConnectorSignals;
-  unconnected: ConnectorTypeWithStatus[];
-  pollingType: string | null;
+  unconnected: PublicConnectorCatalogStatusItem[];
+  pollingConnectorRef: ConnectorRef | null;
   onClose: () => void;
-  onSelect: (type: ConnectorRef) => void;
+  onSelect: (connectorRef: ConnectorRef) => void;
 }) {
   const search = useGet(signals.addDialogSearch$);
   const setSearch = useSet(signals.setAddDialogSearch$);
@@ -5577,11 +5568,11 @@ function AddConnectorsDialog({
               return (
                 <button
                   type="button"
-                  key={item.type}
+                  key={item.connectorRef}
                   onClick={() => {
-                    return onSelect(item.type);
+                    return onSelect(item.connectorRef);
                   }}
-                  disabled={pollingType === item.type}
+                  disabled={pollingConnectorRef === item.connectorRef}
                   aria-label={`Connect ${item.label}`}
                   className="rounded-lg bg-card overflow-hidden transition-colors hover:bg-muted/30 cursor-pointer text-left w-full"
                   style={{ border: "0.7px solid hsl(var(--gray-400))" }}
@@ -5593,7 +5584,7 @@ function AddConnectorsDialog({
                     <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
                       {item.label}
                     </span>
-                    {pollingType === item.type ? (
+                    {pollingConnectorRef === item.connectorRef ? (
                       <IconLoader2
                         size={16}
                         stroke={1.5}
@@ -5607,7 +5598,7 @@ function AddConnectorsDialog({
                   </div>
                   <div className="px-4 pb-4 pt-1">
                     <div className="text-xs text-muted-foreground line-clamp-2">
-                      {item.helpText}
+                      {item.description}
                     </div>
                   </div>
                 </button>
@@ -5756,7 +5747,7 @@ function ComposerConnectorPermissionDialog({
   return (
     <PermissionsDialog
       agentId={agentId}
-      connectorType={connector.type}
+      connectorRef={connector.connectorRef}
       connectorLabel={connector.label}
       metadata$={signals.permissionMetadata$}
       displayName={agentDisplayName}
@@ -5767,7 +5758,7 @@ function ComposerConnectorPermissionDialog({
       onApply={async (intent, { metadata: appliedMetadata }) => {
         await savePermissionDraftPolicies({
           scope: { agentId },
-          connectorRef: connector.type,
+          connectorRef: connector.connectorRef,
           metadata: appliedMetadata,
           initialPolicies,
           initialGrants: activeSnapshot.grants,
@@ -5788,7 +5779,7 @@ function ConnectorsPopoverButton({
   agentDisplayName,
   agentConnectors,
   connectorsLoading,
-  savingType,
+  savingConnectorRef,
   computerUse,
   onOpenAddDialog,
   onToggle,
@@ -5798,10 +5789,13 @@ function ConnectorsPopoverButton({
   agentDisplayName: string;
   agentConnectors: ComposerConnectorItem[];
   connectorsLoading: boolean;
-  savingType: string | null;
+  savingConnectorRef: ConnectorRef | null;
   computerUse: ComposerComputerUse | undefined;
   onOpenAddDialog: () => void;
-  onToggle: (type: ConnectorRef, checked: boolean) => void | Promise<void>;
+  onToggle: (
+    connectorRef: ConnectorRef,
+    checked: boolean,
+  ) => void | Promise<void>;
 }) {
   const search = useGet(signals.popoverSearch$);
   const setSearch = useSet(signals.setPopoverSearch$);
@@ -5812,21 +5806,21 @@ function ConnectorsPopoverButton({
     signals.setComputerUseDownloadDialogOpen$,
   );
   const permissionEntryEnabled = useGet(composerConnectorPermissionsEnabled$);
-  const permissionConnectorType = useGet(signals.permissionConnector$);
-  const setPermissionConnectorType = useSet(signals.setPermissionConnector$);
+  const permissionConnectorRef = useGet(signals.permissionConnectorRef$);
+  const setPermissionConnectorRef = useSet(signals.setPermissionConnectorRef$);
   const showSearch = agentConnectors.length > 20;
   const permissionConnector =
-    permissionEntryEnabled && permissionConnectorType
+    permissionEntryEnabled && permissionConnectorRef
       ? agentConnectors.find((c) => {
-          return c.type === permissionConnectorType;
+          return c.connectorRef === permissionConnectorRef;
         })
       : undefined;
 
   // Use snapshot order if available, otherwise preserve catalog order.
   const sorted = sortOrder
     ? [...agentConnectors].sort((a, b) => {
-        const ai = sortOrder.indexOf(a.type);
-        const bi = sortOrder.indexOf(b.type);
+        const ai = sortOrder.indexOf(a.connectorRef);
+        const bi = sortOrder.indexOf(b.connectorRef);
         if (ai === -1 && bi === -1) {
           return 0;
         }
@@ -5851,7 +5845,7 @@ function ConnectorsPopoverButton({
     if (open) {
       // Snapshot the sort order when popover opens
       const freshSort = agentConnectors.map((c) => {
-        return c.type;
+        return c.connectorRef;
       });
       setSortOrder(freshSort);
     } else {
@@ -5923,7 +5917,7 @@ function ConnectorsPopoverButton({
                 {visibleConnectors.map((item) => {
                   return (
                     <label
-                      key={item.type}
+                      key={item.connectorRef}
                       className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
                     >
                       <span className="flex h-4 w-4 shrink-0 items-center justify-center">
@@ -5935,13 +5929,13 @@ function ConnectorsPopoverButton({
                       {permissionEntryEnabled &&
                         agentId &&
                         item.authorized &&
-                        item.hasPermissions && (
+                        item.permissionSummary.hasPermissions && (
                           <button
                             type="button"
                             onClick={(event) => {
                               event.preventDefault();
                               event.stopPropagation();
-                              setPermissionConnectorType(item.type);
+                              setPermissionConnectorRef(item.connectorRef);
                             }}
                             aria-label={`Configure ${item.label} permissions`}
                             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -5952,9 +5946,9 @@ function ConnectorsPopoverButton({
                       <LoadingSwitch
                         checked={item.authorized}
                         onCheckedChange={onDomEventFn(async (checked) => {
-                          await onToggle(item.type, checked);
+                          await onToggle(item.connectorRef, checked);
                         })}
-                        loading={savingType === item.type}
+                        loading={savingConnectorRef === item.connectorRef}
                         ariaLabel={`${item.authorized ? "Remove" : "Add"} ${item.label}`}
                         size="sm"
                       />
@@ -6005,7 +5999,7 @@ function ConnectorsPopoverButton({
           agentDisplayName={agentDisplayName}
           connector={permissionConnector}
           onClose={() => {
-            setPermissionConnectorType(null);
+            setPermissionConnectorRef(null);
           }}
         />
       )}
@@ -6920,40 +6914,46 @@ export function useZeroChatComposer({
   };
 
   // Connectors: connected (org-level) + authorized (agent-level) → available
-  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
+  const connectorCatalogItemsLoadable = useLastLoadable(
+    allConnectorCatalogItems$,
+  );
   const authorizedConnectorsLoadable = useLastLoadable(
     composerConnectors.authorizedConnectors$,
     { equalityFn: equalArrays },
   );
   const pageSignal = useGet(pageSignal$);
-  const selectedConnType = useGet(composerConnectors.selectedConnectType$);
-  const pendingConnectType = useGet(composerConnectors.pendingConnectType$);
-  const setPendingConnectType = useSet(
-    composerConnectors.setPendingConnectType$,
+  const selectedConnectorRef = useGet(composerConnectors.selectedConnectorRef$);
+  const pendingConnectorRef = useGet(composerConnectors.pendingConnectorRef$);
+  const setPendingConnectorRef = useSet(
+    composerConnectors.setPendingConnectorRef$,
   );
-  const setSelectedConnType = useSet(
-    composerConnectors.setSelectedConnectType$,
+  const setSelectedConnectorRef = useSet(
+    composerConnectors.setSelectedConnectorRef$,
   );
-  const pollingConnType = useGet(pollingOAuthAuthCodeConnectorType$);
+  const pollingConnectorRef = useGet(pollingOAuthAuthCodeConnectorRef$);
   const authorizeFn = useSet(composerConnectors.authorizeConnector$);
   const deauthorizeFn = useSet(composerConnectors.deauthorizeConnector$);
-  const optimisticConnected = useGet(justConnectedTypes$);
+  const optimisticConnected = useGet(justConnectedRefs$);
 
-  const savingType = useGet(composerConnectors.savingType$);
-  const setSavingType = useSet(composerConnectors.setSavingType$);
+  const savingConnectorRef = useGet(composerConnectors.savingConnectorRef$);
+  const setSavingConnectorRef = useSet(
+    composerConnectors.setSavingConnectorRef$,
+  );
   const agentRecordId = loadableDataOrNull(
     useLastLoadable(composerConnectors.agentId$),
   );
 
   const connectorsLoading =
-    allTypesLoadable.state !== "hasData" ||
+    connectorCatalogItemsLoadable.state !== "hasData" ||
     authorizedConnectorsLoadable.state !== "hasData";
 
-  const allConnectors =
-    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  const connectorCatalogItems =
+    connectorCatalogItemsLoadable.state === "hasData"
+      ? connectorCatalogItemsLoadable.data
+      : [];
   const connectorMap = new Map(
-    allConnectors.map((c) => {
-      return [c.type, c];
+    connectorCatalogItems.map((connector) => {
+      return [connector.connectorRef, connector];
     }),
   );
   const authorizedConnectors =
@@ -6962,43 +6962,37 @@ export function useZeroChatComposer({
       : [];
   const authorizedSet = new Set(authorizedConnectors);
 
-  const unconnectedConnectors = allConnectors.filter((c) => {
-    return !c.connected;
+  const unconnectedConnectors = connectorCatalogItems.filter((connector) => {
+    return (
+      !connector.connected && !optimisticConnected.has(connector.connectorRef)
+    );
   });
 
   // Show all org-connected services so user can toggle authorization on/off per agent.
-  // available = connected ∧ authorized → the connector is actually usable in this agent.
-  const connectedTypes = allConnectors.filter((c) => {
-    return c.connected || optimisticConnected.has(c.type);
+  const connectedCatalogItems = connectorCatalogItems.filter((connector) => {
+    return (
+      connector.connected || optimisticConnected.has(connector.connectorRef)
+    );
   });
-  const agentConnectors: ComposerConnectorItem[] = connectedTypes.map((c) => {
-    const connected = c.connected || optimisticConnected.has(c.type);
-    const authorized = authorizedSet.has(c.type);
-    return {
-      type: c.type,
-      label: c.label,
-      helpText: c.helpText,
-      icon: c.icon,
-      tags: c.tags,
-      connected,
-      authorized,
-      available: connected && authorized,
-      hasPermissions: c.permissionSummary.hasPermissions,
-    };
-  });
+  const agentConnectors: ComposerConnectorItem[] = connectedCatalogItems.map(
+    (connector) => {
+      const authorized = authorizedSet.has(connector.connectorRef);
+      return { ...connector, authorized };
+    },
+  );
 
-  const handleConnectSuccess = async (type: ConnectorRef) => {
-    const label = connectorMap.get(type)?.label ?? type;
+  const handleConnectSuccess = async (connectorRef: ConnectorRef) => {
+    const label = connectorMap.get(connectorRef)?.label ?? connectorRef;
     const authorized = await tapError(
       (async () => {
-        await authorizeFn(type, pageSignal);
+        await authorizeFn(connectorRef, pageSignal);
         return true;
       })(),
       () => {
         toast.error(
           `${label} connected but could not be authorized for ${displayName}`,
           {
-            id: `connector-save-error-${type}`,
+            id: `connector-save-error-${connectorRef}`,
           },
         );
       },
@@ -7007,17 +7001,19 @@ export function useZeroChatComposer({
       return false;
     }
     toast.success(`${label} connected and authorized for ${displayName}`, {
-      id: `connector-connected-${type}`,
+      id: `connector-connected-${connectorRef}`,
     });
     return true;
   };
 
-  const handleToggle = async (type: ConnectorRef, checked: boolean) => {
-    setSavingType(type);
+  const handleToggle = async (connectorRef: ConnectorRef, checked: boolean) => {
+    setSavingConnectorRef(connectorRef);
     await bestEffort(
-      checked ? authorizeFn(type, pageSignal) : deauthorizeFn(type, pageSignal),
+      checked
+        ? authorizeFn(connectorRef, pageSignal)
+        : deauthorizeFn(connectorRef, pageSignal),
     );
-    setSavingType(null);
+    setSavingConnectorRef(null);
   };
 
   const handleSend = () => {
@@ -7221,7 +7217,7 @@ export function useZeroChatComposer({
                     agentDisplayName={displayName}
                     agentConnectors={agentConnectors}
                     connectorsLoading={connectorsLoading}
-                    savingType={savingType}
+                    savingConnectorRef={savingConnectorRef}
                     computerUse={computerUse}
                     onOpenAddDialog={() => {
                       return setShowAddDialog(true);
@@ -7267,23 +7263,23 @@ export function useZeroChatComposer({
         <ActiveGoalObjectiveDialog threadId={chatThreadId} />
         <WebsiteTemplatePreviewDialogSlot />
       </div>
-      {selectedConnType && (
+      {selectedConnectorRef && (
         <ConnectModal
-          selectedType={selectedConnType}
+          selectedConnectorRef={selectedConnectorRef}
           agentId={nullToUndefined(agentRecordId)}
           onClose={() => {
-            return setSelectedConnType(null);
+            return setSelectedConnectorRef(null);
           }}
           onSuccess={async () => {
-            const type = pendingConnectType ?? selectedConnType;
-            if (type && !authorizedSet.has(type)) {
-              const authorized = await handleConnectSuccess(type);
+            const connectorRef = pendingConnectorRef ?? selectedConnectorRef;
+            if (connectorRef && !authorizedSet.has(connectorRef)) {
+              const authorized = await handleConnectSuccess(connectorRef);
               if (!authorized) {
-                setPendingConnectType(null);
+                setPendingConnectorRef(null);
                 return;
               }
             }
-            setPendingConnectType(null);
+            setPendingConnectorRef(null);
             setShowAddDialog(false);
           }}
         />
@@ -7292,14 +7288,14 @@ export function useZeroChatComposer({
         <AddConnectorsDialog
           signals={composerConnectors}
           unconnected={unconnectedConnectors}
-          pollingType={pollingConnType}
+          pollingConnectorRef={pollingConnectorRef}
           onClose={() => {
-            setPendingConnectType(null);
+            setPendingConnectorRef(null);
             return setShowAddDialog(false);
           }}
-          onSelect={(type) => {
-            setPendingConnectType(type);
-            setSelectedConnType(type);
+          onSelect={(connectorRef) => {
+            setPendingConnectorRef(connectorRef);
+            setSelectedConnectorRef(connectorRef);
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4771,12 +4771,12 @@ function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
   const completeLoadable = useLoadable(signals.complete$);
   const complete =
     completeLoadable.state === "hasData" && completeLoadable.data;
-  const displayMetadata = useLastResolved(signals.displayMetadata$);
+  const catalogItem = useLastResolved(signals.catalogItem$);
   const [activateLoadable, activate] = useLoadableSet(signals.activate$);
   const loading =
     completeLoadable.state === "loading" ||
     activateLoadable.state === "loading";
-  if (!available || !displayMetadata) {
+  if (!available || !catalogItem) {
     return null;
   }
 
@@ -4787,14 +4787,14 @@ function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <ConnectorIcon icon={displayMetadata.icon} size={22} />
+          <ConnectorIcon icon={catalogItem.icon} size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
-            {displayMetadata.label}
+            {catalogItem.label}
           </div>
           <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
-            {displayMetadata.helpText}
+            {catalogItem.description}
           </div>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -18,6 +18,7 @@ import {
   IconCheck,
 } from "@tabler/icons-react";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -31,23 +32,23 @@ import { agents$ } from "../../signals/agent.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   connectConnectorOAuthAuthCode$,
   connectConnectorNoAuth$,
-  connectFlowType$,
+  connectFlowConnectorRef$,
   connectorsSearch$,
   connectorsConnectionFilter$,
   disconnectConnector$,
-  filteredConnectorTypes$,
+  filteredConnectorCatalogItems$,
   setConnectorsConnectionFilter$,
   setConnectorsSearch$,
-  selectedConnectorType$,
-  setSelectedConnectorType$,
-  pollingOAuthAuthCodeConnectorType$,
-  pollingOAuthDeviceAuthConnectorType$,
-  justConnectedTypes$,
-  scopeReviewType$,
-  setScopeReviewType$,
+  selectedConnectorRef$,
+  setSelectedConnectorRef$,
+  pollingOAuthAuthCodeConnectorRef$,
+  pollingOAuthDeviceAuthConnectorRef$,
+  justConnectedRefs$,
+  scopeReviewConnectorRef$,
+  setScopeReviewConnectorRef$,
   isStandaloneMode,
   getAvailableStatusAuthCodeAuthMethod,
   getOnlyAvailableStatusBrowserAuthMethodDetail,
@@ -56,7 +57,6 @@ import {
   getConnectorStatusConnectLaunchMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
-  type ConnectorTypeWithStatus,
   type ConnectorsConnectionFilter,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
@@ -74,9 +74,9 @@ import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { ConnectorAccessManagementDialog } from "./components/settings/connector-access-management-dialog.tsx";
 import {
   closeConnectorAccessManagement$,
-  connectorAuthorizedAgentsByType$,
-  managedConnectorAccessType$,
-  setManagedConnectorAccessType$,
+  connectorAuthorizedAgentsByRef$,
+  managedConnectorAccessRef$,
+  setManagedConnectorAccessRef$,
 } from "../../signals/zero-page/settings/connector-access-management.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
@@ -122,7 +122,7 @@ function ConnectorCategoryMenu({
   groups,
 }: {
   activeCategoryId: string | null;
-  groups: readonly ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
+  groups: readonly ConnectorCategoryGroup<PublicConnectorCatalogStatusItem>[];
 }) {
   if (groups.length <= 1) {
     return null;
@@ -477,8 +477,8 @@ function ConnectorCategoryGroupSection({
   group,
   renderCard,
 }: {
-  group: ConnectorCategoryGroup<ConnectorTypeWithStatus>;
-  renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
+  group: ConnectorCategoryGroup<PublicConnectorCatalogStatusItem>;
+  renderCard: (connector: PublicConnectorCatalogStatusItem) => ReactNode;
 }) {
   if (group.kind === "group") {
     return (
@@ -544,22 +544,20 @@ function truncateAgentName(name: string): string {
 }
 
 function ConnectorAccessButton({
-  connectorType,
+  connectorRef,
   connectorLabel,
   onClick,
 }: {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly connectorLabel: string;
   readonly onClick: () => void;
 }) {
-  const agentsByTypeLoadable = useLastLoadable(
-    connectorAuthorizedAgentsByType$,
-  );
+  const agentsByRefLoadable = useLastLoadable(connectorAuthorizedAgentsByRef$);
   const agents =
-    agentsByTypeLoadable.state === "hasData"
-      ? (agentsByTypeLoadable.data.get(connectorType) ?? [])
+    agentsByRefLoadable.state === "hasData"
+      ? (agentsByRefLoadable.data.get(connectorRef) ?? [])
       : [];
-  const loading = agentsByTypeLoadable.state === "loading";
+  const loading = agentsByRefLoadable.state === "loading";
   const visibleNames = agents
     .slice(0, CONNECTOR_CARD_AGENT_NAME_LIMIT)
     .map((agent) => {
@@ -605,6 +603,7 @@ function ConnectorAccessButton({
 
 function GlobalConnectorCard({
   connector,
+  isConnected,
   isPolling,
   onConnect,
   onDisconnect,
@@ -613,7 +612,8 @@ function GlobalConnectorCard({
   isDisconnecting,
   showManageAccess,
 }: {
-  connector: ConnectorTypeWithStatus;
+  connector: PublicConnectorCatalogStatusItem;
+  isConnected: boolean;
   isPolling: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
@@ -635,7 +635,7 @@ function GlobalConnectorCard({
         </span>
       );
     }
-    if (connector.connected && connectionStatus === "reconnect-required") {
+    if (isConnected && connectionStatus === "reconnect-required") {
       return (
         <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
           <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
@@ -645,7 +645,7 @@ function GlobalConnectorCard({
         </span>
       );
     }
-    if (connector.connected && connectionStatus === "scope-mismatch") {
+    if (isConnected && connectionStatus === "scope-mismatch") {
       return (
         <span className="flex min-w-0 items-center gap-2 text-[11px]">
           <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
@@ -655,12 +655,12 @@ function GlobalConnectorCard({
         </span>
       );
     }
-    if (connector.connected) {
+    if (isConnected) {
       const expiryText = connectorExpiryCountdownText(connector);
       const connectedText =
         expiryText ??
-        (connector.connector?.externalUsername
-          ? `@${connector.connector.externalUsername}`
+        (connector.connection?.externalUsername
+          ? `@${connector.connection.externalUsername}`
           : "Connected");
       return (
         <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
@@ -697,11 +697,11 @@ function GlobalConnectorCard({
         <div className="flex shrink-0 items-center gap-2 overflow-hidden">
           {status}
         </div>
-        {connector.connected && (
+        {isConnected && (
           <div className="flex min-w-0 flex-1 items-center justify-end gap-0">
             {showManageAccess && (
               <ConnectorAccessButton
-                connectorType={connector.type}
+                connectorRef={connector.connectorRef}
                 connectorLabel={connector.label}
                 onClick={onManageAccess}
               />
@@ -748,7 +748,7 @@ function AvailableConnectorCard({
   isPolling,
   onConnect,
 }: {
-  connector: ConnectorTypeWithStatus;
+  connector: PublicConnectorCatalogStatusItem;
   isPolling: boolean;
   onConnect: () => void;
 }) {
@@ -805,7 +805,7 @@ function AvailableConnectorCard({
           data-testid="connector-help-text"
           className="text-xs text-muted-foreground line-clamp-2"
         >
-          {connector.helpText ?? ""}
+          {connector.description}
         </div>
       </div>
     </div>
@@ -821,9 +821,9 @@ function renderBuiltinList({
   connectionFilter,
 }: {
   loadingState: "loading" | "hasData" | "hasError";
-  grouped: ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
+  grouped: ConnectorCategoryGroup<PublicConnectorCatalogStatusItem>[];
   filteredCount: number;
-  renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
+  renderCard: (connector: PublicConnectorCatalogStatusItem) => ReactNode;
   search: string;
   connectionFilter: ConnectorsConnectionFilter;
 }): ReactNode {
@@ -894,39 +894,41 @@ function renderBuiltinList({
   });
 }
 
-function connectorLabelForType(
-  connectors: readonly ConnectorTypeWithStatus[],
-  type: ConnectorRef | null,
+function connectorLabelForRef(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+  connectorRef: ConnectorRef | null,
 ): string | null {
-  if (!type) {
+  if (!connectorRef) {
     return null;
   }
   return (
     connectors.find((connector) => {
-      return connector.type === type;
-    })?.label ?? type
+      return connector.connectorRef === connectorRef;
+    })?.label ?? connectorRef
   );
 }
 
 export function ZeroConnectorsPage() {
-  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const filteredTypesLoadable = useLastLoadable(filteredConnectorTypes$);
+  const allCatalogItemsLoadable = useLastLoadable(allConnectorCatalogItems$);
+  const filteredCatalogItemsLoadable = useLastLoadable(
+    filteredConnectorCatalogItems$,
+  );
   const catalogStatusLoadable = useLastLoadable(connectorCatalogStatus$);
-  const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
-  const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
-  const connectFlowType = useGet(connectFlowType$);
+  const pollingAuthCodeRef = useGet(pollingOAuthAuthCodeConnectorRef$);
+  const pollingDeviceAuthRef = useGet(pollingOAuthDeviceAuthConnectorRef$);
+  const connectFlowRef = useGet(connectFlowConnectorRef$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
   const [disconnectLoadable, disconnect] = useLoadableSet(disconnectConnector$);
   const signal = useGet(pageSignal$);
-  const selectedType = useGet(selectedConnectorType$);
-  const setSelected = useSet(setSelectedConnectorType$);
-  const scopeReviewType = useGet(scopeReviewType$);
-  const setScopeReviewType = useSet(setScopeReviewType$);
-  const managedConnectorType = useGet(managedConnectorAccessType$);
-  const setManagedConnectorType = useSet(setManagedConnectorAccessType$);
+  const selectedConnectorRef = useGet(selectedConnectorRef$);
+  const setSelected = useSet(setSelectedConnectorRef$);
+  const scopeReviewConnectorRef = useGet(scopeReviewConnectorRef$);
+  const setScopeReviewConnectorRef = useSet(setScopeReviewConnectorRef$);
+  const managedConnectorRef = useGet(managedConnectorAccessRef$);
+  const setManagedConnectorRef = useSet(setManagedConnectorAccessRef$);
   const closeManagedConnector = useSet(closeConnectorAccessManagement$);
-  const optimisticConnected = useGet(justConnectedTypes$);
+  const optimisticConnected = useGet(justConnectedRefs$);
   const activeTab = useGet(connectorsPageTab$);
   const setActiveTab = useSet(setConnectorsPageTab$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
@@ -935,7 +937,7 @@ export function ZeroConnectorsPage() {
   const attachScrollTracking = useSet(attachConnectorCategoryScrollTracking$);
   const resetActiveCategory = useSet(resetActiveConnectorCategory$);
   const categoryTrackingEnabled =
-    activeTab === "builtin" && filteredTypesLoadable.state === "hasData";
+    activeTab === "builtin" && filteredCatalogItemsLoadable.state === "hasData";
   const scrollContainerRef = useScrollTrackingRef(
     categoryTrackingEnabled,
     attachScrollTracking,
@@ -950,52 +952,56 @@ export function ZeroConnectorsPage() {
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
 
   const filteredConnectors =
-    filteredTypesLoadable.state === "hasData" ? filteredTypesLoadable.data : [];
+    filteredCatalogItemsLoadable.state === "hasData"
+      ? filteredCatalogItemsLoadable.data
+      : [];
   const categoryMetadata =
     catalogStatusLoadable.state === "hasData"
       ? catalogStatusLoadable.data.categoryMetadata
       : undefined;
   const allConnectors =
-    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
-  const managedConnectorLabel = connectorLabelForType(
+    allCatalogItemsLoadable.state === "hasData"
+      ? allCatalogItemsLoadable.data
+      : [];
+  const managedConnectorLabel = connectorLabelForRef(
     allConnectors,
-    managedConnectorType,
+    managedConnectorRef,
   );
   const disconnecting = disconnectLoadable.state === "loading";
 
-  const connectHandler = (type: ConnectorRef) => {
+  const connectHandler = (connectorRef: ConnectorRef) => {
     const ct = filteredConnectors.find((c) => {
-      return c.type === type;
+      return c.connectorRef === connectorRef;
     });
     if (!ct) {
       return;
     }
     const launchMode = getConnectorStatusConnectLaunchMode(ct);
     if (launchMode === "modal") {
-      setSelected(type);
+      setSelected(connectorRef);
       return;
     }
     if (launchMode === "browser-auth") {
       const authMethod = getOnlyAvailableStatusBrowserAuthMethodDetail(ct);
       if (!authMethod) {
-        setSelected(type);
+        setSelected(connectorRef);
         return;
       }
       detach(
-        connect(type, authMethod, { connectorLabel: ct.label }, signal),
+        connect(connectorRef, authMethod, { connectorLabel: ct.label }, signal),
         Reason.DomCallback,
       );
       return;
     }
     const authMethod = getOnlyAvailableStatusNoAuthMethod(ct);
     if (!authMethod) {
-      setSelected(type);
+      setSelected(connectorRef);
       return;
     }
     detach(
       connectNoAuth(
         {
-          type,
+          connectorRef,
           authMethod,
           options: { connectorLabel: ct.label },
         },
@@ -1006,69 +1012,67 @@ export function ZeroConnectorsPage() {
   };
 
   const disconnectHandler = async (
-    type: ConnectorRef,
+    connectorRef: ConnectorRef,
     connectorLabel: string,
   ) => {
     if (disconnecting) {
       return;
     }
-    await disconnect(type, connectorLabel, signal);
+    await disconnect(connectorRef, connectorLabel, signal);
   };
 
-  const getOptimisticConnector = (c: ConnectorTypeWithStatus) => {
-    return optimisticConnected.has(c.type) && !c.connected
-      ? { ...c, connected: true }
-      : c;
-  };
-
-  const renderCard = (c: ConnectorTypeWithStatus) => {
-    const optimisticConnector = getOptimisticConnector(c);
+  const renderCard = (c: PublicConnectorCatalogStatusItem) => {
+    const isConnected = c.connected || optimisticConnected.has(c.connectorRef);
     const isPolling =
-      pollingAuthCodeType === c.type ||
-      pollingDeviceAuthType === c.type ||
-      connectFlowType === c.type;
-    if (!optimisticConnector.connected) {
+      pollingAuthCodeRef === c.connectorRef ||
+      pollingDeviceAuthRef === c.connectorRef ||
+      connectFlowRef === c.connectorRef;
+    if (!isConnected) {
       return (
         <AvailableConnectorCard
-          key={c.type}
-          connector={optimisticConnector}
+          key={c.connectorRef}
+          connector={c}
           isPolling={isPolling}
           onConnect={() => {
-            return connectHandler(c.type);
+            return connectHandler(c.connectorRef);
           }}
         />
       );
     }
     return (
       <GlobalConnectorCard
-        key={c.type}
-        connector={optimisticConnector}
+        key={c.connectorRef}
+        connector={c}
+        isConnected={isConnected}
         isPolling={isPolling}
         isDisconnecting={disconnecting}
         showManageAccess
         onConnect={() => {
-          return connectHandler(c.type);
+          return connectHandler(c.connectorRef);
         }}
         onDisconnect={() => {
-          detach(disconnectHandler(c.type, c.label), Reason.DomCallback);
+          detach(
+            disconnectHandler(c.connectorRef, c.label),
+            Reason.DomCallback,
+          );
         }}
         onManageAccess={() => {
-          setManagedConnectorType(c.type);
+          setManagedConnectorRef(c.connectorRef);
         }}
         onReviewScopes={() => {
-          return setScopeReviewType(c.type);
+          return setScopeReviewConnectorRef(c.connectorRef);
         }}
       />
     );
   };
 
   const grouped = groupConnectorsByCategory(
-    filteredConnectors.map(getOptimisticConnector),
+    filteredConnectors,
     categoryMetadata,
   );
 
   const builtinList = renderBuiltinList({
-    loadingState: filteredTypesLoadable.state,
+    loadingState: filteredCatalogItemsLoadable.state,
     grouped,
     filteredCount: filteredConnectors.length,
     renderCard,
@@ -1096,7 +1100,7 @@ export function ZeroConnectorsPage() {
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
         <div className="relative mx-auto w-full max-w-[900px]">
           {activeTab === "builtin" &&
-            filteredTypesLoadable.state === "hasData" && (
+            filteredCatalogItemsLoadable.state === "hasData" && (
               <ConnectorCategoryMenu
                 activeCategoryId={activeCategoryId}
                 groups={grouped}
@@ -1136,7 +1140,7 @@ export function ZeroConnectorsPage() {
         </div>
       </main>
 
-      {selectedType && (
+      {selectedConnectorRef && (
         <ConnectModal
           onClose={() => {
             return setSelected(null);
@@ -1144,27 +1148,27 @@ export function ZeroConnectorsPage() {
           onSuccess={() => {
             const label =
               allConnectors.find((c) => {
-                return c.type === selectedType;
-              })?.label ?? selectedType;
+                return c.connectorRef === selectedConnectorRef;
+              })?.label ?? selectedConnectorRef;
             toast.success(`${label} connected`);
           }}
         />
       )}
 
-      {scopeReviewType && (
+      {scopeReviewConnectorRef && (
         <ScopeReviewModal
-          connectorType={scopeReviewType}
+          connectorRef={scopeReviewConnectorRef}
           onClose={() => {
-            return setScopeReviewType(null);
+            return setScopeReviewConnectorRef(null);
           }}
-          onReconnect={(type) => {
-            setScopeReviewType(null);
+          onReconnect={(connectorRef) => {
+            setScopeReviewConnectorRef(null);
             const connector = allConnectors.find((connector) => {
-              return connector.type === type;
+              return connector.connectorRef === connectorRef;
             });
-            const connection = connector?.connector ?? null;
+            const connection = connector?.connection ?? null;
             if (!connector || !connection) {
-              setSelected(type);
+              setSelected(connectorRef);
               return;
             }
             const authMethodId = getAvailableStatusAuthCodeAuthMethod(
@@ -1175,12 +1179,12 @@ export function ZeroConnectorsPage() {
               ? getConnectorStatusAuthMethod(connector, authMethodId)
               : null;
             if (!authMethod) {
-              setSelected(type);
+              setSelected(connectorRef);
               return;
             }
             detach(
               connect(
-                type,
+                connectorRef,
                 authMethod,
                 { connectorLabel: connector.label },
                 signal,
@@ -1191,9 +1195,9 @@ export function ZeroConnectorsPage() {
         />
       )}
 
-      {managedConnectorType && managedConnectorLabel && (
+      {managedConnectorRef && managedConnectorLabel && (
         <ConnectorAccessManagementDialog
-          connectorType={managedConnectorType}
+          connectorRef={managedConnectorRef}
           connectorLabel={managedConnectorLabel}
           onClose={closeManagedConnector}
         />

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -4,23 +4,25 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   connectConnectorOAuthAuthCode$,
   connectConnectorNoAuth$,
-  connectFlowType$,
+  connectFlowConnectorRef$,
   getConnectorStatusConnectLaunchMode,
   getOnlyAvailableStatusBrowserAuthMethodDetail,
   getOnlyAvailableStatusNoAuthMethod,
-  justConnectedTypes$,
-  pollingOAuthAuthCodeConnectorType$,
-  type ConnectorStatusAuthMethodDetail,
-  type ConnectorTypeWithStatus,
+  justConnectedRefs$,
+  pollingOAuthAuthCodeConnectorRef$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
-  directedAuthorizeType$,
+  directedAuthorizeRef$,
   directedAuthorizeAgentId$,
   directedAuthorizeAgentName$,
   agentEnabledTypes$,
@@ -30,7 +32,7 @@ import {
   directedAuthorizeConnectModalKey$,
   setDirectedAuthorizeConnectModalKey$,
   type DirectedAuthorizeConnectModalKey,
-} from "../../signals/connectors-page/directed-authorize-type.ts";
+} from "../../signals/connectors-page/directed-authorize-ref.ts";
 import {
   routeChatActionCallback$,
   runChatActionCallback$,
@@ -84,48 +86,48 @@ function AuthorizeAction({
 // ---------------------------------------------------------------------------
 
 function useDirectedAuthorizeParams(): {
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string;
 } | null {
-  const type = useGet(directedAuthorizeType$);
+  const routeType = useGet(directedAuthorizeRef$);
   const agentId = useGet(directedAuthorizeAgentId$);
-  if (!type || !agentId) {
+  if (!routeType || !agentId) {
     return null;
   }
-  const parsed = connectorRefSchema.safeParse(type);
+  const parsed = connectorRefSchema.safeParse(routeType);
   if (!parsed.success) {
     return null;
   }
-  return { connectorType: parsed.data, agentId };
+  return { connectorRef: parsed.data, agentId };
 }
 
-function useDirectedAuthorizeCatalogState(connectorType: ConnectorRef | null) {
-  const justConnected = useGet(justConnectedTypes$);
-  const allLoadable = useLastLoadable(allConnectorTypes$);
+function useDirectedAuthorizeCatalogState(connectorRef: ConnectorRef | null) {
+  const justConnected = useGet(justConnectedRefs$);
+  const allLoadable = useLastLoadable(allConnectorCatalogItems$);
   const catalogLoaded = allLoadable.state === "hasData";
   const allData = catalogLoaded ? allLoadable.data : [];
-  const item = connectorType
+  const item = connectorRef
     ? allData.find((connector) => {
-        return connector.type === connectorType;
+        return connector.connectorRef === connectorRef;
       })
     : undefined;
   const isConnected =
-    connectorType !== null &&
-    (justConnected.has(connectorType) || item?.connected === true);
+    connectorRef !== null &&
+    (justConnected.has(connectorRef) || item?.connected === true);
   return {
     item,
     isConnected,
     catalogLoading:
-      connectorType !== null &&
-      !justConnected.has(connectorType) &&
+      connectorRef !== null &&
+      !justConnected.has(connectorRef) &&
       allLoadable.state === "loading",
     unavailable:
-      connectorType !== null && catalogLoaded && !item && !isConnected,
+      connectorRef !== null && catalogLoaded && !item && !isConnected,
   };
 }
 
 function useDirectedAuthorizePermissionState(
-  connectorType: ConnectorRef | null,
+  connectorRef: ConnectorRef | null,
   agentId: string | null,
 ) {
   const justAuthorizedKeys = useGet(justAuthorizedConnectorAgentKeys$);
@@ -139,13 +141,13 @@ function useDirectedAuthorizePermissionState(
   const enabledTypes = enabledData === null ? [] : enabledData.enabledTypes;
   return {
     isAuthorized:
-      connectorType !== null &&
+      connectorRef !== null &&
       agentId !== null &&
       (isJustAuthorizedConnectorAgent(justAuthorizedKeys, {
-        connectorType,
+        connectorRef,
         agentId,
       }) ||
-        enabledTypes.includes(connectorType)),
+        enabledTypes.includes(connectorRef)),
     permissionLoading:
       agentId !== null &&
       (enabledLoadable.state === "loading" ||
@@ -166,24 +168,22 @@ function useDirectedAuthorizeAgentName(agentId: string | null): string {
 }
 
 function canAuthorizeConnector(
-  item:
-    | { readonly availableAuthMethods: readonly ConnectorAuthMethodId[] }
-    | undefined,
+  item: Pick<PublicConnectorCatalogStatusItem, "authMethods"> | undefined,
   isConnected: boolean,
 ): boolean {
-  return isConnected || (item ? item.availableAuthMethods.length > 0 : false);
+  return isConnected || (item ? item.authMethods.length > 0 : false);
 }
 
 function directedAuthorizeConnectModalOpen(
   key: DirectedAuthorizeConnectModalKey | null,
   args: {
-    readonly connectorType: ConnectorRef | null;
+    readonly connectorRef: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },
 ): boolean {
   return (
-    key?.connectorType === args.connectorType &&
+    key?.connectorRef === args.connectorRef &&
     key.agentId === args.agentId &&
     key.signal === args.signal
   );
@@ -200,7 +200,7 @@ function DirectedAuthorizeCardContent({
   canAuthorize,
   onAuthorize,
 }: {
-  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
+  readonly icon: PublicConnectorCatalogStatusItem["icon"] | undefined;
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;
@@ -257,20 +257,20 @@ function DirectedAuthorizeCardContent({
 function runDirectedAuthorize(params: {
   readonly canAuthorize: boolean;
   readonly isConnected: boolean;
-  readonly item: ConnectorTypeWithStatus | undefined;
-  readonly connectorType: ConnectorRef;
+  readonly item: PublicConnectorCatalogStatusItem | undefined;
+  readonly connectorRef: ConnectorRef;
   readonly connectorLabel: string;
   readonly agentId: string;
-  readonly authMethod: ConnectorStatusAuthMethodDetail | null;
+  readonly authMethod: PublicConnectorCatalogAuthMethodDetail | null;
   readonly signal: AbortSignal;
   readonly authorize: (
-    connectorType: ConnectorRef,
+    connectorRef: ConnectorRef,
     agentId: string,
     signal: AbortSignal,
   ) => Promise<void>;
   readonly connect: (
-    connectorType: ConnectorRef,
-    method: ConnectorStatusAuthMethodDetail,
+    connectorRef: ConnectorRef,
+    method: PublicConnectorCatalogAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
       readonly agentId?: string;
@@ -279,7 +279,7 @@ function runDirectedAuthorize(params: {
   ) => Promise<boolean>;
   readonly connectNoAuth: (
     args: {
-      readonly type: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly options: {
         readonly connectorLabel?: string;
@@ -299,7 +299,7 @@ function runDirectedAuthorize(params: {
     detach(
       (async () => {
         await params.authorize(
-          params.connectorType,
+          params.connectorRef,
           params.agentId,
           params.signal,
         );
@@ -324,7 +324,7 @@ function runDirectedAuthorize(params: {
         let connected = false;
         if (browserAuthMethod) {
           connected = await params.connect(
-            params.connectorType,
+            params.connectorRef,
             browserAuthMethod,
             {
               connectorLabel: params.connectorLabel,
@@ -335,7 +335,7 @@ function runDirectedAuthorize(params: {
         } else if (noAuthMethod) {
           connected = await params.connectNoAuth(
             {
-              type: params.connectorType,
+              connectorRef: params.connectorRef,
               authMethod: noAuthMethod,
               options: {
                 connectorLabel: params.connectorLabel,
@@ -356,15 +356,15 @@ function runDirectedAuthorize(params: {
     );
     return;
   }
-  if (params.item && params.item.availableAuthMethods.length > 0) {
+  if (params.item && params.item.authMethods.length > 0) {
     params.openConnectModal();
   }
 }
 
 function DirectedAuthorizeCard() {
   const params = useDirectedAuthorizeParams();
-  const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
-  const connectFlowType = useGet(connectFlowType$);
+  const pollingConnectorRef = useGet(pollingOAuthAuthCodeConnectorRef$);
+  const connectFlowConnectorRef = useGet(connectFlowConnectorRef$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
   const authorize = useSet(authorizeConnector$);
@@ -376,17 +376,17 @@ function DirectedAuthorizeCard() {
   );
   const actionCallback = useGet(routeChatActionCallback$);
   const runCallback = useSet(runChatActionCallback$);
-  const connectorTypeForState = params?.connectorType ?? null;
+  const connectorRefForState = params?.connectorRef ?? null;
   const agentName = useDirectedAuthorizeAgentName(params?.agentId ?? null);
   const { item, isConnected, catalogLoading, unavailable } =
-    useDirectedAuthorizeCatalogState(connectorTypeForState);
+    useDirectedAuthorizeCatalogState(connectorRefForState);
   const { isAuthorized, permissionLoading } =
     useDirectedAuthorizePermissionState(
-      connectorTypeForState,
+      connectorRefForState,
       params?.agentId ?? null,
     );
   const connectModalOpen = directedAuthorizeConnectModalOpen(connectModalKey, {
-    connectorType: connectorTypeForState,
+    connectorRef: connectorRefForState,
     agentId: params?.agentId ?? null,
     signal,
   });
@@ -395,9 +395,10 @@ function DirectedAuthorizeCard() {
     return null;
   }
 
-  const { connectorType, agentId } = params;
+  const { connectorRef, agentId } = params;
   const isConnecting =
-    pollingType === connectorType || connectFlowType === connectorType;
+    pollingConnectorRef === connectorRef ||
+    connectFlowConnectorRef === connectorRef;
   if (unavailable) {
     return null;
   }
@@ -407,8 +408,8 @@ function DirectedAuthorizeCard() {
   const selectedAuthMethod = item
     ? getOnlyAvailableStatusBrowserAuthMethodDetail(item)
     : null;
-  const connectorLabel = item?.label ?? connectorType;
-  const connectorDescription = item?.helpText ?? "";
+  const connectorLabel = item?.label ?? connectorRef;
+  const connectorDescription = item?.description ?? "";
   const handleAuthorizeSuccess = async () => {
     if (actionCallback.callbackPrompt && actionCallback.threadId) {
       await runCallback(
@@ -427,7 +428,7 @@ function DirectedAuthorizeCard() {
       canAuthorize,
       isConnected,
       item,
-      connectorType,
+      connectorRef,
       connectorLabel,
       agentId,
       authMethod: selectedAuthMethod,
@@ -438,7 +439,7 @@ function DirectedAuthorizeCard() {
       reloadAuthorization,
       onSuccess: handleAuthorizeSuccess,
       openConnectModal: () => {
-        setDirectedAuthorizeConnectModalKey({ connectorType, agentId, signal });
+        setDirectedAuthorizeConnectModalKey({ connectorRef, agentId, signal });
       },
     });
   };
@@ -458,7 +459,7 @@ function DirectedAuthorizeCard() {
       />
       {connectModalOpen && (
         <ConnectModal
-          selectedType={connectorType}
+          selectedConnectorRef={connectorRef}
           agentId={agentId}
           onSuccess={async () => {
             reloadAuthorization();

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -4,6 +4,10 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -13,16 +17,16 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
-  allConnectorTypes$,
+  allConnectorCatalogItems$,
   connectConnectorOAuthAuthCode$,
   connectConnectorNoAuth$,
-  connectFlowType$,
+  connectFlowConnectorRef$,
   getOnlyAvailableStatusBrowserAuthMethodDetail,
   getOnlyAvailableStatusNoAuthMethod,
   getConnectorStatusConnectLaunchMode,
-  justConnectedTypes$,
-  pollingOAuthAuthCodeConnectorType$,
-  pollingOAuthDeviceAuthConnectorType$,
+  justConnectedRefs$,
+  pollingOAuthAuthCodeConnectorRef$,
+  pollingOAuthDeviceAuthConnectorRef$,
   submitManualGrant$,
   manualGrantFormSubmitting$,
   setManualGrantFormValue$,
@@ -32,8 +36,6 @@ import {
   getOnlyManualConnectorStatusAuthMethod,
   hasConnectorStatusProviderDrivenConnectMethod,
   manualGrantInputValuesForMethod,
-  type ConnectorTypeWithStatus,
-  type ConnectorStatusAuthMethodDetail,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../signals/zero-page/settings/token-input.ts";
 import {
@@ -44,7 +46,7 @@ import {
   withCleanup,
 } from "../../signals/utils.ts";
 import {
-  directedConnectType$,
+  directedConnectRef$,
   directedConnectAgentId$,
   directedConnectAgentName$,
   manualGrantDialogKey$,
@@ -53,7 +55,7 @@ import {
   setDirectedConnectModalKey$,
   type DirectedConnectModalKey,
   type DirectedConnectManualGrantDialogKey,
-} from "../../signals/connectors-page/directed-connect-type.ts";
+} from "../../signals/connectors-page/directed-connect-ref.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
 import { Vm0LogoLink } from "./zero-directed-shared.tsx";
@@ -66,13 +68,13 @@ import {
 } from "../../signals/chat-page/action-callback.ts";
 
 function runDirectedConnect(params: {
-  item: ConnectorTypeWithStatus;
-  connectorType: ConnectorRef;
+  item: PublicConnectorCatalogStatusItem;
+  connectorRef: ConnectorRef;
   agentId: string | null;
   signal: AbortSignal;
   connect: (
-    type: ConnectorRef,
-    method: ConnectorStatusAuthMethodDetail,
+    connectorRef: ConnectorRef,
+    method: PublicConnectorCatalogAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
       readonly agentId?: string;
@@ -81,7 +83,7 @@ function runDirectedConnect(params: {
   ) => Promise<boolean>;
   connectNoAuth: (
     args: {
-      readonly type: ConnectorRef;
+      readonly connectorRef: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly options: {
         readonly connectorLabel?: string;
@@ -108,7 +110,7 @@ function runDirectedConnect(params: {
   if (
     launchMode === "modal" &&
     manualGrantMethod &&
-    params.item.availableAuthMethods.length === 1
+    params.item.authMethods.length === 1
   ) {
     params.openManualGrantDialog();
     return;
@@ -129,7 +131,7 @@ function runDirectedConnect(params: {
           return;
         }
         const connected = await params.connect(
-          params.connectorType,
+          params.connectorRef,
           authMethod,
           {
             connectorLabel: params.item.label,
@@ -148,7 +150,7 @@ function runDirectedConnect(params: {
         }
         const connected = await params.connectNoAuth(
           {
-            type: params.connectorType,
+            connectorRef: params.connectorRef,
             authMethod,
             options: {
               connectorLabel: params.item.label,
@@ -167,16 +169,16 @@ function runDirectedConnect(params: {
 }
 
 function ManualGrantForm({
-  type,
+  connectorRef,
   agentId,
   connectorLabel,
   manualGrantMethod,
   onSuccess,
 }: {
-  type: ConnectorRef;
+  connectorRef: ConnectorRef;
   agentId: string | null;
   connectorLabel: string;
-  manualGrantMethod: ConnectorStatusAuthMethodDetail;
+  manualGrantMethod: PublicConnectorCatalogAuthMethodDetail;
   onSuccess: () => void | Promise<void>;
 }) {
   const submit = useSet(submitManualGrant$);
@@ -184,10 +186,10 @@ function ManualGrantForm({
   const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
   const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
-  const fieldValues = manualGrantFormValuesFor(type);
-  const submittingType = useGet(manualGrantFormSubmitting$);
+  const fieldValues = manualGrantFormValuesFor(connectorRef);
+  const submittingRef = useGet(manualGrantFormSubmitting$);
   const setSubmitting = useSet(setManualGrantFormSubmitting$);
-  const submitting = submittingType === type;
+  const submitting = submittingRef === connectorRef;
 
   const allFilled = manualGrantMethod.manualFields.every((field) => {
     return !field.required || hasTokenInputValue(fieldValues[field.id]);
@@ -199,13 +201,13 @@ function ManualGrantForm({
       if (!allFilled || submitting) {
         return;
       }
-      setSubmitting(type);
+      setSubmitting(connectorRef);
       await withCleanup(
         bestEffort(
           (async () => {
             const connected = await submit(
               {
-                type,
+                connectorRef,
                 authMethod: manualGrantMethod.id,
                 inputValues: manualGrantInputValuesForMethod(
                   manualGrantMethod,
@@ -222,7 +224,7 @@ function ManualGrantForm({
               return;
             }
             await onSuccess();
-            clearForm(type);
+            clearForm(connectorRef);
           })(),
         ),
         () => {
@@ -251,7 +253,11 @@ function ManualGrantForm({
               placeholder={fieldConfig.placeholder ?? undefined}
               value={fieldValues[fieldConfig.id] ?? ""}
               onChange={(e) => {
-                return setFormValue(type, fieldConfig.id, e.target.value);
+                return setFormValue(
+                  connectorRef,
+                  fieldConfig.id,
+                  e.target.value,
+                );
               }}
             />
           </div>
@@ -270,7 +276,7 @@ function ManualGrantForm({
 }
 
 function ManualGrantDialog({
-  type,
+  connectorRef,
   agentId,
   icon,
   connectorLabel,
@@ -279,11 +285,11 @@ function ManualGrantDialog({
   onOpenChange,
   onSuccess,
 }: {
-  type: ConnectorRef;
+  connectorRef: ConnectorRef;
   agentId: string | null;
-  icon: ConnectorTypeWithStatus["icon"] | undefined;
+  icon: PublicConnectorCatalogStatusItem["icon"] | undefined;
   connectorLabel: string;
-  manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
+  manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void | Promise<void>;
@@ -301,7 +307,7 @@ function ManualGrantDialog({
           </div>
         </DialogHeader>
         <ManualGrantForm
-          type={type}
+          connectorRef={connectorRef}
           agentId={agentId}
           connectorLabel={connectorLabel}
           manualGrantMethod={manualGrantMethod}
@@ -360,13 +366,13 @@ function ConnectActions({
 
 function DirectedConnectModal({
   open,
-  connectorType,
+  connectorRef,
   agentId,
   onClose,
   onSuccess,
 }: {
   readonly open: boolean;
-  readonly connectorType: ConnectorRef;
+  readonly connectorRef: ConnectorRef;
   readonly agentId: string | null;
   readonly onClose: () => void;
   readonly onSuccess: () => void | Promise<void>;
@@ -376,7 +382,7 @@ function DirectedConnectModal({
   }
   return (
     <ConnectModal
-      selectedType={connectorType}
+      selectedConnectorRef={connectorRef}
       {...(agentId ? { agentId } : {})}
       onClose={onClose}
       onSuccess={onSuccess}
@@ -385,7 +391,7 @@ function DirectedConnectModal({
 }
 
 function DirectedConnectDialogs({
-  connectorType,
+  connectorRef,
   icon,
   connectorLabel,
   manualGrantMethod,
@@ -396,10 +402,10 @@ function DirectedConnectDialogs({
   setConnectModalOpen,
   onSuccess,
 }: {
-  readonly connectorType: ConnectorRef;
-  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
+  readonly connectorRef: ConnectorRef;
+  readonly icon: PublicConnectorCatalogStatusItem["icon"] | undefined;
   readonly connectorLabel: string;
-  readonly manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
+  readonly manualGrantMethod: PublicConnectorCatalogAuthMethodDetail | null;
   readonly manualGrantDialogOpen: boolean;
   readonly setManualGrantDialogOpen: (open: boolean) => void;
   readonly agentId: string | null | undefined;
@@ -410,7 +416,7 @@ function DirectedConnectDialogs({
   return (
     <>
       <ManualGrantDialog
-        type={connectorType}
+        connectorRef={connectorRef}
         agentId={agentId ?? null}
         icon={icon}
         connectorLabel={connectorLabel}
@@ -421,7 +427,7 @@ function DirectedConnectDialogs({
       />
       <DirectedConnectModal
         open={connectModalOpen}
-        connectorType={connectorType}
+        connectorRef={connectorRef}
         agentId={agentId ?? null}
         onClose={() => {
           setConnectModalOpen(false);
@@ -432,42 +438,42 @@ function DirectedConnectDialogs({
   );
 }
 
-function useDirectedConnectConnectorType(): ConnectorRef | null {
-  const type = useGet(directedConnectType$);
-  if (!type) {
+function useDirectedConnectConnectorRef(): ConnectorRef | null {
+  const routeType = useGet(directedConnectRef$);
+  if (!routeType) {
     return null;
   }
-  const parsed = connectorRefSchema.safeParse(type);
+  const parsed = connectorRefSchema.safeParse(routeType);
   return parsed.success ? parsed.data : null;
 }
 
-function useDirectedConnectCatalogState(connectorType: ConnectorRef | null): {
-  readonly item: ConnectorTypeWithStatus | undefined;
+function useDirectedConnectCatalogState(connectorRef: ConnectorRef | null): {
+  readonly item: PublicConnectorCatalogStatusItem | undefined;
   readonly isConnected: boolean;
   readonly isLoading: boolean;
   readonly unavailable: boolean;
 } {
-  const justConnected = useGet(justConnectedTypes$);
-  const allLoadable = useLastLoadable(allConnectorTypes$);
+  const justConnected = useGet(justConnectedRefs$);
+  const allLoadable = useLastLoadable(allConnectorCatalogItems$);
   const catalogLoaded = allLoadable.state === "hasData";
   const allData = catalogLoaded ? allLoadable.data : [];
-  const item = connectorType
+  const item = connectorRef
     ? allData.find((connector) => {
-        return connector.type === connectorType;
+        return connector.connectorRef === connectorRef;
       })
     : undefined;
   const optimisticallyConnected =
-    connectorType !== null && justConnected.has(connectorType);
+    connectorRef !== null && justConnected.has(connectorRef);
   const isConnected = optimisticallyConnected || (item?.connected ?? false);
   return {
     item,
     isConnected,
     isLoading:
-      connectorType !== null &&
+      connectorRef !== null &&
       !optimisticallyConnected &&
       allLoadable.state === "loading",
     unavailable:
-      connectorType !== null &&
+      connectorRef !== null &&
       catalogLoaded &&
       !item &&
       !optimisticallyConnected,
@@ -477,13 +483,13 @@ function useDirectedConnectCatalogState(connectorType: ConnectorRef | null): {
 function directedConnectManualGrantDialogOpen(
   key: DirectedConnectManualGrantDialogKey | null,
   args: {
-    readonly connectorType: ConnectorRef | null;
+    readonly connectorRef: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },
 ): boolean {
   return (
-    key?.connectorType === args.connectorType &&
+    key?.connectorRef === args.connectorRef &&
     key.agentId === args.agentId &&
     key.signal === args.signal
   );
@@ -492,13 +498,13 @@ function directedConnectManualGrantDialogOpen(
 function directedConnectModalOpen(
   key: DirectedConnectModalKey | null,
   args: {
-    readonly connectorType: ConnectorRef | null;
+    readonly connectorRef: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },
 ): boolean {
   return (
-    key?.connectorType === args.connectorType &&
+    key?.connectorRef === args.connectorRef &&
     key.agentId === args.agentId &&
     key.signal === args.signal
   );
@@ -515,7 +521,7 @@ function DirectedConnectCardContent({
   canConnect,
   onConnect,
 }: {
-  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
+  readonly icon: PublicConnectorCatalogStatusItem["icon"] | undefined;
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;
@@ -569,17 +575,17 @@ function DirectedConnectCardContent({
 }
 
 function DirectedConnectCard() {
-  const connectorType = useDirectedConnectConnectorType();
+  const connectorRef = useDirectedConnectConnectorRef();
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
-  const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
-  const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
-  const connectFlowType = useGet(connectFlowType$);
+  const pollingAuthCodeRef = useGet(pollingOAuthAuthCodeConnectorRef$);
+  const pollingDeviceAuthRef = useGet(pollingOAuthDeviceAuthConnectorRef$);
+  const connectFlowRef = useGet(connectFlowConnectorRef$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
   const signal = useGet(pageSignal$);
   const { item, isConnected, isLoading, unavailable } =
-    useDirectedConnectCatalogState(connectorType);
+    useDirectedConnectCatalogState(connectorRef);
   const manualGrantDialogKey = useGet(manualGrantDialogKey$);
   const setManualGrantDialogKey = useSet(setManualGrantDialogKey$);
   const connectModalKey = useGet(directedConnectModalKey$);
@@ -588,15 +594,15 @@ function DirectedConnectCard() {
   const runCallback = useSet(runChatActionCallback$);
   const manualGrantDialogOpen = directedConnectManualGrantDialogOpen(
     manualGrantDialogKey,
-    { connectorType, agentId, signal },
+    { connectorRef, agentId, signal },
   );
   const connectModalOpen = directedConnectModalOpen(connectModalKey, {
-    connectorType,
+    connectorRef,
     agentId,
     signal,
   });
 
-  if (!connectorType) {
+  if (!connectorRef) {
     return null;
   }
 
@@ -607,19 +613,19 @@ function DirectedConnectCard() {
       ? agentNameLoadable.data.displayName
       : "Zero";
   const isConnecting =
-    pollingAuthCodeType === connectorType ||
-    pollingDeviceAuthType === connectorType ||
-    connectFlowType === connectorType;
+    pollingAuthCodeRef === connectorRef ||
+    pollingDeviceAuthRef === connectorRef ||
+    connectFlowRef === connectorRef;
   if (unavailable) {
     return null;
   }
-  const authMethods = item?.availableAuthMethods ?? [];
+  const authMethods = item?.authMethods ?? [];
   const manualGrantMethod = item
     ? getOnlyManualConnectorStatusAuthMethod(item)
     : null;
   const canConnect = authMethods.length > 0;
-  const connectorLabel = item?.label ?? connectorType;
-  const connectorDescription = item?.helpText ?? "";
+  const connectorLabel = item?.label ?? connectorRef;
+  const connectorDescription = item?.description ?? "";
   const handleConnectSuccess = async () => {
     if (actionCallback.callbackPrompt && actionCallback.threadId && agentId) {
       await runCallback(
@@ -639,16 +645,24 @@ function DirectedConnectCard() {
     }
     runDirectedConnect({
       item,
-      connectorType,
+      connectorRef,
       agentId,
       signal,
       connect,
       connectNoAuth,
       openManualGrantDialog: () => {
-        return setManualGrantDialogKey({ connectorType, agentId, signal });
+        return setManualGrantDialogKey({
+          connectorRef,
+          agentId,
+          signal,
+        });
       },
       openConnectModal: () => {
-        setDirectedConnectModalKey({ connectorType, agentId, signal });
+        setDirectedConnectModalKey({
+          connectorRef,
+          agentId,
+          signal,
+        });
       },
       onSuccess: handleConnectSuccess,
     });
@@ -668,21 +682,21 @@ function DirectedConnectCard() {
         onConnect={handleConnect}
       />
       <DirectedConnectDialogs
-        connectorType={connectorType}
+        connectorRef={connectorRef}
         icon={item?.icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         manualGrantDialogOpen={manualGrantDialogOpen}
         setManualGrantDialogOpen={(open) => {
           setManualGrantDialogKey(
-            open ? { connectorType, agentId, signal } : null,
+            open ? { connectorRef, agentId, signal } : null,
           );
         }}
         agentId={agentId}
         connectModalOpen={connectModalOpen}
         setConnectModalOpen={(open) => {
           setDirectedConnectModalKey(
-            open ? { connectorType, agentId, signal } : null,
+            open ? { connectorRef, agentId, signal } : null,
           );
         }}
         onSuccess={handleConnectSuccess}


### PR DESCRIPTION
## Summary

- remove the Platform-owned `ConnectorTypeWithStatus` and `ConnectorCatalogDisplayMetadata` shadow models
- carry canonical `PublicConnectorCatalogStatusItem` fields through discovery, connection, permissions, chat, insights, and job flows
- derive auth-method facts from canonical `authMethods` and retain only genuinely client-owned composer authorization state
- rename in-memory connector identity state from type-oriented names to `ConnectorRef`-oriented names

## Compatibility

- leaves API routes and JSON fields such as `type` and `enabledTypes` unchanged
- leaves database, R2, feature-switch behavior, and `vm0.connections.hiddenTypes` persistence unchanged
- remains independently deployable against the existing server catalog contract

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/app lint`
- `cd turbo && pnpm -F @vm0/app check-types`
- `cd turbo && pnpm knip --workspace @vm0/app`
- `cd turbo && pnpm -F @vm0/app exec vitest run src/signals/__tests__/connector-form-signals.test.ts src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx src/views/zero-page/__tests__/zero-jobs-page.test.tsx src/views/network-insights/__tests__/network-insights-page.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx --maxWorkers=4 --silent=passed-only` (160 tests)

Closes #22452

Parent objective: https://github.com/vm0-ai/vm0-connectors/issues/1
