### PR TITLE
chore(api): replace simple existence sql tags

### DIFF
--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -529,17 +529,21 @@ function recordPollTimingMetrics(args: {
   ]);
 }
 
-function runnerPollPriorityOrder(args: {
-  readonly runnerId: string | undefined;
-  readonly runnerGroup: string;
-  readonly currentDate: Date;
-}): SQL[] {
+function runnerPollPriorityOrder(
+  db: Pick<Db, "select">,
+  args: {
+    readonly runnerId: string | undefined;
+    readonly runnerGroup: string;
+    readonly currentDate: Date;
+  },
+): SQL[] {
   if (!args.runnerId) {
     return [];
   }
   return [
     desc(
       runnerSessionAffinityPollPriority({
+        db,
         runnerId: args.runnerId,
         runnerGroup: args.runnerGroup,
         currentDate: args.currentDate,
@@ -587,7 +591,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const db = set(writeDb$);
   const pendingJobLookupStartedAtMs = now();
   const currentDate = nowDate();
-  const sessionAffinityPriorityOrder = runnerPollPriorityOrder({
+  const sessionAffinityPriorityOrder = runnerPollPriorityOrder(db, {
     runnerId: body.data.runnerId,
     runnerGroup: group,
     currentDate,

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, sql, type SQL } from "drizzle-orm";
+import { and, eq, exists, sql, type SQL } from "drizzle-orm";
 import { artifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatMessages } from "@vm0/db/schema/chat-message";
@@ -53,39 +53,59 @@ function publicArtifactObjectKey(url: string): string | null {
   return key.length > 0 ? key : null;
 }
 
-function uploadedArtifactAccessCondition(args: UserArtifactUrlAccessArgs): SQL {
-  return sql`EXISTS (
-    SELECT 1
-    FROM ${runUploadedFiles}
-    WHERE ${eq(runUploadedFiles.userId, args.userId)}
-      AND ${eq(runUploadedFiles.orgId, args.orgId)}
-      AND ${eq(runUploadedFiles.url, args.artifactUrl)}
-    LIMIT 1
-  )`;
+function uploadedArtifactAccessCondition(
+  db: Pick<Db, "select">,
+  args: UserArtifactUrlAccessArgs,
+): SQL {
+  return exists(
+    db
+      .select({ id: runUploadedFiles.id })
+      .from(runUploadedFiles)
+      .where(
+        and(
+          eq(runUploadedFiles.userId, args.userId),
+          eq(runUploadedFiles.orgId, args.orgId),
+          eq(runUploadedFiles.url, args.artifactUrl),
+        ),
+      ),
+  );
 }
 
-function attachedArtifactAccessCondition(args: UserArtifactUrlAccessArgs): SQL {
+function attachedArtifactAccessCondition(
+  db: Pick<Db, "select">,
+  args: UserArtifactUrlAccessArgs,
+): SQL {
   const objectKey = publicArtifactObjectKey(args.artifactUrl);
   if (objectKey === null) {
     return sql`FALSE`;
   }
 
-  return sql`EXISTS (
-    SELECT 1
-    FROM ${chatMessages}
-    INNER JOIN ${chatThreads}
-      ON ${eq(chatThreads.id, chatMessages.chatThreadId)}
-    INNER JOIN ${agentComposes}
-      ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
-    WHERE ${eq(chatThreads.userId, args.userId)}
-      AND ${eq(agentComposes.orgId, args.orgId)}
-      AND EXISTS (
-        SELECT 1
-        FROM jsonb_array_elements(COALESCE(${chatMessages.attachFileMetadata}, '[]'::jsonb)) AS attached_file
-        WHERE attached_file->>'objectKey' = ${objectKey}
+  const attachedFile = sql`jsonb_array_elements(
+    COALESCE(${chatMessages.attachFileMetadata}, '[]'::jsonb)
+  ) AS attached_file`;
+  const attachedFileObjectKey = sql`attached_file->>'objectKey'`;
+  return exists(
+    db
+      .select({ id: chatMessages.id })
+      .from(chatMessages)
+      .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
+      .innerJoin(
+        agentComposes,
+        eq(agentComposes.id, chatThreads.agentComposeId),
       )
-    LIMIT 1
-  )`;
+      .where(
+        and(
+          eq(chatThreads.userId, args.userId),
+          eq(agentComposes.orgId, args.orgId),
+          exists(
+            db
+              .select({ one: sql`1`.mapWith(Number) })
+              .from(attachedFile)
+              .where(eq(attachedFileObjectKey, objectKey)),
+          ),
+        ),
+      ),
+  );
 }
 
 async function userCanAccessArtifactUrl(
@@ -96,8 +116,8 @@ async function userCanAccessArtifactUrl(
     db,
     sql`
       SELECT (
-        ${uploadedArtifactAccessCondition(args)}
-        OR ${attachedArtifactAccessCondition(args)}
+        ${uploadedArtifactAccessCondition(db, args)}
+        OR ${attachedArtifactAccessCondition(db, args)}
       ) AS "canAccess"
     `,
     artifactAccessRowSchema,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -839,7 +839,7 @@ async function getLatestRunsByThreadId(
         isNotNull(chatMessages.content),
         inArray(chatMessages.runId, runIds),
         inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(db),
       ),
     )
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
@@ -39,7 +39,7 @@ export const monitorChatMessageQueue$ = command(
           isNull(chatMessages.runId),
           isNotNull(chatMessages.content),
           isNull(chatMessages.error),
-          visibleChatMessageCondition(),
+          visibleChatMessageCondition(db),
           notExists(
             db
               .select({ id: chatMessageQueue.id })

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1392,7 +1392,7 @@ async function getLatestRunsByThreadId(
         isNotNull(chatMessages.content),
         inArray(chatMessages.runId, runIds),
         inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(db),
       ),
     )
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -5,6 +5,7 @@ import {
   and,
   arrayContains,
   eq,
+  exists,
   gt,
   isNotNull,
   sql,
@@ -74,26 +75,30 @@ function capableWorkspaceCondition(args: {
 }
 
 function runnerStateHas(args: {
+  readonly db: Pick<Db, "select">;
   readonly runnerId?: string;
   readonly runnerGroup: string;
   readonly freshAfter: Date;
   readonly resourceCondition: SQL;
 }): SQL {
-  const runnerCondition = args.runnerId
-    ? sql`AND ${eq(runnerState.runnerId, args.runnerId)}`
-    : sql.empty();
-  return sql`EXISTS (
-    SELECT 1
-    FROM ${runnerState}
-    WHERE ${eq(runnerState.runnerGroup, args.runnerGroup)}
-      ${runnerCondition}
-      AND ${runnerState.mode} = 'running'
-      AND ${gt(runnerState.lastSeenAt, args.freshAfter)}
-      AND ${args.resourceCondition}
-  )`;
+  return exists(
+    args.db
+      .select({ runnerId: runnerState.runnerId })
+      .from(runnerState)
+      .where(
+        and(
+          eq(runnerState.runnerGroup, args.runnerGroup),
+          ...(args.runnerId ? [eq(runnerState.runnerId, args.runnerId)] : []),
+          eq(runnerState.mode, "running"),
+          gt(runnerState.lastSeenAt, args.freshAfter),
+          args.resourceCondition,
+        ),
+      ),
+  );
 }
 
 export function runnerSessionAffinityPollPriority(args: {
+  readonly db: Pick<Db, "select">;
   readonly runnerId: string;
   readonly runnerGroup: string;
   readonly currentDate: Date;
@@ -118,6 +123,7 @@ export function runnerSessionAffinityPollPriority(args: {
   const workspaceCondition = capableWorkspaceCondition({ sessionId, profile });
   const global = (resourceCondition: SQL) => {
     return runnerStateHas({
+      db: args.db,
       runnerGroup: args.runnerGroup,
       freshAfter,
       resourceCondition,
@@ -125,6 +131,7 @@ export function runnerSessionAffinityPollPriority(args: {
   };
   const local = (resourceCondition: SQL) => {
     return runnerStateHas({
+      db: args.db,
       runnerId: args.runnerId,
       runnerGroup: args.runnerGroup,
       freshAfter,

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -85,7 +85,7 @@ async function selectIncompleteRoundFrontier(
           AND NOT (
             ${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)
           )
-          AND ${visibleChatMessageCondition()}
+          AND ${visibleChatMessageCondition(db)}
           AND (
             (${isSuccessfulRun})
             OR (
@@ -176,7 +176,7 @@ async function loadSelectedIncompleteRounds(
         eq(chatMessages.chatThreadId, threadId),
         inArray(chatMessages.runId, runIds),
         inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(db),
         ...(selection.successfulRunId === null
           ? []
           : [afterSuccessfulRunBoundary(threadId, selection.successfulRunId)]),

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -89,7 +89,7 @@ async function loadThinkingContextMessages(args: {
         eq(chatMessages.chatThreadId, args.threadId),
         isNotNull(chatMessages.content),
         inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(args.db),
         not(queuedUserMessageExists(args.db)),
         isNull(chatMessages.runLifecycleEvent),
         isNull(chatMessages.recommendedFollowups),

--- a/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
@@ -6,7 +6,8 @@ import {
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { eq, isNotNull, isNull, ne, notExists, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 
 import { env } from "../../lib/env";
 import {
@@ -53,6 +54,7 @@ const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   htm: "text/html",
   json: "application/json",
 };
+const revoker = alias(chatMessages, "revoker");
 
 interface InsertAssistantEventMessagesInput {
   readonly runId: string;
@@ -103,24 +105,30 @@ export async function touchChatThreadLastMessageAt(
   });
 }
 
-export function visibleChatMessageCondition() {
-  return sql`NOT EXISTS (
-      SELECT 1
-      FROM ${chatMessages} AS revoker
-      WHERE revoker.revokes_message_id = ${chatMessages.id}
-    )
-    AND NOT (
-      ${chatMessages.role} = 'user'
-      AND ${isNull(chatMessages.runId)}
-      AND ${isNotNull(chatMessages.revokesMessageId)}
-      AND ${isNull(chatMessages.content)}
-      AND ${isNull(chatMessages.error)}
-    )
-    AND NOT (
-      ${chatMessages.role} = 'user'
-      AND ${isNull(chatMessages.runId)}
-      AND ${isNotNull(chatMessages.interruptsRunId)}
-    )`;
+export function visibleChatMessageCondition(db: Pick<Db, "select">) {
+  return sql.join(
+    [
+      notExists(
+        db
+          .select({ id: revoker.id })
+          .from(revoker)
+          .where(eq(revoker.revokesMessageId, chatMessages.id)),
+      ),
+      or(
+        ne(chatMessages.role, "user"),
+        isNotNull(chatMessages.runId),
+        isNull(chatMessages.revokesMessageId),
+        isNotNull(chatMessages.content),
+        isNotNull(chatMessages.error),
+      ),
+      or(
+        ne(chatMessages.role, "user"),
+        isNotNull(chatMessages.runId),
+        isNull(chatMessages.interruptsRunId),
+      ),
+    ],
+    sql` AND `,
+  );
 }
 
 export function resolveAttachFileUrls(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -52,6 +52,7 @@ import {
   asc,
   desc,
   eq,
+  exists,
   gt,
   gte,
   ilike,
@@ -59,6 +60,7 @@ import {
   isNotNull,
   isNull,
   lt,
+  notExists,
   or,
   type SQL,
   sql,
@@ -107,6 +109,8 @@ const nullableTimestampDecoder = nullableDriverValueDecoder(
 );
 const TERMINAL_MESSAGE_ORDER_SEQUENCE = 2_147_483_647;
 const matchedChatMessage = alias(chatMessages, "matched_chat_message");
+const hostedRunUploadedFiles = alias(runUploadedFiles, "hosted_files");
+const HOSTED_ARTIFACT_KINDS = ["hosted-site", "presentation-html"] as const;
 
 function chatMessageOrderSequenceSql() {
   return sql`CASE
@@ -240,12 +244,6 @@ const messageColumns = {
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
   )`.mapWith(nullableTriggerSourceDecoder),
-  isGoalRun: sql`EXISTS (
-    SELECT 1
-    FROM ${zeroRuns}
-    WHERE ${eq(zeroRuns.id, chatMessages.runId)}
-      AND ${isNotNull(zeroRuns.goalId)}
-  )`.mapWith(pgBooleanDecoder),
   usagePayload: chatMessages.usagePayload,
   runEventId: chatMessages.runEventId,
   goalEvent: chatMessages.goalEvent,
@@ -409,6 +407,20 @@ const messageColumns = {
     LIMIT 1
   )`.mapWith(nullableTextDecoder),
 } as const;
+
+function selectedMessageColumns(db: Pick<Db, "select">) {
+  return {
+    ...messageColumns,
+    isGoalRun: exists(
+      db
+        .select({ id: zeroRuns.id })
+        .from(zeroRuns)
+        .where(
+          and(eq(zeroRuns.id, chatMessages.runId), isNotNull(zeroRuns.goalId)),
+        ),
+    ).mapWith(pgBooleanDecoder),
+  } as const;
+}
 
 const searchMessageColumns = {
   messageId: chatMessages.id,
@@ -715,23 +727,33 @@ function toPagedMessage(
 
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
 
-function noActiveRunsForCurrentThreadCondition() {
-  return sql`NOT EXISTS (
-    SELECT 1
-    FROM ${zeroRuns}
-    INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
-    WHERE ${eq(zeroRuns.chatThreadId, chatThreads.id)}
-      AND ${inArray(agentRuns.status, ACTIVE_RUN_STATUSES)}
-  )`;
+function noActiveRunsForCurrentThreadCondition(db: Pick<Db, "select">): SQL {
+  return notExists(
+    db
+      .select({ id: zeroRuns.id })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(
+        and(
+          eq(zeroRuns.chatThreadId, chatThreads.id),
+          inArray(agentRuns.status, ACTIVE_RUN_STATUSES),
+        ),
+      ),
+  );
 }
 
-function noActiveGoalsForCurrentThreadCondition() {
-  return sql`NOT EXISTS (
-    SELECT 1
-    FROM ${threadGoals}
-    WHERE ${eq(threadGoals.chatThreadId, chatThreads.id)}
-      AND ${threadGoals.status} = 'active'
-  )`;
+function noActiveGoalsForCurrentThreadCondition(db: Pick<Db, "select">): SQL {
+  return notExists(
+    db
+      .select({ id: threadGoals.id })
+      .from(threadGoals)
+      .where(
+        and(
+          eq(threadGoals.chatThreadId, chatThreads.id),
+          eq(threadGoals.status, "active"),
+        ),
+      ),
+  );
 }
 
 function ownedChatThreadDetail(
@@ -807,8 +829,8 @@ export function zeroChatThreadUnreads(args: {
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
           ),
-          noActiveRunsForCurrentThreadCondition(),
-          noActiveGoalsForCurrentThreadCondition(),
+          noActiveRunsForCurrentThreadCondition(db),
+          noActiveGoalsForCurrentThreadCondition(db),
           ...(args.includeCanonicalSlackThreads
             ? []
             : [excludeCanonicalSlackChatThreads(db, chatThreads.id)]),
@@ -845,8 +867,8 @@ export function zeroChatThreadUnreadAgentIds(args: {
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
           ),
-          noActiveRunsForCurrentThreadCondition(),
-          noActiveGoalsForCurrentThreadCondition(),
+          noActiveRunsForCurrentThreadCondition(db),
+          noActiveGoalsForCurrentThreadCondition(db),
           ...(args.includeCanonicalSlackThreads
             ? []
             : [excludeCanonicalSlackChatThreads(db, chatThreads.id)]),
@@ -940,7 +962,8 @@ export function zeroChatThreadArtifacts(args: {
         return null;
       }
 
-      const rows = await get(db$)
+      const db = get(db$);
+      const rows = await db
         .select({
           runId: runUploadedFiles.runId,
           externalId: runUploadedFiles.externalId,
@@ -959,12 +982,17 @@ export function zeroChatThreadArtifacts(args: {
             eq(runUploadedFiles.userId, args.userId),
             or(
               eq(zeroRuns.chatThreadId, args.threadId),
-              sql`EXISTS (
-                SELECT 1
-                FROM ${chatMessages}
-                WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-                  AND ${eq(chatMessages.chatThreadId, args.threadId)}
-              )`,
+              exists(
+                db
+                  .select({ id: chatMessages.id })
+                  .from(chatMessages)
+                  .where(
+                    and(
+                      eq(chatMessages.runId, runUploadedFiles.runId),
+                      eq(chatMessages.chatThreadId, args.threadId),
+                    ),
+                  ),
+              ),
             ),
           ),
         )
@@ -1038,30 +1066,40 @@ function artifactCallerVisibilityConditions(args: {
   ];
 }
 
-function artifactFileVisibilityConditions(): SQL[] {
+function artifactFileVisibilityConditions(
+  db: Pick<Db, "select">,
+): (SQL | undefined)[] {
+  const hostedArtifactKind = sql`${hostedRunUploadedFiles.metadata}->>'artifactKind'`;
+  const artifactKind = sql`${runUploadedFiles.metadata}->>'artifactKind'`;
   return [
     isNotNull(runUploadedFiles.url),
-    sql`(
-      NOT EXISTS (
-        SELECT 1
-        FROM ${runUploadedFiles} hosted_files
-        WHERE hosted_files.run_id = ${runUploadedFiles.runId}
-          AND (
-            hosted_files.metadata->>'artifactKind' IN ('hosted-site', 'presentation-html')
-          )
-      )
-      OR ${runUploadedFiles.metadata}->>'artifactKind' IN ('hosted-site', 'presentation-html')
-    )`,
+    or(
+      notExists(
+        db
+          .select({ id: hostedRunUploadedFiles.id })
+          .from(hostedRunUploadedFiles)
+          .where(
+            and(
+              eq(hostedRunUploadedFiles.runId, runUploadedFiles.runId),
+              inArray(hostedArtifactKind, HOSTED_ARTIFACT_KINDS),
+            ),
+          ),
+      ),
+      inArray(artifactKind, HOSTED_ARTIFACT_KINDS),
+    ),
   ];
 }
 
-function artifactVisibilityConditions(args: {
-  readonly userId: string;
-  readonly orgId: string;
-}): SQL[] {
+function artifactVisibilityConditions(
+  db: Pick<Db, "select">,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+  },
+): (SQL | undefined)[] {
   return [
     ...artifactCallerVisibilityConditions(args),
-    ...artifactFileVisibilityConditions(),
+    ...artifactFileVisibilityConditions(db),
   ];
 }
 
@@ -1203,7 +1241,7 @@ async function listChangedArtifacts(args: {
     ? sql`(${effectiveUpdatedAt}, ${runUploadedFiles.id}) > (${args.cursor.updatedAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
     : sql`${effectiveUpdatedAt} >= (${args.updatedAfter}::timestamptz AT TIME ZONE 'UTC') - (${ARTIFACT_SYNC_REPLAY_WINDOW_MINUTES} * interval '1 minute')`;
   const callerConditions = artifactCallerVisibilityConditions(args.query);
-  const fileConditions = artifactFileVisibilityConditions();
+  const fileConditions = artifactFileVisibilityConditions(args.db);
   const rows = await executeRawRows(
     args.db,
     sql`
@@ -1317,7 +1355,7 @@ async function listArtifactHistory(args: {
   const keysetClause = args.cursor
     ? sql`AND (${runUploadedFiles.createdAt}, ${runUploadedFiles.id}) < (${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
     : sql.empty();
-  const conditions = artifactVisibilityConditions(args.query);
+  const conditions = artifactVisibilityConditions(args.db, args.query);
   const rows = await executeRawRows(
     args.db,
     sql`
@@ -1463,11 +1501,11 @@ export const artifactFavoriteUrls$ = command(
 );
 
 async function artifactUrlIsVisible(
-  db: Pick<Db, "execute">,
+  db: Pick<Db, "execute" | "select">,
   args: ArtifactFavoriteArgs,
 ): Promise<boolean> {
   const conditions = [
-    ...artifactVisibilityConditions(args),
+    ...artifactVisibilityConditions(db, args),
     eq(runUploadedFiles.url, args.artifactUrl),
   ];
   const rows = await executeRawRows(
@@ -1600,7 +1638,7 @@ function chatSearchContextSideQuery(
           ? lt(chatMessages.createdAt, matchedChatMessage.createdAt)
           : gt(chatMessages.createdAt, matchedChatMessage.createdAt),
         isNotNull(chatMessages.content),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(db),
         excludeGoalMarkerCondition(),
       ),
     )
@@ -1724,7 +1762,7 @@ export function zeroChatSearch(args: {
       eq(chatThreads.userId, args.userId),
       eq(agentComposes.orgId, args.orgId),
       isNotNull(chatMessages.content),
-      visibleChatMessageCondition(),
+      visibleChatMessageCondition(db),
       excludeGoalMarkerCondition(),
       ilike(chatMessages.content, pattern),
       ...(args.includeCanonicalSlackThreads
@@ -1810,7 +1848,7 @@ export function zeroChatThreadMessagesPage(args: {
 
     if (args.sinceId === undefined && args.beforeId === undefined) {
       const latestRows = await db
-        .select(messageColumns)
+        .select(selectedMessageColumns(db))
         .from(chatMessages)
         .where(threadFilter)
         .orderBy(
@@ -1853,7 +1891,7 @@ export function zeroChatThreadMessagesPage(args: {
 
       if (args.sinceId !== undefined) {
         rows = await db
-          .select(messageColumns)
+          .select(selectedMessageColumns(db))
           .from(chatMessages)
           .where(and(threadFilter, cursorAfterCondition))
           .orderBy(
@@ -1864,7 +1902,7 @@ export function zeroChatThreadMessagesPage(args: {
           .limit(args.limit);
       } else {
         const previousRows = await db
-          .select(messageColumns)
+          .select(selectedMessageColumns(db))
           .from(chatMessages)
           .where(and(threadFilter, cursorBeforeCondition))
           .orderBy(
@@ -1902,7 +1940,7 @@ export function zeroChatThreadMessageById(args: {
 
     const db = get(db$);
     const [row] = await db
-      .select(messageColumns)
+      .select(selectedMessageColumns(db))
       .from(chatMessages)
       .where(
         and(

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -201,7 +201,7 @@ async function getLatestTitleContextMessages(
     eq(chatMessages.chatThreadId, threadId),
     isNotNull(chatMessages.content),
     inArray(chatMessages.role, ["user", "assistant"]),
-    visibleChatMessageCondition(),
+    visibleChatMessageCondition(db),
     completedConversationContextMessageCondition(db),
   ];
   if (options?.excludeRunId !== undefined) {
@@ -428,7 +428,7 @@ async function getLatestFollowupContextMessages(
         eq(chatMessages.chatThreadId, threadId),
         isNotNull(chatMessages.content),
         inArray(chatMessages.role, ["user", "assistant"]),
-        visibleChatMessageCondition(),
+        visibleChatMessageCondition(db),
         completedConversationContextMessageCondition(db),
       ),
     )

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -2,7 +2,7 @@ import type StripeSDK from "stripe";
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
-import { eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { and, eq, exists, isNotNull, isNull, lte, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -121,12 +121,17 @@ export const triggerAutoRecharge$ = command(
     }
 
     const planEligibility = orgPlanEntitlementReadsEnabled(orgId)
-      ? sql`EXISTS (
-          SELECT 1
-          FROM ${orgPlanEntitlements}
-          WHERE ${eq(orgPlanEntitlements.orgId, orgId)}
-            AND ${orgPlanEntitlements.autoRechargeAllowed} = true
-        )`
+      ? exists(
+          writeDb
+            .select({ orgId: orgPlanEntitlements.orgId })
+            .from(orgPlanEntitlements)
+            .where(
+              and(
+                eq(orgPlanEntitlements.orgId, orgId),
+                eq(orgPlanEntitlements.autoRechargeAllowed, true),
+              ),
+            ),
+        )
       : sql`${orgMetadata.tier} IN ('pro', 'team', 'custom')`;
 
     const clearPendingFlag = async (): Promise<void> => {

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -2,7 +2,18 @@ import { command } from "ccstate";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, count, eq, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  ne,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -617,11 +628,12 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
           and(
             eq(agentRuns.status, "queued"),
             lt(agentRuns.createdAt, cutoff),
-            sql`NOT EXISTS (
-              SELECT 1
-              FROM ${agentRunQueue}
-              WHERE ${eq(agentRunQueue.runId, agentRuns.id)}
-            )`,
+            notExists(
+              tx
+                .select({ runId: agentRunQueue.runId })
+                .from(agentRunQueue)
+                .where(eq(agentRunQueue.runId, agentRuns.id)),
+            ),
           ),
         )
         .orderBy(agentRuns.createdAt, agentRuns.id)
@@ -650,11 +662,12 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
           and(
             eq(agentRuns.status, "queued"),
             inArray(agentRuns.id, candidateRunIds),
-            sql`NOT EXISTS (
-              SELECT 1
-              FROM ${agentRunQueue}
-              WHERE ${eq(agentRunQueue.runId, agentRuns.id)}
-            )`,
+            notExists(
+              tx
+                .select({ runId: agentRunQueue.runId })
+                .from(agentRunQueue)
+                .where(eq(agentRunQueue.runId, agentRuns.id)),
+            ),
           ),
         )
         .returning({

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -198,6 +198,47 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         builder.innerJoinLateral({}, sql\`true\`);
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const otherUsers = alias(users, "other_users");
+        const condition = eq(users.id, 1);
+        const rawRelation = sql\`jsonb_array_elements(\${users.tags}) AS item\`;
+        sql\`EXISTS (SELECT 1 FROM \${rawRelation} WHERE \${condition})\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} AS u WHERE \${condition})\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE TRUE)\`;
+        sql\`EXISTS (SELECT \${users.id} FROM \${users} WHERE \${condition})\`;
+        sql\`EXISTS (SELECT 1 FROM \${users})\`;
+        sql\`EXISTS (
+          SELECT 1 FROM \${users}
+          LEFT JOIN \${otherUsers} ON \${condition}
+          WHERE \${condition}
+        )\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition} OR \${condition})\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition} FOR UPDATE)\`;
+        sql\`EXISTS (
+          SELECT 1 FROM \${users}
+          WHERE EXISTS (SELECT 1 FROM \${otherUsers} WHERE \${condition})
+        )\`;
+        sql\`SELECT EXISTS (SELECT 1 FROM \${users} WHERE \${condition})\`;
+        sql\`NOT EXISTS (SELECT 1 FROM \${users} WHERE \${condition}) AND \${condition}\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition}); SELECT 1\`;
+        sql\`WITH selected AS (SELECT 1) SELECT EXISTS (
+          SELECT 1 FROM \${users} WHERE \${condition}
+        )\`;
+      `,
+    },
+    {
+      code: `
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const table = { getSQL() {} };
+        const predicate = { getSQL() {} };
+        sql\`EXISTS (SELECT 1 FROM \${table} WHERE \${predicate})\`;
+      `,
+    },
   ],
   invalid: [
     {
@@ -221,6 +262,61 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "emptyFragment" },
         { messageId: "emptyFragment" },
       ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { and, eq, isNotNull, sql } from "drizzle-orm";
+        sql\`EXISTS (
+          SELECT 1
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+            AND \${isNotNull(users.name)}
+        )\`;
+      `,
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, isNotNull, sql as query } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const otherUsers = alias(users, "other_users");
+        const tag = drizzle.sql;
+        query\` not   exists(
+          select 1 from \${users}
+          inner join \${otherUsers} on \${eq(otherUsers.id, users.id)}
+          where \${eq(users.id, 1)} and \${isNotNull(otherUsers.name)}
+          limit 1
+        ) \`;
+        drizzle.sql\`EXISTS (SELECT 1 FROM \${otherUsers} WHERE \${eq(otherUsers.id, 1)})\`;
+        tag\`NOT EXISTS (SELECT 1 FROM \${users} WHERE \${eq(users.id, 1)})\`;
+      `,
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "notExists" },
+        },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "notExists" },
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${users.id} = \${1})\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
     },
     {
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -128,6 +128,27 @@ export function isDrizzleColumnType(
   return brandType?.isStringLiteral() === true && brandType.value === "Column";
 }
 
+export function isDrizzleTableType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  if (type.isUnion()) {
+    return type.types.every((member) => {
+      return isDrizzleTableType(checker, member, location);
+    });
+  }
+  if (!isDrizzleWrapperType(checker, type)) {
+    return false;
+  }
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return false;
+  }
+  const brandType = propertyType(checker, metadataType, "brand", location);
+  return brandType?.isStringLiteral() === true && brandType.value === "Table";
+}
+
 export function isDrizzleArrayColumnType(
   checker: TypeChecker,
   type: Type,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -33,6 +33,7 @@ import {
   isDrizzleColumnType,
   isDrizzleSqlTag,
   isDrizzleSymbol,
+  isDrizzleTableType,
   isDrizzleWrapperType,
   isNamedDrizzleSignature,
   resolvedSymbol,
@@ -50,6 +51,33 @@ const COMPARISON_HELPERS = new Map<string, string>([
 
 type BooleanToken = "operand" | "and" | "or" | "(" | ")";
 type BooleanExpressionKind = "operand" | "and" | "or";
+type ExistenceKeyword =
+  | "and"
+  | "exists"
+  | "from"
+  | "inner"
+  | "join"
+  | "limit"
+  | "not"
+  | "on"
+  | "select"
+  | "where"
+  | "one"
+  | "("
+  | ")";
+
+interface ExistenceExpressionToken {
+  readonly kind: "expression";
+  readonly index: number;
+}
+
+type ExistenceToken = ExistenceKeyword | ExistenceExpressionToken;
+
+interface ExistenceTemplateMatch {
+  readonly helper: "exists" | "notExists";
+  readonly tableExpressionIndexes: readonly number[];
+  readonly predicateExpressionIndexes: readonly number[];
+}
 
 function quasiText(node: TSESTree.TemplateElement): string {
   return node.value.cooked ?? node.value.raw;
@@ -299,6 +327,147 @@ function booleanHelper(quasis: readonly string[]): "and" | "or" | undefined {
     : undefined;
 }
 
+function tokenizeExistenceQuasi(quasi: string): ExistenceKeyword[] | undefined {
+  const tokens: ExistenceKeyword[] = [];
+  let offset = 0;
+  while (offset < quasi.length) {
+    const whitespace = /^\s+/.exec(quasi.slice(offset));
+    if (whitespace !== null) {
+      offset += whitespace[0].length;
+      continue;
+    }
+    const character = quasi[offset];
+    if (character === "(" || character === ")") {
+      tokens.push(character);
+      offset += 1;
+      continue;
+    }
+    const one = /^1\b/.exec(quasi.slice(offset));
+    if (one !== null) {
+      tokens.push("one");
+      offset += one[0].length;
+      continue;
+    }
+    const keyword =
+      /^(AND|EXISTS|FROM|INNER|JOIN|LIMIT|NOT|ON|SELECT|WHERE)\b/i.exec(
+        quasi.slice(offset),
+      );
+    if (keyword === null) {
+      return undefined;
+    }
+    const value = keyword[1]?.toLowerCase();
+    if (
+      value !== "and" &&
+      value !== "exists" &&
+      value !== "from" &&
+      value !== "inner" &&
+      value !== "join" &&
+      value !== "limit" &&
+      value !== "not" &&
+      value !== "on" &&
+      value !== "select" &&
+      value !== "where"
+    ) {
+      return undefined;
+    }
+    tokens.push(value);
+    offset += keyword[0].length;
+  }
+  return tokens;
+}
+
+function existenceTokens(
+  quasis: readonly string[],
+): ExistenceToken[] | undefined {
+  const tokens: ExistenceToken[] = [];
+  for (let index = 0; index < quasis.length; index += 1) {
+    const quasiTokens = tokenizeExistenceQuasi(quasis[index] ?? "");
+    if (quasiTokens === undefined) {
+      return undefined;
+    }
+    tokens.push(...quasiTokens);
+    if (index < quasis.length - 1) {
+      tokens.push({ kind: "expression", index });
+    }
+  }
+  return tokens;
+}
+
+function existenceTemplateMatch(
+  quasis: readonly string[],
+): ExistenceTemplateMatch | undefined {
+  const tokens = existenceTokens(quasis);
+  if (tokens === undefined) {
+    return undefined;
+  }
+  const parsedTokens = tokens;
+  let offset = 0;
+  const tableExpressionIndexes: number[] = [];
+  const predicateExpressionIndexes: number[] = [];
+
+  function consume(keyword: ExistenceKeyword): boolean {
+    if (parsedTokens[offset] !== keyword) {
+      return false;
+    }
+    offset += 1;
+    return true;
+  }
+
+  function consumeExpression(target: number[]): boolean {
+    const token = parsedTokens[offset];
+    if (typeof token === "string" || token === undefined) {
+      return false;
+    }
+    target.push(token.index);
+    offset += 1;
+    return true;
+  }
+
+  const negated = consume("not");
+  if (
+    !consume("exists") ||
+    !consume("(") ||
+    !consume("select") ||
+    !consume("one") ||
+    !consume("from") ||
+    !consumeExpression(tableExpressionIndexes)
+  ) {
+    return undefined;
+  }
+
+  while (consume("inner")) {
+    if (
+      !consume("join") ||
+      !consumeExpression(tableExpressionIndexes) ||
+      !consume("on") ||
+      !consumeExpression(predicateExpressionIndexes)
+    ) {
+      return undefined;
+    }
+  }
+
+  if (!consume("where") || !consumeExpression(predicateExpressionIndexes)) {
+    return undefined;
+  }
+  while (consume("and")) {
+    if (!consumeExpression(predicateExpressionIndexes)) {
+      return undefined;
+    }
+  }
+  if (consume("limit") && !consume("one")) {
+    return undefined;
+  }
+  if (!consume(")") || offset !== parsedTokens.length) {
+    return undefined;
+  }
+
+  return {
+    helper: negated ? "notExists" : "exists",
+    tableExpressionIndexes,
+    predicateExpressionIndexes,
+  };
+}
+
 export const preferDrizzleApis = createRule({
   name: "prefer-drizzle-apis",
   defaultOptions: [],
@@ -317,6 +486,8 @@ export const preferDrizzleApis = createRule({
       emptyFragment:
         "Use Drizzle sql.empty() for this intentionally empty SQL fragment.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
+      existencePredicate:
+        "Use Drizzle {{helper}}(...) with a select builder for this equivalent existence predicate.",
     },
   },
   create(context) {
@@ -755,6 +926,36 @@ export const preferDrizzleApis = createRule({
           quasis[0] === ""
         ) {
           context.report({ node, messageId: "emptyFragment" });
+          return;
+        }
+        const existence = existenceTemplateMatch(quasis);
+        if (
+          existence !== undefined &&
+          existence.tableExpressionIndexes.every((index) => {
+            const expressionNode = expressions[index];
+            if (expressionNode === undefined) {
+              return false;
+            }
+            const expression = expressionType(expressionNode);
+            return isDrizzleTableType(
+              checker,
+              expression.type,
+              expression.location,
+            );
+          }) &&
+          existence.predicateExpressionIndexes.every((index) => {
+            const expressionNode = expressions[index];
+            return (
+              expressionNode !== undefined &&
+              isDrizzleWrapperType(checker, expressionType(expressionNode).type)
+            );
+          })
+        ) {
+          context.report({
+            node,
+            messageId: "existencePredicate",
+            data: { helper: existence.helper },
+          });
           return;
         }
         for (let index = 0; index < expressions.length - 1; index += 1) {


### PR DESCRIPTION
## Summary

- replace all 12 standalone production `EXISTS` / `NOT EXISTS` SQL tags with Drizzle select builders and the exact surrounding database or transaction receiver
- keep PostgreSQL-only JSON relations and extraction as narrow raw leaves while moving their tables, joins, aliases, correlations, and predicates into typed builders
- extend `api/prefer-drizzle-apis` with an exact type-aware matcher for the proven standalone existence shape, including conservative near-miss coverage

## Query boundary

The refreshed AST inventory now leaves exactly seven production existence-containing SQL tags. They are complete or scalar statements whose CTE, locking, result-decoding, aggregate, or nested statement structure belongs to later #22439 slices:

- runner claim lock/update/delete CTE
- public chat-send active-run query
- two callback active/competing-run queries
- snapshot rebuild CTE
- incomplete-context scalar boundary expression
- artifact visibility `SELECT EXISTS` statement

The attached-file query retains only `jsonb_array_elements(...)`, JSON extraction, and the required mapped `SELECT 1` as raw leaves. No raw wrapper or allowlist is added.

## Safety and performance

- preserves correlations, null semantics, transaction ownership, queue lock/recheck behavior, result cardinality, and statement count
- adds no query, connection, schema change, migration, persisted-data change, API change, protocol change, feature switch, assertion, or suppression
- rendered legacy and candidate forms were compared for all converted families, including parameter placement and aliases
- 12 representative PostgreSQL 17 `EXPLAIN (ANALYZE, BUFFERS)` pairs had identical plan structure, estimated cost, index/join choices, and buffer reads/hits; timing differences were warm-cache noise
- full API ESLint measured 23.693s before and 19.590s after on this workspace, showing no matcher-time regression

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test -- --maxWorkers=1 --silent=passed-only` (678 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected API integration suites against a freshly migrated database with one Vitest process and one worker (254 tests)
- focused post-rebase runner-affinity integration tests (2 tests)
- `pnpm knip --workspace api --workspace @vm0/eslint-rules`
- `git diff --check`

Closes #22445

Parent context: #22439
