### PR TITLE
fix(api): extend sandbox token lifetime

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -25,6 +25,9 @@ import { singleton } from "../../lib/singleton";
 
 const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
+// Covers the runner's two-hour execution budget plus claim, startup,
+// finalization, and terminal report time.
+const SANDBOX_TOKEN_TTL_SECONDS = 3 * 60 * 60;
 
 const CONDITIONAL_CAPABILITIES = [
   ["banking:read", FeatureSwitchKey.Banking],
@@ -282,7 +285,7 @@ export function generateSandboxToken(
     runId,
     orgId,
     iat: nowSeconds,
-    exp: nowSeconds + 2 * 60 * 60,
+    exp: nowSeconds + SANDBOX_TOKEN_TTL_SECONDS,
   };
 
   return SANDBOX_TOKEN_PREFIX + signJwt(payload);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9555,7 +9555,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
-  it("keeps claim auth valid through timeout finalization and expires it after three hours", async () => {
+  it("keeps claim auth valid through timeout completion and final telemetry", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -9576,13 +9576,6 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     };
 
     mockNow(issuedAt + 2 * 60 * 60 * 1000 + 60_000);
-    const telemetry = await webhooks.requestAgentTelemetry(
-      { runId: run.runId },
-      sandboxHeaders,
-      [200],
-    );
-    expect(telemetry.body).toStrictEqual({ success: true, id: run.runId });
-
     const completion = await webhooks.requestAgentComplete(
       {
         runId: run.runId,
@@ -9597,6 +9590,13 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const failed = await api.readRun(actor, run.runId);
     expect(failed.status).toBe("failed");
     expect(failed.error).toBe("runner job timed out");
+
+    const telemetry = await webhooks.requestAgentTelemetry(
+      { runId: run.runId },
+      sandboxHeaders,
+      [200],
+    );
+    expect(telemetry.body).toStrictEqual({ success: true, id: run.runId });
 
     mockNow(issuedAt + 3 * 60 * 60 * 1000 + 1000);
     const expiredTelemetry = await webhooks.requestAgentTelemetry(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9555,6 +9555,59 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
+  it("keeps claim auth valid through timeout finalization and expires it after three hours", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const issuedAt = now();
+    mockNow(issuedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "time out after the runner execution budget",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const sandboxHeaders = {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    };
+
+    mockNow(issuedAt + 2 * 60 * 60 * 1000 + 60_000);
+    const telemetry = await webhooks.requestAgentTelemetry(
+      { runId: run.runId },
+      sandboxHeaders,
+      [200],
+    );
+    expect(telemetry.body).toStrictEqual({ success: true, id: run.runId });
+
+    const completion = await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 124,
+        error: "runner job timed out",
+        lastEventSequence: 0,
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(completion.body).toStrictEqual({ success: true, status: "failed" });
+    const failed = await api.readRun(actor, run.runId);
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("runner job timed out");
+
+    mockNow(issuedAt + 3 * 60 * 60 * 1000 + 1000);
+    const expiredTelemetry = await webhooks.requestAgentTelemetry(
+      { runId: run.runId },
+      sandboxHeaders,
+      [401],
+    );
+    expectApiError(expiredTelemetry.body);
+    expect(expiredTelemetry.body.error.code).toBe("UNAUTHORIZED");
+  });
+
   it("acknowledges a clean exit whose missing checkpoint fails the run", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);


### PR DESCRIPTION
## Summary

- extend runner claim sandbox tokens from two hours to three hours
- keep completion and final telemetry authenticated after the runner's two-hour execution limit
- cover the runner's actual completion-before-final-telemetry ordering and the new expiry boundary through API routes

## Scope

- keeps the `ZERO_TOKEN` lifetime unchanged
- does not change the runner execution timeout or webhook authentication semantics

## Validation

- `pnpm exec prettier --check apps/api/src/signals/auth/tokens.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "keeps claim auth valid through timeout completion and final telemetry" --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "auth tokens|RUN-03" --maxWorkers=1 --silent=passed-only`

A local full API suite attempt with `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` passed 2,291 tests and had three unrelated local fixture, ordering, or concurrency failures. The concurrency case passed when rerun serially. The submitted head subsequently passed all eight API test shards and the Turbo CI gate in GitHub Actions.

Closes #22477
