### PR TITLE
refactor(sandbox-fc): encapsulate creation completions

### DIFF
--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -39,6 +39,7 @@
 //!   power loss, aborted in-flight creation tasks) are reconciled at
 //!   startup via flock-based liveness probe.
 
+mod completion;
 mod host;
 mod naming;
 mod state;

--- a/crates/sandbox-fc/src/network/pool/completion.rs
+++ b/crates/sandbox-fc/src/network/pool/completion.rs
@@ -1,0 +1,208 @@
+use std::future::Future;
+
+use tokio::sync::{mpsc, watch};
+use tracing::warn;
+
+use super::super::error::{NetworkError, Result};
+use super::host::{NamespaceDeleteOutcome, NetnsLifecycleOps};
+use super::types::NetnsInfo;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct PendingId(pub(super) u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NetnsKind {
+    Plain,
+    Proxy,
+}
+
+pub(super) struct CreationCompletion {
+    pub(super) id: PendingId,
+    pub(super) kind: NetnsKind,
+    pub(super) result: Result<NetnsInfo>,
+}
+
+pub(super) struct PreparedCreationWait {
+    pub(super) completions: Vec<CreationCompletion>,
+    pub(super) receiver: watch::Receiver<()>,
+}
+
+/// Owns durable creation completions and the broadcast signal used by waiters.
+///
+/// The mpsc queue is the source of truth. The watch channel is only a progress
+/// hint, so every caller that may wait must use [`Self::prepare_wait`].
+pub(super) struct CreationCompletionCoordinator {
+    tx: mpsc::UnboundedSender<CreationCompletion>,
+    rx: mpsc::UnboundedReceiver<CreationCompletion>,
+    wake_tx: watch::Sender<()>,
+}
+
+impl CreationCompletionCoordinator {
+    pub(super) fn new() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (wake_tx, _) = watch::channel(());
+        Self { tx, rx, wake_tx }
+    }
+
+    pub(super) fn notifier(&self, ops: NetnsLifecycleOps) -> CreationNotifier {
+        CreationNotifier {
+            tx: self.tx.clone(),
+            wake_tx: self.wake_tx.clone(),
+            ops,
+        }
+    }
+
+    pub(super) fn try_recv(&mut self) -> Option<CreationCompletion> {
+        self.rx.try_recv().ok()
+    }
+
+    fn drain(&mut self) -> Vec<CreationCompletion> {
+        let mut completions = Vec::new();
+        while let Some(completion) = self.try_recv() {
+            completions.push(completion);
+        }
+        completions
+    }
+
+    /// Arms a wake receiver before draining so a caller cannot miss a completion
+    /// between deciding to wait and observing the durable queue.
+    pub(super) fn prepare_wait(&mut self) -> PreparedCreationWait {
+        let receiver = self.wake_tx.subscribe();
+        let completions = self.drain();
+        PreparedCreationWait {
+            completions,
+            receiver,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn enqueue_for_test(&self, completion: CreationCompletion) {
+        self.tx.send(completion).expect("completion receiver open");
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct CreationNotifier {
+    tx: mpsc::UnboundedSender<CreationCompletion>,
+    wake_tx: watch::Sender<()>,
+    ops: NetnsLifecycleOps,
+}
+
+impl CreationNotifier {
+    pub(super) async fn send(self, completion: CreationCompletion) {
+        match self.tx.send(completion) {
+            Ok(()) => self.wake(),
+            Err(err) => {
+                let completion = err.0;
+                if let Ok(ns) = completion.result {
+                    warn!(
+                        name = %ns.name,
+                        host_device = %ns.host_device,
+                        "namespace creation completed after pool receiver dropped; deleting"
+                    );
+                    let outcome = (self.ops.delete_namespace)(ns.clone()).await;
+                    if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+                        warn!(
+                            name = %ns.name,
+                            host_device = %ns.host_device,
+                            "failed to delete namespace after completion delivery failed; startup orphan reconciliation will retry"
+                        );
+                    }
+                }
+                self.wake();
+            }
+        }
+    }
+
+    fn wake(&self) {
+        // Watch versions every successful send; the payload itself is unused.
+        // With no receiver, the mpsc queue still retains the completion.
+        let _ = self.wake_tx.send(());
+    }
+}
+
+pub(super) fn spawn_creation_worker<F>(
+    id: PendingId,
+    kind: NetnsKind,
+    notifier: CreationNotifier,
+    future: F,
+) where
+    F: Future<Output = Result<NetnsInfo>> + Send + 'static,
+{
+    let worker = tokio::spawn(future);
+    tokio::spawn(async move {
+        let result = match worker.await {
+            Ok(result) => result,
+            Err(error) => Err(join_error_to_creation_error(error, kind)),
+        };
+        notifier.send(CreationCompletion { id, kind, result }).await;
+    });
+}
+
+fn join_error_to_creation_error(error: tokio::task::JoinError, kind: NetnsKind) -> NetworkError {
+    if error.is_panic() {
+        NetworkError::Prerequisite(format!(
+            "{kind:?} namespace creation task panicked: {error}"
+        ))
+    } else {
+        NetworkError::Prerequisite(format!(
+            "{kind:?} namespace creation task cancelled: {error}"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failed_completion(id: u64) -> CreationCompletion {
+        CreationCompletion {
+            id: PendingId(id),
+            kind: NetnsKind::Plain,
+            result: Err(NetworkError::Prerequisite("test completion".into())),
+        }
+    }
+
+    #[tokio::test]
+    async fn prepare_wait_drains_completion_sent_without_receiver() {
+        let mut coordinator = CreationCompletionCoordinator::new();
+        let notifier = coordinator.notifier(NetnsLifecycleOps::trusted_for_test());
+        notifier.send(failed_completion(1)).await;
+
+        let prepared = coordinator.prepare_wait();
+
+        assert_eq!(prepared.completions.len(), 1);
+        assert_eq!(prepared.completions[0].id, PendingId(1));
+        assert!(!prepared.receiver.has_changed().unwrap());
+    }
+
+    #[tokio::test]
+    async fn prepared_receiver_observes_later_completion() {
+        let mut coordinator = CreationCompletionCoordinator::new();
+        let notifier = coordinator.notifier(NetnsLifecycleOps::trusted_for_test());
+        let prepared = coordinator.prepare_wait();
+        assert!(prepared.completions.is_empty());
+
+        notifier.send(failed_completion(2)).await;
+
+        assert!(prepared.receiver.has_changed().unwrap());
+        let completion = coordinator.try_recv().unwrap();
+        assert_eq!(completion.id, PendingId(2));
+    }
+
+    #[tokio::test]
+    async fn one_completion_wakes_all_prepared_receivers_and_drains_once() {
+        let mut coordinator = CreationCompletionCoordinator::new();
+        let notifier = coordinator.notifier(NetnsLifecycleOps::trusted_for_test());
+        let first = coordinator.prepare_wait();
+        let second = coordinator.prepare_wait();
+
+        notifier.send(failed_completion(3)).await;
+
+        assert!(first.receiver.has_changed().unwrap());
+        assert!(second.receiver.has_changed().unwrap());
+        let completion = coordinator.try_recv().unwrap();
+        assert_eq!(completion.id, PendingId(3));
+        assert!(coordinator.try_recv().is_none());
+    }
+}

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashSet, VecDeque};
 use std::fs::File;
+#[cfg(test)]
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -9,7 +10,7 @@ use futures_util::future::join_all;
 use nix::fcntl::Flock;
 #[cfg(test)]
 use nix::fcntl::FlockArg;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tracing::{error, info, warn};
 
 use crate::paths::LockPaths;
@@ -20,6 +21,10 @@ use super::super::readiness::DnsReadinessError;
 use super::super::readiness::{
     DNS_READINESS_OPERATION_TIMEOUT, DnsReadinessProbe, production_dns_readiness_probe,
     run_dns_readiness_probe,
+};
+use super::completion::{
+    CreationCompletion, CreationCompletionCoordinator, CreationNotifier, NetnsKind, PendingId,
+    PreparedCreationWait, spawn_creation_worker,
 };
 #[cfg(test)]
 use super::host::ConntrackFlushOutcome;
@@ -57,61 +62,6 @@ fn next_pool_instance_id() -> u64 {
     NEXT_NETNS_POOL_INSTANCE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct PendingId(u64);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NetnsKind {
-    Plain,
-    Proxy,
-}
-
-struct CreationCompletion {
-    id: PendingId,
-    kind: NetnsKind,
-    result: Result<NetnsInfo>,
-}
-
-#[derive(Clone)]
-struct CreationNotifier {
-    tx: mpsc::UnboundedSender<CreationCompletion>,
-    generation: Arc<AtomicU64>,
-    wake_tx: watch::Sender<u64>,
-    ops: NetnsLifecycleOps,
-}
-
-impl CreationNotifier {
-    async fn send(self, completion: CreationCompletion) {
-        match self.tx.send(completion) {
-            Ok(()) => self.wake(),
-            Err(err) => {
-                let completion = err.0;
-                if let Ok(ns) = completion.result {
-                    warn!(
-                        name = %ns.name,
-                        host_device = %ns.host_device,
-                        "namespace creation completed after pool receiver dropped; deleting"
-                    );
-                    let outcome = (self.ops.delete_namespace)(ns.clone()).await;
-                    if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
-                        warn!(
-                            name = %ns.name,
-                            host_device = %ns.host_device,
-                            "failed to delete namespace after completion delivery failed; startup orphan reconciliation will retry"
-                        );
-                    }
-                }
-                self.wake();
-            }
-        }
-    }
-
-    fn wake(&self) {
-        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        let _ = self.wake_tx.send(generation);
-    }
-}
-
 #[derive(Clone)]
 struct NetnsPoolInner {
     state: Arc<tokio::sync::Mutex<NetnsPoolState>>,
@@ -146,7 +96,7 @@ pub(crate) struct NetnsPoolHandle {
 enum AcquirePlan {
     Ready(NetnsLease),
     Delete(Vec<NetnsInfo>, NetnsLifecycleOps),
-    Wait(watch::Receiver<u64>),
+    Wait(watch::Receiver<()>),
 }
 
 struct ReleasePlan {
@@ -159,7 +109,7 @@ struct ReleasePlan {
 struct CleanupPlan {
     namespaces: Vec<NetnsInfo>,
     ops: NetnsLifecycleOps,
-    wait_for_pending: Option<watch::Receiver<u64>>,
+    wait_for_pending: Option<watch::Receiver<()>>,
     dns_input_filter_comment: Option<String>,
     done: bool,
 }
@@ -177,10 +127,7 @@ struct NetnsPoolState {
     pending_plain: HashSet<PendingId>,
     /// In-flight background namespace creation tasks (proxy).
     pending_proxy: HashSet<PendingId>,
-    completion_tx: mpsc::UnboundedSender<CreationCompletion>,
-    completion_rx: mpsc::UnboundedReceiver<CreationCompletion>,
-    completion_generation: Arc<AtomicU64>,
-    completion_wake_tx: watch::Sender<u64>,
+    completion: CreationCompletionCoordinator,
     /// Namespaces checked out from this pool instance.
     in_flight: HashSet<String>,
     /// In-flight namespaces that must be deleted instead of reused.
@@ -209,23 +156,6 @@ struct NetnsPoolState {
 }
 
 impl NetnsPoolState {
-    fn completion_state() -> (
-        mpsc::UnboundedSender<CreationCompletion>,
-        mpsc::UnboundedReceiver<CreationCompletion>,
-        Arc<AtomicU64>,
-        watch::Sender<u64>,
-    ) {
-        let (completion_tx, completion_rx) = mpsc::unbounded_channel();
-        let completion_generation = Arc::new(AtomicU64::new(0));
-        let (completion_wake_tx, _) = watch::channel(0);
-        (
-            completion_tx,
-            completion_rx,
-            completion_generation,
-            completion_wake_tx,
-        )
-    }
-
     #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
         let file = tempfile::tempfile().expect("create test netns pool lock file");
@@ -233,19 +163,13 @@ impl NetnsPoolState {
             Ok(lock) => lock,
             Err((_, errno)) => panic!("lock test netns pool file: {errno}"),
         };
-        let (completion_tx, completion_rx, completion_generation, completion_wake_tx) =
-            Self::completion_state();
-
         Self {
             active: false,
             plain_queue: VecDeque::new(),
             proxy_queue: VecDeque::new(),
             pending_plain: HashSet::new(),
             pending_proxy: HashSet::new(),
-            completion_tx,
-            completion_rx,
-            completion_generation,
-            completion_wake_tx,
+            completion: CreationCompletionCoordinator::new(),
             in_flight: HashSet::new(),
             non_reusable: HashSet::new(),
             instance_id: next_pool_instance_id(),
@@ -300,9 +224,6 @@ impl NetnsPoolState {
             Some(dns_port) => Some(setup_dns_input_filter(index, dns_port).await?),
             None => None,
         };
-        let (completion_tx, completion_rx, completion_generation, completion_wake_tx) =
-            Self::completion_state();
-
         let mut pool = Self {
             active: true,
             plain_queue: VecDeque::with_capacity(BUFFER_SIZE),
@@ -313,10 +234,7 @@ impl NetnsPoolState {
             }),
             pending_plain: HashSet::new(),
             pending_proxy: HashSet::new(),
-            completion_tx,
-            completion_rx,
-            completion_generation,
-            completion_wake_tx,
+            completion: CreationCompletionCoordinator::new(),
             in_flight: HashSet::new(),
             non_reusable: HashSet::new(),
             instance_id: next_pool_instance_id(),
@@ -380,12 +298,7 @@ impl NetnsPoolState {
     }
 
     fn creation_notifier(&self) -> CreationNotifier {
-        CreationNotifier {
-            tx: self.completion_tx.clone(),
-            generation: Arc::clone(&self.completion_generation),
-            wake_tx: self.completion_wake_tx.clone(),
-            ops: self.ops.clone(),
-        }
+        self.completion.notifier(self.ops.clone())
     }
 
     fn spawn_plain_creation(&mut self) -> Result<()> {
@@ -434,13 +347,13 @@ impl NetnsPoolState {
 
     async fn drain_initial_warmup(&mut self) {
         loop {
-            let mut waiter = if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
-                None
-            } else {
-                Some(self.completion_wake_tx.subscribe())
-            };
-
-            let delete = self.drain_completed(true);
+            let (delete, mut waiter) =
+                if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
+                    (self.drain_completed(true), None)
+                } else {
+                    let (delete, waiter) = self.prepare_completion_wait(true);
+                    (delete, Some(waiter))
+                };
             if !delete.is_empty() {
                 delete_namespaces_with_ops(self.ops.clone(), delete).await;
             }
@@ -610,7 +523,33 @@ impl NetnsPoolState {
 
     fn drain_completed(&mut self, queue_when_inactive: bool) -> Vec<NetnsInfo> {
         let mut delete = Vec::new();
-        while let Ok(completion) = self.completion_rx.try_recv() {
+        while let Some(completion) = self.completion.try_recv() {
+            self.apply_completion(completion, queue_when_inactive, &mut delete);
+        }
+        delete
+    }
+
+    fn prepare_completion_wait(
+        &mut self,
+        queue_when_inactive: bool,
+    ) -> (Vec<NetnsInfo>, watch::Receiver<()>) {
+        let PreparedCreationWait {
+            completions,
+            receiver,
+        } = self.completion.prepare_wait();
+        (
+            self.apply_completions(completions, queue_when_inactive),
+            receiver,
+        )
+    }
+
+    fn apply_completions(
+        &mut self,
+        completions: Vec<CreationCompletion>,
+        queue_when_inactive: bool,
+    ) -> Vec<NetnsInfo> {
+        let mut delete = Vec::new();
+        for completion in completions {
             self.apply_completion(completion, queue_when_inactive, &mut delete);
         }
         delete
@@ -682,11 +621,7 @@ impl NetnsPoolState {
                 self.spawn_creation(kind)?;
             }
 
-            let waiter = self.completion_wake_tx.subscribe();
-
-            // Subscribe before the re-check to avoid missing a completion
-            // between the decision to wait and dropping the outer mutex.
-            let delete = self.drain_completed(false);
+            let (delete, waiter) = self.prepare_completion_wait(false);
             if !delete.is_empty() {
                 return Ok(AcquirePlan::Delete(delete, self.ops.clone()));
             }
@@ -926,11 +861,13 @@ impl NetnsPoolState {
         let mut namespaces = self.drain_completed(true);
         let mut wait_for_pending = if self.pending_plain.is_empty() && self.pending_proxy.is_empty()
         {
+            namespaces.extend(self.drain_completed(true));
             None
         } else {
-            Some(self.completion_wake_tx.subscribe())
+            let (completed, waiter) = self.prepare_completion_wait(true);
+            namespaces.extend(completed);
+            Some(waiter)
         };
-        namespaces.extend(self.drain_completed(true));
         if self.pending_plain.is_empty() && self.pending_proxy.is_empty() {
             wait_for_pending = None;
         }
@@ -1361,28 +1298,6 @@ where
         return Err(NetworkError::DnsReadiness(error));
     }
     Ok(namespace)
-}
-
-fn spawn_creation_worker<F>(id: PendingId, kind: NetnsKind, notifier: CreationNotifier, future: F)
-where
-    F: Future<Output = Result<NetnsInfo>> + Send + 'static,
-{
-    let worker = tokio::spawn(future);
-    tokio::spawn(async move {
-        let result = match worker.await {
-            Ok(result) => result,
-            Err(e) => Err(join_error_to_creation_error(e, kind)),
-        };
-        notifier.send(CreationCompletion { id, kind, result }).await;
-    });
-}
-
-fn join_error_to_creation_error(e: tokio::task::JoinError, kind: NetnsKind) -> NetworkError {
-    if e.is_panic() {
-        NetworkError::Prerequisite(format!("{kind:?} namespace creation task panicked: {e}"))
-    } else {
-        NetworkError::Prerequisite(format!("{kind:?} namespace creation task cancelled: {e}"))
-    }
 }
 
 async fn delete_namespaces_with_ops(ops: NetnsLifecycleOps, namespaces: Vec<NetnsInfo>) {
@@ -1980,7 +1895,9 @@ mod tests {
         let mut state = dns_pending_state(&["vm0-ns-test-good"], lifecycle.ops);
         state.dns_readiness_state = DnsReadinessState::Ready;
         state.dns_readiness_probe = probe_for_test(|_| async { Err(DnsReadinessError::timeout()) });
-        let mut completion = state.completion_wake_tx.subscribe();
+        let prepared = state.completion.prepare_wait();
+        assert!(prepared.completions.is_empty());
+        let mut completion = prepared.receiver;
         state.spawn_proxy_creation_for_test(async { Ok(test_info("vm0-ns-test-bad")) });
         let mut pool = NetnsPool::from_state_for_test(state);
         wait_for_sync(
@@ -2253,13 +2170,11 @@ mod tests {
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
         pool.ops = ops;
-        pool.completion_tx
-            .send(CreationCompletion {
-                id: PendingId(999),
-                kind: NetnsKind::Plain,
-                result: Ok(test_info("unknown-ns")),
-            })
-            .unwrap();
+        pool.completion.enqueue_for_test(CreationCompletion {
+            id: PendingId(999),
+            kind: NetnsKind::Plain,
+            result: Ok(test_info("unknown-ns")),
+        });
 
         let mut pool = NetnsPool::from_state_for_test(pool);
         pool.cleanup().await.unwrap();
@@ -2285,20 +2200,16 @@ mod tests {
             let pending_ids: Vec<PendingId> = pool.pending_set(kind).iter().copied().collect();
             assert_eq!(pending_ids.len(), 2);
 
-            pool.completion_tx
-                .send(CreationCompletion {
-                    id: pending_ids[0],
-                    kind,
-                    result: Ok(test_info("completed-ns-0")),
-                })
-                .unwrap();
-            pool.completion_tx
-                .send(CreationCompletion {
-                    id: pending_ids[1],
-                    kind,
-                    result: Ok(test_info("completed-ns-1")),
-                })
-                .unwrap();
+            pool.completion.enqueue_for_test(CreationCompletion {
+                id: pending_ids[0],
+                kind,
+                result: Ok(test_info("completed-ns-0")),
+            });
+            pool.completion.enqueue_for_test(CreationCompletion {
+                id: pending_ids[1],
+                kind,
+                result: Ok(test_info("completed-ns-1")),
+            });
 
             let delete = pool.drain_completed(false);
             let queue = pool.target_queue(kind);


### PR DESCRIPTION
## Summary

- encapsulate namespace creation completion queue and wake coordination in a private coordinator
- enforce subscribe-before-drain wait preparation for warmup, acquire, and cleanup paths
- preserve the subscription-free ready acquire path and cancellation-safe completion ownership

## Scope

- internal Rust refactor only
- no public API, network behavior, retry, persisted data, or deployment contract changes

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p sandbox-fc --all-targets`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Closes #22514
