### PR TITLE
fix: navigate unread sidebar agents with keyboard shortcuts

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -9,7 +9,7 @@ import { activeRoute$ } from "../active-route.ts";
 import { eventDrivenChatThreads$ } from "../chat-page/chat-thread-event-sourcing.ts";
 import { setChatShortcutHelpOpen$ } from "../chat-page/chat-shortcut-help.ts";
 import { openAgentListDialog$ } from "./zero-sidebar-state.ts";
-import { pinnedAgents$ } from "./zero-pinned-agents.ts";
+import { displayedPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { writeToClipboard } from "./clipboard.ts";
 import { isStandaloneMode } from "./settings/connectors.ts";
 
@@ -100,7 +100,7 @@ export const navigateAdjacentPinnedAgent$ = command(
     const currentAgentId = await get(currentChatAgentId$);
     signal.throwIfAborted();
     const targetAgentId = adjacentPinnedAgentId(
-      await get(pinnedAgents$),
+      await get(displayedPinnedAgents$),
       currentAgentId,
       direction,
     );

--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -1,7 +1,8 @@
 import { command, computed } from "ccstate";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
-import { defaultAgentId$, sortedAgents$ } from "../agent.ts";
+import { defaultAgentId$, sortedAgents$, subagents$ } from "../agent.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
+import { unreadAgentIds$ } from "../chat-page/sidebar-unread-threads.ts";
 import {
   updateUserPreference$,
   userPreferences$,
@@ -39,6 +40,20 @@ export const pinnedAgents$ = computed(async (get) => {
   return list.filter((a) => {
     return pinnedIds.has(a.id);
   });
+});
+
+export const displayedPinnedAgents$ = computed(async (get) => {
+  const pinnedAgents = await get(pinnedAgents$);
+  const unreadAgentIds = await get(unreadAgentIds$);
+  const pinnedAgentIds = new Set(
+    pinnedAgents.map((agent) => {
+      return agent.id;
+    }),
+  );
+  const unreadOnlyAgents = (await get(subagents$)).filter((agent) => {
+    return unreadAgentIds.has(agent.id) && !pinnedAgentIds.has(agent.id);
+  });
+  return [...pinnedAgents, ...unreadOnlyAgents];
 });
 
 export const setAgentPinned$ = command(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1781,6 +1781,41 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("moves to an unread unpinned agent shown in the sidebar", async () => {
+    prepareAgentTeam();
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID],
+    });
+    context.mocks.api(chatThreadsContract.unreadAgents, ({ respond }) => {
+      return respond(200, { agentIds: [SUPPORT_AGENT_ID] });
+    });
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${RESEARCH_AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: true },
+    });
+
+    const nav = await waitFor(() => {
+      const current = sidebar();
+      expect(within(current).getByText("Support Agent")).toBeInTheDocument();
+      return current;
+    });
+    expect(
+      within(agentRowByName(nav, "Support Agent")).getByLabelText("Unread"),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, {
+      key: "}",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${SUPPORT_AGENT_ID}/chat`);
+    });
+  });
+
   it("moves to the first chat thread for the next pinned agent from a chat thread", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -41,6 +41,7 @@ import {
   defaultAgentName$,
 } from "../../signals/agent.ts";
 import {
+  displayedPinnedAgents$,
   setAgentPinned$,
   pinnedAgents$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
@@ -206,7 +207,7 @@ export function PinnedAgentListSection({
     typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
   const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
-  const subagents = useLastResolved(subagents$) ?? [];
+  const displayedPinnedAgentsResolved = useLastResolved(displayedPinnedAgents$);
   const features = useGet(featureSwitch$);
   const agentUnreadIndicatorsEnabled =
     features[FeatureSwitchKey.AgentUnreadIndicators] ?? false;
@@ -226,13 +227,7 @@ export function PinnedAgentListSection({
       return agent.id;
     }),
   );
-  const unreadOnlyAgents =
-    agentUnreadIndicatorsEnabled && unreadAgentIds
-      ? subagents.filter((agent) => {
-          return unreadAgentIds.has(agent.id) && !pinnedAgentIds.has(agent.id);
-        })
-      : [];
-  const displayedPinnedAgents = [...pinnedAgents, ...unreadOnlyAgents];
+  const displayedPinnedAgents = displayedPinnedAgentsResolved ?? pinnedAgents;
 
   const selectedAgentId =
     routeAgentId ?? (routeThreadId ? null : sidebarAgentId);


### PR DESCRIPTION
## Summary

- derive the pinned sidebar agent list once, including unpinned agents shown because they are unread
- use that same visible order for `Ctrl+Shift+[` and `Ctrl+Shift+]` navigation
- cover navigation from a pinned agent to an unread, unpinned agent with a page-level Vitest

## User impact

Keyboard navigation no longer skips agents that appear in the sidebar through the agent unread indicator.

## Verification

- `pnpm --dir turbo --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx` — 46 passed
- `pnpm --dir turbo --filter @vm0/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint on the four changed files
- `pnpm --dir turbo exec knip --workspace apps/platform`
