### PR TITLE
test(platform): remove retired onboarding route fixtures

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/billing-redirect.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/billing-redirect.test.ts
@@ -16,11 +16,9 @@ describe("billingRedirectAllowed", () => {
     ).toBeTruthy();
   });
 
-  it("rejects the retired WWW onboarding origin", () => {
+  it("rejects a non-App origin", () => {
     expect(
-      billingRedirectAllowed(
-        "https://www.vm7.ai:8443/onboarding?billing=success",
-      ),
+      billingRedirectAllowed("https://example.com/onboarding?billing=success"),
     ).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -38,15 +38,15 @@ describe("zero onboarding routing", () => {
     );
   });
 
-  it("does not register the retired numeric onboarding path", async () => {
+  it("does not register nested onboarding paths", async () => {
     detachedSetupPage({
       context,
-      path: "/onboarding/491858?vm0_source=homepage",
+      path: "/onboarding/unknown?vm0_source=homepage",
     });
 
     await expect(
       screen.findByRole("heading", { name: "Page not found" }),
     ).resolves.toBeInTheDocument();
-    expect(pathname()).toBe("/onboarding/491858");
+    expect(pathname()).toBe("/onboarding/unknown");
   });
 });


### PR DESCRIPTION
## Summary

- remove the last concrete retired onboarding hash from the platform routing test while preserving coverage that nested onboarding routes are not registered
- replace the retired WWW billing-return fixture with a generic non-App origin while preserving the redirect allowlist regression check
- keep the GitHub Actions assertions that verify `ONBOARDING_URL` is absent from generated API environments

## Verification

- `pnpm vitest --run apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx apps/api/src/lib/__tests__/billing-redirect.test.ts` — 2 files, 4 tests passed
- Prettier check passed for both changed files
- ESLint passed for both changed files
- exact repository scan found no legacy WWW onboarding URLs or hashed onboarding paths
- `git diff --check`
