### PR TITLE
ci: use google for runner tls checks

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -730,7 +730,7 @@ echo "PASS: environment variables"
 # Test 9: verify HTTPS works through proxy for each runtime
 # All traffic goes through mitmproxy, so TLS must trust the proxy CA.
 echo "--- Test: HTTPS through proxy ---"
-TLS_URL="https://www.vm0.ai"
+TLS_URL="https://www.google.com"
 tls_check() {
   local label=$1 cmd=$2 t=${3:-15}
   local output status


### PR DESCRIPTION
## Summary

- use `https://www.google.com` as the shared HTTPS target in the runner runtime TLS matrix
- keep the independent GitHub and Cargo TLS checks unchanged

## Scope

This is a CI-only target change. It does not alter runner or guest production code, proxy configuration, TLS trust setup, commands, timeouts, or failure handling.

## Validation

- `bash -n .github/scripts/runner-behavior-exec.sh`
- `shellcheck .github/scripts/runner-behavior-exec.sh`
- `git diff --check`

The full guest/proxy path is exercised by the runner behavior metal lane in PR CI.
