### PR TITLE
ci: split runner behavior tests into four fail-fast lanes

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -666,7 +666,7 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
-  # Balance these scenarios by recent CI timings across three concurrent
+  # Balance these scenarios by recent CI timings across four concurrent
   # metal-host users.
   # Run balloon first in lane A, exec last in lane B, and upgrade last in lane C
   # to stagger the three heaviest scenarios during normal runs.
@@ -692,45 +692,10 @@ jobs:
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
       - name: Test balloon memory reclaim
-        id: balloon
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-balloon.sh
-
-      - name: Test local active input with real Codex
-        id: local_codex_active_input_smoke
-        timeout-minutes: 8
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: .github/scripts/runner-behavior-local-codex-active-input-smoke.sh
-
-      - name: Summarize runner behavior lane A results
-        env:
-          BALLOON_RESULT: ${{ steps.balloon.outcome }}
-          LOCAL_CODEX_ACTIVE_INPUT_SMOKE_RESULT: ${{ steps.local_codex_active_input_smoke.outcome }}
-        run: |
-          FAILED=0
-
-          check_result() {
-            local name=$1 result=$2
-            if [ "$result" = "success" ]; then
-              echo "✅ $name: $result"
-            else
-              echo "::error::$name: expected success, got ${result:-missing}"
-              FAILED=1
-            fi
-          }
-
-          echo "::group::Runner Behavior Lane A Results"
-          check_result "balloon" "$BALLOON_RESULT"
-          check_result "local-codex-active-input-smoke" "$LOCAL_CODEX_ACTIVE_INPUT_SMOKE_RESULT"
-          echo "::endgroup::"
-
-          exit "$FAILED"
 
   runner-behavior-lane-b:
     runs-on: ubuntu-latest
@@ -753,65 +718,17 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
-      - name: Test runner service drain + resume
-        id: drain_resume
+      - name: Test workspace cache promotion across runner restart
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-drain-resume.sh
-
-      - name: Test runner local cancel
-        id: cancel
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-cancel.sh
-
-      - name: Test exec process containment
-        id: process_containment
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-process-containment.sh
+        run: .github/scripts/runner-behavior-workspace-cache-promotion.sh
 
       - name: Test runner exec
-        id: exec
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-exec.sh
-
-      - name: Summarize runner behavior lane B results
-        env:
-          DRAIN_RESUME_RESULT: ${{ steps.drain_resume.outcome }}
-          CANCEL_RESULT: ${{ steps.cancel.outcome }}
-          PROCESS_CONTAINMENT_RESULT: ${{ steps.process_containment.outcome }}
-          EXEC_RESULT: ${{ steps.exec.outcome }}
-        run: |
-          FAILED=0
-
-          check_result() {
-            local name=$1 result=$2
-            if [ "$result" = "success" ]; then
-              echo "✅ $name: $result"
-            else
-              echo "::error::$name: expected success, got ${result:-missing}"
-              FAILED=1
-            fi
-          }
-
-          echo "::group::Runner Behavior Lane B Results"
-          check_result "drain-resume" "$DRAIN_RESUME_RESULT"
-          check_result "cancel" "$CANCEL_RESULT"
-          check_result "process-containment" "$PROCESS_CONTAINMENT_RESULT"
-          check_result "exec" "$EXEC_RESULT"
-          echo "::endgroup::"
-
-          exit "$FAILED"
 
   runner-behavior-lane-c:
     runs-on: ubuntu-latest
@@ -834,76 +751,76 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
+      - name: Test runner service drain + resume
+        timeout-minutes: 5
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-drain-resume.sh
+
+      - name: Test runner local cancel
+        timeout-minutes: 5
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-cancel.sh
+
+      - name: Run upgrade test
+        timeout-minutes: 5
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-upgrade-local.sh
+
+  runner-behavior-lane-d:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 35
+    env:
+      METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+      HOST: ${{ needs.runner-build.outputs.host }}
+      JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+      BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
+      DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+      DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
       - name: Run benchmark
-        id: benchmark
         timeout-minutes: 8
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-benchmark.sh
 
+      - name: Test local active input with real Codex
+        timeout-minutes: 8
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: .github/scripts/runner-behavior-local-codex-active-input-smoke.sh
+
       - name: Test local active input with real Claude Code
-        id: local_claude_active_input_smoke
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
         run: .github/scripts/runner-behavior-local-claude-active-input-smoke.sh
 
       - name: Test VM keep-alive across conversation turns
-        id: keep_alive
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-keep-alive.sh
 
-      - name: Test workspace cache promotion across runner restart
-        id: workspace_cache_promotion
+      - name: Test exec process containment
         timeout-minutes: 5
-        continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-workspace-cache-promotion.sh
-
-      - name: Run upgrade test
-        id: upgrade_local
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-upgrade-local.sh
-
-      - name: Summarize runner behavior lane C results
-        env:
-          BENCHMARK_RESULT: ${{ steps.benchmark.outcome }}
-          LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT: ${{ steps.local_claude_active_input_smoke.outcome }}
-          KEEP_ALIVE_RESULT: ${{ steps.keep_alive.outcome }}
-          WORKSPACE_CACHE_PROMOTION_RESULT: ${{ steps.workspace_cache_promotion.outcome }}
-          UPGRADE_LOCAL_RESULT: ${{ steps.upgrade_local.outcome }}
-        run: |
-          FAILED=0
-
-          check_result() {
-            local name=$1 result=$2
-            if [ "$result" = "success" ]; then
-              echo "✅ $name: $result"
-            else
-              echo "::error::$name: expected success, got ${result:-missing}"
-              FAILED=1
-            fi
-          }
-
-          echo "::group::Runner Behavior Lane C Results"
-          check_result "benchmark" "$BENCHMARK_RESULT"
-          check_result "local-claude-active-input-smoke" "$LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT"
-          check_result "keep-alive" "$KEEP_ALIVE_RESULT"
-          check_result "workspace-cache-promotion" "$WORKSPACE_CACHE_PROMOTION_RESULT"
-          check_result "upgrade-local" "$UPGRADE_LOCAL_RESULT"
-          echo "::endgroup::"
-
-          exit "$FAILED"
+        run: .github/scripts/runner-behavior-process-containment.sh
 
   ci-gate-crates:
     runs-on: ubuntu-latest
@@ -921,6 +838,7 @@ jobs:
       - runner-behavior-lane-a
       - runner-behavior-lane-b
       - runner-behavior-lane-c
+      - runner-behavior-lane-d
       - nbd-cow-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
@@ -969,6 +887,7 @@ jobs:
           check_result "runner-behavior-lane-a" "${{ needs.runner-behavior-lane-a.result }}" "true"
           check_result "runner-behavior-lane-b" "${{ needs.runner-behavior-lane-b.result }}" "true"
           check_result "runner-behavior-lane-c" "${{ needs.runner-behavior-lane-c.result }}" "true"
+          check_result "runner-behavior-lane-d" "${{ needs.runner-behavior-lane-d.result }}" "true"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
 
           echo "::endgroup::"


### PR DESCRIPTION
## Summary

- split the 11 runner behavior scenarios into four lanes balanced from recent successful CI timings
- stop each lane at its first failed scenario instead of continuing and summarizing failures later
- wire the fourth lane into the Crates CI gate while staggering the heaviest scenarios

## Exclusions

- already-running parallel lanes are not cancelled when another lane fails; fail-fast applies to subsequent scenarios within each lane

## Validation

- `cd turbo && pnpm prettier --write --ignore-unknown ../.github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- static YAML contract check for four lanes, 11 unique scenarios, fail-fast steps, and CI gate wiring
- `git diff --check`
