### PR TITLE
refactor(ci): remove unreachable connector copy status handling

### DIFF
--- a/.github/scripts/check-connector-source-freeze.sh
+++ b/.github/scripts/check-connector-source-freeze.sh
@@ -47,14 +47,6 @@ while IFS= read -r -d '' status; do
         blocked_changes+=("$rendered_change")
       fi
       ;;
-    C*)
-      IFS= read -r -d '' old_path
-      IFS= read -r -d '' new_path
-      if is_frozen_path "$new_path"; then
-        printf -v rendered_change '%q -> %q' "$old_path" "$new_path"
-        blocked_changes+=("$rendered_change")
-      fi
-      ;;
     D*)
       IFS= read -r -d '' _
       ;;


### PR DESCRIPTION
## Summary

- remove unreachable copy-status handling from the connector source freeze guard
- keep connector additions, modifications, and renames blocked while allowing deletions

## Scope

- follow-up cleanup for #22491
- no connector freeze policy or workflow behavior changes

## Validation

- `bash -n .github/scripts/check-connector-source-freeze.sh .github/scripts/tests/check-connector-source-freeze-test.sh`
- `shellcheck .github/scripts/check-connector-source-freeze.sh .github/scripts/tests/check-connector-source-freeze-test.sh`
- `bash .github/scripts/tests/check-connector-source-freeze-test.sh`
- `bash .github/scripts/tests/changed-base-ref-test.sh`
- `.github/scripts/check-connector-source-freeze.sh origin/main HEAD`
- `git diff --check origin/main..HEAD`
