### PR TITLE
perf(runner): attribute sandbox start phases

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -8,7 +8,7 @@ use futures_util::FutureExt;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
     SandboxFactory, SandboxId, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
-    SandboxNbdNetlinkConnectStage,
+    SandboxNbdNetlinkConnectStage, SandboxStartObserver, SandboxStartStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -115,6 +115,15 @@ const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_MULTIPLE: &str =
     "runner_fresh_sandbox_factory_nbd_size_zero_retries_multiple";
 const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_register";
 const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
+const RUNNER_FRESH_SANDBOX_START_BACKEND_LAUNCH: &str = "runner_fresh_sandbox_start_backend_launch";
+const RUNNER_FRESH_SANDBOX_START_SNAPSHOT_LOAD_RESUME: &str =
+    "runner_fresh_sandbox_start_snapshot_load_resume";
+const RUNNER_FRESH_SANDBOX_START_GUEST_CONNECTION_WAIT: &str =
+    "runner_fresh_sandbox_start_guest_connection_wait";
+const RUNNER_FRESH_SANDBOX_START_GUEST_DNS_READINESS: &str =
+    "runner_fresh_sandbox_start_guest_dns_readiness";
+const RUNNER_FRESH_SANDBOX_START_RUNTIME_FINALIZE: &str =
+    "runner_fresh_sandbox_start_runtime_finalize";
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
     "runner_fresh_sandbox_retry_without_workspace_image";
 const RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY: &str = "runner_fresh_sandbox_dns_readiness_retry";
@@ -128,11 +137,38 @@ const SANDBOX_FACTORY_CREATE_FAILED: &str = "sandbox_factory_create_failed";
 const SANDBOX_FACTORY_CREATE_STAGE_FAILED: &str = "sandbox_factory_create_stage_failed";
 const SANDBOX_PROXY_REGISTER_FAILED: &str = "sandbox_proxy_register_failed";
 const SANDBOX_START_FAILED: &str = "sandbox_start_failed";
+const SANDBOX_START_STAGE_FAILED: &str = "sandbox_start_stage_failed";
 const DNS_READINESS_RETRY_PREPARE_FAILED: &str = "replacement_prepare_failed";
 const SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN: &str = "cleanup_uncertain";
 
 struct FreshSandboxFactoryCreateObserver<'a> {
     telemetry: &'a mut JobTelemetry,
+}
+
+struct FreshSandboxStartObserver<'a> {
+    telemetry: &'a mut JobTelemetry,
+}
+
+impl SandboxStartObserver for FreshSandboxStartObserver<'_> {
+    fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool) {
+        let error = (!success).then_some(SANDBOX_START_STAGE_FAILED);
+        self.telemetry.record(
+            fresh_sandbox_start_stage_action(stage),
+            duration,
+            success,
+            error,
+        );
+    }
+}
+
+fn fresh_sandbox_start_stage_action(stage: SandboxStartStage) -> &'static str {
+    match stage {
+        SandboxStartStage::BackendLaunch => RUNNER_FRESH_SANDBOX_START_BACKEND_LAUNCH,
+        SandboxStartStage::SnapshotLoadResume => RUNNER_FRESH_SANDBOX_START_SNAPSHOT_LOAD_RESUME,
+        SandboxStartStage::GuestConnectionWait => RUNNER_FRESH_SANDBOX_START_GUEST_CONNECTION_WAIT,
+        SandboxStartStage::GuestDnsReadiness => RUNNER_FRESH_SANDBOX_START_GUEST_DNS_READINESS,
+        SandboxStartStage::RuntimeFinalize => RUNNER_FRESH_SANDBOX_START_RUNTIME_FINALIZE,
+    }
 }
 
 impl SandboxCreateObserver for FreshSandboxFactoryCreateObserver<'_> {
@@ -927,7 +963,11 @@ async fn create_started_sandbox(
         }
     };
     let sandbox_start_started = Instant::now();
-    if let Err(e) = sandbox.start().await {
+    let start_result = {
+        let mut observer = FreshSandboxStartObserver { telemetry };
+        sandbox.start_with_observer(&mut observer).await
+    };
+    if let Err(e) = start_result {
         let guest_dns_readiness = matches!(&e, SandboxError::GuestDnsReadiness { .. });
         telemetry.record(
             RUNNER_FRESH_SANDBOX_START,

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,10 +1,13 @@
+use std::path::Path;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::{
-    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxCreateObserver,
-    SandboxCreateStage, SandboxError, SandboxFactory, SandboxId, SandboxInitializationPhase,
-    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
+    CopyFileOptions, ExecRequest, ExecResult, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
+    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
+    SandboxFactory, SandboxId, SandboxInitializationPhase, SandboxNbdCowCreateOutcome,
+    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxStartObserver,
+    SandboxStartStage, StartProcessRequest,
 };
 use sandbox_mock::MockSandboxFactory;
 
@@ -99,11 +102,135 @@ fn assert_action_outcome(
     assert_eq!(op.2.as_deref(), error, "{action} error");
 }
 
+fn assert_action_duration(telemetry: &JobTelemetry, action: &str, duration_ms: u64) {
+    let ops = telemetry.pending_ops_with_duration_snapshot();
+    let op = ops
+        .iter()
+        .find(|op| op.0 == action)
+        .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
+    assert_eq!(op.1, duration_ms, "{action} duration");
+}
+
+struct ObservedStartSandbox {
+    inner: Box<dyn Sandbox>,
+    failed_stage: Option<SandboxStartStage>,
+    omit_optional_stages: bool,
+}
+
+#[async_trait]
+impl Sandbox for ObservedStartSandbox {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn source_ip(&self) -> &str {
+        self.inner.source_ip()
+    }
+
+    fn host_process_pid(&self) -> Option<u32> {
+        self.inner.host_process_pid()
+    }
+
+    async fn start(&mut self) -> sandbox::Result<()> {
+        self.inner.start().await
+    }
+
+    async fn start_with_observer(
+        &mut self,
+        observer: &mut dyn SandboxStartObserver,
+    ) -> sandbox::Result<()> {
+        for (index, stage) in SandboxStartStage::ALL.iter().copied().enumerate() {
+            if self.omit_optional_stages
+                && matches!(
+                    stage,
+                    SandboxStartStage::SnapshotLoadResume | SandboxStartStage::GuestDnsReadiness
+                )
+            {
+                continue;
+            }
+            let success = self.failed_stage != Some(stage);
+            observer.record_stage(stage, Duration::from_millis(index as u64 + 30), success);
+            if !success {
+                return Err(SandboxError::Start {
+                    message: "observed mock start failure".to_string(),
+                });
+            }
+        }
+        self.inner.start().await
+    }
+
+    async fn stop(&mut self) -> sandbox::Result<()> {
+        self.inner.stop().await
+    }
+
+    async fn kill(&mut self) -> sandbox::Result<()> {
+        self.inner.kill().await
+    }
+
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
+        self.inner.park().await
+    }
+
+    async fn unpark(&mut self) -> sandbox::Result<()> {
+        self.inner.unpark().await
+    }
+
+    async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        self.inner.exec(request).await
+    }
+
+    async fn exec_with_diagnostic_label(
+        &self,
+        request: &ExecRequest<'_>,
+        label: &'static str,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.exec_with_diagnostic_label(request, label).await
+    }
+
+    async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
+        self.inner.read_file(path, max_bytes).await
+    }
+
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> sandbox::Result<sandbox::CopyFileResult> {
+        self.inner.copy_file(path, host_path, options).await
+    }
+
+    async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_file(path, content).await
+    }
+
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_private_file(path, content).await
+    }
+
+    async fn start_process(
+        &self,
+        request: &StartProcessRequest<'_>,
+    ) -> sandbox::Result<sandbox::GuestProcessHandle> {
+        self.inner.start_process(request).await
+    }
+
+    async fn wait_process(
+        &self,
+        handle: sandbox::GuestProcessHandle,
+        timeout: Duration,
+    ) -> sandbox::Result<ProcessExit> {
+        self.inner.wait_process(handle, timeout).await
+    }
+}
+
 struct ObservedMockSandboxFactory {
     inner: MockSandboxFactory,
     failed_stage: Option<SandboxCreateStage>,
     failed_nbd_cow_stage: Option<SandboxNbdCowCreateStage>,
     failed_nbd_netlink_connect_stage: Option<SandboxNbdNetlinkConnectStage>,
+    failed_start_stage: Option<SandboxStartStage>,
+    omit_optional_start_stages: bool,
 }
 
 impl ObservedMockSandboxFactory {
@@ -113,6 +240,8 @@ impl ObservedMockSandboxFactory {
             failed_stage: None,
             failed_nbd_cow_stage: None,
             failed_nbd_netlink_connect_stage: None,
+            failed_start_stage: None,
+            omit_optional_start_stages: false,
         }
     }
 
@@ -122,6 +251,8 @@ impl ObservedMockSandboxFactory {
             failed_stage: Some(stage),
             failed_nbd_cow_stage: None,
             failed_nbd_netlink_connect_stage: None,
+            failed_start_stage: None,
+            omit_optional_start_stages: false,
         }
     }
 
@@ -131,6 +262,8 @@ impl ObservedMockSandboxFactory {
             failed_stage: None,
             failed_nbd_cow_stage: Some(stage),
             failed_nbd_netlink_connect_stage: None,
+            failed_start_stage: None,
+            omit_optional_start_stages: false,
         }
     }
 
@@ -140,6 +273,30 @@ impl ObservedMockSandboxFactory {
             failed_stage: None,
             failed_nbd_cow_stage: None,
             failed_nbd_netlink_connect_stage: Some(stage),
+            failed_start_stage: None,
+            omit_optional_start_stages: false,
+        }
+    }
+
+    fn with_failed_start_stage(stage: SandboxStartStage) -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+            failed_stage: None,
+            failed_nbd_cow_stage: None,
+            failed_nbd_netlink_connect_stage: None,
+            failed_start_stage: Some(stage),
+            omit_optional_start_stages: false,
+        }
+    }
+
+    fn without_optional_start_stages() -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+            failed_stage: None,
+            failed_nbd_cow_stage: None,
+            failed_nbd_netlink_connect_stage: None,
+            failed_start_stage: None,
+            omit_optional_start_stages: true,
         }
     }
 }
@@ -155,7 +312,12 @@ impl SandboxFactory for ObservedMockSandboxFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
-        self.inner.create(config).await
+        let inner = self.inner.create(config).await?;
+        Ok(Box::new(ObservedStartSandbox {
+            inner,
+            failed_stage: self.failed_start_stage,
+            omit_optional_stages: self.omit_optional_start_stages,
+        }))
     }
 
     async fn create_with_observer(
@@ -226,7 +388,7 @@ impl SandboxFactory for ObservedMockSandboxFactory {
         ] {
             observer.record_nbd_cow_outcome(outcome);
         }
-        self.inner.create(config).await
+        self.create(config).await
     }
 
     async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
@@ -271,6 +433,14 @@ const FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS: &[&str] = &[
     "runner_fresh_sandbox_factory_nbd_acquire_source_demand_scan",
     "runner_fresh_sandbox_factory_nbd_ebusy_retries_none",
     "runner_fresh_sandbox_factory_nbd_size_zero_retries_none",
+];
+
+const FRESH_SANDBOX_START_STAGE_ACTIONS: &[&str] = &[
+    "runner_fresh_sandbox_start_backend_launch",
+    "runner_fresh_sandbox_start_snapshot_load_resume",
+    "runner_fresh_sandbox_start_guest_connection_wait",
+    "runner_fresh_sandbox_start_guest_dns_readiness",
+    "runner_fresh_sandbox_start_runtime_finalize",
 ];
 
 const RUNNER_PRE_SPAWN_PHASE_ACTIONS: &[&str] = &[
@@ -368,6 +538,10 @@ async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
     assert_lacks_action(&telemetry, "runner_claim_to_executor_start");
     assert_lacks_action(&telemetry, "runner_claim_resume_session_validation");
     assert_lacks_action(&telemetry, "runner_claim_task_schedule_wait");
+    assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
+    for action in FRESH_SANDBOX_START_STAGE_ACTIONS {
+        assert_lacks_action(&telemetry, action);
+    }
 }
 
 #[tokio::test]
@@ -469,6 +643,10 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
+    for (index, action) in FRESH_SANDBOX_START_STAGE_ACTIONS.iter().enumerate() {
+        assert_action_success(&telemetry, action, true);
+        assert_action_duration(&telemetry, action, index as u64 + 30);
+    }
     let operations = telemetry.pending_ops_with_duration_snapshot();
     for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
         let matching: Vec<_> = operations
@@ -482,6 +660,95 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
+}
+
+#[tokio::test]
+async fn execute_job_omits_inapplicable_sandbox_start_stages() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::without_optional_start_stages();
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+
+    for action in [
+        "runner_fresh_sandbox_start_backend_launch",
+        "runner_fresh_sandbox_start_guest_connection_wait",
+        "runner_fresh_sandbox_start_runtime_finalize",
+    ] {
+        assert_action_success(&telemetry, action, true);
+    }
+    assert_lacks_action(
+        &telemetry,
+        "runner_fresh_sandbox_start_snapshot_load_resume",
+    );
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_guest_dns_readiness");
+    assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
+}
+
+#[tokio::test]
+async fn execute_job_records_failed_sandbox_start_stage_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory =
+        ObservedMockSandboxFactory::with_failed_start_stage(SandboxStartStage::GuestConnectionWait);
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+
+    assert!(
+        outcome
+            .error()
+            .is_some_and(|error| error.contains("observed mock start failure"))
+    );
+
+    for action in [
+        "runner_fresh_sandbox_start_backend_launch",
+        "runner_fresh_sandbox_start_snapshot_load_resume",
+    ] {
+        assert_action_success(&telemetry, action, true);
+    }
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_start_guest_connection_wait",
+        false,
+        Some("sandbox_start_stage_failed"),
+    );
+    assert_action_duration(
+        &telemetry,
+        "runner_fresh_sandbox_start_guest_connection_wait",
+        32,
+    );
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_guest_dns_readiness");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_runtime_finalize");
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_start",
+        false,
+        Some("sandbox_start_failed"),
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU64;
 use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
@@ -12,8 +12,8 @@ use sandbox::{
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
     SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome, StartProcessRequest,
-    WriteFileEntry,
+    SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver,
+    SandboxStartStage, StartProcessRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -85,6 +85,27 @@ const PROCESS_LOG_READER_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Timeout for guest lifecycle acknowledgements during same-session park/unpark.
 const GUEST_PARK_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct SandboxStartTiming<'a> {
+    observer: Option<&'a mut dyn SandboxStartObserver>,
+}
+
+impl<'a> SandboxStartTiming<'a> {
+    fn new(observer: Option<&'a mut dyn SandboxStartObserver>) -> Self {
+        Self { observer }
+    }
+
+    fn record(&mut self, stage: SandboxStartStage, started: Instant, success: bool) {
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record_stage(stage, started.elapsed(), success);
+        }
+    }
+}
+
+struct SnapshotLoadPaths {
+    snapshot: String,
+    memory: String,
+}
 
 fn build_fresh_boot_firecracker_config(
     resources: &sandbox::ResourceLimits,
@@ -1008,11 +1029,11 @@ impl FirecrackerSandbox {
         Ok(client)
     }
 
-    /// Start from a snapshot using `--api-sock` and bind mounts.
-    async fn start_from_snapshot(
+    /// Launch from a snapshot using `--api-sock` and bind mounts.
+    async fn launch_from_snapshot(
         &mut self,
         runtime_cancel: CancellationToken,
-    ) -> sandbox::Result<ApiClient> {
+    ) -> sandbox::Result<(ApiClient, SnapshotLoadPaths)> {
         let snapshot =
             self.factory_config
                 .snapshot
@@ -1094,16 +1115,261 @@ impl FirecrackerSandbox {
             .spawn_and_wait_for_api(command, &api_sock, runtime_cancel, "snapshot restore")
             .await?;
 
-        load_snapshot_and_apply_rate_limits(
-            &client,
-            &snapshot_str,
-            &memory_str,
-            self.device_rate_limits.as_ref(),
-        )
-        .await?;
+        Ok((
+            client,
+            SnapshotLoadPaths {
+                snapshot: snapshot_str,
+                memory: memory_str,
+            },
+        ))
+    }
 
-        info!(id = %self.id, "snapshot loaded and resumed");
-        Ok(client)
+    async fn start_with_optional_observer(
+        &mut self,
+        observer: Option<&mut dyn SandboxStartObserver>,
+    ) -> sandbox::Result<()> {
+        if self.current_state() != SandboxState::Created {
+            return Err(SandboxError::InvalidState {
+                context: SandboxInvalidStateContext::Sandbox,
+                state: self.current_state().to_string(),
+                message: "sandbox already started".into(),
+            });
+        }
+
+        let mut timing = SandboxStartTiming::new(observer);
+        let backend_started = Instant::now();
+        if self.factory_config.dns_port.is_some()
+            && let Err(error) = self.network.mark_non_reusable()
+        {
+            timing.record(SandboxStartStage::BackendLaunch, backend_started, false);
+            return Err(error);
+        }
+
+        let runtime_cancel = CancellationToken::new();
+
+        // Start the vsock listener BEFORE launching Firecracker.
+        // The UDS must be bound before the guest tries to connect.
+        let vsock_path = self.sock_paths.vsock().display().to_string();
+        let mut vsock_task = tokio::spawn(async move {
+            VsockHost::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT).await
+        });
+
+        let launch_result = if self.factory_config.snapshot.is_some() {
+            self.launch_from_snapshot(runtime_cancel.clone())
+                .await
+                .map(|(client, paths)| (client, Some(paths)))
+        } else {
+            self.start_fresh(runtime_cancel.clone())
+                .await
+                .map(|client| (client, None))
+        };
+
+        let (client, snapshot_paths) = match launch_result {
+            Ok(result) => {
+                timing.record(SandboxStartStage::BackendLaunch, backend_started, true);
+                result
+            }
+            Err(error) => {
+                timing.record(SandboxStartStage::BackendLaunch, backend_started, false);
+                abort_and_join(vsock_task).await;
+                self.runtime.kill_process().await;
+                return Err(error);
+            }
+        };
+
+        if let Some(paths) = snapshot_paths {
+            let snapshot_started = Instant::now();
+            let snapshot_result = load_snapshot_and_apply_rate_limits(
+                &client,
+                &paths.snapshot,
+                &paths.memory,
+                self.device_rate_limits.as_ref(),
+            )
+            .await;
+            match snapshot_result {
+                Ok(()) => {
+                    info!(id = %self.id, "snapshot loaded and resumed");
+                    timing.record(
+                        SandboxStartStage::SnapshotLoadResume,
+                        snapshot_started,
+                        true,
+                    );
+                }
+                Err(error) => {
+                    timing.record(
+                        SandboxStartStage::SnapshotLoadResume,
+                        snapshot_started,
+                        false,
+                    );
+                    abort_and_join(vsock_task).await;
+                    self.runtime.kill_process().await;
+                    return Err(error);
+                }
+            }
+        }
+
+        // The listener overlaps backend startup. Measure only the remaining
+        // critical-path wait after launch and optional snapshot restore.
+        let guest_connection_started = Instant::now();
+        let (guest_connection_result, abort_vsock_on_failure) = tokio::select! {
+            result = &mut vsock_task => {
+                let result = match result {
+                    Ok(Ok(guest)) => Ok(guest),
+                    Ok(Err(error)) => Err(SandboxError::Start {
+                        message: format!("vsock connection: {error}"),
+                    }),
+                    Err(error) => Err(SandboxError::Start {
+                        message: format!("vsock task: {error}"),
+                    }),
+                };
+                (result, false)
+            }
+            state = wait_for_process_exit(self.state_tx.subscribe()) => {
+                (
+                    Err(SandboxError::Start {
+                        message: format!("process exited before vsock connected (state={state})"),
+                    }),
+                    true,
+                )
+            }
+        };
+        let vsock_guest = match guest_connection_result {
+            Ok(guest) => {
+                timing.record(
+                    SandboxStartStage::GuestConnectionWait,
+                    guest_connection_started,
+                    true,
+                );
+                guest
+            }
+            Err(error) => {
+                timing.record(
+                    SandboxStartStage::GuestConnectionWait,
+                    guest_connection_started,
+                    false,
+                );
+                if abort_vsock_on_failure {
+                    abort_and_join(vsock_task).await;
+                }
+                self.runtime.kill_process().await;
+                return Err(error);
+            }
+        };
+
+        let vsock_guest = Arc::new(vsock_guest);
+
+        if let Some(dns_port) = self.factory_config.dns_port {
+            let dns_started = Instant::now();
+            match wait_for_guest_dns_readiness(&vsock_guest).await {
+                Ok(()) => {
+                    timing.record(SandboxStartStage::GuestDnsReadiness, dns_started, true);
+                }
+                Err(error) => {
+                    timing.record(SandboxStartStage::GuestDnsReadiness, dns_started, false);
+                    capture_guest_dns_failure_snapshot(
+                        vsock_guest.as_ref(),
+                        GuestDnsFailureDiagnosticContext {
+                            sandbox_id: &self.id,
+                            profile: &self.factory_config.profile,
+                            namespace: self.network.name(),
+                            host_device: self.network.host_device(),
+                            peer_ip: self.network.peer_ip(),
+                            dns_port,
+                        },
+                    )
+                    .await;
+                    warn!(
+                        id = %self.id,
+                        profile = %self.factory_config.profile,
+                        namespace = %self.network.name(),
+                        peer_ip = %self.network.peer_ip(),
+                        stage = "guest_dns_readiness",
+                        outcome = %error.last_failure,
+                        attempts = error.attempts,
+                        elapsed_ms = duration_ms(error.elapsed),
+                        "guest DNS readiness probe failed"
+                    );
+                    self.runtime.kill_process().await;
+                    return Err(SandboxError::GuestDnsReadiness {
+                        message: format!(
+                            "guest DNS readiness for namespace {}: {error}",
+                            self.network.name(),
+                        ),
+                    });
+                }
+            }
+        }
+
+        let finalize_started = Instant::now();
+        if self.factory_config.dns_port.is_some()
+            && let Err(error) = self.network.mark_reusable()
+        {
+            timing.record(SandboxStartStage::RuntimeFinalize, finalize_started, false);
+            self.runtime.kill_process().await;
+            return Err(error);
+        }
+
+        *self.guest.lock().await = Some(vsock_guest);
+
+        let control_sock_path = self.sock_paths.control_sock();
+        let Some(termination_handle) = self
+            .runtime
+            .process_termination_handle(self.park_coordinator.clone())
+        else {
+            timing.record(SandboxStartStage::RuntimeFinalize, finalize_started, false);
+            self.guest.lock().await.take();
+            self.runtime.kill_process().await;
+            return Err(SandboxError::Start {
+                message: "process monitor missing before control socket bind".into(),
+            });
+        };
+        let control_server = match control::bind_server(
+            control_sock_path.clone(),
+            self.guest_operation_start_gate(),
+            termination_handle,
+        ) {
+            Ok(server) => server,
+            Err(error) => {
+                timing.record(SandboxStartStage::RuntimeFinalize, finalize_started, false);
+                self.guest.lock().await.take();
+                self.runtime.kill_process().await;
+                return Err(SandboxError::Start {
+                    message: format!(
+                        "control socket bind {}: {error}",
+                        control_sock_path.display()
+                    ),
+                });
+            }
+        };
+
+        // Use CAS to avoid overwriting Stopped if the process crashed between
+        // spawn and vsock connect (the process monitor may have already
+        // recorded process exit).
+        if !self.transition(SandboxState::Created, SandboxState::Running) {
+            timing.record(SandboxStartStage::RuntimeFinalize, finalize_started, false);
+            self.guest.lock().await.take();
+            control_server.close();
+            self.runtime.kill_process().await;
+            return Err(SandboxError::Start {
+                message: "process exited during startup".into(),
+            });
+        }
+
+        // Start control socket server for `runner exec` and host-side
+        // termination requests.
+        self.runtime
+            .set_control(control_server.spawn(runtime_cancel));
+
+        // Spawn balloon controller to reclaim unused guest memory.
+        self.runtime.set_balloon(balloon::spawn(
+            client,
+            self.config.resources.memory_mb,
+            self.state_tx.subscribe(),
+        ));
+
+        info!(id = %self.id, "sandbox started");
+        timing.record(SandboxStartStage::RuntimeFinalize, finalize_started, true);
+        Ok(())
     }
 }
 
@@ -1496,169 +1762,14 @@ impl Sandbox for FirecrackerSandbox {
     // -- lifecycle --
 
     async fn start(&mut self) -> sandbox::Result<()> {
-        if self.current_state() != SandboxState::Created {
-            return Err(SandboxError::InvalidState {
-                context: SandboxInvalidStateContext::Sandbox,
-                state: self.current_state().to_string(),
-                message: "sandbox already started".into(),
-            });
-        }
+        self.start_with_optional_observer(None).await
+    }
 
-        if self.factory_config.dns_port.is_some() {
-            self.network.mark_non_reusable()?;
-        }
-
-        let runtime_cancel = CancellationToken::new();
-
-        // Start the vsock listener BEFORE launching Firecracker.
-        // The UDS must be bound before the guest tries to connect.
-        let vsock_path = self.sock_paths.vsock().display().to_string();
-        let mut vsock_task = tokio::spawn(async move {
-            VsockHost::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT).await
-        });
-
-        let start_result = if self.factory_config.snapshot.is_some() {
-            self.start_from_snapshot(runtime_cancel.clone()).await
-        } else {
-            self.start_fresh(runtime_cancel.clone()).await
-        };
-
-        let client = match start_result {
-            Ok(client) => client,
-            Err(e) => {
-                abort_and_join(vsock_task).await;
-                self.runtime.kill_process().await;
-                return Err(e);
-            }
-        };
-
-        // Wait for guest to connect via vsock.
-        let vsock_guest = tokio::select! {
-            result = &mut vsock_task => {
-                match result {
-                    Ok(Ok(g)) => g,
-                    Ok(Err(e)) => {
-                        self.runtime.kill_process().await;
-                        return Err(SandboxError::Start {
-                            message: format!("vsock connection: {e}"),
-                        });
-                    }
-                    Err(e) => {
-                        self.runtime.kill_process().await;
-                        return Err(SandboxError::Start {
-                            message: format!("vsock task: {e}"),
-                        });
-                    }
-                }
-            }
-            state = wait_for_process_exit(self.state_tx.subscribe()) => {
-                abort_and_join(vsock_task).await;
-                self.runtime.kill_process().await;
-                return Err(SandboxError::Start {
-                    message: format!("process exited before vsock connected (state={state})"),
-                });
-            }
-        };
-
-        let vsock_guest = Arc::new(vsock_guest);
-
-        if let Some(dns_port) = self.factory_config.dns_port {
-            match wait_for_guest_dns_readiness(&vsock_guest).await {
-                Ok(()) => {
-                    if let Err(error) = self.network.mark_reusable() {
-                        self.runtime.kill_process().await;
-                        return Err(error);
-                    }
-                }
-                Err(error) => {
-                    capture_guest_dns_failure_snapshot(
-                        vsock_guest.as_ref(),
-                        GuestDnsFailureDiagnosticContext {
-                            sandbox_id: &self.id,
-                            profile: &self.factory_config.profile,
-                            namespace: self.network.name(),
-                            host_device: self.network.host_device(),
-                            peer_ip: self.network.peer_ip(),
-                            dns_port,
-                        },
-                    )
-                    .await;
-                    warn!(
-                        id = %self.id,
-                        profile = %self.factory_config.profile,
-                        namespace = %self.network.name(),
-                        peer_ip = %self.network.peer_ip(),
-                        stage = "guest_dns_readiness",
-                        outcome = %error.last_failure,
-                        attempts = error.attempts,
-                        elapsed_ms = duration_ms(error.elapsed),
-                        "guest DNS readiness probe failed"
-                    );
-                    self.runtime.kill_process().await;
-                    return Err(SandboxError::GuestDnsReadiness {
-                        message: format!(
-                            "guest DNS readiness for namespace {}: {error}",
-                            self.network.name(),
-                        ),
-                    });
-                }
-            }
-        }
-
-        *self.guest.lock().await = Some(vsock_guest);
-
-        let control_sock_path = self.sock_paths.control_sock();
-        let Some(termination_handle) = self
-            .runtime
-            .process_termination_handle(self.park_coordinator.clone())
-        else {
-            self.guest.lock().await.take();
-            self.runtime.kill_process().await;
-            return Err(SandboxError::Start {
-                message: "process monitor missing before control socket bind".into(),
-            });
-        };
-        let control_server = match control::bind_server(
-            control_sock_path.clone(),
-            self.guest_operation_start_gate(),
-            termination_handle,
-        ) {
-            Ok(server) => server,
-            Err(e) => {
-                self.guest.lock().await.take();
-                self.runtime.kill_process().await;
-                return Err(SandboxError::Start {
-                    message: format!("control socket bind {}: {e}", control_sock_path.display()),
-                });
-            }
-        };
-
-        // Use CAS to avoid overwriting Stopped if the process crashed between
-        // spawn and vsock connect (the process monitor may have already
-        // recorded process exit).
-        if !self.transition(SandboxState::Created, SandboxState::Running) {
-            self.guest.lock().await.take();
-            control_server.close();
-            self.runtime.kill_process().await;
-            return Err(SandboxError::Start {
-                message: "process exited during startup".into(),
-            });
-        }
-
-        // Start control socket server for `runner exec` and host-side
-        // termination requests.
-        self.runtime
-            .set_control(control_server.spawn(runtime_cancel));
-
-        // Spawn balloon controller to reclaim unused guest memory.
-        self.runtime.set_balloon(balloon::spawn(
-            client,
-            self.config.resources.memory_mb,
-            self.state_tx.subscribe(),
-        ));
-
-        info!(id = %self.id, "sandbox started");
-        Ok(())
+    async fn start_with_observer(
+        &mut self,
+        observer: &mut dyn SandboxStartObserver,
+    ) -> sandbox::Result<()> {
+        self.start_with_optional_observer(Some(observer)).await
     }
 
     async fn stop(&mut self) -> sandbox::Result<()> {

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3053,6 +3053,40 @@ async fn process_monitor_reports_startup_exit_as_stopped() {
     handle.wait().await;
 }
 
+#[derive(Default)]
+struct RecordingSandboxStartObserver {
+    records: Vec<(SandboxStartStage, bool)>,
+}
+
+impl SandboxStartObserver for RecordingSandboxStartObserver {
+    fn record_stage(&mut self, stage: SandboxStartStage, _duration: Duration, success: bool) {
+        self.records.push((stage, success));
+    }
+}
+
+#[tokio::test]
+async fn start_with_observer_reports_backend_launch_failure() {
+    let workspace = tempfile::tempdir().unwrap();
+    let mut sandbox = test_sandbox_with_state(SandboxState::Created);
+    sandbox.sandbox_paths = SandboxPaths::new(workspace.path().join("workspace"));
+    sandbox.sock_paths = SockPaths::new(workspace.path().join("sock"));
+    let mut observer = RecordingSandboxStartObserver::default();
+
+    let error = sandbox
+        .start_with_observer(&mut observer)
+        .await
+        .unwrap_err();
+
+    let SandboxError::Start { message } = error else {
+        panic!("expected startup error");
+    };
+    assert!(message.contains("COW device missing before sandbox start"));
+    assert_eq!(
+        observer.records,
+        vec![(SandboxStartStage::BackendLaunch, false)]
+    );
+}
+
 #[tokio::test]
 async fn spawn_and_wait_for_api_adopts_process_and_secures_socket() {
     let workspace = tempfile::tempdir().unwrap();

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -348,7 +348,7 @@ impl SnapshotAttempt {
 
         // Spawn Firecracker inside `unshare --mount` so the COW-device bind
         // mount lives in a private mount namespace and dies with the process.
-        // Mirrors the spawn pattern in `sandbox.rs::start_from_snapshot`.
+        // Mirrors the spawn pattern in `sandbox.rs::launch_from_snapshot`.
         if let Err(e) = self.cleanup_resources.process.spawn(SnapshotProcessSpawn {
             cow_device_path: &cow_device_path,
             drive_bind: &drive_bind,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -41,7 +41,10 @@ pub use factory::{
     SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
-pub use sandbox::{Sandbox, SandboxParkNonReusableReason, SandboxParkOutcome};
+pub use sandbox::{
+    Sandbox, SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver,
+    SandboxStartStage,
+};
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -35,6 +35,66 @@ impl SandboxParkNonReusableReason {
     }
 }
 
+/// Fixed low-cardinality stages on the sandbox start critical path.
+///
+/// Providers report only stages that apply to a start. The snapshot stage is
+/// absent for a fresh boot, and the DNS stage is absent when the provider does
+/// not perform a guest DNS readiness check. On a successful start, reported
+/// stages are ordered, non-overlapping wall-clock intervals. Concurrent work
+/// belongs to the interval that contains it; for example, guest connection
+/// waiting measures only the residual wait after backend startup completes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxStartStage {
+    /// Prepares and launches the backend through its control API readiness.
+    BackendLaunch,
+    /// Loads and resumes an applicable backend snapshot.
+    SnapshotLoadResume,
+    /// Waits for the residual guest control connection after backend startup.
+    GuestConnectionWait,
+    /// Proves that the configured guest DNS path is ready.
+    GuestDnsReadiness,
+    /// Publishes the guest and starts the remaining host runtime services.
+    RuntimeFinalize,
+}
+
+impl SandboxStartStage {
+    /// All start stages in stable catalog order.
+    ///
+    /// Providers can omit stages that do not apply. This order describes the
+    /// successful critical path, not a completeness guarantee after failure or
+    /// cancellation.
+    pub const ALL: [Self; 5] = [
+        Self::BackendLaunch,
+        Self::SnapshotLoadResume,
+        Self::GuestConnectionWait,
+        Self::GuestDnsReadiness,
+        Self::RuntimeFinalize,
+    ];
+}
+
+/// Receives optional low-cardinality sandbox start timing records.
+///
+/// Providers that override [`Sandbox::start_with_observer`] invoke the callback
+/// for every applicable stage when it resolves, before running failure
+/// diagnostics or cleanup. Earlier successful callbacks remain valid when a
+/// later stage fails. Cancellation can leave a completed prefix without a
+/// callback for the in-progress stage. Implementations using the default method
+/// report no stages.
+///
+/// For an overriding implementation, successful start stages are
+/// non-overlapping and cover the provider start critical path after lifecycle
+/// precondition checks. A failed parent start can additionally include
+/// diagnostics and cleanup after the failed stage callback. Observer callbacks
+/// are informational and never own lifecycle transitions or cleanup.
+pub trait SandboxStartObserver: Send {
+    /// Records one completed start stage.
+    ///
+    /// `success` is the result of this stage, not the final result of the full
+    /// start. A provider invokes this callback at most once per applicable
+    /// stage.
+    fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool);
+}
+
 /// A process-isolation environment that runs guest workloads for the runner.
 ///
 /// Implementations are created by a [`SandboxFactory`](crate::SandboxFactory)
@@ -103,6 +163,19 @@ pub trait Sandbox: Send + Sync + Any {
     /// `start` is equivalent to a sandbox that was never started, and
     /// the caller may drop the instance without calling `stop`/`kill`.
     async fn start(&mut self) -> Result<()>;
+    /// Start the sandbox while reporting provider-supported phase timings.
+    ///
+    /// This has the same lifecycle, success, failure, and cleanup contract as
+    /// [`start`](Self::start). An overriding implementation reports each stage
+    /// applicable to its provider and must not use observer callbacks as
+    /// cleanup authority. The default implementation preserves existing
+    /// provider behavior and emits no callbacks.
+    async fn start_with_observer(
+        &mut self,
+        _observer: &mut dyn SandboxStartObserver,
+    ) -> Result<()> {
+        self.start().await
+    }
     /// Shut the guest down gracefully, then terminate the backing process.
     ///
     /// The guest is first notified via the IPC channel (with an


### PR DESCRIPTION
## Summary

- add a provider-neutral, default-no-op sandbox start observer with five fixed low-cardinality stages
- attribute Firecracker backend launch, optional snapshot load/resume, residual guest connection wait, optional DNS readiness, and runtime finalization without overlapping successful-path intervals
- map completed stage results into runner job telemetry while retaining the existing `runner_fresh_sandbox_start` parent and failure behavior
- cover successful, optional, failed, and non-reporting provider paths at the runner boundary, plus a concrete Firecracker early-failure path

## Behavior and compatibility

This PR is observation-only. It does not change startup ordering, process ownership, snapshot requests, rate limits, timeouts, retries, guest DNS validation, network reuse rules, cleanup, or error propagation.

It adds no feature switch, database or persisted state, API or queue payload, runner/guest protocol, or guest image requirement. Providers that do not override the observer-aware start method continue to call `start()` and emit no child stages.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox -p sandbox-fc -p runner --no-deps --all-features`
- `cargo test -p sandbox` (33 passed)
- `cargo test -p sandbox-fc` (739 passed)
- `cargo test -p runner --bin runner` (2,777 passed, 13 ignored)

Closes #22516
