### PR TITLE
fix(ci): build app previews from PR merge commits

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1254,7 +1254,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # PR checks run against GitHub's synthetic merge commit. Build that
+          # same commit so the deployed app matches the code exercised by E2E.
+          ref: ${{ github.sha }}
 
       - uses: ./.github/actions/toolchain-init
 


### PR DESCRIPTION
## Summary

- build the Cloudflare app preview from `github.sha`, matching the synthetic PR merge commit used by the rest of the workflow
- keep app preview E2E aligned with `main` even when a PR branch has not merged the latest base changes
- document the merge-commit requirement next to the checkout to prevent the preview and test revisions from drifting again

## Root cause

In [the failed Playwright job](https://github.com/vm0-ai/vm0/actions/runs/29897843481/job/88852182394), E2E checked out the synthetic merge commit and expected the new `/onboarding` route from `main`. The `deploy-app` job instead explicitly checked out PR head `30f09e399afc4d122cea242cbe4f14ddee2bf462`, which predated the onboarding move, so the Cloudflare preview returned the app's 404 page for `/onboarding`.

After PR #22498 merged `main` into its branch, the deployed head contained the route and the same Playwright job passed. This change removes that version mismatch for stale PR branches.

## Verification

- `pnpm dlx prettier@3.8.1 --check .github/workflows/turbo.yml`
- `actionlint` 1.7.12 on `.github/workflows/turbo.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `git diff --check`

No local Vitest suite or dev server was run, per repository PR verification policy.
