### PR TITLE
feat: report unread chat threads in the morning brief email

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -602,11 +602,11 @@ describe("cron execute morning briefs", () => {
     // sources are annotated as failed instead of gating the whole brief.
     const { runId } = await findMorningBriefThread(scenario);
     const input = capturedMorningBriefInput();
-    expect(input.sources.github?.ok).toBe(false);
-    expect(input.sources.gmail?.ok).toBe(false);
-    expect(input.sources.calendar?.ok).toBe(false);
-    expect(input.sources.chatThreads?.ok).toBe(true);
-    expect(input.sources.chatThreads?.data?.threads).toEqual([]);
+    expect(input.sources.github?.ok).toBeFalsy();
+    expect(input.sources.gmail?.ok).toBeFalsy();
+    expect(input.sources.calendar?.ok).toBeFalsy();
+    expect(input.sources.chatThreads?.ok).toBeTruthy();
+    expect(input.sources.chatThreads?.data?.threads).toStrictEqual([]);
 
     mockUploadedBriefOutput(
       JSON.stringify({

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -267,6 +267,7 @@ async function setupMorningBriefActor(
 ): Promise<Scenario> {
   mockEnv("CRON_SECRET", CRON_SECRET);
   mockEnv("RESEND_FROM_DOMAIN", "vm0.bot");
+  mockEnv("APP_URL", "https://app.vm0.test");
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
   mockNow(BEFORE_SEVEN_LOCAL);
 
@@ -364,6 +365,33 @@ async function findMorningBriefThread(scenario: Scenario): Promise<{
     throw new Error("Expected a Morning Brief chat thread");
   }
   return found;
+}
+
+function capturedMorningBriefInput(): {
+  readonly sources: Record<
+    string,
+    { readonly ok: boolean; readonly data?: { readonly threads?: unknown[] } }
+  >;
+} {
+  const put = context.mocks.s3.send.mock.calls
+    .map(([command]) => {
+      return command as {
+        readonly constructor: { readonly name: string };
+        readonly input?: { readonly Key?: string; readonly Body?: string };
+      };
+    })
+    .find((command) => {
+      return (
+        command.constructor.name === "PutObjectCommand" &&
+        command.input?.Key?.endsWith("input.json") === true
+      );
+    });
+  if (!put?.input?.Body) {
+    throw new Error("Expected the staged morning brief input.json upload");
+  }
+  return JSON.parse(put.input.Body) as ReturnType<
+    typeof capturedMorningBriefInput
+  >;
 }
 
 function mockUploadedBriefOutput(body: string): void {
@@ -561,11 +589,63 @@ describe("cron execute morning briefs", () => {
     clearMockNow();
   });
 
-  it("skips members without supported connectors", async () => {
+  it("delivers a brief from vm0 chat threads when no connectors are connected", async () => {
+    context.mocks.resend.send.mockResolvedValue({
+      data: { id: "resend-threads-only-brief" },
+      error: null,
+    });
     const scenario = await setupMorningBriefActor({ connectConnectors: false });
     mockNow(AFTER_SEVEN_LOCAL);
     await executeMorningBriefsCron();
-    await expect(findMorningBriefThreadOrNull(scenario)).resolves.toBeNull();
+
+    // The brief runs on the internal chat-threads source alone; connector
+    // sources are annotated as failed instead of gating the whole brief.
+    const { runId } = await findMorningBriefThread(scenario);
+    const input = capturedMorningBriefInput();
+    expect(input.sources.github?.ok).toBe(false);
+    expect(input.sources.gmail?.ok).toBe(false);
+    expect(input.sources.calendar?.ok).toBe(false);
+    expect(input.sources.chatThreads?.ok).toBe(true);
+    expect(input.sources.chatThreads?.data?.threads).toEqual([]);
+
+    mockUploadedBriefOutput(
+      JSON.stringify({
+        version: 1,
+        headline: "One task finished while you were away.",
+        sections: [
+          {
+            key: "unread_threads",
+            title: "Task results you haven't seen",
+            items: [
+              {
+                title: "Competitor research finished",
+                detail: "The report is ready in the thread.",
+                url: "https://app.vm0.test/chats/123e4567-e89b-12d3-a456-426614174000",
+              },
+              {
+                title: "Sketchy link that must be dropped",
+                url: "https://evil.example.com/chats/1",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    await completeMorningBriefRun(scenario, runId, 0);
+    await drainOutbox();
+
+    const emails = sentMorningBriefEmails();
+    expect(emails).toHaveLength(1);
+    const email = emails[0];
+    if (!email) {
+      throw new Error("Expected a morning brief email");
+    }
+    expect(email.html).toContain("Competitor research finished");
+    // App-origin thread links survive sanitization; foreign hosts do not.
+    expect(email.html).toContain(
+      "https://app.vm0.test/chats/123e4567-e89b-12d3-a456-426614174000",
+    );
+    expect(email.html).not.toContain("evil.example.com");
     clearMockNow();
   });
 

--- a/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
@@ -39,6 +39,7 @@ const callbackPayloadSchema = z.object({
 const SECTION_KEYS = [
   "schedule",
   "needs_attention",
+  "unread_threads",
   "github_updates",
   "email_updates",
   "suggestions",
@@ -76,17 +77,20 @@ function isAllowedSourceHost(hostname: string): boolean {
   );
 }
 
-/** Only https links straight into Gmail, Calendar, or GitHub survive. */
+/** Only https links into Gmail, Calendar, GitHub, or the vm0 app survive. */
 function sanitizeSourceUrl(url: string | undefined): string | undefined {
   if (!url) {
     return undefined;
   }
   const parsed = safeUrlParse(url);
-  if (
-    !parsed ||
-    parsed.protocol !== "https:" ||
-    !isAllowedSourceHost(parsed.hostname)
-  ) {
+  if (!parsed || parsed.protocol !== "https:") {
+    return undefined;
+  }
+  const app = safeUrlParse(appUrl());
+  if (app && parsed.origin === app.origin) {
+    return url;
+  }
+  if (!isAllowedSourceHost(parsed.hostname)) {
     return undefined;
   }
   return url;

--- a/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
@@ -1,13 +1,30 @@
 /**
  * Server-side collectors for the Morning Brief input bundle.
  *
- * Each source (GitHub, Gmail, Google Calendar) resolves the member's connector
- * access token through the shared credential runtime, pulls a bounded window
- * of data, and reports independently: a failed source is annotated in the
- * input JSON instead of blocking the brief.
+ * Connector sources (GitHub, Gmail, Google Calendar) resolve the member's
+ * connector access token through the shared credential runtime and pull a
+ * bounded window of data. The chat-threads source reads unread vm0 chat
+ * threads straight from the database. Each source reports independently: a
+ * failed source is annotated in the input JSON instead of blocking the brief.
  */
 import { z } from "zod";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import {
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  isNotNull,
+  isNull,
+  lte,
+  ne,
+  or,
+} from "drizzle-orm";
 
+import { env } from "../../lib/env";
 import type { Db } from "../external/db";
 import { settle } from "../utils";
 import { nowDate } from "../external/time";
@@ -28,8 +45,10 @@ const MAX_GMAIL_MESSAGES = 25;
 const MAX_GITHUB_NOTIFICATIONS = 50;
 const MAX_GITHUB_SEARCH_RESULTS = 25;
 const MAX_CALENDAR_EVENTS = 50;
+const MAX_UNREAD_THREADS = 10;
+const MAX_THREAD_MESSAGES = 3;
 
-export const MORNING_BRIEF_CONNECTOR_REFS = [
+const MORNING_BRIEF_CONNECTOR_REFS = [
   "github",
   "gmail",
   "google-calendar",
@@ -521,6 +540,108 @@ async function collectCalendar(
   return { events };
 }
 
+// --- Unread vm0 chat threads ------------------------------------------------
+
+interface MorningBriefThreadMessage {
+  readonly role: string;
+  readonly content: string;
+  readonly at: string;
+}
+
+interface MorningBriefUnreadThread {
+  readonly threadId: string;
+  readonly title: string | null;
+  /** Deep link into the vm0 app; ready to use as the brief item url. */
+  readonly url: string;
+  readonly lastMessageAt: string;
+  readonly recentMessages: readonly MorningBriefThreadMessage[];
+}
+
+export interface MorningBriefChatThreadsData {
+  readonly threads: readonly MorningBriefUnreadThread[];
+}
+
+/**
+ * Threads whose latest message landed inside the window and past the user's
+ * read watermark — typically runs that finished after the user left. The
+ * Morning Brief thread itself is excluded so yesterday's brief never reports
+ * on itself.
+ */
+async function collectUnreadChatThreads(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly since: Date;
+  readonly until: Date;
+  readonly excludeChatThreadId: string | null;
+}): Promise<MorningBriefChatThreadsData> {
+  const appUrl = env("APP_URL");
+  const rows = await args.db
+    .select({
+      id: chatThreads.id,
+      title: chatThreads.title,
+      lastMessageAt: chatThreads.lastMessageAt,
+    })
+    .from(chatThreads)
+    .innerJoin(agentComposes, eq(chatThreads.agentComposeId, agentComposes.id))
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(chatThreads.userId, args.userId),
+        gte(chatThreads.lastMessageAt, args.since),
+        lte(chatThreads.lastMessageAt, args.until),
+        or(
+          isNull(chatThreads.lastReadAt),
+          gt(chatThreads.lastMessageAt, chatThreads.lastReadAt),
+        ),
+        ...(args.excludeChatThreadId
+          ? [ne(chatThreads.id, args.excludeChatThreadId)]
+          : []),
+      ),
+    )
+    .orderBy(desc(chatThreads.lastMessageAt))
+    .limit(MAX_UNREAD_THREADS);
+
+  const threads: MorningBriefUnreadThread[] = [];
+  for (const row of rows) {
+    const messages = await args.db
+      .select({
+        role: chatMessages.role,
+        content: chatMessages.content,
+        createdAt: chatMessages.createdAt,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, row.id),
+          isNotNull(chatMessages.content),
+        ),
+      )
+      .orderBy(desc(chatMessages.createdAt))
+      .limit(MAX_THREAD_MESSAGES);
+    threads.push({
+      threadId: row.id,
+      title: row.title,
+      url: `${appUrl}/chats/${row.id}`,
+      lastMessageAt: row.lastMessageAt.toISOString(),
+      recentMessages: messages
+        .reverse()
+        .filter((message) => {
+          return message.content !== null;
+        })
+        .map((message) => {
+          return {
+            role: message.role,
+            content: message.content ?? "",
+            at: message.createdAt.toISOString(),
+          };
+        }),
+    });
+  }
+
+  return { threads };
+}
+
 // --- Combined input ---------------------------------------------------------
 
 interface MorningBriefSource<T> {
@@ -539,6 +660,7 @@ export interface MorningBriefInput {
     readonly github: MorningBriefSource<MorningBriefGithubData>;
     readonly gmail: MorningBriefSource<MorningBriefGmailData>;
     readonly calendar: MorningBriefSource<MorningBriefCalendarData>;
+    readonly chatThreads: MorningBriefSource<MorningBriefChatThreadsData>;
   };
 }
 
@@ -570,6 +692,8 @@ interface CollectMorningBriefInputArgs {
   readonly until: Date;
   readonly dayStart: Date;
   readonly dayEnd: Date;
+  /** The member's Morning Brief thread; never reported as unread. */
+  readonly excludeChatThreadId: string | null;
   readonly signal: AbortSignal;
 }
 
@@ -599,7 +723,7 @@ export async function collectMorningBriefInput(
     });
   };
 
-  const [github, gmail, calendar] = await Promise.all([
+  const [github, gmail, calendar, chatThreadsSource] = await Promise.all([
     withAccess("github", (access) => {
       return collectGithub(access, args.since, args.signal);
     }),
@@ -608,6 +732,16 @@ export async function collectMorningBriefInput(
     }),
     withAccess("google-calendar", (access) => {
       return collectCalendar(access, args.dayStart, args.dayEnd, args.signal);
+    }),
+    collectSource(() => {
+      return collectUnreadChatThreads({
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        since: args.since,
+        until: args.until,
+        excludeChatThreadId: args.excludeChatThreadId,
+      });
     }),
   ]);
 
@@ -620,6 +754,6 @@ export async function collectMorningBriefInput(
       since: args.since.toISOString(),
       until: args.until.toISOString(),
     },
-    sources: { github, gmail, calendar },
+    sources: { github, gmail, calendar, chatThreads: chatThreadsSource },
   };
 }

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -2,7 +2,6 @@ import { randomBytes } from "node:crypto";
 
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { connectors } from "@vm0/db/schema/connector";
 import {
   morningBriefDeliveries,
   morningBriefSchedules,
@@ -10,7 +9,7 @@ import {
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
-import { and, asc, eq, inArray, isNotNull, lte } from "drizzle-orm";
+import { and, asc, eq, isNotNull, lte } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -27,7 +26,6 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   collectMorningBriefInput,
-  MORNING_BRIEF_CONNECTOR_REFS,
   type MorningBriefInput,
 } from "./morning-brief-collect.service";
 import {
@@ -110,26 +108,6 @@ async function claimSchedule(
   return claimed.length > 0;
 }
 
-async function connectedMorningBriefConnectors(
-  db: Db,
-  orgId: string,
-  userId: string,
-): Promise<readonly string[]> {
-  const rows = await db
-    .select({ type: connectors.type })
-    .from(connectors)
-    .where(
-      and(
-        eq(connectors.orgId, orgId),
-        eq(connectors.userId, userId),
-        inArray(connectors.type, [...MORNING_BRIEF_CONNECTOR_REFS]),
-      ),
-    );
-  return rows.map((row) => {
-    return row.type;
-  });
-}
-
 async function markDeliveryFailed(
   db: Db,
   deliveryId: string,
@@ -156,11 +134,12 @@ function buildMorningBriefAppendSystemPrompt(args: {
     "# Morning Brief run",
     `You are generating the user's Morning Brief for ${args.briefDate} (timezone ${args.timezone}).`,
     "",
-    "1. Download the collected data (GitHub, Gmail, Google Calendar) with an HTTP GET request to this URL (valid for 30 minutes):",
+    "1. Download the collected data (GitHub, Gmail, Google Calendar, unread vm0 chat threads) with an HTTP GET request to this URL (valid for 30 minutes):",
     args.inputUrl,
     "2. Analyze the data and write the brief. Only use predefined sections, omit empty ones, order by importance:",
     "   - `schedule`: today's meetings and events",
     "   - `needs_attention`: items that need the user's action or reply",
+    "   - `unread_threads`: vm0 chat threads with results the user has not read yet — summarize what each task produced while they were away",
     "   - `github_updates`: PRs, reviews, CI, mentions involving the user",
     "   - `email_updates`: notable email threads",
     "   - `suggestions`: at most 3 suggestions, each grounded in today's data",
@@ -171,9 +150,9 @@ function buildMorningBriefAppendSystemPrompt(args: {
     "   {",
     '     "version": 1,',
     '     "headline": "one-sentence generic summary without sensitive details",',
-    '     "sections": [{"key": "schedule|needs_attention|github_updates|email_updates|suggestions", "title": "string", "items": [{"title": "string", "detail": "string (optional)", "url": "https source link (optional)"}]}]',
+    '     "sections": [{"key": "schedule|needs_attention|unread_threads|github_updates|email_updates|suggestions", "title": "string", "items": [{"title": "string", "detail": "string (optional)", "url": "https source link (optional)"}]}]',
     "   }",
-    "   Item `url` values must point at the original Gmail message, Calendar event, or GitHub page.",
+    "   Item `url` values must point at the original Gmail message, Calendar event, GitHub page, or the vm0 chat thread `url` provided in the input.",
     "5. Also post the same brief as well-formatted Markdown in this chat so the user can read it here and ask follow-up questions.",
     "6. If a source in the input is marked failed, mention briefly in the brief that the source was unavailable.",
     "The email is assembled server-side from the uploaded JSON; do not try to send any email yourself.",
@@ -184,7 +163,8 @@ function allSourcesFailed(input: MorningBriefInput): boolean {
   return (
     !input.sources.github.ok &&
     !input.sources.gmail.ok &&
-    !input.sources.calendar.ok
+    !input.sources.calendar.ok &&
+    !input.sources.chatThreads.ok
   );
 }
 
@@ -196,7 +176,7 @@ interface ClaimedMorningBrief {
   readonly currentTime: Date;
 }
 
-/** Feature, connector, and once-per-local-date gates; claims the delivery row. */
+/** Feature and once-per-local-date gates; claims the delivery row. */
 async function admitMorningBriefDelivery(
   db: Db,
   row: DueMorningBriefRow,
@@ -215,16 +195,6 @@ async function admitMorningBriefDelivery(
   );
   signal.throwIfAborted();
   if (!isFeatureEnabled(FeatureSwitchKey.MorningBrief, featureSwitchContext)) {
-    return null;
-  }
-
-  const connected = await connectedMorningBriefConnectors(
-    db,
-    row.orgId,
-    row.userId,
-  );
-  signal.throwIfAborted();
-  if (connected.length === 0) {
     return null;
   }
 
@@ -286,6 +256,7 @@ const stageMorningBriefInput$ = command(
       until: currentTime,
       dayStart,
       dayEnd,
+      excludeChatThreadId: row.chatThreadId,
       signal,
     });
     signal.throwIfAborted();
@@ -294,7 +265,7 @@ const stageMorningBriefInput$ = command(
       await markDeliveryFailed(
         db,
         claimed.deliveryId,
-        "All connector sources failed",
+        "All morning brief sources failed",
         currentTime,
       );
       signal.throwIfAborted();
@@ -659,19 +630,6 @@ async function admitManualMorningBrief(
     };
   }
 
-  const connected = await connectedMorningBriefConnectors(
-    db,
-    args.orgId,
-    args.userId,
-  );
-  signal.throwIfAborted();
-  if (connected.length === 0) {
-    return {
-      kind: "bad_request",
-      message: "Connect GitHub, Gmail, or Google Calendar first",
-    };
-  }
-
   // Ensure a schedule row exists so the created chat thread binding
   // persists across manual triggers (next_run_at stays untouched).
   await db
@@ -786,7 +744,10 @@ export const triggerMorningBriefNow$ = command(
 
     const staged = await set(stageMorningBriefInput$, claimed, signal);
     if (!staged) {
-      return { kind: "bad_request", message: "All connector sources failed" };
+      return {
+        kind: "bad_request",
+        message: "All morning brief sources failed",
+      };
     }
 
     const started = await set(


### PR DESCRIPTION
## Summary

The Morning Brief previously drew only on external connector signals (GitHub, Gmail, Google Calendar), so a user who kicked off a long task and closed the tab never heard about the result. This PR adds the user's own vm0 activity as a fourth brief source and turns the email into a recall channel:

- **New collector** (`morning-brief-collect.service.ts`): queries `chat_threads` for threads whose `last_message_at` falls inside the brief window and is past the `last_read_at` watermark (or the thread was never read) — exactly the "run finished but the user never came back" case, since terminal run markers advance `last_message_at`. Scoped to the member's org via `agent_composes`, capped at 10 threads with the last 3 messages each, and always excludes the member's own Morning Brief thread so yesterday's brief never reports on itself. Ready-to-use `APP_URL/chats/<id>` deep links are computed server-side.
- **New `unread_threads` section**: added to the agent prompt (positioned right after `needs_attention`) and to the server-side output schema. The email link sanitizer now also allows app-origin URLs so thread deep links survive, while foreign hosts are still stripped.
- **Connector gate removed** (intentional semantic change): briefs no longer require a connected GitHub/Gmail/Calendar connector, in both the cron and manual-trigger paths. The internal chat-threads source is always available, so newly registered users with zero connectors — the main recall target — now get briefs too. Failed connector sources are still annotated per-source, and the brief only aborts if *all four* sources fail. The feature remains double-gated by the `MorningBrief` feature switch and the opt-in user preference, so rollout scope is unchanged.

## Verification

- ESLint and Prettier pass on all touched files (full `tsc` OOMs in my sandbox; relying on CI).
- Integration test updated: replaced "skips members without supported connectors" with an end-to-end test asserting that a connector-less member still gets a brief, that the staged `input.json` marks connector sources failed but `chatThreads` ok, and that an `unread_threads` section renders in the sent email with the app-origin link preserved and an evil-host link stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)