### PR TITLE
fix(runner): bound mitmdump extraction lifecycle

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -141,6 +141,8 @@ pub async fn run_benchmark(
         registry_path: runner_paths.proxy_registry(),
         registry_lock_path: runner_paths.proxy_registry_lock(),
         builtin_firewall_catalog_cache_path: runner_paths.builtin_firewall_catalog_cache(),
+        runtime_dir: runner_paths.mitmdump_runtime_dir(),
+        runtime_lock_path: runner_paths.mitmdump_runtime_lock(),
         api_url: runner_config.server.as_ref().map(|s| s.url.clone()),
         client_session_id: uuid::Uuid::new_v4().to_string(),
     })

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -13,7 +13,7 @@ pub(super) const MITM_BACKOFF_MAX: Duration = Duration::from_secs(30);
 /// Stop retrying mitmproxy after this many consecutive failures.
 pub(super) const MITM_MAX_CONSECUTIVE_FAILURES: u32 = 20;
 
-pub(super) type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<tokio::process::Child>>;
+pub(super) type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<proxy::ManagedMitmdump>>;
 
 /// Spawn a background mitm restart task when the backoff timer fires
 /// and no restart is already in flight.
@@ -33,13 +33,15 @@ pub(super) async fn maybe_spawn_mitm_restart(
     // `stopping` Arc, locked to `true` before kill — so this only
     // sweeps pre-existing entries.
     while crash_rx.try_recv().is_ok() {}
-    let params = mitm.begin_restart().await;
-    retry.handle = Some(tokio::spawn(params.spawn()));
+    retry.handle = Some(match mitm.begin_restart().await {
+        Ok(params) => tokio::spawn(params.spawn()),
+        Err(error) => tokio::spawn(async move { Err(error) }),
+    });
 }
 
 /// Handle the result of a background mitm restart task.
 pub(super) fn handle_mitm_restart_result(
-    result: Result<tokio::process::Child, String>,
+    result: Result<proxy::ManagedMitmdump, String>,
     mitm: &mut proxy::MitmProxy,
     retry: &mut RetryState<MitmRestartHandle>,
 ) {
@@ -134,6 +136,8 @@ mod tests {
             builtin_firewall_catalog_cache_path: dir
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         })
@@ -160,7 +164,11 @@ mod tests {
             .spawn()
             .unwrap();
 
-        handle_mitm_restart_result(Ok(child), &mut mitm, &mut retry);
+        handle_mitm_restart_result(
+            Ok(proxy::ManagedMitmdump::unmanaged(child)),
+            &mut mitm,
+            &mut retry,
+        );
 
         assert_eq!(retry.backoff, MITM_BACKOFF_INITIAL);
         assert_eq!(retry.consecutive_failures, 0);
@@ -235,7 +243,9 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()
             .unwrap();
-        retry.handle = Some(tokio::spawn(async move { Ok(child) }));
+        retry.handle = Some(tokio::spawn(async move {
+            Ok(proxy::ManagedMitmdump::unmanaged(child))
+        }));
 
         finish_mitm_restart_before_shutdown(&mut mitm, &mut retry).await;
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -450,6 +450,8 @@ async fn run_start_with_home(
         registry_path: paths.proxy_registry(),
         registry_lock_path: paths.proxy_registry_lock(),
         builtin_firewall_catalog_cache_path: paths.builtin_firewall_catalog_cache(),
+        runtime_dir: paths.mitmdump_runtime_dir(),
+        runtime_lock_path: paths.mitmdump_runtime_lock(),
         api_url: Some(server.url.clone()),
         client_session_id: runner_client_session_id,
     })

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -128,6 +128,14 @@ impl RunnerPaths {
         self.base_dir.join("mitm-addon")
     }
 
+    pub fn mitmdump_runtime_dir(&self) -> PathBuf {
+        self.base_dir.join("mitmdump-runtime")
+    }
+
+    pub fn mitmdump_runtime_lock(&self) -> PathBuf {
+        self.base_dir.join("mitmdump-runtime.lock")
+    }
+
     pub fn proxy_registry(&self) -> PathBuf {
         self.base_dir.join("proxy-registry.json")
     }
@@ -595,6 +603,19 @@ mod tests {
         assert_eq!(
             home.mitmdump_bin("11.1.3"),
             PathBuf::from("/test/mitmproxy/11.1.3/mitmdump")
+        );
+    }
+
+    #[test]
+    fn mitmdump_runtime_paths() {
+        let paths = RunnerPaths::new(PathBuf::from("/test/runner"));
+        assert_eq!(
+            paths.mitmdump_runtime_dir(),
+            PathBuf::from("/test/runner/mitmdump-runtime")
+        );
+        assert_eq!(
+            paths.mitmdump_runtime_lock(),
+            PathBuf::from("/test/runner/mitmdump-runtime.lock")
         );
     }
 

--- a/crates/runner/src/proxy/managed_process.rs
+++ b/crates/runner/src/proxy/managed_process.rs
@@ -1,0 +1,225 @@
+//! Ownership and shutdown of one managed mitmdump process tree.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use super::runtime::{MitmdumpRuntime, preserve_launch};
+use crate::error::{RunnerError, RunnerResult};
+
+/// Timeout for graceful shutdown before SIGKILL.
+///
+/// Usage upload drain is handled before SIGTERM; this only bounds mitmproxy's
+/// own graceful process exit.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Owns the direct PyInstaller bootloader, its process group, and the private
+/// directory containing its one-file extraction.
+pub(crate) struct ManagedMitmdump {
+    child: Option<tokio::process::Child>,
+    process_group: Option<nix::unistd::Pid>,
+    leader_reaped: bool,
+    launch: Option<tempfile::TempDir>,
+    runtime: Option<Arc<MitmdumpRuntime>>,
+}
+
+impl ManagedMitmdump {
+    pub(super) fn new(
+        child: tokio::process::Child,
+        launch: tempfile::TempDir,
+        runtime: Arc<MitmdumpRuntime>,
+    ) -> RunnerResult<Self> {
+        let pid = child.id().ok_or_else(|| {
+            RunnerError::Internal("spawned mitmdump has no process id".to_string())
+        })?;
+        let pid = i32::try_from(pid).map_err(|error| {
+            RunnerError::Internal(format!("convert mitmdump process id: {error}"))
+        })?;
+        Ok(Self {
+            child: Some(child),
+            process_group: Some(nix::unistd::Pid::from_raw(pid)),
+            leader_reaped: false,
+            launch: Some(launch),
+            runtime: Some(runtime),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn unmanaged(child: tokio::process::Child) -> Self {
+        Self {
+            child: Some(child),
+            process_group: None,
+            leader_reaped: false,
+            launch: None,
+            runtime: None,
+        }
+    }
+
+    pub(super) fn id(&self) -> Option<u32> {
+        self.child.as_ref()?.id()
+    }
+
+    pub(super) fn child(&self) -> Option<&tokio::process::Child> {
+        self.child.as_ref()
+    }
+
+    pub(super) fn child_mut(&mut self) -> Option<&mut tokio::process::Child> {
+        self.child.as_mut()
+    }
+
+    pub(super) fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let status = match self.child.as_mut() {
+            Some(child) => child.try_wait()?,
+            None => None,
+        };
+        if status.is_some() {
+            self.leader_reaped = true;
+        }
+        Ok(status)
+    }
+
+    pub(super) async fn force_stop(mut self) -> RunnerResult<()> {
+        let is_running = self
+            .try_wait()
+            .map_err(|error| RunnerError::Internal(format!("check mitmdump process: {error}")))?
+            .is_none();
+        if is_running {
+            self.signal_force()?;
+            self.wait_for_leader().await?;
+        }
+        self.close_launch().await
+    }
+
+    pub(super) async fn stop_gracefully(mut self) -> RunnerResult<()> {
+        let Some(child) = self.child.as_mut() else {
+            return self.close_launch().await;
+        };
+        info!("stopping mitmdump");
+        send_sigterm(child);
+
+        match tokio::time::timeout(STOP_TIMEOUT, child.wait()).await {
+            Ok(Ok(status)) => {
+                self.leader_reaped = true;
+                info!(code = status.code(), "mitmdump stopped");
+            }
+            Ok(Err(error)) => {
+                return Err(RunnerError::Internal(format!(
+                    "wait for mitmdump shutdown: {error}"
+                )));
+            }
+            Err(_) => {
+                warn!("mitmdump did not exit in time, sending SIGKILL");
+                self.signal_force()?;
+                self.wait_for_leader().await?;
+            }
+        }
+        self.close_launch().await
+    }
+
+    fn signal_force(&mut self) -> RunnerResult<()> {
+        if let Some(process_group) = self.process_group {
+            return match nix::sys::signal::killpg(process_group, nix::sys::signal::Signal::SIGKILL)
+            {
+                Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+                Err(error) => Err(RunnerError::Internal(format!(
+                    "kill mitmdump process group {}: {error}",
+                    process_group.as_raw()
+                ))),
+            };
+        }
+        let Some(child) = self.child.as_mut() else {
+            return Ok(());
+        };
+        match child.start_kill() {
+            Ok(()) => Ok(()),
+            Err(error) => Err(RunnerError::Internal(format!(
+                "kill mitmdump process: {error}"
+            ))),
+        }
+    }
+
+    async fn wait_for_leader(&mut self) -> RunnerResult<()> {
+        if self.leader_reaped {
+            return Ok(());
+        }
+        let Some(child) = self.child.as_mut() else {
+            return Ok(());
+        };
+        child.wait().await.map_err(|error| {
+            RunnerError::Internal(format!("wait for killed mitmdump process: {error}"))
+        })?;
+        self.leader_reaped = true;
+        Ok(())
+    }
+
+    async fn close_launch(&mut self) -> RunnerResult<()> {
+        let Some(launch) = self.launch.take() else {
+            return Ok(());
+        };
+        let Some(runtime) = self.runtime.as_ref() else {
+            preserve_launch(launch, &"missing mitmdump runtime owner");
+            return Err(RunnerError::Internal(
+                "missing mitmdump runtime owner".to_string(),
+            ));
+        };
+        runtime.close_launch(launch).await
+    }
+}
+
+impl Drop for ManagedMitmdump {
+    fn drop(&mut self) {
+        if let Err(error) = self.try_wait() {
+            warn!(error = %error, "failed to query mitmdump during drop cleanup");
+        }
+        if !self.leader_reaped
+            && let Err(error) = self.signal_force()
+        {
+            warn!(error = %error, "failed to signal mitmdump during drop cleanup");
+        }
+
+        let mut child = self.child.take();
+        if !self.leader_reaped
+            && let Some(child) = child.as_mut()
+            && let Err(error) = child.start_kill()
+        {
+            warn!(error = %error, "failed to kill direct mitmdump child during drop cleanup");
+        }
+        let Some(launch) = self.launch.take() else {
+            crate::child_cleanup::kill_and_reap_child_on_drop("mitmdump", &mut child);
+            return;
+        };
+        let Some(runtime) = self.runtime.take() else {
+            preserve_launch(launch, &"missing mitmdump runtime owner during drop");
+            crate::child_cleanup::kill_and_reap_child_on_drop("mitmdump", &mut child);
+            return;
+        };
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            preserve_launch(launch, &"no active tokio runtime during mitmdump drop");
+            crate::child_cleanup::kill_and_reap_child_on_drop("mitmdump", &mut child);
+            return;
+        };
+        // Persist before handing ownership to the task. If runtime shutdown
+        // cancels it, startup reconciliation can still recover the directory.
+        let launch_path = launch.keep();
+        handle.spawn(async move {
+            if let Some(mut child) = child
+                && let Err(error) = child.wait().await
+            {
+                warn!(error = %error, "failed to reap mitmdump during drop cleanup");
+            }
+            if let Err(error) = runtime.close_launch_path(launch_path).await {
+                warn!(error = %error, "failed to close mitmdump launch during drop cleanup");
+            }
+        });
+    }
+}
+
+fn send_sigterm(child: &tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGTERM,
+        );
+    }
+}

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -31,13 +31,18 @@
 //! Usage drain is a shutdown path for billing and usage reports, while JSONL
 //! flush is a per-upload network-log path.
 //!
-//! `MitmProxy::new` prepares addon files, an empty registry, crash channel, and
-//! initial usage state. `start` spawns `mitmdump` and monitor tasks. Unexpected
-//! stdout close notifies the runner unless the child is stopping gracefully.
-//! `begin_restart` kills the old child, permanently silences its monitor, and
-//! returns fresh spawn parameters; `complete_restart` stores the new child.
-//! Shutdown writes a usage flush request, signals the addon, waits boundedly
-//! for `usage-pending`, then calls `stop`.
+//! `MitmProxy::new` exclusively locks the runner-local proxy runtime, removes
+//! stale private launch directories after terminating their marked processes,
+//! and prepares addon files, an empty registry, crash channel, and initial
+//! usage state. `start` gives each `mitmdump` process group a private `TMPDIR`
+//! and starts monitor tasks. Unexpected stdout close notifies the runner unless
+//! the child is stopping gracefully. `begin_restart` terminates the old process
+//! group, removes its private launch directory, permanently silences its
+//! monitor, and returns fresh spawn parameters; `complete_restart` stores the
+//! new child. Shutdown writes a usage flush request, signals the addon, waits
+//! boundedly for `usage-pending`, then calls `stop`. Recovery and shutdown only
+//! act on runner-owned private paths and marked processes; legacy shared
+//! `/tmp/_MEI*` paths are deliberately left untouched.
 //!
 //! Addon-side details live in `crates/runner/mitm-addon/src/mitm_addon.py`
 //! (mitmproxy hook orchestration),
@@ -49,13 +54,16 @@
 //! semantics).
 
 mod flush;
+mod managed_process;
 mod process;
 mod registry;
+mod runtime;
 mod stderr;
 
 pub use flush::{
     MitmJsonlFlushHandle, USAGE_FLUSH_TIMEOUT, wait_usage_flush_requesting,
     write_usage_flush_request,
 };
+pub(crate) use managed_process::ManagedMitmdump;
 pub use process::{MitmProxy, ProxyConfig};
 pub use registry::{ProxyRegistryHandle, VmRegistration};

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -12,7 +12,9 @@ use tracing::{error, info, warn};
 use super::flush::{
     MitmJsonlFlushHandle, UsageFlushTarget, new_usage_state_id, usage_flush_state_guard,
 };
+use super::managed_process::ManagedMitmdump;
 use super::registry::{ProxyRegistryHandle, VmRegistration, write_empty_registry};
+use super::runtime::{MitmdumpRuntime, RUNTIME_MARKER_ENV};
 use super::stderr::log_mitmdump_stderr_line;
 use crate::error::{RunnerError, RunnerResult};
 
@@ -27,12 +29,6 @@ const ADDON_READY_FILENAME: &str = "addon-ready";
 const TEXT_BUSY_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(20);
 const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
 const RUNNER_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Timeout for graceful shutdown before SIGKILL.
-///
-/// Usage upload drain is handled before SIGTERM; this only bounds mitmproxy's
-/// own graceful process exit.
-const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Configuration for starting the proxy.
 #[derive(Clone)]
@@ -51,6 +47,10 @@ pub struct ProxyConfig {
     pub registry_lock_path: PathBuf,
     /// Path where the runner-owned builtin firewall catalog cache is written.
     pub builtin_firewall_catalog_cache_path: PathBuf,
+    /// Private parent directory for per-launch PyInstaller extraction roots.
+    pub runtime_dir: PathBuf,
+    /// Exclusive lock serializing owners of proxy runtime state.
+    pub runtime_lock_path: PathBuf,
     /// VM0 API URL passed to the addon (optional).
     pub api_url: Option<String>,
     /// Runner-runtime client session id passed to the addon for vm0 API requests.
@@ -61,7 +61,8 @@ pub struct ProxyConfig {
 pub struct MitmProxy {
     port: u16,
     config: ProxyConfig,
-    child: Option<tokio::process::Child>,
+    runtime: Option<Arc<MitmdumpRuntime>>,
+    child: Option<ManagedMitmdump>,
     /// Sender used by the stdout monitor task to signal unexpected exit.
     crash_tx: mpsc::Sender<()>,
     /// Set to `true` during graceful `stop()` / `Drop` to suppress crash notifications.
@@ -80,6 +81,11 @@ impl MitmProxy {
     /// Returns `(proxy, crash_rx)`. The caller should select on `crash_rx` to
     /// detect unexpected mitmdump exits and trigger a restart.
     pub async fn new(config: ProxyConfig) -> RunnerResult<(Self, mpsc::Receiver<()>)> {
+        // Acquire ownership before addon/registry preparation, which removes
+        // and replaces files shared by every proxy using this runner base dir.
+        let runtime =
+            MitmdumpRuntime::acquire(config.runtime_dir.clone(), config.runtime_lock_path.clone())
+                .await?;
         let port = find_available_port()?;
 
         // Write addon scripts to directory.
@@ -131,6 +137,7 @@ impl MitmProxy {
             Self {
                 port,
                 config,
+                runtime: Some(runtime),
                 child: None,
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
@@ -145,8 +152,18 @@ impl MitmProxy {
 
     /// Spawn the mitmdump process.
     pub async fn start(&mut self) -> RunnerResult<()> {
+        if self.child.is_some() {
+            return Err(RunnerError::Internal(
+                "mitmdump process is already started".to_string(),
+            ));
+        }
+        let runtime = self
+            .runtime
+            .as_ref()
+            .ok_or_else(|| RunnerError::Internal("missing mitmdump runtime owner".to_string()))?;
         let child = spawn_mitmdump(
             &self.config,
+            runtime,
             self.port,
             &self.crash_tx,
             &self.stopping,
@@ -221,7 +238,8 @@ impl MitmProxy {
             }
         };
         if child_exited {
-            self.child = None;
+            // Retain the lifecycle owner so the later async stop path can
+            // remove its private launch directory deterministically.
             return None;
         }
 
@@ -247,7 +265,6 @@ impl MitmProxy {
                     code = status.code(),
                     "mitmdump exited before usage flush request"
                 );
-                self.child = None;
                 return false;
             }
             Ok(None) => {}
@@ -256,7 +273,7 @@ impl MitmProxy {
             }
         }
 
-        let signaled = send_usage_flush_signal(child);
+        let signaled = child.child().is_some_and(send_usage_flush_signal);
         if !signaled {
             error!(
                 r#type = "usage_underbilling",
@@ -278,7 +295,6 @@ impl MitmProxy {
                     code = status.code(),
                     "mitmdump exited after usage flush request"
                 );
-                self.child = None;
                 false
             }
             Ok(None) => true,
@@ -303,14 +319,14 @@ impl MitmProxy {
     ///
     /// The caller should spawn the mitmdump process (potentially in a
     /// background task) and then call `complete_restart` with the result.
-    pub async fn begin_restart(&mut self) -> MitmRestartParams {
+    pub async fn begin_restart(&mut self) -> RunnerResult<MitmRestartParams> {
         // Silence the old monitor permanently: after this call, no one
         // else holds a handle that could reset its `Arc<AtomicBool>`
         // back to `false`, so the monitor is guaranteed to read `true`
         // regardless of scheduling order between `kill().await` and
         // the stdout-pipe drain.
         self.stopping.store(true, Ordering::Release);
-        if let Some(child) = self.child.as_mut() {
+        if let Some(mut child) = self.child.take() {
             match child.try_wait() {
                 Ok(Some(_status)) => {}
                 Ok(None) => error!(
@@ -329,8 +345,7 @@ impl MitmProxy {
                     "failed to query mitmdump status before restart kill; in-memory usage may be lost"
                 ),
             }
-            let _ = child.kill().await;
-            self.child = None;
+            child.force_stop().await?;
         }
         // Fresh flag for the incoming process's monitor.
         let new_stopping = Arc::new(AtomicBool::new(false));
@@ -342,78 +357,37 @@ impl MitmProxy {
             expected_usage_state_id: usage_state_id.clone(),
             usage_state_started_at_ms,
         };
-        MitmRestartParams {
+        Ok(MitmRestartParams {
             config: self.config.clone(),
+            runtime: self.runtime.clone(),
             port: self.port,
             crash_tx: self.crash_tx.clone(),
             stopping: new_stopping,
             usage_state_id,
-        }
+        })
     }
 
     /// Finish a restart by storing the newly spawned child process.
-    pub fn complete_restart(&mut self, child: tokio::process::Child) {
+    pub fn complete_restart(&mut self, child: ManagedMitmdump) {
         self.child = Some(child);
     }
 
     /// Gracefully stop mitmdump (SIGTERM → timeout → SIGKILL).
     pub async fn stop(&mut self) -> RunnerResult<()> {
         self.stopping.store(true, Ordering::Release);
-        let Some(ref mut child) = self.child else {
+        let Some(child) = self.child.take() else {
             return Ok(());
         };
-        info!("stopping mitmdump");
-        send_sigterm(child);
-
-        match tokio::time::timeout(STOP_TIMEOUT, child.wait()).await {
-            Ok(Ok(status)) => {
-                info!(code = status.code(), "mitmdump stopped");
-            }
-            Ok(Err(e)) => {
-                warn!(error = %e, "mitmdump wait failed");
-            }
-            Err(_) => {
-                warn!("mitmdump did not exit in time, sending SIGKILL");
-                let _ = child.kill().await;
-            }
-        }
-        self.child = None;
-        Ok(())
+        child.stop_gracefully().await
     }
 
     /// Immediately kill and reap mitmdump without the graceful SIGTERM window.
     pub async fn kill_now(&mut self) -> RunnerResult<()> {
         self.stopping.store(true, Ordering::Release);
-        let Some(ref mut child) = self.child else {
+        let Some(child) = self.child.take() else {
             return Ok(());
         };
-        if child
-            .try_wait()
-            .map_err(|e| RunnerError::Internal(format!("check mitmdump process: {e}")))?
-            .is_some()
-        {
-            self.child = None;
-            return Ok(());
-        }
-        if let Err(kill_error) = child.start_kill() {
-            if child
-                .try_wait()
-                .map_err(|e| RunnerError::Internal(format!("recheck mitmdump process: {e}")))?
-                .is_some()
-            {
-                self.child = None;
-                return Ok(());
-            }
-            return Err(RunnerError::Internal(format!(
-                "kill mitmdump process after startup failure: {kill_error}"
-            )));
-        }
-        child
-            .wait()
-            .await
-            .map_err(|e| RunnerError::Internal(format!("wait for killed mitmdump process: {e}")))?;
-        self.child = None;
-        Ok(())
+        child.force_stop().await
     }
 }
 
@@ -437,9 +411,12 @@ impl MitmProxy {
                     registry_path: std::path::PathBuf::new(),
                     registry_lock_path: std::path::PathBuf::new(),
                     builtin_firewall_catalog_cache_path: std::path::PathBuf::new(),
+                    runtime_dir: std::path::PathBuf::new(),
+                    runtime_lock_path: std::path::PathBuf::new(),
                     api_url: None,
                     client_session_id: "runner-session-test".to_string(),
                 },
+                runtime: None,
                 child: None,
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
@@ -460,7 +437,7 @@ impl MitmProxy {
     }
 
     pub fn set_child_for_test(&mut self, child: tokio::process::Child) {
-        self.child = Some(child);
+        self.child = Some(ManagedMitmdump::unmanaged(child));
     }
 
     pub fn set_addon_dir_for_test(&mut self, addon_dir: PathBuf) {
@@ -471,7 +448,7 @@ impl MitmProxy {
 impl Drop for MitmProxy {
     fn drop(&mut self) {
         self.stopping.store(true, Ordering::Release);
-        crate::child_cleanup::kill_and_reap_child_on_drop("mitmdump", &mut self.child);
+        drop(self.child.take());
     }
 }
 
@@ -480,6 +457,7 @@ impl Drop for MitmProxy {
 /// can happen in a background task without borrowing `MitmProxy`.
 pub(crate) struct MitmRestartParams {
     config: ProxyConfig,
+    runtime: Option<Arc<MitmdumpRuntime>>,
     port: u16,
     crash_tx: mpsc::Sender<()>,
     stopping: Arc<AtomicBool>,
@@ -488,9 +466,13 @@ pub(crate) struct MitmRestartParams {
 
 impl MitmRestartParams {
     /// Spawn mitmdump using these parameters. Suitable for `tokio::spawn`.
-    pub(crate) async fn spawn(self) -> RunnerResult<tokio::process::Child> {
+    pub(crate) async fn spawn(self) -> RunnerResult<ManagedMitmdump> {
+        let runtime = self
+            .runtime
+            .ok_or_else(|| RunnerError::Internal("missing mitmdump runtime owner".to_string()))?;
         spawn_mitmdump(
             &self.config,
+            &runtime,
             self.port,
             &self.crash_tx,
             &self.stopping,
@@ -503,14 +485,17 @@ impl MitmRestartParams {
 /// Spawn a mitmdump process, wire up stdout/stderr monitors, and wait for
 /// it to become ready. This is a free function so it can run in a
 /// `tokio::spawn` without borrowing `MitmProxy`.
-pub(crate) async fn spawn_mitmdump(
+async fn spawn_mitmdump(
     config: &ProxyConfig,
+    runtime: &Arc<MitmdumpRuntime>,
     port: u16,
     crash_tx: &mpsc::Sender<()>,
     stopping: &Arc<AtomicBool>,
     usage_state_id: &str,
-) -> RunnerResult<tokio::process::Child> {
+) -> RunnerResult<ManagedMitmdump> {
     let _prepared_ca = crate::ca::prepare_for_proxy(&config.ca_dir, &config.ca_lock_path).await?;
+    let launch = runtime.create_launch_dir().await?;
+    let launch_path = launch.path().to_path_buf();
     let addon_ready_path = config.addon_dir.join(ADDON_READY_FILENAME);
     match tokio::fs::remove_file(&addon_ready_path).await {
         Ok(()) => {}
@@ -572,12 +557,15 @@ pub(crate) async fn spawn_mitmdump(
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+    cmd.env("TMPDIR", &launch_path)
+        .env(RUNTIME_MARKER_ENV, &launch_path)
+        .process_group(0);
     cmd.kill_on_drop(true);
 
     // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)` which is
-    // async-signal-safe. This ensures the kernel sends SIGKILL to the
-    // mitmdump child when the parent runner process dies, preventing
-    // orphaned processes after runner crashes or restarts.
+    // async-signal-safe. This covers the direct PyInstaller bootloader; its
+    // forked application child is covered by managed process-group shutdown
+    // and marker-based reconciliation.
     unsafe {
         cmd.pre_exec(|| {
             nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
@@ -587,11 +575,12 @@ pub(crate) async fn spawn_mitmdump(
 
     info!(port, bin = %config.mitmdump_bin.display(), "starting mitmdump");
 
-    let mut child = spawn_mitmdump_child(&mut cmd, &config.mitmdump_bin).await?;
+    let child = spawn_mitmdump_child(&mut cmd, &config.mitmdump_bin).await?;
+    let mut child = ManagedMitmdump::new(child, launch, Arc::clone(runtime))?;
 
     // Stream stdout to tracing; when the pipe closes (process exited),
     // send a crash notification unless we're in a graceful stop.
-    if let Some(stdout) = child.stdout.take() {
+    if let Some(stdout) = child.child_mut().and_then(|child| child.stdout.take()) {
         let crash_tx = crash_tx.clone();
         let stopping = Arc::clone(stopping);
         tokio::spawn(async move {
@@ -607,7 +596,7 @@ pub(crate) async fn spawn_mitmdump(
             }
         });
     }
-    if let Some(stderr) = child.stderr.take() {
+    if let Some(stderr) = child.child_mut().and_then(|child| child.stderr.take()) {
         tokio::spawn(async move {
             let mut lines = tokio::io::BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
@@ -618,8 +607,10 @@ pub(crate) async fn spawn_mitmdump(
         });
     }
 
-    if let Err(e) = wait_for_ready(
-        &mut child,
+    if let Err(error) = wait_for_ready(
+        child.child_mut().ok_or_else(|| {
+            RunnerError::Internal("missing mitmdump child during readiness check".to_string())
+        })?,
         port,
         &addon_ready_path,
         usage_state_id,
@@ -628,8 +619,8 @@ pub(crate) async fn spawn_mitmdump(
     .await
     {
         stopping.store(true, Ordering::Release);
-        let _ = child.kill().await;
-        return Err(e);
+        child.force_stop().await?;
+        return Err(error);
     }
 
     Ok(child)
@@ -751,15 +742,6 @@ fn find_available_port() -> RunnerResult<u16> {
     Ok(port)
 }
 
-fn send_sigterm(child: &tokio::process::Child) {
-    if let Some(pid) = child.id() {
-        let _ = nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(pid as i32),
-            nix::sys::signal::Signal::SIGTERM,
-        );
-    }
-}
-
 fn send_usage_flush_signal(child: &tokio::process::Child) -> bool {
     let Some(pid) = child.id() else {
         return false;
@@ -783,6 +765,7 @@ mod tests {
             r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
+printf '%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
 port=""
 ready_path=""
 usage_state_id=""
@@ -814,6 +797,87 @@ while True:
     conn, _ = sock.accept()
     conn.close()
 PY
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    fn write_forking_listening_mitmdump(path: &Path) {
+        std::fs::write(
+            path,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+port=""
+ready_path=""
+usage_state_id=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--listen-port" ]; then
+    port="$arg"
+  fi
+  case "$arg" in
+    vm0_addon_ready_path=*) ready_path="${arg#vm0_addon_ready_path=}" ;;
+    vm0_usage_state_id=*) usage_state_id="${arg#vm0_usage_state_id=}" ;;
+  esac
+  prev="$arg"
+done
+python3 - "$port" "$ready_path" "$usage_state_id" "$0.descendant" <<'PY' &
+import os
+import signal
+import socket
+import sys
+from pathlib import Path
+
+for handled in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(handled, signal.SIG_IGN)
+Path(sys.argv[4]).write_text(str(os.getpid()), encoding="utf-8")
+ready_path = Path(sys.argv[2])
+ready_path.parent.mkdir(parents=True, exist_ok=True)
+ready_path.write_text(sys.argv[3], encoding="utf-8")
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(sys.argv[1])))
+sock.listen(1)
+while True:
+    conn, _ = sock.accept()
+    conn.close()
+PY
+wait "$!"
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    fn write_forking_failing_mitmdump(path: &Path) {
+        std::fs::write(
+            path,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n%s\n' "$TMPDIR" "$VM0_MITMDUMP_RUNTIME_DIR" > "$0.env"
+python3 - "$0.descendant" <<'PY' &
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+for handled in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(handled, signal.SIG_IGN)
+Path(sys.argv[1]).write_text(str(os.getpid()), encoding="utf-8")
+while True:
+    time.sleep(60)
+PY
+while [ ! -s "$0.descendant" ]; do
+  sleep 0.01
+done
+exit 42
 "#,
         )
         .unwrap();
@@ -922,6 +986,74 @@ PY
         }
     }
 
+    async fn wait_for_pid_absent(pid: u32) -> bool {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match crate::process::read_process_stat(pid).await {
+                    Some(stat) if crate::process::process_stat_is_live(&stat) => {
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                    Some(_) | None => return,
+                }
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    async fn wait_for_file(path: &Path) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !tokio::fs::try_exists(path).await.unwrap_or(false) {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {}", path.display()));
+    }
+
+    async fn acquire_test_runtime(config: &ProxyConfig) -> Arc<MitmdumpRuntime> {
+        MitmdumpRuntime::acquire(config.runtime_dir.clone(), config.runtime_lock_path.clone())
+            .await
+            .unwrap()
+    }
+
+    fn test_proxy_config(root: &Path, home: &HomePaths, mitmdump_bin: PathBuf) -> ProxyConfig {
+        ProxyConfig {
+            mitmdump_bin,
+            ca_dir: home.ca_dir(),
+            ca_lock_path: home.ca_lock(),
+            addon_dir: root.join("addon"),
+            registry_path: root.join("proxy-registry.json"),
+            registry_lock_path: root.join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: root.join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: root.join("mitmdump-runtime"),
+            runtime_lock_path: root.join("mitmdump-runtime.lock"),
+            api_url: None,
+            client_session_id: "runner-session-test".to_string(),
+        }
+    }
+
+    async fn assert_no_launch_dirs(runtime_dir: &Path) {
+        let mut entries = tokio::fs::read_dir(runtime_dir).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            assert!(
+                !entry.file_name().as_encoded_bytes().starts_with(b"launch-"),
+                "unexpected live launch directory: {}",
+                entry.path().display()
+            );
+        }
+    }
+
+    async fn wait_for_path_absent(path: &Path) -> bool {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while tokio::fs::try_exists(path).await.unwrap_or(false) {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
     #[test]
     fn find_port_returns_nonzero() {
         let port = find_available_port().unwrap();
@@ -1001,6 +1133,8 @@ PY
             builtin_firewall_catalog_cache_path: dir
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         };
@@ -1033,6 +1167,8 @@ PY
             builtin_firewall_catalog_cache_path: dir
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         };
@@ -1196,6 +1332,8 @@ PY
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
             builtin_firewall_catalog_cache_path: builtin_firewall_catalog_cache_path.clone(),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         };
@@ -1203,13 +1341,33 @@ PY
         let stopping = Arc::new(AtomicBool::new(false));
         let port = find_available_port().unwrap();
 
-        let mut child = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
-            .await
-            .unwrap();
+        let runtime = acquire_test_runtime(&config).await;
+        let child = spawn_mitmdump(
+            &config,
+            &runtime,
+            port,
+            &crash_tx,
+            &stopping,
+            "usage-state-test",
+        )
+        .await
+        .unwrap();
         stopping.store(true, Ordering::Release);
-        let _ = child.kill().await;
+        child.stop_gracefully().await.unwrap();
 
         let args = std::fs::read_to_string(fake_mitmdump.with_extension("args")).unwrap();
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let environment: Vec<&str> = environment.lines().collect();
+        assert_eq!(environment.len(), 2);
+        assert_eq!(environment[0], environment[1]);
+        let launch_path = Path::new(environment[0]);
+        assert_eq!(launch_path.parent(), Some(config.runtime_dir.as_path()));
+        assert!(
+            launch_path
+                .file_name()
+                .is_some_and(|name| name.as_encoded_bytes().starts_with(b"launch-"))
+        );
+        assert!(!launch_path.exists());
         assert!(
             home.ca_dir().join("mitmproxy-ca.pem").is_file(),
             "proxy preparation should rebuild missing combined CA"
@@ -1278,6 +1436,8 @@ PY
             builtin_firewall_catalog_cache_path: dir
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         };
@@ -1285,9 +1445,18 @@ PY
         let stopping = Arc::new(AtomicBool::new(false));
         let port = find_available_port().unwrap();
 
-        let error = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
-            .await
-            .unwrap_err();
+        let runtime = acquire_test_runtime(&config).await;
+        let error = spawn_mitmdump(
+            &config,
+            &runtime,
+            port,
+            &crash_tx,
+            &stopping,
+            "usage-state-test",
+        )
+        .await
+        .err()
+        .expect("expected unrecoverable CA error");
 
         assert!(
             error.to_string().contains("proxy CA") && error.to_string().contains("not recoverable"),
@@ -1308,7 +1477,7 @@ PY
         write_fake_listening_mitmdump(&fake_mitmdump);
 
         let config = ProxyConfig {
-            mitmdump_bin: fake_mitmdump,
+            mitmdump_bin: fake_mitmdump.clone(),
             ca_dir: home.ca_dir(),
             ca_lock_path: home.ca_lock(),
             addon_dir: dir.path().join("addon"),
@@ -1317,6 +1486,8 @@ PY
             builtin_firewall_catalog_cache_path: dir
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
+            runtime_dir: dir.path().join("mitmdump-runtime"),
+            runtime_lock_path: dir.path().join("mitmdump-runtime.lock"),
             api_url: None,
             client_session_id: "runner-session-test".to_string(),
         };
@@ -1324,10 +1495,20 @@ PY
         let stopping = Arc::new(AtomicBool::new(false));
         let port = find_available_port().unwrap();
 
-        let child = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
-            .await
-            .unwrap();
+        let runtime = acquire_test_runtime(&config).await;
+        let child = spawn_mitmdump(
+            &config,
+            &runtime,
+            port,
+            &crash_tx,
+            &stopping,
+            "usage-state-test",
+        )
+        .await
+        .unwrap();
         let pid = nix::unistd::Pid::from_raw(child.id().unwrap() as i32);
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let launch_path = PathBuf::from(environment.lines().next().unwrap());
         stopping.store(true, Ordering::Release);
         drop(child);
 
@@ -1335,6 +1516,189 @@ PY
             wait_for_reaped_pid(pid).await,
             "dropping mitmdump Child should kill and reap the process"
         );
+        assert!(
+            wait_for_path_absent(&launch_path).await,
+            "drop cleanup should remove {}",
+            launch_path.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_failure_kills_forked_descendant_and_removes_launch_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
+        let fake_mitmdump = dir.path().join("failing-mitmdump");
+        write_forking_failing_mitmdump(&fake_mitmdump);
+        let config = test_proxy_config(dir.path(), &home, fake_mitmdump.clone());
+        let runtime = acquire_test_runtime(&config).await;
+        let (crash_tx, _crash_rx) = mpsc::channel(1);
+        let stopping = Arc::new(AtomicBool::new(false));
+
+        let error = spawn_mitmdump(
+            &config,
+            &runtime,
+            find_available_port().unwrap(),
+            &crash_tx,
+            &stopping,
+            "usage-state-test",
+        )
+        .await
+        .err()
+        .expect("expected startup failure");
+
+        assert!(
+            error
+                .to_string()
+                .contains("mitmdump exited immediately with 42"),
+            "unexpected error: {error}"
+        );
+        let descendant_pid: u32 =
+            std::fs::read_to_string(fake_mitmdump.with_extension("descendant"))
+                .unwrap()
+                .parse()
+                .unwrap();
+        assert!(
+            wait_for_pid_absent(descendant_pid).await,
+            "startup failure left forked descendant {descendant_pid} alive"
+        );
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let launch_path = PathBuf::from(environment.lines().next().unwrap());
+        assert!(!launch_path.exists());
+        assert_no_launch_dirs(&config.runtime_dir).await;
+    }
+
+    #[tokio::test]
+    async fn restart_kills_forked_descendant_and_replaces_launch_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
+        let fake_mitmdump = dir.path().join("forking-mitmdump");
+        write_forking_listening_mitmdump(&fake_mitmdump);
+        let config = test_proxy_config(dir.path(), &home, fake_mitmdump.clone());
+        let runtime_dir = config.runtime_dir.clone();
+        let (mut proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
+        proxy.start().await.unwrap();
+
+        let descendant_path = fake_mitmdump.with_extension("descendant");
+        wait_for_file(&descendant_path).await;
+        let old_descendant_pid: u32 = std::fs::read_to_string(&descendant_path)
+            .unwrap()
+            .parse()
+            .unwrap();
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let old_launch = PathBuf::from(environment.lines().next().unwrap());
+
+        let restart = proxy.begin_restart().await.unwrap();
+
+        assert!(
+            wait_for_pid_absent(old_descendant_pid).await,
+            "restart left forked descendant {old_descendant_pid} alive"
+        );
+        assert!(!old_launch.exists(), "restart left old launch directory");
+        assert_no_launch_dirs(&runtime_dir).await;
+
+        let child = restart.spawn().await.unwrap();
+        proxy.complete_restart(child);
+        proxy.kill_now().await.unwrap();
+        assert_no_launch_dirs(&runtime_dir).await;
+    }
+
+    #[tokio::test]
+    async fn repeated_start_keeps_the_active_process_and_launch_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
+        let fake_mitmdump = dir.path().join("fake-mitmdump");
+        write_fake_listening_mitmdump(&fake_mitmdump);
+        let config = test_proxy_config(dir.path(), &home, fake_mitmdump.clone());
+        let (mut proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
+        proxy.start().await.unwrap();
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let launch_path = PathBuf::from(environment.lines().next().unwrap());
+
+        let error = proxy.start().await.unwrap_err();
+
+        assert!(error.to_string().contains("already started"));
+        assert!(launch_path.is_dir());
+        assert!(
+            proxy.child.as_mut().unwrap().try_wait().unwrap().is_none(),
+            "repeated start terminated the active mitmdump"
+        );
+        proxy.kill_now().await.unwrap();
+        assert!(!launch_path.exists());
+    }
+
+    #[tokio::test]
+    async fn proxy_runtime_lock_prevents_concurrent_owners() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let config = test_proxy_config(dir.path(), &home, dir.path().join("mitmdump"));
+        let (first, _first_crash_rx) = MitmProxy::new(config.clone()).await.unwrap();
+
+        let error = MitmProxy::new(config.clone())
+            .await
+            .err()
+            .expect("expected runtime lock conflict");
+        assert!(
+            error.to_string().contains("mitmdump runtime lock")
+                && error.to_string().contains("already held"),
+            "unexpected error: {error}"
+        );
+
+        drop(first);
+        let (_next, _next_crash_rx) = MitmProxy::new(config).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn proxy_startup_reconciles_only_marked_private_launches() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let config = test_proxy_config(dir.path(), &home, dir.path().join("mitmdump"));
+        let runtime = acquire_test_runtime(&config).await;
+        let launch = runtime.create_launch_dir().await.unwrap();
+        let stale_launch = launch.path().to_path_buf();
+        std::fs::create_dir(stale_launch.join("_MEI-stale")).unwrap();
+        std::fs::write(stale_launch.join("_MEI-stale/payload"), b"stale").unwrap();
+
+        let mut stale_process = tokio::process::Command::new("sleep")
+            .arg("60")
+            .env("TMPDIR", &stale_launch)
+            .env(RUNTIME_MARKER_ENV, &stale_launch)
+            .process_group(0)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let stale_pid = stale_process.id().unwrap();
+        let stale_launch = launch.keep();
+        drop(runtime);
+
+        let unrelated_sibling = config.runtime_dir.join("keep-me");
+        std::fs::create_dir(&unrelated_sibling).unwrap();
+        let unrelated_shared = tempfile::Builder::new()
+            .prefix("_MEI-vm0-unrelated-")
+            .tempdir_in("/tmp")
+            .unwrap();
+
+        let (_proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
+
+        let status = tokio::time::timeout(Duration::from_secs(2), stale_process.wait())
+            .await
+            .expect("stale marked process was not terminated")
+            .unwrap();
+        assert!(
+            !status.success(),
+            "stale process unexpectedly exited cleanly"
+        );
+        assert!(
+            wait_for_pid_absent(stale_pid).await,
+            "stale marked process {stale_pid} remains live"
+        );
+        assert!(!stale_launch.exists());
+        assert!(unrelated_sibling.is_dir());
+        assert!(unrelated_shared.path().is_dir());
     }
 
     #[tokio::test]
@@ -1347,7 +1711,7 @@ PY
             .stderr(std::process::Stdio::null())
             .spawn()
             .unwrap();
-        proxy.child = Some(child);
+        proxy.set_child_for_test(child);
 
         assert!(proxy.usage_flush_target().is_some());
 
@@ -1355,7 +1719,7 @@ PY
     }
 
     #[tokio::test]
-    async fn usage_flush_target_skips_exited_child() {
+    async fn usage_flush_target_retains_exited_child_for_async_cleanup() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
         let mut child = tokio::process::Command::new("true")
             .stdin(std::process::Stdio::null())
@@ -1364,10 +1728,11 @@ PY
             .spawn()
             .unwrap();
         child.wait().await.unwrap();
-        proxy.child = Some(child);
+        proxy.set_child_for_test(child);
 
         assert!(proxy.usage_flush_target().is_none());
-        assert!(proxy.child.is_none());
+        assert!(proxy.child.is_some());
+        proxy.kill_now().await.unwrap();
     }
 
     #[tokio::test]
@@ -1380,7 +1745,7 @@ PY
             .spawn()
             .unwrap();
         child.wait().await.unwrap();
-        proxy.child = Some(child);
+        proxy.set_child_for_test(child);
 
         proxy.kill_now().await.unwrap();
 
@@ -1423,7 +1788,7 @@ while True:
         let mut child = command.spawn().unwrap();
         let stdout = child.stdout.take().unwrap();
         let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
-        proxy.child = Some(child);
+        proxy.set_child_for_test(child);
 
         let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
             .await
@@ -1439,8 +1804,7 @@ while True:
             .unwrap();
         assert_eq!(signaled.as_deref(), Some("signaled"));
         assert!(signal_file.exists(), "child did not observe SIGUSR1");
-        let _ = proxy.child.as_mut().unwrap().kill().await;
-        proxy.child = None;
+        proxy.kill_now().await.unwrap();
     }
 
     #[test]
@@ -1451,7 +1815,7 @@ while True:
     }
 
     #[tokio::test]
-    async fn request_usage_flush_returns_false_for_exited_child() {
+    async fn request_usage_flush_retains_exited_child_for_async_cleanup() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
         let mut child = tokio::process::Command::new("bash")
             .arg("-c")
@@ -1470,10 +1834,11 @@ while True:
         assert!(ready_lines.next_line().await.unwrap().is_none());
         let status = child.wait().await.unwrap();
         assert!(status.success(), "child exited with {status}");
-        proxy.child = Some(child);
+        proxy.set_child_for_test(child);
 
         assert!(!proxy.request_usage_flush());
-        assert!(proxy.child.is_none());
+        assert!(proxy.child.is_some());
+        proxy.kill_now().await.unwrap();
     }
 
     /// Regression for #10624: `begin_restart` must lock the old
@@ -1487,7 +1852,7 @@ while True:
         let (mut proxy, _crash_rx) = MitmProxy::noop();
         let old_stopping = Arc::clone(&proxy.stopping);
 
-        let params = proxy.begin_restart().await;
+        let params = proxy.begin_restart().await.unwrap();
 
         // Old flag is now permanently `true`; any task still holding
         // `old_stopping` (the old monitor) will observe graceful
@@ -1513,9 +1878,9 @@ while True:
     async fn repeated_begin_restart_produces_independent_flags() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
 
-        let first = proxy.begin_restart().await;
-        let second = proxy.begin_restart().await;
-        let third = proxy.begin_restart().await;
+        let first = proxy.begin_restart().await.unwrap();
+        let second = proxy.begin_restart().await.unwrap();
+        let third = proxy.begin_restart().await.unwrap();
 
         // Every handed-out Arc is distinct.
         assert!(!Arc::ptr_eq(&first.stopping, &second.stopping));
@@ -1538,7 +1903,7 @@ while True:
     #[tokio::test]
     async fn stop_after_begin_restart_targets_current_flag() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
-        let params = proxy.begin_restart().await;
+        let params = proxy.begin_restart().await.unwrap();
         let current = Arc::clone(&params.stopping);
         assert!(!current.load(Ordering::Acquire));
 

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -1,0 +1,380 @@
+//! Private filesystem ownership for PyInstaller one-file extraction.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use nix::fcntl::Flock;
+use nix::sys::signal::Signal;
+use tracing::{info, warn};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::process::{ProcessStat, ProcessStatRead, process_stat_is_live};
+
+pub(super) const RUNTIME_MARKER_ENV: &str = "VM0_MITMDUMP_RUNTIME_DIR";
+const RUNTIME_MARKER_PREFIX: &[u8] = b"VM0_MITMDUMP_RUNTIME_DIR=";
+const LAUNCH_PREFIX: &str = "launch-";
+const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+const PROCESS_SCAN_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Clone, Copy)]
+struct ProcessIdentity {
+    pid: u32,
+    starttime: u64,
+}
+
+/// Serializes owners of the runner-local proxy resources and scopes every
+/// PyInstaller extraction to one private launch directory.
+pub(super) struct MitmdumpRuntime {
+    root: PathBuf,
+    _lock: Flock<File>,
+}
+
+impl MitmdumpRuntime {
+    pub(super) async fn acquire(root: PathBuf, lock_path: PathBuf) -> RunnerResult<Arc<Self>> {
+        crate::private_fs::ensure_private_dir(&root).await?;
+        let root = tokio::fs::canonicalize(&root).await.map_err(|error| {
+            RunnerError::Config(format!(
+                "canonicalize mitmdump runtime directory {}: {error}",
+                root.display()
+            ))
+        })?;
+        let runtime_lock = crate::lock::try_acquire(lock_path.clone())
+            .await
+            .map_err(|error| {
+                RunnerError::Config(format!(
+                    "acquire mitmdump runtime lock {}: {error}",
+                    lock_path.display()
+                ))
+            })?;
+        let runtime = Arc::new(Self {
+            root,
+            _lock: runtime_lock,
+        });
+        runtime.reconcile().await?;
+        Ok(runtime)
+    }
+
+    pub(super) async fn create_launch_dir(&self) -> RunnerResult<tempfile::TempDir> {
+        self.reconcile().await?;
+        tempfile::Builder::new()
+            .prefix(LAUNCH_PREFIX)
+            .tempdir_in(&self.root)
+            .map_err(|error| {
+                RunnerError::Internal(format!(
+                    "create mitmdump launch directory in {}: {error}",
+                    self.root.display()
+                ))
+            })
+    }
+
+    pub(super) async fn close_launch(&self, launch: tempfile::TempDir) -> RunnerResult<()> {
+        // Persist before the first await so task cancellation cannot let
+        // TempDir remove a directory that a marked descendant still uses.
+        let path = launch.keep();
+        self.close_launch_path(path).await
+    }
+
+    pub(super) async fn close_launch_path(&self, path: PathBuf) -> RunnerResult<()> {
+        if !self.is_launch_path(&path) {
+            return Err(RunnerError::Internal(format!(
+                "refusing to close unowned mitmdump launch path {}",
+                path.display()
+            )));
+        }
+        if let Err(error) = self.terminate_marked_processes(Some(&path)).await {
+            warn!(path = %path.display(), error = %error, "preserving mitmdump launch directory for later reconciliation");
+            return Err(error);
+        }
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(RunnerError::Internal(format!(
+                "remove mitmdump launch directory {}: {error}",
+                path.display()
+            ))),
+        }
+    }
+
+    async fn reconcile(&self) -> RunnerResult<()> {
+        let launch_dirs = self.discover_launch_dirs().await?;
+        if launch_dirs.is_empty() {
+            return Ok(());
+        }
+        self.terminate_marked_processes(None).await?;
+
+        let mut removed = 0usize;
+        for launch_dir in launch_dirs {
+            match tokio::fs::remove_dir_all(&launch_dir).await {
+                Ok(()) => removed += 1,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(RunnerError::Internal(format!(
+                        "remove stale mitmdump launch directory {}: {error}",
+                        launch_dir.display()
+                    )));
+                }
+            }
+        }
+        if removed > 0 {
+            info!(removed, root = %self.root.display(), "reconciled stale mitmdump launch directories");
+        }
+        Ok(())
+    }
+
+    async fn discover_launch_dirs(&self) -> RunnerResult<Vec<PathBuf>> {
+        let expected_uid = nix::unistd::geteuid().as_raw();
+        let mut entries = tokio::fs::read_dir(&self.root).await.map_err(|error| {
+            RunnerError::Internal(format!(
+                "read mitmdump runtime directory {}: {error}",
+                self.root.display()
+            ))
+        })?;
+        let mut launch_dirs = Vec::new();
+        loop {
+            let entry = entries.next_entry().await.map_err(|error| {
+                RunnerError::Internal(format!(
+                    "read entry in mitmdump runtime directory {}: {error}",
+                    self.root.display()
+                ))
+            })?;
+            let Some(entry) = entry else {
+                break;
+            };
+            let name = entry.file_name();
+            if !name.as_bytes().starts_with(LAUNCH_PREFIX.as_bytes()) {
+                continue;
+            }
+            let path = entry.path();
+            let metadata = tokio::fs::symlink_metadata(&path).await.map_err(|error| {
+                RunnerError::Internal(format!(
+                    "inspect mitmdump launch path {}: {error}",
+                    path.display()
+                ))
+            })?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                return Err(RunnerError::Config(format!(
+                    "mitmdump launch path {} is not an owned directory",
+                    path.display()
+                )));
+            }
+            if metadata.uid() != expected_uid {
+                return Err(RunnerError::Config(format!(
+                    "mitmdump launch directory {} is owned by uid {}, expected {}",
+                    path.display(),
+                    metadata.uid(),
+                    expected_uid
+                )));
+            }
+            launch_dirs.push(path);
+        }
+        launch_dirs.sort();
+        Ok(launch_dirs)
+    }
+
+    async fn terminate_marked_processes(&self, exact_path: Option<&Path>) -> RunnerResult<()> {
+        let deadline = tokio::time::Instant::now() + PROCESS_EXIT_TIMEOUT;
+        let mut consecutive_empty_scans = 0u8;
+        loop {
+            let processes = self.scan_marked_processes(exact_path).await?;
+            if processes.is_empty() {
+                consecutive_empty_scans += 1;
+                if consecutive_empty_scans == 2 {
+                    return Ok(());
+                }
+            } else {
+                consecutive_empty_scans = 0;
+                for process in processes {
+                    signal_stable_process(process).await?;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                let target = exact_path.unwrap_or(&self.root);
+                return Err(RunnerError::Internal(format!(
+                    "timed out terminating mitmdump processes using {}",
+                    target.display()
+                )));
+            }
+            tokio::time::sleep(PROCESS_SCAN_INTERVAL).await;
+        }
+    }
+
+    async fn scan_marked_processes(
+        &self,
+        exact_path: Option<&Path>,
+    ) -> RunnerResult<Vec<ProcessIdentity>> {
+        let expected_uid = nix::unistd::geteuid().as_raw();
+        let mut entries = tokio::fs::read_dir("/proc").await.map_err(|error| {
+            RunnerError::Internal(format!("scan /proc for mitmdump runtime owners: {error}"))
+        })?;
+        let mut processes = Vec::new();
+        let mut seen = HashSet::new();
+        loop {
+            let entry = entries.next_entry().await.map_err(|error| {
+                RunnerError::Internal(format!(
+                    "read /proc entry for mitmdump runtime owners: {error}"
+                ))
+            })?;
+            let Some(entry) = entry else {
+                break;
+            };
+            let Some(pid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<u32>().ok())
+            else {
+                continue;
+            };
+            let metadata = match entry.metadata().await {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(RunnerError::Internal(format!(
+                        "inspect /proc/{pid} for mitmdump runtime owner: {error}"
+                    )));
+                }
+            };
+            if metadata.uid() != expected_uid {
+                continue;
+            }
+            let Some(environ) = read_process_environ(pid).await? else {
+                continue;
+            };
+            let Some(marker) = runtime_marker(&environ) else {
+                continue;
+            };
+            let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker));
+            if !self.is_launch_path(marker_path)
+                || exact_path.is_some_and(|expected| marker_path != expected)
+            {
+                continue;
+            }
+            let before = match crate::process::read_process_stat_checked(pid).await {
+                ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
+                ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+                ProcessStatRead::Unreadable(error) => {
+                    return Err(RunnerError::Internal(format!(
+                        "read /proc/{pid}/stat for mitmdump runtime owner: {error}"
+                    )));
+                }
+                ProcessStatRead::Invalid => {
+                    return Err(RunnerError::Internal(format!(
+                        "parse /proc/{pid}/stat for mitmdump runtime owner"
+                    )));
+                }
+            };
+            let Some(rechecked_environ) = read_process_environ(pid).await? else {
+                continue;
+            };
+            if runtime_marker(&rechecked_environ) != Some(marker) {
+                continue;
+            }
+            let after = match crate::process::read_process_stat_checked(pid).await {
+                ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
+                ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+                ProcessStatRead::Unreadable(error) => {
+                    return Err(RunnerError::Internal(format!(
+                        "recheck /proc/{pid}/stat for mitmdump runtime owner: {error}"
+                    )));
+                }
+                ProcessStatRead::Invalid => {
+                    return Err(RunnerError::Internal(format!(
+                        "reparse /proc/{pid}/stat for mitmdump runtime owner"
+                    )));
+                }
+            };
+            if !same_process(&before, &after) || !seen.insert((pid, after.starttime)) {
+                continue;
+            }
+            processes.push(ProcessIdentity {
+                pid,
+                starttime: after.starttime,
+            });
+        }
+        Ok(processes)
+    }
+
+    fn is_launch_path(&self, path: &Path) -> bool {
+        path.parent() == Some(self.root.as_path())
+            && path
+                .file_name()
+                .is_some_and(|name| name.as_bytes().starts_with(LAUNCH_PREFIX.as_bytes()))
+    }
+}
+
+async fn read_process_environ(pid: u32) -> RunnerResult<Option<Vec<u8>>> {
+    match tokio::fs::read(format!("/proc/{pid}/environ")).await {
+        Ok(environ) => Ok(Some(environ)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) if process_comm_is_mitmdump(pid).await? => Err(RunnerError::Internal(format!(
+            "read /proc/{pid}/environ for mitmdump runtime owner: {error}"
+        ))),
+        Err(_) => Ok(None),
+    }
+}
+
+async fn process_comm_is_mitmdump(pid: u32) -> RunnerResult<bool> {
+    let path = format!("/proc/{pid}/comm");
+    match tokio::fs::read(&path).await {
+        Ok(comm) => Ok(comm.strip_suffix(b"\n").unwrap_or(&comm) == b"mitmdump"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(RunnerError::Internal(format!(
+            "read {path} after an unreadable process environment: {error}"
+        ))),
+    }
+}
+
+fn runtime_marker(environ: &[u8]) -> Option<&[u8]> {
+    environ
+        .split(|byte| *byte == 0)
+        .find_map(|entry| entry.strip_prefix(RUNTIME_MARKER_PREFIX))
+}
+
+fn same_process(before: &ProcessStat, after: &ProcessStat) -> bool {
+    before.pgid == after.pgid && before.starttime == after.starttime
+}
+
+async fn signal_stable_process(process: ProcessIdentity) -> RunnerResult<()> {
+    let current = match crate::process::read_process_stat_checked(process.pid).await {
+        ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
+        ProcessStatRead::Found(_) | ProcessStatRead::Missing => return Ok(()),
+        ProcessStatRead::Unreadable(error) => {
+            return Err(RunnerError::Internal(format!(
+                "recheck /proc/{}/stat before mitmdump cleanup signal: {error}",
+                process.pid
+            )));
+        }
+        ProcessStatRead::Invalid => {
+            return Err(RunnerError::Internal(format!(
+                "reparse /proc/{}/stat before mitmdump cleanup signal",
+                process.pid
+            )));
+        }
+    };
+    if current.starttime != process.starttime {
+        return Ok(());
+    }
+    let pid = i32::try_from(process.pid).map_err(|error| {
+        RunnerError::Internal(format!(
+            "convert mitmdump cleanup pid {}: {error}",
+            process.pid
+        ))
+    })?;
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), Signal::SIGKILL) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+        Err(error) => Err(RunnerError::Internal(format!(
+            "kill mitmdump runtime owner pid {}: {error}",
+            process.pid
+        ))),
+    }
+}
+
+pub(super) fn preserve_launch(launch: tempfile::TempDir, error: &impl std::fmt::Display) {
+    let path = launch.path().to_path_buf();
+    let _kept_path = launch.keep();
+    warn!(path = %path.display(), error = %error, "preserving mitmdump launch directory for later reconciliation");
+}

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -231,7 +231,7 @@ impl MitmdumpRuntime {
             };
             let metadata = match entry.metadata().await {
                 Ok(metadata) => metadata,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) if process_disappeared(&error) => continue,
                 Err(error) => {
                     return Err(RunnerError::Internal(format!(
                         "inspect /proc/{pid} for mitmdump runtime owner: {error}"
@@ -256,6 +256,7 @@ impl MitmdumpRuntime {
             let before = match crate::process::read_process_stat_checked(pid).await {
                 ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
                 ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+                ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
                 ProcessStatRead::Unreadable(error) => {
                     return Err(RunnerError::Internal(format!(
                         "read /proc/{pid}/stat for mitmdump runtime owner: {error}"
@@ -276,6 +277,7 @@ impl MitmdumpRuntime {
             let after = match crate::process::read_process_stat_checked(pid).await {
                 ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
                 ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+                ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
                 ProcessStatRead::Unreadable(error) => {
                     return Err(RunnerError::Internal(format!(
                         "recheck /proc/{pid}/stat for mitmdump runtime owner: {error}"
@@ -309,7 +311,7 @@ impl MitmdumpRuntime {
 async fn read_process_environ(pid: u32) -> RunnerResult<Option<Vec<u8>>> {
     match tokio::fs::read(format!("/proc/{pid}/environ")).await {
         Ok(environ) => Ok(Some(environ)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) if process_disappeared(&error) => Ok(None),
         Err(error) if process_comm_is_mitmdump(pid).await? => Err(RunnerError::Internal(format!(
             "read /proc/{pid}/environ for mitmdump runtime owner: {error}"
         ))),
@@ -321,11 +323,15 @@ async fn process_comm_is_mitmdump(pid: u32) -> RunnerResult<bool> {
     let path = format!("/proc/{pid}/comm");
     match tokio::fs::read(&path).await {
         Ok(comm) => Ok(comm.strip_suffix(b"\n").unwrap_or(&comm) == b"mitmdump"),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) if process_disappeared(&error) => Ok(false),
         Err(error) => Err(RunnerError::Internal(format!(
             "read {path} after an unreadable process environment: {error}"
         ))),
     }
+}
+
+fn process_disappeared(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound || error.raw_os_error() == Some(nix::libc::ESRCH)
 }
 
 fn runtime_marker(environ: &[u8]) -> Option<&[u8]> {
@@ -342,6 +348,7 @@ async fn signal_stable_process(process: ProcessIdentity) -> RunnerResult<()> {
     let current = match crate::process::read_process_stat_checked(process.pid).await {
         ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
         ProcessStatRead::Found(_) | ProcessStatRead::Missing => return Ok(()),
+        ProcessStatRead::Unreadable(error) if process_disappeared(&error) => return Ok(()),
         ProcessStatRead::Unreadable(error) => {
             return Err(RunnerError::Internal(format!(
                 "recheck /proc/{}/stat before mitmdump cleanup signal: {error}",


### PR DESCRIPTION
## Summary

- scope each mitmdump launch to a runner-owned private `TMPDIR` and serialize ownership of shared proxy runtime state
- supervise the PyInstaller bootloader and its process group through start failures, restarts, graceful stops, forced stops, and dropped owners
- reconcile crash leftovers using an exact runner marker while deliberately leaving legacy and unrelated shared `/tmp/_MEI*` paths untouched
- cover active-launch protection, descendant cleanup, lock exclusion, crash reconciliation, and cleanup on every lifecycle path

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` — 2781 passed, 13 ignored; guest inventory passed
- real runner host with the official mitmdump 12.2.3 binary:
  - completed a proxied HTTPS VM job successfully
  - restarted the PyInstaller application child five times while keeping exactly one current private extraction
  - recovered after a forced runner `SIGKILL`, removed the stale launch, and started a new one
  - removed all private launch directories on normal service stop
  - preserved an unrelated shared `/tmp/_MEI*` sentinel throughout validation

Fixes #22473