### PR TITLE
perf(sandbox-fc): reconcile pool resources from one snapshot

### DIFF
--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -109,7 +109,7 @@ reserve_index() {
   local index=$1
   local path="/var/lock/vm0-netns-pool-${index}.lock"
   local candidate_fd
-  exec {candidate_fd}>"$path"
+  exec {candidate_fd}>>"$path"
   if flock -n "$candidate_fd"; then
     RESERVED_FDS+=("$candidate_fd")
     RESERVED_INDEXES+=("$index")

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -42,8 +42,6 @@ RECONCILE_LOCK_INFO="$RECONCILE_TEST_DIR/pool-indexes"
 RECONCILE_IDLE_RELEASE="$RECONCILE_TEST_DIR/release-idle"
 RECONCILE_IDLE_RELEASED="$RECONCILE_TEST_DIR/idle-released"
 RECONCILE_ACTIVE_RELEASE="$RECONCILE_TEST_DIR/release-active"
-RECONCILE_SNAPSHOT_READY="$RECONCILE_TEST_DIR/snapshot-ready"
-RECONCILE_SNAPSHOT_RELEASE="$RECONCILE_TEST_DIR/release-snapshot"
 RECONCILE_LOCK_HOLDER_PID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
@@ -63,8 +61,7 @@ cleanup_submit_pid() {
 cleanup() {
   local status=$?
   trap - EXIT
-  touch "$RECONCILE_IDLE_RELEASE" "$RECONCILE_ACTIVE_RELEASE" \
-    "$RECONCILE_SNAPSHOT_RELEASE"
+  touch "$RECONCILE_IDLE_RELEASE" "$RECONCILE_ACTIVE_RELEASE"
   if [ "$status" -ne 0 ]; then
     print_service_logs
   fi
@@ -89,8 +86,8 @@ REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
 
 # Reserve four pool indexes before the runner starts. Two become clean
 # historical indexes, one owns a synthetic firewall-only orphan, and one
-# remains active throughout reconciliation. The namespace-list wrapper gates
-# the snapshot so the first three locks are released only after the runner has
+# remains active throughout reconciliation. The first three locks are released
+# during own-index cleanup, after the runner has captured their resources and
 # acquired a different index.
 sudo bash -s -- \
   "$RECONCILE_LOCK_INFO" \
@@ -241,10 +238,6 @@ case "$COMMAND_NAME" in
   ip)
     if [ "${1:-}" = "netns" ] && [ "${2:-}" = "list" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.netns-list"
-      if mkdir "$VM0_RECONCILE_COUNT_DIR/netns-list-gate" 2>/dev/null; then
-        touch "$VM0_RECONCILE_SNAPSHOT_READY"
-        while [ ! -e "$VM0_RECONCILE_SNAPSHOT_RELEASE" ]; do sleep 0.05; done
-      fi
       if REAL_OUTPUT=$("$VM0_RECONCILE_REAL_IP" "$@"); then
         STATUS=0
       else
@@ -275,6 +268,12 @@ case "$COMMAND_NAME" in
     if [ "${1:-}" = "netns" ] && [ "${2:-}" = "del" ] \
       && [ "${3:-}" = "vm0-ns-${OWN_POOL_HEX}-fd" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-netns-delete"
+      touch "$VM0_RECONCILE_IDLE_RELEASE"
+      for _ in $(seq 1 200); do
+        [ -e "$VM0_RECONCILE_IDLE_RELEASED" ] && break
+        sleep 0.05
+      done
+      [ -e "$VM0_RECONCILE_IDLE_RELEASED" ] || exit 1
       exec "$VM0_RECONCILE_REAL_IP" "$@"
     fi
     if contains_argument "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" "$@" \
@@ -307,23 +306,8 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --env "VM0_RECONCILE_REAL_IP6TABLES_SAVE=$REAL_IP6TABLES_SAVE" \
   --env "VM0_RECONCILE_FIREWALL_POOL_HEX=$RECONCILE_FIREWALL_POOL_HEX" \
   --env "VM0_RECONCILE_ACTIVE_POOL_HEX=$RECONCILE_ACTIVE_POOL_HEX" \
-  --env "VM0_RECONCILE_SNAPSHOT_READY=$RECONCILE_SNAPSHOT_READY" \
-  --env "VM0_RECONCILE_SNAPSHOT_RELEASE=$RECONCILE_SNAPSHOT_RELEASE"
-
-for _ in $(seq 1 200); do
-  [ -e "$RECONCILE_SNAPSHOT_READY" ] && break
-  sleep 0.05
-done
-[ -e "$RECONCILE_SNAPSHOT_READY" ] \
-  || fail "runner did not begin namespace reconciliation snapshot"
-touch "$RECONCILE_IDLE_RELEASE"
-for _ in $(seq 1 200); do
-  [ -e "$RECONCILE_IDLE_RELEASED" ] && break
-  sleep 0.05
-done
-[ -e "$RECONCILE_IDLE_RELEASED" ] \
-  || fail "timed out releasing idle namespace pool indexes"
-touch "$RECONCILE_SNAPSHOT_RELEASE"
+  --env "VM0_RECONCILE_IDLE_RELEASE=$RECONCILE_IDLE_RELEASE" \
+  --env "VM0_RECONCILE_IDLE_RELEASED=$RECONCILE_IDLE_RELEASED"
 
 # Submit a long-running job in background
 echo "--- Submitting long-running job ---"

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -167,7 +167,7 @@ find_own_pool_hex() {
   for fd in /proc/"$PPID"/fd/*; do
     target=$(readlink "$fd" 2>/dev/null || true)
     case "$target" in
-      /var/lock/vm0-netns-pool-*.lock)
+      */vm0-netns-pool-*.lock)
         index=${target##*/vm0-netns-pool-}
         index=${index%.lock}
         case "$index" in

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -42,6 +42,8 @@ RECONCILE_LOCK_INFO="$RECONCILE_TEST_DIR/pool-indexes"
 RECONCILE_IDLE_RELEASE="$RECONCILE_TEST_DIR/release-idle"
 RECONCILE_IDLE_RELEASED="$RECONCILE_TEST_DIR/idle-released"
 RECONCILE_ACTIVE_RELEASE="$RECONCILE_TEST_DIR/release-active"
+RECONCILE_FIREWALL_DELETE_STARTED="$RECONCILE_TEST_DIR/firewall-delete-started"
+RECONCILE_FIREWALL_DELETE_RELEASE="$RECONCILE_TEST_DIR/release-firewall-delete"
 RECONCILE_LOCK_HOLDER_PID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
@@ -61,10 +63,13 @@ cleanup_submit_pid() {
 cleanup() {
   local status=$?
   trap - EXIT
-  touch "$RECONCILE_IDLE_RELEASE" "$RECONCILE_ACTIVE_RELEASE"
   if [ "$status" -ne 0 ]; then
     print_service_logs
   fi
+  sudo touch \
+    "$RECONCILE_IDLE_RELEASE" \
+    "$RECONCILE_ACTIVE_RELEASE" \
+    "$RECONCILE_FIREWALL_DELETE_RELEASE"
   echo "--- Cleanup ---"
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   cleanup_submit_pid "$SUBMIT_PID"
@@ -192,8 +197,14 @@ contains_argument() {
 
 case "$COMMAND_NAME" in
   iptables-save | ip6tables-save)
+    SNAPSHOT_CAPTURE=false
+    SNAPSHOT_MARKER=""
     if [ "${1:-}" = "-t" ] && [ -n "${2:-}" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/${COMMAND_NAME}.${2}"
+      SNAPSHOT_MARKER="$VM0_RECONCILE_COUNT_DIR/snapshot-${COMMAND_NAME}.${2}"
+      if mkdir "$SNAPSHOT_MARKER" 2>/dev/null; then
+        SNAPSHOT_CAPTURE=true
+      fi
     fi
     if [ "$COMMAND_NAME" = "iptables-save" ]; then
       REAL_COMMAND=$VM0_RECONCILE_REAL_IPTABLES_SAVE
@@ -205,10 +216,15 @@ case "$COMMAND_NAME" in
     else
       STATUS=$?
     fi
+    if [ "$STATUS" -eq 0 ] && [ "$SNAPSHOT_CAPTURE" = true ]; then
+      touch "$SNAPSHOT_MARKER/succeeded"
+    fi
     if [ "$STATUS" -eq 0 ] && [ "${1:-}" = "-t" ] && [ "${2:-}" = "filter" ]; then
       OWN_POOL_HEX=$(find_own_pool_hex)
       printf '%s\n' "$OWN_POOL_HEX" >"$VM0_RECONCILE_COUNT_DIR/own-pool"
-      if [ "$COMMAND_NAME" = "iptables-save" ]; then
+      if [ "$COMMAND_NAME" = "iptables-save" ] \
+        && [ ! -e "$VM0_RECONCILE_COUNT_DIR/firewall-snapshot-seeded" ]; then
+        touch "$VM0_RECONCILE_COUNT_DIR/firewall-snapshot-seeded"
         printf '%s\n' \
           "-A VM0-RECONCILE-OWN -m comment --comment \"vm0-ns-${OWN_POOL_HEX}-fd\" -j ACCEPT" \
           "-A VM0-RECONCILE-IDLE -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT" \
@@ -230,6 +246,12 @@ case "$COMMAND_NAME" in
         printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-unlocked"
       fi
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-delete"
+      touch "$VM0_RECONCILE_FIREWALL_DELETE_STARTED"
+      for _ in $(seq 1 1200); do
+        [ -e "$VM0_RECONCILE_FIREWALL_DELETE_RELEASE" ] && break
+        sleep 0.05
+      done
+      [ -e "$VM0_RECONCILE_FIREWALL_DELETE_RELEASE" ] || exit 1
       exit 0
     fi
     if contains_argument VM0-RECONCILE-DECOY "$@"; then
@@ -309,9 +331,76 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --env "VM0_RECONCILE_REAL_IP6TABLES_SAVE=$REAL_IP6TABLES_SAVE" \
   --env "VM0_RECONCILE_FIREWALL_POOL_INDEX=${RECONCILE_POOL_INDEXES[2]}" \
   --env "VM0_RECONCILE_FIREWALL_POOL_HEX=$RECONCILE_FIREWALL_POOL_HEX" \
+  --env "VM0_RECONCILE_FIREWALL_DELETE_STARTED=$RECONCILE_FIREWALL_DELETE_STARTED" \
+  --env "VM0_RECONCILE_FIREWALL_DELETE_RELEASE=$RECONCILE_FIREWALL_DELETE_RELEASE" \
   --env "VM0_RECONCILE_ACTIVE_POOL_HEX=$RECONCILE_ACTIVE_POOL_HEX" \
   --env "VM0_RECONCILE_IDLE_RELEASE=$RECONCILE_IDLE_RELEASE" \
   --env "VM0_RECONCILE_IDLE_RELEASED=$RECONCILE_IDLE_RELEASED"
+
+assert_reconcile_count() {
+  local name=$1 expected=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0
+  if [ -f "$path" ]; then
+    actual=$(wc -l <"$path")
+  fi
+  [ "$actual" -eq "$expected" ] \
+    || fail "expected $expected reconciliation $name call(s), found $actual"
+}
+
+assert_reconcile_count_at_least() {
+  local name=$1 minimum=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0
+  if [ -f "$path" ]; then
+    actual=$(wc -l <"$path")
+  fi
+  [ "$actual" -ge "$minimum" ] \
+    || fail "expected at least $minimum reconciliation $name call(s), found $actual"
+}
+
+# Pause the runner at the cross-pool mutation boundary. This keeps later
+# warm-up or namespace failure cleanup from being mistaken for another startup
+# discovery pass while also proving that the target pool lock is still held.
+echo "--- Waiting for startup reconciliation checkpoint ---"
+for _ in $(seq 1 1200); do
+  [ -e "$RECONCILE_FIREWALL_DELETE_STARTED" ] && break
+  sleep 0.05
+done
+[ -e "$RECONCILE_FIREWALL_DELETE_STARTED" ] \
+  || fail "startup reconciliation did not reach the firewall cleanup checkpoint"
+
+echo "--- Test: startup reconciliation uses one host snapshot ---"
+# A fully captured snapshot must read every table exactly once. If a source was
+# abandoned, the preserved targeted fallback may re-read IPv4 tables for the
+# synthetic own-index namespace. The unique IPv6 and namespace cardinalities
+# still reject the historical per-index discovery loop in that failure path.
+FIREWALL_SNAPSHOT_SUCCEEDED=true
+for source in \
+  iptables-save.raw \
+  iptables-save.nat \
+  iptables-save.filter \
+  ip6tables-save.filter; do
+  if [ ! -e "$RECONCILE_COUNT_DIR/snapshot-${source}/succeeded" ]; then
+    FIREWALL_SNAPSHOT_SUCCEEDED=false
+  fi
+done
+if [ "$FIREWALL_SNAPSHOT_SUCCEEDED" = true ]; then
+  assert_reconcile_count iptables-save.raw 1
+  assert_reconcile_count iptables-save.nat 1
+  assert_reconcile_count iptables-save.filter 1
+else
+  assert_reconcile_count_at_least iptables-save.raw 1
+  assert_reconcile_count_at_least iptables-save.nat 1
+  assert_reconcile_count_at_least iptables-save.filter 1
+fi
+assert_reconcile_count ip6tables-save.filter 1
+assert_reconcile_count ip.netns-list 1
+assert_reconcile_count iptables.own-delete 1
+assert_reconcile_count ip.own-link-delete 1
+assert_reconcile_count ip.own-netns-delete 1
+assert_reconcile_count iptables.firewall-only-delete 1
+assert_reconcile_count iptables.firewall-only-unlocked 0
+assert_reconcile_count iptables.decoy-delete 0
+assert_reconcile_count ip.active-delete 0
+sudo touch "$RECONCILE_FIREWALL_DELETE_RELEASE"
+echo "PASS: startup reconciled one snapshot without modifying the active pool"
 
 # Submit a long-running job in background
 echo "--- Submitting long-running job ---"
@@ -348,30 +437,6 @@ for _ in $(seq 1 60); do
 done
 [ "$SANDBOX_READY" = true ] || fail "sandbox not found after 60s"
 echo "Found run $RUN_ID (sandbox $SANDBOX_ID)"
-
-assert_reconcile_count() {
-  local name=$1 expected=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0
-  if [ -f "$path" ]; then
-    actual=$(wc -l <"$path")
-  fi
-  [ "$actual" -eq "$expected" ] \
-    || fail "expected $expected reconciliation $name call(s), found $actual"
-}
-
-echo "--- Test: startup reconciliation uses one host snapshot ---"
-assert_reconcile_count iptables-save.raw 1
-assert_reconcile_count iptables-save.nat 1
-assert_reconcile_count iptables-save.filter 1
-assert_reconcile_count ip6tables-save.filter 1
-assert_reconcile_count ip.netns-list 1
-assert_reconcile_count iptables.own-delete 1
-assert_reconcile_count ip.own-link-delete 1
-assert_reconcile_count ip.own-netns-delete 1
-assert_reconcile_count iptables.firewall-only-delete 1
-assert_reconcile_count iptables.firewall-only-unlocked 0
-assert_reconcile_count iptables.decoy-delete 0
-assert_reconcile_count ip.active-delete 0
-echo "PASS: startup reconciled one snapshot without modifying the active pool"
 
 # Test 1: cancel the job via runner local cancel
 echo "--- Test: runner local cancel ---"

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -35,6 +35,16 @@ set -euo pipefail
 BIN_DIR=$1; SVC=$2; GROUP=$3; GROUP_DIR=$4; RUNNER_DIR=$5
 SUBMIT_PID=""
 SUBMIT_OUTPUT=$(mktemp)
+RECONCILE_TEST_DIR=$(mktemp -d "/tmp/vm0-${SVC}-reconcile.XXXXXX")
+RECONCILE_BIN_DIR="$RECONCILE_TEST_DIR/bin"
+RECONCILE_COUNT_DIR="$RECONCILE_TEST_DIR/counts"
+RECONCILE_LOCK_INFO="$RECONCILE_TEST_DIR/pool-indexes"
+RECONCILE_IDLE_RELEASE="$RECONCILE_TEST_DIR/release-idle"
+RECONCILE_IDLE_RELEASED="$RECONCILE_TEST_DIR/idle-released"
+RECONCILE_ACTIVE_RELEASE="$RECONCILE_TEST_DIR/release-active"
+RECONCILE_SNAPSHOT_READY="$RECONCILE_TEST_DIR/snapshot-ready"
+RECONCILE_SNAPSHOT_RELEASE="$RECONCILE_TEST_DIR/release-snapshot"
+RECONCILE_LOCK_HOLDER_PID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 
@@ -53,6 +63,8 @@ cleanup_submit_pid() {
 cleanup() {
   local status=$?
   trap - EXIT
+  touch "$RECONCILE_IDLE_RELEASE" "$RECONCILE_ACTIVE_RELEASE" \
+    "$RECONCILE_SNAPSHOT_RELEASE"
   if [ "$status" -ne 0 ]; then
     print_service_logs
   fi
@@ -61,14 +73,244 @@ cleanup() {
   cleanup_submit_pid "$SUBMIT_PID"
   sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
   rm -f "$SUBMIT_OUTPUT"
+  if [ -n "$RECONCILE_LOCK_HOLDER_PID" ]; then
+    wait "$RECONCILE_LOCK_HOLDER_PID" 2>/dev/null || true
+  fi
+  sudo rm -rf "$RECONCILE_TEST_DIR"
   exit "$status"
 }
 trap cleanup EXIT
 
+mkdir -p "$RECONCILE_BIN_DIR" "$RECONCILE_COUNT_DIR"
+REAL_IP=$(command -v ip)
+REAL_IPTABLES=$(command -v iptables)
+REAL_IPTABLES_SAVE=$(command -v iptables-save)
+REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
+
+# Reserve four pool indexes before the runner starts. Two become clean
+# historical indexes, one owns a synthetic firewall-only orphan, and one
+# remains active throughout reconciliation. The namespace-list wrapper gates
+# the snapshot so the first three locks are released only after the runner has
+# acquired a different index.
+sudo bash -s -- \
+  "$RECONCILE_LOCK_INFO" \
+  "$RECONCILE_IDLE_RELEASE" \
+  "$RECONCILE_IDLE_RELEASED" \
+  "$RECONCILE_ACTIVE_RELEASE" <<'LOCK_HOLDER' &
+set -euo pipefail
+LOCK_INFO=$1
+IDLE_RELEASE=$2
+IDLE_RELEASED=$3
+ACTIVE_RELEASE=$4
+declare -a RESERVED_FDS=()
+declare -a RESERVED_INDEXES=()
+
+reserve_index() {
+  local index=$1
+  local path="/var/lock/vm0-netns-pool-${index}.lock"
+  local candidate_fd
+  exec {candidate_fd}>"$path"
+  if flock -n "$candidate_fd"; then
+    RESERVED_FDS+=("$candidate_fd")
+    RESERVED_INDEXES+=("$index")
+  else
+    exec {candidate_fd}>&-
+  fi
+}
+
+# Prefer existing persistent lock files. Create new files only if the host has
+# fewer than four idle indexes available.
+for index in $(seq 63 -1 0); do
+  [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] || continue
+  reserve_index "$index"
+  [ "${#RESERVED_INDEXES[@]}" -eq 4 ] && break
+done
+if [ "${#RESERVED_INDEXES[@]}" -lt 4 ]; then
+  for index in $(seq 63 -1 0); do
+    [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] && continue
+    reserve_index "$index"
+    [ "${#RESERVED_INDEXES[@]}" -eq 4 ] && break
+  done
+fi
+[ "${#RESERVED_INDEXES[@]}" -eq 4 ] || exit 1
+printf '%s\n' "${RESERVED_INDEXES[@]}" >"$LOCK_INFO"
+
+while [ ! -e "$IDLE_RELEASE" ]; do sleep 0.05; done
+for position in 0 1 2; do
+  flock -u "${RESERVED_FDS[$position]}"
+done
+touch "$IDLE_RELEASED"
+
+while [ ! -e "$ACTIVE_RELEASE" ]; do sleep 0.05; done
+LOCK_HOLDER
+RECONCILE_LOCK_HOLDER_PID=$!
+
+for _ in $(seq 1 200); do
+  [ -s "$RECONCILE_LOCK_INFO" ] && break
+  kill -0 "$RECONCILE_LOCK_HOLDER_PID" 2>/dev/null \
+    || fail "failed to reserve namespace pool indexes"
+  sleep 0.05
+done
+[ -s "$RECONCILE_LOCK_INFO" ] || fail "timed out reserving namespace pool indexes"
+mapfile -t RECONCILE_POOL_INDEXES <"$RECONCILE_LOCK_INFO"
+printf -v RECONCILE_FIREWALL_POOL_HEX '%02x' "${RECONCILE_POOL_INDEXES[2]}"
+printf -v RECONCILE_ACTIVE_POOL_HEX '%02x' "${RECONCILE_POOL_INDEXES[3]}"
+
+cat >"$RECONCILE_BIN_DIR/network-command" <<'NETWORK_COMMAND'
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND_NAME=${0##*/}
+
+find_own_pool_hex() {
+  local fd target index
+  for fd in /proc/"$PPID"/fd/*; do
+    target=$(readlink "$fd" 2>/dev/null || true)
+    case "$target" in
+      /var/lock/vm0-netns-pool-*.lock)
+        index=${target##*/vm0-netns-pool-}
+        index=${index%.lock}
+        case "$index" in
+          '' | *[!0-9]*) continue ;;
+        esac
+        if [ "$index" -lt 64 ]; then
+          printf '%02x\n' "$index"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+contains_argument() {
+  local expected=$1
+  shift
+  local argument
+  for argument in "$@"; do
+    [ "$argument" = "$expected" ] && return 0
+  done
+  return 1
+}
+
+case "$COMMAND_NAME" in
+  iptables-save | ip6tables-save)
+    if [ "${1:-}" = "-t" ] && [ -n "${2:-}" ]; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/${COMMAND_NAME}.${2}"
+    fi
+    if [ "$COMMAND_NAME" = "iptables-save" ]; then
+      REAL_COMMAND=$VM0_RECONCILE_REAL_IPTABLES_SAVE
+    else
+      REAL_COMMAND=$VM0_RECONCILE_REAL_IP6TABLES_SAVE
+    fi
+    if "$REAL_COMMAND" "$@"; then
+      STATUS=0
+    else
+      STATUS=$?
+    fi
+    if [ "$STATUS" -eq 0 ] && [ "${1:-}" = "-t" ] && [ "${2:-}" = "filter" ]; then
+      OWN_POOL_HEX=$(find_own_pool_hex)
+      printf '%s\n' "$OWN_POOL_HEX" >"$VM0_RECONCILE_COUNT_DIR/own-pool"
+      if [ "$COMMAND_NAME" = "iptables-save" ]; then
+        printf '%s\n' \
+          "-A FORWARD -m comment --comment \"vm0-ns-${OWN_POOL_HEX}-fd\" -j ACCEPT" \
+          "-A INPUT -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT"
+      fi
+    fi
+    exit "$STATUS"
+    ;;
+  iptables)
+    OWN_POOL_HEX=$(find_own_pool_hex)
+    if contains_argument "vm0-ns-${OWN_POOL_HEX}-fd" "$@"; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.own-delete"
+      exit 0
+    fi
+    if contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-delete"
+      exit 0
+    fi
+    exec "$VM0_RECONCILE_REAL_IPTABLES" "$@"
+    ;;
+  ip)
+    if [ "${1:-}" = "netns" ] && [ "${2:-}" = "list" ]; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.netns-list"
+      if mkdir "$VM0_RECONCILE_COUNT_DIR/netns-list-gate" 2>/dev/null; then
+        touch "$VM0_RECONCILE_SNAPSHOT_READY"
+        while [ ! -e "$VM0_RECONCILE_SNAPSHOT_RELEASE" ]; do sleep 0.05; done
+      fi
+      if "$VM0_RECONCILE_REAL_IP" "$@"; then
+        STATUS=0
+      else
+        STATUS=$?
+      fi
+      if [ "$STATUS" -eq 0 ]; then
+        OWN_POOL_HEX=$(find_own_pool_hex)
+        printf '%s\n' "$OWN_POOL_HEX" >"$VM0_RECONCILE_COUNT_DIR/own-pool"
+        printf '%s\n' \
+          "vm0-ns-${OWN_POOL_HEX}-fd" \
+          "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc"
+      fi
+      exit "$STATUS"
+    fi
+
+    OWN_POOL_HEX=$(find_own_pool_hex)
+    if [ "${1:-}" = "link" ] && [ "${2:-}" = "del" ] \
+      && [ "${3:-}" = "vm0-ve-${OWN_POOL_HEX}-fd" ]; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-link-delete"
+      exit 0
+    fi
+    if [ "${1:-}" = "netns" ] && [ "${2:-}" = "del" ] \
+      && [ "${3:-}" = "vm0-ns-${OWN_POOL_HEX}-fd" ]; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-netns-delete"
+      exit 0
+    fi
+    if contains_argument "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" "$@" \
+      || contains_argument "vm0-ve-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" "$@"; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.active-delete"
+      exit 0
+    fi
+    exec "$VM0_RECONCILE_REAL_IP" "$@"
+    ;;
+esac
+
+exit 127
+NETWORK_COMMAND
+chmod 755 "$RECONCILE_BIN_DIR/network-command"
+for command in ip iptables iptables-save ip6tables-save; do
+  ln -s network-command "$RECONCILE_BIN_DIR/$command"
+done
+
 # Start transient runner service
 echo "--- Starting runner ---"
 sudo "$BIN_DIR/runner" service start --name "$SVC" \
-  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+  --config "$RUNNER_DIR/runner.yaml" --local \
+  --env USE_MOCK_CLAUDE=true \
+  --env USE_MOCK_CODEX=true \
+  --env "PATH=$RECONCILE_BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  --env "VM0_RECONCILE_COUNT_DIR=$RECONCILE_COUNT_DIR" \
+  --env "VM0_RECONCILE_REAL_IP=$REAL_IP" \
+  --env "VM0_RECONCILE_REAL_IPTABLES=$REAL_IPTABLES" \
+  --env "VM0_RECONCILE_REAL_IPTABLES_SAVE=$REAL_IPTABLES_SAVE" \
+  --env "VM0_RECONCILE_REAL_IP6TABLES_SAVE=$REAL_IP6TABLES_SAVE" \
+  --env "VM0_RECONCILE_FIREWALL_POOL_HEX=$RECONCILE_FIREWALL_POOL_HEX" \
+  --env "VM0_RECONCILE_ACTIVE_POOL_HEX=$RECONCILE_ACTIVE_POOL_HEX" \
+  --env "VM0_RECONCILE_SNAPSHOT_READY=$RECONCILE_SNAPSHOT_READY" \
+  --env "VM0_RECONCILE_SNAPSHOT_RELEASE=$RECONCILE_SNAPSHOT_RELEASE"
+
+for _ in $(seq 1 200); do
+  [ -e "$RECONCILE_SNAPSHOT_READY" ] && break
+  sleep 0.05
+done
+[ -e "$RECONCILE_SNAPSHOT_READY" ] \
+  || fail "runner did not begin namespace reconciliation snapshot"
+touch "$RECONCILE_IDLE_RELEASE"
+for _ in $(seq 1 200); do
+  [ -e "$RECONCILE_IDLE_RELEASED" ] && break
+  sleep 0.05
+done
+[ -e "$RECONCILE_IDLE_RELEASED" ] \
+  || fail "timed out releasing idle namespace pool indexes"
+touch "$RECONCILE_SNAPSHOT_RELEASE"
 
 # Submit a long-running job in background
 echo "--- Submitting long-running job ---"
@@ -106,6 +348,28 @@ done
 [ "$SANDBOX_READY" = true ] || fail "sandbox not found after 60s"
 echo "Found run $RUN_ID (sandbox $SANDBOX_ID)"
 
+assert_reconcile_count() {
+  local name=$1 expected=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0
+  if [ -f "$path" ]; then
+    actual=$(wc -l <"$path")
+  fi
+  [ "$actual" -eq "$expected" ] \
+    || fail "expected $expected reconciliation $name call(s), found $actual"
+}
+
+echo "--- Test: startup reconciliation uses one host snapshot ---"
+assert_reconcile_count iptables-save.raw 1
+assert_reconcile_count iptables-save.nat 1
+assert_reconcile_count iptables-save.filter 1
+assert_reconcile_count ip6tables-save.filter 1
+assert_reconcile_count ip.netns-list 1
+assert_reconcile_count iptables.own-delete 1
+assert_reconcile_count ip.own-link-delete 1
+assert_reconcile_count ip.own-netns-delete 1
+assert_reconcile_count iptables.firewall-only-delete 1
+assert_reconcile_count ip.active-delete 0
+echo "PASS: startup reconciled one snapshot without modifying the active pool"
+
 # Test 1: cancel the job via runner local cancel
 echo "--- Test: runner local cancel ---"
 sudo "$BIN_DIR/runner" local cancel --run "$RUN_ID" --group "$GROUP" || fail "cancel command failed"
@@ -137,6 +401,10 @@ echo "PASS: submit exited with non-zero after cancel (${ELAPSED}s)"
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
 rm -f "$SUBMIT_OUTPUT"
+touch "$RECONCILE_ACTIVE_RELEASE"
+wait "$RECONCILE_LOCK_HOLDER_PID"
+RECONCILE_LOCK_HOLDER_PID=""
+sudo rm -rf "$RECONCILE_TEST_DIR"
 trap - EXIT
 
 echo "=== Cancel test passed ==="

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -214,7 +214,8 @@ case "$COMMAND_NAME" in
       if [ "$COMMAND_NAME" = "iptables-save" ]; then
         printf '%s\n' \
           "-A VM0-RECONCILE-OWN -m comment --comment \"vm0-ns-${OWN_POOL_HEX}-fd\" -j ACCEPT" \
-          "-A VM0-RECONCILE-IDLE -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT"
+          "-A VM0-RECONCILE-IDLE -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT" \
+          "-A VM0-RECONCILE-DECOY -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns-extra\" -j REJECT"
       fi
     fi
     exit "$STATUS"
@@ -229,6 +230,10 @@ case "$COMMAND_NAME" in
     if contains_argument VM0-RECONCILE-IDLE "$@" \
       && contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-delete"
+      exit 0
+    fi
+    if contains_argument VM0-RECONCILE-DECOY "$@"; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.decoy-delete"
       exit 0
     fi
     exec "$VM0_RECONCILE_REAL_IPTABLES" "$@"
@@ -375,6 +380,7 @@ assert_reconcile_count iptables.own-delete 1
 assert_reconcile_count ip.own-link-delete 1
 assert_reconcile_count ip.own-netns-delete 1
 assert_reconcile_count iptables.firewall-only-delete 1
+assert_reconcile_count iptables.decoy-delete 0
 assert_reconcile_count ip.active-delete 0
 echo "PASS: startup reconciled one snapshot without modifying the active pool"
 

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -226,6 +226,9 @@ case "$COMMAND_NAME" in
     fi
     if contains_argument VM0-RECONCILE-IDLE "$@" \
       && contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
+      if flock -n "/var/lock/vm0-netns-pool-${VM0_RECONCILE_FIREWALL_POOL_INDEX}.lock" true; then
+        printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-unlocked"
+      fi
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-delete"
       exit 0
     fi
@@ -304,6 +307,7 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --env "VM0_RECONCILE_REAL_IPTABLES=$REAL_IPTABLES" \
   --env "VM0_RECONCILE_REAL_IPTABLES_SAVE=$REAL_IPTABLES_SAVE" \
   --env "VM0_RECONCILE_REAL_IP6TABLES_SAVE=$REAL_IP6TABLES_SAVE" \
+  --env "VM0_RECONCILE_FIREWALL_POOL_INDEX=${RECONCILE_POOL_INDEXES[2]}" \
   --env "VM0_RECONCILE_FIREWALL_POOL_HEX=$RECONCILE_FIREWALL_POOL_HEX" \
   --env "VM0_RECONCILE_ACTIVE_POOL_HEX=$RECONCILE_ACTIVE_POOL_HEX" \
   --env "VM0_RECONCILE_IDLE_RELEASE=$RECONCILE_IDLE_RELEASE" \
@@ -364,6 +368,7 @@ assert_reconcile_count iptables.own-delete 1
 assert_reconcile_count ip.own-link-delete 1
 assert_reconcile_count ip.own-netns-delete 1
 assert_reconcile_count iptables.firewall-only-delete 1
+assert_reconcile_count iptables.firewall-only-unlocked 0
 assert_reconcile_count iptables.decoy-delete 0
 assert_reconcile_count ip.active-delete 0
 echo "PASS: startup reconciled one snapshot without modifying the active pool"

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -220,7 +220,7 @@ case "$COMMAND_NAME" in
     exit "$STATUS"
     ;;
   iptables)
-    OWN_POOL_HEX=$(find_own_pool_hex)
+    OWN_POOL_HEX=$(<"$VM0_RECONCILE_COUNT_DIR/own-pool")
     if contains_argument VM0-RECONCILE-OWN "$@" \
       && contains_argument "vm0-ns-${OWN_POOL_HEX}-fd" "$@"; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.own-delete"
@@ -261,7 +261,7 @@ case "$COMMAND_NAME" in
       exit "$STATUS"
     fi
 
-    OWN_POOL_HEX=$(find_own_pool_hex)
+    OWN_POOL_HEX=$(<"$VM0_RECONCILE_COUNT_DIR/own-pool")
     if [ "${1:-}" = "link" ] && [ "${2:-}" = "del" ] \
       && [ "${3:-}" = "vm0-ve-${OWN_POOL_HEX}-fd" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-link-delete"

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -213,19 +213,21 @@ case "$COMMAND_NAME" in
       printf '%s\n' "$OWN_POOL_HEX" >"$VM0_RECONCILE_COUNT_DIR/own-pool"
       if [ "$COMMAND_NAME" = "iptables-save" ]; then
         printf '%s\n' \
-          "-A FORWARD -m comment --comment \"vm0-ns-${OWN_POOL_HEX}-fd\" -j ACCEPT" \
-          "-A INPUT -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT"
+          "-A VM0-RECONCILE-OWN -m comment --comment \"vm0-ns-${OWN_POOL_HEX}-fd\" -j ACCEPT" \
+          "-A VM0-RECONCILE-IDLE -m comment --comment \"vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns\" -j REJECT"
       fi
     fi
     exit "$STATUS"
     ;;
   iptables)
     OWN_POOL_HEX=$(find_own_pool_hex)
-    if contains_argument "vm0-ns-${OWN_POOL_HEX}-fd" "$@"; then
+    if contains_argument VM0-RECONCILE-OWN "$@" \
+      && contains_argument "vm0-ns-${OWN_POOL_HEX}-fd" "$@"; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.own-delete"
       exit 0
     fi
-    if contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
+    if contains_argument VM0-RECONCILE-IDLE "$@" \
+      && contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-delete"
       exit 0
     fi
@@ -238,7 +240,7 @@ case "$COMMAND_NAME" in
         touch "$VM0_RECONCILE_SNAPSHOT_READY"
         while [ ! -e "$VM0_RECONCILE_SNAPSHOT_RELEASE" ]; do sleep 0.05; done
       fi
-      if "$VM0_RECONCILE_REAL_IP" "$@"; then
+      if REAL_OUTPUT=$("$VM0_RECONCILE_REAL_IP" "$@"); then
         STATUS=0
       else
         STATUS=$?
@@ -246,9 +248,15 @@ case "$COMMAND_NAME" in
       if [ "$STATUS" -eq 0 ]; then
         OWN_POOL_HEX=$(find_own_pool_hex)
         printf '%s\n' "$OWN_POOL_HEX" >"$VM0_RECONCILE_COUNT_DIR/own-pool"
-        printf '%s\n' \
-          "vm0-ns-${OWN_POOL_HEX}-fd" \
-          "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc"
+        [ -z "$REAL_OUTPUT" ] || printf '%s\n' "$REAL_OUTPUT"
+        if ! awk -v name="vm0-ns-${OWN_POOL_HEX}-fd" \
+          '$1 == name { found = 1 } END { exit !found }' <<<"$REAL_OUTPUT"; then
+          printf '%s\n' "vm0-ns-${OWN_POOL_HEX}-fd"
+        fi
+        if ! awk -v name="vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" \
+          '$1 == name { found = 1 } END { exit !found }' <<<"$REAL_OUTPUT"; then
+          printf '%s\n' "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc"
+        fi
       fi
       exit "$STATUS"
     fi
@@ -257,12 +265,12 @@ case "$COMMAND_NAME" in
     if [ "${1:-}" = "link" ] && [ "${2:-}" = "del" ] \
       && [ "${3:-}" = "vm0-ve-${OWN_POOL_HEX}-fd" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-link-delete"
-      exit 0
+      exec "$VM0_RECONCILE_REAL_IP" "$@"
     fi
     if [ "${1:-}" = "netns" ] && [ "${2:-}" = "del" ] \
       && [ "${3:-}" = "vm0-ns-${OWN_POOL_HEX}-fd" ]; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/ip.own-netns-delete"
-      exit 0
+      exec "$VM0_RECONCILE_REAL_IP" "$@"
     fi
     if contains_argument "vm0-ns-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" "$@" \
       || contains_argument "vm0-ve-${VM0_RECONCILE_ACTIVE_POOL_HEX}-fc" "$@"; then

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::future::Future;
 use std::pin::Pin;
@@ -899,21 +899,14 @@ enum SnapshotSource<T> {
 }
 
 #[derive(Debug)]
-struct CapturedFirewallRule {
-    pool_index: u32,
-    rule: String,
-}
-
-#[derive(Debug)]
 struct FirewallTableSnapshot {
     command: &'static str,
     table: &'static str,
-    rules: SnapshotSource<Vec<CapturedFirewallRule>>,
+    rules_by_pool: SnapshotSource<BTreeMap<u32, Vec<String>>>,
 }
 
 #[derive(Debug)]
 struct CapturedNamespace {
-    pool_index: u32,
     name: String,
     host_device: String,
 }
@@ -924,7 +917,7 @@ struct ReconciliationSnapshot {
     ipv4_nat: FirewallTableSnapshot,
     ipv4_filter: FirewallTableSnapshot,
     ipv6_filter: FirewallTableSnapshot,
-    namespaces: SnapshotSource<Vec<CapturedNamespace>>,
+    namespaces_by_pool: SnapshotSource<BTreeMap<u32, Vec<CapturedNamespace>>>,
 }
 
 impl ReconciliationSnapshot {
@@ -941,7 +934,7 @@ impl ReconciliationSnapshot {
             ipv4_nat,
             ipv4_filter,
             ipv6_filter,
-            namespaces,
+            namespaces_by_pool: namespaces,
         }
     }
 
@@ -953,12 +946,12 @@ impl ReconciliationSnapshot {
             &self.ipv4_filter,
             &self.ipv6_filter,
         ] {
-            if let SnapshotSource::Captured(rules) = &table.rules {
-                indexes.extend(rules.iter().map(|rule| rule.pool_index));
+            if let SnapshotSource::Captured(rules_by_pool) = &table.rules_by_pool {
+                indexes.extend(rules_by_pool.keys().copied());
             }
         }
-        if let SnapshotSource::Captured(namespaces) = &self.namespaces {
-            indexes.extend(namespaces.iter().map(|namespace| namespace.pool_index));
+        if let SnapshotSource::Captured(namespaces_by_pool) = &self.namespaces_by_pool {
+            indexes.extend(namespaces_by_pool.keys().copied());
         }
         indexes
     }
@@ -969,18 +962,21 @@ async fn capture_firewall_table(
     save_command: &'static str,
     table: &'static str,
 ) -> FirewallTableSnapshot {
-    let rules = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT).await {
-        Ok(output) => SnapshotSource::Captured(
-            output
-                .lines()
-                .filter_map(|line| {
-                    firewall_rule_pool_index(line).map(|pool_index| CapturedFirewallRule {
-                        pool_index,
-                        rule: line.to_string(),
-                    })
-                })
-                .collect(),
-        ),
+    let rules_by_pool = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT)
+        .await
+    {
+        Ok(output) => {
+            let mut rules_by_pool: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+            for line in output.lines() {
+                if let Some(pool_index) = firewall_rule_pool_index(line) {
+                    rules_by_pool
+                        .entry(pool_index)
+                        .or_default()
+                        .push(line.to_string());
+                }
+            }
+            SnapshotSource::Captured(rules_by_pool)
+        }
         Err(error) => {
             warn!(save_command, table, %error, "failed to capture firewall rules for startup reconciliation");
             SnapshotSource::Abandoned
@@ -989,7 +985,7 @@ async fn capture_firewall_table(
     FirewallTableSnapshot {
         command,
         table,
-        rules,
+        rules_by_pool,
     }
 }
 
@@ -1021,7 +1017,7 @@ fn pool_index_from_comment(comment: &str) -> Option<u32> {
     (pool_index < MAX_POOLS && format_hex_index(pool_index) == pool_hex).then_some(pool_index)
 }
 
-async fn capture_namespaces() -> SnapshotSource<Vec<CapturedNamespace>> {
+async fn capture_namespaces() -> SnapshotSource<BTreeMap<u32, Vec<CapturedNamespace>>> {
     let output = match exec_with_timeout("ip", &["netns", "list"], NETNS_COMMAND_TIMEOUT).await {
         Ok(output) => output,
         Err(error) => {
@@ -1030,38 +1026,41 @@ async fn capture_namespaces() -> SnapshotSource<Vec<CapturedNamespace>> {
         }
     };
 
-    SnapshotSource::Captured(
-        output
-            .lines()
-            .filter_map(|line| line.split_whitespace().next())
-            .filter_map(|name| {
-                let parsed = parse_netns_name(name)?;
-                let pool_idx = format_hex_index(parsed.pool_index);
-                let ns_idx = format_hex_index(parsed.namespace_index);
-                Some(CapturedNamespace {
-                    pool_index: parsed.pool_index,
-                    name: name.to_string(),
-                    host_device: make_host_device(&pool_idx, &ns_idx),
-                })
-            })
-            .collect(),
-    )
+    let mut namespaces_by_pool: BTreeMap<u32, Vec<CapturedNamespace>> = BTreeMap::new();
+    for name in output
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+    {
+        let Some(parsed) = parse_netns_name(name) else {
+            continue;
+        };
+        let pool_idx = format_hex_index(parsed.pool_index);
+        let ns_idx = format_hex_index(parsed.namespace_index);
+        namespaces_by_pool
+            .entry(parsed.pool_index)
+            .or_default()
+            .push(CapturedNamespace {
+                name: name.to_string(),
+                host_device: make_host_device(&pool_idx, &ns_idx),
+            });
+    }
+    SnapshotSource::Captured(namespaces_by_pool)
 }
 
 async fn delete_firewall_rules_from_snapshot(
     snapshot: &FirewallTableSnapshot,
     pool_index: u32,
 ) -> NamespaceDeleteOutcome {
-    let SnapshotSource::Captured(rules) = &snapshot.rules else {
+    let SnapshotSource::Captured(rules_by_pool) = &snapshot.rules_by_pool else {
         return NamespaceDeleteOutcome::Abandoned;
+    };
+    let Some(rules) = rules_by_pool.get(&pool_index) else {
+        return NamespaceDeleteOutcome::Deleted;
     };
 
     let mut outcomes = Vec::new();
-    for captured in rules
-        .iter()
-        .filter(|captured| captured.pool_index == pool_index)
-    {
-        let rule = captured.rule.replacen("-A ", "-D ", 1);
+    for captured in rules {
+        let rule = captured.replacen("-A ", "-D ", 1);
         let mut args: Vec<&str> = vec!["-t", snapshot.table];
         args.extend(rule.split_whitespace().map(|token| token.trim_matches('"')));
         outcomes.push(
@@ -1102,17 +1101,12 @@ async fn cleanup_namespaces_from_snapshot(
     index: u32,
 ) -> NamespaceDeleteOutcome {
     let firewall = delete_pool_firewall_rules_from_snapshot(snapshot, index).await;
-    let SnapshotSource::Captured(namespaces) = &snapshot.namespaces else {
+    let SnapshotSource::Captured(namespaces_by_pool) = &snapshot.namespaces_by_pool else {
         return NamespaceDeleteOutcome::Abandoned;
     };
-    let namespaces: Vec<_> = namespaces
-        .iter()
-        .filter(|namespace| namespace.pool_index == index)
-        .collect();
-
-    if namespaces.is_empty() {
+    let Some(namespaces) = namespaces_by_pool.get(&index) else {
         return firewall;
-    }
+    };
 
     let idx_str = format_hex_index(index);
     info!(count = namespaces.len(), index = %idx_str, "cleaning up orphaned namespaces");

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::future::Future;
 use std::pin::Pin;
@@ -891,80 +892,275 @@ async fn create_namespace_inner(
     Ok(())
 }
 
-/// Clean up all resources matching a given pool index.
-///
-/// Deletes orphaned host iptables rules first, then discovers and deletes
-/// remaining namespaces and their veth devices. If the pool-wide iptables
-/// cleanup is abandoned, each namespace falls back to full cleanup.
-async fn cleanup_namespaces_by_index(index: u32) {
-    let idx_str = format_hex_index(index);
-    let prefix = format!("{NS_PREFIX}{idx_str}-");
+#[derive(Debug)]
+enum SnapshotSource<T> {
+    Captured(T),
+    Abandoned,
+}
 
-    // 1. Clean orphaned host iptables rules whose comment matches this pool index.
-    //    The Rust-side `contains()` does substring matching, so the prefix matches
-    //    all namespaces in this pool. This catches rules left behind even if the
-    //    namespace itself was already deleted.
-    let iptables = delete_pool_firewall_rules_by_comment(&prefix).await;
+#[derive(Debug)]
+struct CapturedFirewallRule {
+    pool_index: u32,
+    rule: String,
+}
 
-    // 2. Discover and delete any remaining namespaces (+ their veth devices).
-    let Ok(output) = exec_with_timeout("ip", &["netns", "list"], NETNS_COMMAND_TIMEOUT).await
-    else {
-        error!(index, "failed to list namespaces for cleanup");
-        return;
-    };
-    let ns_names: Vec<String> = output
-        .lines()
-        .filter_map(|line| line.split_whitespace().next())
-        .filter(|name| name.starts_with(&prefix))
-        .map(String::from)
-        .collect();
+#[derive(Debug)]
+struct FirewallTableSnapshot {
+    command: &'static str,
+    table: &'static str,
+    rules: SnapshotSource<Vec<CapturedFirewallRule>>,
+}
 
-    if ns_names.is_empty() {
-        return;
+#[derive(Debug)]
+struct CapturedNamespace {
+    pool_index: u32,
+    name: String,
+    host_device: String,
+}
+
+#[derive(Debug)]
+struct ReconciliationSnapshot {
+    ipv4_raw: FirewallTableSnapshot,
+    ipv4_nat: FirewallTableSnapshot,
+    ipv4_filter: FirewallTableSnapshot,
+    ipv6_filter: FirewallTableSnapshot,
+    namespaces: SnapshotSource<Vec<CapturedNamespace>>,
+}
+
+impl ReconciliationSnapshot {
+    async fn capture() -> Self {
+        let (ipv4_raw, ipv4_nat, ipv4_filter, ipv6_filter, namespaces) = tokio::join!(
+            capture_firewall_table("iptables", "iptables-save", "raw"),
+            capture_firewall_table("iptables", "iptables-save", "nat"),
+            capture_firewall_table("iptables", "iptables-save", "filter"),
+            capture_firewall_table("ip6tables", "ip6tables-save", "filter"),
+            capture_namespaces(),
+        );
+        Self {
+            ipv4_raw,
+            ipv4_nat,
+            ipv4_filter,
+            ipv6_filter,
+            namespaces,
+        }
     }
 
-    info!(count = ns_names.len(), index = %idx_str, "cleaning up orphaned namespaces");
-    let mut set = tokio::task::JoinSet::new();
-    for ns_name in ns_names {
-        set.spawn(async move {
-            if let Some(parsed) = parse_netns_name(&ns_name) {
+    fn candidate_pool_indexes(&self, own_index: u32) -> BTreeSet<u32> {
+        let mut indexes = BTreeSet::from([own_index]);
+        for table in [
+            &self.ipv4_raw,
+            &self.ipv4_nat,
+            &self.ipv4_filter,
+            &self.ipv6_filter,
+        ] {
+            if let SnapshotSource::Captured(rules) = &table.rules {
+                indexes.extend(rules.iter().map(|rule| rule.pool_index));
+            }
+        }
+        if let SnapshotSource::Captured(namespaces) = &self.namespaces {
+            indexes.extend(namespaces.iter().map(|namespace| namespace.pool_index));
+        }
+        indexes
+    }
+}
+
+async fn capture_firewall_table(
+    command: &'static str,
+    save_command: &'static str,
+    table: &'static str,
+) -> FirewallTableSnapshot {
+    let rules = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT).await {
+        Ok(output) => SnapshotSource::Captured(
+            output
+                .lines()
+                .filter_map(|line| {
+                    firewall_rule_pool_index(line).map(|pool_index| CapturedFirewallRule {
+                        pool_index,
+                        rule: line.to_string(),
+                    })
+                })
+                .collect(),
+        ),
+        Err(error) => {
+            warn!(save_command, table, %error, "failed to capture firewall rules for startup reconciliation");
+            SnapshotSource::Abandoned
+        }
+    };
+    FirewallTableSnapshot {
+        command,
+        table,
+        rules,
+    }
+}
+
+fn firewall_rule_pool_index(line: &str) -> Option<u32> {
+    if !line.starts_with("-A ") {
+        return None;
+    }
+
+    let mut tokens = line.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if token == "--comment" {
+            return tokens
+                .next()
+                .map(|comment| comment.trim_matches('"'))
+                .and_then(pool_index_from_comment);
+        }
+    }
+    None
+}
+
+fn pool_index_from_comment(comment: &str) -> Option<u32> {
+    if let Some(parsed) = parse_netns_name(comment) {
+        return Some(parsed.pool_index);
+    }
+
+    let suffix = comment.strip_prefix(NS_PREFIX)?;
+    let pool_hex = suffix.strip_suffix("-dns")?;
+    let pool_index = u32::from_str_radix(pool_hex, 16).ok()?;
+    (pool_index < MAX_POOLS && format_hex_index(pool_index) == pool_hex).then_some(pool_index)
+}
+
+async fn capture_namespaces() -> SnapshotSource<Vec<CapturedNamespace>> {
+    let output = match exec_with_timeout("ip", &["netns", "list"], NETNS_COMMAND_TIMEOUT).await {
+        Ok(output) => output,
+        Err(error) => {
+            error!(%error, "failed to capture namespaces for startup reconciliation");
+            return SnapshotSource::Abandoned;
+        }
+    };
+
+    SnapshotSource::Captured(
+        output
+            .lines()
+            .filter_map(|line| line.split_whitespace().next())
+            .filter_map(|name| {
+                let parsed = parse_netns_name(name)?;
                 let pool_idx = format_hex_index(parsed.pool_index);
                 let ns_idx = format_hex_index(parsed.namespace_index);
-                let host_device = make_host_device(&pool_idx, &ns_idx);
-                match iptables {
-                    NamespaceDeleteOutcome::Deleted => {
-                        info!(name = %ns_name, "deleting namespace");
-                        let outcome =
-                            delete_namespace_link_and_netns(&ns_name, &host_device).await;
-                        if matches!(outcome, NamespaceDeleteOutcome::Deleted) {
-                            info!(name = %ns_name, "namespace deleted");
-                        } else {
-                            warn!(
-                                name = %ns_name,
-                                host_device,
-                                "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
-                            );
-                        }
+                Some(CapturedNamespace {
+                    pool_index: parsed.pool_index,
+                    name: name.to_string(),
+                    host_device: make_host_device(&pool_idx, &ns_idx),
+                })
+            })
+            .collect(),
+    )
+}
+
+async fn delete_firewall_rules_from_snapshot(
+    snapshot: &FirewallTableSnapshot,
+    pool_index: u32,
+) -> NamespaceDeleteOutcome {
+    let SnapshotSource::Captured(rules) = &snapshot.rules else {
+        return NamespaceDeleteOutcome::Abandoned;
+    };
+
+    let mut outcomes = Vec::new();
+    for captured in rules
+        .iter()
+        .filter(|captured| captured.pool_index == pool_index)
+    {
+        let rule = captured.rule.replacen("-A ", "-D ", 1);
+        let mut args: Vec<&str> = vec!["-t", snapshot.table];
+        args.extend(rule.split_whitespace().map(|token| token.trim_matches('"')));
+        outcomes.push(
+            exec_xtables_ignore_errors_with_timeout(snapshot.command, &args, NETNS_COMMAND_TIMEOUT)
+                .await,
+        );
+    }
+    NamespaceDeleteOutcome::from_best_effort(outcomes)
+}
+
+async fn delete_pool_firewall_rules_from_snapshot(
+    snapshot: &ReconciliationSnapshot,
+    pool_index: u32,
+) -> NamespaceDeleteOutcome {
+    let (raw, nat, filter, ipv6_filter) = tokio::join!(
+        delete_firewall_rules_from_snapshot(&snapshot.ipv4_raw, pool_index),
+        delete_firewall_rules_from_snapshot(&snapshot.ipv4_nat, pool_index),
+        delete_firewall_rules_from_snapshot(&snapshot.ipv4_filter, pool_index),
+        delete_firewall_rules_from_snapshot(&snapshot.ipv6_filter, pool_index),
+    );
+    if [raw, nat, filter, ipv6_filter]
+        .into_iter()
+        .all(|outcome| matches!(outcome, NamespaceDeleteOutcome::Deleted))
+    {
+        NamespaceDeleteOutcome::Deleted
+    } else {
+        NamespaceDeleteOutcome::Abandoned
+    }
+}
+
+/// Clean up all captured resources matching a given pool index.
+///
+/// Deletes orphaned host firewall rules first, then deletes captured
+/// namespaces and their veth devices. If snapshot-backed firewall cleanup is
+/// abandoned, each namespace retains the existing fresh-discovery fallback.
+async fn cleanup_namespaces_from_snapshot(
+    snapshot: &ReconciliationSnapshot,
+    index: u32,
+) -> NamespaceDeleteOutcome {
+    let firewall = delete_pool_firewall_rules_from_snapshot(snapshot, index).await;
+    let SnapshotSource::Captured(namespaces) = &snapshot.namespaces else {
+        return NamespaceDeleteOutcome::Abandoned;
+    };
+    let namespaces: Vec<_> = namespaces
+        .iter()
+        .filter(|namespace| namespace.pool_index == index)
+        .collect();
+
+    if namespaces.is_empty() {
+        return firewall;
+    }
+
+    let idx_str = format_hex_index(index);
+    info!(count = namespaces.len(), index = %idx_str, "cleaning up orphaned namespaces");
+    let mut set = tokio::task::JoinSet::new();
+    for namespace in namespaces {
+        let ns_name = namespace.name.clone();
+        let host_device = namespace.host_device.clone();
+        set.spawn(async move {
+            match firewall {
+                NamespaceDeleteOutcome::Deleted => {
+                    info!(name = %ns_name, "deleting namespace");
+                    let outcome = delete_namespace_link_and_netns(&ns_name, &host_device).await;
+                    if matches!(outcome, NamespaceDeleteOutcome::Deleted) {
+                        info!(name = %ns_name, "namespace deleted");
+                    } else {
+                        warn!(
+                            name = %ns_name,
+                            host_device,
+                            "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
+                        );
                     }
-                    NamespaceDeleteOutcome::Abandoned => {
-                        delete_namespace_resources(&ns_name, &host_device).await;
-                    }
+                    outcome
+                }
+                NamespaceDeleteOutcome::Abandoned => {
+                    delete_namespace_resources(&ns_name, &host_device).await
                 }
             }
         });
     }
-    while set.join_next().await.is_some() {}
+
+    let mut outcome = firewall;
+    while let Some(result) = set.join_next().await {
+        if !matches!(result, Ok(NamespaceDeleteOutcome::Deleted)) {
+            outcome = NamespaceDeleteOutcome::Abandoned;
+        }
+    }
+    outcome
 }
 
-/// Clean orphans from `own_index` and every other pool index that currently
-/// has no active owner.
+/// Clean orphans from `own_index` and captured pool indexes with no active
+/// owner.
 ///
 /// `NetnsPool::cleanup` is best-effort — SIGKILL, panic, OOM, power loss,
 /// and aborted in-flight creation tasks can all leave kernel resources
-/// alive after a runner exits. This function is the correctness guarantee:
-/// on every startup, the flock is used as a liveness probe to identify
-/// pool indexes with no owner, and any namespaces under those indexes are
-/// treated as orphans and deleted.
+/// alive after a runner exits. This function is the correctness guarantee for
+/// `own_index`: every startup captures host resources once and cleans the
+/// acquired index before reuse. Captured resources under other indexes are
+/// deleted only after their flock proves that they have no active owner.
 ///
 /// `_own_lock` is a borrow witness — taking it proves the caller holds a
 /// pool-index flock, which is the permission required to do kernel-side
@@ -974,36 +1170,48 @@ pub(super) async fn reconcile_orphan_namespaces(
     own_index: u32,
     _own_lock: &Flock<File>,
 ) {
+    let snapshot = ReconciliationSnapshot::capture().await;
+    let candidate_indexes = snapshot.candidate_pool_indexes(own_index);
+    let candidate_count = candidate_indexes.len();
+
     // Own index: critical-path cleanup. Warm-up immediately afterwards
     // starts at ns_index 0 and will collide with any surviving orphan.
-    // `cleanup_namespaces_by_index` swallows failures by design — its
-    // only fallible step (`ip netns list`) is near-infallible on a
-    // working runner, and the inner deletes go through
-    // best-effort command helpers so a per-namespace `Result` would carry no
-    // signal. If reconcile silently fails here, the EEXIST that
-    // warm-up's `ip netns add` produces is the diagnostic — chronologically
-    // paired with the `error!` at the cleanup site. See #10826 for the
-    // full analysis (closed as won't-fix).
-    cleanup_namespaces_by_index(own_index).await;
+    // Cleanup remains best-effort. If it is abandoned, the EEXIST that
+    // warm-up's `ip netns add` produces is the diagnostic, chronologically
+    // paired with the warning at the cleanup site. See #10826 for the full
+    // analysis (closed as won't-fix).
+    let own_outcome = cleanup_namespaces_from_snapshot(&snapshot, own_index).await;
 
-    // Other indexes: advisory cleanup for arbitrary prior runners. Failures
-    // are not our problem — the next runner that claims the index will
-    // retry. The `if index == own_index` check is defensive; the flock
-    // would also deny us (Linux flock is per-OFD but same-process locks
-    // on the same file still conflict), so dropping the check would only
-    // waste two syscalls per call.
-    for index in 0..MAX_POOLS {
+    // Other captured indexes: advisory cleanup for arbitrary prior runners.
+    // The snapshot only discovers candidates; a current flock remains the
+    // authority to mutate resources for an index. A missed or failed cleanup
+    // is retried when a future runner directly acquires that index.
+    let mut reconciled = 1_usize;
+    let mut skipped = 0_usize;
+    let mut abandoned = usize::from(matches!(own_outcome, NamespaceDeleteOutcome::Abandoned));
+    for index in candidate_indexes {
         if index == own_index {
             continue;
         }
         let Some(_guard) = try_claim_idle_pool_lock(locks, index) else {
+            skipped += 1;
             continue;
         };
         info!(index, "reconciling orphaned namespaces from idle pool");
-        cleanup_namespaces_by_index(index).await;
+        let outcome = cleanup_namespaces_from_snapshot(&snapshot, index).await;
+        reconciled += 1;
+        abandoned += usize::from(matches!(outcome, NamespaceDeleteOutcome::Abandoned));
         // `_guard` drops here, releasing the lock before the next iteration
         // so a concurrently-starting runner can immediately claim the index.
     }
+    info!(
+        own_index,
+        candidate_count,
+        reconciled,
+        skipped,
+        abandoned,
+        "startup namespace reconciliation complete"
+    );
 }
 
 /// Try to acquire a non-blocking flock on an existing pool lock file.

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -635,16 +635,28 @@ async fn delete_firewall_rules_from_table(
             return NamespaceDeleteOutcome::Abandoned;
         }
     };
+    delete_firewall_rule_lines(
+        command,
+        table,
+        output
+            .lines()
+            .filter(|line| line.starts_with("-A ") && line.contains(comment)),
+    )
+    .await
+}
+
+async fn delete_firewall_rule_lines<'a>(
+    command: &str,
+    table: &str,
+    rules: impl Iterator<Item = &'a str>,
+) -> NamespaceDeleteOutcome {
     // Sequential: the legacy xtables lock serializes writes to the same table anyway.
     // Note: split_whitespace + trim_matches('"') is safe because namespace
     // comment values (e.g. "vm0-ns-00-0a") never contain spaces. If they
     // did, iptables-save would quote them as `--comment "foo bar"` and the
     // split would incorrectly break the value into separate arguments.
     let mut outcomes = Vec::new();
-    for line in output
-        .lines()
-        .filter(|line| line.starts_with("-A ") && line.contains(comment))
-    {
+    for line in rules {
         let rule = line.replacen("-A ", "-D ", 1);
         let mut args: Vec<&str> = vec!["-t", table];
         args.extend(rule.split_whitespace().map(|t| t.trim_matches('"')));
@@ -1058,17 +1070,12 @@ async fn delete_firewall_rules_from_snapshot(
         return NamespaceDeleteOutcome::Deleted;
     };
 
-    let mut outcomes = Vec::new();
-    for captured in rules {
-        let rule = captured.replacen("-A ", "-D ", 1);
-        let mut args: Vec<&str> = vec!["-t", snapshot.table];
-        args.extend(rule.split_whitespace().map(|token| token.trim_matches('"')));
-        outcomes.push(
-            exec_xtables_ignore_errors_with_timeout(snapshot.command, &args, NETNS_COMMAND_TIMEOUT)
-                .await,
-        );
-    }
-    NamespaceDeleteOutcome::from_best_effort(outcomes)
+    delete_firewall_rule_lines(
+        snapshot.command,
+        snapshot.table,
+        rules.iter().map(String::as_str),
+    )
+    .await
 }
 
 async fn delete_pool_firewall_rules_from_snapshot(


### PR DESCRIPTION
## Summary

- capture IPv4, IPv6, and network-namespace state once during namespace-pool startup reconciliation
- classify exact vm0 namespace and DNS firewall comments by pool index, then reconcile only represented indexes
- keep acquired-index cleanup synchronous and require a current pool flock before cross-index deletion
- extend the real runner cancel scenario to verify one discovery pass, own-index cleanup, firewall-only cleanup, and active-index isolation

## Safety and compatibility

- preserves existing pool lock files, resource names, bounded command execution, xtables waits, and best-effort fallback behavior
- does not change APIs, persisted state, queue payloads, runner protocols, or guest contracts
- does not move reconciliation into the background or increase the sandbox readiness timeout

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (738 passed)
- `cargo test -p runner --all-targets --all-features` (2776 passed, 13 ignored by the existing suite)
- `bash -n .github/scripts/runner-behavior-cancel.sh`
- `shellcheck .github/scripts/runner-behavior-cancel.sh`
- `git diff --check`

Closes #22543
