### PR TITLE
fix(platform): restore catalog-authored connector icons

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -87,10 +87,21 @@ export default [
             "Use now() from src/lib/time instead of Date.now() so tests can control the platform clock.",
         },
       ],
+    },
+  },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/**/__tests__/**", "src/mocks/**", "src/test/**"],
+    rules: {
       "no-restricted-imports": [
         "error",
         {
           paths: [
+            {
+              name: "@vm0/connectors/static-connector-icons",
+              message:
+                "Platform production code must render connector icons from public catalog descriptors.",
+            },
             {
               name: "@vm0/connectors/firewalls",
               message:

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -3,6 +3,30 @@ import ccstatePlugin from "@vm0/eslint-rules/ccstate";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginReact from "eslint-plugin-react";
 
+function firewallImportRestrictions() {
+  return {
+    paths: [
+      {
+        name: "@vm0/connectors/firewalls",
+        message:
+          "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+      },
+      {
+        name: "@vm0/core/firewalls",
+        message:
+          "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+      },
+    ],
+    patterns: [
+      {
+        group: ["@vm0/connectors/firewalls/*", "@vm0/core/firewalls/*"],
+        message:
+          "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+      },
+    ],
+  };
+}
+
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   ...baseConfig,
@@ -87,6 +111,7 @@ export default [
             "Use now() from src/lib/time instead of Date.now() so tests can control the platform clock.",
         },
       ],
+      "no-restricted-imports": ["error", firewallImportRestrictions()],
     },
   },
   {
@@ -102,24 +127,9 @@ export default [
               message:
                 "Platform production code must render connector icons from public catalog descriptors.",
             },
-            {
-              name: "@vm0/connectors/firewalls",
-              message:
-                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
-            },
-            {
-              name: "@vm0/core/firewalls",
-              message:
-                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
-            },
+            ...firewallImportRestrictions().paths,
           ],
-          patterns: [
-            {
-              group: ["@vm0/connectors/firewalls/*", "@vm0/core/firewalls/*"],
-              message:
-                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
-            },
-          ],
+          patterns: firewallImportRestrictions().patterns,
         },
       ],
     },

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -243,6 +243,7 @@ export function createConnectorSignals(
 
     const connectOptions = {
       connectorLabel: connector.label,
+      connectorIcon: connector.icon,
       agentId: descriptor.agentId,
     };
     const connectionCompleted =

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -2,6 +2,10 @@ import {
   connectorRefSchema,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  publicConnectorCatalogIconSchema,
+  type PublicConnectorCatalogIcon,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { command } from "ccstate";
 import { createElement } from "react";
 import { ZeroConnectorRedirectingPage } from "../../views/zero-page/zero-connector-redirecting-page.tsx";
@@ -16,6 +20,23 @@ function connectorTypeFromPath(value: string | undefined): ConnectorRef | null {
   return parsed.success ? parsed.data : null;
 }
 
+function connectorIconFromSearchParams(
+  searchParams: URLSearchParams,
+): PublicConnectorCatalogIcon | undefined {
+  const url = searchParams.get("iconUrl");
+  const invertInDarkMode = searchParams.get("iconInvertInDarkMode");
+  if (!url || (invertInDarkMode !== "true" && invertInDarkMode !== "false")) {
+    return undefined;
+  }
+  const scale = searchParams.get("iconScale");
+  const parsed = publicConnectorCatalogIconSchema.safeParse({
+    url,
+    invertInDarkMode: invertInDarkMode === "true",
+    ...(scale === null ? {} : { scale: Number(scale) }),
+  });
+  return parsed.success ? parsed.data : undefined;
+}
+
 export const setupConnectorRedirectingPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const params = get(pathParams$);
@@ -27,12 +48,13 @@ export const setupConnectorRedirectingPage$ = command(
       searchParams.get("label")?.trim() || connectorType || "connector";
     const status: ConnectorRedirectingStatus =
       searchParams.get("status") === "error" ? "error" : "redirecting";
+    const connectorIcon = connectorIconFromSearchParams(searchParams);
 
     set(
       updatePage$,
       createElement(ZeroConnectorRedirectingPage, {
-        connectorType,
         connectorLabel,
+        connectorIcon,
         status,
       }),
     );

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { generateRouterPath } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 
@@ -7,12 +8,20 @@ export type ConnectorRedirectingStatus = "redirecting" | "error";
 export function connectorRedirectingPath(args: {
   readonly type: ConnectorRef;
   readonly label: string;
+  readonly icon: PublicConnectorCatalogIcon;
   readonly status?: ConnectorRedirectingStatus;
 }): string {
   const pathname = generateRouterPath(ROUTES.connectorRedirecting, {
     type: args.type,
   });
-  const searchParams = new URLSearchParams({ label: args.label });
+  const searchParams = new URLSearchParams({
+    label: args.label,
+    iconUrl: args.icon.url,
+    iconInvertInDarkMode: String(args.icon.invertInDarkMode),
+  });
+  if (args.icon.scale !== undefined) {
+    searchParams.set("iconScale", String(args.icon.scale));
+  }
   if (args.status === "error") {
     searchParams.set("status", args.status);
   }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -34,6 +34,7 @@ import type {
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogConnectionStatus,
+  PublicConnectorCatalogIcon,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
@@ -70,6 +71,9 @@ const { get$: hiddenConnectorRefsRaw$, set$: setHiddenConnectorRefs$ } =
 type PostConnectOptions = {
   readonly connectorLabel?: string;
   readonly agentId?: string;
+};
+type BrowserAuthPostConnectOptions = PostConnectOptions & {
+  readonly connectorIcon: PublicConnectorCatalogIcon;
 };
 // ---------------------------------------------------------------------------
 // Derived state
@@ -2043,6 +2047,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       readonly connectorRef: ConnectorRef;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly connectorLabel: string;
+      readonly connectorIcon: PublicConnectorCatalogIcon;
       readonly agentId: string | undefined;
       readonly beforeStart: (signal: AbortSignal) => Promise<void>;
     },
@@ -2056,6 +2061,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     const redirectingPath = connectorRedirectingPath({
       type: args.connectorRef,
       label: args.connectorLabel,
+      icon: args.connectorIcon,
     });
     const authWindow = window.open(redirectingPath, "_blank", popupFeatures);
 
@@ -2125,6 +2131,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
             authWindow.location.href = connectorRedirectingPath({
               type: args.connectorRef,
               label: args.connectorLabel,
+              icon: args.connectorIcon,
               status: "error",
             });
           }
@@ -2142,7 +2149,7 @@ export const connectConnectorOAuthAuthCode$ = command(
     { get, set },
     connectorRef: ConnectorRef,
     method: PublicConnectorCatalogAuthMethodDetail,
-    options: PostConnectOptions,
+    options: BrowserAuthPostConnectOptions,
     signal: AbortSignal,
   ) => {
     signal.throwIfAborted();
@@ -2178,6 +2185,7 @@ export const connectConnectorOAuthAuthCode$ = command(
             connectorRef,
             method,
             connectorLabel: options.connectorLabel ?? connectorRef,
+            connectorIcon: options.connectorIcon,
             agentId: options.agentId,
             beforeStart: async (sig) => {
               await set(onConnectorChanged$, sig);
@@ -2285,7 +2293,7 @@ export const connectConnectorOAuthAuthCodeAndSettle$ = command(
       readonly connectorRef: ConnectorRef;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly onSuccess: () => void | Promise<void>;
-      readonly options: PostConnectOptions;
+      readonly options: BrowserAuthPostConnectOptions;
     },
     signal: AbortSignal,
   ): Promise<void> => {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -7,6 +7,10 @@ import {
 } from "@vm0/core";
 import { zeroBillingCheckoutContract } from "@vm0/api-contracts/contracts/zero-billing";
 import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
   zeroConnectorManualGrantContract,
   zeroConnectorOauthStartContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -36,6 +40,47 @@ function mockOnboardingNeeded(): void {
   context.mocks.data.onboardingStatus({
     needsOnboarding: true,
     onboardingComplete: false,
+  });
+}
+
+function mockGithubCatalogItem(
+  icon: PublicConnectorCatalogStatusItem["icon"],
+): void {
+  const github: PublicConnectorCatalogStatusItem = {
+    connectorRef: "github",
+    label: "Catalog GitHub",
+    description: "Connect Catalog GitHub to continue",
+    icon,
+    category: "developer-tools",
+    generation: [],
+    tags: [],
+    authMethods: [
+      {
+        id: "oauth",
+        label: "OAuth",
+        description: null,
+        grantKind: "auth-code",
+        manualFields: [],
+        startOptions: [],
+      },
+    ],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: "oauth",
+    connectNotice: null,
+  };
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [github] });
   });
 }
 
@@ -118,6 +163,44 @@ function chooseTemplate(
 }
 
 describe("onboarding flow", () => {
+  it("renders workflow connector marks from catalog metadata", async () => {
+    mockGithubCatalogItem({
+      url: "https://icons.example.test/onboarding-github.svg",
+      invertInDarkMode: true,
+      scale: 1.4,
+    });
+
+    await openGithubWorkflowRun();
+
+    const connectorLabel = await screen.findByText(
+      "Connect the Catalog GitHub to continue the workflow",
+    );
+    const connectorRow = connectorLabel.parentElement?.parentElement;
+    if (!connectorRow) {
+      throw new Error("Expected Catalog GitHub connector row");
+    }
+    const rowIcon = connectorRow.querySelector<HTMLImageElement>(
+      'img[src="https://icons.example.test/onboarding-github.svg"]',
+    );
+    expect(rowIcon).toHaveClass("zero-icon-mono");
+    expect(rowIcon).toHaveStyle({ transform: "scale(1.4)" });
+
+    const pageIcons = document.querySelectorAll<HTMLImageElement>(
+      'img[src="https://icons.example.test/onboarding-github.svg"]',
+    );
+    expect(pageIcons.length).toBeGreaterThanOrEqual(2);
+
+    click(buttonByAriaLabel("Preview workflow details"));
+    const preview = await screen.findByRole("dialog", {
+      name: "Auto-merge GitHub PRs",
+    });
+    const previewIcon = preview.querySelector<HTMLImageElement>(
+      'img[src="https://icons.example.test/onboarding-github.svg"]',
+    );
+    expect(previewIcon).toHaveClass("zero-icon-mono");
+    expect(previewIcon).toHaveStyle({ transform: "scale(1.4)" });
+  });
+
   it("moves from workflow selection to a connector-aware first run", async () => {
     await openMakePage();
     chooseMakeOption("Workflow automation");

--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -3,10 +3,6 @@ import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { IconCircleCheck, IconLoader2 } from "@tabler/icons-react";
 import { Button, cn } from "@vm0/ui";
 import {
-  getStaticConnectorIconMetadata,
-  isStaticConnectorIconType,
-} from "@vm0/connectors/static-connector-icons";
-import {
   connectorRefSchema,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -34,19 +30,6 @@ function connectorRefs(values: readonly string[]): ConnectorRef[] {
     const parsed = connectorRefSchema.safeParse(value);
     return parsed.success ? [parsed.data] : [];
   });
-}
-
-export function OnboardingConnectorIcon({
-  connectorId,
-  size = 22,
-}: {
-  readonly connectorId: string;
-  readonly size?: number;
-}) {
-  const icon = isStaticConnectorIconType(connectorId)
-    ? getStaticConnectorIconMetadata(connectorId)
-    : undefined;
-  return <ConnectorIcon icon={icon} size={size} />;
 }
 
 function promptHelpText(helpText: string | undefined): string {
@@ -84,7 +67,7 @@ function OnboardingConnectorRow({
       )}
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/40">
-        <OnboardingConnectorIcon connectorId={connectorRef} />
+        <ConnectorIcon icon={item?.icon} size={22} />
       </span>
       <div className="min-w-0 flex-1">
         {variant === "workflow" ? (
@@ -200,7 +183,10 @@ export function OnboardingConnectorSetup({
                     return connect(
                       connectorRef,
                       authMethod,
-                      { connectorLabel: connector.label },
+                      {
+                        connectorLabel: connector.label,
+                        connectorIcon: connector.icon,
+                      },
                       pageSignal,
                     );
                   },

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import {
   IconArrowRight,
   IconBox,
@@ -22,6 +22,7 @@ import {
   updateOnboardingDraft$,
   updateOnboardingUi$,
 } from "../../signals/onboarding/onboarding-state.ts";
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import {
   CUSTOM_WORKFLOW_ID,
@@ -31,13 +32,13 @@ import {
   type OnboardingWorkflowCategory,
   type OnboardingWorkflowCategoryId,
 } from "./onboarding-data.ts";
-import { OnboardingConnectorIcon } from "./onboarding-connectors.tsx";
 import { useOnboardingNavigation } from "./onboarding-navigation.ts";
 import {
   OnboardingDialog,
   OnboardingFooter,
   OnboardingShell,
 } from "./onboarding-shell.tsx";
+import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 
 const CATEGORY_ICONS: Readonly<Record<OnboardingWorkflowCategoryId, Icon>> = {
   engineering: IconCode,
@@ -50,6 +51,21 @@ const CATEGORY_ICONS: Readonly<Record<OnboardingWorkflowCategoryId, Icon>> = {
   operations: IconSun,
   everyone: IconSparkles,
 };
+
+function WorkflowConnectorIcon({
+  connectorRef,
+  size,
+}: {
+  readonly connectorRef: string;
+  readonly size: number;
+}) {
+  const catalogByRefLoadable = useLastLoadable(connectorCatalogStatusByRef$);
+  const icon =
+    catalogByRefLoadable.state === "hasData"
+      ? catalogByRefLoadable.data.get(connectorRef)?.icon
+      : undefined;
+  return <ConnectorIcon icon={icon} size={size} />;
+}
 
 export function WorkflowConnectorPills({
   connectorIds,
@@ -71,7 +87,7 @@ export function WorkflowConnectorPills({
             key={connectorId}
             className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-muted/30"
           >
-            <OnboardingConnectorIcon connectorId={connectorId} size={14} />
+            <WorkflowConnectorIcon connectorRef={connectorId} size={14} />
           </span>
         );
       })}
@@ -123,8 +139,8 @@ export function WorkflowPreview({
           <div className="flex w-full max-w-md items-center justify-between gap-3">
             {firstConnector ? (
               <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border bg-background shadow-sm">
-                <OnboardingConnectorIcon
-                  connectorId={firstConnector}
+                <WorkflowConnectorIcon
+                  connectorRef={firstConnector}
                   size={32}
                 />
               </span>
@@ -152,8 +168,8 @@ export function WorkflowPreview({
                   aria-hidden="true"
                 />
                 <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-border bg-background shadow-sm">
-                  <OnboardingConnectorIcon
-                    connectorId={lastConnector}
+                  <WorkflowConnectorIcon
+                    connectorRef={lastConnector}
                     size={32}
                   />
                 </span>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -216,6 +216,18 @@ describe("chat message action cards", () => {
     let sent = false;
     const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
 
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "gmail",
+        label: "Gmail",
+        icon: {
+          url: "https://icons.example.test/gmail-catalog.svg",
+          invertInDarkMode: true,
+          scale: 1.25,
+        },
+      }),
+    ]);
+
     context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
       draftRequests += 1;
       return respond(200, {
@@ -339,6 +351,11 @@ describe("chat message action cards", () => {
         within(card).getByText("To: recipient@example.com"),
       ).toBeInTheDocument();
       expect(within(card).queryByText("sender@example.com")).toBeNull();
+      const icon = card.querySelector<HTMLImageElement>(
+        'img[src="https://icons.example.test/gmail-catalog.svg"]',
+      );
+      expect(icon).toHaveClass("zero-icon-mono");
+      expect(icon).toHaveStyle({ transform: "scale(1.25)" });
     }
     const untrustedLink = queryAllByRoleFast("link").find((link) => {
       return link.textContent === "Untrusted email";
@@ -590,6 +607,8 @@ describe("chat message action cards", () => {
     let deleted = false;
     let draftRequests = 0;
 
+    mockConnectorCatalogStatus([]);
+
     context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
       draftRequests += 1;
       if (deleted) {
@@ -645,6 +664,9 @@ describe("chat message action cards", () => {
     });
 
     const card = await screen.findByLabelText("Open draft email: Delete me");
+    expect(
+      within(card).getByLabelText("Connector icon unavailable"),
+    ).toBeInTheDocument();
     expect(draftRequests).toBe(1);
     await user.click(card);
     const sidebar = await screen.findByTestId("mail-draft-sidebar");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -23,6 +23,48 @@ describe("connector redirecting page", () => {
     expect(
       screen.getByText("Preparing a secure connection"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Connector icon unavailable"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a validated catalog icon for an unknown server connector ref", async () => {
+    detachedSetupPage({
+      context,
+      path: "/connectors/server-only/redirecting?label=Server+Only&iconUrl=https%3A%2F%2Ficons.example.test%2Fserver-only.svg&iconInvertInDarkMode=true&iconScale=1.5",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Redirecting to Server Only…" }),
+    ).resolves.toBeInTheDocument();
+    const icon = document.querySelector<HTMLImageElement>(
+      'img[src="https://icons.example.test/server-only.svg"]',
+    );
+    expect(icon).toHaveClass("zero-icon-mono");
+    expect(icon).toHaveStyle({ transform: "scale(1.5)" });
+  });
+
+  it("rejects invalid route icon metadata", async () => {
+    detachedSetupPage({
+      context,
+      path: "/connectors/server-only/redirecting?label=Server+Only&iconUrl=http%3A%2F%2Ficons.example.test%2Fserver-only.svg&iconInvertInDarkMode=true",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Redirecting to Server Only…" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Connector icon unavailable"),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(
+        'img[src="http://icons.example.test/server-only.svg"]',
+      ),
+    ).toBeNull();
   });
 
   it("renders an actionable error when OAuth cannot start", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1529,6 +1529,11 @@ describe("connectors page", () => {
         connectorRef: "stripe",
         label: "Public Stripe",
         description: "Public Stripe description",
+        icon: {
+          url: "https://icons.example.test/stripe-catalog.svg",
+          invertInDarkMode: true,
+          scale: 1.5,
+        },
         authMethods: [
           {
             id: "oauth",
@@ -1566,7 +1571,7 @@ describe("connectors page", () => {
       expect(startCount).toBe(1);
       expect(openMock.calls).toHaveLength(1);
       expect(openMock.calls[0]).toStrictEqual({
-        url: "/connectors/stripe/redirecting?label=Public+Stripe",
+        url: "/connectors/stripe/redirecting?label=Public+Stripe&iconUrl=https%3A%2F%2Ficons.example.test%2Fstripe-catalog.svg&iconInvertInDarkMode=true&iconScale=1.5",
         target: "_blank",
         features: "width=600,height=700",
       });
@@ -1626,6 +1631,10 @@ describe("connectors page", () => {
         connectorRef: "stripe",
         label: "Public Stripe",
         description: "Public Stripe description",
+        icon: {
+          url: "https://icons.example.test/stripe-error.svg",
+          invertInDarkMode: false,
+        },
         authMethods: [
           {
             id: "oauth",
@@ -1657,7 +1666,7 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       expect(authWindow.location.href).toBe(
-        "/connectors/stripe/redirecting?label=Public+Stripe&status=error",
+        "/connectors/stripe/redirecting?label=Public+Stripe&iconUrl=https%3A%2F%2Ficons.example.test%2Fstripe-error.svg&iconInvertInDarkMode=false&status=error",
       );
       expect(authWindow.closed).toBeFalsy();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -94,6 +94,9 @@ type PostConnectOptions = {
   readonly connectorLabel?: string;
   readonly agentId?: string;
 };
+type BrowserAuthPostConnectOptions = PostConnectOptions & {
+  readonly connectorIcon: PublicConnectorCatalogStatusItem["icon"];
+};
 
 type SubmitManualGrantFn = (
   connectorRef: ConnectorRef,
@@ -107,7 +110,7 @@ type ConnectOAuthAuthCodeAndSettleFn = (
   connectorRef: ConnectorRef,
   method: PublicConnectorCatalogAuthMethodDetail,
   onSuccess: () => void | Promise<void>,
-  options: PostConnectOptions,
+  options: BrowserAuthPostConnectOptions,
   signal: AbortSignal,
 ) => Promise<void>;
 
@@ -386,6 +389,7 @@ function OAuthAuthCodeConnectButton({
             onSuccess,
             {
               connectorLabel: item.label,
+              connectorIcon: item.icon,
               ...(agentId ? { agentId } : {}),
             },
             signal,

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -1,11 +1,11 @@
 import { IconChevronRight, IconLoader2 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import type { ZeroMailDraftStatus } from "@vm0/api-contracts/contracts/zero-mail";
 import { cn } from "@vm0/ui";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
 import {
   currentMailDraftId$,
@@ -16,8 +16,6 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 interface MailDraftCardProps {
   readonly signals: MailDraftSignals;
 }
-
-const GMAIL_ICON = getStaticConnectorIconMetadata("gmail");
 
 function statusLabel(status: ZeroMailDraftStatus): string {
   switch (status) {
@@ -49,8 +47,13 @@ function MailDraftCardSkeleton() {
 
 function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const draftLoadable = useLoadable(signals.draft$);
+  const catalogByRefLoadable = useLastLoadable(connectorCatalogStatusByRef$);
   const selectedMailDraftId = useGet(currentMailDraftId$);
   const openSidebar = useSet(openMailDraftSidebar$);
+  const gmailIcon =
+    catalogByRefLoadable.state === "hasData"
+      ? catalogByRefLoadable.data.get("gmail")?.icon
+      : undefined;
 
   if (draftLoadable.state === "loading") {
     return <MailDraftCardSkeleton />;
@@ -66,7 +69,7 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const content = (
     <>
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-background">
-        <ConnectorIcon icon={GMAIL_ICON} size={23} />
+        <ConnectorIcon icon={gmailIcon} size={23} />
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium leading-5 text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,27 +1,19 @@
 import { IconAlertCircle, IconLoader2 } from "@tabler/icons-react";
-import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
-import {
-  getStaticConnectorIconMetadata,
-  isStaticConnectorIconType,
-} from "@vm0/connectors/static-connector-icons";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import type { ConnectorRedirectingStatus } from "../../signals/connectors-page/connector-redirecting.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 
 export function ZeroConnectorRedirectingPage({
-  connectorType,
   connectorLabel,
+  connectorIcon,
   status,
 }: {
-  readonly connectorType: ConnectorRef | null;
   readonly connectorLabel: string;
+  readonly connectorIcon: PublicConnectorCatalogIcon | undefined;
   readonly status: ConnectorRedirectingStatus;
 }) {
-  const icon =
-    connectorType && isStaticConnectorIconType(connectorType)
-      ? getStaticConnectorIconMetadata(connectorType)
-      : undefined;
   const hasError = status === "error";
 
   return (
@@ -30,7 +22,7 @@ export function ZeroConnectorRedirectingPage({
         <VM0Logo />
         <div className="flex w-full flex-col items-center gap-4">
           <div className="flex items-center justify-center rounded-[10px] bg-gray-50 p-2.5 dark:bg-muted">
-            <ConnectorIcon icon={icon} size={20} />
+            <ConnectorIcon icon={connectorIcon} size={20} />
           </div>
           <div className="flex flex-col items-center gap-2.5">
             <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -983,7 +983,7 @@ export function ZeroConnectorsPage() {
         return connect(
           connectorRef,
           authMethod,
-          { connectorLabel: ct.label },
+          { connectorLabel: ct.label, connectorIcon: ct.icon },
           signal,
         );
       },
@@ -1175,7 +1175,10 @@ export function ZeroConnectorsPage() {
               connect(
                 connectorRef,
                 authMethod,
-                { connectorLabel: connector.label },
+                {
+                  connectorLabel: connector.label,
+                  connectorIcon: connector.icon,
+                },
                 signal,
               ),
               Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -273,6 +273,7 @@ function runDirectedAuthorize(params: {
     method: PublicConnectorCatalogAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
+      readonly connectorIcon: PublicConnectorCatalogStatusItem["icon"];
       readonly agentId?: string;
     },
     signal: AbortSignal,
@@ -318,16 +319,17 @@ function runDirectedAuthorize(params: {
     launchMode === "no-auth" && params.item
       ? getOnlyAvailableStatusNoAuthMethod(params.item)
       : null;
-  if (browserAuthMethod || noAuthMethod) {
+  if ((browserAuthMethod && params.item) || noAuthMethod) {
     detach(
       (async () => {
         let connected = false;
-        if (browserAuthMethod) {
+        if (browserAuthMethod && params.item) {
           connected = await params.connect(
             params.connectorRef,
             browserAuthMethod,
             {
               connectorLabel: params.connectorLabel,
+              connectorIcon: params.item.icon,
               agentId: params.agentId,
             },
             params.signal,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -77,6 +77,7 @@ function runDirectedConnect(params: {
     method: PublicConnectorCatalogAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
+      readonly connectorIcon: PublicConnectorCatalogStatusItem["icon"];
       readonly agentId?: string;
     },
     signal: AbortSignal,
@@ -135,6 +136,7 @@ function runDirectedConnect(params: {
           authMethod,
           {
             connectorLabel: params.item.label,
+            connectorIcon: params.item.icon,
             ...(params.agentId ? { agentId: params.agentId } : {}),
           },
           params.signal,


### PR DESCRIPTION
## Summary

- render Platform connector marks from public catalog icon descriptors in onboarding, Gmail draft cards, and browser-auth redirect pages
- carry the initiating catalog descriptor through the unauthenticated OAuth popup and validate it before rendering, with the generic icon as the fallback for old or invalid URLs
- reject future production Platform imports of the complete static connector icon map while keeping test and mock fixtures outside the boundary

## Compatibility and exclusions

- already-loaded callers that omit redirect icon metadata keep their existing redirect and error behavior and render the generic fallback
- manual, device, managed, and no-auth connection flows are unchanged
- this does not change connector catalog publication, source selection, API authorization, database state, skill/firewall data, or the external-source cutover

## Validation

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm knip`
- `pnpm check-types` (pre-commit hook)
- `pnpm -F @vm0/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --silent=passed-only` (91 tests)

Closes #22528

Parent context: https://github.com/vm0-ai/vm0-connectors/issues/1
