### PR TITLE
chore(api): broaden exact drizzle helper lint coverage

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -144,22 +144,29 @@ returned fields independently of `.set({...})`. Likewise, raw SQL passed to
 `insert(...).select(...)` is the write source rather than a returned field; only
 a subsequent `returning(...)` introduces a result-mapping boundary.
 
-Use typed operators such as `eq`, `gt`, `isNull`, `isNotNull`, and `like`
-instead of an equivalent SQL tag. They make the operation explicit and, when
-the helper supports it, preserve the schema relationship between a column and
-its bound value. Pass value arrays directly to `inArray(column, values)`; do not
-rebuild parameter lists with `sql.join(...)`. Use `asc(...)` and `desc(...)` for
-ordering leaves, and use `arrayContains(...)` when the left operand is an
-array-valued schema column and an SQL wrapper intentionally constructs the
-right JSON value.
+Use typed operators such as `eq`, `gt`, `isNull`, `isNotNull`, `not`, `exists`,
+and `notExists` instead of an equivalent SQL tag. Use `like`, `notLike`,
+`ilike`, and `notIlike` for dynamic pattern leaves, and `between` /
+`notBetween` for exact range leaves. These helpers make the operation explicit
+and, when supported, preserve the schema relationship between a column and its
+bound value. Pass value arrays directly to `inArray(column, values)` or
+`notInArray(column, values)`; do not rebuild parameter lists with
+`sql.join(...)`. Use `asc(...)` and `desc(...)` for ordering leaves. Use
+`arrayContains(...)`, `arrayContained(...)`, or `arrayOverlaps(...)` only when
+the left operand is statically array-valued and the right operand preserves the
+intended array encoding or is an explicit SQL wrapper.
 
-Likewise, use `sum(...)`, `count(...)`, `countDistinct(...)`, `max(...)`, or
-`min(...)` for an exact aggregate leaf. Keep an existing outer SQL cast,
-`FILTER`, `COALESCE`, alias, and `.mapWith(...)` when that outer expression owns
-a stricter result decoder or nullability contract. Keep literal predicates as
-literals when changing them into helper arguments would introduce a parameter
-and alter planner-visible query shape; a `LIKE ... ESCAPE` suffix also remains
-outside the `like(...)` leaf.
+Likewise, use `count()`, `count(...)`, `countDistinct(...)`, `avg(...)`,
+`avgDistinct(...)`, `sum(...)`, `sumDistinct(...)`, `max(...)`, or `min(...)`
+for an exact aggregate leaf. Use the helper directly at a structured selection
+boundary when its decoder owns an equal-or-stronger result contract. When the
+leaf remains inside otherwise irreducible SQL, interpolate the helper while
+keeping an existing outer SQL cast, `FILTER`, `COALESCE`, alias, row schema, and
+`.mapWith(...)` that owns the selected result. Do not replace a whole aggregate
+when the helper's decoder would weaken a non-column result. Keep literal
+predicates as literals when changing them into helper arguments would introduce
+a parameter and alter planner-visible query shape; a `LIKE ... ESCAPE` suffix
+also remains outside the pattern-helper leaf.
 
 This preference also applies to a replaceable leaf inside otherwise irreducible
 SQL. Interpolate the typed operator in place of that leaf while retaining the

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { command, computed } from "ccstate";
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   getProviderRuntimeModel,
@@ -35,10 +35,7 @@ import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
-import {
-  pgIntegerDecoder,
-  pgTextDecoder,
-} from "../../lib/db-structured-result";
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { request$ } from "../context/hono";
 import { bodyResultOf, queryOf } from "../context/request";
@@ -243,7 +240,7 @@ async function loadComposeVersion(
 
 async function countMessages(db: ReadonlyDb, botId: string): Promise<number> {
   const [row] = await db
-    .select({ count: sql`count(*)::int`.mapWith(pgIntegerDecoder) })
+    .select({ count: count() })
     .from(telegramMessages)
     .where(eq(telegramMessages.installationId, botId));
   return row?.count ?? 0;

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { gte, isNotNull, lt, sql } from "drizzle-orm";
+import { count, gte, isNotNull, lt, sql } from "drizzle-orm";
 
 import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
@@ -29,7 +29,7 @@ export const aggregateUsageDaily$ = command(
         ${agentRuns.userId},
         ${agentRuns.orgId},
         ${targetDate}::date,
-        COUNT(*)::int,
+        ${count()}::int,
         COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint
       FROM ${agentRuns}
       WHERE ${gte(agentRuns.createdAt, yesterday)}

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { eq, lt, sql, type SQL } from "drizzle-orm";
+import { count, eq, lt, sql, type SQL } from "drizzle-orm";
 import { chatThreadEvents } from "@vm0/db/schema/chat-thread-event";
 import { chatThreadSnapshots } from "@vm0/db/schema/chat-thread-snapshot";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -153,7 +153,7 @@ function rebuiltCte(): SQL {
         LIMIT 1
       ) marker ON true
       LEFT JOIN LATERAL (
-        SELECT COUNT(*)::int AS count
+        SELECT ${count()}::int AS count
         FROM ${chatThreadEvents} event
         WHERE event.user_id = scope.user_id
           AND event.org_id = scope.org_id
@@ -163,7 +163,7 @@ function rebuiltCte(): SQL {
           )
       ) events_after_marker ON true
       LEFT JOIN LATERAL (
-        SELECT COUNT(*)::int AS count
+        SELECT ${count()}::int AS count
         FROM jsonb_array_elements(
           COALESCE(snapshot.chat_threads, '[]'::jsonb)
         ) AS old_thread(thread)
@@ -218,7 +218,7 @@ function compactChatThreadSnapshotBatchSql(args: {
     ${rebuiltCte()},
     ${upsertedCte(args.updatedAt)}
     SELECT
-      COUNT(*)::int AS "scopes",
+      ${count()}::int AS "scopes",
       COALESCE(SUM(rebuilt.events_applied), 0)::int AS "eventsApplied",
       COALESCE(SUM(rebuilt.removed_deleted_agent_threads), 0)::int AS "removedDeletedAgentThreads"
     FROM rebuilt
@@ -281,7 +281,7 @@ async function compactChatThreadSnapshotsForAllScopes(
           AND (event.created_at, event.id) < (marker.created_at, marker.id)
         RETURNING 1
       )
-      SELECT COUNT(*)::int AS "count"
+      SELECT ${count()}::int AS "count"
       FROM pruned
     `,
     prunedEventsRowSchema,

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -5,10 +5,9 @@ import type {
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { and, count, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
 
 import {
-  pgIntegerDecoder,
   pgInt8ToSafeIntegerDecoder,
   pgTextDecoder,
 } from "../../lib/db-structured-result";
@@ -62,7 +61,7 @@ async function queryAgentRunsDaily(
   const rows = await db
     .select({
       date: sql`DATE(${agentRuns.createdAt})`.mapWith(pgTextDecoder).as("date"),
-      run_count: sql`COUNT(*)::int`.mapWith(pgIntegerDecoder).as("run_count"),
+      run_count: count().as("run_count"),
       run_time_ms:
         sql`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`
           .mapWith(pgInt8ToSafeIntegerDecoder)

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -6,11 +6,10 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-insights";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { and, desc, eq, gte, max, min, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, max, min, sql } from "drizzle-orm";
 
 import {
   nullableDriverValueDecoder,
-  pgIntegerDecoder,
   pgTextDecoder,
 } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
@@ -210,9 +209,7 @@ export function zeroInsightsRange(args: {
         maxDate: max(insightsDaily.date)
           .mapWith(nullableTextDecoder)
           .as("max_date"),
-        totalDays: sql`COUNT(*)::int`
-          .mapWith(pgIntegerDecoder)
-          .as("total_days"),
+        totalDays: count().as("total_days"),
       })
       .from(insightsDaily)
       .where(

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { sql } from "drizzle-orm";
+import { count, sql } from "drizzle-orm";
 import type {
   UsageInsightBucket,
   UsageInsightChatRow,
@@ -586,7 +586,7 @@ async function queryUsageInsightTopChats(
           WHERE zr.chat_thread_id IS NOT NULL
           GROUP BY zr.chat_thread_id
         )
-        SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100
+        SELECT ${count()}::bigint AS cnt FROM agg WHERE rn > 100
       `,
       usageInsightCountRowSchema,
     );

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { sql, type SQL } from "drizzle-orm";
+import { count, sql, type SQL } from "drizzle-orm";
 import {
   type UsageRecordKind,
   type UsageRecordRow,
@@ -296,7 +296,7 @@ async function queryUsageRecordTotals(
     db,
     sql`
       ${recordCte}
-      SELECT COUNT(*)::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
+      SELECT ${count()}::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
       FROM record ${where}
     `,
     usageRecordTotalsSqlRowSchema,

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,6 +1,6 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { chatMessages } from "@vm0/db/schema/chat-message";
-import { and, eq, like, or, sql } from "drizzle-orm";
+import { and, count, eq, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -158,7 +158,7 @@ export async function holdOrgAdmissionLockFixture(args: {
       const rows = await executeRawRows(
         db(),
         sql`
-          SELECT count(*)::int AS "waiterCount"
+          SELECT ${count()}::int AS "waiterCount"
           FROM pg_locks AS waiting
           WHERE waiting.locktype = 'advisory'
             AND NOT waiting.granted
@@ -232,7 +232,7 @@ export async function holdChatMessageWritesFixture(args: {
             INNER JOIN blocked AS blocker
               ON blocker.pid = ANY(pg_blocking_pids(activity.pid))
           )
-          SELECT count(*)::int AS "waiterCount"
+          SELECT ${count()}::int AS "waiterCount"
           FROM blocked
         `,
         waiterCountRowSchema,

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -51,6 +51,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       code: `${drizzlePreamble}
         import { gte, sql } from "drizzle-orm";
         const value = 1;
+        const condition = gte(users.id, 1);
         const fragment = sql\`\${users.id} + \${value}\`;
         sql\`SELECT \${users.id} FROM \${users} WHERE \${fragment}\`;
         sql\`\${users.id}::text = \${"1"}\`;
@@ -63,9 +64,16 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`\${gte(users.deletedAt, sql\`\${"2026-01-01"}::timestamp\`)}\`;
         sql\`MAX(\${users.id} + 1) FILTER (WHERE \${users.id} > 0)\`;
         sql\`MAX(\${users.id}) OVER (ORDER BY id)\`;
+        sql\`COUNT(\${users.id}) FILTER (WHERE (\${condition})) OVER (ORDER BY id)\`;
         sql\`MAX(\${fragment})\`;
         sql\`SUM(\${users.id})\`;
-        sql\`SELECT MIN(\${users.id}) FROM \${users}\`;
+        sql\`COUNT(\${users.id})\`;
+        sql\`COUNT(DISTINCT \${users.id})\`;
+        sql\`AVG(\${users.id})\`;
+        sql\`AVG(DISTINCT \${users.id})\`;
+        sql\`SUM(DISTINCT \${users.id})\`;
+        sql\`COUNT(*)\`;
+        sql\`SELECT αcount(*), αsum(\${users.id}) FROM \${users}\`;
         sql\`\${users.id}\`;
       `,
     },
@@ -121,13 +129,10 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`\${users.id} IN (\${transformedList})\`;
         sql\`\${users.id} IN (\${mutableList})\`;
         sql\`\${users.id} IN (\${listWithArgument(ids)})\`;
-        sql\`\${users.name} NOT LIKE \${"prefix%"}\`;
-        sql\`\${users.name} ILIKE \${"prefix%"}\`;
         sql\`\${users.id} NOT IN (\${mutableList})\`;
         sql\`SELECT \${users.id} DESC\`;
         sql\`ORDER BY \${users.id} DESCENDING\`;
         concrete(sql\`\${condition} AND \${condition}\`);
-        sql\`\${condition} AND NOT \${condition}\`;
         sql\`\${users.name} @> \${sql\`jsonb_build_array('tag')\`}\`;
         sql\`\${condition} @> \${sql\`jsonb_build_array('tag')\`}\`;
         void mutableList;
@@ -239,6 +244,31 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`EXISTS (SELECT 1 FROM \${table} WHERE \${predicate})\`;
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const condition = eq(users.id, 1);
+        const tagsSql = sql\`\${users.tags}\`;
+        sql\`\${users} LIKE \${"prefix%"}\`;
+        sql\`\${users.name} NOT LIKE \${1}\`;
+        sql\`\${users.id} BETWEEN \${1} OR \${2}\`;
+        sql\`\${users.id} NOT BETWEEN \${1} OR \${2}\`;
+        sql\`\${users.id} IS NOT \${condition}\`;
+        sql\`1 NOT \${condition}\`;
+        sql\`\${users.id} <@ \${tagsSql}\`;
+        sql\`\${users.tags} && \${["one"]}\`;
+        sql\`SELECT 'COUNT(*)', "COUNT(*)", $$COUNT(*)$$, $body$COUNT(*)$body$\`;
+        sql\`SELECT /* COUNT(*) /* nested COUNT(*) */ */ 1 -- COUNT(*)
+          FROM \${users}\`;
+        sql\`COUNT(*) OVER (PARTITION BY \${users.id})\`;
+        sql\`COUNT(*) FILTER (WHERE (\${condition})) OVER (ORDER BY \${users.id})\`;
+        sql\`SELECT pg_catalog . count(*), pg_catalog.sum(\${users.id}) FROM \${users}\`;
+        sql\`'\${condition} NOT \${condition} COUNT(\${users.id})'\`;
+        sql\`SELECT $body$\${condition} COUNT(*)$body$\`;
+        sql\`SELECT /* \${condition} COUNT(*) */ 1\`;
+        sql\`discount(*)\`;
+      `,
+    },
   ],
   invalid: [
     {
@@ -261,6 +291,108 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "emptyFragment" },
         { messageId: "emptyFragment" },
         { messageId: "emptyFragment" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql as query } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        const condition = eq(users.id, 1);
+        const nameSql = query\`\${users.name}\`.mapWith(users.name);
+        const aliasedNameSql = nameSql.as("aliased_name");
+        const selected = db.select({ id: users.id }).from(users);
+        const tag = drizzle.sql;
+        query\`NOT \${condition}\`;
+        drizzle.sql\`WHERE NOT \${condition} AND \${condition}\`;
+        tag\`\${users.name} NOT LIKE \${"prefix%"} ESCAPE '\\\\'\`;
+        query\`\${users.name} ILIKE \${"prefix%"}\`;
+        drizzle.sql\`\${users.name} NOT ILIKE \${query\`LOWER(\${"prefix%"})\`}\`;
+        tag\`\${nameSql} ILIKE \${"prefix%"}\`;
+        query\`\${aliasedNameSql} NOT LIKE \${"prefix%"}\`;
+        tag\`\${users.id} BETWEEN \${1} AND \${2}\`;
+        tag\`\${users.deletedAt} BETWEEN \${"2026-01-01"}::timestamp AND \${"2026-01-02"}::timestamp\`;
+        query\`WHERE \${users.id} NOT BETWEEN \${1} AND \${2} ORDER BY 1\`;
+        drizzle.sql\`EXISTS \${selected}\`;
+        tag\`NOT EXISTS \${selected}\`;
+        function pattern<T extends typeof users.name>(left: T) {
+          query\`\${left} NOT ILIKE \${"prefix%"}\`;
+        }
+        void pattern;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "not" } },
+        { messageId: "typedApi", data: { helper: "not" } },
+        { messageId: "typedApi", data: { helper: "notLike" } },
+        { messageId: "typedApi", data: { helper: "ilike" } },
+        { messageId: "typedApi", data: { helper: "notIlike" } },
+        { messageId: "typedApi", data: { helper: "ilike" } },
+        { messageId: "typedApi", data: { helper: "notLike" } },
+        { messageId: "typedApi", data: { helper: "between" } },
+        { messageId: "typedApi", data: { helper: "between" } },
+        { messageId: "typedApi", data: { helper: "notBetween" } },
+        { messageId: "typedApi", data: { helper: "exists" } },
+        { messageId: "typedApi", data: { helper: "notExists" } },
+        { messageId: "typedApi", data: { helper: "notIlike" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL, type SQLWrapper } from "drizzle-orm";
+        const tagsSql = sql\`\${users.tags}\`;
+        const typedTagsSql = sql\`\${users.tags}\`.mapWith(users.tags);
+        const aliasedTagsSql = typedTagsSql.as("aliased_tags");
+        sql\`\${users.tags} <@ \${tagsSql}\`;
+        sql\`\${users.tags} && \${tagsSql}\`;
+        sql\`\${typedTagsSql} @> \${tagsSql}\`;
+        sql\`\${aliasedTagsSql} <@ \${tagsSql}\`;
+        function overlaps<T extends typeof users.tags>(left: T, right: SQLWrapper) {
+          sql\`\${left} && \${right}\`;
+        }
+        function overlapsSql<T extends SQL<string[]>>(left: T, right: SQLWrapper) {
+          sql\`\${left} && \${right}\`;
+        }
+        void overlaps;
+        void overlapsSql;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "arrayContained" } },
+        { messageId: "typedApi", data: { helper: "arrayOverlaps" } },
+        { messageId: "typedApi", data: { helper: "arrayContains" } },
+        { messageId: "typedApi", data: { helper: "arrayContained" } },
+        { messageId: "typedApi", data: { helper: "arrayOverlaps" } },
+        { messageId: "typedApi", data: { helper: "arrayOverlaps" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const condition = eq(users.id, 1);
+        sql\`SELECT COUNT(*)::int, COUNT(*) FILTER (WHERE \${condition}) FROM \${users}\`;
+        sql\`SELECT SUM(\${users.id}) FROM \${users}\`;
+        sql\`SELECT COUNT(\${users.id}) FROM \${users}\`;
+        sql\`SELECT COUNT(DISTINCT \${users.id}) FROM \${users}\`;
+        sql\`SELECT AVG(\${users.id}) FROM \${users}\`;
+        sql\`SELECT AVG(DISTINCT \${users.id}) FROM \${users}\`;
+        sql\`SELECT SUM(DISTINCT \${users.id}) FROM \${users}\`;
+        sql\`SELECT MIN(\${users.id}) FROM \${users}\`;
+        const fragment = sql\`\${users.id} + 1\`;
+        sql\`COUNT(*)\`.mapWith(Number);
+        sql\`SUM(\${fragment})\`.mapWith(users.id);
+        sql\`MAX(\${fragment})\`.mapWith(users.id);
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "sum" } },
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "countDistinct" } },
+        { messageId: "typedApi", data: { helper: "avg" } },
+        { messageId: "typedApi", data: { helper: "avgDistinct" } },
+        { messageId: "typedApi", data: { helper: "sumDistinct" } },
+        { messageId: "typedApi", data: { helper: "min" } },
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "sum" } },
+        { messageId: "typedApi", data: { helper: "max" } },
       ],
     },
     {
@@ -521,6 +653,8 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`\${users.name} LIKE \${"prefix%"} ESCAPE '\\\\'\`;
         sql\`\${users.name} IN (\${nameList})\`;
         sql\`\${users.name} IN (\${nameSqlList()})\`;
+        sql\`\${users.name} NOT IN (\${nameList})\`;
+        sql\`\${users.name} NOT IN (\${nameSqlList()})\`;
         sql\`ORDER BY \${users.name} ASC, \${users.id} DESC NULLS FIRST\`;
         sql\`COALESCE(SUM(\${users.id}), 0)\`;
         sql\`COUNT(\${users.id}) FILTER (WHERE \${condition})::int\`;
@@ -533,6 +667,8 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "like" } },
         { messageId: "typedApi", data: { helper: "inArray" } },
         { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "notInArray" } },
+        { messageId: "typedApi", data: { helper: "notInArray" } },
         { messageId: "typedApi", data: { helper: "asc" } },
         { messageId: "typedApi", data: { helper: "desc" } },
         { messageId: "typedApi", data: { helper: "sum" } },
@@ -580,8 +716,25 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           where: (fields, operators) =>
             operators.sql\`\${operators.eq(fields.id, 1)} AND \${operators.isNotNull(fields.name)}\`,
         });
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`NOT \${operators.eq(fields.id, 1)}\`,
+        });
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.name} ILIKE \${"prefix%"}\`,
+        });
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.id} BETWEEN \${1} AND \${2}\`,
+        });
       `,
-      errors: [{ messageId: "typedApi", data: { helper: "like" } }],
+      errors: [
+        { messageId: "typedApi", data: { helper: "like" } },
+        { messageId: "typedApi", data: { helper: "not" } },
+        { messageId: "typedApi", data: { helper: "ilike" } },
+        { messageId: "typedApi", data: { helper: "between" } },
+      ],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -249,6 +249,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         import { eq, sql } from "drizzle-orm";
         const condition = eq(users.id, 1);
         const tagsSql = sql\`\${users.tags}\`;
+        const qualifiedAggregate = sql.raw("pg_catalog.");
         sql\`\${users} LIKE \${"prefix%"}\`;
         sql\`\${users.name} NOT LIKE \${1}\`;
         sql\`\${users.id} BETWEEN \${1} OR \${2}\`;
@@ -263,6 +264,8 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`COUNT(*) OVER (PARTITION BY \${users.id})\`;
         sql\`COUNT(*) FILTER (WHERE (\${condition})) OVER (ORDER BY \${users.id})\`;
         sql\`SELECT pg_catalog . count(*), pg_catalog.sum(\${users.id}) FROM \${users}\`;
+        sql\`\${qualifiedAggregate} count(*)\`;
+        sql\`\${qualifiedAggregate} sum(\${users.id})\`;
         sql\`'\${condition} NOT \${condition} COUNT(\${users.id})'\`;
         sql\`SELECT $body$\${condition} COUNT(*)$body$\`;
         sql\`SELECT /* \${condition} COUNT(*) */ 1\`;

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -5,6 +5,7 @@ import {
 } from "@typescript-eslint/utils";
 import {
   SymbolFlags,
+  TypeFlags,
   type Declaration,
   type Node,
   type Signature,
@@ -84,6 +85,12 @@ export function isDrizzleWrapperType(
   checker: TypeChecker,
   type: Type,
 ): boolean {
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return (
+      constraint !== undefined && isDrizzleWrapperType(checker, constraint)
+    );
+  }
   if (isDrizzleSymbol(checker, checker.getPropertyOfType(type, "getSQL"))) {
     return true;
   }
@@ -107,25 +114,50 @@ function propertyType(
     : checker.getTypeOfSymbolAtLocation(symbol, location);
 }
 
+function drizzleBrand(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): string | undefined {
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return undefined;
+  }
+  const brandType = propertyType(checker, metadataType, "brand", location);
+  return brandType?.isStringLiteral() === true ? brandType.value : undefined;
+}
+
+function everyConcreteType(
+  checker: TypeChecker,
+  type: Type,
+  predicate: (member: Type) => boolean,
+): boolean {
+  if (type.isUnion()) {
+    return type.types.every((member) => {
+      return everyConcreteType(checker, member, predicate);
+    });
+  }
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return (
+      constraint !== undefined &&
+      everyConcreteType(checker, constraint, predicate)
+    );
+  }
+  return predicate(type);
+}
+
 export function isDrizzleColumnType(
   checker: TypeChecker,
   type: Type,
   location: Node,
 ): boolean {
-  if (type.isUnion()) {
-    return type.types.every((member) => {
-      return isDrizzleColumnType(checker, member, location);
-    });
-  }
-  if (!isDrizzleWrapperType(checker, type)) {
-    return false;
-  }
-  const metadataType = propertyType(checker, type, "_", location);
-  if (metadataType === undefined) {
-    return false;
-  }
-  const brandType = propertyType(checker, metadataType, "brand", location);
-  return brandType?.isStringLiteral() === true && brandType.value === "Column";
+  return everyConcreteType(checker, type, (member) => {
+    return (
+      isDrizzleWrapperType(checker, member) &&
+      drizzleBrand(checker, member, location) === "Column"
+    );
+  });
 }
 
 export function isDrizzleTableType(
@@ -133,34 +165,51 @@ export function isDrizzleTableType(
   type: Type,
   location: Node,
 ): boolean {
-  if (type.isUnion()) {
-    return type.types.every((member) => {
-      return isDrizzleTableType(checker, member, location);
-    });
-  }
-  if (!isDrizzleWrapperType(checker, type)) {
-    return false;
-  }
-  const metadataType = propertyType(checker, type, "_", location);
-  if (metadataType === undefined) {
-    return false;
-  }
-  const brandType = propertyType(checker, metadataType, "brand", location);
-  return brandType?.isStringLiteral() === true && brandType.value === "Table";
+  return everyConcreteType(checker, type, (member) => {
+    return (
+      isDrizzleWrapperType(checker, member) &&
+      drizzleBrand(checker, member, location) === "Table"
+    );
+  });
 }
 
-export function isDrizzleArrayColumnType(
+export function isDrizzlePatternOperandType(
   checker: TypeChecker,
   type: Type,
   location: Node,
 ): boolean {
-  if (!isDrizzleColumnType(checker, type, location)) {
-    return false;
-  }
-  const metadataType = propertyType(checker, type, "_", location);
-  if (metadataType === undefined) {
-    return false;
-  }
-  const dataType = propertyType(checker, metadataType, "data", location);
-  return dataType !== undefined && checker.isArrayType(dataType);
+  return everyConcreteType(checker, type, (member) => {
+    if (!isDrizzleWrapperType(checker, member)) {
+      return false;
+    }
+    const brand = drizzleBrand(checker, member, location);
+    return brand === "Column" || brand === "SQL" || brand === "SQL.Aliased";
+  });
+}
+
+export function isDrizzleArrayOperandType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  return everyConcreteType(checker, type, (member) => {
+    if (!isDrizzleWrapperType(checker, member)) {
+      return false;
+    }
+    const metadataType = propertyType(checker, member, "_", location);
+    if (metadataType === undefined) {
+      return false;
+    }
+    const brand = drizzleBrand(checker, member, location);
+    const valueType =
+      brand === "Column"
+        ? propertyType(checker, metadataType, "data", location)
+        : brand === "SQL" || brand === "SQL.Aliased"
+          ? propertyType(checker, metadataType, "type", location)
+          : undefined;
+    return (
+      valueType !== undefined &&
+      (checker.isArrayType(valueType) || checker.isTupleType(valueType))
+    );
+  });
 }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -29,8 +29,9 @@ import {
 } from "typescript";
 
 import {
-  isDrizzleArrayColumnType,
+  isDrizzleArrayOperandType,
   isDrizzleColumnType,
+  isDrizzlePatternOperandType,
   isDrizzleSqlTag,
   isDrizzleSymbol,
   isDrizzleTableType,
@@ -40,13 +41,115 @@ import {
 } from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
-const COMPARISON_HELPERS = new Map<string, string>([
-  ["=", "eq"],
-  ["<>", "ne"],
-  [">", "gt"],
-  [">=", "gte"],
-  ["<", "lt"],
-  ["<=", "lte"],
+type BinaryLeftOperand = "array" | "pattern" | "wrapper";
+type BinaryRightOperand = "any" | "string-or-wrapper" | "wrapper";
+type BinaryRightBoundary = "pattern" | "predicate";
+
+interface BinaryHelper {
+  readonly helper: string;
+  readonly left: BinaryLeftOperand;
+  readonly right: BinaryRightOperand;
+  readonly rightBoundary: BinaryRightBoundary;
+}
+
+const BINARY_HELPERS = new Map<string, BinaryHelper>([
+  [
+    "=",
+    { helper: "eq", left: "wrapper", right: "any", rightBoundary: "predicate" },
+  ],
+  [
+    "<>",
+    { helper: "ne", left: "wrapper", right: "any", rightBoundary: "predicate" },
+  ],
+  [
+    ">",
+    { helper: "gt", left: "wrapper", right: "any", rightBoundary: "predicate" },
+  ],
+  [
+    ">=",
+    {
+      helper: "gte",
+      left: "wrapper",
+      right: "any",
+      rightBoundary: "predicate",
+    },
+  ],
+  [
+    "<",
+    { helper: "lt", left: "wrapper", right: "any", rightBoundary: "predicate" },
+  ],
+  [
+    "<=",
+    {
+      helper: "lte",
+      left: "wrapper",
+      right: "any",
+      rightBoundary: "predicate",
+    },
+  ],
+  [
+    "LIKE",
+    {
+      helper: "like",
+      left: "pattern",
+      right: "string-or-wrapper",
+      rightBoundary: "pattern",
+    },
+  ],
+  [
+    "NOT LIKE",
+    {
+      helper: "notLike",
+      left: "pattern",
+      right: "string-or-wrapper",
+      rightBoundary: "pattern",
+    },
+  ],
+  [
+    "ILIKE",
+    {
+      helper: "ilike",
+      left: "pattern",
+      right: "string-or-wrapper",
+      rightBoundary: "pattern",
+    },
+  ],
+  [
+    "NOT ILIKE",
+    {
+      helper: "notIlike",
+      left: "pattern",
+      right: "string-or-wrapper",
+      rightBoundary: "pattern",
+    },
+  ],
+  [
+    "@>",
+    {
+      helper: "arrayContains",
+      left: "array",
+      right: "wrapper",
+      rightBoundary: "predicate",
+    },
+  ],
+  [
+    "<@",
+    {
+      helper: "arrayContained",
+      left: "array",
+      right: "wrapper",
+      rightBoundary: "predicate",
+    },
+  ],
+  [
+    "&&",
+    {
+      helper: "arrayOverlaps",
+      left: "array",
+      right: "wrapper",
+      rightBoundary: "predicate",
+    },
+  ],
 ]);
 
 type BooleanToken = "operand" | "and" | "or" | "(" | ")";
@@ -195,21 +298,65 @@ function orderingMatch(quasi: string): OrderingMatch | undefined {
 }
 
 interface AggregateMatch {
-  helper: "count" | "countDistinct" | "max" | "min" | "sum";
+  helper:
+    | "avg"
+    | "avgDistinct"
+    | "count"
+    | "countDistinct"
+    | "max"
+    | "min"
+    | "sum"
+    | "sumDistinct";
   start: number;
 }
 
-function aggregateMatch(quasi: string): AggregateMatch | undefined {
-  const countDistinct = /\bCOUNT\s*\(\s*DISTINCT\s*$/i.exec(quasi);
-  if (countDistinct !== null) {
-    return { helper: "countDistinct", start: countDistinct.index };
+function previousNonWhitespaceCharacter(
+  source: string,
+  start: number,
+): string | undefined {
+  let offset = start - 1;
+  while (offset >= 0 && /\s/.test(source[offset] ?? "")) {
+    offset -= 1;
   }
-  const aggregate = /\b(SUM|COUNT|MAX|MIN)\s*\(\s*$/i.exec(quasi);
+  return offset < 0 ? undefined : source[offset];
+}
+
+function isSqlIdentifierCharacter(character: string | undefined): boolean {
+  if (character === undefined) {
+    return false;
+  }
+  return /[\w$]/.test(character) || character.charCodeAt(0) > 0x7f;
+}
+
+function hasSqlIdentifierPrefix(source: string, start: number): boolean {
+  return (
+    isSqlIdentifierCharacter(source[start - 1]) ||
+    previousNonWhitespaceCharacter(source, start) === "."
+  );
+}
+
+function aggregateMatch(quasi: string): AggregateMatch | undefined {
+  const distinct = /\b(AVG|COUNT|SUM)\s*\(\s*DISTINCT\s*$/i.exec(quasi);
+  if (distinct !== null && !hasSqlIdentifierPrefix(quasi, distinct.index)) {
+    const aggregate = distinct[1]?.toLowerCase();
+    const helper =
+      aggregate === "avg"
+        ? "avgDistinct"
+        : aggregate === "count"
+          ? "countDistinct"
+          : "sumDistinct";
+    return { helper, start: distinct.index };
+  }
+  const aggregate = /\b(AVG|SUM|COUNT|MAX|MIN)\s*\(\s*$/i.exec(quasi);
   if (aggregate === null) {
+    return undefined;
+  }
+  if (hasSqlIdentifierPrefix(quasi, aggregate.index)) {
     return undefined;
   }
   const helper = aggregate[1]?.toLowerCase();
   if (
+    helper !== "avg" &&
     helper !== "sum" &&
     helper !== "count" &&
     helper !== "max" &&
@@ -223,6 +370,247 @@ function aggregateMatch(quasi: string): AggregateMatch | undefined {
 function aggregateRemainder(quasi: string): string | undefined {
   const close = /^\s*\)/.exec(quasi);
   return close === null ? undefined : quasi.slice(close[0].length);
+}
+
+interface UnaryPredicateMatch {
+  readonly helper: "exists" | "not" | "notExists";
+  readonly start: number;
+}
+
+function unaryPredicateMatch(quasi: string): UnaryPredicateMatch | undefined {
+  const match = /\b(?:(NOT)\s+)?(EXISTS)\s*$|\b(NOT)\s*$/i.exec(quasi);
+  if (match === null) {
+    return undefined;
+  }
+  if (match[2] !== undefined) {
+    return {
+      helper: match[1] === undefined ? "exists" : "notExists",
+      start: match.index,
+    };
+  }
+  return { helper: "not", start: match.index };
+}
+
+interface RangeMatch {
+  readonly helper: "between" | "notBetween";
+}
+
+function rangeMatch(
+  firstSeparator: string,
+  secondSeparator: string,
+): RangeMatch | undefined {
+  const secondRemainder = removeRightOperandPostfix(secondSeparator);
+  if (secondRemainder?.trim().toUpperCase() !== "AND") {
+    return undefined;
+  }
+  const operator = firstSeparator.trim().toUpperCase();
+  if (operator === "BETWEEN") {
+    return { helper: "between" };
+  }
+  return operator === "NOT BETWEEN" ? { helper: "notBetween" } : undefined;
+}
+
+type SqlLexicalState =
+  | { readonly kind: "block-comment"; readonly depth: number }
+  | { readonly kind: "code" }
+  | { readonly kind: "dollar-quote"; readonly delimiter: string }
+  | { readonly kind: "double-quote" }
+  | { readonly kind: "line-comment" }
+  | { readonly kind: "single-quote" };
+
+function sqlCodeMask(source: string): string {
+  const mask = source.split("");
+  let state: SqlLexicalState = { kind: "code" };
+  let offset = 0;
+  while (offset < source.length) {
+    if (source[offset] === "\u0000") {
+      mask[offset] = "\u0000";
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "code") {
+      const pair = source.slice(offset, offset + 2);
+      if (pair === "--") {
+        mask[offset] = " ";
+        mask[offset + 1] = " ";
+        state = { kind: "line-comment" };
+        offset += 2;
+        continue;
+      }
+      if (pair === "/*") {
+        mask[offset] = " ";
+        mask[offset + 1] = " ";
+        state = { kind: "block-comment", depth: 1 };
+        offset += 2;
+        continue;
+      }
+      const character = source[offset];
+      if (character === "'") {
+        mask[offset] = " ";
+        state = { kind: "single-quote" };
+        offset += 1;
+        continue;
+      }
+      if (character === '"') {
+        mask[offset] = " ";
+        state = { kind: "double-quote" };
+        offset += 1;
+        continue;
+      }
+      if (character === "$") {
+        const delimiter = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/.exec(
+          source.slice(offset),
+        )?.[0];
+        if (delimiter !== undefined) {
+          for (let index = 0; index < delimiter.length; index += 1) {
+            mask[offset + index] = " ";
+          }
+          state = { kind: "dollar-quote", delimiter };
+          offset += delimiter.length;
+          continue;
+        }
+      }
+      offset += 1;
+      continue;
+    }
+
+    const character = source[offset];
+    mask[offset] = character === "\n" ? "\n" : " ";
+    if (state.kind === "line-comment") {
+      if (character === "\n") {
+        state = { kind: "code" };
+      }
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "block-comment") {
+      const pair = source.slice(offset, offset + 2);
+      if (pair === "/*") {
+        mask[offset + 1] = " ";
+        state = { kind: "block-comment", depth: state.depth + 1 };
+        offset += 2;
+        continue;
+      }
+      if (pair === "*/") {
+        mask[offset + 1] = " ";
+        const depth: number = state.depth - 1;
+        state =
+          depth === 0 ? { kind: "code" } : { kind: "block-comment", depth };
+        offset += 2;
+        continue;
+      }
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "dollar-quote") {
+      if (source.startsWith(state.delimiter, offset)) {
+        for (let index = 0; index < state.delimiter.length; index += 1) {
+          mask[offset + index] = " ";
+        }
+        offset += state.delimiter.length;
+        state = { kind: "code" };
+      } else {
+        offset += 1;
+      }
+      continue;
+    }
+
+    const quote = state.kind === "single-quote" ? "'" : '"';
+    if (character !== quote) {
+      offset += 1;
+      continue;
+    }
+    if (source[offset + 1] === quote) {
+      mask[offset + 1] = " ";
+      offset += 2;
+      continue;
+    }
+    let backslashes = 0;
+    for (
+      let index = offset - 1;
+      index >= 0 && source[index] === "\\";
+      index -= 1
+    ) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) {
+      state = { kind: "code" };
+    }
+    offset += 1;
+  }
+  return mask.join("");
+}
+
+function skipSqlWhitespace(source: string, start: number): number {
+  let offset = start;
+  while (/\s/.test(source[offset] ?? "")) {
+    offset += 1;
+  }
+  return offset;
+}
+
+function sqlKeywordAt(
+  source: string,
+  offset: number,
+  keyword: string,
+): boolean {
+  if (source.slice(offset, offset + keyword.length).toUpperCase() !== keyword) {
+    return false;
+  }
+  return !/[\w$]/.test(source[offset + keyword.length] ?? "");
+}
+
+function hasAggregateWindowSuffix(source: string, start: number): boolean {
+  let offset = skipSqlWhitespace(source, start);
+  if (sqlKeywordAt(source, offset, "OVER")) {
+    return true;
+  }
+  if (!sqlKeywordAt(source, offset, "FILTER")) {
+    return false;
+  }
+  offset = skipSqlWhitespace(source, offset + "FILTER".length);
+  if (source[offset] !== "(") {
+    return false;
+  }
+  let depth = 0;
+  while (offset < source.length) {
+    const character = source[offset];
+    if (character === "(") {
+      depth += 1;
+    } else if (character === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        offset += 1;
+        break;
+      }
+    }
+    offset += 1;
+  }
+  return (
+    depth === 0 &&
+    sqlKeywordAt(source, skipSqlWhitespace(source, offset), "OVER")
+  );
+}
+
+interface SqlSourceMatch {
+  readonly end: number;
+  readonly start: number;
+}
+
+function countStarMatches(code: string): readonly SqlSourceMatch[] {
+  const count = /\bCOUNT\s*\(\s*\*\s*\)/gi;
+  const matches: SqlSourceMatch[] = [];
+  for (const match of code.matchAll(count)) {
+    const start = match.index;
+    if (hasSqlIdentifierPrefix(code, start)) {
+      continue;
+    }
+    if (hasAggregateWindowSuffix(code, start + match[0].length)) {
+      continue;
+    }
+    matches.push({ start, end: start + match[0].length });
+  }
+  return matches;
 }
 
 function tokenizeBooleanQuasi(quasi: string): BooleanToken[] | undefined {
@@ -493,16 +881,26 @@ export const preferDrizzleApis = createRule({
   create(context) {
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
+    const expressionTypeCache = new WeakMap<
+      TSESTree.Expression,
+      { readonly location: Node; readonly type: Type }
+    >();
 
     function expressionType(node: TSESTree.Expression): {
       readonly location: Node;
       readonly type: Type;
     } {
+      const cached = expressionTypeCache.get(node);
+      if (cached !== undefined) {
+        return cached;
+      }
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      return {
+      const result = {
         location: tsNode,
         type: checker.getTypeAtLocation(tsNode),
       };
+      expressionTypeCache.set(node, result);
+      return result;
     }
 
     function report(node: TSESTree.Node, helper: string): void {
@@ -650,6 +1048,59 @@ export const preferDrizzleApis = createRule({
       return (
         (type.flags & TypeFlags.StringLike) !== 0 ||
         isDrizzleWrapperType(checker, type)
+      );
+    }
+
+    function binaryLeftMatches(
+      expected: BinaryLeftOperand,
+      expression: { readonly location: Node; readonly type: Type },
+    ): boolean {
+      if (expected === "wrapper") {
+        return isDrizzleWrapperType(checker, expression.type);
+      }
+      if (expected === "pattern") {
+        return isDrizzlePatternOperandType(
+          checker,
+          expression.type,
+          expression.location,
+        );
+      }
+      return isDrizzleArrayOperandType(
+        checker,
+        expression.type,
+        expression.location,
+      );
+    }
+
+    function binaryRightMatches(
+      expected: BinaryRightOperand,
+      type: Type,
+    ): boolean {
+      if (expected === "any") {
+        return true;
+      }
+      return expected === "wrapper"
+        ? isDrizzleWrapperType(checker, type)
+        : isStringOrDrizzleWrapper(type);
+    }
+
+    function hasDirectMapWith(
+      node: TSESTree.TaggedTemplateExpression,
+    ): boolean {
+      const member = node.parent;
+      if (
+        member.type !== AST_NODE_TYPES.MemberExpression ||
+        member.object !== node ||
+        !isDrizzleMethod(member, "mapWith")
+      ) {
+        return false;
+      }
+      const call = member.parent;
+      return (
+        call.type === AST_NODE_TYPES.CallExpression &&
+        call.callee === member &&
+        call.arguments.length === 1 &&
+        call.arguments[0]?.type !== AST_NODE_TYPES.SpreadElement
       );
     }
 
@@ -919,6 +1370,8 @@ export const preferDrizzleApis = createRule({
         }
 
         const quasis = node.quasi.quasis.map(quasiText);
+        const syntaxSource = sqlCodeMask(quasis.join("\u0000"));
+        const syntaxQuasis = syntaxSource.split("\u0000");
         const expressions = node.quasi.expressions;
         if (
           expressions.length === 0 &&
@@ -928,7 +1381,17 @@ export const preferDrizzleApis = createRule({
           context.report({ node, messageId: "emptyFragment" });
           return;
         }
-        const existence = existenceTemplateMatch(quasis);
+        const countStars = countStarMatches(syntaxSource);
+        for (const match of countStars) {
+          const isWholeAggregate =
+            expressions.length === 0 &&
+            syntaxSource.slice(0, match.start).trim() === "" &&
+            syntaxSource.slice(match.end).trim() === "";
+          if (!isWholeAggregate || hasDirectMapWith(node)) {
+            report(node, "count");
+          }
+        }
+        const existence = existenceTemplateMatch(syntaxQuasis);
         if (
           existence !== undefined &&
           existence.tableExpressionIndexes.every((index) => {
@@ -966,46 +1429,57 @@ export const preferDrizzleApis = createRule({
           }
           const left = expressionType(leftNode);
           const right = expressionType(rightNode);
-          const middle = quasis[index + 1] ?? "";
-          const suffix = quasis[index + 2] ?? "";
+          const middle = syntaxQuasis[index + 1] ?? "";
+          const rawSuffix = quasis[index + 2] ?? "";
+          const binary = BINARY_HELPERS.get(middle.trim().toUpperCase());
           if (
-            hasPredicateLeftBoundary(quasis[index] ?? "") &&
-            hasPredicateRightBoundary(suffix)
+            binary !== undefined &&
+            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+            (binary.rightBoundary === "pattern"
+              ? hasPatternRightBoundary(rawSuffix)
+              : hasPredicateRightBoundary(rawSuffix)) &&
+            binaryLeftMatches(binary.left, left) &&
+            binaryRightMatches(binary.right, right.type)
           ) {
-            const comparison = COMPARISON_HELPERS.get(middle.trim());
-            if (
-              comparison !== undefined &&
-              isDrizzleWrapperType(checker, left.type)
-            ) {
-              report(leftNode, comparison);
-            }
+            report(leftNode, binary.helper);
           }
+          const membership = /^\s+(NOT\s+)?IN\s*\(\s*$/i.exec(middle);
           if (
-            middle.trim().toUpperCase() === "LIKE" &&
-            hasPredicateLeftBoundary(quasis[index] ?? "") &&
-            hasPatternRightBoundary(suffix) &&
-            isDrizzleWrapperType(checker, left.type) &&
-            isStringOrDrizzleWrapper(right.type)
-          ) {
-            report(leftNode, "like");
-          }
-          if (
-            /^\s+IN\s*\(\s*$/i.test(middle) &&
-            hasPredicateLeftBoundary(quasis[index] ?? "") &&
-            membershipRightBoundary(suffix) &&
+            membership !== null &&
+            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+            membershipRightBoundary(rawSuffix) &&
             isDrizzleColumnType(checker, left.type, left.location) &&
             hasParameterListOrigin(rightNode)
           ) {
-            report(leftNode, "inArray");
+            report(
+              leftNode,
+              membership[1] === undefined ? "inArray" : "notInArray",
+            );
           }
+        }
+
+        for (let index = 0; index < expressions.length - 2; index += 1) {
+          const leftNode = expressions[index];
+          const minimumNode = expressions[index + 1];
+          const maximumNode = expressions[index + 2];
           if (
-            middle.trim() === "@>" &&
-            hasPredicateLeftBoundary(quasis[index] ?? "") &&
-            hasPredicateRightBoundary(suffix) &&
-            isDrizzleArrayColumnType(checker, left.type, left.location) &&
-            isDrizzleWrapperType(checker, right.type)
+            leftNode === undefined ||
+            minimumNode === undefined ||
+            maximumNode === undefined
           ) {
-            report(leftNode, "arrayContains");
+            continue;
+          }
+          const range = rangeMatch(
+            syntaxQuasis[index + 1] ?? "",
+            quasis[index + 2] ?? "",
+          );
+          if (
+            range !== undefined &&
+            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+            hasPredicateRightBoundary(quasis[index + 3] ?? "") &&
+            isDrizzleWrapperType(checker, expressionType(leftNode).type)
+          ) {
+            report(leftNode, range.helper);
           }
         }
 
@@ -1015,14 +1489,25 @@ export const preferDrizzleApis = createRule({
             continue;
           }
           const expression = expressionType(expressionNode);
-          const prefix = quasis[index] ?? "";
-          const suffix = quasis[index + 1] ?? "";
+          const prefix = syntaxQuasis[index] ?? "";
+          const suffix = syntaxQuasis[index + 1] ?? "";
+          const rawSuffix = quasis[index + 1] ?? "";
+
+          const unary = unaryPredicateMatch(prefix);
+          if (
+            unary !== undefined &&
+            hasPredicateLeftBoundary(prefix.slice(0, unary.start)) &&
+            hasPredicateRightBoundary(rawSuffix) &&
+            isDrizzleWrapperType(checker, expression.type)
+          ) {
+            report(expressionNode, unary.helper);
+          }
 
           const nullMatch = nullPredicateMatch(suffix);
           if (
             nullMatch !== undefined &&
             hasPredicateLeftBoundary(prefix) &&
-            hasPredicateRightBoundary(suffix.slice(nullMatch.length)) &&
+            hasPredicateRightBoundary(rawSuffix.slice(nullMatch.length)) &&
             isDrizzleWrapperType(checker, expression.type)
           ) {
             report(expressionNode, nullMatch.helper);
@@ -1038,11 +1523,13 @@ export const preferDrizzleApis = createRule({
           }
 
           const aggregate = aggregateMatch(prefix);
-          const aggregateSuffix = aggregateRemainder(suffix);
+          const aggregateSuffix = aggregateRemainder(
+            syntaxQuasis.slice(index + 1).join("\u0000"),
+          );
           if (
             aggregate === undefined ||
             aggregateSuffix === undefined ||
-            /^\s*OVER\b/i.test(aggregateSuffix) ||
+            hasAggregateWindowSuffix(aggregateSuffix, 0) ||
             !isDrizzleWrapperType(checker, expression.type)
           ) {
             continue;
@@ -1052,18 +1539,21 @@ export const preferDrizzleApis = createRule({
             prefix.slice(0, aggregate.start).trim() === "" &&
             aggregateSuffix.trim() === "";
           if (!isWholeAggregate) {
-            if (aggregate.helper !== "min") {
-              report(expressionNode, aggregate.helper);
-            }
+            report(expressionNode, aggregate.helper);
           } else if (
-            (aggregate.helper === "max" || aggregate.helper === "min") &&
-            isDrizzleColumnType(checker, expression.type, expression.location)
+            hasDirectMapWith(node) ||
+            ((aggregate.helper === "max" || aggregate.helper === "min") &&
+              isDrizzleColumnType(
+                checker,
+                expression.type,
+                expression.location,
+              ))
           ) {
             report(node, aggregate.helper);
           }
         }
 
-        const boolean = booleanHelper(quasis);
+        const boolean = booleanHelper(syntaxQuasis);
         if (boolean === undefined) {
           return;
         }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -52,6 +52,8 @@ interface BinaryHelper {
   readonly rightBoundary: BinaryRightBoundary;
 }
 
+const TEMPLATE_EXPRESSION_BOUNDARY = "\u0000";
+
 const BINARY_HELPERS = new Map<string, BinaryHelper>([
   [
     "=",
@@ -333,7 +335,7 @@ function hasSqlIdentifierPrefix(source: string, start: number): boolean {
   return (
     isSqlIdentifierCharacter(source[start - 1]) ||
     previous === "." ||
-    previous === "\u0000"
+    previous === TEMPLATE_EXPRESSION_BOUNDARY
   );
 }
 
@@ -425,8 +427,8 @@ function sqlCodeMask(source: string): string {
   let state: SqlLexicalState = { kind: "code" };
   let offset = 0;
   while (offset < source.length) {
-    if (source[offset] === "\u0000") {
-      mask[offset] = "\u0000";
+    if (source[offset] === TEMPLATE_EXPRESSION_BOUNDARY) {
+      mask[offset] = TEMPLATE_EXPRESSION_BOUNDARY;
       offset += 1;
       continue;
     }
@@ -1372,8 +1374,10 @@ export const preferDrizzleApis = createRule({
         }
 
         const quasis = node.quasi.quasis.map(quasiText);
-        const syntaxSource = sqlCodeMask(quasis.join("\u0000"));
-        const syntaxQuasis = syntaxSource.split("\u0000");
+        const syntaxSource = sqlCodeMask(
+          quasis.join(TEMPLATE_EXPRESSION_BOUNDARY),
+        );
+        const syntaxQuasis = syntaxSource.split(TEMPLATE_EXPRESSION_BOUNDARY);
         const expressions = node.quasi.expressions;
         if (
           expressions.length === 0 &&
@@ -1526,7 +1530,7 @@ export const preferDrizzleApis = createRule({
 
           const aggregate = aggregateMatch(prefix);
           const aggregateSuffix = aggregateRemainder(
-            syntaxQuasis.slice(index + 1).join("\u0000"),
+            syntaxQuasis.slice(index + 1).join(TEMPLATE_EXPRESSION_BOUNDARY),
           );
           if (
             aggregate === undefined ||

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -329,9 +329,11 @@ function isSqlIdentifierCharacter(character: string | undefined): boolean {
 }
 
 function hasSqlIdentifierPrefix(source: string, start: number): boolean {
+  const previous = previousNonWhitespaceCharacter(source, start);
   return (
     isSqlIdentifierCharacter(source[start - 1]) ||
-    previousNonWhitespaceCharacter(source, start) === "."
+    previous === "." ||
+    previous === "\u0000"
   );
 }
 
@@ -1529,6 +1531,7 @@ export const preferDrizzleApis = createRule({
           if (
             aggregate === undefined ||
             aggregateSuffix === undefined ||
+            (index > 0 && prefix.slice(0, aggregate.start).trim() === "") ||
             hasAggregateWindowSuffix(aggregateSuffix, 0) ||
             !isDrizzleWrapperType(checker, expression.type)
           ) {


### PR DESCRIPTION
## Summary

- broaden `api/prefer-drizzle-apis` with exact type-aware matcher families for unary predicates, pattern/range/membership/array operators, aggregate leaves, and literal `COUNT(*)`
- convert all 12 newly diagnosed production `COUNT(*)` leaves: three structured selections use `count()` directly, while nine irreducible statements keep their outer SQL, casts, aliases, schemas, and execution boundaries
- add lexical and type-provenance safeguards plus in-place database guidance so `sql` remains available whenever helper equivalence cannot be proven

## Installed-helper audit

- Existing coverage remains for comparisons, null predicates, `like`, locally traceable `inArray`, `arrayContains`, contextual `and` / `or`, complete simple `exists` / `notExists`, ordering, lateral joins, and the previously safe aggregate shapes.
- New direct coverage includes `not`, direct-wrapper `exists` / `notExists`, `notLike`, `ilike`, `notIlike`, `between`, `notBetween`, `notInArray`, `arrayContained`, `arrayOverlaps`, `avg`, `avgDistinct`, `sumDistinct`, embedded `min`, and non-window literal `count(*)`.
- Intentionally contextual forms remain accepted: concrete `and` / `or` trees, subquery or untraceable membership, direct array values with different empty/encoding behavior, static planner-visible literals, qualified functions, window-owned aggregates, and whole aggregates whose helper decoder is not proven equal or stronger.
- The existing handwritten CTE `r.source NOT IN (...)` remains raw because `r` has no typed Drizzle alias column; converting it belongs to a statement-builder slice, not this leaf matcher.

## Safety and performance

- matchers resolve real Drizzle tags, symbols, columns, SQL expressions, aliases, unions, and constrained generics rather than trusting structural lookalikes
- the bounded `COUNT(*)` scanner masks single/double/dollar-quoted regions, line comments, nested block comments, and Unicode identifier prefixes; it excludes qualified and `FILTER (...) OVER` / `OVER` aggregates
- embedded helpers render the same SQL and parameter order; a `PgDialect.sqlToQuery(...)` comparison covered every new family and confirmed that custom columns gain the intended encoder for range values
- direct structured `count()` keeps the JavaScript `number` contract while removing the old `int4` cast limit; decoder-sensitive bare whole aggregates remain raw unless an outer `.mapWith(...)` owns decoding
- representative PostgreSQL 17 `EXPLAIN (ANALYZE, BUFFERS)` pairs for `COUNT(*)::int` and `COUNT(*)` had identical aggregate/scan structure and buffer access; timing differed only from cache warming
- paired type-aware API ESLint measurements were 25.61s/26.99s (parent/candidate) and, after alternating snapshots later, 33.79s/29.25s; there is no stable matcher-time regression
- no query, round trip, schema, migration, persisted-data, API, protocol, feature-switch, assertion, suppression, raw wrapper, or allowlist is added

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules exec vitest run --maxWorkers=4 --silent=passed-only` (46 files, 682 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- focused Telegram state, usage, insights, usage insight/record, snapshot compaction, and chat-message API integration suites (7 files, 125 tests)
- `pnpm knip` and pre-commit `pnpm knip --cache`
- pre-commit full Turbo typecheck (13 packages)
- `git diff --check`

Closes #22521

Parent context: #22439
