### PR TITLE
feat: enable canonical slack for the staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -114,6 +114,10 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroWebSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroMail]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.CanonicalSlackIngress]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.CanonicalSlackWebVisibility]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerChatThreadSuggestions]).toBe(
       true,
@@ -142,6 +146,10 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroWebSearch]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroMail]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.CanonicalSlackIngress]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.CanonicalSlackWebVisibility]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -228,12 +228,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Route newly admitted per-user Slack threads through canonical chat ingress.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.CanonicalSlackWebVisibility]: {
     maintainer: "lancy@vm0.ai",
     description:
       "Show canonical Slack chat threads in Web chat surfaces for enrolled users.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZeroScrape]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `canonicalSlackIngress` for the vm0 staff org via the existing hashed org allowlist
- enable `canonicalSlackWebVisibility` for the same staff org
- keep both switches disabled by default for every other organization
- cover the staff and non-staff rollout matrix in the core feature-switch test

## User impact

All current and future members of the vm0 staff organization inherit canonical Slack ingress and Web Chat visibility by default, while retaining the existing per-user Lab override behavior.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 passed)