### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,10 +113,10 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.216"
-CODEX_CLI_VERSION="0.144.6"
+CLAUDE_CODE_VERSION="2.1.217"
+CODEX_CLI_VERSION="0.145.0"
 GWS_CLI_VERSION="0.22.5"
-XURL_VERSION="1.2.3"
+XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.32.3"
 PNPM_VERSION="11.15.1"
 CHROMIUM_VERSION="150.0.7871.124-1~deb12u1"
@@ -461,9 +461,9 @@ install_runtimes() {
       arm64) PLATFORM=\"linux-arm64\" ;;
       *) echo \"Unsupported architecture: \$ARCH\" >&2; exit 1 ;;
     esac
-    GCS_BUCKET=\"https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases\"
-    curl -fsSL \"\${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/\${PLATFORM}/claude\" -o /usr/local/bin/claude
-    CHECKSUM=\$(curl -fsSL \"\${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/manifest.json\" \
+    DOWNLOAD_BASE_URL=\"https://downloads.claude.ai/claude-code-releases\"
+    curl -fsSL \"\${DOWNLOAD_BASE_URL}/${CLAUDE_CODE_VERSION}/\${PLATFORM}/claude\" -o /usr/local/bin/claude
+    CHECKSUM=\$(curl -fsSL \"\${DOWNLOAD_BASE_URL}/${CLAUDE_CODE_VERSION}/manifest.json\" \
       | jq -r \".platforms[\\\"\$PLATFORM\\\"].checksum\")
     echo \"\${CHECKSUM}  /usr/local/bin/claude\" | sha256sum -c -
     chmod +x /usr/local/bin/claude


### PR DESCRIPTION
## Summary

- Update Claude Code from 2.1.216 to 2.1.217.
- Update Codex CLI from 0.144.6 to 0.145.0.
- Update xurl from 1.2.3 to 1.3.1.
- Move Claude Code downloads from the retired Google Storage endpoint to Anthropic’s current official downloads endpoint.

## Verification

- Confirmed each updated version is the latest stable release from its authoritative registry.
- Confirmed Claude Code 2.1.217 manifests and binaries are available for linux-x64 and linux-arm64.
- Confirmed the pinned Chromium package remains the latest Bookworm security release.
- Confirmed Node.js 24 remains the latest LTS major and PostgreSQL 18 remains the latest major.
- Ran bash -n crates/runner/scripts/build-template.sh.
- Ran git diff --check.