### PR TITLE
fix(guest-agent): set sol reasoning effort to max

### DIFF
--- a/.github/scripts/runner-behavior-drain-resume.sh
+++ b/.github/scripts/runner-behavior-drain-resume.sh
@@ -24,6 +24,7 @@ SVC="${JOB_REF}-drain"
 UNIT="vm0-runner-${SVC}.service"
 DRAIN_DROP_IN="/run/systemd/system/${UNIT}.d/50-vm0-drain.conf"
 GROUP="vm0/drain-${JOB_REF}"
+GROUP_DIR="/var/lib/vm0-runner/groups/${GROUP}"
 SUBMIT_A_PID=""
 SUBMIT_B_PID=""
 RELEASE_FIFO_READY=""
@@ -48,11 +49,13 @@ cleanup() {
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   cleanup_submit_pid "$SUBMIT_B_PID"
   cleanup_submit_pid "$SUBMIT_A_PID"
+  sudo rm -rf -- "$GROUP_DIR"
 }
 trap cleanup EXIT
 
-# Clean up any residual transient unit from a previous CI run.
+# Clean up residual service and queue state from previous CI attempts.
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+sudo rm -rf -- "$GROUP_DIR"
 
 # Start transient runner service.
 echo "--- Starting runner ---"

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -184,7 +184,7 @@ fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
 pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'static str> {
     let bare = model.strip_prefix("openai/").unwrap_or(model);
     match bare {
-        "gpt-5.6-sol" => Some("xhigh"),
+        "gpt-5.6-sol" => Some("max"),
         "gpt-5.6-terra" => Some("low"),
         "gpt-5.6-luna" => Some("max"),
         "gpt-5.5" => Some("xhigh"),
@@ -662,13 +662,10 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_xhigh() {
+    fn build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_max() {
         for model in ["gpt-5.6-sol", "openai/gpt-5.6-sol"] {
             let args = build_codex_args_for_test(model, "", "p");
-            assert!(codex_args_have_config(
-                &args,
-                "model_reasoning_effort=xhigh"
-            ));
+            assert!(codex_args_have_config(&args, "model_reasoning_effort=max"));
         }
     }
 


### PR DESCRIPTION
## Summary

- default GPT-5.6 Sol runs to `max` reasoning effort instead of `xhigh`
- keep the shared override consistent for both Codex exec and app-server backends
- cover both bare and `openai/`-prefixed Sol model names in the existing regression test
- reset the drain/resume CI test queue before and after each attempt so retries cannot consume stale local jobs

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_max`
- CI-equivalent Bash syntax, ShellCheck, and workflow shell compatibility checks
- all `.github/scripts/tests/*.sh` tests
