### PR TITLE
feat(connectors): add app oauth callback page

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -315,6 +315,92 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
 });
 
 describe("CONN-02: OAuth start and callback", () => {
+  it("uses App callbacks for enabled connectors while returning structured callback results", async () => {
+    mockGitHubConnectorOAuth();
+
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    const startResponse = await connectorsApi.requestOauthStart(
+      actor,
+      "github",
+      "oauth",
+      {
+        statuses: [200],
+        authorizeAgent: true,
+        callbackTarget: "app",
+      },
+    );
+    if (startResponse.status !== 200) {
+      throw new Error(`Unexpected OAuth start status ${startResponse.status}`);
+    }
+    const authorizationUrl = await connectorsApi.continueOauth(
+      "github",
+      startResponse.body.authorizationUrl,
+    );
+    expect(
+      new URL(authorizationUrl.searchParams.get("redirect_uri") ?? "").pathname,
+    ).toBe("/connectors/github/callback");
+    const state = stateFromAuthorizationUrl(authorizationUrl.toString());
+
+    await expect(
+      connectorsApi.completeOauthCallbackResult("github", {
+        code: "github-app-success-code",
+        state,
+      }),
+    ).resolves.toStrictEqual({
+      status: "success",
+      username: "bdd-github-user",
+    });
+    await expect(
+      connectorsApi.readConnectorByType(actor, "github"),
+    ).resolves.toMatchObject({
+      type: "github",
+      externalUsername: "bdd-github-user",
+      connectionStatus: "connected",
+    });
+
+    const failedActor = bdd.user();
+    const failedStartResponse = await connectorsApi.requestOauthStart(
+      failedActor,
+      "github",
+      "oauth",
+      {
+        statuses: [200],
+        authorizeAgent: true,
+        callbackTarget: "app",
+      },
+    );
+    if (failedStartResponse.status !== 200) {
+      throw new Error(
+        `Unexpected OAuth start status ${failedStartResponse.status}`,
+      );
+    }
+    const failedAuthorizationUrl = await connectorsApi.continueOauth(
+      "github",
+      failedStartResponse.body.authorizationUrl,
+    );
+    const failedState = stateFromAuthorizationUrl(
+      failedAuthorizationUrl.toString(),
+    );
+    await expect(
+      connectorsApi.completeOauthCallbackResult("github", {
+        error: "access_denied",
+        error_description: "Provider denied access",
+        state: failedState,
+      }),
+    ).resolves.toStrictEqual({
+      status: "error",
+      message: "Provider denied access",
+    });
+    const failedConnector = await connectorsApi.requestReadConnectorByType(
+      failedActor,
+      "github",
+      [404],
+    );
+    expectApiError(failedConnector.body);
+    expect(failedConnector.body.error.code).toBe("NOT_FOUND");
+  });
+
   it("starts GitHub OAuth, completes the callback, rejects replay visibly, and keeps safe connector state", async () => {
     mockGitHubConnectorOAuth();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -342,15 +342,21 @@ describe("CONN-02: OAuth start and callback", () => {
     ).toBe("/connectors/github/callback");
     const state = stateFromAuthorizationUrl(authorizationUrl.toString());
 
-    await expect(
-      connectorsApi.completeOauthCallbackResult("github", {
+    const callbackResult = await connectorsApi.completeOauthCallbackResult(
+      "github",
+      {
         code: "github-app-success-code",
         state,
-      }),
-    ).resolves.toStrictEqual({
+      },
+    );
+    expect(callbackResult.body).toStrictEqual({
       status: "success",
       username: "bdd-github-user",
     });
+    expect(callbackResult.headers.get("cache-control")).toBe("no-store");
+    expect(callbackResult.headers.getSetCookie()).toStrictEqual(
+      expect.arrayContaining([...CONNECTOR_OAUTH_COOKIE_CLEARS]),
+    );
     await expect(
       connectorsApi.readConnectorByType(actor, "github"),
     ).resolves.toMatchObject({
@@ -382,13 +388,13 @@ describe("CONN-02: OAuth start and callback", () => {
     const failedState = stateFromAuthorizationUrl(
       failedAuthorizationUrl.toString(),
     );
-    await expect(
-      connectorsApi.completeOauthCallbackResult("github", {
+    const failedCallbackResult =
+      await connectorsApi.completeOauthCallbackResult("github", {
         error: "access_denied",
         error_description: "Provider denied access",
         state: failedState,
-      }),
-    ).resolves.toStrictEqual({
+      });
+    expect(failedCallbackResult.body).toStrictEqual({
       status: "error",
       message: "Provider denied access",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1349,7 +1349,7 @@ export function createConnectorBddApi(context: TestContext) {
         [200],
       );
       expectStatus(response, 200);
-      return response.body;
+      return response;
     },
 
     /**

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1272,6 +1272,7 @@ export function createConnectorBddApi(context: TestContext) {
         readonly statuses: readonly (200 | 400 | 401 | 403 | 500)[];
         readonly agentId?: string;
         readonly authorizeAgent?: true;
+        readonly callbackTarget?: "app";
       },
     ) {
       const client = setupApp({ context })(zeroConnectorOauthStartContract);
@@ -1283,6 +1284,9 @@ export function createConnectorBddApi(context: TestContext) {
             authMethod,
             ...(options.agentId ? { agentId: options.agentId } : {}),
             ...(options.authorizeAgent ? { authorizeAgent: true } : {}),
+            ...(options.callbackTarget
+              ? { callbackTarget: options.callbackTarget }
+              : {}),
           },
         }),
         options.statuses,
@@ -1332,6 +1336,20 @@ export function createConnectorBddApi(context: TestContext) {
         client.callback({ params: { type }, query, headers: {} }),
         [307],
       );
+    },
+
+    async completeOauthCallbackResult(type: string, query: CallbackQuery) {
+      const client = setupApp({ context })(connectorsTypeCallbackContract);
+      const response = await accept(
+        client.callback({
+          params: { type },
+          query: { ...query, responseMode: "json" },
+          headers: {},
+        }),
+        [200],
+      );
+      expectStatus(response, 200);
+      return response.body;
     },
 
     /**

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -396,11 +396,11 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("uses App callbacks for enabled connectors", async () => {
+  it("uses App callbacks for allowlisted connectors", async () => {
     mockEnv("APP_URL", "https://app.vm0.test");
     mockAuthenticatedSession();
 
-    const response = await requestOauthStart("github", {
+    const response = await requestOauthStart("google-maps", {
       callbackTarget: "app",
       headers: authHeaders(),
       origin: API_ORIGIN,
@@ -409,7 +409,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(response.status).toBe(200);
     const authorizationUrl = await authorizationUrlFromResponse(response);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://app.vm0.test/connectors/github/callback",
+      "https://app.vm0.test/connectors/google-maps/callback",
     );
     await rejectProviderAuthorization(authorizationUrl);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -97,6 +97,7 @@ async function requestOauthStart(
   options: {
     readonly authMethod?: ConnectorRegistryAuthMethodId;
     readonly authenticated?: boolean;
+    readonly callbackTarget?: "app";
     readonly headers?: HeadersInit;
     readonly origin?: string;
   } = {},
@@ -113,7 +114,12 @@ async function requestOauthStart(
   return await app.request(oauthStartUrl(type, options.origin), {
     method: "POST",
     headers,
-    body: JSON.stringify({ authMethod: options.authMethod ?? "oauth" }),
+    body: JSON.stringify({
+      authMethod: options.authMethod ?? "oauth",
+      ...(options.callbackTarget
+        ? { callbackTarget: options.callbackTarget }
+        : {}),
+    }),
   });
 }
 
@@ -390,6 +396,24 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
+  it("uses App callbacks for enabled connectors", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("github", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.test/connectors/github/callback",
+    );
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
   it("stores provider PKCE context for server-side OAuth handoff", async () => {
     mockAuthenticatedSession();
 
@@ -419,12 +443,13 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("uses the configured API origin for Cloudflare OAuth callback URLs", async () => {
+  it("keeps API-origin callbacks on the API when the app target is requested", async () => {
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("cloudflare", {
       headers: authHeaders(),
       origin: WEB_ORIGIN,
+      callbackTarget: "app",
     });
 
     expect(response.status).toBe(200);

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -26,9 +26,8 @@ type PrepareConnectorAuthCodeStartWithMethodResult =
     };
 
 export function prepareConnectorAuthCodeStartWithMethod(args: {
-  readonly connectorRef: string;
   readonly method: ConnectorAuthMethodRuntimeConfig;
-  readonly origin: string;
+  readonly redirectUri: string;
   readonly readEnv: ConnectorEnvReader;
 }): PrepareConnectorAuthCodeStartWithMethodResult {
   if (args.method.grant.kind !== "auth-code" || !args.method.client) {
@@ -45,7 +44,7 @@ export function prepareConnectorAuthCodeStartWithMethod(args: {
   return {
     ok: true,
     state,
-    redirectUri: `${args.origin}/api/connectors/${args.connectorRef}/callback`,
+    redirectUri: args.redirectUri,
     authClient,
   };
 }

--- a/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
@@ -2,11 +2,13 @@ import {
   connectorAuthCodeGrantCallbackOrigin,
   connectorOpenIdAuthGrantCallbackOrigin,
 } from "@vm0/connectors/connector-utils";
+import { isConnectorAppOauthCallbackEnabled } from "@vm0/connectors/app-oauth-callback";
 import type {
   ConnectorAuthMethodRuntimeConfig,
   ConnectorBrowserAuthCallbackOrigin,
 } from "@vm0/connectors/connectors";
 
+import { env } from "../../lib/env";
 import {
   getOAuthApiOrigin,
   getOAuthCanonicalRedirectUrl,
@@ -29,17 +31,32 @@ function resolveCallbackOrigin(
   }
 }
 
-export function getConnectorOAuthCallbackOriginForMethod(args: {
+export function getConnectorOAuthCallbackUrlForMethod(args: {
   readonly request: Request;
   readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly connectorRef: string;
+  readonly callbackTarget: "app" | undefined;
 }): string {
   if (args.method.grant.kind !== "auth-code") {
     throw new Error("Auth-code connector method required");
   }
-  return resolveCallbackOrigin(
-    args.request,
-    connectorAuthCodeGrantCallbackOrigin(args.method.grant),
+  const callbackOrigin = connectorAuthCodeGrantCallbackOrigin(
+    args.method.grant,
   );
+  if (
+    args.callbackTarget === "app" &&
+    isConnectorAppOauthCallbackEnabled(args.connectorRef) &&
+    callbackOrigin === "web"
+  ) {
+    return new URL(
+      `/connectors/${encodeURIComponent(args.connectorRef)}/callback`,
+      env("APP_URL"),
+    ).toString();
+  }
+  return new URL(
+    `/api/connectors/${encodeURIComponent(args.connectorRef)}/callback`,
+    resolveCallbackOrigin(args.request, callbackOrigin),
+  ).toString();
 }
 
 export function getConnectorOpenIdCallbackOriginForMethod(args: {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -17,7 +17,7 @@ import {
   type ConnectorAuthProviderGrantResult,
 } from "@vm0/connectors/auth-providers";
 
-import { request$ } from "../context/hono";
+import { request$, setResHeader$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
 import { db$, writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
@@ -996,9 +996,15 @@ const callbackConnectorInner$ = command(
         );
     signal.throwIfAborted();
 
-    return query.responseMode === "json"
-      ? { status: 200 as const, body: callbackResultFromRedirect(response) }
-      : response;
+    if (query.responseMode !== "json") {
+      return response;
+    }
+
+    set(setResHeader$, "Cache-Control", "no-store");
+    for (const cookie of response.headers.getSetCookie()) {
+      set(setResHeader$, "Set-Cookie", cookie, { append: true });
+    }
+    return { status: 200 as const, body: callbackResultFromRedirect(response) };
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,5 +1,8 @@
 import { command } from "ccstate";
-import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
+import {
+  connectorsTypeCallbackContract,
+  type ConnectorOauthCallbackResult,
+} from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
   connectorAuthMethodIdSchema,
   type ConnectorRef,
@@ -430,6 +433,31 @@ function successRedirectResponse(args: {
   return response;
 }
 
+function callbackResultFromRedirect(
+  response: Response,
+): ConnectorOauthCallbackResult {
+  const location = response.headers.get("location");
+  if (!location) {
+    throw new Error("Connector callback response is missing a redirect");
+  }
+  const url = new URL(location);
+  if (url.pathname === "/connector/success") {
+    return {
+      status: "success",
+      username: url.searchParams.get("username") || null,
+    };
+  }
+  if (url.pathname === "/connector/error") {
+    return {
+      status: "error",
+      message:
+        url.searchParams.get("message") ||
+        "OAuth authorization failed. Please try again.",
+    };
+  }
+  throw new Error(`Unexpected connector callback redirect: ${location}`);
+}
+
 function callbackOAuthContext(args: {
   readonly storedContext: string | undefined;
   readonly realmId: string | undefined;
@@ -770,6 +798,7 @@ const handleOpenIdConnectorCallback$ = command(
 
 function authCodeCallbackPreflight(args: {
   readonly type: ConnectorRef;
+  readonly query: ConnectorCallbackQuery;
   readonly request: Request;
   readonly origin: string;
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -783,6 +812,9 @@ function authCodeCallbackPreflight(args: {
   });
   if (!connectorResult.ok) {
     return connectorResult.response;
+  }
+  if (args.query.responseMode === "json") {
+    return null;
   }
   const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrlForMethods(
     args.request,
@@ -940,30 +972,33 @@ const callbackConnectorInner$ = command(
     const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
     signal.throwIfAborted();
 
-    if (hasOpenIdCallbackFields(query)) {
-      return await set(
-        handleOpenIdConnectorCallback$,
-        {
-          type,
-          query,
-          origin,
-          snapshot,
-        },
-        signal,
-      );
-    }
+    const response = hasOpenIdCallbackFields(query)
+      ? await set(
+          handleOpenIdConnectorCallback$,
+          {
+            type,
+            query,
+            origin,
+            snapshot,
+          },
+          signal,
+        )
+      : await set(
+          handleAuthCodeConnectorCallback$,
+          {
+            type,
+            query,
+            request,
+            origin,
+            snapshot,
+          },
+          signal,
+        );
+    signal.throwIfAborted();
 
-    return await set(
-      handleAuthCodeConnectorCallback$,
-      {
-        type,
-        query,
-        request,
-        origin,
-        snapshot,
-      },
-      signal,
-    );
+    return query.responseMode === "json"
+      ? { status: 200 as const, body: callbackResultFromRedirect(response) }
+      : response;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -49,7 +49,7 @@ import { getConnectorOAuthAuthorizationUrl } from "../services/connector-oauth-s
 import type { RouteEntry } from "../route-entry";
 import { settle } from "../utils";
 import {
-  getConnectorOAuthCallbackOriginForMethod,
+  getConnectorOAuthCallbackUrlForMethod,
   getConnectorOpenIdCallbackOriginForMethod,
 } from "./connector-oauth-origin";
 import {
@@ -502,14 +502,15 @@ const startConnectorOauthInner$ = command(
       return internalServerError("Connector execution is not configured");
     }
 
-    const origin = getConnectorOAuthCallbackOriginForMethod({
+    const redirectUri = getConnectorOAuthCallbackUrlForMethod({
       request,
       method,
+      connectorRef: resolved.connectorRef,
+      callbackTarget: bodyResult.data.callbackTarget,
     });
     const prepared = prepareConnectorAuthCodeStartWithMethod({
-      connectorRef: resolved.connectorRef,
       method,
-      origin,
+      redirectUri,
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -58,6 +58,7 @@ import { setupComputerUseAuthorizationPage$ } from "./computer-use-authorization
 import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-page-setup.ts";
 import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
 import { setupConnectorRedirectingPage$ } from "./connectors-page/connector-redirecting-page-setup.ts";
+import { setupConnectorCallbackPage$ } from "./connectors-page/connector-callback-page-setup.ts";
 import { setupEmailUnsubscribePage$ } from "./email-unsubscribe/email-unsubscribe-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupMorningBriefUnsubscribePage$ } from "./morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts";
@@ -173,6 +174,14 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.computerUseAuthorize,
     setup: setupAuthPageWrapper(setupComputerUseAuthorizationPage$),
+  },
+  {
+    path: ROUTES.connectorCallbackResult,
+    setup: setupConnectorCallbackPage$,
+  },
+  {
+    path: ROUTES.connectorCallback,
+    setup: setupConnectorCallbackPage$,
   },
   {
     path: ROUTES.connectorRedirecting,

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -54,12 +54,10 @@ function resultFromPath(
 }
 
 function callbackPageElement(
-  connectorRef: ConnectorRef | null,
   label: string,
   result: ConnectorCallbackPageResult,
 ): React.JSX.Element {
   return createElement(ZeroConnectorCallbackPage, {
-    connectorRef,
     connectorLabel: label,
     status: result.status,
     username: result.status === "success" ? result.username : null,
@@ -104,7 +102,7 @@ export const setupConnectorCallbackPage$ = command(
     );
 
     if (pathResult) {
-      set(updatePage$, callbackPageElement(connectorRef, label, pathResult));
+      set(updatePage$, callbackPageElement(label, pathResult));
       set(updateDocumentTitle$, `Connect ${label}`);
       await set(hideAppSkeleton$, signal);
       return;
@@ -113,7 +111,7 @@ export const setupConnectorCallbackPage$ = command(
     if (!connectorRef) {
       set(
         updatePage$,
-        callbackPageElement(connectorRef, label, {
+        callbackPageElement(label, {
           status: "error",
           message: "Invalid connector callback URL.",
         }),
@@ -123,10 +121,7 @@ export const setupConnectorCallbackPage$ = command(
       return;
     }
 
-    set(
-      updatePage$,
-      callbackPageElement(connectorRef, label, { status: "loading" }),
-    );
+    set(updatePage$, callbackPageElement(label, { status: "loading" }));
     set(updateDocumentTitle$, `Connect ${label}`);
     await set(hideAppSkeleton$, signal);
 
@@ -136,7 +131,7 @@ export const setupConnectorCallbackPage$ = command(
       Object.fromEntries(searchParams),
       signal,
     );
-    set(updatePage$, callbackPageElement(connectorRef, label, result));
+    set(updatePage$, callbackPageElement(label, result));
 
     const resultSearchParams = new URLSearchParams();
     if (result.status === "success" && result.username) {

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -54,10 +54,12 @@ function resultFromPath(
 }
 
 function callbackPageElement(
+  connectorRef: ConnectorRef | null,
   label: string,
   result: ConnectorCallbackPageResult,
 ): React.JSX.Element {
   return createElement(ZeroConnectorCallbackPage, {
+    connectorRef,
     connectorLabel: label,
     status: result.status,
     username: result.status === "success" ? result.username : null,
@@ -102,7 +104,7 @@ export const setupConnectorCallbackPage$ = command(
     );
 
     if (pathResult) {
-      set(updatePage$, callbackPageElement(label, pathResult));
+      set(updatePage$, callbackPageElement(connectorRef, label, pathResult));
       set(updateDocumentTitle$, `Connect ${label}`);
       await set(hideAppSkeleton$, signal);
       return;
@@ -111,7 +113,7 @@ export const setupConnectorCallbackPage$ = command(
     if (!connectorRef) {
       set(
         updatePage$,
-        callbackPageElement(label, {
+        callbackPageElement(connectorRef, label, {
           status: "error",
           message: "Invalid connector callback URL.",
         }),
@@ -121,7 +123,10 @@ export const setupConnectorCallbackPage$ = command(
       return;
     }
 
-    set(updatePage$, callbackPageElement(label, { status: "loading" }));
+    set(
+      updatePage$,
+      callbackPageElement(connectorRef, label, { status: "loading" }),
+    );
     set(updateDocumentTitle$, `Connect ${label}`);
     await set(hideAppSkeleton$, signal);
 
@@ -131,7 +136,7 @@ export const setupConnectorCallbackPage$ = command(
       Object.fromEntries(searchParams),
       signal,
     );
-    set(updatePage$, callbackPageElement(label, result));
+    set(updatePage$, callbackPageElement(connectorRef, label, result));
 
     const resultSearchParams = new URLSearchParams();
     if (result.status === "success" && result.username) {

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -1,0 +1,150 @@
+import {
+  connectorsTypeCallbackContract,
+  type ConnectorOauthCallbackResult,
+} from "@vm0/api-contracts/contracts/connectors-type-callback";
+import {
+  connectorRefSchema,
+  type ConnectorRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import { command } from "ccstate";
+import { createElement } from "react";
+import { accept } from "../../lib/accept.ts";
+import { ZeroConnectorCallbackPage } from "../../views/zero-page/zero-connector-callback-page.tsx";
+import { zeroClient$ } from "../api-client.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { pathParams$, replacePathSilently$, searchParams$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+
+type ConnectorCallbackPageResult =
+  | { readonly status: "loading" }
+  | ConnectorOauthCallbackResult;
+
+function connectorRefFromPath(value: string | undefined): ConnectorRef | null {
+  const parsed = connectorRefSchema.safeParse(value?.toLowerCase());
+  return parsed.success ? parsed.data : null;
+}
+
+function connectorLabel(connectorRef: ConnectorRef | null): string {
+  if (!connectorRef) {
+    return "Connector";
+  }
+  return connectorRef === "github" ? "GitHub" : connectorRef.toUpperCase();
+}
+
+function resultFromPath(
+  status: string | undefined,
+  searchParams: URLSearchParams,
+): ConnectorOauthCallbackResult | null {
+  if (status === "success") {
+    return {
+      status,
+      username: searchParams.get("username"),
+    };
+  }
+  if (status === "error") {
+    return {
+      status,
+      message:
+        searchParams.get("message") || "An error occurred during connection.",
+    };
+  }
+  return null;
+}
+
+function callbackPageElement(
+  label: string,
+  result: ConnectorCallbackPageResult,
+): React.JSX.Element {
+  return createElement(ZeroConnectorCallbackPage, {
+    connectorLabel: label,
+    status: result.status,
+    username: result.status === "success" ? result.username : null,
+    errorMessage: result.status === "error" ? result.message : null,
+  });
+}
+
+const completeConnectorCallback$ = command(
+  async (
+    { get },
+    connectorRef: ConnectorRef,
+    query: Record<string, string>,
+    signal: AbortSignal,
+  ): Promise<ConnectorOauthCallbackResult> => {
+    const client = get(zeroClient$)(connectorsTypeCallbackContract, {
+      apiBase: "api",
+    });
+    const response = await accept(
+      client.callback({
+        params: { type: connectorRef },
+        query: { ...query, responseMode: "json" },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return response.body;
+  },
+);
+
+export const setupConnectorCallbackPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(pathParams$);
+    const connectorRef = connectorRefFromPath(
+      typeof params?.type === "string" ? params.type : undefined,
+    );
+    const label = connectorLabel(connectorRef);
+    const searchParams = get(searchParams$);
+    const pathResult = resultFromPath(
+      typeof params?.status === "string" ? params.status : undefined,
+      searchParams,
+    );
+
+    if (pathResult) {
+      set(updatePage$, callbackPageElement(label, pathResult));
+      set(updateDocumentTitle$, `Connect ${label}`);
+      await set(hideAppSkeleton$, signal);
+      return;
+    }
+
+    if (!connectorRef) {
+      set(
+        updatePage$,
+        callbackPageElement(label, {
+          status: "error",
+          message: "Invalid connector callback URL.",
+        }),
+      );
+      set(updateDocumentTitle$, `Connect ${label}`);
+      await set(hideAppSkeleton$, signal);
+      return;
+    }
+
+    set(updatePage$, callbackPageElement(label, { status: "loading" }));
+    set(updateDocumentTitle$, `Connect ${label}`);
+    await set(hideAppSkeleton$, signal);
+
+    const result = await set(
+      completeConnectorCallback$,
+      connectorRef,
+      Object.fromEntries(searchParams),
+      signal,
+    );
+    set(updatePage$, callbackPageElement(label, result));
+
+    const resultSearchParams = new URLSearchParams();
+    if (result.status === "success" && result.username) {
+      resultSearchParams.set("username", result.username);
+    }
+    if (result.status === "error") {
+      resultSearchParams.set("message", result.message);
+    }
+    set(
+      replacePathSilently$,
+      ROUTES.connectorCallbackResult,
+      { type: connectorRef, status: result.status },
+      resultSearchParams,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -22,6 +22,8 @@ export const ROUTES = {
   connectors: "/connectors",
   customConnectorProposal: "/connectors/custom/proposal",
   computerUseAuthorize: "/computer-use/authorize/:requestToken",
+  connectorCallback: "/connectors/:type/callback",
+  connectorCallbackResult: "/connectors/:type/callback/:status",
   connectorRedirecting: "/connectors/:type/redirecting",
   directedConnect: "/connectors/:type/connect",
   directedAuthorize: "/connectors/:type/authorize",

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -5,6 +5,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
+import { isConnectorAppOauthCallbackEnabled } from "@vm0/connectors/app-oauth-callback";
 import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
@@ -2108,6 +2109,9 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                   body: {
                     authMethod: args.method.id,
                     authorizeAgent: true,
+                    ...(isConnectorAppOauthCallbackEnabled(args.connectorRef)
+                      ? { callbackTarget: "app" as const }
+                      : {}),
                     ...(args.agentId ? { agentId: args.agentId } : {}),
                   },
                   fetchOptions: { signal },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -452,6 +452,7 @@ describe("chat message action cards", () => {
           authMethod: "oauth",
           agentId: AGENT_ID,
           authorizeAgent: true,
+          callbackTarget: "app",
         });
         connected = true;
         authorized = true;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -31,13 +31,11 @@ describe("connector callback page", () => {
 
     await expect(
       screen.findByRole("heading", {
-        name: "GitHub connected successfully.",
+        name: "GitHub connected",
       }),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("octocat")).toBeInTheDocument();
-    expect(
-      screen.getByText(/You can close this tab now\./),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/You can close this window\./)).toBeInTheDocument();
     expect(observedQuery).toMatchObject({
       code: "oauth-code",
       state: "oauth-state",
@@ -74,7 +72,7 @@ describe("connector callback page", () => {
     });
 
     await expect(
-      screen.findByRole("heading", { name: "NOTION connection failed." }),
+      screen.findByRole("heading", { name: "Couldn’t connect NOTION" }),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText(/Provider denied access/)).toBeInTheDocument();
     await waitFor(() => {
@@ -97,7 +95,7 @@ describe("connector callback page", () => {
 
     await expect(
       screen.findByRole("heading", {
-        name: "GitHub connected successfully.",
+        name: "GitHub connected",
       }),
     ).resolves.toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -1,0 +1,104 @@
+import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname, search } from "../../../signals/location.ts";
+
+const context = testContext();
+
+describe("connector callback page", () => {
+  it("forwards provider parameters and renders a durable success page", async () => {
+    let observedQuery: Readonly<Record<string, string | undefined>> = {};
+    context.mocks.api(
+      connectorsTypeCallbackContract.callback,
+      ({ params, query, respond }) => {
+        expect(params.type).toBe("github");
+        observedQuery = query;
+        return respond(200, {
+          status: "success",
+          username: "octocat",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/callback?code=oauth-code&state=oauth-state",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "GitHub connected successfully.",
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("octocat")).toBeInTheDocument();
+    expect(
+      screen.getByText(/You can close this tab now\./),
+    ).toBeInTheDocument();
+    expect(observedQuery).toMatchObject({
+      code: "oauth-code",
+      state: "oauth-state",
+      responseMode: "json",
+    });
+    await waitFor(() => {
+      expect(pathname()).toBe("/connectors/github/callback/success");
+    });
+    expect(search()).toBe("?username=octocat");
+  });
+
+  it("renders the API failure result without retaining OAuth parameters", async () => {
+    context.mocks.api(
+      connectorsTypeCallbackContract.callback,
+      ({ query, respond }) => {
+        expect(query).toMatchObject({
+          error: "access_denied",
+          error_description: "Provider denied access",
+          state: "oauth-state",
+          responseMode: "json",
+        });
+        return respond(200, {
+          status: "error",
+          message: "Provider denied access",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/notion/callback?error=access_denied&error_description=Provider+denied+access&state=oauth-state",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "NOTION connection failed." }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText(/Provider denied access/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(pathname()).toBe("/connectors/notion/callback/error");
+    });
+    expect(search()).toBe("?message=Provider+denied+access");
+  });
+
+  it("restores a completed result page without replaying the callback", async () => {
+    context.mocks.api(connectorsTypeCallbackContract.callback, ({ never }) => {
+      return never();
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/callback/success?username=octocat",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "GitHub connected successfully.",
+      }),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -18,7 +18,7 @@ describe("connector redirecting page", () => {
       screen.findByRole("heading", { name: "Redirecting to GitHub…" }),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.getByText("You’ll continue on GitHub to authorize Zero."),
+      screen.getByText("You’ll continue on GitHub to authorize VM0."),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Preparing a secure connection"),
@@ -79,7 +79,7 @@ describe("connector redirecting page", () => {
       screen.findByRole("heading", { name: "Couldn’t open GitHub" }),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.getByText("Return to Zero and try connecting again."),
+      screen.getByText("Return to VM0 and try connecting again."),
     ).toBeInTheDocument();
     expect(screen.getByText("Close window")).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1398,8 +1398,9 @@ describe("connectors page", () => {
     context.mocks.browser.open(authWindow);
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
-      ({ params, respond }) => {
+      ({ body, params, respond }) => {
         expect(params.type).toBe("google-maps");
+        expect(body.callbackTarget).toBe("app");
         return respond(200, {
           authorizationUrl: "https://oauth.test/google-maps/authorize",
         });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -123,6 +123,7 @@ function mockConnectorOauthStart(): { readonly authWindow: Window } {
         authMethod: "oauth",
         agentId: AGENT_ID,
         authorizeAgent: true,
+        callbackTarget: "app",
       });
       return respond(200, {
         authorizationUrl: `https://oauth.test/${params.type}/authorize`,

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -19,6 +19,7 @@ import {
 } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isConnectorAppOauthCallbackEnabled } from "@vm0/connectors/app-oauth-callback";
 import {
   zeroConnectorOauthStartContract,
   zeroConnectorOpenIdStartContract,
@@ -216,7 +217,17 @@ function startGoogleDriveConnectAndRun(params: {
                 .createClient(zeroConnectorOauthStartContract, {
                   apiBase: OAUTH_API_BASE,
                 })
-                .start(request),
+                .start({
+                  ...request,
+                  body: {
+                    ...request.body,
+                    ...(isConnectorAppOauthCallbackEnabled(
+                      params.connector.connectorRef,
+                    )
+                      ? { callbackTarget: "app" as const }
+                      : {}),
+                  },
+                }),
               [200],
             );
       params.pageSignal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,0 +1,107 @@
+import {
+  IconCheck,
+  IconLoader2,
+  IconMoon,
+  IconSun,
+  IconX,
+} from "@tabler/icons-react";
+import { useGet, useSet } from "ccstate-react";
+import { setTheme$, theme$ } from "../../signals/theme.ts";
+import { VM0Logo } from "../components/vm0-logo.tsx";
+
+type ConnectorCallbackPageStatus = "loading" | "success" | "error";
+
+export function ZeroConnectorCallbackPage({
+  connectorLabel,
+  status,
+  username,
+  errorMessage,
+}: {
+  readonly connectorLabel: string;
+  readonly status: ConnectorCallbackPageStatus;
+  readonly username: string | null;
+  readonly errorMessage: string | null;
+}): React.JSX.Element {
+  const theme = useGet(theme$);
+  const setTheme = useSet(setTheme$);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <button
+        type="button"
+        onClick={() => {
+          setTheme(theme === "dark" ? "light" : "dark");
+        }}
+        className="fixed right-6 top-6 flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-card text-foreground transition-colors hover:bg-muted"
+        aria-label="Toggle theme"
+      >
+        {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      </button>
+
+      <div className="min-h-[380px] w-full max-w-[400px] overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex flex-col items-center p-10">
+          <div className="mb-8 flex items-center gap-2">
+            <VM0Logo />
+            <span className="text-2xl text-foreground">Platform</span>
+          </div>
+
+          <div
+            className="mt-4 flex flex-col items-center gap-4"
+            aria-live="polite"
+          >
+            {status === "success" ? (
+              <IconCheck size={40} className="text-lime-600" stroke={1} />
+            ) : status === "error" ? (
+              <IconX size={40} className="text-red-500" stroke={1} />
+            ) : (
+              <IconLoader2
+                size={40}
+                className="animate-spin text-muted-foreground"
+                stroke={1}
+              />
+            )}
+
+            <div className="flex flex-col items-center gap-2 text-center">
+              {status === "success" ? (
+                <>
+                  <h1 className="text-lg font-medium leading-7 text-foreground">
+                    {connectorLabel} connected successfully.
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    {username ? (
+                      <>
+                        Connected as <strong>{username}</strong>.
+                      </>
+                    ) : (
+                      "Your account has been connected."
+                    )}{" "}
+                    You can close this tab now.
+                  </p>
+                </>
+              ) : status === "error" ? (
+                <>
+                  <h1 className="text-lg font-medium leading-7 text-foreground">
+                    {connectorLabel} connection failed.
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    {errorMessage || "An error occurred during connection."}{" "}
+                    Please close this window and try again.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h1 className="text-lg font-medium leading-7 text-foreground">
+                    Connecting {connectorLabel}…
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    Please wait while we finish connecting your account.
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,107 +1,93 @@
+import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
 import {
-  IconCheck,
-  IconLoader2,
-  IconMoon,
-  IconSun,
-  IconX,
-} from "@tabler/icons-react";
-import { useGet, useSet } from "ccstate-react";
-import { setTheme$, theme$ } from "../../signals/theme.ts";
-import { VM0Logo } from "../components/vm0-logo.tsx";
+  getStaticConnectorIconMetadata,
+  isStaticConnectorIconType,
+} from "@vm0/connectors/static-connector-icons";
+import { Button } from "@vm0/ui/components/ui/button";
+import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 type ConnectorCallbackPageStatus = "loading" | "success" | "error";
 
 export function ZeroConnectorCallbackPage({
+  connectorRef,
   connectorLabel,
   status,
   username,
   errorMessage,
 }: {
+  readonly connectorRef: string | null;
   readonly connectorLabel: string;
   readonly status: ConnectorCallbackPageStatus;
   readonly username: string | null;
   readonly errorMessage: string | null;
 }): React.JSX.Element {
-  const theme = useGet(theme$);
-  const setTheme = useSet(setTheme$);
+  const connectorIcon =
+    connectorRef && isStaticConnectorIconType(connectorRef)
+      ? getStaticConnectorIconMetadata(connectorRef)
+      : undefined;
+  const title =
+    status === "success"
+      ? `${connectorLabel} connected`
+      : status === "error"
+        ? `Couldn’t connect ${connectorLabel}`
+        : `Connecting ${connectorLabel}…`;
+  const description =
+    status === "success" ? (
+      username ? (
+        <>
+          Connected as <strong>{username}</strong>. You can close this window.
+        </>
+      ) : (
+        "Your account has been connected. You can close this window."
+      )
+    ) : status === "error" ? (
+      <>
+        {errorMessage || "An error occurred during connection."} Close this
+        window and try again.
+      </>
+    ) : (
+      "Please wait while we finish connecting your account."
+    );
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
-      <button
-        type="button"
-        onClick={() => {
-          setTheme(theme === "dark" ? "light" : "dark");
-        }}
-        className="fixed right-6 top-6 flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-card text-foreground transition-colors hover:bg-muted"
-        aria-label="Toggle theme"
-      >
-        {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-      </button>
-
-      <div className="min-h-[380px] w-full max-w-[400px] overflow-hidden rounded-xl border border-border bg-card">
-        <div className="flex flex-col items-center p-10">
-          <div className="mb-8 flex items-center gap-2">
-            <VM0Logo />
-            <span className="text-2xl text-foreground">Platform</span>
-          </div>
-
+    <ZeroConnectorFlowCard
+      connectorIcon={connectorIcon}
+      title={title}
+      description={description}
+    >
+      {status === "loading" ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
+          <span>Finishing the secure connection</span>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-4">
           <div
-            className="mt-4 flex flex-col items-center gap-4"
-            aria-live="polite"
+            className={
+              status === "success"
+                ? "flex items-center gap-2 text-sm text-emerald-600"
+                : "flex items-center gap-2 text-sm text-destructive"
+            }
           >
             {status === "success" ? (
-              <IconCheck size={40} className="text-lime-600" stroke={1} />
-            ) : status === "error" ? (
-              <IconX size={40} className="text-red-500" stroke={1} />
+              <IconCheck size={16} aria-hidden="true" />
             ) : (
-              <IconLoader2
-                size={40}
-                className="animate-spin text-muted-foreground"
-                stroke={1}
-              />
+              <IconAlertCircle size={16} aria-hidden="true" />
             )}
-
-            <div className="flex flex-col items-center gap-2 text-center">
-              {status === "success" ? (
-                <>
-                  <h1 className="text-lg font-medium leading-7 text-foreground">
-                    {connectorLabel} connected successfully.
-                  </h1>
-                  <p className="text-sm leading-5 text-muted-foreground">
-                    {username ? (
-                      <>
-                        Connected as <strong>{username}</strong>.
-                      </>
-                    ) : (
-                      "Your account has been connected."
-                    )}{" "}
-                    You can close this tab now.
-                  </p>
-                </>
-              ) : status === "error" ? (
-                <>
-                  <h1 className="text-lg font-medium leading-7 text-foreground">
-                    {connectorLabel} connection failed.
-                  </h1>
-                  <p className="text-sm leading-5 text-muted-foreground">
-                    {errorMessage || "An error occurred during connection."}{" "}
-                    Please close this window and try again.
-                  </p>
-                </>
-              ) : (
-                <>
-                  <h1 className="text-lg font-medium leading-7 text-foreground">
-                    Connecting {connectorLabel}…
-                  </h1>
-                  <p className="text-sm leading-5 text-muted-foreground">
-                    Please wait while we finish connecting your account.
-                  </p>
-                </>
-              )}
-            </div>
+            <span>
+              {status === "success" ? "Connected" : "Connection failed"}
+            </span>
           </div>
+          <Button
+            variant="outline"
+            onClick={() => {
+              window.close();
+            }}
+          >
+            Close window
+          </Button>
         </div>
-      </div>
-    </div>
+      )}
+    </ZeroConnectorFlowCard>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,30 +1,20 @@
 import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  getStaticConnectorIconMetadata,
-  isStaticConnectorIconType,
-} from "@vm0/connectors/static-connector-icons";
 import { Button } from "@vm0/ui/components/ui/button";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 type ConnectorCallbackPageStatus = "loading" | "success" | "error";
 
 export function ZeroConnectorCallbackPage({
-  connectorRef,
   connectorLabel,
   status,
   username,
   errorMessage,
 }: {
-  readonly connectorRef: string | null;
   readonly connectorLabel: string;
   readonly status: ConnectorCallbackPageStatus;
   readonly username: string | null;
   readonly errorMessage: string | null;
 }): React.JSX.Element {
-  const connectorIcon =
-    connectorRef && isStaticConnectorIconType(connectorRef)
-      ? getStaticConnectorIconMetadata(connectorRef)
-      : undefined;
   const title =
     status === "success"
       ? `${connectorLabel} connected`
@@ -51,7 +41,7 @@ export function ZeroConnectorCallbackPage({
 
   return (
     <ZeroConnectorFlowCard
-      connectorIcon={connectorIcon}
+      connectorIcon={undefined}
       title={title}
       description={description}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
@@ -1,0 +1,37 @@
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ReactNode } from "react";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { Vm0LogoLink } from "./zero-directed-shared.tsx";
+
+export function ZeroConnectorFlowCard({
+  connectorIcon,
+  title,
+  description,
+  children,
+}: {
+  readonly connectorIcon: PublicConnectorCatalogIcon | undefined;
+  readonly title: string;
+  readonly description: ReactNode;
+  readonly children: ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-background pointer-events-none">
+      <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
+        <Vm0LogoLink />
+        <div
+          className="flex w-full flex-col items-center gap-4"
+          aria-live="polite"
+        >
+          <div className="flex flex-col items-center gap-2.5">
+            <h1 className="text-lg font-medium text-foreground">{title}</h1>
+            <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
+              <ConnectorIcon icon={connectorIcon} size={20} />
+            </div>
+            <p className="w-64 text-sm text-muted-foreground">{description}</p>
+          </div>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -2,8 +2,7 @@ import { IconAlertCircle, IconLoader2 } from "@tabler/icons-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import type { ConnectorRedirectingStatus } from "../../signals/connectors-page/connector-redirecting.ts";
-import { VM0Logo } from "../components/vm0-logo.tsx";
-import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 export function ZeroConnectorRedirectingPage({
   connectorLabel,
@@ -17,52 +16,40 @@ export function ZeroConnectorRedirectingPage({
   const hasError = status === "error";
 
   return (
-    <div className="fixed inset-0 z-10 flex items-center justify-center bg-background">
-      <div className="flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <VM0Logo />
-        <div className="flex w-full flex-col items-center gap-4">
-          <div className="flex items-center justify-center rounded-[10px] bg-gray-50 p-2.5 dark:bg-muted">
-            <ConnectorIcon icon={connectorIcon} size={20} />
+    <ZeroConnectorFlowCard
+      connectorIcon={connectorIcon}
+      title={
+        hasError
+          ? `Couldn’t open ${connectorLabel}`
+          : `Redirecting to ${connectorLabel}…`
+      }
+      description={
+        hasError
+          ? "Return to VM0 and try connecting again."
+          : `You’ll continue on ${connectorLabel} to authorize VM0.`
+      }
+    >
+      {hasError ? (
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex items-center gap-2 text-sm text-destructive">
+            <IconAlertCircle size={16} aria-hidden="true" />
+            <span>Unable to start the connection</span>
           </div>
-          <div className="flex flex-col items-center gap-2.5">
-            <h1 className="text-lg font-medium text-foreground">
-              {hasError
-                ? `Couldn’t open ${connectorLabel}`
-                : `Redirecting to ${connectorLabel}…`}
-            </h1>
-            <p className="w-64 text-sm text-muted-foreground">
-              {hasError
-                ? "Return to Zero and try connecting again."
-                : `You’ll continue on ${connectorLabel} to authorize Zero.`}
-            </p>
-          </div>
-          {hasError ? (
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex items-center gap-2 text-sm text-destructive">
-                <IconAlertCircle size={16} aria-hidden="true" />
-                <span>Unable to start the connection</span>
-              </div>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  window.close();
-                }}
-              >
-                Close window
-              </Button>
-            </div>
-          ) : (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <IconLoader2
-                size={16}
-                className="animate-spin"
-                aria-hidden="true"
-              />
-              <span>Preparing a secure connection</span>
-            </div>
-          )}
+          <Button
+            variant="outline"
+            onClick={() => {
+              window.close();
+            }}
+          >
+            Close window
+          </Button>
         </div>
-      </div>
-    </div>
+      ) : (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
+          <span>Preparing a secure connection</span>
+        </div>
+      )}
+    </ZeroConnectorFlowCard>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/connectors-type-callback.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors-type-callback.ts
@@ -5,6 +5,24 @@ import { connectorRefSchema } from "./connector-identity";
 
 const c = initContract();
 
+export const connectorOauthCallbackResultSchema = z.discriminatedUnion(
+  "status",
+  [
+    z.object({
+      status: z.literal("success"),
+      username: z.string().nullable(),
+    }),
+    z.object({
+      status: z.literal("error"),
+      message: z.string(),
+    }),
+  ],
+);
+
+export type ConnectorOauthCallbackResult = z.infer<
+  typeof connectorOauthCallbackResultSchema
+>;
+
 export const connectorsTypeCallbackContract = c.router({
   callback: {
     method: "GET",
@@ -19,6 +37,7 @@ export const connectorsTypeCallbackContract = c.router({
         realmId: z.string().optional(),
         error: z.string().optional(),
         error_description: z.string().optional(),
+        responseMode: z.literal("json").optional(),
         "openid.mode": z.string().optional(),
         "openid.ns": z.string().optional(),
         "openid.op_endpoint": z.string().optional(),
@@ -33,6 +52,7 @@ export const connectorsTypeCallbackContract = c.router({
       })
       .catchall(z.string()),
     responses: {
+      200: connectorOauthCallbackResultSchema,
       307: c.noBody(),
     },
     summary: "Complete connector browser authorization",

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -101,6 +101,7 @@ export const zeroConnectorOauthStartContract = c.router({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
+      callbackTarget: z.literal("app").optional(),
     }),
     responses: {
       200: connectorOauthStartResponseSchema,

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -32,6 +32,10 @@
       "import": "./src/feature-switch-key.ts",
       "types": "./src/feature-switch-key.ts"
     },
+    "./app-oauth-callback": {
+      "import": "./src/app-oauth-callback.ts",
+      "types": "./src/app-oauth-callback.ts"
+    },
     "./firewall-expander": {
       "import": "./src/firewall-expander.ts",
       "types": "./src/firewall-expander.ts"

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -1,0 +1,8 @@
+// Add a connector only after its OAuth app accepts the App callback URL.
+const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set(["github"]);
+
+export function isConnectorAppOauthCallbackEnabled(
+  connectorRef: string,
+): boolean {
+  return ENABLED_CONNECTOR_REFS.has(connectorRef);
+}

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -14,6 +14,7 @@ const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
   "google-meet",
   "google-search-console",
   "google-sheets",
+  "stripe",
   "youtube",
 ]);
 

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -1,5 +1,21 @@
 // Add a connector only after its OAuth app accepts the App callback URL.
-const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set(["github"]);
+const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
+  "github",
+  "gmail",
+  "google-ads",
+  "google-analytics",
+  "google-calendar",
+  "google-cloud",
+  "google-contacts",
+  "google-docs",
+  "google-drive",
+  "google-forms",
+  "google-maps",
+  "google-meet",
+  "google-search-console",
+  "google-sheets",
+  "youtube",
+]);
 
 export function isConnectorAppOauthCallbackEnabled(
   connectorRef: string,


### PR DESCRIPTION
## Summary

- add App-hosted connector OAuth callback, success, and failure pages modeled on vm0-marketing
- forward provider callback parameters to the API, complete OAuth there, persist the connector credentials, and return a structured result
- keep legacy marketing callbacks and API-origin connector callbacks compatible across independent frontend/API deployments
- replace callback URLs with durable result URLs so OAuth codes and state are not retained or replayed

## Testing

- API connector BDD and OAuth start tests: 51 passed
- related App connector, directed authorization, action card, and artifact tests: 147 passed
- callback page tests: 3 passed
- affected workspace lint and type checks
- full repository Knip and pre-commit type checks