### PR TITLE
fix(runner): classify guest dns readiness failures

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -262,6 +262,8 @@ fi
 
 NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
 FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
+IPV6_FILTER_RULES=$(sudo ip6tables-save -t filter) \
+  || fail "failed to read IPv6 filter rules"
 RAW_RULES=$(sudo iptables-save -t raw) || fail "failed to read raw rules"
 
 PROXY_RULES=$(printf '%s\n' "$NAT_RULES" \
@@ -470,6 +472,61 @@ DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
   | sed -nE 's/.*--comment "?([^ " ]+)"?.*/\1/p' \
   | head -n 1)
 [ -n "$DNS_FILTER_COMMENT" ] || fail "DNS INPUT filter comment missing"
+DNS_FILTER_POOL=${DNS_FILTER_COMMENT#vm0-ns-}
+DNS_FILTER_POOL=${DNS_FILTER_POOL%-dns}
+DNS_FILTER_INTERFACE="vm0-ve-${DNS_FILTER_POOL}-+"
+
+assert_dns_input_filter_family() {
+  local family=$1 rules=$2 comment_rules targetless reject protocol
+  comment_rules=$(printf '%s\n' "$rules" \
+    | grep -F -- "--comment ${DNS_FILTER_COMMENT}" || true)
+  [ "$(printf '%s\n' "$comment_rules" | grep -c . || true)" -eq 4 ] \
+    || fail "$family DNS INPUT filter expected four rules: $comment_rules"
+  [ "$(printf '%s\n' "$comment_rules" \
+    | grep -F -c -- "--dport ${DNS_PORT}" || true)" -eq 4 ] \
+    || fail "$family DNS INPUT filter does not consistently use port ${DNS_PORT}"
+  targetless=$(printf '%s\n' "$comment_rules" | grep -Fv -- " -j " || true)
+  reject=$(printf '%s\n' "$comment_rules" | grep -F -- "-j REJECT" || true)
+  [ "$(printf '%s\n' "$targetless" | grep -c . || true)" -eq 2 ] \
+    || fail "$family DNS INPUT filter expected two targetless rules: $comment_rules"
+  [ "$(printf '%s\n' "$reject" | grep -c . || true)" -eq 2 ] \
+    || fail "$family DNS INPUT filter expected two REJECT rules: $comment_rules"
+  if printf '%s\n' "$targetless" | grep -F -- "! -i" >/dev/null; then
+    fail "$family targetless DNS INPUT rule inverted its interface: $targetless"
+  fi
+  [ "$(printf '%s\n' "$targetless" \
+    | grep -F -c -- "-i ${DNS_FILTER_INTERFACE}" || true)" -eq 2 ] \
+    || fail "$family targetless DNS INPUT rules do not all match ${DNS_FILTER_INTERFACE}"
+  [ "$(printf '%s\n' "$reject" \
+    | grep -F -c -- "! -i ${DNS_FILTER_INTERFACE}" || true)" -eq 2 ] \
+    || fail "$family DNS INPUT REJECT rules do not all invert ${DNS_FILTER_INTERFACE}"
+  for protocol in udp tcp; do
+    [ "$(printf '%s\n' "$targetless" | grep -F -c -- "-p ${protocol}" || true)" -eq 1 ] \
+      || fail "$family targetless DNS INPUT ${protocol} rule missing or duplicated"
+    [ "$(printf '%s\n' "$reject" | grep -F -c -- "-p ${protocol}" || true)" -eq 1 ] \
+      || fail "$family DNS INPUT ${protocol} REJECT rule missing or duplicated"
+  done
+}
+
+assert_dns_input_filter_family IPv4 "$FILTER_RULES"
+assert_dns_input_filter_family IPv6 "$IPV6_FILTER_RULES"
+
+DNS_INPUT_UDP_RULE=$(sudo iptables-save -c -t filter \
+  | grep -F -- "--comment ${DNS_FILTER_COMMENT}" \
+  | grep -F -- "-i ${DNS_FILTER_INTERFACE}" \
+  | grep -F -- "-p udp" \
+  | grep -Fv -- " -j " \
+  | head -n 1 || true)
+DNS_INPUT_TCP_RULE=$(sudo iptables-save -c -t filter \
+  | grep -F -- "--comment ${DNS_FILTER_COMMENT}" \
+  | grep -F -- "-i ${DNS_FILTER_INTERFACE}" \
+  | grep -F -- "-p tcp" \
+  | grep -Fv -- " -j " \
+  | head -n 1 || true)
+DNS_INPUT_UDP_BEFORE=$(rule_packet_count "$DNS_INPUT_UDP_RULE")
+DNS_INPUT_TCP_BEFORE=$(rule_packet_count "$DNS_INPUT_TCP_RULE")
+[ -n "$DNS_INPUT_UDP_BEFORE" ] || fail "IPv4 UDP DNS INPUT counter missing"
+[ -n "$DNS_INPUT_TCP_BEFORE" ] || fail "IPv4 TCP DNS INPUT counter missing"
 
 # Submit a long-running job in background (keeps sandbox alive during tests)
 echo "--- Submitting long-running job ---"
@@ -786,6 +843,25 @@ OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "$TCP
   || fail "TCP DNS resolution failed: $OUTPUT"
 [ "$OUTPUT" = "TCP_DNS_OK=true" ] || fail "unexpected TCP DNS output: $OUTPUT"
 echo "  tcp: $OUTPUT"
+
+DNS_INPUT_UDP_RULE=$(sudo iptables-save -c -t filter \
+  | grep -F -- "--comment ${DNS_FILTER_COMMENT}" \
+  | grep -F -- "-i ${DNS_FILTER_INTERFACE}" \
+  | grep -F -- "-p udp" \
+  | grep -Fv -- " -j " \
+  | head -n 1 || true)
+DNS_INPUT_TCP_RULE=$(sudo iptables-save -c -t filter \
+  | grep -F -- "--comment ${DNS_FILTER_COMMENT}" \
+  | grep -F -- "-i ${DNS_FILTER_INTERFACE}" \
+  | grep -F -- "-p tcp" \
+  | grep -Fv -- " -j " \
+  | head -n 1 || true)
+DNS_INPUT_UDP_AFTER=$(rule_packet_count "$DNS_INPUT_UDP_RULE")
+DNS_INPUT_TCP_AFTER=$(rule_packet_count "$DNS_INPUT_TCP_RULE")
+[ "$DNS_INPUT_UDP_AFTER" -gt "$DNS_INPUT_UDP_BEFORE" ] \
+  || fail "IPv4 UDP DNS INPUT counter did not increase"
+[ "$DNS_INPUT_TCP_AFTER" -gt "$DNS_INPUT_TCP_BEFORE" ] \
+  || fail "IPv4 TCP DNS INPUT counter did not increase"
 
 
 # Default dnsmasq wildcard sockets must still reject requests that

--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -3,6 +3,7 @@ use std::io::SeekFrom;
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
+use sandbox_fc::DNS_DIAGNOSTIC_HOSTNAME;
 use sandbox_fc::DNS_READINESS_HOSTNAME;
 use tokio::io::{AsyncBufRead, AsyncReadExt, AsyncSeekExt};
 use tokio::sync::mpsc;
@@ -122,6 +123,9 @@ where
 
 async fn handle_dns_line(network_log_manager: &NetworkLogManager, line: &str) {
     if let Some(entry) = parse_dns_line(line) {
+        if entry.domain == DNS_DIAGNOSTIC_HOSTNAME {
+            return;
+        }
         // Capture the timestamp before handing the row to the manager so
         // it reflects DNS observation time, not delayed write time.
         let timestamp = Utc::now();
@@ -479,6 +483,24 @@ mod tests {
 
         assert!(observation.query_observed);
         assert!(observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_ignores_post_failure_diagnostic_hostname() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let rows = [
+            readiness_log_row(DNS_DIAGNOSTIC_HOSTNAME, "query"),
+            readiness_log_row(DNS_DIAGNOSTIC_HOSTNAME, "config"),
+        ]
+        .join("\n");
+        tokio::fs::write(&path, format!("{rows}\n")).await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, 0).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
         assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
     }
 
@@ -848,6 +870,23 @@ mod tests {
             .await
         );
         manager.flush_path(&path).await;
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn post_failure_diagnostic_query_is_not_persisted_as_guest_traffic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("diagnostic.jsonl");
+        let manager = NetworkLogManager::new();
+        let _session = manager.register_source_ip("10.0.0.1", path.clone()).await;
+
+        handle_dns_line(
+            &manager,
+            "dnsmasq[1234]: 42 10.0.0.1/54321 query[A] vm0-diagnostic.invalid from 10.0.0.1",
+        )
+        .await;
+        manager.flush_path(&path).await;
+
         assert!(!path.exists());
     }
 

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -4,7 +4,7 @@ use tokio::io::AsyncReadExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use sandbox_fc::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
+use sandbox_fc::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
 
 use super::log::tail_stderr;
 use super::port::DnsPortReservation;
@@ -224,6 +224,8 @@ fn dnsmasq_args(port: u16, interface_pattern: &str) -> Vec<String> {
         format!("--interface={interface_pattern}"),
         format!("--address=/{DNS_READINESS_HOSTNAME}/{DNS_READINESS_IPV4}"),
         format!("--local=/{DNS_READINESS_HOSTNAME}/"),
+        format!("--address=/{DNS_DIAGNOSTIC_HOSTNAME}/{DNS_READINESS_IPV4}"),
+        format!("--local=/{DNS_DIAGNOSTIC_HOSTNAME}/"),
         "--server".into(),
         "8.8.8.8".into(),
         "--server".into(),
@@ -260,6 +262,8 @@ mod tests {
                 "--interface=vm0-ve-0a-*",
                 "--address=/vm0-readiness.invalid/192.0.2.1",
                 "--local=/vm0-readiness.invalid/",
+                "--address=/vm0-diagnostic.invalid/192.0.2.1",
+                "--local=/vm0-diagnostic.invalid/",
                 "--server",
                 "8.8.8.8",
                 "--server",

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -448,7 +448,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
     )
     .await;
     let mut used_retry = false;
-    let mut dns_retry_started: Option<Instant> = None;
+    let mut dns_retry: Option<(Instant, bool)> = None;
     let prepared = loop {
         let result = create_started_sandbox(
             factory,
@@ -464,13 +464,20 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         )
         .await;
 
-        if let Some(started) = dns_retry_started.take() {
+        if let Some((started, workspace_fallback)) = dns_retry.take() {
             let success = result.is_ok();
             telemetry.record(
                 RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY,
                 started.elapsed(),
                 success,
                 (!success).then_some(DNS_READINESS_RETRY_PREPARE_FAILED),
+            );
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %sandbox_id,
+                success,
+                workspace_fallback,
+                "guest DNS readiness replacement completed"
             );
         }
 
@@ -551,7 +558,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 error = %failure.error,
                 "guest DNS readiness failed; retrying with a fresh sandbox attachment"
             );
-            dns_retry_started = Some(Instant::now());
+            dns_retry = Some((Instant::now(), cache_hit));
         }
 
         if cache_hit {
@@ -988,7 +995,7 @@ async fn create_started_sandbox(
                     false
                 }
             };
-        network_log_session
+        let network_log_observation = network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         if guest_dns_readiness {
@@ -1005,6 +1012,9 @@ async fn create_started_sandbox(
                 query_observed = observation.query_observed,
                 result_observed = observation.result_observed,
                 scan_status = observation.status.as_str(),
+                dns_drain_status = network_log_observation.drain_status("dns"),
+                kmsg_drain_status = network_log_observation.drain_status("kmsg"),
+                writer_backpressure_observed = network_log_observation.writer_backpressure_observed(),
                 "guest DNS readiness network log observation"
             );
         }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -141,6 +141,42 @@ const SANDBOX_START_STAGE_FAILED: &str = "sandbox_start_stage_failed";
 const DNS_READINESS_RETRY_PREPARE_FAILED: &str = "replacement_prepare_failed";
 const SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN: &str = "cleanup_uncertain";
 
+struct DnsReadinessReplacement {
+    started: Instant,
+    workspace_fallback: bool,
+}
+
+impl DnsReadinessReplacement {
+    fn new(workspace_fallback: bool) -> Self {
+        Self {
+            started: Instant::now(),
+            workspace_fallback,
+        }
+    }
+
+    fn complete(
+        self,
+        context: &ExecutionContext,
+        sandbox_id: SandboxId,
+        telemetry: &mut JobTelemetry,
+        success: bool,
+    ) {
+        telemetry.record(
+            RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY,
+            self.started.elapsed(),
+            success,
+            (!success).then_some(DNS_READINESS_RETRY_PREPARE_FAILED),
+        );
+        warn!(
+            run_id = %context.run_id,
+            sandbox_id = %sandbox_id,
+            success,
+            workspace_fallback = self.workspace_fallback,
+            "guest DNS readiness replacement completed"
+        );
+    }
+}
+
 struct FreshSandboxFactoryCreateObserver<'a> {
     telemetry: &'a mut JobTelemetry,
 }
@@ -448,7 +484,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
     )
     .await;
     let mut used_retry = false;
-    let mut dns_retry: Option<(Instant, bool)> = None;
+    let mut dns_replacement: Option<DnsReadinessReplacement> = None;
     let prepared = loop {
         let result = create_started_sandbox(
             factory,
@@ -464,21 +500,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         )
         .await;
 
-        if let Some((started, workspace_fallback)) = dns_retry.take() {
+        if let Some(replacement) = dns_replacement.take() {
             let success = result.is_ok();
-            telemetry.record(
-                RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY,
-                started.elapsed(),
-                success,
-                (!success).then_some(DNS_READINESS_RETRY_PREPARE_FAILED),
-            );
-            warn!(
-                run_id = %context.run_id,
-                sandbox_id = %sandbox_id,
-                success,
-                workspace_fallback,
-                "guest DNS readiness replacement completed"
-            );
+            replacement.complete(context, sandbox_id, telemetry, success);
         }
 
         let failure = match result {
@@ -558,7 +582,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 error = %failure.error,
                 "guest DNS readiness failed; retrying with a fresh sandbox attachment"
             );
-            dns_retry = Some((Instant::now(), cache_hit));
+            dns_replacement = Some(DnsReadinessReplacement::new(cache_hit));
         }
 
         if cache_hit {
@@ -585,6 +609,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
             match prepare_fresh_storage(context, None, config, &controls.cancel, telemetry).await {
                 Ok(prepared_storage) => controls.prepared_storage = prepared_storage,
                 Err(error) => {
+                    if let Some(replacement) = dns_replacement.take() {
+                        replacement.complete(context, sandbox_id, telemetry, false);
+                    }
                     telemetry.record(
                         "runner_fresh_sandbox_prepare",
                         prepare_started.elapsed(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -273,7 +273,7 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
     });
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let outcome = execute_new_sandbox_with_prepared_notifier(
+    let (outcome, events) = capture_sandbox_run_events(execute_new_sandbox_with_prepared_notifier(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -287,9 +287,9 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             sandbox_prepared: Some(&notifier),
         },
-    )
-    .await
-    .unwrap();
+    ))
+    .await;
+    let outcome = outcome.unwrap();
 
     assert_eq!(outcome.exit_code(), 0);
     assert_eq!(overrides.create_configs().len(), 2);
@@ -303,6 +303,17 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
         true,
         None,
     );
+    let completion = captured_events_named(&events, "guest DNS readiness replacement completed");
+    assert_eq!(completion.len(), 1, "events={events:#?}");
+    assert_eq!(completion[0].level, Level::WARN);
+    assert_captured_field(completion[0], "success", "true");
+    assert_captured_field(completion[0], "workspace_fallback", "false");
+
+    let observation = captured_events_named(&events, "guest DNS readiness network log observation");
+    assert_eq!(observation.len(), 1, "events={events:#?}");
+    assert_captured_field(observation[0], "dns_drain_status", "not_configured");
+    assert_captured_field(observation[0], "kmsg_drain_status", "not_configured");
+    assert_captured_field(observation[0], "writer_backpressure_observed", "false");
 }
 
 #[tokio::test]
@@ -373,7 +384,7 @@ async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
     let ctx = minimal_context();
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let result = execute_new_sandbox(
+    let (result, events) = capture_sandbox_run_events(execute_new_sandbox(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -384,7 +395,7 @@ async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
         &default_params(),
         &mut telemetry,
         tokio_util::sync::CancellationToken::new(),
-    )
+    ))
     .await;
 
     let error = result.err().expect("second DNS failure must be returned");
@@ -399,6 +410,10 @@ async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
         false,
         Some("replacement_prepare_failed"),
     );
+    let completion = captured_events_named(&events, "guest DNS readiness replacement completed");
+    assert_eq!(completion.len(), 1, "events={events:#?}");
+    assert_captured_field(completion[0], "success", "false");
+    assert_captured_field(completion[0], "workspace_fallback", "false");
 }
 
 #[tokio::test]
@@ -413,7 +428,7 @@ async fn execute_new_sandbox_does_not_retry_an_unrelated_start_failure() {
     let ctx = minimal_context();
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let result = execute_new_sandbox(
+    let (result, events) = capture_sandbox_run_events(execute_new_sandbox(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -424,7 +439,7 @@ async fn execute_new_sandbox_does_not_retry_an_unrelated_start_failure() {
         &default_params(),
         &mut telemetry,
         tokio_util::sync::CancellationToken::new(),
-    )
+    ))
     .await;
 
     let error = result
@@ -434,6 +449,10 @@ async fn execute_new_sandbox_does_not_retry_an_unrelated_start_failure() {
     assert_eq!(overrides.create_configs().len(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
+    assert!(
+        captured_events_named(&events, "guest DNS readiness replacement completed").is_empty(),
+        "events={events:#?}"
+    );
 }
 
 #[tokio::test]
@@ -447,7 +466,7 @@ async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
     let ctx = minimal_context();
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let result = execute_new_sandbox(
+    let (result, events) = capture_sandbox_run_events(execute_new_sandbox(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -458,7 +477,7 @@ async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
         &default_params(),
         &mut telemetry,
         tokio_util::sync::CancellationToken::new(),
-    )
+    ))
     .await;
 
     let error = result
@@ -473,6 +492,10 @@ async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
         "runner_fresh_sandbox_dns_readiness_retry",
         false,
         Some("cleanup_uncertain"),
+    );
+    assert!(
+        captured_events_named(&events, "guest DNS readiness replacement completed").is_empty(),
+        "events={events:#?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -35,7 +35,8 @@ use super::support::{
     api_storage, assert_proxy_registry_empty, create_overridden_sandbox, default_params,
     make_reusable_idle_sandbox, minimal_context, run_new_sandbox_outcome, run_new_sandbox_status,
     sandbox_create_error, sandbox_exec_error, sandbox_write_file_error, seed_workspace_image_cache,
-    test_budget_lease, test_device_rate_limits, test_executor_config, test_telemetry,
+    seed_workspace_image_cache_with_fingerprints, test_budget_lease, test_device_rate_limits,
+    test_executor_config, test_telemetry,
 };
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -77,6 +77,39 @@ fn assert_no_telemetry_action(telemetry: &crate::telemetry::JobTelemetry, action
     );
 }
 
+async fn capture_sandbox_run_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: std::future::Future,
+{
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let output = future.await;
+    drop(guard);
+    (output, captured.entries())
+}
+
+fn captured_events_named<'a>(events: &'a [CapturedEvent], message: &str) -> Vec<&'a CapturedEvent> {
+    events
+        .iter()
+        .filter(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .collect()
+}
+
+fn assert_captured_field(event: &CapturedEvent, field: &str, expected: &str) {
+    let actual = event
+        .fields
+        .get(field)
+        .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+    assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
+}
+
 fn telemetry_action_outcomes(
     telemetry: &crate::telemetry::JobTelemetry,
     action: &str,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -203,6 +203,87 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
 }
 
 #[tokio::test]
+async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        message: "first attachment failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    let mount_path = format!("{CANONICAL_WORKING_DIR}/data");
+    let manifest = StorageManifest {
+        storages: vec![api_storage(
+            "dns-retry-storage",
+            &mount_path,
+            "v1",
+            "https://storage.example/archive.tar.gz",
+        )],
+        artifacts: Vec::new(),
+    };
+    let storage_fingerprints =
+        crate::storage_fingerprints::StorageFingerprints::from_manifest(&manifest);
+    ctx.storage_manifest = Some(manifest);
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-cache-dns-prepare-failure".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    seed_workspace_image_cache_with_fingerprints(
+        &cache,
+        &runner_paths,
+        "sess-cache-dns-prepare-failure",
+        16,
+        &storage_fingerprints,
+    )
+    .await;
+    tokio::fs::write(config.home.locks_dir(), b"not a directory")
+        .await
+        .unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let (result, events) = capture_sandbox_run_events(execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    ))
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        overrides.create_configs().len(),
+        1,
+        "result={:?}; telemetry={:?}",
+        result.as_ref().err(),
+        telemetry.pending_ops_snapshot(),
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        false,
+        Some("replacement_prepare_failed"),
+    );
+    let completion = captured_events_named(&events, "guest DNS readiness replacement completed");
+    assert_eq!(completion.len(), 1, "events={events:#?}");
+    assert_captured_field(completion[0], "success", "false");
+    assert_captured_field(completion[0], "workspace_fallback", "true");
+}
+
+#[tokio::test]
 async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -148,7 +148,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
         seed_workspace_image_cache(&cache, &runner_paths, "sess-cache-dns-retry", 16).await;
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let outcome = execute_new_sandbox(
+    let (outcome, events) = capture_sandbox_run_events(execute_new_sandbox(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -159,9 +159,9 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
         &params,
         &mut telemetry,
         tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    ))
+    .await;
+    let outcome = outcome.unwrap();
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_none());
@@ -196,6 +196,10 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
         true,
         None,
     );
+    let completion = captured_events_named(&events, "guest DNS readiness replacement completed");
+    assert_eq!(completion.len(), 1, "events={events:#?}");
+    assert_captured_field(completion[0], "success", "true");
+    assert_captured_field(completion[0], "workspace_fallback", "true");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -28,4 +28,6 @@ pub(super) use self::sandbox::{
     sandbox_write_file_error,
 };
 pub(super) use self::tracing::{CapturedEvent, CapturedEvents};
-pub(super) use self::workspace_cache::seed_workspace_image_cache;
+pub(super) use self::workspace_cache::{
+    seed_workspace_image_cache, seed_workspace_image_cache_with_fingerprints,
+};

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -5,6 +5,7 @@ use sandbox::SandboxId;
 
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
@@ -15,6 +16,23 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
     runner_paths: &RunnerPaths,
     session_id: &str,
     workspace_disk_mb: u32,
+) -> PathBuf {
+    seed_workspace_image_cache_with_fingerprints(
+        cache,
+        runner_paths,
+        session_id,
+        workspace_disk_mb,
+        &StorageFingerprints::default(),
+    )
+    .await
+}
+
+pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerprints(
+    cache: &SessionWorkspaceCache,
+    runner_paths: &RunnerPaths,
+    session_id: &str,
+    workspace_disk_mb: u32,
+    storage_fingerprints: &StorageFingerprints,
 ) -> PathBuf {
     let sandbox_id = SandboxId::new_v4();
     let run_id = RunId::new_v4();
@@ -50,7 +68,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
                 None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-06-01T00:00:00.000Z".into(),
-                &crate::storage_fingerprints::StorageFingerprints::default(),
+                storage_fingerprints,
             )
             .await
             .unwrap()

--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -15,6 +15,7 @@ use tracing::warn;
 use crate::ids::RunId;
 
 const DEFAULT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+const DRAIN_STATUS_NOT_CONFIGURED: &str = "not_configured";
 /// Maximum ready lines handled before yielding and rechecking drain control state.
 const READY_LINE_DRAIN_SLICE_SIZE: usize = 64;
 
@@ -82,13 +83,56 @@ impl NetworkLogDrainCoordinator {
         }
     }
 
-    pub async fn drain(&self, context: NetworkLogDrainContext<'_>) {
-        join_all(
+    pub async fn drain(&self, context: NetworkLogDrainContext<'_>) -> NetworkLogDrainReport {
+        let outcomes = join_all(
             self.producers
                 .iter()
                 .map(|producer| producer.drain(context, self.timeout)),
         )
         .await;
+        NetworkLogDrainReport {
+            producers: self
+                .producers
+                .iter()
+                .zip(outcomes)
+                .map(|(producer, outcome)| (producer.name, outcome))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NetworkLogDrainOutcome {
+    Acknowledged,
+    ProducerUnavailable,
+    RequestTimeout,
+    AckDropped,
+    AckTimeout,
+}
+
+impl NetworkLogDrainOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Acknowledged => "acknowledged",
+            Self::ProducerUnavailable => "producer_unavailable",
+            Self::RequestTimeout => "request_timeout",
+            Self::AckDropped => "ack_dropped",
+            Self::AckTimeout => "ack_timeout",
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct NetworkLogDrainReport {
+    producers: Vec<(&'static str, NetworkLogDrainOutcome)>,
+}
+
+impl NetworkLogDrainReport {
+    pub(crate) fn status(&self, producer: &str) -> &'static str {
+        self.producers
+            .iter()
+            .find_map(|(name, outcome)| (*name == producer).then_some(outcome.as_str()))
+            .unwrap_or(DRAIN_STATUS_NOT_CONFIGURED)
     }
 }
 
@@ -104,13 +148,17 @@ impl NetworkLogDrainProducer {
         (Self { name, tx }, rx)
     }
 
-    pub(crate) async fn drain(&self, context: NetworkLogDrainContext<'_>, wait: Duration) {
+    pub(crate) async fn drain(
+        &self,
+        context: NetworkLogDrainContext<'_>,
+        wait: Duration,
+    ) -> NetworkLogDrainOutcome {
         let (ack_tx, ack_rx) = oneshot::channel();
         match timeout(wait, self.tx.send(NetworkLogDrainRequest { ack: ack_tx })).await {
             Ok(Ok(())) => {}
             Ok(Err(_)) => {
                 warn_drain!(context, self.name, "network log drain producer unavailable");
-                return;
+                return NetworkLogDrainOutcome::ProducerUnavailable;
             }
             Err(_) => {
                 warn_drain!(
@@ -119,14 +167,15 @@ impl NetworkLogDrainProducer {
                     timeout_ms = wait.as_millis(),
                     "network log drain request timed out"
                 );
-                return;
+                return NetworkLogDrainOutcome::RequestTimeout;
             }
         }
 
         match timeout(wait, ack_rx).await {
-            Ok(Ok(())) => {}
+            Ok(Ok(())) => NetworkLogDrainOutcome::Acknowledged,
             Ok(Err(_)) => {
-                warn_drain!(context, self.name, "network log drain producer dropped ack")
+                warn_drain!(context, self.name, "network log drain producer dropped ack");
+                NetworkLogDrainOutcome::AckDropped
             }
             Err(_) => {
                 warn_drain!(
@@ -134,7 +183,8 @@ impl NetworkLogDrainProducer {
                     self.name,
                     timeout_ms = wait.as_millis(),
                     "network log drain producer timed out"
-                )
+                );
+                NetworkLogDrainOutcome::AckTimeout
             }
         }
     }
@@ -331,6 +381,96 @@ mod tests {
             path,
             generation: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn drain_reports_acknowledged_producers_and_unconfigured_names() {
+        let path = Path::new("network.jsonl");
+        let (dns, mut dns_rx) = NetworkLogDrainProducer::channel("dns");
+        let (kmsg, mut kmsg_rx) = NetworkLogDrainProducer::channel("kmsg");
+        let acknowledge = tokio::spawn(async move {
+            dns_rx.recv().await.unwrap().ack();
+            kmsg_rx.recv().await.unwrap().ack();
+        });
+
+        let report = NetworkLogDrainCoordinator::new(vec![dns, kmsg])
+            .drain(drain_context(path))
+            .await;
+        acknowledge.await.unwrap();
+
+        assert_eq!(report.status("dns"), "acknowledged");
+        assert_eq!(report.status("kmsg"), "acknowledged");
+        assert_eq!(report.status("other"), "not_configured");
+        assert_eq!(
+            NetworkLogDrainCoordinator::noop()
+                .drain(drain_context(path))
+                .await
+                .status("dns"),
+            "not_configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn producer_drain_reports_unavailable() {
+        let path = Path::new("network.jsonl");
+        let (producer, drain_rx) = NetworkLogDrainProducer::channel("dns");
+        drop(drain_rx);
+
+        let outcome = producer
+            .drain(drain_context(path), Duration::from_secs(1))
+            .await;
+
+        assert_eq!(outcome, NetworkLogDrainOutcome::ProducerUnavailable);
+    }
+
+    #[tokio::test]
+    async fn producer_drain_reports_request_timeout() {
+        let path = Path::new("network.jsonl");
+        let (producer, _drain_rx) = NetworkLogDrainProducer::channel("dns");
+        let mut acknowledgements = Vec::new();
+        for _ in 0..64 {
+            let (ack, ack_rx) = oneshot::channel();
+            producer
+                .tx
+                .try_send(NetworkLogDrainRequest { ack })
+                .unwrap();
+            acknowledgements.push(ack_rx);
+        }
+
+        let outcome = producer
+            .drain(drain_context(path), Duration::from_millis(1))
+            .await;
+
+        assert_eq!(outcome, NetworkLogDrainOutcome::RequestTimeout);
+        drop(acknowledgements);
+    }
+
+    #[tokio::test]
+    async fn producer_drain_reports_dropped_ack() {
+        let path = Path::new("network.jsonl");
+        let (producer, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
+        let drop_ack = tokio::spawn(async move {
+            drop(drain_rx.recv().await.unwrap());
+        });
+
+        let outcome = producer
+            .drain(drain_context(path), Duration::from_secs(1))
+            .await;
+        drop_ack.await.unwrap();
+
+        assert_eq!(outcome, NetworkLogDrainOutcome::AckDropped);
+    }
+
+    #[tokio::test]
+    async fn producer_drain_reports_ack_timeout() {
+        let path = Path::new("network.jsonl");
+        let (producer, _drain_rx) = NetworkLogDrainProducer::channel("dns");
+
+        let outcome = producer
+            .drain(drain_context(path), Duration::from_millis(1))
+            .await;
+
+        assert_eq!(outcome, NetworkLogDrainOutcome::AckTimeout);
     }
 
     #[tokio::test]

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
+use tokio::sync::mpsc::error::TrySendError;
 #[cfg(test)]
 use tokio::sync::{Notify, Semaphore};
 use tracing::warn;
@@ -70,6 +71,22 @@ pub struct NetworkLogSession {
     closed: bool,
 }
 
+/// Failure-scoped state observed while closing one network-log session.
+pub struct NetworkLogCloseObservation {
+    drain: crate::network_log_drain::NetworkLogDrainReport,
+    writer_backpressure_observed: bool,
+}
+
+impl NetworkLogCloseObservation {
+    pub(crate) fn drain_status(&self, producer: &str) -> &'static str {
+        self.drain.status(producer)
+    }
+
+    pub(crate) fn writer_backpressure_observed(&self) -> bool {
+        self.writer_backpressure_observed
+    }
+}
+
 impl NetworkLogSession {
     /// Close local Rust-side network logs for this run before upload reads the file.
     ///
@@ -81,12 +98,16 @@ impl NetworkLogSession {
     /// before the final path flush. Rows accepted before finalization remain
     /// tracked by the path pending count; rows racing after finalization are
     /// rejected instead of being missed by upload.
-    pub async fn close_for_upload(mut self, run_id: RunId, drain: &NetworkLogDrainCoordinator) {
+    pub async fn close_for_upload(
+        mut self,
+        run_id: RunId,
+        drain: &NetworkLogDrainCoordinator,
+    ) -> NetworkLogCloseObservation {
         let current = self
             .manager
             .begin_session_drain(&self.source_ip, &self.path, self.generation)
             .await;
-        if current {
+        let drain = if current {
             drain
                 .drain(NetworkLogDrainContext {
                     run_id,
@@ -94,15 +115,22 @@ impl NetworkLogSession {
                     path: &self.path,
                     generation: self.generation,
                 })
-                .await;
-        }
-        self.manager
+                .await
+        } else {
+            Default::default()
+        };
+        let writer_backpressure_observed = self
+            .manager
             .finalize_session(&self.source_ip, &self.path, self.generation)
             .await;
         #[cfg(test)]
         self.manager.before_close_upload_flush_for_test().await;
         self.manager.flush_path(&self.path).await;
         self.closed = true;
+        NetworkLogCloseObservation {
+            drain,
+            writer_backpressure_observed,
+        }
     }
 }
 
@@ -233,9 +261,25 @@ impl NetworkLogManager {
             warn!("network log writer pool has no shards");
             return false;
         };
-        let permit = match sender.reserve_owned().await {
+        let permit = match sender.try_reserve_owned() {
             Ok(permit) => permit,
-            Err(_) => {
+            Err(TrySendError::Full(sender)) => {
+                self.inner
+                    .state
+                    .mark_writer_backpressure(source_ip, &snapshot)
+                    .await;
+                match sender.reserve_owned().await {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        warn!(
+                            path = %snapshot.path.display(),
+                            "network log writer shard closed before append was accepted"
+                        );
+                        return false;
+                    }
+                }
+            }
+            Err(TrySendError::Closed(_)) => {
                 warn!(
                     path = %snapshot.path.display(),
                     "network log writer shard closed before append was accepted"
@@ -278,11 +322,11 @@ impl NetworkLogManager {
             .await
     }
 
-    async fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) {
+    async fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
         self.inner
             .state
             .finalize_session(source_ip, path, generation)
-            .await;
+            .await
     }
 
     /// Wait until all currently accepted Rust-side writes for `path` finish.
@@ -683,6 +727,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queue_full_is_reported_without_losing_or_reordering_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let manager = NetworkLogManager::new_with_write_gate_and_config(
+            started.clone(),
+            release.clone(),
+            WriterConfig {
+                shards: 1,
+                queue_capacity: 1,
+                max_batch_rows: 1,
+                max_batch_bytes: DEFAULT_MAX_BATCH_BYTES,
+            },
+        );
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","index":1}))
+                .await
+        );
+        started.notified().await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","index":2}))
+                .await
+        );
+
+        let third = manager.append_for_ip("10.200.0.2", json!({"type":"dns","index":3}));
+        let mut third = std::pin::pin!(third);
+        assert!(
+            poll_fn(|cx| match third.as_mut().poll(cx) {
+                Poll::Ready(_) => Poll::Ready(false),
+                Poll::Pending => Poll::Ready(true),
+            })
+            .await
+        );
+
+        release.add_permits(3);
+        assert!(third.await);
+        let observation = session
+            .close_for_upload(RunId::nil(), &NetworkLogDrainCoordinator::noop())
+            .await;
+
+        assert!(observation.writer_backpressure_observed());
+        let indices: Vec<u64> = read_json_lines(&path)
+            .iter()
+            .map(|line| line["index"].as_u64().unwrap())
+            .collect();
+        assert_eq!(indices, [1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn immediately_reserved_session_reports_no_writer_backpressure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let manager = NetworkLogManager::new();
+        let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"ready.test"}))
+                .await
+        );
+
+        let observation = session
+            .close_for_upload(RunId::nil(), &NetworkLogDrainCoordinator::noop())
+            .await;
+
+        assert!(!observation.writer_backpressure_observed());
+        assert_eq!(observation.drain_status("dns"), "not_configured");
+    }
+
+    #[tokio::test]
     async fn queue_full_rejects_row_after_source_reregister_same_path() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("network.jsonl");
@@ -725,7 +842,7 @@ mod tests {
         );
 
         manager.unregister_source_ip("10.200.0.2").await;
-        let _new_session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+        let new_session = manager.register_source_ip("10.200.0.2", path.clone()).await;
         release.add_permits(2);
         assert!(
             !third.await,
@@ -739,6 +856,13 @@ mod tests {
             .map(|line| line["host"].as_str().unwrap())
             .collect();
         assert_eq!(hosts, ["first.test", "second.test"]);
+        let observation = new_session
+            .close_for_upload(RunId::nil(), &NetworkLogDrainCoordinator::noop())
+            .await;
+        assert!(
+            !observation.writer_backpressure_observed(),
+            "an old source generation must not mark its replacement"
+        );
     }
 
     #[tokio::test]
@@ -942,9 +1066,10 @@ mod tests {
         drop(drain_rx);
         let drain = NetworkLogDrainCoordinator::new(vec![producer]);
 
-        session.close_for_upload(RunId::nil(), &drain).await;
+        let observation = session.close_for_upload(RunId::nil(), &drain).await;
 
         assert!(!source_ip_registered(&manager, "10.200.0.2").await);
+        assert_eq!(observation.drain_status("closed"), "producer_unavailable");
         assert!(
             !manager
                 .append_for_ip(
@@ -968,10 +1093,11 @@ mod tests {
             drop(request);
         });
 
-        session.close_for_upload(RunId::nil(), &drain).await;
+        let observation = session.close_for_upload(RunId::nil(), &drain).await;
         receiver.await.unwrap();
 
         assert!(!source_ip_registered(&manager, "10.200.0.2").await);
+        assert_eq!(observation.drain_status("dropped-ack"), "ack_dropped");
         assert!(
             !manager
                 .append_for_ip(
@@ -999,11 +1125,12 @@ mod tests {
             Duration::from_millis(1),
         );
 
-        session.close_for_upload(RunId::nil(), &drain).await;
+        let observation = session.close_for_upload(RunId::nil(), &drain).await;
 
         let lines = read_json_lines(&path);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "accepted.test");
+        assert_eq!(observation.drain_status("held"), "ack_timeout");
         assert!(
             !manager
                 .append_for_ip(

--- a/crates/runner/src/network_log_manager/state.rs
+++ b/crates/runner/src/network_log_manager/state.rs
@@ -18,8 +18,16 @@ struct State {
 }
 
 enum SourceState {
-    Active { path: PathBuf, generation: u64 },
-    Draining { path: PathBuf, generation: u64 },
+    Active {
+        path: PathBuf,
+        generation: u64,
+        writer_backpressure_observed: bool,
+    },
+    Draining {
+        path: PathBuf,
+        generation: u64,
+        writer_backpressure_observed: bool,
+    },
 }
 
 impl SourceState {
@@ -37,6 +45,19 @@ impl SourceState {
 
     fn matches(&self, path: &Path, generation: u64) -> bool {
         self.generation() == generation && self.path() == path
+    }
+
+    fn writer_backpressure_observed(&self) -> bool {
+        match self {
+            Self::Active {
+                writer_backpressure_observed,
+                ..
+            }
+            | Self::Draining {
+                writer_backpressure_observed,
+                ..
+            } => *writer_backpressure_observed,
+        }
     }
 }
 
@@ -113,6 +134,7 @@ impl NetworkLogState {
             SourceState::Active {
                 path: path.clone(),
                 generation,
+                writer_backpressure_observed: false,
             },
         );
         SourceRegistration {
@@ -166,6 +188,30 @@ impl NetworkLogState {
         })
     }
 
+    pub(super) async fn mark_writer_backpressure(
+        &self,
+        source_ip: &str,
+        snapshot: &SourceSnapshot,
+    ) {
+        let mut state = self.state.lock().await;
+        let Some(source_state) = state.source_paths.get_mut(source_ip) else {
+            return;
+        };
+        if !source_state.matches(&snapshot.path, snapshot.generation) {
+            return;
+        }
+        match source_state {
+            SourceState::Active {
+                writer_backpressure_observed,
+                ..
+            }
+            | SourceState::Draining {
+                writer_backpressure_observed,
+                ..
+            } => *writer_backpressure_observed = true,
+        }
+    }
+
     pub(super) async fn begin_session_drain(
         &self,
         source_ip: &str,
@@ -179,24 +225,34 @@ impl NetworkLogState {
         if !source_state.matches(path, generation) {
             return false;
         }
+        let writer_backpressure_observed = source_state.writer_backpressure_observed();
         state.source_paths.insert(
             source_ip.to_string(),
             SourceState::Draining {
                 path: path.to_path_buf(),
                 generation,
+                writer_backpressure_observed,
             },
         );
         true
     }
 
-    pub(super) async fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) {
+    pub(super) async fn finalize_session(
+        &self,
+        source_ip: &str,
+        path: &Path,
+        generation: u64,
+    ) -> bool {
         let mut state = self.state.lock().await;
         let Some(source_state) = state.source_paths.get(source_ip) else {
-            return;
+            return false;
         };
-        if source_state.matches(path, generation) {
-            state.source_paths.remove(source_ip);
+        if !source_state.matches(path, generation) {
+            return false;
         }
+        let writer_backpressure_observed = source_state.writer_backpressure_observed();
+        state.source_paths.remove(source_ip);
+        writer_backpressure_observed
     }
 
     pub(super) async fn flush_path(&self, path: &Path) {

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -42,7 +42,7 @@ pub(crate) struct GuestDnsFailureDiagnosticContext<'a> {
     pub(crate) startup_mode: &'static str,
 }
 
-pub(crate) async fn capture_guest_dns_failure_snapshot(
+pub(crate) async fn capture_guest_dns_failure_diagnostics(
     guest: &VsockHost,
     context: GuestDnsFailureDiagnosticContext<'_>,
 ) {
@@ -63,7 +63,7 @@ pub(crate) async fn capture_guest_dns_failure_snapshot(
             "guest DNS failure diagnostic snapshot timed out"
         );
     }
-    capture_host_namespace_readiness(context).await;
+    run_host_namespace_control_probe(context).await;
 }
 
 async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
@@ -195,7 +195,7 @@ async fn capture_pool_filter_rules(program: &str, args: &[&str], comment: Option
     )
 }
 
-async fn capture_host_namespace_readiness(context: GuestDnsFailureDiagnosticContext<'_>) {
+async fn run_host_namespace_control_probe(context: GuestDnsFailureDiagnosticContext<'_>) {
     let started = Instant::now();
     let output = match probe_namespace_dns_diagnostic(
         context.namespace.to_string(),

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -1,11 +1,16 @@
 //! Bounded passive evidence for terminal guest DNS readiness failures.
 
-use std::time::Duration;
+use std::future::Future;
+use std::time::{Duration, Instant};
 
 use tracing::warn;
 use vsock_host::{ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput, VsockHost};
 
 use crate::command::{CommandError, exec_with_timeout};
+use crate::duration::duration_ms;
+use crate::network::{
+    make_pool_dns_filter_comment, parse_netns_name, probe_namespace_dns_diagnostic,
+};
 
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(2);
 const HOST_COMMAND_TIMEOUT: Duration = Duration::from_millis(1_500);
@@ -14,6 +19,7 @@ const GUEST_WAIT_TIMEOUT: Duration = Duration::from_millis(1_750);
 const GUEST_OUTPUT_LIMIT_BYTES: u32 = 4 * 1024;
 const LOG_OUTPUT_LIMIT_BYTES: usize = 4 * 1024;
 const GUEST_DIAGNOSTIC_LABEL: &str = "guest-dns-failure-diagnostics";
+const CONTROL_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 const GUEST_STATE_COMMAND: &str = r#"set +e
 /usr/sbin/ip -details -statistics link show dev eth0 2>&1
@@ -33,33 +39,55 @@ pub(crate) struct GuestDnsFailureDiagnosticContext<'a> {
     pub(crate) host_device: &'a str,
     pub(crate) peer_ip: &'a str,
     pub(crate) dns_port: u16,
+    pub(crate) attachment_generation: u64,
+    pub(crate) startup_mode: &'static str,
 }
 
 pub(crate) async fn capture_guest_dns_failure_snapshot(
     guest: &VsockHost,
     context: GuestDnsFailureDiagnosticContext<'_>,
 ) {
-    if tokio::time::timeout(SNAPSHOT_TIMEOUT, capture_snapshot(guest, context))
-        .await
-        .is_err()
-    {
-        warn!(
-            id = context.sandbox_id,
-            profile = context.profile,
-            namespace = context.namespace,
-            host_device = context.host_device,
-            peer_ip = context.peer_ip,
-            dns_port = context.dns_port,
-            timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
-            "guest DNS failure diagnostic snapshot timed out"
-        );
-    }
+    capture_passive_then_control(
+        async {
+            if tokio::time::timeout(SNAPSHOT_TIMEOUT, capture_snapshot(guest, context))
+                .await
+                .is_err()
+            {
+                warn!(
+                    id = context.sandbox_id,
+                    profile = context.profile,
+                    namespace = context.namespace,
+                    host_device = context.host_device,
+                    peer_ip = context.peer_ip,
+                    dns_port = context.dns_port,
+                    attachment_generation = context.attachment_generation,
+                    startup_mode = context.startup_mode,
+                    timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
+                    "guest DNS failure diagnostic snapshot timed out"
+                );
+            }
+        },
+        || capture_host_namespace_readiness(context),
+    )
+    .await;
+}
+
+async fn capture_passive_then_control<P, C, CF>(passive: P, control: C)
+where
+    P: Future<Output = ()>,
+    C: FnOnce() -> CF,
+    CF: Future<Output = ()>,
+{
+    passive.await;
+    control().await;
 }
 
 async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
     let namespace = context.namespace;
     let peer_ip = context.peer_ip;
-    let listener_filter = format!("sport = :{}", context.dns_port);
+    let listener_port = format!(":{}", context.dns_port);
+    let pool_filter_comment =
+        parse_netns_name(namespace).map(|parsed| make_pool_dns_filter_comment(parsed.pool_index));
 
     let namespace_links_args = [
         "netns",
@@ -82,9 +110,21 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
     ];
     let raw_rules_args = ["-c", "-t", "raw"];
     let nat_rules_args = ["-c", "-t", "nat"];
+    let filter_rules_args = ["-c", "-t", "filter"];
     let conntrack_source_args = ["-L", "-s", peer_ip];
     let conntrack_destination_args = ["-L", "-d", peer_ip];
-    let listener_args = ["-H", "-lunt", listener_filter.as_str()];
+    let namespace_conntrack_args = [
+        "netns",
+        "exec",
+        namespace,
+        "conntrack",
+        "-L",
+        "-p",
+        "udp",
+        "--dport",
+        "53",
+    ];
+    let listener_args = ["-H", "-luntpm", "sport", "=", listener_port.as_str()];
 
     let (
         guest_state,
@@ -92,8 +132,11 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
         namespace_nat,
         host_raw_rules,
         host_nat_rules,
+        host_filter_rules_ipv4,
+        host_filter_rules_ipv6,
         conntrack_source,
         conntrack_destination,
+        namespace_dns_conntrack,
         dnsmasq_listener,
     ) = tokio::join!(
         capture_guest_state(guest),
@@ -101,12 +144,23 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
         exec_with_timeout("ip", &namespace_nat_args, HOST_COMMAND_TIMEOUT),
         exec_with_timeout("iptables-save", &raw_rules_args, HOST_COMMAND_TIMEOUT),
         exec_with_timeout("iptables-save", &nat_rules_args, HOST_COMMAND_TIMEOUT),
+        capture_pool_filter_rules(
+            "iptables-save",
+            &filter_rules_args,
+            pool_filter_comment.as_deref(),
+        ),
+        capture_pool_filter_rules(
+            "ip6tables-save",
+            &filter_rules_args,
+            pool_filter_comment.as_deref(),
+        ),
         exec_with_timeout("conntrack", &conntrack_source_args, HOST_COMMAND_TIMEOUT),
         exec_with_timeout(
             "conntrack",
             &conntrack_destination_args,
             HOST_COMMAND_TIMEOUT,
         ),
+        exec_with_timeout("ip", &namespace_conntrack_args, HOST_COMMAND_TIMEOUT),
         exec_with_timeout("ss", &listener_args, HOST_COMMAND_TIMEOUT),
     );
 
@@ -123,6 +177,8 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
         "host_nat_rules",
         filtered_command_output(host_nat_rules, namespace),
     );
+    log_component(context, "host_filter_rules_ipv4", host_filter_rules_ipv4);
+    log_component(context, "host_filter_rules_ipv6", host_filter_rules_ipv6);
     log_component(
         context,
         "conntrack_source",
@@ -135,9 +191,47 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
     );
     log_component(
         context,
+        "namespace_dns_conntrack",
+        command_output(namespace_dns_conntrack),
+    );
+    log_component(
+        context,
         "dnsmasq_listener",
         command_output(dnsmasq_listener),
     );
+}
+
+async fn capture_pool_filter_rules(program: &str, args: &[&str], comment: Option<&str>) -> String {
+    let Some(comment) = comment else {
+        return "identity_error=invalid_namespace".to_string();
+    };
+    filtered_command_output(
+        exec_with_timeout(program, args, HOST_COMMAND_TIMEOUT).await,
+        comment,
+    )
+}
+
+async fn capture_host_namespace_readiness(context: GuestDnsFailureDiagnosticContext<'_>) {
+    let started = Instant::now();
+    let output = match probe_namespace_dns_diagnostic(
+        context.namespace.to_string(),
+        CONTROL_PROBE_TIMEOUT,
+    )
+    .await
+    {
+        Ok(attempts) => format!(
+            "diagnostic_traffic=true success=true attempts={attempts} elapsed_ms={}",
+            duration_ms(started.elapsed()),
+        ),
+        Err(error) => format!(
+            "diagnostic_traffic=true success=false stage={} io_kind={:?} attempts={} elapsed_ms={}",
+            error.stage_label(),
+            error.io_kind(),
+            error.attempts(),
+            duration_ms(started.elapsed()),
+        ),
+    };
+    log_component(context, "host_namespace_readiness", output);
 }
 
 async fn capture_guest_state(guest: &VsockHost) -> String {
@@ -245,6 +339,8 @@ fn log_component(
         host_device = context.host_device,
         peer_ip = context.peer_ip,
         dns_port = context.dns_port,
+        attachment_generation = context.attachment_generation,
+        startup_mode = context.startup_mode,
         component,
         output,
         "guest DNS failure diagnostic component"
@@ -254,6 +350,62 @@ fn log_component(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn control_probe_starts_only_after_passive_capture_finishes() {
+        let passive_entered = Arc::new(tokio::sync::Notify::new());
+        let passive_release = Arc::new(tokio::sync::Notify::new());
+        let control_started = Arc::new(AtomicUsize::new(0));
+        let entered = passive_entered.notified();
+        let task = tokio::spawn(capture_passive_then_control(
+            {
+                let passive_entered = Arc::clone(&passive_entered);
+                let passive_release = Arc::clone(&passive_release);
+                async move {
+                    passive_entered.notify_one();
+                    passive_release.notified().await;
+                }
+            },
+            {
+                let control_started = Arc::clone(&control_started);
+                move || async move {
+                    control_started.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        ));
+
+        entered.await;
+        assert_eq!(control_started.load(Ordering::SeqCst), 0);
+        passive_release.notify_one();
+        task.await.unwrap();
+        assert_eq!(control_started.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn control_probe_starts_after_passive_capture_times_out() {
+        let control_started = Arc::new(AtomicUsize::new(0));
+
+        capture_passive_then_control(
+            async {
+                assert!(
+                    tokio::time::timeout(Duration::from_millis(1), std::future::pending::<()>(),)
+                        .await
+                        .is_err()
+                );
+            },
+            {
+                let control_started = Arc::clone(&control_started);
+                move || async move {
+                    control_started.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(control_started.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn bounded_output_truncates_at_utf8_boundary() {
@@ -284,5 +436,28 @@ mod tests {
             filtered,
             "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP"
         );
+    }
+
+    #[test]
+    fn filtered_command_output_keeps_only_exact_pool_dns_rules() {
+        let comment = "vm0-ns-0c-dns";
+        let output = [
+            "-A INPUT -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns",
+            "-A INPUT ! -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns -j REJECT",
+            "-A INPUT -i vm0-ve-0b-+ -p udp --dport 5353 -m comment --comment vm0-ns-0b-dns",
+            "-A INPUT -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns-old",
+        ]
+        .join("\n");
+
+        let filtered = filtered_command_output(Ok(output), comment);
+
+        assert_eq!(filtered.lines().count(), 2);
+        assert!(
+            filtered
+                .lines()
+                .all(|line| line_has_exact_comment(line, comment))
+        );
+        assert!(filtered.contains("-j REJECT"));
+        assert!(filtered.lines().any(|line| !line.contains("-j")));
     }
 }

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -1,6 +1,5 @@
-//! Bounded passive evidence for terminal guest DNS readiness failures.
+//! Bounded evidence and namespace control for terminal guest DNS readiness failures.
 
-use std::future::Future;
 use std::time::{Duration, Instant};
 
 use tracing::warn;
@@ -47,39 +46,24 @@ pub(crate) async fn capture_guest_dns_failure_snapshot(
     guest: &VsockHost,
     context: GuestDnsFailureDiagnosticContext<'_>,
 ) {
-    capture_passive_then_control(
-        async {
-            if tokio::time::timeout(SNAPSHOT_TIMEOUT, capture_snapshot(guest, context))
-                .await
-                .is_err()
-            {
-                warn!(
-                    id = context.sandbox_id,
-                    profile = context.profile,
-                    namespace = context.namespace,
-                    host_device = context.host_device,
-                    peer_ip = context.peer_ip,
-                    dns_port = context.dns_port,
-                    attachment_generation = context.attachment_generation,
-                    startup_mode = context.startup_mode,
-                    timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
-                    "guest DNS failure diagnostic snapshot timed out"
-                );
-            }
-        },
-        || capture_host_namespace_readiness(context),
-    )
-    .await;
-}
-
-async fn capture_passive_then_control<P, C, CF>(passive: P, control: C)
-where
-    P: Future<Output = ()>,
-    C: FnOnce() -> CF,
-    CF: Future<Output = ()>,
-{
-    passive.await;
-    control().await;
+    if tokio::time::timeout(SNAPSHOT_TIMEOUT, capture_snapshot(guest, context))
+        .await
+        .is_err()
+    {
+        warn!(
+            id = context.sandbox_id,
+            profile = context.profile,
+            namespace = context.namespace,
+            host_device = context.host_device,
+            peer_ip = context.peer_ip,
+            dns_port = context.dns_port,
+            attachment_generation = context.attachment_generation,
+            startup_mode = context.startup_mode,
+            timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
+            "guest DNS failure diagnostic snapshot timed out"
+        );
+    }
+    capture_host_namespace_readiness(context).await;
 }
 
 async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
@@ -350,62 +334,6 @@ fn log_component(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    #[tokio::test]
-    async fn control_probe_starts_only_after_passive_capture_finishes() {
-        let passive_entered = Arc::new(tokio::sync::Notify::new());
-        let passive_release = Arc::new(tokio::sync::Notify::new());
-        let control_started = Arc::new(AtomicUsize::new(0));
-        let entered = passive_entered.notified();
-        let task = tokio::spawn(capture_passive_then_control(
-            {
-                let passive_entered = Arc::clone(&passive_entered);
-                let passive_release = Arc::clone(&passive_release);
-                async move {
-                    passive_entered.notify_one();
-                    passive_release.notified().await;
-                }
-            },
-            {
-                let control_started = Arc::clone(&control_started);
-                move || async move {
-                    control_started.fetch_add(1, Ordering::SeqCst);
-                }
-            },
-        ));
-
-        entered.await;
-        assert_eq!(control_started.load(Ordering::SeqCst), 0);
-        passive_release.notify_one();
-        task.await.unwrap();
-        assert_eq!(control_started.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn control_probe_starts_after_passive_capture_times_out() {
-        let control_started = Arc::new(AtomicUsize::new(0));
-
-        capture_passive_then_control(
-            async {
-                assert!(
-                    tokio::time::timeout(Duration::from_millis(1), std::future::pending::<()>(),)
-                        .await
-                        .is_err()
-                );
-            },
-            {
-                let control_started = Arc::clone(&control_started);
-                move || async move {
-                    control_started.fetch_add(1, Ordering::SeqCst);
-                }
-            },
-        )
-        .await;
-
-        assert_eq!(control_started.load(Ordering::SeqCst), 1);
-    }
 
     #[test]
     fn bounded_output_truncates_at_utf8_boundary() {

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -57,8 +57,8 @@ pub use config::{
 pub use control::FirecrackerControl;
 pub use factory::{PREWARM_SCRIPT, config_hash};
 pub use network::{
-    DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4, NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig,
-    ParsedNetnsName, parse_netns_name,
+    DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4, NetnsInfo, NetnsLease,
+    NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -5,8 +5,9 @@ mod readiness;
 
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
-pub(crate) use pool::NetnsPoolHandle;
 pub use pool::{
     NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
-pub use readiness::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
+pub(crate) use pool::{NetnsPoolHandle, make_pool_dns_filter_comment};
+pub(crate) use readiness::probe_namespace_dns_diagnostic;
+pub use readiness::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -45,6 +45,7 @@ mod naming;
 mod state;
 mod types;
 
+pub(crate) use naming::make_pool_dns_filter_comment;
 pub use naming::{ParsedNetnsName, parse_netns_name};
 pub use state::NetnsPool;
 pub(crate) use state::NetnsPoolHandle;

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -20,7 +20,8 @@ use super::super::error::{NetworkError, Result};
 use super::super::{GUEST_NETWORK, GuestNetwork};
 use super::naming::{
     MAX_NAMESPACES, MAX_POOLS, NS_PREFIX, format_hex_index, generate_veth_ip_pair,
-    make_host_device, make_host_device_iptables_pattern, make_ns_name, parse_netns_name,
+    make_host_device, make_host_device_iptables_pattern, make_ns_name,
+    make_pool_dns_filter_comment, parse_netns_name,
 };
 use super::types::NetnsInfo;
 
@@ -145,27 +146,34 @@ async fn exec_xtables_ignore_errors_with_timeout(
     exec_ignore_errors_with_timeout(program, &args, timeout).await
 }
 
-/// Restrict the runner-managed DNS port to this pool's VM-facing veths.
+/// Observe and restrict the runner-managed DNS port by pool-facing interface.
 ///
 /// dnsmasq's default socket mode avoids per-address listener churn by using
 /// wildcard sockets. These INPUT rules preserve the old kernel-level listener
 /// isolation: public, management, and other runners' interfaces see the port as
-/// unreachable, while REDIRECT traffic arriving on this pool's veths proceeds
-/// to dnsmasq. Both address families are covered because dnsmasq can create
-/// IPv4 and IPv6 wildcard sockets.
+/// unreachable, while REDIRECT traffic arriving on this pool's veths increments
+/// a counter-only rule and continues to dnsmasq under the later INPUT policy.
+/// Both address families are covered because dnsmasq can create IPv4 and IPv6
+/// wildcard sockets.
 pub(super) async fn setup_dns_input_filter(pool_index: u32, dns_port: u16) -> Result<String> {
     let pool_idx = format_hex_index(pool_index);
     let interface = make_host_device_iptables_pattern(&pool_idx);
-    let comment = format!("{NS_PREFIX}{pool_idx}-dns");
+    let comment = make_pool_dns_filter_comment(pool_index);
     let firewall = vec![FirewallRestoreTable {
         table: "filter",
         rules: ["udp", "tcp"]
-            .map(|protocol| {
-                format!(
-                    "-I INPUT 1 ! -i {interface} -p {protocol} --dport {dns_port} -m comment --comment {comment} -j REJECT"
-                )
+            .into_iter()
+            .flat_map(|protocol| {
+                [
+                    format!(
+                        "-I INPUT 1 -i {interface} -p {protocol} --dport {dns_port} -m comment --comment {comment}"
+                    ),
+                    format!(
+                        "-I INPUT 1 ! -i {interface} -p {protocol} --dport {dns_port} -m comment --comment {comment} -j REJECT"
+                    ),
+                ]
             })
-            .into(),
+            .collect(),
     }];
     let (ipv4, ipv6) = tokio::join!(
         apply_firewall_rules_with_restore("iptables-restore", &firewall),

--- a/crates/sandbox-fc/src/network/pool/naming.rs
+++ b/crates/sandbox-fc/src/network/pool/naming.rs
@@ -43,6 +43,10 @@ pub(super) fn make_host_device_iptables_pattern(pool_idx: &str) -> String {
     format!("{HOST_PREFIX}{pool_idx}-+")
 }
 
+pub(crate) fn make_pool_dns_filter_comment(pool_index: u32) -> String {
+    format!("{NS_PREFIX}{}-dns", format_hex_index(pool_index))
+}
+
 /// Generate a unique /30 IP pair for a veth link.
 ///
 /// Each namespace gets a /30 subnet from the `10.200.0.0/16` range:
@@ -130,6 +134,11 @@ mod tests {
     #[test]
     fn make_host_device_formats_correctly() {
         assert_eq!(make_host_device("01", "ff"), "vm0-ve-01-ff");
+    }
+
+    #[test]
+    fn make_pool_dns_filter_comment_formats_correctly() {
+        assert_eq!(make_pool_dns_filter_comment(12), "vm0-ns-0c-dns");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -514,10 +514,11 @@ impl NetnsPoolState {
         }
     }
 
-    fn checkout(&mut self, info: NetnsInfo) -> std::result::Result<NetnsLease, NetnsInfo> {
+    fn checkout(&mut self, mut info: NetnsInfo) -> std::result::Result<NetnsLease, NetnsInfo> {
         if !self.in_flight.insert(info.name.clone()) {
             return Err(info);
         }
+        info.attachment_generation = info.attachment_generation.saturating_add(1);
         Ok(NetnsLease::new(info, self.instance_id))
     }
 
@@ -2634,6 +2635,27 @@ mod tests {
         assert!(pool.in_flight.is_empty());
         assert_eq!(pool.plain_queue.len(), 1);
         assert_eq!(pool.plain_queue.front().unwrap().name(), "ready-ns");
+    }
+
+    #[tokio::test]
+    async fn attachment_generation_increments_when_namespace_is_reused() {
+        let mut pool = NetnsPoolState::inactive_for_test();
+        pool.active = true;
+        pool.ops = NetnsLifecycleOps::trusted_for_test();
+        let first = pool.checkout(test_info("reused-ns")).unwrap();
+        assert_eq!(first.info().attachment_generation(), 1);
+        let mut first = Some(first);
+        let handle = NetnsPoolHandle::from_state_for_test(pool);
+
+        let outcome = handle.release(&mut first).await;
+        assert!(matches!(outcome, NetnsReleaseOutcome::Released));
+
+        let second = {
+            let mut pool = handle.inner.state.lock().await;
+            let info = pool.plain_queue.pop_front().unwrap();
+            pool.checkout(info).unwrap()
+        };
+        assert_eq!(second.info().attachment_generation(), 2);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -15,6 +15,8 @@ pub struct NetnsInfo {
     /// Veth namespace-side IP (e.g. `10.200.0.2`). This is the source IP
     /// that the proxy sees after NAT, used as the VM registry key.
     pub(super) peer_ip: String,
+    /// Process-local count of successful checkouts for this namespace.
+    pub(super) attachment_generation: u64,
 }
 
 impl NetnsInfo {
@@ -23,6 +25,7 @@ impl NetnsInfo {
             name,
             host_device,
             peer_ip,
+            attachment_generation: 0,
         }
     }
 
@@ -39,6 +42,11 @@ impl NetnsInfo {
     /// Returns the namespace-side veth IP used to identify the VM behind NAT.
     pub fn peer_ip(&self) -> &str {
         &self.peer_ip
+    }
+
+    /// Returns the process-local checkout generation for this attachment.
+    pub(crate) fn attachment_generation(&self) -> u64 {
+        self.attachment_generation
     }
 }
 

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -21,7 +21,7 @@ pub const DNS_READINESS_HOSTNAME: &str = "vm0-readiness.invalid";
 /// Local-only hostname reserved for post-failure namespace diagnostics.
 pub const DNS_DIAGNOSTIC_HOSTNAME: &str = "vm0-diagnostic.invalid";
 
-/// TEST-NET address returned for [`DNS_READINESS_HOSTNAME`].
+/// TEST-NET address returned for the readiness and diagnostic hostnames.
 pub const DNS_READINESS_IPV4: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
 
 pub(super) const DNS_READINESS_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -18,6 +18,9 @@ use crate::duration::duration_ms;
 /// Local-only hostname used to validate a namespace's DNS redirect path.
 pub const DNS_READINESS_HOSTNAME: &str = "vm0-readiness.invalid";
 
+/// Local-only hostname reserved for post-failure namespace diagnostics.
+pub const DNS_DIAGNOSTIC_HOSTNAME: &str = "vm0-diagnostic.invalid";
+
 /// TEST-NET address returned for [`DNS_READINESS_HOSTNAME`].
 pub const DNS_READINESS_IPV4: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
 
@@ -60,9 +63,9 @@ enum DnsReadinessStage {
     Timeout,
 }
 
-impl fmt::Display for DnsReadinessStage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
+impl DnsReadinessStage {
+    fn as_str(self) -> &'static str {
+        match self {
             Self::SpawnThread => "spawn_thread",
             Self::OpenCurrentNamespace => "open_current_namespace",
             Self::OpenTargetNamespace => "open_target_namespace",
@@ -77,7 +80,13 @@ impl fmt::Display for DnsReadinessStage {
             Self::RestoreNamespace => "restore_namespace",
             Self::WaitForThread => "wait_for_thread",
             Self::Timeout => "timeout",
-        })
+        }
+    }
+}
+
+impl fmt::Display for DnsReadinessStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -115,11 +124,15 @@ impl DnsReadinessError {
         self.stage
     }
 
-    fn io_kind(&self) -> Option<io::ErrorKind> {
+    pub(crate) fn stage_label(&self) -> &'static str {
+        self.stage.as_str()
+    }
+
+    pub(crate) fn io_kind(&self) -> Option<io::ErrorKind> {
         self.io_kind
     }
 
-    fn attempts(&self) -> u16 {
+    pub(crate) fn attempts(&self) -> u16 {
         self.attempts
     }
 
@@ -180,23 +193,42 @@ pub(super) async fn run_dns_readiness_probe(
 }
 
 pub(super) async fn probe_namespace_dns(namespace: String) -> Result<u16, DnsReadinessError> {
+    probe_namespace_dns_for_hostname(namespace, PROBE_TIMEOUT, DNS_READINESS_HOSTNAME).await
+}
+
+pub(crate) async fn probe_namespace_dns_diagnostic(
+    namespace: String,
+    probe_timeout: Duration,
+) -> Result<u16, DnsReadinessError> {
+    probe_namespace_dns_for_hostname(namespace, probe_timeout, DNS_DIAGNOSTIC_HOSTNAME).await
+}
+
+async fn probe_namespace_dns_for_hostname(
+    namespace: String,
+    probe_timeout: Duration,
+    hostname: &'static str,
+) -> Result<u16, DnsReadinessError> {
     let (tx, rx) = oneshot::channel();
     std::thread::Builder::new()
         .name("vm0-dns-readiness".into())
         .spawn(move || {
-            let result = probe_namespace_dns_blocking(&namespace);
+            let result = probe_namespace_dns_blocking(&namespace, probe_timeout, hostname);
             let _ = tx.send(result);
         })
         .map_err(|error| DnsReadinessError::io(DnsReadinessStage::SpawnThread, &error))?;
 
-    match tokio::time::timeout(PROBE_TIMEOUT + PROBE_THREAD_GRACE, rx).await {
+    match tokio::time::timeout(probe_timeout + PROBE_THREAD_GRACE, rx).await {
         Ok(Ok(result)) => result,
         Ok(Err(_)) => Err(DnsReadinessError::stage(DnsReadinessStage::WaitForThread)),
         Err(_) => Err(DnsReadinessError::stage(DnsReadinessStage::Timeout)),
     }
 }
 
-fn probe_namespace_dns_blocking(namespace: &str) -> Result<u16, DnsReadinessError> {
+fn probe_namespace_dns_blocking(
+    namespace: &str,
+    probe_timeout: Duration,
+    hostname: &str,
+) -> Result<u16, DnsReadinessError> {
     let current = File::open("/proc/self/ns/net")
         .map_err(|error| DnsReadinessError::io(DnsReadinessStage::OpenCurrentNamespace, &error))?;
     let target = File::open(Path::new(NETNS_DIR).join(namespace))
@@ -206,7 +238,8 @@ fn probe_namespace_dns_blocking(namespace: &str) -> Result<u16, DnsReadinessErro
 
     let result = probe_dns_endpoint(
         SocketAddrV4::new(DNS_READINESS_IPV4, DNS_PORT),
-        PROBE_TIMEOUT,
+        probe_timeout,
+        hostname,
     );
     let restore = setns(&current, CloneFlags::CLONE_NEWNET)
         .map_err(|errno| DnsReadinessError::errno(DnsReadinessStage::RestoreNamespace, errno));
@@ -218,6 +251,7 @@ fn probe_namespace_dns_blocking(namespace: &str) -> Result<u16, DnsReadinessErro
 fn probe_dns_endpoint(
     destination: SocketAddrV4,
     timeout: Duration,
+    hostname: &str,
 ) -> Result<u16, DnsReadinessError> {
     let socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
         .map_err(|error| DnsReadinessError::io(DnsReadinessStage::BindSocket, &error))?;
@@ -241,8 +275,8 @@ fn probe_dns_endpoint(
 
         attempts = attempts.saturating_add(1);
         let transaction_id = NEXT_TRANSACTION_ID.fetch_add(1, Ordering::Relaxed);
-        let query =
-            build_dns_query(transaction_id).map_err(|error| error.with_attempts(attempts))?;
+        let query = build_dns_query(transaction_id, hostname)
+            .map_err(|error| error.with_attempts(attempts))?;
         if let Err(error) = socket.send(&query) {
             last_error =
                 DnsReadinessError::io(DnsReadinessStage::SendQuery, &error).with_attempts(attempts);
@@ -287,7 +321,7 @@ fn sleep_before_retry(deadline: Instant) {
     }
 }
 
-fn build_dns_query(transaction_id: u16) -> Result<Vec<u8>, DnsReadinessError> {
+fn build_dns_query(transaction_id: u16, hostname: &str) -> Result<Vec<u8>, DnsReadinessError> {
     let mut query = Vec::with_capacity(64);
     query.extend_from_slice(&transaction_id.to_be_bytes());
     query.extend_from_slice(&DNS_QUERY_FLAGS_RECURSION_DESIRED.to_be_bytes());
@@ -295,7 +329,7 @@ fn build_dns_query(transaction_id: u16) -> Result<Vec<u8>, DnsReadinessError> {
     query.extend_from_slice(&0_u16.to_be_bytes());
     query.extend_from_slice(&0_u16.to_be_bytes());
     query.extend_from_slice(&0_u16.to_be_bytes());
-    for label in DNS_READINESS_HOSTNAME.split('.') {
+    for label in hostname.split('.') {
         let length = u8::try_from(label.len())
             .map_err(|_| DnsReadinessError::stage(DnsReadinessStage::BuildQuery))?;
         query.push(length);
@@ -422,7 +456,7 @@ mod tests {
 
     #[test]
     fn query_uses_readiness_name_and_a_record() {
-        let query = build_dns_query(0x1234).unwrap();
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
 
         assert_eq!(query.get(..2).unwrap(), &0x1234_u16.to_be_bytes());
         assert_eq!(
@@ -438,8 +472,24 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_query_uses_distinct_fixed_name() {
+        let query = build_dns_query(0x1234, DNS_DIAGNOSTIC_HOSTNAME).unwrap();
+
+        assert!(
+            query
+                .windows("vm0-diagnostic".len())
+                .any(|part| part == b"vm0-diagnostic")
+        );
+        assert!(
+            !query
+                .windows("vm0-readiness".len())
+                .any(|part| part == b"vm0-readiness")
+        );
+    }
+
+    #[test]
     fn response_validation_accepts_expected_compressed_a_record() {
-        let query = build_dns_query(0x1234).unwrap();
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
         let response = response_for_query(&query, DNS_READINESS_IPV4);
 
         validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).unwrap();
@@ -447,7 +497,7 @@ mod tests {
 
     #[test]
     fn response_validation_rejects_wrong_transaction_and_answer() {
-        let query = build_dns_query(0x1234).unwrap();
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
         let response = response_for_query(&query, Ipv4Addr::new(192, 0, 2, 2));
 
         assert!(validate_dns_response(&response, 0x4321, DNS_READINESS_IPV4).is_err());
@@ -456,7 +506,7 @@ mod tests {
 
     #[test]
     fn response_validation_rejects_truncated_name() {
-        let query = build_dns_query(0x1234).unwrap();
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
         let mut response = response_for_query(&query, DNS_READINESS_IPV4);
         response.truncate(13);
 
@@ -477,7 +527,7 @@ mod tests {
             server.send_to(&response, peer).unwrap();
         });
 
-        probe_dns_endpoint(destination, Duration::from_secs(1)).unwrap();
+        probe_dns_endpoint(destination, Duration::from_secs(1), DNS_READINESS_HOSTNAME).unwrap();
         server_thread.join().unwrap();
     }
 
@@ -497,7 +547,11 @@ mod tests {
             release_rx.recv().unwrap();
         });
 
-        let result = probe_dns_endpoint(destination, Duration::from_millis(30));
+        let result = probe_dns_endpoint(
+            destination,
+            Duration::from_millis(30),
+            DNS_READINESS_HOSTNAME,
+        );
 
         let received = received_rx.recv_timeout(Duration::from_secs(1));
         release_tx.send(()).unwrap();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -39,7 +39,7 @@ use crate::exec_operation_result::{
 };
 use crate::factory::InvariantConfig;
 use crate::guest_dns_failure_diagnostics::{
-    GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_snapshot,
+    GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_diagnostics,
 };
 use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
@@ -1270,7 +1270,7 @@ impl FirecrackerSandbox {
                 }
                 Err(error) => {
                     timing.record(SandboxStartStage::GuestDnsReadiness, dns_started, false);
-                    capture_guest_dns_failure_snapshot(
+                    capture_guest_dns_failure_diagnostics(
                         vsock_guest.as_ref(),
                         GuestDnsFailureDiagnosticContext {
                             sandbox_id: &self.id,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -537,6 +537,10 @@ impl SandboxNetwork {
         self.info.host_device()
     }
 
+    fn attachment_generation(&self) -> u64 {
+        self.info.attachment_generation()
+    }
+
     fn mark_non_reusable(&mut self) -> sandbox::Result<()> {
         let lease = self.lease.as_mut().ok_or_else(|| SandboxError::Start {
             message: "network lease missing while marking attachment non-reusable".into(),
@@ -1275,6 +1279,12 @@ impl FirecrackerSandbox {
                             host_device: self.network.host_device(),
                             peer_ip: self.network.peer_ip(),
                             dns_port,
+                            attachment_generation: self.network.attachment_generation(),
+                            startup_mode: if self.factory_config.snapshot.is_some() {
+                                "snapshot_restore"
+                            } else {
+                                "fresh"
+                            },
                         },
                     )
                     .await;


### PR DESCRIPTION
## Summary

- add pool-scoped IPv4/IPv6 UDP/TCP INPUT counter rules and correlate failures with namespace attachment generation and startup mode
- capture exact, bounded passive filter/socket/conntrack evidence before running a separately bounded namespace DNS control probe
- report DNS/kmsg drain outcomes, source-generation writer backpressure, and DNS replacement completion, with metal assertions for counter and isolation behavior

## Behavior and compatibility

The new INPUT rules are targetless and therefore only count matching packets; the existing non-pool REJECT rules and packet fate are unchanged. The active control runs only after a terminal readiness failure and uses a distinct fixed `.invalid` hostname whose dnsmasq row is excluded from guest network logs and readiness evidence.

This PR does not change the readiness gate, retry budget, workload admission, DNS queue capacity, row ordering/delivery, API contracts, database schema, migrations, persisted application data, or guest protocol.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-targets --all-features` (2797 runner tests and 751 sandbox-fc tests passed)
- `bash -n .github/scripts/runner-behavior-exec.sh`
- repository pre-commit hooks

Closes #22533

Relates to #22481
