### PR TITLE
fix(artifacts): show indexeddb cache immediately on page return

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -390,6 +390,7 @@ export const remoteArtifacts$ = computed(
 // (reads degrade to an empty list), so it is always a safe fallback.
 export const cachedArtifacts$ = computed(
   async (get): Promise<ArtifactsPageData> => {
+    get(internalArtifactsReload$);
     const dbPromise = get(chatIdb$);
     const artifacts = await artifactItemCacheStores(
       dbPromise,

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1528,6 +1528,37 @@ describe("artifacts page", () => {
     expect(cached[0]).not.toHaveProperty("isFavorited");
   });
 
+  it("renders the cache immediately when returning while the remote refresh is pending", async () => {
+    setupTeam();
+    const scope = testAuthScope("return-to-cache");
+    const artifact = createArtifact({
+      artifactItemId: "return-cache-run:file-1",
+      runId: "return-cache-run",
+      filename: "return-cache-summary.html",
+    });
+    mockArtifacts([artifact]);
+
+    setupArtifactsPage({ scope });
+
+    await screen.findByText("return-cache-summary.html");
+    await waitFor(async () => {
+      await expect(cachedArtifactIds(scope)).resolves.toStrictEqual([
+        artifact.artifactItemId,
+      ]);
+    });
+
+    context.mocks.api(artifactsContract.list, ({ never }) => {
+      return never();
+    });
+    click(linkByText("Agents"));
+    await screen.findByRole("heading", { level: 1, name: /agents/i });
+    click(linkByText("Artifacts"));
+
+    await expect(
+      screen.findByText("return-cache-summary.html"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("normalizes older remote artifacts without a size", async () => {
     setupTeam();
     const scope = testAuthScope("remote-size-default");


### PR DESCRIPTION
## Summary

- invalidate the cache-first Artifact computed whenever the page reloads
- re-read IndexedDB immediately when users return to Artifacts instead of retaining an earlier empty result
- keep the remote refresh and existing merge/deduplication flow unchanged
- add a page-level regression test covering empty cache, remote fill, navigation away, and return while the API remains pending

## User impact

Returning to the Artifact page now shows the last cached Artifact set immediately while the incremental API refresh runs in the background.

## Verification

- `pnpm exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx`
- `pnpm lint` in `turbo/apps/platform`
- `pnpm check-types` in `turbo/apps/platform`
- focused regression test confirmed to fail without the invalidation dependency and pass with it

## Repository check note

The repository-wide pre-commit type check completed 12 of 13 workspaces, including `@vm0/app`, before the unrelated `api` TypeScript process exceeded the runtime Node heap limit and aborted. Platform production and test type checks pass independently.