### PR TITLE
docs: update auth preview url example

### DIFF
--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -10,7 +10,7 @@
 # by the Playwright suite and have been removed from this file.
 #
 # Required env vars:
-#   VM0_AUTH_URL   - Target auth URL (e.g., https://staging-so.vm6.ai)
+#   VM0_AUTH_URL   - Target auth URL (e.g., https://pr-123-app.omby.ai)
 #
 # Optional env vars:
 #   VM0_API_BACKEND_URL            - API URL, used as a local fallback for auth URL


### PR DESCRIPTION
## Summary

- replace the retired staging-so.vm6.ai example in the browser E2E documentation
- use the current per-PR Cloudflare app preview hostname shape

This is the companion documentation cleanup for vm0-marketing PR #244. The two PRs are independent and can merge in either order.

## Verification

- git diff --check
- confirmed Turbo passes VM0_AUTH_URL from the current app-preview-url output
- confirmed the example matches resolve-app-preview-url.sh for PR environments

No runtime or test behavior changes.