### PR TITLE
fix: enforce current policy for chat model routes

### DIFF
--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -42,14 +42,6 @@ export function payloadTooLarge(message: string) {
   return httpError(413, "PAYLOAD_TOO_LARGE", message);
 }
 
-export function providerDeleted() {
-  return httpError(
-    422,
-    "PROVIDER_DELETED",
-    "The selected model provider is no longer available",
-  );
-}
-
 export function insufficientCredits() {
   return httpError(
     402,

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -111,6 +111,33 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
   await publishUserSignal([userId], "threadListChanged");
 }
 
+export async function publishThreadListChangedSafely(
+  userId: string,
+): Promise<void> {
+  await tapError(publishThreadListChanged(userId), (error) => {
+    L.warn("Failed to publish thread list changed signal", { error });
+  });
+}
+
+/**
+ * Notify an open chat thread that server-owned detail fields changed without a
+ * request from that client. The client re-fetches the authoritative detail.
+ */
+export async function publishChatThreadDetailChangedSafely(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], `chatThreadDetailChanged:${threadId}`),
+    (error) => {
+      L.warn("Failed to publish chat thread detail changed signal", {
+        threadId,
+        error,
+      });
+    },
+  );
+}
+
 /**
  * Notify a chat thread's UI that a new message row was appended. The thread's
  * message data source subscribes to this topic and refetches, so derived state

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1261,6 +1261,69 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
+  it("starts a fresh goal session after current policy changes framework", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before the goal route changes framework",
+    });
+    const objective = "Continue autonomously through the current model route";
+    await createGoalForRun(actor, first.runId, objective);
+
+    const provider = await misc.upsertOrgModelProvider(
+      actor,
+      { type: "openai-api-key", secret: "goal-openai-key" },
+      [201],
+    );
+    if (provider.status !== 201) {
+      throw new Error("Expected the goal OpenAI provider to be created");
+    }
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.6-terra",
+        isDefault: true,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: provider.body.provider.id,
+      },
+    ]);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before the goal route changed"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, objective);
+        });
+      },
+    );
+    const continuation = userMessages(messages.messages).find((message) => {
+      return isGoalContinuationUserMessage(message, objective);
+    });
+    if (!continuation?.runId) {
+      throw new Error("Expected goal continuation run id");
+    }
+    const goalContext = await waitForRunContext(actor, continuation.runId);
+    expect(goalContext.body.sessionId).toBeNull();
+    expect(goalContext.body.environment.OPENAI_MODEL).toBe("gpt-5.6-terra");
+    expect(goalContext.body.environment.ANTHROPIC_MODEL).toBeUndefined();
+
+    await api.requestCancelRun(actor, continuation.runId, [200]);
+    await waitForRunStatus(actor, continuation.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
   it("auto-sends a queued user message before continuing an active goal", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
@@ -2552,7 +2615,7 @@ describe("CHAT-02: auto-send after failures", () => {
 });
 
 describe("CHAT-02: auto-send across a model switch", () => {
-  it("preserves the CLI session across same-family queued model switches without regenerating an existing title", async () => {
+  it("recovers a queued message through the current same-family workspace default", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -2604,16 +2667,20 @@ describe("CHAT-02: auto-send across a model switch", () => {
       prompt: "And stringify?",
     });
     const secondHeaders = await claimChatRun(runnerGroup, second.runId);
-    await chat.updateThreadModelSelection(
-      actor,
-      first.threadId,
-      "claude-sonnet-4-6",
-    );
     await queueChatMessage(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "queued after model switch",
+      prompt: "queued before policy removal",
     });
+    await chatCallbacks.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "Use JSON.stringify(value)."),
     ]);
@@ -2627,7 +2694,7 @@ describe("CHAT-02: auto-send across a model switch", () => {
       (items) => {
         return userMessages(items).some((message) => {
           return (
-            message.content === "queued after model switch" &&
+            message.content === "queued before policy removal" &&
             message.runId !== undefined
           );
         });
@@ -2635,13 +2702,13 @@ describe("CHAT-02: auto-send across a model switch", () => {
     );
     const claimed = userMessages(messages.messages).find((message) => {
       return (
-        message.content === "queued after model switch" &&
+        message.content === "queued before policy removal" &&
         message.runId !== undefined
       );
     });
     if (!claimed?.runId) {
       throw new Error(
-        "Expected the queued message to be auto-claimed after the model switch",
+        "Expected the queued message to be auto-claimed after policy removal",
       );
     }
 
@@ -2652,6 +2719,9 @@ describe("CHAT-02: auto-send across a model switch", () => {
     expect(autoContext.body.sessionId).toBe(`bdd-cli-${second.runId}`);
     expect(Object.keys(autoContext.body.environment)).toContain(
       "ANTHROPIC_API_KEY",
+    );
+    expect(autoContext.body.environment.ANTHROPIC_MODEL).toBe(
+      "claude-sonnet-4-6",
     );
 
     const thread = await chat.readThread(actor, first.threadId);
@@ -2664,13 +2734,15 @@ describe("CHAT-02: auto-send across a model switch", () => {
     if (threadEvents.status !== 200) {
       throw new Error("Expected chat thread events to load");
     }
-    expect(threadEvents.body.events).toContainEqual(
-      expect.objectContaining({
-        kind: "model_selection_updated",
-        chatThreadId: first.threadId,
-        selectedModel: "claude-sonnet-4-6",
+    expect(
+      threadEvents.body.events.filter((event) => {
+        return (
+          event.kind === "model_selection_updated" &&
+          event.chatThreadId === first.threadId &&
+          event.selectedModel === "claude-sonnet-4-6"
+        );
       }),
-    );
+    ).toHaveLength(1);
 
     expect(titlePrompts).toHaveLength(1);
     const initialTitlePrompt = titlePrompts[0];

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -195,7 +195,7 @@ describe("CHAT-01 chat thread lifecycle", () => {
     });
 
     await api.renameThread(owner, thread.id, "Pinned launch plan");
-    await api.updateThreadModelSelection(owner, thread.id, "gpt-5.4-mini");
+    await api.updateThreadModelSelection(owner, thread.id, "gpt-5.6-terra");
     await api.pinThread(owner, thread.id);
     const readEmpty = await api.markThreadRead(owner, thread.id);
 
@@ -215,7 +215,7 @@ describe("CHAT-01 chat thread lifecycle", () => {
       expect.objectContaining({
         kind: "model_selection_updated",
         chatThreadId: thread.id,
-        selectedModel: "gpt-5.4-mini",
+        selectedModel: "gpt-5.6-terra",
       }),
     );
     expect(detail.lastReadAt).toStrictEqual(expect.any(String));
@@ -602,7 +602,7 @@ describe("CHAT-02 chat messages and visible validation", () => {
       {
         agentId: agent.agentId,
         prompt: "Persist the model selected at send time",
-        model: "gpt-5.4-mini",
+        model: "gpt-5.6-terra",
       },
       [201],
     );
@@ -623,7 +623,7 @@ describe("CHAT-02 chat messages and visible validation", () => {
       expect.objectContaining({
         kind: "created",
         chatThreadId: modelSelected.body.threadId,
-        selectedModel: "gpt-5.4-mini",
+        selectedModel: "gpt-5.6-terra",
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1032,7 +1032,7 @@ describe("CHAT-02: interrupting active chat runs", () => {
 
 describe("CHAT-02: queueing and recalling messages", () => {
   it("queues, retries, and recalls messages behind an active run", async () => {
-    const { actor, agentId } = await entitledChatActor();
+    const { actor, agentId, providerId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await sendChatRun(actor, {
@@ -1055,6 +1055,15 @@ describe("CHAT-02: queueing and recalling messages", () => {
       throw new Error("Expected the queued send to be accepted");
     }
     expect(queued.body.runId).toBeNull();
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-opus-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
     const queuedRetry = await chat.requestSendMessage(
       actor,
       {
@@ -1066,6 +1075,11 @@ describe("CHAT-02: queueing and recalling messages", () => {
       [201],
     );
     expect(queuedRetry.body).toStrictEqual(queued.body);
+    await expectNoThreadModelUpdateEvent(
+      actor,
+      first.threadId,
+      "claude-opus-4-6",
+    );
 
     // Another user's send cannot claim the queued message's client id.
     const stranger = bdd.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2864,7 +2864,45 @@ describe("CHAT-02: run-level model overrides", () => {
       first.threadId,
       "claude-sonnet-4-6",
     );
-    await cancelChatRun(actor, second.runId);
+    await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
+
+    const { providerId: openRouterProviderId } = await upsertOrgModelProvider(
+      actor,
+      {
+        type: "openrouter-api-key",
+        secret: "rerouted-openrouter-key",
+      },
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "openrouter-api-key",
+        credentialScope: "org",
+        modelProviderId: openRouterProviderId,
+      },
+    ]);
+
+    const third = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "follow up after the upstream provider changes",
+    });
+    const thirdClaim = await claimChatRun(runnerGroup, third.runId);
+    expect(claimEnvironment(thirdClaim.claim).ANTHROPIC_AUTH_TOKEN).toBe(
+      modelProviderSecretPlaceholder(
+        "openrouter-api-key",
+        "OPENROUTER_API_KEY",
+      ),
+    );
+    expect(thirdClaim.claim.cliAgentType).toBe("claude-code");
+    expect(thirdClaim.claim.resumeSession).toBeNull();
+    await expectNoThreadModelUpdateEvent(
+      actor,
+      first.threadId,
+      "claude-sonnet-4-6",
+    );
+    await cancelChatRun(actor, third.runId);
   }, 90_000);
 
   it("rejects invalid model selections without creating visible state", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -660,6 +660,7 @@ async function upsertOrgModelProvider(
     readonly type:
       | "anthropic-api-key"
       | "deepseek-api-key"
+      | "openai-api-key"
       | "openrouter-api-key"
       | "vm0";
     readonly secret?: string;
@@ -1068,6 +1069,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
 
     // Another user's send cannot claim the queued message's client id.
     const stranger = bdd.user();
+    await api.ensureOrgModelProvider(stranger);
     const strangerAgent = await bdd.createAgent(stranger, {
       displayName: "Cross-user client-id agent",
     });
@@ -1895,6 +1897,169 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
+  it("recovers a removed thread model through the current workspace route", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "start before the thread model is removed",
+      model: "claude-sonnet-4-6",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    expect(firstClaim.claim.cliAgentType).toBe("claude-code");
+    expect(claimEnvironment(firstClaim.claim).ANTHROPIC_MODEL).toBe(
+      "claude-sonnet-4-6",
+    );
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+
+    await seedVm0ManagedModelKey("gpt-5.6-terra");
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.6-terra",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+
+    const recovered = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue through the current workspace default",
+    });
+    const recoveredClaim = await claimChatRun(runnerGroup, recovered.runId);
+    expect(recoveredClaim.claim.cliAgentType).toBe("codex");
+    expect(recoveredClaim.claim.resumeSession).toBeNull();
+    const recoveredEnvironment = claimEnvironment(recoveredClaim.claim);
+    expect(recoveredEnvironment.OPENAI_MODEL).toBe("gpt-5.6-terra");
+    expect(recoveredEnvironment.ANTHROPIC_MODEL).toBeUndefined();
+
+    const threadEvents = await chat.requestThreadEvents(actor, {}, [200]);
+    if (threadEvents.status !== 200) {
+      throw new Error("Expected chat thread events to load");
+    }
+    expect(
+      threadEvents.body.events.filter((event) => {
+        return (
+          event.kind === "model_selection_updated" &&
+          event.chatThreadId === first.threadId &&
+          event.selectedModel === "gpt-5.6-terra"
+        );
+      }),
+    ).toHaveLength(1);
+
+    await cancelChatRun(actor, recovered.runId);
+  }, 90_000);
+
+  it("does not overwrite a concurrent explicit thread model selection", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+    const thread = await chat.createThread(actor, {
+      agentId,
+      model: "claude-sonnet-4-6",
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-opus-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+      {
+        model: "claude-sonnet-5",
+        isDefault: false,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const [sent, updated] = await Promise.all([
+      chat.requestSendMessage(
+        actor,
+        {
+          agentId,
+          threadId: thread.id,
+          prompt: "send while choosing a new sticky model",
+        },
+        [201],
+      ),
+      chat.requestUpdateThreadModelSelection(
+        actor,
+        thread.id,
+        "claude-sonnet-5",
+        [204],
+      ),
+    ]);
+    expect(updated.status).toBe(204);
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected the concurrent send to create a run");
+    }
+    const racedClaim = await claimChatRun(runnerGroup, sent.body.runId);
+    expect(["claude-opus-4-6", "claude-sonnet-5"]).toContain(
+      claimEnvironment(racedClaim.claim).ANTHROPIC_MODEL,
+    );
+    await cancelChatRun(actor, sent.body.runId);
+
+    const followUp = await sendChatRun(actor, {
+      agentId,
+      threadId: thread.id,
+      prompt: "continue on the explicit sticky model",
+    });
+    const followUpClaim = await claimChatRun(runnerGroup, followUp.runId);
+    expect(claimEnvironment(followUpClaim.claim).ANTHROPIC_MODEL).toBe(
+      "claude-sonnet-5",
+    );
+
+    const events = await chat.requestThreadEvents(actor, {}, [200]);
+    if (events.status !== 200) {
+      throw new Error("Expected chat thread events to load");
+    }
+    expect(
+      events.body.events.filter((event) => {
+        return (
+          event.kind === "model_selection_updated" &&
+          event.chatThreadId === thread.id &&
+          event.selectedModel === "claude-sonnet-5"
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      events.body.events.filter((event) => {
+        return (
+          event.kind === "model_selection_updated" &&
+          event.chatThreadId === thread.id &&
+          event.selectedModel === "claude-opus-4-6"
+        );
+      }).length,
+    ).toBeLessThanOrEqual(1);
+    await cancelChatRun(actor, followUp.runId);
+  }, 90_000);
+
   it("passes Codex fast mode only for feature-enabled ChatGPT subscription GPT 5.5 and GPT 5.6 sends", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -2057,6 +2222,84 @@ describe("CHAT-02: model-first provider policies", () => {
       "Codex fast mode is only available for ChatGPT (Codex) GPT 5.5 and GPT 5.6 runs",
     );
     await chat.requestReadThread(actor, rejectedThreadId, [404]);
+  }, 90_000);
+
+  it("normalizes persisted fast mode after the current provider route changes", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    await misc.upsertPersonalModelProvider(
+      actor,
+      {
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secrets: { CODEX_AUTH_JSON: codexAuthJson() },
+      },
+      [200, 201],
+    );
+    const { providerId: openAiProviderId } = await upsertOrgModelProvider(
+      actor,
+      {
+        type: "openai-api-key",
+        secret: "rerouted-openai-key",
+      },
+    );
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.CodexFastMode]: true },
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.5",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "start fast before the provider route changes",
+      model: "gpt-5.5",
+      runOptions: { codexServiceTier: "fast" },
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders, {
+      cliAgentType: "codex",
+    });
+
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.5",
+        isDefault: true,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: openAiProviderId,
+      },
+    ]);
+    const followUp = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue from a client that still has fast cached",
+      runOptions: { codexServiceTier: "fast" },
+    });
+    const followUpClaim = await claimChatRun(runnerGroup, followUp.runId);
+    const environment = claimEnvironment(followUpClaim.claim);
+    expect(environment.OPENAI_API_KEY).toBe(
+      modelProviderSecretPlaceholder("openai-api-key", "OPENAI_API_KEY"),
+    );
+    expect(environment.OPENAI_MODEL).toBe("gpt-5.5");
+    expect(environment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
+    expect(
+      (await chat.readThread(actor, first.threadId)).codexServiceTier,
+    ).toBeNull();
+    await expectNoThreadModelUpdateEvent(actor, first.threadId, "gpt-5.5");
+    await cancelChatRun(actor, followUp.runId);
   }, 90_000);
 
   it("routes OpenRouter provider pins through runtime model aliases and firewall auth", async () => {
@@ -2552,9 +2795,8 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
-  it("uses the stored provider pin on follow-up sends", async () => {
-    const { actor, agentId, runnerGroup, providerId } =
-      await entitledChatActor();
+  it("re-resolves a sticky model through the current provider policy", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await sendChatRun(actor, {
@@ -2574,24 +2816,36 @@ describe("CHAT-02: run-level model overrides", () => {
       "claude-sonnet-4-6",
     );
 
-    // Org providers are per-type singletons, so the public rotation surface
-    // is re-upserting the same provider with a new secret. Follow-up sends use
-    // the stored provider pin and pick up the rotated provider configuration.
-    const rotated = await upsertOrgModelProvider(actor, {
-      type: "anthropic-api-key",
-      secret: "rotated-anthropic-key",
-    });
-    expect(rotated).toStrictEqual({ providerId, created: false });
+    await misc.upsertPersonalModelProvider(
+      actor,
+      {
+        type: "claude-code-oauth-token",
+        secret: "rerouted-claude-oauth-token",
+      },
+      [200, 201],
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "claude-code-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+    ]);
 
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "follow up after the provider rotation",
+      prompt: "follow up after the provider policy reroute",
     });
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
     const environment = claimEnvironment(secondClaim.claim);
-    expect(environment.ANTHROPIC_API_KEY).toBe(
-      modelProviderSecretPlaceholder("anthropic-api-key", "ANTHROPIC_API_KEY"),
+    expect(environment.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      modelProviderSecretPlaceholder(
+        "claude-code-oauth-token",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+      ),
     );
     expect(environment.ANTHROPIC_MODEL).toBe("claude-sonnet-4-6");
     expect(secondClaim.claim.resumeSession?.sessionId).toBe(
@@ -2605,12 +2859,18 @@ describe("CHAT-02: run-level model overrides", () => {
       first.threadId,
       "claude-sonnet-4-6",
     );
+    await expectNoThreadModelUpdateEvent(
+      actor,
+      first.threadId,
+      "claude-sonnet-4-6",
+    );
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
   it("rejects invalid model selections without creating visible state", async () => {
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
+    await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
       displayName: "Invalid model selection agent",
     });
@@ -2632,6 +2892,23 @@ describe("CHAT-02: run-level model overrides", () => {
       "model: Invalid model selection",
     );
     await chat.requestReadThread(actor, vm0ThreadId, [404]);
+
+    const unavailableThreadId = randomUUID();
+    const unavailable = await chat.requestSendMessage(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "use a supported model outside workspace policy",
+        clientThreadId: unavailableThreadId,
+        model: "gpt-5.6-terra",
+      },
+      [400],
+    );
+    expectApiError(unavailable.body);
+    expect(unavailable.body.error.message).toBe(
+      "The selected model is not available in this workspace",
+    );
+    await chat.requestReadThread(actor, unavailableThreadId, [404]);
 
     // Removed sentinel models fail contract validation.
     for (const selectedModel of [
@@ -3571,6 +3848,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
 
   it("rejects unusable computer-use host selections", async () => {
     const actor = bdd.user();
+    await api.ensureOrgModelProvider(actor);
     bdd.acceptAgentStorageWrites();
     const agent = await bdd.createAgent(actor, {
       displayName: "Computer-use guard agent",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -95,6 +95,7 @@ interface EntitledChatActor {
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly runnerGroup: string;
+  readonly providerId: string;
 }
 
 type EntitledChatActorWithoutRunner = Omit<EntitledChatActor, "runnerGroup">;
@@ -109,12 +110,12 @@ async function entitledChatActorWithoutRunner(
   mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   chatCallbacks.disableVapid();
   await api.grantProEntitlement(actor);
-  await api.ensureOrgModelProvider(actor);
+  const { providerId } = await api.ensureOrgModelProvider(actor);
   const agent = await bdd.createAgent(actor, {
     displayName,
     visibility: "private",
   });
-  return { actor, agentId: agent.agentId };
+  return { actor, agentId: agent.agentId, providerId };
 }
 
 async function entitledChatActor(
@@ -284,6 +285,7 @@ async function sendNoCreditMessage(
     readonly prompt: string;
   },
 ): Promise<string> {
+  await api.ensureOrgModelProvider(actor);
   const sent = await chat.requestSendMessage(actor, body, [201]);
   if (sent.status !== 201 || sent.body.runId !== null) {
     throw new Error("Expected a no-credit send without a run");
@@ -517,6 +519,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
   it("returns chat thread snapshot and lifecycle events with cursor expiry", async () => {
     const actor = bdd.user();
+    await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
       displayName: "Thread event sourcing agent",
     });
@@ -669,6 +672,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
   it("compacts chat thread snapshots from event markers and prunes deleted agent threads", async () => {
     mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
     const actor = bdd.user();
+    await api.ensureOrgModelProvider(actor);
     const liveAgent = await bdd.createAgent(actor, {
       displayName: "Snapshot compaction live agent",
     });
@@ -807,6 +811,52 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     );
   }, 90_000);
 
+  it("rejects explicit thread models outside current workspace policy", async () => {
+    const { actor, agentId, providerId } = await entitledChatActor(
+      "Unavailable explicit thread model agent",
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-opus-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const rejectedThreadId = randomUUID();
+    const rejectedCreate = await chat.requestCreateThread(
+      actor,
+      {
+        agentId,
+        clientThreadId: rejectedThreadId,
+        model: "claude-sonnet-4-6",
+      },
+      [400],
+    );
+    expectApiError(rejectedCreate.body);
+    expect(rejectedCreate.body.error.message).toBe(
+      "The selected model is not available in this workspace",
+    );
+    await chat.requestReadThread(actor, rejectedThreadId, [404]);
+
+    const thread = await chat.createThread(actor, {
+      agentId,
+      model: "claude-opus-4-6",
+    });
+    const rejectedUpdate = await chat.requestUpdateThreadModelSelection(
+      actor,
+      thread.id,
+      "claude-sonnet-4-6",
+      [400],
+    );
+    expectApiError(rejectedUpdate.body);
+    expect(rejectedUpdate.body.error.message).toBe(
+      "The selected model is not available in this workspace",
+    );
+  }, 90_000);
+
   it("rejects restricted model pins for limited-free-1 workspaces", async () => {
     const { actor, agentId } = await entitledChatActor(
       "Limited free model pin agent",
@@ -823,6 +873,22 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       tier: "limited-free-1",
       credits: billingStatus.credits,
     });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+      {
+        model: "MiniMax-M3",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
 
     const thread = await chat.createThread(actor, {
       agentId,
@@ -860,6 +926,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
   it("updates the Computer Use host binding on a chat thread", async () => {
     const actor = bdd.user();
+    await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
       displayName: "Computer-use thread agent",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -33,6 +33,8 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { composesMainContract } from "@vm0/api-contracts/contracts/composes";
 import type { ApiErrorResponse } from "@vm0/api-contracts/contracts/errors";
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
+import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
 import {
   storagesCommitContract,
   storagesDownloadContract,
@@ -83,6 +85,7 @@ import { zeroChatThreadsArtifactsSyncRoutes } from "../../zero-chat-threads-arti
 import { zeroHostRoutes } from "../../zero-host";
 import { zeroMemoryActivityRoutes } from "../../zero-memory-activity";
 import { zeroMemoryRoutes } from "../../zero-memory";
+import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroUploadsCompleteRoutes } from "../../zero-uploads-complete";
 import { zeroUploadsHtmlDomEditSnapshotRoutes } from "../../zero-uploads-html-dom-edit-snapshot";
 import { zeroUploadsPrepareRoutes } from "../../zero-uploads-prepare";
@@ -91,10 +94,6 @@ import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 export { hostedTextFile } from "./api-bdd-host-files";
 export { storageTextFile } from "./api-bdd-storage-files";
-
-function defaultCreateThreadModel(): string {
-  return "claude-sonnet-4-6";
-}
 
 type StorageType = "volume" | "artifact";
 
@@ -246,6 +245,7 @@ const chatFilesRoutes = [
   ...zeroHostRoutes,
   ...zeroMemoryRoutes,
   ...zeroMemoryActivityRoutes,
+  ...zeroModelPoliciesRoutes,
   ...storagesPrepareRoutes,
   ...storagesCommitRoutes,
   ...storagesListRoutes,
@@ -280,6 +280,26 @@ export function createChatFilesBddApi(context: TestContext) {
 
   function threadsClient() {
     return chatFilesApp(context)(chatThreadsContract);
+  }
+
+  function modelPoliciesClient() {
+    return chatFilesApp(context)(zeroModelPoliciesMainContract);
+  }
+
+  async function defaultCreateThreadModel(
+    actor: ApiTestUser | null,
+  ): Promise<string> {
+    if (!actor?.orgId) {
+      return DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+    }
+    const response = await accept(
+      modelPoliciesClient().list({ headers: authenticate(context, actor) }),
+      [200],
+    );
+    return (
+      response.body.workspaceDefaultModel ??
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL
+    );
   }
 
   function threadByIdClient() {
@@ -445,7 +465,7 @@ export function createChatFilesBddApi(context: TestContext) {
               ? {}
               : { clientThreadId: body.clientThreadId }),
             ...(body.eventId === undefined ? {} : { eventId: body.eventId }),
-            model: body.model ?? defaultCreateThreadModel(),
+            model: body.model ?? (await defaultCreateThreadModel(actor)),
           },
         }),
         [201],
@@ -462,7 +482,7 @@ export function createChatFilesBddApi(context: TestContext) {
         readonly eventId?: string;
         readonly model?: string;
       },
-      statuses: readonly (201 | 401 | 402 | 404)[],
+      statuses: readonly (201 | 400 | 401 | 402 | 404)[],
     ) {
       return await accept(
         threadsClient().create({
@@ -474,7 +494,7 @@ export function createChatFilesBddApi(context: TestContext) {
               ? {}
               : { clientThreadId: body.clientThreadId }),
             ...(body.eventId === undefined ? {} : { eventId: body.eventId }),
-            model: body.model ?? defaultCreateThreadModel(),
+            model: body.model ?? (await defaultCreateThreadModel(actor)),
           },
         }),
         statuses,
@@ -1259,13 +1279,15 @@ export function createChatFilesBddApi(context: TestContext) {
             chatMessagesContract,
           )
         : chatMessagesClient();
+      const defaultModel =
+        "prompt" in body &&
+        body.threadId === undefined &&
+        body.model === undefined
+          ? await defaultCreateThreadModel(actor)
+          : undefined;
       const requestBody =
         "prompt" in body
           ? (() => {
-              const defaultModel =
-                body.threadId === undefined && body.model === undefined
-                  ? defaultCreateThreadModel()
-                  : undefined;
               const selectedModel = body.model ?? defaultModel;
               return {
                 agentId: body.agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -970,14 +970,7 @@ async function sendChatRunMessage(
   },
 ): Promise<{ readonly runId: string; readonly threadId: string }> {
   const chat = createChatFilesBddApi(context);
-  const sent = await chat.requestSendMessage(
-    actor,
-    {
-      ...body,
-      ...(body.threadId === undefined ? { model: "claude-sonnet-5" } : {}),
-    },
-    [201],
-  );
+  const sent = await chat.requestSendMessage(actor, body, [201]);
   if (sent.status !== 201 || sent.body.runId === null) {
     throw new Error("Expected the entitled chat send to create a run");
   }
@@ -4757,7 +4750,10 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
         [201],
       );
     }
-    const thread = await chat.createThread(actor, { agentId: agent.agentId });
+    const thread = await chat.createThread(actor, {
+      agentId: agent.agentId,
+      model: "claude-sonnet-4-6",
+    });
     const sent = await chat.requestSendMessage(
       actor,
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { chatThreadMetadataContract } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
 
@@ -91,7 +92,7 @@ describe("GET /api/zero/chat-threads/:id/metadata", () => {
     expect(response.body).toStrictEqual({
       id: fixture.threadId,
       title: "Launch plan",
-      selectedModel: "claude-sonnet-4-6",
+      selectedModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-model-selection.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-model-selection.test.ts
@@ -13,12 +13,14 @@ import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createRunsApi } from "./helpers/api-bdd-runs";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 
 const context = testContext();
 const store = createStore();
 const bdd = createBddApi(context);
 const chat = createChatFilesBddApi(context);
+const api = createRunsApi(context);
 
 interface ChatThreadFixture {
   readonly userId: string;
@@ -30,6 +32,23 @@ interface ChatThreadFixture {
 async function seedChatThread(title: string): Promise<ChatThreadFixture> {
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
+  const { providerId } = await api.ensureOrgModelProvider(actor);
+  await api.updateOrgModelPolicies(actor, [
+    {
+      model: "claude-sonnet-4-6",
+      isDefault: true,
+      defaultProviderType: "anthropic-api-key",
+      credentialScope: "org",
+      modelProviderId: providerId,
+    },
+    {
+      model: "claude-sonnet-5",
+      isDefault: false,
+      defaultProviderType: "anthropic-api-key",
+      credentialScope: "org",
+      modelProviderId: providerId,
+    },
+  ]);
   const agent = await bdd.createAgent(actor, {
     displayName: "Chat thread model selection agent",
     visibility: "private",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
@@ -5,6 +5,7 @@ import {
   chatThreadRenameContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
 
@@ -113,7 +114,7 @@ describe("POST /api/zero/chat-threads/:id/rename", () => {
     expect(metadataResponse.body).toStrictEqual({
       id: fixture.threadId,
       title: "CLI renamed title",
-      selectedModel: "claude-sonnet-4-6",
+      selectedModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -469,12 +469,28 @@ describe("zero workflows", () => {
   it("runs a workflow slash command with workflow timing attribution", async () => {
     const actor = user({ orgRole: "org:admin" });
     await api.grantProEntitlement(actor);
-    await api.ensureOrgModelProvider(actor);
+    const provider = await miscApi.upsertOrgModelProvider(
+      actor,
+      { type: "openai-api-key", secret: "workflow-openai-key" },
+      [201],
+    );
+    if (provider.status !== 201) {
+      throw new Error("Expected the workflow OpenAI provider to be created");
+    }
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.6-terra",
+        isDefault: true,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: provider.body.provider.id,
+      },
+    ]);
     const agent = await createAgent(actor, {
       displayName: "Workflow Runner Agent",
       visibility: "private",
     });
-    api.configureRunnerGroup();
+    const runnerGroup = api.configureRunnerGroup();
 
     const created = await createWorkflow(actor, {
       agentId: agent.agentId,
@@ -494,6 +510,13 @@ describe("zero workflows", () => {
     expect(run.body.chatThreadId).toStrictEqual(expect.any(String));
     expect(run.body.runId).toStrictEqual(expect.any(String));
     expectZeroPreCreateSource(run.body.runId, "workflow_slash_command");
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.body.runId);
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.environment?.OPENAI_MODEL).toBe("gpt-5.6-terra");
+    expect(claim.environment?.ANTHROPIC_MODEL).toBeUndefined();
+    await api.requestCancelRun(actor, run.body.runId, [200]);
   });
 
   it("requires agent write-permission to create public workflows under an agent", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -8,11 +8,7 @@ import {
   type GenerationTemplateRequest,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  isCodexFastModeModel,
-  modelProviderCredentialScopeSchema,
-  modelProviderTypeSchema,
-} from "@vm0/api-contracts/contracts/model-providers";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
@@ -23,6 +19,7 @@ import {
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
+import { conversations } from "@vm0/db/schema/conversation";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -55,7 +52,6 @@ import {
   conflict,
   insufficientCredits,
   notFound,
-  providerDeleted,
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
@@ -87,12 +83,16 @@ import {
 } from "../services/zero-chat-title.service";
 import { generateAndPersistInitialThinkingMessage } from "../services/zero-chat-initial-thinking.service";
 import {
+  isCodexFastServiceTierSupported,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
   type ModelFirstPin,
-  modelProviderPinAvailable,
   resolveModelFirstProviderAdmission,
   resolveModelSelectionPin,
 } from "../services/zero-model-selection.service";
+import {
+  chatThreadModelPinColumns,
+  resolvePersistedChatThreadModel,
+} from "../services/zero-chat-thread-model.service";
 import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
@@ -179,7 +179,6 @@ interface ResolvedThread {
   readonly sessionId: string | undefined;
   readonly incompleteContext: string;
   readonly computerUseHostId: string | null;
-  readonly codexServiceTier: CodexServiceTier | null;
   readonly isNewThread: boolean;
   readonly isClientThreadRetry: boolean;
 }
@@ -201,6 +200,23 @@ interface WebChatPriorRun {
 interface LatestThreadSession {
   readonly sessionId: string;
   readonly selectedModel: string | null;
+  readonly modelProvider: string | null;
+  readonly cliAgentType: string | null;
+}
+
+type ModelFirstProviderAdmission = Awaited<
+  ReturnType<typeof resolveModelFirstProviderAdmission>
+>;
+
+interface ResolvedRunConfiguration {
+  readonly modelPin: ThreadModelPin;
+  readonly providerAdmission: ModelFirstProviderAdmission;
+  readonly codexServiceTier: "fast" | undefined;
+}
+
+interface ResolvedThreadAndRunConfiguration {
+  readonly thread: ResolvedThread;
+  readonly runConfiguration: ResolvedRunConfiguration;
 }
 
 type IncomingModelSelection = NormalSendBody["modelSelection"];
@@ -226,7 +242,7 @@ interface PreparedNormalSend {
   readonly computerUseHostGrant: ResolvedComputerUseHostGrant | null;
   readonly persistedExplicitSelection: boolean;
   readonly initialThinkingEnabled: boolean;
-  readonly codexFastModeEnabled: boolean;
+  readonly runConfiguration: ResolvedRunConfiguration;
 }
 
 function shouldTouchThreadSortFromNormalSend(
@@ -252,7 +268,6 @@ interface ResolvedComputerUseHostGrant {
 
 type NormalSendFailure =
   | ReturnType<typeof notFound>
-  | ReturnType<typeof providerDeleted>
   | ReturnType<typeof forbidden>
   | ReturnType<typeof conflict>
   | ReturnType<typeof insufficientCredits>
@@ -752,9 +767,13 @@ async function latestSessionForThread(
     .select({
       result: agentRuns.result,
       selectedModel: zeroRuns.selectedModel,
+      modelProvider: zeroRuns.modelProvider,
+      cliAgentType: conversations.cliAgentType,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .leftJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
     // Only web-source runs join the thread's session-continuity chain, so
     // Workflow Automation runs never resume a web session and a later web turn
     // never resumes an automated one. The 'web' filter (before .limit) is
@@ -776,20 +795,12 @@ async function latestSessionForThread(
       return {
         sessionId: row.result.agentSessionId,
         selectedModel: row.selectedModel,
+        modelProvider: row.modelProvider,
+        cliAgentType: row.cliAgentType,
       };
     }
   }
   return undefined;
-}
-
-function selectedModelForSessionDecision(params: {
-  readonly modelSelection: IncomingModelSelection;
-  readonly threadSelectedModel: string | null;
-}): string | null {
-  if (params.modelSelection) {
-    return params.modelSelection.selectedModel;
-  }
-  return params.threadSelectedModel;
 }
 
 async function getLatestRunsByThreadId(
@@ -954,35 +965,6 @@ async function resolveClientThreadRetryRun(
   };
 }
 
-async function getStoredThreadModelPin(
-  db: Db,
-  threadId: string,
-): Promise<ThreadModelPin | null> {
-  const [thread] = await db
-    .select({
-      modelProviderId: chatThreads.modelProviderId,
-      modelProviderType: chatThreads.modelProviderType,
-      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
-      selectedModel: chatThreads.selectedModel,
-    })
-    .from(chatThreads)
-    .where(eq(chatThreads.id, threadId))
-    .limit(1);
-  if (!thread?.selectedModel) {
-    return null;
-  }
-  return {
-    modelProviderId: thread.modelProviderId,
-    modelProviderType: modelProviderTypeSchema
-      .nullable()
-      .parse(thread.modelProviderType),
-    modelProviderCredentialScope: modelProviderCredentialScopeSchema
-      .nullable()
-      .parse(thread.modelProviderCredentialScope),
-    selectedModel: thread.selectedModel,
-  };
-}
-
 function emptyModelFirstThreadPin(): ThreadModelPin {
   return {
     modelProviderId: null,
@@ -992,179 +974,77 @@ function emptyModelFirstThreadPin(): ThreadModelPin {
   };
 }
 
-async function resolveStoredModelFirstPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly pin: ThreadModelPin;
-}): Promise<
-  | ThreadModelPin
-  | ReturnType<typeof providerDeleted>
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>
-> {
-  if (!params.pin.selectedModel) {
-    return params.pin;
-  }
-  if (params.pin.modelProviderId) {
-    const available = await modelProviderPinAvailable({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      modelProviderId: params.pin.modelProviderId,
-    });
-    if (!available) {
-      return providerDeleted();
-    }
-    return params.pin;
-  }
-  if (params.pin.modelProviderType || params.pin.modelProviderCredentialScope) {
-    return params.pin;
-  }
-  return resolveModelSelectionPin({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelSelection: {
-      modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
-      selectedModel: params.pin.selectedModel,
-    },
-  });
-}
-
-async function resolveRunModelPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly threadId: string;
-  readonly modelSelection: IncomingModelSelection;
-}): Promise<
-  | ThreadModelPin
-  | ReturnType<typeof providerDeleted>
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>
-> {
-  if (!params.modelSelection) {
-    const existing = await getStoredThreadModelPin(params.db, params.threadId);
-    if (!existing) {
-      return badRequestMessage("A model selection is required");
-    }
-    const pin = await resolveStoredModelFirstPin({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      pin: existing,
-    });
-    if ("status" in pin) {
-      return pin;
-    }
-    return pin;
-  }
-
-  const pin = await resolveModelSelectionPin({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelSelection: params.modelSelection,
-  });
-  if ("status" in pin) {
-    return pin;
-  }
-  return pin;
-}
-
-async function validateModelSelection(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly modelSelection: IncomingModelSelection;
-}): Promise<
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>
-  | undefined
-> {
-  if (params.modelSelection) {
-    const pin = await resolveModelSelectionPin({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      modelSelection: params.modelSelection,
-    });
-    if ("status" in pin) {
-      return pin;
-    }
-  }
-  return undefined;
-}
-
-async function resolveCodexServiceTierValidationPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly body: NormalSendBody;
-}): Promise<
-  | ThreadModelPin
-  | ReturnType<typeof providerDeleted>
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>
-> {
-  if (params.body.modelSelection) {
-    return await resolveModelSelectionPin({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      modelSelection: params.body.modelSelection,
-    });
-  }
-  if (params.body.threadId) {
-    const existing = await getStoredThreadModelPin(
-      params.db,
-      params.body.threadId,
-    );
-    if (!existing) {
-      return badRequestMessage("A model selection is required");
-    }
-    return await resolveStoredModelFirstPin({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      pin: existing,
-    });
-  }
-  return badRequestMessage("A model selection is required");
-}
-
-async function validateCodexServiceTierBeforeThread(params: {
+async function resolveExplicitRunConfiguration(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly body: NormalSendBody;
   readonly codexFastModeEnabled: boolean;
-}): Promise<NormalSendFailure | undefined> {
-  if (!codexFastServiceTierRequested(params.body)) {
+  readonly timing?: ApiDispatchTimingCollector;
+}): Promise<ResolvedRunConfiguration | NormalSendFailure | undefined> {
+  const modelSelection = params.body.modelSelection;
+  if (!modelSelection) {
     return undefined;
   }
-  const modelPin = await resolveCodexServiceTierValidationPin(params);
+  const modelPin = await measureApiDispatchTiming(
+    params.timing,
+    "api_dispatch_pre_create_zero_web_chat_resolve_model_pin",
+    "nested",
+    () => {
+      return resolveModelSelectionPin({
+        db: params.db,
+        orgId: params.orgId,
+        userId: params.userId,
+        modelSelection,
+      });
+    },
+  );
   if ("status" in modelPin) {
     return modelPin;
   }
-  const providerAdmission = await resolveModelFirstProviderAdmission({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelPin,
-    requestedModelProvider: undefined,
-  });
-  const codexServiceTierError = validateCodexServiceTier({
-    body: params.body,
-    modelPin,
-    providerAdmission,
-    codexFastModeEnabled: params.codexFastModeEnabled,
-  });
+  const providerAdmission = await measureApiDispatchTiming(
+    params.timing,
+    "api_dispatch_pre_create_zero_web_chat_resolve_provider_admission",
+    "nested",
+    () => {
+      return resolveModelFirstProviderAdmission({
+        db: params.db,
+        orgId: params.orgId,
+        userId: params.userId,
+        modelPin,
+        requestedModelProvider: undefined,
+      });
+    },
+  );
+  if (providerAdmission.error && providerAdmission.error.status !== 402) {
+    return providerAdmission.error;
+  }
+  const codexServiceTierError = await measureApiDispatchTiming(
+    params.timing,
+    "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_validate_codex_service_tier",
+    "nested",
+    () => {
+      return validateCodexServiceTier({
+        body: params.body,
+        modelPin,
+        providerAdmission,
+        codexFastModeEnabled: params.codexFastModeEnabled,
+      });
+    },
+  );
   if (codexServiceTierError) {
     return codexServiceTierError;
   }
-  return providerAdmission.error;
+  return {
+    modelPin,
+    providerAdmission,
+    codexServiceTier: codexServiceTierForRun({
+      body: params.body,
+      modelPin,
+      providerAdmission,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    }),
+  };
 }
 
 async function resolveNormalSendFeatureSwitches(
@@ -1250,10 +1130,7 @@ async function maybePersistExplicitCodexServiceTier(params: {
   readonly userId: string;
   readonly body: NormalSendBody;
 }): Promise<void> {
-  if (
-    params.body.modelSelection === undefined &&
-    params.body.runOptions === undefined
-  ) {
+  if (params.body.modelSelection === undefined) {
     return;
   }
   await params.db
@@ -1399,10 +1276,7 @@ async function createChatThread(
           userId: args.userId,
           agentComposeId: args.agentId,
           title: null,
-          modelProviderId: args.pin.modelProviderId,
-          modelProviderType: args.pin.modelProviderType,
-          modelProviderCredentialScope: args.pin.modelProviderCredentialScope,
-          selectedModel: args.pin.selectedModel,
+          ...chatThreadModelPinColumns(args.pin),
           codexServiceTier: args.codexServiceTier,
         })
         .onConflictDoNothing({ target: chatThreads.id })
@@ -1445,10 +1319,7 @@ async function createChatThread(
         userId: args.userId,
         agentComposeId: args.agentId,
         title: null,
-        modelProviderId: args.pin.modelProviderId,
-        modelProviderType: args.pin.modelProviderType,
-        modelProviderCredentialScope: args.pin.modelProviderCredentialScope,
-        selectedModel: args.pin.selectedModel,
+        ...chatThreadModelPinColumns(args.pin),
         codexServiceTier: args.codexServiceTier,
       })
       .returning({ id: chatThreads.id, createdAt: chatThreads.createdAt });
@@ -1470,36 +1341,17 @@ async function createChatThread(
   });
 }
 
-async function resolveInitialThreadModelPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
+function resolveInitialThreadModelPin(params: {
   readonly existingThreadId: string | undefined;
-  readonly modelSelection: IncomingModelSelection;
-}): Promise<
-  | ThreadModelPin
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>
-> {
+  readonly explicitRunConfiguration: ResolvedRunConfiguration | undefined;
+}): ThreadModelPin | ReturnType<typeof badRequestMessage> {
   if (params.existingThreadId) {
     return emptyModelFirstThreadPin();
   }
-  if (!params.modelSelection) {
+  if (!params.explicitRunConfiguration?.modelPin.selectedModel) {
     return badRequestMessage("A model selection is required");
   }
-  const pin = await resolveModelSelectionPin({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelSelection: params.modelSelection,
-  });
-  if ("status" in pin) {
-    return pin;
-  }
-  if (!pin.selectedModel) {
-    return badRequestMessage("A model selection is required");
-  }
-  return pin;
+  return params.explicitRunConfiguration.modelPin;
 }
 
 async function resolveThread(params: {
@@ -1511,10 +1363,15 @@ async function resolveThread(params: {
   readonly clientThreadId: string | undefined;
   readonly chatThreadEventId: string | undefined;
   readonly initialPin: ThreadModelPin;
-  readonly codexServiceTier: CodexServiceTier | null;
-  readonly modelSelection: IncomingModelSelection;
-}): Promise<ResolvedThread | ReturnType<typeof notFound>> {
+  readonly explicitRunConfiguration: ResolvedRunConfiguration | undefined;
+  readonly requestedCodexServiceTier: CodexServiceTier | undefined;
+  readonly persistRequestedCodexServiceTier: boolean;
+  readonly codexFastModeEnabled: boolean;
+}): Promise<ResolvedThreadAndRunConfiguration | NormalSendFailure> {
   if (!params.existingThreadId) {
+    if (!params.explicitRunConfiguration) {
+      return badRequestMessage("A model selection is required");
+    }
     const thread = await createChatThread(params.db, {
       userId: params.userId,
       orgId: params.orgId,
@@ -1522,28 +1379,29 @@ async function resolveThread(params: {
       clientThreadId: params.clientThreadId,
       chatThreadEventId: params.chatThreadEventId,
       pin: params.initialPin,
-      codexServiceTier: params.codexServiceTier,
+      codexServiceTier:
+        params.explicitRunConfiguration.codexServiceTier ?? null,
     });
     if ("status" in thread) {
       return thread;
     }
     return {
-      threadId: thread.id,
-      sessionId: undefined,
-      incompleteContext: "",
-      computerUseHostId: null,
-      codexServiceTier: params.codexServiceTier,
-      isNewThread: !thread.clientThreadAlreadyExisted,
-      isClientThreadRetry: thread.clientThreadAlreadyExisted,
+      thread: {
+        threadId: thread.id,
+        sessionId: undefined,
+        incompleteContext: "",
+        computerUseHostId: null,
+        isNewThread: !thread.clientThreadAlreadyExisted,
+        isClientThreadRetry: thread.clientThreadAlreadyExisted,
+      },
+      runConfiguration: params.explicitRunConfiguration,
     };
   }
 
   const [thread] = await params.db
     .select({
       id: chatThreads.id,
-      selectedModel: chatThreads.selectedModel,
       computerUseHostId: chatThreads.computerUseHostId,
-      codexServiceTier: chatThreads.codexServiceTier,
     })
     .from(chatThreads)
     .where(
@@ -1557,25 +1415,53 @@ async function resolveThread(params: {
     return notFound("Chat thread not found");
   }
 
+  let runConfiguration = params.explicitRunConfiguration;
+  if (!runConfiguration) {
+    const persisted = await resolvePersistedChatThreadModel({
+      db: params.db,
+      orgId: params.orgId,
+      userId: params.userId,
+      threadId: thread.id,
+      requestedCodexServiceTier: params.requestedCodexServiceTier,
+      persistRequestedCodexServiceTier: params.persistRequestedCodexServiceTier,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    });
+    if (!persisted) {
+      return notFound("Chat thread not found");
+    }
+    if ("status" in persisted) {
+      return persisted;
+    }
+    runConfiguration = {
+      modelPin: persisted.pin,
+      providerAdmission: persisted.providerAdmission,
+      codexServiceTier: persisted.runCodexServiceTier,
+    };
+  }
+
   const [latestSession, incompleteContext] = await Promise.all([
     latestSessionForThread(params.db, thread.id),
     loadWebChatIncompleteContext(params.db, thread.id),
   ]);
   const startNewSession = shouldStartNewChatSession({
     latestModel: latestSession?.selectedModel,
-    nextModel: selectedModelForSessionDecision({
-      modelSelection: params.modelSelection,
-      threadSelectedModel: thread.selectedModel,
-    }),
+    nextModel: runConfiguration.modelPin.selectedModel,
+    latestModelProvider: latestSession?.modelProvider,
+    nextModelProvider:
+      runConfiguration.providerAdmission.effectiveModelProvider,
+    latestCliAgentType: latestSession?.cliAgentType,
+    nextCliAgentType: runConfiguration.providerAdmission.cliAgentType,
   });
   return {
-    threadId: thread.id,
-    sessionId: startNewSession ? undefined : latestSession?.sessionId,
-    incompleteContext: startNewSession ? "" : incompleteContext,
-    computerUseHostId: thread.computerUseHostId,
-    codexServiceTier: thread.codexServiceTier,
-    isNewThread: false,
-    isClientThreadRetry: false,
+    thread: {
+      threadId: thread.id,
+      sessionId: startNewSession ? undefined : latestSession?.sessionId,
+      incompleteContext: startNewSession ? "" : incompleteContext,
+      computerUseHostId: thread.computerUseHostId,
+      isNewThread: false,
+      isClientThreadRetry: false,
+    },
+    runConfiguration,
   };
 }
 
@@ -2189,20 +2075,23 @@ function loadTimedAuthorizedAgent(
   );
 }
 
-function validateTimedModelSelection(
+function resolveTimedExplicitRunConfiguration(
   args: NormalSendArgs,
   db: Db,
-): ReturnType<typeof validateModelSelection> {
+  featureSwitches: NormalSendFeatureSwitches,
+): ReturnType<typeof resolveExplicitRunConfiguration> {
   return measureApiDispatchTiming(
     args.timing,
     "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_validate_model_selection",
     "nested",
     () => {
-      return validateModelSelection({
+      return resolveExplicitRunConfiguration({
         db,
         orgId: args.orgId,
         userId: args.userId,
-        modelSelection: args.body.modelSelection,
+        body: args.body,
+        codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
+        timing: args.timing,
       });
     },
   );
@@ -2222,42 +2111,18 @@ function resolveTimedNormalSendFeatureSwitches(
   );
 }
 
-function validateTimedCodexServiceTierBeforeThread(
-  args: NormalSendArgs,
-  db: Db,
-  featureSwitches: NormalSendFeatureSwitches,
-): ReturnType<typeof validateCodexServiceTierBeforeThread> {
-  return measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_validate_codex_service_tier",
-    "nested",
-    () => {
-      return validateCodexServiceTierBeforeThread({
-        db,
-        orgId: args.orgId,
-        userId: args.userId,
-        body: args.body,
-        codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
-      });
-    },
-  );
-}
-
 function resolveTimedInitialThreadModelPin(
   args: NormalSendArgs,
-  db: Db,
-): ReturnType<typeof resolveInitialThreadModelPin> {
+  explicitRunConfiguration: ResolvedRunConfiguration | undefined,
+): Promise<ReturnType<typeof resolveInitialThreadModelPin>> {
   return measureApiDispatchTiming(
     args.timing,
     "api_dispatch_pre_create_zero_web_chat_prepare_normal_send_resolve_initial_thread_model_pin",
     "nested",
     () => {
       return resolveInitialThreadModelPin({
-        db,
-        orgId: args.orgId,
-        userId: args.userId,
         existingThreadId: args.body.threadId,
-        modelSelection: args.body.modelSelection,
+        explicitRunConfiguration,
       });
     },
   );
@@ -2267,6 +2132,8 @@ function resolveTimedThread(
   args: NormalSendArgs,
   db: Db,
   initialPin: ThreadModelPin,
+  explicitRunConfiguration: ResolvedRunConfiguration | undefined,
+  featureSwitches: NormalSendFeatureSwitches,
 ): ReturnType<typeof resolveThread> {
   return measureApiDispatchTiming(
     args.timing,
@@ -2282,8 +2149,12 @@ function resolveTimedThread(
         clientThreadId: args.body.clientThreadId,
         chatThreadEventId: args.body.chatThreadEventId,
         initialPin,
-        codexServiceTier: args.body.runOptions?.codexServiceTier ?? null,
-        modelSelection: args.body.modelSelection,
+        explicitRunConfiguration,
+        requestedCodexServiceTier: args.body.runOptions?.codexServiceTier,
+        persistRequestedCodexServiceTier:
+          args.body.modelSelection !== undefined ||
+          args.body.runOptions !== undefined,
+        codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
       });
     },
   );
@@ -2381,42 +2252,47 @@ const prepareNormalSend$ = command(
       return agent;
     }
 
-    const modelError = await validateTimedModelSelection(args, db);
-    signal.throwIfAborted();
-    if (modelError) {
-      return modelError;
-    }
-    const featureSwitches = await resolveTimedNormalSendFeatureSwitches(
-      args,
-      db,
-    );
-    signal.throwIfAborted();
-    const codexServiceTierError =
-      await validateTimedCodexServiceTierBeforeThread(
-        args,
-        db,
-        featureSwitches,
-      );
-    signal.throwIfAborted();
-    if (codexServiceTierError) {
-      return codexServiceTierError;
-    }
     const generationTemplateError = validateGenerationTemplatePrompt(args.body);
     if (generationTemplateError) {
       return generationTemplateError;
     }
 
-    const initialPin = await resolveTimedInitialThreadModelPin(args, db);
+    const featureSwitches = await resolveTimedNormalSendFeatureSwitches(
+      args,
+      db,
+    );
+    signal.throwIfAborted();
+    const explicitRunConfiguration = await resolveTimedExplicitRunConfiguration(
+      args,
+      db,
+      featureSwitches,
+    );
+    signal.throwIfAborted();
+    if (explicitRunConfiguration && "status" in explicitRunConfiguration) {
+      return explicitRunConfiguration;
+    }
+
+    const initialPin = await resolveTimedInitialThreadModelPin(
+      args,
+      explicitRunConfiguration,
+    );
     signal.throwIfAborted();
     if ("status" in initialPin) {
       return initialPin;
     }
 
-    const thread = await resolveTimedThread(args, db, initialPin);
+    const threadAndRunConfiguration = await resolveTimedThread(
+      args,
+      db,
+      initialPin,
+      explicitRunConfiguration,
+      featureSwitches,
+    );
     signal.throwIfAborted();
-    if ("status" in thread) {
-      return thread;
+    if ("status" in threadAndRunConfiguration) {
+      return threadAndRunConfiguration;
     }
+    const { thread, runConfiguration } = threadAndRunConfiguration;
 
     const priorContext = await prepareTimedRecentChatContext(args, db, thread);
     signal.throwIfAborted();
@@ -2448,7 +2324,7 @@ const prepareNormalSend$ = command(
       computerUseHostGrant,
       persistedExplicitSelection,
       initialThinkingEnabled: args.zeroPreCreateSource === undefined,
-      codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
+      runConfiguration,
     };
   },
 );
@@ -2905,52 +2781,6 @@ async function appendInsufficientCreditsMessages(params: {
   };
 }
 
-type ModelFirstProviderAdmission = Awaited<
-  ReturnType<typeof resolveModelFirstProviderAdmission>
->;
-
-async function resolveTimedRunModelPin(
-  args: NormalSendArgs,
-  prepared: PreparedNormalSend,
-): ReturnType<typeof resolveRunModelPin> {
-  return await measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_web_chat_resolve_model_pin",
-    "nested",
-    async () => {
-      return await resolveRunModelPin({
-        db: prepared.db,
-        orgId: args.orgId,
-        userId: args.userId,
-        threadId: prepared.thread.threadId,
-        modelSelection: args.body.modelSelection,
-      });
-    },
-  );
-}
-
-async function resolveTimedProviderAdmission(params: {
-  readonly args: NormalSendArgs;
-  readonly prepared: PreparedNormalSend;
-  readonly modelPin: ThreadModelPin;
-  readonly requestedModelProvider: string | undefined;
-}): ReturnType<typeof resolveModelFirstProviderAdmission> {
-  return await measureApiDispatchTiming(
-    params.args.timing,
-    "api_dispatch_pre_create_zero_web_chat_resolve_provider_admission",
-    "nested",
-    async () => {
-      return await resolveModelFirstProviderAdmission({
-        db: params.prepared.db,
-        orgId: params.args.orgId,
-        userId: params.args.userId,
-        modelPin: params.modelPin,
-        requestedModelProvider: params.requestedModelProvider,
-      });
-    },
-  );
-}
-
 function codexFastServiceTierRequested(body: NormalSendBody): boolean {
   return body.runOptions?.codexServiceTier === "fast";
 }
@@ -2970,8 +2800,11 @@ function validateCodexServiceTier(params: {
     );
   }
   if (
-    params.providerAdmission.effectiveModelProvider === "codex-oauth-token" &&
-    isCodexFastModeModel(params.modelPin.selectedModel)
+    isCodexFastServiceTierSupported({
+      selectedModel: params.modelPin.selectedModel,
+      effectiveModelProvider: params.providerAdmission.effectiveModelProvider,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    })
   ) {
     return undefined;
   }
@@ -2986,10 +2819,12 @@ function codexServiceTierForRun(params: {
   readonly providerAdmission: ModelFirstProviderAdmission;
   readonly codexFastModeEnabled: boolean;
 }): "fast" | undefined {
-  return params.codexFastModeEnabled &&
-    codexFastServiceTierRequested(params.body) &&
-    params.providerAdmission.effectiveModelProvider === "codex-oauth-token" &&
-    isCodexFastModeModel(params.modelPin.selectedModel)
+  return codexFastServiceTierRequested(params.body) &&
+    isCodexFastServiceTierSupported({
+      selectedModel: params.modelPin.selectedModel,
+      effectiveModelProvider: params.providerAdmission.effectiveModelProvider,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    })
     ? "fast"
     : undefined;
 }
@@ -2997,10 +2832,10 @@ function codexServiceTierForRun(params: {
 function buildCreateZeroRunArgs(params: {
   readonly args: NormalSendArgs;
   readonly prepared: PreparedNormalSend;
-  readonly modelPin: ThreadModelPin;
-  readonly providerAdmission: ModelFirstProviderAdmission;
 }) {
-  const { args, prepared, modelPin, providerAdmission } = params;
+  const { args, prepared } = params;
+  const { modelPin, providerAdmission, codexServiceTier } =
+    prepared.runConfiguration;
   const fullPrompt = buildFullPrompt(args.body.prompt, args.body.attachFiles);
   return {
     auth: args.auth,
@@ -3011,12 +2846,7 @@ function buildCreateZeroRunArgs(params: {
     modelProviderCredentialScope:
       modelPin.modelProviderCredentialScope ?? undefined,
     selectedModelOverride: modelPin.selectedModel ?? undefined,
-    codexServiceTier: codexServiceTierForRun({
-      body: args.body,
-      modelPin,
-      providerAdmission,
-      codexFastModeEnabled: prepared.codexFastModeEnabled,
-    }),
+    codexServiceTier,
     callbacks: [
       {
         internalKind: "chat" as const,
@@ -3056,8 +2886,6 @@ function buildCreateZeroRunArgs(params: {
 async function buildTimedCreateZeroRunArgs(params: {
   readonly args: NormalSendArgs;
   readonly prepared: PreparedNormalSend;
-  readonly modelPin: ThreadModelPin;
-  readonly providerAdmission: ModelFirstProviderAdmission;
 }): Promise<ReturnType<typeof buildCreateZeroRunArgs>> {
   return await measureApiDispatchTiming(
     params.args.timing,
@@ -3176,20 +3004,11 @@ const createNormalChatRun$ = command(
   ) => {
     const { args, prepared } = params;
     const createNormalRunStartedAt = now();
-    const modelPin = await resolveTimedRunModelPin(args, prepared);
-    signal.throwIfAborted();
-    if ("status" in modelPin) {
-      return modelPin;
-    }
-
-    const providerAdmission = await resolveTimedProviderAdmission({
-      args,
-      prepared,
-      modelPin,
-      requestedModelProvider: undefined,
-    });
-    signal.throwIfAborted();
+    const { modelPin, providerAdmission } = prepared.runConfiguration;
     if (providerAdmission.error) {
+      if (providerAdmission.error.status !== 402) {
+        return providerAdmission.error;
+      }
       return await appendInsufficientCreditsMessages({
         prepared,
         body: args.body,
@@ -3203,21 +3022,9 @@ const createNormalChatRun$ = command(
       });
     }
 
-    const codexServiceTierError = validateCodexServiceTier({
-      body: args.body,
-      modelPin,
-      providerAdmission,
-      codexFastModeEnabled: prepared.codexFastModeEnabled,
-    });
-    if (codexServiceTierError) {
-      return codexServiceTierError;
-    }
-
     const createRunArgs = await buildTimedCreateZeroRunArgs({
       args,
       prepared,
-      modelPin,
-      providerAdmission,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -243,6 +243,10 @@ interface PreparedNormalSend {
   readonly persistedExplicitSelection: boolean;
   readonly initialThinkingEnabled: boolean;
   readonly runConfiguration: ResolvedRunConfiguration;
+  readonly clientMessagePrechecked: boolean;
+  readonly preflightClientMessageConflict:
+    | ReturnType<typeof duplicateClientMessageIdResponse>
+    | undefined;
 }
 
 function shouldTouchThreadSortFromNormalSend(
@@ -2245,11 +2249,37 @@ const prepareNormalSend$ = command(
     { set },
     args: NormalSendArgs,
     signal: AbortSignal,
-  ): Promise<PreparedNormalSend | NormalSendFailure> => {
+  ): Promise<
+    PreparedNormalSend | NormalSendFailure | CreatedChatMessageResponse
+  > => {
     const db = set(writeDb$);
     const agent = await loadTimedAuthorizedAgent(args, db, signal);
     if ("status" in agent) {
       return agent;
+    }
+
+    const preflightThreadId = args.body.threadId ?? args.body.clientThreadId;
+    const clientMessagePrechecked = Boolean(
+      preflightThreadId && args.body.clientMessageId,
+    );
+    const preflightClientMessageResponse = preflightThreadId
+      ? await measureApiDispatchTiming(
+          args.timing,
+          "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
+          "nested",
+          () => {
+            return resolveClientMessageSend({
+              db,
+              userId: args.userId,
+              threadId: preflightThreadId,
+              clientMessageId: args.body.clientMessageId,
+            });
+          },
+        )
+      : undefined;
+    signal.throwIfAborted();
+    if (preflightClientMessageResponse?.status === 201) {
+      return preflightClientMessageResponse;
     }
 
     const generationTemplateError = validateGenerationTemplatePrompt(args.body);
@@ -2325,6 +2355,8 @@ const prepareNormalSend$ = command(
       persistedExplicitSelection,
       initialThinkingEnabled: args.zeroPreCreateSource === undefined,
       runConfiguration,
+      clientMessagePrechecked,
+      preflightClientMessageConflict: preflightClientMessageResponse,
     };
   },
 );
@@ -3119,19 +3151,25 @@ const sendNormalMessage$ = command(
       return prepared;
     }
 
-    const clientMessageResolution = await measureApiDispatchTiming(
-      args.timing,
-      "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
-      "nested",
-      async () => {
-        return await resolveClientMessageSend({
-          db: prepared.db,
-          userId: args.userId,
-          threadId: prepared.thread.threadId,
-          clientMessageId: args.body.clientMessageId,
-        });
-      },
-    );
+    const clientMessageResolution =
+      prepared.preflightClientMessageConflict ??
+      (!prepared.clientMessagePrechecked ||
+      args.body.revokesMessageId !== undefined ||
+      prepared.thread.isClientThreadRetry
+        ? await measureApiDispatchTiming(
+            args.timing,
+            "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
+            "nested",
+            async () => {
+              return await resolveClientMessageSend({
+                db: prepared.db,
+                userId: args.userId,
+                threadId: prepared.thread.threadId,
+                clientMessageId: args.body.clientMessageId,
+              });
+            },
+          )
+        : undefined);
     signal.throwIfAborted();
     if (clientMessageResolution) {
       return clientMessageResolution;

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
@@ -13,6 +13,7 @@ import { notFound } from "../../lib/error";
 import { createChatThread$ } from "../services/zero-chat-thread.service";
 import { zeroComposeExists } from "../services/zero-compose-data.service";
 import { resolveModelSelectionPin } from "../services/zero-model-selection.service";
+import { chatThreadModelPinColumns } from "../services/zero-chat-thread-model.service";
 import type { RouteEntry } from "../route-entry";
 
 const createBody$ = bodyResultOf(chatThreadsContract.create);
@@ -63,10 +64,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       title: body.data.title,
       clientThreadId: body.data.clientThreadId,
       eventId: body.data.eventId,
-      modelProviderId: pin.modelProviderId,
-      modelProviderType: pin.modelProviderType,
-      modelProviderCredentialScope: pin.modelProviderCredentialScope,
-      selectedModel: pin.selectedModel,
+      ...chatThreadModelPinColumns(pin),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-model-selection.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-model-selection.ts
@@ -4,7 +4,6 @@ import {
   chatThreadModelSelectionContract,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { isCodexFastModeModel } from "@vm0/api-contracts/contracts/model-providers";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -19,10 +18,12 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { appendChatThreadEvent } from "../services/zero-chat-thread-event.service";
 import {
+  isCodexFastServiceTierSupported,
   resolveModelFirstProviderAdmission,
   resolveModelSelectionPin,
   type ModelFirstPin,
 } from "../services/zero-model-selection.service";
+import { chatThreadModelPinColumns } from "../services/zero-chat-thread-model.service";
 import type { RouteEntry } from "../route-entry";
 
 const modelSelectionBody$ = bodyResultOf(
@@ -67,8 +68,11 @@ async function validateCodexServiceTierPatch(params: {
     return providerAdmission.error;
   }
   if (
-    providerAdmission.effectiveModelProvider === "codex-oauth-token" &&
-    isCodexFastModeModel(params.pin.selectedModel)
+    isCodexFastServiceTierSupported({
+      selectedModel: params.pin.selectedModel,
+      effectiveModelProvider: providerAdmission.effectiveModelProvider,
+      codexFastModeEnabled: true,
+    })
   ) {
     return undefined;
   }
@@ -125,10 +129,7 @@ const updateModelSelectionInner$ = command(
       const [thread] = await tx
         .update(chatThreads)
         .set({
-          modelProviderId: pin.modelProviderId,
-          modelProviderType: pin.modelProviderType,
-          modelProviderCredentialScope: pin.modelProviderCredentialScope,
-          selectedModel: pin.selectedModel,
+          ...chatThreadModelPinColumns(pin),
           codexServiceTier: body.data.codexServiceTier ?? null,
           updatedAt,
         })

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -16,6 +16,7 @@ import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -41,7 +42,10 @@ import { nowDate } from "../../lib/time";
 import { requireAgentPermission } from "../../lib/require-agent-permission";
 import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { postRunUserMessage } from "../services/zero-chat-run-message.service";
+import {
+  postRunUserMessage,
+  resolveRunChatThreadModelContext,
+} from "../services/zero-chat-run-message.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import { deleteZeroWorkflow$ } from "../services/zero-workflow-delete.service";
 import { zeroWorkflowDetail } from "../services/zero-workflow-detail.service";
@@ -1103,6 +1107,21 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
   signal.throwIfAborted();
 
+  const modelContext = await resolveRunChatThreadModelContext({
+    db: writeDb,
+    orgId: auth.orgId,
+    userId: auth.userId,
+    threadId: chatThreadId,
+  });
+  signal.throwIfAborted();
+  if ("status" in modelContext) {
+    return modelContext;
+  }
+  const { pin, providerAdmission, runCodexServiceTier } = modelContext;
+  if (providerAdmission.error) {
+    return providerAdmission.error;
+  }
+
   // Invoking a workflow is exactly typing its slash command in chat.
   const prompt = workflowSlashPrompt(workflow);
   const result = await set(
@@ -1114,11 +1133,22 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         userId: auth.userId,
         tokenType: "session",
       },
-      body: { prompt, agentId: agent.id },
+      body: {
+        prompt,
+        agentId: agent.id,
+        ...(providerAdmission.effectiveModelProvider
+          ? { modelProvider: providerAdmission.effectiveModelProvider }
+          : {}),
+      },
       apiStartTime: now.getTime(),
       triggerSource: "web",
       zeroPreCreateSource: "workflow_slash_command",
       chatThreadId,
+      modelProviderId: pin.modelProviderId ?? undefined,
+      modelProviderCredentialScope:
+        pin.modelProviderCredentialScope ?? undefined,
+      selectedModelOverride: pin.selectedModel ?? undefined,
+      codexServiceTier: runCodexServiceTier,
       callbacks: [
         {
           internalKind: "chat",
@@ -1144,6 +1174,17 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     prompt,
     appendQueueMarker: result.body.status === "queued",
   });
+  signal.throwIfAborted();
+
+  await writeDb
+    .update(zeroRuns)
+    .set({
+      modelProvider: providerAdmission.effectiveModelProvider,
+      modelProviderId: pin.modelProviderId,
+      modelProviderCredentialScope: pin.modelProviderCredentialScope,
+      selectedModel: pin.selectedModel,
+    })
+    .where(eq(zeroRuns.id, result.body.runId));
   signal.throwIfAborted();
 
   return {

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -1,4 +1,26 @@
-import { normalizeRunModelId } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  MODEL_PROVIDER_TYPES,
+  areProvidersCompatible,
+  normalizeRunModelId,
+  type ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import type { Db, ReadonlyDb } from "../external/db";
+
+function isKnownModelProvider(
+  value: string | null | undefined,
+): value is ModelProviderType {
+  return (
+    value !== null &&
+    value !== undefined &&
+    Object.hasOwn(MODEL_PROVIDER_TYPES, value)
+  );
+}
 
 /**
  * Return the vendor/model stem used for chat session continuity.
@@ -23,7 +45,25 @@ function chatSessionModelFamily(model: string): string {
 export function shouldStartNewChatSession(args: {
   readonly latestModel: string | null | undefined;
   readonly nextModel: string | null;
+  readonly latestModelProvider?: string | null;
+  readonly nextModelProvider?: string | null;
+  readonly latestCliAgentType?: string | null;
+  readonly nextCliAgentType?: string | null;
 }): boolean {
+  if (
+    args.latestCliAgentType &&
+    args.nextCliAgentType &&
+    args.latestCliAgentType !== args.nextCliAgentType
+  ) {
+    return true;
+  }
+  if (
+    isKnownModelProvider(args.latestModelProvider) &&
+    isKnownModelProvider(args.nextModelProvider) &&
+    !areProvidersCompatible(args.latestModelProvider, args.nextModelProvider)
+  ) {
+    return true;
+  }
   if (
     args.latestModel === undefined ||
     args.latestModel === null ||
@@ -35,5 +75,44 @@ export function shouldStartNewChatSession(args: {
   return (
     chatSessionModelFamily(args.latestModel) !==
     chatSessionModelFamily(args.nextModel)
+  );
+}
+
+export async function canReuseChatSessionForModelRoute(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly threadId: string;
+  readonly sessionId: string;
+  readonly nextModel: string | null;
+  readonly nextModelProvider: string | null | undefined;
+  readonly nextCliAgentType: string | null | undefined;
+}): Promise<boolean> {
+  const [previous] = await args.db
+    .select({
+      selectedModel: zeroRuns.selectedModel,
+      modelProvider: zeroRuns.modelProvider,
+      cliAgentType: conversations.cliAgentType,
+    })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, args.threadId),
+        sql`${agentRuns.result}->>'agentSessionId' = ${args.sessionId}`,
+      ),
+    )
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(1);
+  return (
+    !previous ||
+    !shouldStartNewChatSession({
+      latestModel: previous.selectedModel,
+      nextModel: args.nextModel,
+      latestModelProvider: previous.modelProvider,
+      nextModelProvider: args.nextModelProvider,
+      latestCliAgentType: previous.cliAgentType,
+      nextCliAgentType: args.nextCliAgentType,
+    })
   );
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2,11 +2,11 @@ import { randomBytes } from "node:crypto";
 
 import { command } from "ccstate";
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
-import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
 import {
   chatMessages,
@@ -14,7 +14,7 @@ import {
   type ChatMessageRecommendedFollowups,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
+import { conversations } from "@vm0/db/schema/conversation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
@@ -91,6 +91,8 @@ import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { shouldStartNewChatSession } from "./chat-session-continuity.service";
 import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
+import { resolveRunChatThreadModelContext } from "./zero-chat-run-message.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
 
 const log = logger("callback:chat");
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -338,6 +340,8 @@ interface PriorRun {
 interface LatestThreadSession {
   readonly sessionId: string;
   readonly selectedModel: string | null;
+  readonly modelProvider: string | null;
+  readonly cliAgentType: string | null;
 }
 
 interface AgentForAutoSend {
@@ -427,6 +431,9 @@ interface CreateQueuedChatRunInput {
   readonly appendSystemPrompt: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly modelPin: ModelFirstPin;
+  readonly effectiveModelProvider: string | null | undefined;
+  readonly codexServiceTier: "fast" | undefined;
   readonly computerUseHostGrant: {
     readonly hostId: string;
     readonly displayName: string;
@@ -483,15 +490,6 @@ function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
 
-function parseModelProviderCredentialScope(
-  value: string | null,
-): ModelProviderCredentialScope | null {
-  if (value === null || value === "org" || value === "member") {
-    return value;
-  }
-  throw new Error(`Unknown model provider credential scope "${value}"`);
-}
-
 function buildQueuedCreateZeroRunArgs(
   input: CreateQueuedChatRunInput,
   apiStartTime: number,
@@ -507,10 +505,11 @@ function buildQueuedCreateZeroRunArgs(
     apiStartTime,
     chatThreadId: input.threadId,
     computerUseHostId: input.computerUseHostGrant?.hostId,
-    modelProviderId: input.queuedMessage.modelProviderId ?? undefined,
+    modelProviderId: input.modelPin.modelProviderId ?? undefined,
     modelProviderCredentialScope:
-      input.queuedMessage.modelProviderCredentialScope ?? undefined,
-    selectedModelOverride: input.queuedMessage.selectedModel ?? undefined,
+      input.modelPin.modelProviderCredentialScope ?? undefined,
+    selectedModelOverride: input.modelPin.selectedModel ?? undefined,
+    codexServiceTier: input.codexServiceTier,
     callbacks: [
       {
         internalKind: "chat" as const,
@@ -533,8 +532,8 @@ function buildQueuedCreateZeroRunArgs(
       prompt: input.prompt,
       agentId: input.agentId,
       ...(input.sessionId ? { sessionId: input.sessionId } : {}),
-      ...(input.queuedMessage.modelProviderType
-        ? { modelProvider: input.queuedMessage.modelProviderType }
+      ...(input.effectiveModelProvider
+        ? { modelProvider: input.effectiveModelProvider }
         : {}),
     },
   };
@@ -1559,46 +1558,6 @@ async function getLatestRunsByThreadId(
   });
 }
 
-async function resolveQueuedMessageModelPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly queuedMessage: QueuedUserMessage;
-}): Promise<QueuedUserMessage> {
-  if (!params.queuedMessage.selectedModel) {
-    return params.queuedMessage;
-  }
-
-  const [policy] = await params.db
-    .select({
-      model: orgModelPolicies.model,
-      defaultProviderType: orgModelPolicies.defaultProviderType,
-      credentialScope: orgModelPolicies.credentialScope,
-      modelProviderId: orgModelPolicies.modelProviderId,
-    })
-    .from(orgModelPolicies)
-    .where(
-      and(
-        eq(orgModelPolicies.orgId, params.orgId),
-        eq(orgModelPolicies.model, params.queuedMessage.selectedModel),
-      ),
-    )
-    .limit(1);
-
-  if (!policy) {
-    return params.queuedMessage;
-  }
-
-  return {
-    ...params.queuedMessage,
-    modelProviderId: policy.modelProviderId ?? null,
-    modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: parseModelProviderCredentialScope(
-      policy.credentialScope,
-    ),
-    selectedModel: policy.model,
-  };
-}
-
 async function chatThreadForRunFromDb(
   db: Db,
   runId: string,
@@ -1646,9 +1605,13 @@ async function latestSessionForThreadFromDb(
     .select({
       result: agentRuns.result,
       selectedModel: zeroRuns.selectedModel,
+      modelProvider: zeroRuns.modelProvider,
+      cliAgentType: conversations.cliAgentType,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
+    .leftJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
     // D7 session-continuity exclusion: Web and canonical Slack messages share
     // the thread queue but keep independent source-specific session chains.
     .where(
@@ -1665,6 +1628,8 @@ async function latestSessionForThreadFromDb(
       return {
         sessionId: row.result.agentSessionId,
         selectedModel: row.selectedModel,
+        modelProvider: row.modelProvider,
+        cliAgentType: row.cliAgentType,
       };
     }
   }
@@ -1673,11 +1638,17 @@ async function latestSessionForThreadFromDb(
 
 function shouldStartNewSessionForQueuedMessage(params: {
   readonly latestSession: LatestThreadSession | null;
-  readonly queuedMessage: QueuedUserMessage;
+  readonly modelPin: ModelFirstPin;
+  readonly effectiveModelProvider: string | null | undefined;
+  readonly cliAgentType: string | null;
 }): boolean {
   return shouldStartNewChatSession({
     latestModel: params.latestSession?.selectedModel,
-    nextModel: params.queuedMessage.selectedModel,
+    nextModel: params.modelPin.selectedModel,
+    latestModelProvider: params.latestSession?.modelProvider,
+    nextModelProvider: params.effectiveModelProvider,
+    latestCliAgentType: params.latestSession?.cliAgentType,
+    nextCliAgentType: params.cliAgentType,
   });
 }
 
@@ -1821,6 +1792,79 @@ async function buildQueuedFullPrompt(args: {
   return `${content}\n\n${buildWebAttachFilesPrompt(attachFiles)}`;
 }
 
+async function resolveQueuedPrompt(args: {
+  readonly getResolvedAttachFiles: ResolveAttachFiles;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly userId: string;
+  readonly sourcePrompt: string | undefined;
+  readonly timing?: ChatCallbackPreCreateTimingCollector;
+}): Promise<string> {
+  const canonicalPrompt = await measureChatCallbackPreCreateTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prompt",
+    "nested",
+    () => {
+      return buildQueuedFullPrompt({
+        getResolvedAttachFiles: args.getResolvedAttachFiles,
+        queuedMessage: args.queuedMessage,
+        userId: args.userId,
+        timing: args.timing,
+      });
+    },
+  );
+  return args.sourcePrompt ?? canonicalPrompt;
+}
+
+interface QueuedMessageModelRoute {
+  readonly modelPin: ModelFirstPin;
+  readonly effectiveModelProvider: string | null | undefined;
+  readonly cliAgentType: string | null;
+  readonly codexServiceTier: "fast" | undefined;
+}
+
+async function resolveQueuedMessageModelRoute(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly timing?: ChatCallbackPreCreateTimingCollector;
+}): Promise<QueuedMessageModelRoute | null> {
+  const modelContext = await measureChatCallbackPreCreateTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin",
+    "nested",
+    () => {
+      return resolveRunChatThreadModelContext({
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        threadId: args.threadId,
+      });
+    },
+  );
+  if ("status" in modelContext) {
+    log.warn("Auto-send aborted: current model route is unavailable", {
+      threadId: args.threadId,
+      error: modelContext.body.error.message,
+    });
+    return null;
+  }
+  if (modelContext.providerAdmission.error) {
+    log.warn("Auto-send aborted: current model route was not admitted", {
+      threadId: args.threadId,
+      error: modelContext.providerAdmission.error.body.error.message,
+    });
+    return null;
+  }
+  return {
+    modelPin: modelContext.pin,
+    effectiveModelProvider:
+      modelContext.providerAdmission.effectiveModelProvider,
+    cliAgentType: modelContext.providerAdmission.cliAgentType,
+    codexServiceTier: modelContext.runCodexServiceTier,
+  };
+}
+
 async function buildCreateQueuedChatRunInput(args: {
   readonly db: Db;
   readonly getResolvedAttachFiles: ResolveAttachFiles;
@@ -1829,7 +1873,7 @@ async function buildCreateQueuedChatRunInput(args: {
   readonly agent: AgentForAutoSend;
   readonly queuedMessage: QueuedUserMessage;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
-}): Promise<CreateQueuedChatRunInput> {
+}): Promise<CreateQueuedChatRunInput | null> {
   const sourceParams = await decryptQueuedUserMessageRunParams(
     args.queuedMessage.encryptedParams,
     { orgId: args.agent.orgId, userId: args.userId },
@@ -1837,18 +1881,16 @@ async function buildCreateQueuedChatRunInput(args: {
   if (args.queuedMessage.triggerSource === "slack" && !sourceParams) {
     throw new Error("Canonical Slack queue item is missing run params");
   }
-  const resolvedQueuedMessage = await measureChatCallbackPreCreateTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin",
-    "nested",
-    () => {
-      return resolveQueuedMessageModelPin({
-        db: args.db,
-        orgId: args.agent.orgId,
-        queuedMessage: args.queuedMessage,
-      });
-    },
-  );
+  const modelRoute = await resolveQueuedMessageModelRoute({
+    db: args.db,
+    threadId: args.threadId,
+    userId: args.userId,
+    orgId: args.agent.orgId,
+    timing: args.timing,
+  });
+  if (!modelRoute) {
+    return null;
+  }
 
   const [latestSession, loadedIncompleteContext, featureSwitchContext] =
     await measureChatCallbackPreCreateTiming(
@@ -1871,7 +1913,9 @@ async function buildCreateQueuedChatRunInput(args: {
     );
   const startNewSession = shouldStartNewSessionForQueuedMessage({
     latestSession,
-    queuedMessage: resolvedQueuedMessage,
+    modelPin: modelRoute.modelPin,
+    effectiveModelProvider: modelRoute.effectiveModelProvider,
+    cliAgentType: modelRoute.cliAgentType,
   });
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
@@ -1894,7 +1938,7 @@ async function buildCreateQueuedChatRunInput(args: {
     "nested",
     () => {
       return resolveThreadGenerationTemplatePrompt({
-        explicit: resolvedQueuedMessage.generationTemplate,
+        explicit: args.queuedMessage.generationTemplate,
         websiteTemplateV2Enabled: isFeatureEnabled(
           FeatureSwitchKey.WebsiteTemplateV2,
           featureSwitchContext,
@@ -1915,20 +1959,13 @@ async function buildCreateQueuedChatRunInput(args: {
       });
     },
   );
-  const canonicalPrompt = await measureChatCallbackPreCreateTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prompt",
-    "nested",
-    () => {
-      return buildQueuedFullPrompt({
-        getResolvedAttachFiles: args.getResolvedAttachFiles,
-        queuedMessage: resolvedQueuedMessage,
-        userId: args.userId,
-        timing: args.timing,
-      });
-    },
-  );
-  const prompt = sourceParams?.prompt ?? canonicalPrompt;
+  const prompt = await resolveQueuedPrompt({
+    getResolvedAttachFiles: args.getResolvedAttachFiles,
+    queuedMessage: args.queuedMessage,
+    userId: args.userId,
+    sourcePrompt: sourceParams?.prompt,
+    timing: args.timing,
+  });
 
   return {
     orgId: args.agent.orgId,
@@ -1944,7 +1981,10 @@ async function buildCreateQueuedChatRunInput(args: {
       computerUseHostGrant?.displayName ?? null,
     ),
     threadId: args.threadId,
-    queuedMessage: resolvedQueuedMessage,
+    queuedMessage: args.queuedMessage,
+    modelPin: modelRoute.modelPin,
+    effectiveModelProvider: modelRoute.effectiveModelProvider,
+    codexServiceTier: modelRoute.codexServiceTier,
     computerUseHostGrant,
     triggerSource: args.queuedMessage.triggerSource,
     slackDelivery: sourceParams?.slackDelivery,
@@ -2233,6 +2273,9 @@ async function autoSendQueuedMessageForThread(args: {
       });
     },
   );
+  if (!runInput) {
+    return;
+  }
   const activeRunExists = await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run",
@@ -2303,11 +2346,11 @@ async function createQueuedChatRun(args: {
   await args.db
     .update(zeroRuns)
     .set({
-      modelProvider: args.input.queuedMessage.modelProviderType,
-      modelProviderId: args.input.queuedMessage.modelProviderId,
+      modelProvider: args.input.effectiveModelProvider,
+      modelProviderId: args.input.modelPin.modelProviderId,
       modelProviderCredentialScope:
-        args.input.queuedMessage.modelProviderCredentialScope,
-      selectedModel: args.input.queuedMessage.selectedModel,
+        args.input.modelPin.modelProviderCredentialScope,
+      selectedModel: args.input.modelPin.selectedModel,
     })
     .where(eq(zeroRuns.id, created.runId));
   args.signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -36,12 +36,9 @@ import {
 import { resolveDefaultAgent } from "./zero-email-common.service";
 import {
   postRunUserMessage,
-  resolveRunChatThreadModelPin,
+  resolveRunChatThreadModelContext,
 } from "./zero-chat-run-message.service";
-import {
-  resolveModelFirstProviderAdmission,
-  type ModelFirstPin,
-} from "./zero-model-selection.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { createAutomationChatThread } from "./zero-workflow-user-automation-thread.service";
 
@@ -338,6 +335,7 @@ async function ensureMorningBriefChatThread(
 interface MorningBriefModelContext {
   readonly modelPin: ModelFirstPin;
   readonly effectiveModelProvider: string | null | undefined;
+  readonly codexServiceTier: "fast" | undefined;
 }
 
 async function resolveMorningBriefModelContext(
@@ -346,30 +344,24 @@ async function resolveMorningBriefModelContext(
   chatThreadId: string,
 ): Promise<MorningBriefModelContext | null> {
   const { row, deliveryId, currentTime } = claimed;
-  const modelPin = await resolveRunChatThreadModelPin({
+  const modelContext = await resolveRunChatThreadModelContext({
     db,
     orgId: row.orgId,
     userId: row.userId,
     threadId: chatThreadId,
   });
-  if ("status" in modelPin) {
+  if ("status" in modelContext) {
     // Credit / provider admission problems skip silently by design; the
     // schedule already points at tomorrow 7:00.
     await markDeliveryFailed(
       db,
       deliveryId,
-      modelPin.body.error.message,
+      modelContext.body.error.message,
       currentTime,
     );
     return null;
   }
-  const providerAdmission = await resolveModelFirstProviderAdmission({
-    db,
-    orgId: row.orgId,
-    userId: row.userId,
-    modelPin,
-    requestedModelProvider: undefined,
-  });
+  const { pin, providerAdmission, runCodexServiceTier } = modelContext;
   if (providerAdmission.error) {
     await markDeliveryFailed(
       db,
@@ -380,8 +372,9 @@ async function resolveMorningBriefModelContext(
     return null;
   }
   return {
-    modelPin,
+    modelPin: pin,
     effectiveModelProvider: providerAdmission.effectiveModelProvider,
+    codexServiceTier: runCodexServiceTier,
   };
 }
 
@@ -514,6 +507,7 @@ const startMorningBriefRun$ = command(
         modelProviderCredentialScope:
           model.modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: model.modelPin.selectedModel ?? undefined,
+        codexServiceTier: model.codexServiceTier,
         appendSystemPrompt: buildMorningBriefAppendSystemPrompt({
           briefDate,
           timezone,

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -2,60 +2,31 @@ import {
   chatMessages,
   type ChatMessageGoalSnapshot,
 } from "@vm0/db/schema/chat-message";
-import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { and, asc, eq, isNotNull } from "drizzle-orm";
 
-import {
-  badRequestMessage,
-  insufficientCredits,
-  providerDeleted,
-} from "../../lib/error";
+import { badRequestMessage } from "../../lib/error";
 import type { Db } from "../external/db";
 import {
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
 import { nowDate } from "../external/time";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { insertChatMessage } from "./zero-chat-message.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import {
-  MODEL_FIRST_SELECTION_PROVIDER_ID,
-  type ModelFirstPin,
-  modelOnlyModelFirstPin,
-  modelProviderPinAvailable,
-  resolveDefaultModelFirstPin,
-  resolveModelSelectionPin,
-} from "./zero-model-selection.service";
+  resolvePersistedChatThreadModel,
+  type ResolvedPersistedChatThreadModel,
+} from "./zero-chat-thread-model.service";
 
-type RunChatThreadModelPin = ModelFirstPin;
-
-type RunChatThreadModelPinResult =
-  | RunChatThreadModelPin
-  | ReturnType<typeof providerDeleted>
-  | ReturnType<typeof badRequestMessage>
-  | ReturnType<typeof insufficientCredits>;
-
-async function getStoredThreadModelPin(
+async function getFirstRunSelectedModel(
   db: Db,
   threadId: string,
-): Promise<RunChatThreadModelPin | null> {
-  const [thread] = await db
-    .select({ selectedModel: chatThreads.selectedModel })
-    .from(chatThreads)
-    .where(eq(chatThreads.id, threadId))
-    .limit(1);
-  if (!thread?.selectedModel) {
-    return null;
-  }
-  return modelOnlyModelFirstPin(thread.selectedModel);
-}
-
-async function getFirstRunModelPin(
-  db: Db,
-  threadId: string,
-): Promise<RunChatThreadModelPin | null> {
+): Promise<string | null> {
   const [run] = await db
     .select({ selectedModel: zeroRuns.selectedModel })
     .from(chatMessages)
@@ -70,80 +41,42 @@ async function getFirstRunModelPin(
     )
     .orderBy(asc(chatMessages.createdAt), asc(chatMessages.id))
     .limit(1);
-  if (!run?.selectedModel) {
-    return null;
-  }
-  return modelOnlyModelFirstPin(run.selectedModel);
-}
-
-async function existingModelFirstThreadPin(
-  db: Db,
-  threadId: string,
-): Promise<RunChatThreadModelPin | null> {
-  return (
-    (await getStoredThreadModelPin(db, threadId)) ??
-    (await getFirstRunModelPin(db, threadId))
-  );
-}
-
-async function resolveStoredModelFirstPin(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly pin: RunChatThreadModelPin;
-}): Promise<RunChatThreadModelPinResult> {
-  if (!params.pin.selectedModel) {
-    return params.pin;
-  }
-  if (params.pin.modelProviderId) {
-    const available = await modelProviderPinAvailable({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      modelProviderId: params.pin.modelProviderId,
-    });
-    if (!available) {
-      return providerDeleted();
-    }
-    return params.pin;
-  }
-  if (params.pin.modelProviderType || params.pin.modelProviderCredentialScope) {
-    return params.pin;
-  }
-  return resolveModelSelectionPin({
-    db: params.db,
-    orgId: params.orgId,
-    userId: params.userId,
-    modelSelection: {
-      modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
-      selectedModel: params.pin.selectedModel,
-    },
-  });
+  return run?.selectedModel ?? null;
 }
 
 /**
- * Resolve the model pin for a chat-mode run from its linked thread:
- * the thread's stored pin, else its first-run pin, else the org default.
+ * Resolve a chat-derived run against the current workspace model policy.
+ * Legacy threads without a stored model may use their first run as the sticky
+ * preference before normal workspace-default recovery applies.
  */
-export async function resolveRunChatThreadModelPin(params: {
+export async function resolveRunChatThreadModelContext(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
-}): Promise<RunChatThreadModelPinResult> {
-  const existing = await existingModelFirstThreadPin(
-    params.db,
-    params.threadId,
-  );
-  if (existing) {
-    return resolveStoredModelFirstPin({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-      pin: existing,
-    });
+}): Promise<
+  ResolvedPersistedChatThreadModel | ReturnType<typeof badRequestMessage>
+> {
+  const [fallbackSelectedModel, featureSwitchContext] = await Promise.all([
+    getFirstRunSelectedModel(params.db, params.threadId),
+    loadUserFeatureSwitchContext(params.db, params.orgId, params.userId),
+  ]);
+  const resolved = await resolvePersistedChatThreadModel({
+    db: params.db,
+    orgId: params.orgId,
+    userId: params.userId,
+    threadId: params.threadId,
+    fallbackSelectedModel,
+    persistRequestedCodexServiceTier: false,
+    codexFastModeEnabled: isFeatureEnabled(
+      FeatureSwitchKey.CodexFastMode,
+      featureSwitchContext,
+    ),
+  });
+  if (!resolved) {
+    return badRequestMessage("Chat thread not found");
   }
-  return resolveDefaultModelFirstPin(params.db, params.orgId, params.userId);
+  return resolved;
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
@@ -1,23 +1,317 @@
-import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { and, eq } from "drizzle-orm";
 
+import { badRequestMessage } from "../../lib/error";
 import type { Db } from "../external/db";
 import {
+  publishChatThreadDetailChangedSafely,
+  publishThreadListChangedSafely,
+} from "../external/realtime";
+import { nowDate } from "../external/time";
+import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
+import {
+  isCodexFastServiceTierSupported,
   resolveDefaultModelFirstPin,
+  resolveModelFirstProviderAdmission,
+  resolvePersistedModelFirstRoute,
   type ModelFirstPin,
 } from "./zero-model-selection.service";
 
 export function chatThreadModelPinColumns(pin: ModelFirstPin): {
-  readonly modelProviderId: string | null;
-  readonly modelProviderType: string | null;
-  readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
+  readonly modelProviderId: null;
+  readonly modelProviderType: null;
+  readonly modelProviderCredentialScope: null;
   readonly selectedModel: string | null;
 } {
   return {
-    modelProviderId: pin.modelProviderId,
-    modelProviderType: pin.modelProviderType,
-    modelProviderCredentialScope: pin.modelProviderCredentialScope,
+    modelProviderId: null,
+    modelProviderType: null,
+    modelProviderCredentialScope: null,
     selectedModel: pin.selectedModel,
   };
+}
+
+type ModelFirstProviderAdmission = Awaited<
+  ReturnType<typeof resolveModelFirstProviderAdmission>
+>;
+type ChatThreadModelTransaction = Parameters<
+  Parameters<Db["transaction"]>[0]
+>[0];
+
+interface ResolvePersistedChatThreadModelParams {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly fallbackSelectedModel?: string | null;
+  readonly requestedCodexServiceTier?: CodexServiceTier;
+  readonly persistRequestedCodexServiceTier: boolean;
+  readonly codexFastModeEnabled: boolean;
+}
+
+interface LockedChatThreadModel {
+  readonly selectedModel: string | null;
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: string | null;
+  readonly modelProviderCredentialScope: string | null;
+  readonly codexServiceTier: CodexServiceTier | null;
+  readonly agentComposeId: string;
+}
+
+export interface ResolvedPersistedChatThreadModel {
+  readonly pin: ModelFirstPin;
+  readonly providerAdmission: ModelFirstProviderAdmission;
+  readonly runCodexServiceTier: "fast" | undefined;
+  readonly persistedCodexServiceTier: CodexServiceTier | null;
+  readonly selectedModelChanged: boolean;
+}
+
+interface PersistedChatThreadModelTransactionResult {
+  readonly resolved:
+    | ResolvedPersistedChatThreadModel
+    | ReturnType<typeof badRequestMessage>
+    | null;
+  readonly publishThreadList: boolean;
+  readonly publishThreadDetail: boolean;
+}
+
+type CodexTierResolution =
+  | {
+      readonly kind: "error";
+      readonly error: ReturnType<typeof badRequestMessage>;
+    }
+  | {
+      readonly kind: "ok";
+      readonly runCodexServiceTier: "fast" | undefined;
+      readonly persistedCodexServiceTier: CodexServiceTier | null;
+      readonly tierChanged: boolean;
+    };
+
+function transactionResultWithoutPublish(
+  resolved: PersistedChatThreadModelTransactionResult["resolved"],
+): PersistedChatThreadModelTransactionResult {
+  return {
+    resolved,
+    publishThreadList: false,
+    publishThreadDetail: false,
+  };
+}
+
+async function loadLockedChatThreadModel(
+  tx: ChatThreadModelTransaction,
+  params: Pick<ResolvePersistedChatThreadModelParams, "threadId" | "userId">,
+): Promise<LockedChatThreadModel | undefined> {
+  const [thread] = await tx
+    .select({
+      selectedModel: chatThreads.selectedModel,
+      modelProviderId: chatThreads.modelProviderId,
+      modelProviderType: chatThreads.modelProviderType,
+      modelProviderCredentialScope: chatThreads.modelProviderCredentialScope,
+      codexServiceTier: chatThreads.codexServiceTier,
+      agentComposeId: chatThreads.agentComposeId,
+    })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, params.threadId),
+        eq(chatThreads.userId, params.userId),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  return thread;
+}
+
+function resolveCodexTier(args: {
+  readonly persistedTier: CodexServiceTier | null;
+  readonly requestedTier: CodexServiceTier | undefined;
+  readonly persistRequestedTier: boolean;
+  readonly fastSupported: boolean;
+  readonly selectedModelChanged: boolean;
+}): CodexTierResolution {
+  const persistedFastNeedsNormalization =
+    args.persistedTier === "fast" && !args.fastSupported;
+  if (
+    args.persistRequestedTier &&
+    args.requestedTier === "fast" &&
+    !args.fastSupported &&
+    !args.selectedModelChanged &&
+    !persistedFastNeedsNormalization
+  ) {
+    return {
+      kind: "error",
+      error: badRequestMessage(
+        "Codex fast mode is not available for the selected model route",
+      ),
+    };
+  }
+
+  const compatibleStoredTier =
+    args.persistedTier === "fast" && args.fastSupported ? "fast" : null;
+  const runCodexServiceTier = args.persistRequestedTier
+    ? args.requestedTier === "fast" && args.fastSupported
+      ? "fast"
+      : undefined
+    : (compatibleStoredTier ?? undefined);
+  const persistedCodexServiceTier = args.persistRequestedTier
+    ? (runCodexServiceTier ?? null)
+    : compatibleStoredTier;
+  return {
+    kind: "ok",
+    runCodexServiceTier,
+    persistedCodexServiceTier,
+    tierChanged: persistedCodexServiceTier !== args.persistedTier,
+  };
+}
+
+function legacyProviderPinPresent(thread: LockedChatThreadModel): boolean {
+  return (
+    thread.modelProviderId !== null ||
+    thread.modelProviderType !== null ||
+    thread.modelProviderCredentialScope !== null
+  );
+}
+
+async function persistReconciledChatThreadModel(args: {
+  readonly tx: ChatThreadModelTransaction;
+  readonly params: ResolvePersistedChatThreadModelParams;
+  readonly thread: LockedChatThreadModel;
+  readonly pin: ModelFirstPin;
+  readonly persistedCodexServiceTier: CodexServiceTier | null;
+  readonly selectedModelChanged: boolean;
+  readonly tierChanged: boolean;
+}): Promise<void> {
+  if (
+    !args.selectedModelChanged &&
+    !args.tierChanged &&
+    !legacyProviderPinPresent(args.thread)
+  ) {
+    return;
+  }
+
+  const updatedAt = nowDate();
+  await args.tx
+    .update(chatThreads)
+    .set({
+      ...chatThreadModelPinColumns(args.pin),
+      codexServiceTier: args.persistedCodexServiceTier,
+      updatedAt,
+    })
+    .where(
+      and(
+        eq(chatThreads.id, args.params.threadId),
+        eq(chatThreads.userId, args.params.userId),
+      ),
+    );
+  if (args.selectedModelChanged) {
+    await appendChatThreadEvent(args.tx, {
+      kind: "model_selection_updated",
+      userId: args.params.userId,
+      orgId: args.params.orgId,
+      chatThreadId: args.params.threadId,
+      agentComposeId: args.thread.agentComposeId,
+      selectedModel: args.pin.selectedModel,
+      createdAt: updatedAt,
+    });
+  }
+}
+
+async function resolvePersistedChatThreadModelInTransaction(
+  tx: ChatThreadModelTransaction,
+  params: ResolvePersistedChatThreadModelParams,
+): Promise<PersistedChatThreadModelTransactionResult> {
+  const thread = await loadLockedChatThreadModel(tx, params);
+  if (!thread) {
+    return transactionResultWithoutPublish(null);
+  }
+
+  const modelResolution = await resolvePersistedModelFirstRoute({
+    db: tx,
+    orgId: params.orgId,
+    userId: params.userId,
+    selectedModel: thread.selectedModel ?? params.fallbackSelectedModel ?? null,
+  });
+  if (!modelResolution.route) {
+    return transactionResultWithoutPublish(
+      badRequestMessage(
+        "No valid model route is configured for this workspace",
+      ),
+    );
+  }
+
+  const pin: ModelFirstPin = {
+    modelProviderId: modelResolution.route.modelProviderId,
+    modelProviderType: modelResolution.route.modelProviderType,
+    modelProviderCredentialScope:
+      modelResolution.route.modelProviderCredentialScope,
+    selectedModel: modelResolution.route.selectedModel,
+  };
+  const providerAdmission = await resolveModelFirstProviderAdmission({
+    db: tx,
+    orgId: params.orgId,
+    userId: params.userId,
+    modelPin: pin,
+    requestedModelProvider: undefined,
+  });
+  const selectedModelChanged =
+    modelResolution.selectedModelChanged ||
+    thread.selectedModel !== pin.selectedModel;
+  const tier = resolveCodexTier({
+    persistedTier: thread.codexServiceTier,
+    requestedTier: params.requestedCodexServiceTier,
+    persistRequestedTier: params.persistRequestedCodexServiceTier,
+    fastSupported: isCodexFastServiceTierSupported({
+      selectedModel: pin.selectedModel,
+      effectiveModelProvider: providerAdmission.effectiveModelProvider,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    }),
+    selectedModelChanged,
+  });
+  if (tier.kind === "error") {
+    return transactionResultWithoutPublish(tier.error);
+  }
+
+  await persistReconciledChatThreadModel({
+    tx,
+    params,
+    thread,
+    pin,
+    persistedCodexServiceTier: tier.persistedCodexServiceTier,
+    selectedModelChanged,
+    tierChanged: tier.tierChanged,
+  });
+  return {
+    resolved: {
+      pin,
+      providerAdmission,
+      runCodexServiceTier: tier.runCodexServiceTier,
+      persistedCodexServiceTier: tier.persistedCodexServiceTier,
+      selectedModelChanged,
+    },
+    publishThreadList: selectedModelChanged,
+    publishThreadDetail: tier.tierChanged,
+  };
+}
+
+export async function resolvePersistedChatThreadModel(
+  params: ResolvePersistedChatThreadModelParams,
+): Promise<
+  ResolvedPersistedChatThreadModel | ReturnType<typeof badRequestMessage> | null
+> {
+  const result = await params.db.transaction((tx) => {
+    return resolvePersistedChatThreadModelInTransaction(tx, params);
+  });
+
+  await Promise.all([
+    result.publishThreadList
+      ? publishThreadListChangedSafely(params.userId)
+      : Promise.resolve(),
+    result.publishThreadDetail
+      ? publishChatThreadDetailChangedSafely(params.userId, params.threadId)
+      : Promise.resolve(),
+  ]);
+  return result.resolved;
 }
 
 export async function resolveRequiredDefaultChatThreadModelPin(

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -12,8 +12,9 @@ import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   postRunUserMessage,
-  resolveRunChatThreadModelPin,
+  resolveRunChatThreadModelContext,
 } from "./zero-chat-run-message.service";
+import { canReuseChatSessionForModelRoute } from "./chat-session-continuity.service";
 import { hasUnclaimedQueuedUserMessage } from "./zero-chat-queued-message.service";
 import {
   pauseActiveGoalForThread,
@@ -21,10 +22,7 @@ import {
   type GoalBootstrap,
 } from "./zero-goal.service";
 import { normalizeGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
-import {
-  resolveModelFirstProviderAdmission,
-  type ModelFirstPin,
-} from "./zero-model-selection.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 
 const log = logger("api:zero-goal-continuation");
@@ -75,6 +73,8 @@ type ModelContext =
       readonly ok: true;
       readonly modelPin: ModelFirstPin;
       readonly effectiveModelProvider: string | null | undefined;
+      readonly cliAgentType: string | null;
+      readonly codexServiceTier: "fast" | undefined;
     }
   | {
       readonly ok: false;
@@ -234,30 +234,27 @@ async function resolveModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<ModelContext> {
-  const threadModelPin = await resolveRunChatThreadModelPin({
+  const threadModelContext = await resolveRunChatThreadModelContext({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
     threadId: args.chatThreadId,
   });
   args.signal.throwIfAborted();
-  if ("status" in threadModelPin) {
+  if ("status" in threadModelContext) {
     return {
       ok: false,
       failure: {
         kind: "run_error",
-        response: { status: 400, body: threadModelPin.body },
+        response: {
+          status: threadModelContext.status,
+          body: threadModelContext.body,
+        },
       },
     };
   }
 
-  const providerAdmission = await resolveModelFirstProviderAdmission({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    modelPin: threadModelPin,
-    requestedModelProvider: undefined,
-  });
+  const { pin, providerAdmission, runCodexServiceTier } = threadModelContext;
   args.signal.throwIfAborted();
   if (providerAdmission.error) {
     return {
@@ -268,8 +265,10 @@ async function resolveModelContext(args: {
 
   return {
     ok: true,
-    modelPin: threadModelPin,
+    modelPin: pin,
     effectiveModelProvider: providerAdmission.effectiveModelProvider,
+    cliAgentType: providerAdmission.cliAgentType,
+    codexServiceTier: runCodexServiceTier,
   };
 }
 
@@ -296,7 +295,21 @@ const runGoalNow$ = command(
     if (!modelContext.ok) {
       return modelContext.failure;
     }
-    const { modelPin, effectiveModelProvider } = modelContext;
+    const { modelPin, effectiveModelProvider, cliAgentType, codexServiceTier } =
+      modelContext;
+    const sessionId =
+      args.sessionId &&
+      (await canReuseChatSessionForModelRoute({
+        db,
+        threadId: goal.threadId,
+        sessionId: args.sessionId,
+        nextModel: modelPin.selectedModel,
+        nextModelProvider: effectiveModelProvider,
+        nextCliAgentType: cliAgentType,
+      }))
+        ? args.sessionId
+        : undefined;
+    signal.throwIfAborted();
 
     const normalizedGoal = {
       ...goal,
@@ -318,7 +331,7 @@ const runGoalNow$ = command(
         body: {
           prompt,
           agentId: goal.agentId,
-          ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+          ...(sessionId ? { sessionId } : {}),
           ...(effectiveModelProvider
             ? { modelProvider: effectiveModelProvider }
             : {}),
@@ -330,6 +343,7 @@ const runGoalNow$ = command(
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
+        codexServiceTier,
         callbacks: buildGoalChatCallbacks({
           threadId: goal.threadId,
           agentId: goal.agentId,

--- a/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
@@ -41,7 +41,6 @@ interface ResolvedModelFirstPolicyRoute {
   readonly modelProviderType: ModelProviderType;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope;
   readonly selectedModel: SupportedRunModel;
-  readonly cliAgentType: SupportedFramework;
 }
 
 interface PersistedModelFirstRouteResolution {
@@ -114,17 +113,6 @@ function parseModelProviderCredentialScope(
     return value;
   }
   throw new Error(`Unknown model provider credential scope "${value}"`);
-}
-
-function cliAgentTypeForPolicyRoute(
-  providerType: ModelProviderType,
-  selectedModel: SupportedRunModel,
-): SupportedFramework {
-  return getFrameworkForType(
-    providerType === "vm0"
-      ? getVm0ConcreteProviderType(selectedModel)
-      : providerType,
-  );
 }
 
 async function resolveValidPolicyRoute(params: {
@@ -221,7 +209,6 @@ async function resolveValidPolicyRoute(params: {
     modelProviderType: providerType.data,
     modelProviderCredentialScope: credentialScope,
     selectedModel: policy.model,
-    cliAgentType: cliAgentTypeForPolicyRoute(providerType.data, policy.model),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-selection.service.ts
@@ -1,13 +1,20 @@
 import {
-  SUPPORTED_RUN_MODELS,
+  getFrameworkForType,
+  getVm0ConcreteProviderType,
+  isCodexFastModeModel,
   isLimitedFree1RestrictedRunModel,
   isSupportedRunModel,
+  isModelSupportedByProvider,
+  modelProviderTypeSchema,
   type ModelProviderCredentialScope,
+  type ModelProviderType,
+  type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
-import { and, eq, inArray, or } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
@@ -29,6 +36,19 @@ export interface ModelFirstPin {
   readonly selectedModel: string | null;
 }
 
+interface ResolvedModelFirstPolicyRoute {
+  readonly modelProviderId: string | null;
+  readonly modelProviderType: ModelProviderType;
+  readonly modelProviderCredentialScope: ModelProviderCredentialScope;
+  readonly selectedModel: SupportedRunModel;
+  readonly cliAgentType: SupportedFramework;
+}
+
+interface PersistedModelFirstRouteResolution {
+  readonly route: ResolvedModelFirstPolicyRoute | null;
+  readonly selectedModelChanged: boolean;
+}
+
 interface ModelSelectionRequest {
   readonly modelProviderId: string;
   readonly selectedModel: string;
@@ -36,6 +56,21 @@ interface ModelSelectionRequest {
 
 interface AvailableModelProviderPin {
   readonly type: string;
+}
+
+function modelFirstPinFromRoute(
+  route: ResolvedModelFirstPolicyRoute,
+): ModelFirstPin {
+  return {
+    modelProviderId: route.modelProviderId,
+    modelProviderType: route.modelProviderType,
+    modelProviderCredentialScope: route.modelProviderCredentialScope,
+    selectedModel: route.selectedModel,
+  };
+}
+
+function isOAuthMemberProviderType(type: ModelProviderType): boolean {
+  return type === "claude-code-oauth-token" || type === "codex-oauth-token";
 }
 
 async function orgModelCapabilities(
@@ -81,14 +116,112 @@ function parseModelProviderCredentialScope(
   throw new Error(`Unknown model provider credential scope "${value}"`);
 }
 
-export function modelOnlyModelFirstPin(
-  selectedModel: string | null,
-): ModelFirstPin {
+function cliAgentTypeForPolicyRoute(
+  providerType: ModelProviderType,
+  selectedModel: SupportedRunModel,
+): SupportedFramework {
+  return getFrameworkForType(
+    providerType === "vm0"
+      ? getVm0ConcreteProviderType(selectedModel)
+      : providerType,
+  );
+}
+
+async function resolveValidPolicyRoute(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly capabilities: Pick<
+    OrgPlanCapabilities,
+    "restrictedVm0Models" | "supportByok"
+  >;
+  readonly selectedModel: string;
+}): Promise<ResolvedModelFirstPolicyRoute | null> {
+  if (
+    !isSupportedRunModel(params.selectedModel) ||
+    !modelAllowedForOrgPlan({
+      capabilities: params.capabilities,
+      selectedModel: params.selectedModel,
+    })
+  ) {
+    return null;
+  }
+
+  const [policy] = await params.db
+    .select({
+      model: orgModelPolicies.model,
+      defaultProviderType: orgModelPolicies.defaultProviderType,
+      credentialScope: orgModelPolicies.credentialScope,
+      modelProviderId: orgModelPolicies.modelProviderId,
+    })
+    .from(orgModelPolicies)
+    .where(
+      and(
+        eq(orgModelPolicies.orgId, params.orgId),
+        eq(orgModelPolicies.model, params.selectedModel),
+      ),
+    )
+    .limit(1);
+  const providerType = policy
+    ? modelProviderTypeSchema.safeParse(policy.defaultProviderType)
+    : null;
+  if (
+    !policy ||
+    !isSupportedRunModel(policy.model) ||
+    !providerType?.success ||
+    !isModelSupportedByProvider(policy.model, providerType.data) ||
+    !modelProviderAllowedForOrgPlan({
+      capabilities: params.capabilities,
+      modelProviderType: providerType.data,
+    })
+  ) {
+    return null;
+  }
+
+  const credentialScope = parseModelProviderCredentialScope(
+    policy.credentialScope,
+  );
+  if (credentialScope === null) {
+    return null;
+  }
+  if (credentialScope === "member") {
+    if (
+      !isOAuthMemberProviderType(providerType.data) ||
+      policy.modelProviderId !== null
+    ) {
+      return null;
+    }
+  } else if (isOAuthMemberProviderType(providerType.data)) {
+    return null;
+  } else if (providerType.data === "vm0") {
+    if (policy.modelProviderId !== null) {
+      return null;
+    }
+  } else {
+    if (policy.modelProviderId === null) {
+      return null;
+    }
+    const [provider] = await params.db
+      .select({ type: modelProviders.type })
+      .from(modelProviders)
+      .where(
+        and(
+          eq(modelProviders.id, policy.modelProviderId),
+          eq(modelProviders.orgId, params.orgId),
+          eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        ),
+      )
+      .limit(1);
+    if (provider?.type !== providerType.data) {
+      return null;
+    }
+  }
+
   return {
-    modelProviderId: null,
-    modelProviderType: null,
-    modelProviderCredentialScope: null,
-    selectedModel,
+    modelProviderId: policy.modelProviderId,
+    modelProviderType: providerType.data,
+    modelProviderCredentialScope: credentialScope,
+    selectedModel: policy.model,
+    cliAgentType: cliAgentTypeForPolicyRoute(providerType.data, policy.model),
   };
 }
 
@@ -101,133 +234,105 @@ export async function resolveDefaultModelFirstPin(
     await ensureOrgModelPolicies(db, orgId, userId);
   }
   const capabilities = await orgModelCapabilities(db, orgId);
-  const [preference] = await db
-    .select({ selectedModel: orgMembersMetadata.selectedModel })
-    .from(orgMembersMetadata)
+  if (userId !== "__no_preference__") {
+    const [preference] = await db
+      .select({ selectedModel: orgMembersMetadata.selectedModel })
+      .from(orgMembersMetadata)
+      .where(
+        and(
+          eq(orgMembersMetadata.orgId, orgId),
+          eq(orgMembersMetadata.userId, userId),
+        ),
+      )
+      .limit(1);
+    if (preference?.selectedModel) {
+      const preferredRoute = await resolveValidPolicyRoute({
+        db,
+        orgId,
+        capabilities,
+        selectedModel: preference.selectedModel,
+      });
+      if (preferredRoute) {
+        return modelFirstPinFromRoute(preferredRoute);
+      }
+    }
+  }
+
+  const route = await resolveWorkspaceDefaultModelFirstRoute({
+    db,
+    orgId,
+    capabilities,
+  });
+  return route
+    ? modelFirstPinFromRoute(route)
+    : {
+        modelProviderId: null,
+        modelProviderType: null,
+        modelProviderCredentialScope: null,
+        selectedModel: null,
+      };
+}
+
+async function resolveWorkspaceDefaultModelFirstRoute(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly capabilities: Pick<
+    OrgPlanCapabilities,
+    "restrictedVm0Models" | "supportByok"
+  >;
+}): Promise<ResolvedModelFirstPolicyRoute | null> {
+  const [policy] = await params.db
+    .select({ model: orgModelPolicies.model })
+    .from(orgModelPolicies)
     .where(
       and(
-        eq(orgMembersMetadata.orgId, orgId),
-        eq(orgMembersMetadata.userId, userId),
+        eq(orgModelPolicies.orgId, params.orgId),
+        eq(orgModelPolicies.isDefault, true),
       ),
     )
     .limit(1);
-
-  const preferredModel =
-    isSupportedRunModel(preference?.selectedModel) &&
-    modelAllowedForOrgPlan({
-      capabilities,
-      selectedModel: preference.selectedModel,
-    })
-      ? preference.selectedModel
-      : null;
-  const [policy] = await db
-    .select({
-      model: orgModelPolicies.model,
-      defaultProviderType: orgModelPolicies.defaultProviderType,
-      credentialScope: orgModelPolicies.credentialScope,
-      modelProviderId: orgModelPolicies.modelProviderId,
-    })
-    .from(orgModelPolicies)
-    .where(
-      preferredModel
-        ? and(
-            eq(orgModelPolicies.orgId, orgId),
-            eq(orgModelPolicies.model, preferredModel),
-          )
-        : and(
-            eq(orgModelPolicies.orgId, orgId),
-            eq(orgModelPolicies.isDefault, true),
-          ),
-    )
-    .limit(1);
-
-  if (!policy && preferredModel) {
-    return resolveDefaultModelFirstPin(db, orgId, "__no_preference__");
+  if (!policy) {
+    return null;
   }
-
-  if (
-    !policy ||
-    !isSupportedRunModel(policy.model) ||
-    !modelAllowedForOrgPlan({ capabilities, selectedModel: policy.model }) ||
-    !modelProviderAllowedForOrgPlan({
-      capabilities,
-      modelProviderType: policy.defaultProviderType,
-    })
-  ) {
-    const fallbackPolicies = await db
-      .select({
-        model: orgModelPolicies.model,
-        defaultProviderType: orgModelPolicies.defaultProviderType,
-        credentialScope: orgModelPolicies.credentialScope,
-        modelProviderId: orgModelPolicies.modelProviderId,
-      })
-      .from(orgModelPolicies)
-      .where(
-        and(
-          eq(orgModelPolicies.orgId, orgId),
-          inArray(orgModelPolicies.model, [...SUPPORTED_RUN_MODELS]),
-        ),
-      )
-      .limit(SUPPORTED_RUN_MODELS.length);
-    const fallbackPolicy = fallbackPolicies.find((candidate) => {
-      return (
-        isSupportedRunModel(candidate.model) &&
-        modelAllowedForOrgPlan({
-          capabilities,
-          selectedModel: candidate.model,
-        }) &&
-        modelProviderAllowedForOrgPlan({
-          capabilities,
-          modelProviderType: candidate.defaultProviderType,
-        })
-      );
-    });
-    if (
-      fallbackPolicy &&
-      isSupportedRunModel(fallbackPolicy.model) &&
-      modelAllowedForOrgPlan({
-        capabilities,
-        selectedModel: fallbackPolicy.model,
-      }) &&
-      modelProviderAllowedForOrgPlan({
-        capabilities,
-        modelProviderType: fallbackPolicy.defaultProviderType,
-      })
-    ) {
-      return {
-        modelProviderId: fallbackPolicy.modelProviderId ?? null,
-        modelProviderType: fallbackPolicy.defaultProviderType,
-        modelProviderCredentialScope: parseModelProviderCredentialScope(
-          fallbackPolicy.credentialScope,
-        ),
-        selectedModel: fallbackPolicy.model,
-      };
-    }
-    return {
-      modelProviderId: null,
-      modelProviderType: null,
-      modelProviderCredentialScope: null,
-      selectedModel: null,
-    };
-  }
-
-  return {
-    modelProviderId: policy.modelProviderId ?? null,
-    modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: parseModelProviderCredentialScope(
-      policy.credentialScope,
-    ),
+  return resolveValidPolicyRoute({
+    db: params.db,
+    orgId: params.orgId,
+    capabilities: params.capabilities,
     selectedModel: policy.model,
-  };
+  });
 }
 
-export async function modelProviderPinAvailable(params: {
+export async function resolvePersistedModelFirstRoute(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly modelProviderId: string;
-}): Promise<boolean> {
-  return (await loadAvailableModelProviderPin(params)) !== null;
+  readonly selectedModel: string | null;
+}): Promise<PersistedModelFirstRouteResolution> {
+  await ensureOrgModelPolicies(params.db, params.orgId, params.userId);
+  const capabilities = await orgModelCapabilities(params.db, params.orgId);
+  const currentRoute = params.selectedModel
+    ? await resolveValidPolicyRoute({
+        db: params.db,
+        orgId: params.orgId,
+        capabilities,
+        selectedModel: params.selectedModel,
+      })
+    : null;
+  if (currentRoute) {
+    return { route: currentRoute, selectedModelChanged: false };
+  }
+
+  const defaultRoute = await resolveWorkspaceDefaultModelFirstRoute({
+    db: params.db,
+    orgId: params.orgId,
+    capabilities,
+  });
+  return {
+    route: defaultRoute,
+    selectedModelChanged:
+      defaultRoute !== null &&
+      defaultRoute.selectedModel !== params.selectedModel,
+  };
 }
 
 async function loadAvailableModelProviderPin(params: {
@@ -310,45 +415,17 @@ export async function resolveModelSelectionPin(params: {
   }
 
   await ensureOrgModelPolicies(db, orgId, userId);
-  const [policy] = await db
-    .select({
-      model: orgModelPolicies.model,
-      defaultProviderType: orgModelPolicies.defaultProviderType,
-      credentialScope: orgModelPolicies.credentialScope,
-      modelProviderId: orgModelPolicies.modelProviderId,
-    })
-    .from(orgModelPolicies)
-    .where(
-      and(
-        eq(orgModelPolicies.orgId, orgId),
-        eq(orgModelPolicies.model, modelSelection.selectedModel),
-      ),
-    )
-    .limit(1);
-  if (!policy) {
-    return {
-      modelProviderId: null,
-      modelProviderType: null,
-      modelProviderCredentialScope: null,
-      selectedModel: modelSelection.selectedModel,
-    };
-  }
-  if (
-    !modelProviderAllowedForOrgPlan({
-      capabilities,
-      modelProviderType: policy.defaultProviderType,
-    })
-  ) {
-    return insufficientCredits();
-  }
-  return {
-    modelProviderId: policy.modelProviderId ?? null,
-    modelProviderType: policy.defaultProviderType,
-    modelProviderCredentialScope: parseModelProviderCredentialScope(
-      policy.credentialScope,
-    ),
-    selectedModel: policy.model,
-  };
+  const route = await resolveValidPolicyRoute({
+    db,
+    orgId,
+    capabilities,
+    selectedModel: modelSelection.selectedModel,
+  });
+  return route
+    ? modelFirstPinFromRoute(route)
+    : badRequestMessage(
+        "The selected model is not available in this workspace",
+      );
 }
 
 async function resolveEffectiveModelProviderType(params: {
@@ -391,15 +468,55 @@ export async function resolveModelFirstProviderAdmission(params: {
   readonly requestedModelProvider: string | undefined;
 }): Promise<{
   readonly effectiveModelProvider: string | null | undefined;
-  readonly error: Awaited<ReturnType<typeof checkOrgCreditsForRunAdmission>>;
+  readonly cliAgentType: SupportedFramework | null;
+  readonly error:
+    | Awaited<ReturnType<typeof checkOrgCreditsForRunAdmission>>
+    | ReturnType<typeof badRequestMessage>;
 }> {
   const effectiveModelProvider =
     await resolveEffectiveModelProviderType(params);
+  const selectedModel = params.modelPin.selectedModel;
+  const parsedProvider = modelProviderTypeSchema.safeParse(
+    effectiveModelProvider,
+  );
+  const knownProvider = parsedProvider.success ? parsedProvider.data : null;
+  const cliAgentType = knownProvider
+    ? getFrameworkForType(
+        knownProvider === "vm0" && isSupportedRunModel(selectedModel)
+          ? getVm0ConcreteProviderType(selectedModel)
+          : knownProvider,
+      )
+    : null;
+  if (
+    isSupportedRunModel(selectedModel) &&
+    (!knownProvider ||
+      !isModelSupportedByProvider(selectedModel, knownProvider))
+  ) {
+    return {
+      effectiveModelProvider,
+      cliAgentType,
+      error: badRequestMessage(
+        "The selected model is not supported by the current model provider",
+      ),
+    };
+  }
   const error = await checkOrgCreditsForRunAdmission({
     db: params.db,
     orgId: params.orgId,
     modelProviderType: effectiveModelProvider,
-    selectedModel: params.modelPin.selectedModel,
+    selectedModel,
   });
-  return { effectiveModelProvider, error };
+  return { effectiveModelProvider, cliAgentType, error };
+}
+
+export function isCodexFastServiceTierSupported(params: {
+  readonly selectedModel: string | null | undefined;
+  readonly effectiveModelProvider: string | null | undefined;
+  readonly codexFastModeEnabled: boolean;
+}): boolean {
+  return (
+    params.codexFastModeEnabled &&
+    params.effectiveModelProvider === "codex-oauth-token" &&
+    isCodexFastModeModel(params.selectedModel)
+  );
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -14,12 +14,9 @@ import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   postRunUserMessage,
-  resolveRunChatThreadModelPin,
+  resolveRunChatThreadModelContext,
 } from "./zero-chat-run-message.service";
-import {
-  resolveModelFirstProviderAdmission,
-  type ModelFirstPin,
-} from "./zero-model-selection.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
 import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
@@ -74,6 +71,7 @@ type ModelContext =
       readonly ok: true;
       readonly modelPin: ModelFirstPin;
       readonly effectiveModelProvider: string | null | undefined;
+      readonly codexServiceTier: "fast" | undefined;
     }
   | { readonly ok: false; readonly failure: RunFailure };
 
@@ -218,30 +216,27 @@ async function resolveModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<ModelContext> {
-  const threadModelPin = await resolveRunChatThreadModelPin({
+  const threadModelContext = await resolveRunChatThreadModelContext({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
     threadId: args.chatThreadId,
   });
   args.signal.throwIfAborted();
-  if ("status" in threadModelPin) {
+  if ("status" in threadModelContext) {
     return {
       ok: false,
       failure: {
         kind: "run_error",
-        response: { status: 400, body: threadModelPin.body },
+        response: {
+          status: threadModelContext.status,
+          body: threadModelContext.body,
+        },
       },
     };
   }
 
-  const providerAdmission = await resolveModelFirstProviderAdmission({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    modelPin: threadModelPin,
-    requestedModelProvider: undefined,
-  });
+  const { pin, providerAdmission, runCodexServiceTier } = threadModelContext;
   args.signal.throwIfAborted();
   if (providerAdmission.error) {
     return {
@@ -252,8 +247,9 @@ async function resolveModelContext(args: {
 
   return {
     ok: true,
-    modelPin: threadModelPin,
+    modelPin: pin,
     effectiveModelProvider: providerAdmission.effectiveModelProvider,
+    codexServiceTier: runCodexServiceTier,
   };
 }
 
@@ -545,7 +541,7 @@ export const runWorkflowAutomationNow$ = command(
     if (!modelContext.ok) {
       return modelContext.failure;
     }
-    const { modelPin, effectiveModelProvider } = modelContext;
+    const { modelPin, effectiveModelProvider, codexServiceTier } = modelContext;
 
     const computerUseHostGrant = await loadComputerUseHostGrantForAutoSend({
       db,
@@ -595,6 +591,7 @@ export const runWorkflowAutomationNow$ = command(
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
+        codexServiceTier,
         appendSystemPrompt: runInput.appendSystemPrompt,
         callbacks: runInput.callbacks,
         zeroRunMetadata: runInput.zeroRunMetadata,

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -74,6 +74,7 @@ function abortError(message: string): Error {
 
 function chatThreadRealtimeTopics(threadId: string): readonly string[] {
   return [
+    `chatThreadDetailChanged:${threadId}`,
     `chatThreadMessageCreated:${threadId}`,
     `chatThreadMessageUpdated:${threadId}`,
     `chatThreadRunCreated:${threadId}`,
@@ -552,6 +553,7 @@ describe("realtime signals", () => {
         {
           threadId,
           handlers: {
+            onThreadDetailChanged$: keepAliveLoop$,
             onMessageCreated$: keepAliveLoop$,
             onMessageUpdated$: keepAlivePayloadLoop$,
             onRunChanged$: keepAliveLoop$,
@@ -565,7 +567,7 @@ describe("realtime signals", () => {
         context.signal,
       ),
     ).rejects.toThrow(
-      `Realtime subscription ended before ready: chatThreadMessageCreated:${threadId}`,
+      `Realtime subscription ended before ready: chatThreadDetailChanged:${threadId}`,
     );
 
     expectNoChatThreadSubscriptions(threadId);
@@ -584,6 +586,7 @@ describe("realtime signals", () => {
         {
           threadId,
           handlers: {
+            onThreadDetailChanged$: keepAliveLoop$,
             onMessageCreated$: keepAliveLoop$,
             onMessageUpdated$: keepAlivePayloadLoop$,
             onRunChanged$: keepAliveLoop$,
@@ -613,6 +616,7 @@ describe("realtime signals", () => {
       {
         threadId,
         handlers: {
+          onThreadDetailChanged$: keepAliveLoop$,
           onMessageCreated$: keepAliveLoop$,
           onMessageUpdated$: keepAlivePayloadLoop$,
           onRunChanged$: keepAliveLoop$,
@@ -635,6 +639,7 @@ describe("realtime signals", () => {
       {
         threadId,
         handlers: {
+          onThreadDetailChanged$: keepAliveLoop$,
           onMessageCreated$: keepAliveLoop$,
           onMessageUpdated$: keepAlivePayloadLoop$,
           onRunChanged$: keepAliveLoop$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -7,6 +7,7 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 
 export interface ChatThreadRealtimeHandlers {
+  onThreadDetailChanged$: Command<Promise<boolean> | boolean, [AbortSignal]>;
   onMessageCreated$: Command<Promise<boolean>, [AbortSignal]>;
   onMessageUpdated$: Command<
     Promise<boolean> | boolean,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -8,7 +8,6 @@ import {
 } from "ccstate";
 import { animationFrame, delay } from "signal-timers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { toast } from "@vm0/ui/components/ui/sonner";
 import { IN_VITEST } from "../../env.ts";
 import {
   onRef,
@@ -116,10 +115,7 @@ import { reloadBillingStatus$ } from "../zero-page/billing.ts";
 import { subscribeComputerUseHostsChanged$ } from "../zero-page/computer-use-hosts.ts";
 import { reloadWorkflowData$ } from "../workflows-page/workflow-reload.ts";
 import { isCodexFastModeAvailableForSelection } from "../zero-page/model-default-selection.ts";
-import {
-  personalModelProvider$,
-  selectedModelAvailable$,
-} from "../zero-page/model-first-personal-oauth.ts";
+import { personalModelProvider$ } from "../zero-page/model-first-personal-oauth.ts";
 import { openClaudeCodeDeviceAuthDialogPersonal$ } from "../zero-page/settings/claude-code-device-auth.ts";
 import { openCodexDeviceAuthDialogPersonal$ } from "../zero-page/settings/codex-device-auth.ts";
 import type {
@@ -743,17 +739,13 @@ function createModelSelectionForSend({
 }) {
   return command(
     async (
-      { get, set },
+      { get },
       signal: AbortSignal,
     ): Promise<ModelSelectionForSendResult> => {
       const selectedModel = await get(selectedModel$);
       signal.throwIfAborted();
       if (!selectedModel) {
         return { available: true, selection: null };
-      }
-      if (!(await set(selectedModelAvailable$, selectedModel, signal))) {
-        toast.error("The selected model is not available");
-        return { available: false };
       }
       const codexFastModeActive = await get(codexFastModeActive$);
       signal.throwIfAborted();
@@ -2941,6 +2933,12 @@ function createRunTracking({
     await set(initializeIndexedDbMessages$, signal);
     signal.throwIfAborted();
 
+    const onThreadDetailChanged$ = command(({ set }) => {
+      L.debug("onThreadDetailChanged$ fired", { threadId });
+      set(reloadThread$);
+      return false;
+    });
+
     const onMessageCreated$ = command(async ({ set }, sig: AbortSignal) => {
       L.debug("onMessageCreated$ fired", { threadId });
       await set(syncRemoteMessages$, sig);
@@ -3004,6 +3002,7 @@ function createRunTracking({
           {
             threadId,
             handlers: {
+              onThreadDetailChanged$,
               onMessageCreated$,
               onMessageUpdated$,
               onRunChanged$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -723,13 +723,6 @@ function createModelSelection(
   };
 }
 
-type ModelSelectionForSendResult =
-  | { readonly available: false }
-  | {
-      readonly available: true;
-      readonly selection: ModelProviderSelection | null;
-    };
-
 function createModelSelectionForSend({
   selectedModel$,
   codexFastModeActive$,
@@ -741,20 +734,17 @@ function createModelSelectionForSend({
     async (
       { get },
       signal: AbortSignal,
-    ): Promise<ModelSelectionForSendResult> => {
+    ): Promise<ModelProviderSelection | null> => {
       const selectedModel = await get(selectedModel$);
       signal.throwIfAborted();
       if (!selectedModel) {
-        return { available: true, selection: null };
+        return null;
       }
       const codexFastModeActive = await get(codexFastModeActive$);
       signal.throwIfAborted();
-      return {
-        available: true,
-        selection: codexFastModeActive
-          ? { selectedModel, codexServiceTier: "fast" }
-          : { selectedModel },
-      };
+      return codexFastModeActive
+        ? { selectedModel, codexServiceTier: "fast" }
+        : { selectedModel };
     },
   );
 }
@@ -3188,7 +3178,7 @@ interface SendMessageDeps {
   pendingSendCount$: State<number>;
   threadMeta$: Computed<Promise<ThreadMeta | null>>;
   modelSelectionForSend$: Command<
-    Promise<ModelSelectionForSendResult>,
+    Promise<ModelProviderSelection | null>,
     [AbortSignal]
   >;
   draft: DraftSignals;
@@ -3368,11 +3358,8 @@ function createSendMessage(deps: SendMessageDeps) {
         L.debug("sendMessage$ no agentId, abort", { threadId });
         return false;
       }
-      const modelSelectionResult = await set(modelSelectionForSend$, signal);
+      const modelSelection = await set(modelSelectionForSend$, signal);
       signal.throwIfAborted();
-      if (!modelSelectionResult.available) {
-        return false;
-      }
       set(pendingSendCount$, (count) => {
         return count + 1;
       });
@@ -3383,7 +3370,7 @@ function createSendMessage(deps: SendMessageDeps) {
             prompt,
             options,
             agentId: meta.agentId,
-            modelSelection: modelSelectionResult.selection,
+            modelSelection,
           },
           signal,
         ),
@@ -3401,7 +3388,7 @@ interface QueueMessageDeps {
   threadId: string;
   threadMeta$: Computed<Promise<ThreadMeta | null>>;
   modelSelectionForSend$: Command<
-    Promise<ModelSelectionForSendResult>,
+    Promise<ModelProviderSelection | null>,
     [AbortSignal]
   >;
   draft: DraftSignals;
@@ -3454,12 +3441,8 @@ function createQueueMessage(deps: QueueMessageDeps) {
       }
       const generationTemplate = get(draft.generationTemplate$);
 
-      const modelSelectionResult = await set(modelSelectionForSend$, signal);
+      const modelSelection = await set(modelSelectionForSend$, signal);
       signal.throwIfAborted();
-      if (!modelSelectionResult.available) {
-        return false;
-      }
-      const modelSelection = modelSelectionResult.selection;
       const result = await set(
         prepareUserMessageFromDraft$,
         draft,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -375,6 +375,11 @@ function createSubscribeRealtime() {
           const subscriptions: ChatRealtimeSubscription[] = [
             {
               kind: "loop",
+              topic: `chatThreadDetailChanged:${threadId}`,
+              loopCommand$: handlers.onThreadDetailChanged$,
+            },
+            {
+              kind: "loop",
               topic: `chatThreadMessageCreated:${threadId}`,
               loopCommand$: handlers.onMessageCreated$,
             },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -16,6 +16,7 @@ import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { beforeEach, describe, expect, it } from "vitest";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { reloadUserModelPreference$ } from "../../../signals/external/user-model-preference.ts";
 import { codexFastModeLocalDefault$ } from "../../../signals/zero-page/codex-fast-local-default.ts";
 import {
@@ -669,6 +670,77 @@ describe("chat composer models", () => {
     });
   });
 
+  it("reloads a reconciled thread tier before the next send", async () => {
+    const user = userEvent.setup({ delay: null });
+    const codexProvider = buildProvider({
+      id: "00000000-0000-4000-a000-000000000918",
+      type: "codex-oauth-token",
+      framework: "codex",
+      secretName: null,
+      authMethod: "auth_json",
+      secretNames: ["CODEX_AUTH_JSON"],
+    });
+    let sentBody:
+      | {
+          runOptions?: { codexServiceTier?: "fast" };
+        }
+      | undefined;
+
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        id: "00000000-0000-4000-a000-000000000919",
+        model: "gpt-5.5",
+        modelLabel: "GPT 5.5",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+      }),
+    ]);
+    context.mocks.data.personalModelProviders([codexProvider]);
+    const lifecycle = mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      selectedModel: "gpt-5.5",
+      codexServiceTier: "fast",
+      onRunCreate: (body) => {
+        sentBody = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /GPT 5\.5/ }),
+      ).toBeInTheDocument();
+    });
+
+    lifecycle.setCodexServiceTier(null);
+    act(() => {
+      triggerAblyEvent(`chatThreadDetailChanged:${THREAD_ID}`);
+    });
+    await user.click(screen.getByRole("combobox", { name: /GPT 5\.5/ }));
+    const runSpeed = await screen.findByRole("group", { name: "Run speed" });
+    await waitFor(() => {
+      expect(buttonContainingText("Standard", runSpeed)).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    await user.keyboard("{Escape}");
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Continue after server reconciliation",
+    );
+
+    await waitFor(() => {
+      expect(sentBody?.runOptions).toBeUndefined();
+    });
+  });
+
   it("clears Codex fast mode when switching to a non-fast model", async () => {
     const user = userEvent.setup({ delay: null });
     const codexProvider = buildProvider({
@@ -1216,7 +1288,7 @@ describe("chat composer models", () => {
     expect(screen.queryByText("Loading models...")).not.toBeInTheDocument();
   });
 
-  it("blocks a hydrated restricted model for limited-free-1 before sending", async () => {
+  it("lets the server reconcile a hydrated restricted thread model", async () => {
     const user = userEvent.setup({ delay: null });
     let runCreateCount = 0;
     mockBillingCapabilities({ supportByok: true, restrictedVm0Models: true });
@@ -1244,14 +1316,15 @@ describe("chat composer models", () => {
     await fill(input, "Keep this restricted draft");
     await user.keyboard("{Enter}");
 
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(runCreateCount).toBe(0);
-    expect(input.textContent ?? "").toContain("Keep this restricted draft");
+    await waitFor(() => {
+      expect(runCreateCount).toBe(1);
+    });
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
   });
 
-  it("blocks a hydrated BYOK model for limited-free-1 before sending", async () => {
+  it("lets the server reconcile a hydrated BYOK thread model", async () => {
     const user = userEvent.setup({ delay: null });
     let runCreateCount = 0;
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: false });
@@ -1280,14 +1353,15 @@ describe("chat composer models", () => {
     await fill(input, "Keep this BYOK draft");
     await user.keyboard("{Enter}");
 
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(runCreateCount).toBe(0);
-    expect(input.textContent ?? "").toContain("Keep this BYOK draft");
+    await waitFor(() => {
+      expect(runCreateCount).toBe(1);
+    });
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
   });
 
-  it("blocks a hydrated model missing from the current policies", async () => {
+  it("lets the server reconcile a hydrated model missing from policy", async () => {
     const user = userEvent.setup({ delay: null });
     let runCreateCount = 0;
     context.mocks.data.orgModelPolicies([
@@ -1314,14 +1388,15 @@ describe("chat composer models", () => {
     await fill(input, "Keep this stale draft");
     await user.keyboard("{Enter}");
 
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(runCreateCount).toBe(0);
-    expect(input.textContent ?? "").toContain("Keep this stale draft");
+    await waitFor(() => {
+      expect(runCreateCount).toBe(1);
+    });
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
   });
 
-  it("blocks repeated keyboard sends while model validation is loading", async () => {
+  it("does not block an existing thread send on a policy refresh", async () => {
     const user = userEvent.setup({ delay: null });
     const policyGate = context.mocks.deferred<void>();
     const policy = buildModelPolicy({
@@ -1360,10 +1435,9 @@ describe("chat composer models", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Send")).toBeDisabled();
+      expect(runCreateCount).toBe(1);
     });
     await user.keyboard("{Enter}");
-
     policyGate.resolve();
 
     await waitFor(() => {
@@ -1371,7 +1445,7 @@ describe("chat composer models", () => {
     });
   });
 
-  it("revalidates the current model before sending during provider refresh", async () => {
+  it("does not block a persisted thread selection during provider refresh", async () => {
     const user = userEvent.setup({ delay: null });
     const providerReload = context.mocks.deferred<void>();
     const claudeProvider = buildProvider({
@@ -1471,17 +1545,14 @@ describe("chat composer models", () => {
     const input = screen.getByPlaceholderText(PLACEHOLDER);
     await fill(input, "Keep this draft");
     await user.keyboard("{Enter}");
-    expect(runCreateCount).toBe(0);
-    expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(runCreateCount).toBe(1);
+    });
 
     providerReload.resolve();
-
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(runCreateCount).toBe(0);
-    expect(input.textContent ?? "").toContain("Keep this draft");
-    expect(screen.getByText("Model Configure")).toBeInTheDocument();
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
   });
 
   it("blocks routed model sends until the matching device login is opened", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -372,7 +372,7 @@ describe("chat inline feedback", () => {
     });
   });
 
-  it("keeps inline feedback when the unified send is unavailable", async () => {
+  it("lets the server reconcile an unavailable model for inline feedback", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The rollout dates are unclear in this summary.";
     let runCreateCount = 0;
@@ -415,14 +415,16 @@ describe("chat inline feedback", () => {
     await user.keyboard("Mention the dates before the risk summary.");
     await user.click(screen.getByLabelText("Send"));
 
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(runCreateCount).toBe(0);
-    expect(feedbackNotes()).toHaveLength(1);
+    await waitFor(() => {
+      expect(runCreateCount).toBe(1);
+      expect(feedbackNotes()).toHaveLength(0);
+    });
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
   });
 
-  it("submits inline feedback once while model validation is loading", async () => {
+  it("submits inline feedback once while model policy is loading", async () => {
     const user = userEvent.setup({ delay: null });
     const policyGate = context.mocks.deferred<void>();
     const assistantReply = "The rollout dates are unclear in this summary.";
@@ -489,15 +491,14 @@ describe("chat inline feedback", () => {
     await user.keyboard("Mention the dates before the risk summary.");
     await user.keyboard("{Enter}");
 
-    expect(feedbackNotes()).toHaveLength(1);
-    await user.keyboard("{Enter}");
-
-    policyGate.resolve();
-
     await waitFor(() => {
       expect(runCreateCount).toBe(1);
       expect(feedbackNotes()).toHaveLength(0);
     });
+    await user.keyboard("{Enter}");
+    expect(runCreateCount).toBe(1);
+
+    policyGate.resolve();
   });
 
   it("does not submit inline feedback while IME composition is active", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -314,7 +314,7 @@ describe("chat run queue", () => {
     expect(queuedBodies[0]?.content).toBe("排队完整内容");
   });
 
-  it("keeps the draft when the hydrated model is unavailable for queueing", async () => {
+  it("queues when the hydrated model needs server reconciliation", async () => {
     const user = userEvent.setup({ delay: null });
     const queuedBodies: QueuedMessageCapture[] = [];
     context.mocks.data.orgModelPolicies([]);
@@ -334,12 +334,17 @@ describe("chat run queue", () => {
     await fill(composer, "Keep this queued draft");
     await user.keyboard("{Enter}");
 
-    await expect(
-      screen.findByText("The selected model is not available"),
-    ).resolves.toBeInTheDocument();
-    expect(queuedBodies).toHaveLength(0);
-    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
-    expect(composer).toHaveTextContent("Keep this queued draft");
+    await waitFor(() => {
+      expect(queuedBodies).toHaveLength(1);
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Keep this queued draft",
+      );
+    });
+    expect(queuedBodies[0]?.modelSelection).toBeUndefined();
+    expect(
+      screen.queryByText("The selected model is not available"),
+    ).not.toBeInTheDocument();
+    expect(composer.textContent).toBe("");
   });
 
   it("preserves Codex fast mode when queueing a follow-up", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -244,6 +244,7 @@ interface MockLifecycleControl {
   setQueuePosition: (n: number) => void;
   setEvents: (e: AgentEvent[]) => void;
   setThreadList: (list: ThreadListItem[]) => void;
+  setCodexServiceTier: (tier: CodexServiceTier | null) => void;
   completeRun: (content?: string) => void;
   failRun: (error: string) => void;
   cancelRun: () => void;
@@ -990,6 +991,9 @@ export function mockChatLifecycle(
     },
     setThreadList: (list) => {
       threadListOverride = list;
+    },
+    setCodexServiceTier: (tier) => {
+      codexServiceTier = tier;
     },
     completeRun: (content?: string) => {
       runStatus = "completed";

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -609,6 +609,7 @@ export const chatThreadsContract = c.router({
         title: z.string().nullable(),
         createdAt: z.string(),
       }),
+      400: apiErrorSchema,
       401: apiErrorSchema,
       402: apiErrorSchema,
       404: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -1126,7 +1126,9 @@ export const zeroWorkflowsDetailContract = c.router({
     body: c.noBody(),
     responses: {
       200: zeroWorkflowRunResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
+      402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema,


### PR DESCRIPTION
## Summary

- make the current organization model policy authoritative for every chat-derived run
- keep explicit selections strict while lazily reconciling stale persisted selections to the current workspace default under a thread row lock
- route direct, queued, workflow, goal, morning-brief, and manual workflow runs through the same validated model/provider/credential/framework context
- preserve accepted `clientMessageId` retry semantics by resolving existing messages before model-policy reconciliation can mutate thread state
- reset incompatible CLI sessions, normalize Codex fast tier state, and notify open clients when server reconciliation changes thread state
- persist model-only thread selections and clear legacy provider columns without changing the database schema

## Compatibility and exclusions

- no schema migration, bulk historical rewrite, or runner protocol change
- retained nullable legacy provider columns for overlapping old API deployments
- added only additive `400` declarations for strict thread creation and manual workflow-run routing, an additive `402` declaration for manual workflow-run admission, and an ignorable realtime invalidation topic
- non-chat and non-model-first custom provider admission remains unchanged; the final compatibility check is scoped to supported catalog models

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api check-types && pnpm -F api lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F @vm0/app check-types && pnpm -F @vm0/app lint`
- `cd turbo && pnpm knip --cache`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts --maxWorkers=1 --silent=passed-only` (44 passed)
- focused accepted-message idempotency regression test passed
- repository pre-commit formatting and Knip checks passed on the current head
- core API chat message/callback integration tests: 65 passed
- shared chat fixture and ZERO_TOKEN metadata integration tests: 17 passed
- route-selection, workflow, goal, morning-brief, and focused run-lifecycle integration coverage passed
- manual workflow route integration tests: 19 passed
- workflow API contract tests: 16 passed
- platform composer model-routing tests: 37 passed
- platform realtime tests: 16 passed

A full local API run was also attempted. The long-lived local test database and parallel shared mocks produced unrelated cross-file timeouts/state contamination; affected files were rerun with one worker and passed. CI provides the fresh full-suite result.

Closes #22505
