### PR TITLE
fix(guest-agent): bound stalled codex resume startup

### DIFF
--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -106,6 +106,22 @@ impl CliFrameworkBehavior {
     pub(super) fn logs_codex_failure_diagnostics(self) -> bool {
         matches!(self.framework, env::Framework::Codex)
     }
+
+    pub(super) fn is_codex_turn_lifecycle_event(self, event: &serde_json::Value) -> bool {
+        matches!(self.framework, env::Framework::Codex)
+            && matches!(
+                event.get("type").and_then(serde_json::Value::as_str),
+                Some(
+                    "turn.started"
+                        | "turn.completed"
+                        | "turn.failed"
+                        | "item.started"
+                        | "item.updated"
+                        | "item.completed"
+                        | "error"
+                )
+            )
+    }
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -729,6 +729,16 @@ async fn execute_cli_inner(
     let mut termination_runtime =
         CliTerminationRuntime::new(process_group, runtime.post_result_cleanup_policy);
 
+    // A resumed Codex process prints `thread.started` from the resume response
+    // before its real turn notifications begin. Bound only that transition;
+    // once any real lifecycle event arrives, long turns remain unrestricted.
+    let codex_resume_startup_deadline = tokio::time::sleep(Duration::MAX);
+    tokio::pin!(codex_resume_startup_deadline);
+    let codex_resume_startup_guard_enabled =
+        matches!(runtime.framework, env::Framework::Codex) && !runtime.resume_session_id.is_empty();
+    let mut codex_resume_startup_deadline_armed = false;
+    let mut codex_resume_lifecycle_started = false;
+
     // Stuck-tool watchdog: workaround for Claude Code bug where
     // WebSearch/WebFetch hang indefinitely. Track all in-flight tool calls;
     // if a network tool exceeds STUCK_TOOL_TIMEOUT_SECS without producing
@@ -886,6 +896,27 @@ async fn execute_cli_inner(
                             {
                                 ParsedEventAction::Forward => {}
                                 ParsedEventAction::Skip => continue,
+                            }
+                            if codex_resume_startup_guard_enabled
+                                && !codex_resume_lifecycle_started
+                            {
+                                let event_type = event
+                                    .get("type")
+                                    .and_then(serde_json::Value::as_str);
+                                if behavior.is_codex_turn_lifecycle_event(&event) {
+                                    codex_resume_lifecycle_started = true;
+                                    codex_resume_startup_deadline_armed = false;
+                                } else if event_type == Some("thread.started")
+                                    && !codex_resume_startup_deadline_armed
+                                {
+                                    codex_resume_startup_deadline.as_mut().reset(
+                                        tokio::time::Instant::now()
+                                            + Duration::from_secs(
+                                                constants::CODEX_RESUME_STARTUP_TIMEOUT_SECS,
+                                            ),
+                                    );
+                                    codex_resume_startup_deadline_armed = true;
+                                }
                             }
                             let is_result_event = behavior.handles_claude_result_event(&event);
                             if post_result_cleanup_was_armed || is_result_event {
@@ -1076,6 +1107,35 @@ async fn execute_cli_inner(
                     CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 termination_runtime.handle_deadline(termination_deadline.as_mut());
+            }
+            () = &mut codex_resume_startup_deadline, if codex_resume_startup_deadline_armed && cli_status.is_none() => {
+                match try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_closed,
+                    drain_deadline.as_mut(),
+                )? {
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => {
+                        codex_resume_startup_deadline_armed = false;
+                        continue;
+                    }
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
+                }
+                codex_resume_startup_deadline_armed = false;
+                let timeout_secs = constants::CODEX_RESUME_STARTUP_TIMEOUT_SECS;
+                let timeout_error = AgentError::Execution(format!(
+                    "Codex resume startup timeout: no turn lifecycle event received within {timeout_secs} seconds after thread.started"
+                ));
+                termination_runtime.begin_control_failure(
+                    TerminationReason::CodexResumeStartupTimeout,
+                    timeout_error,
+                    ControlTerminationLog::CodexResumeStartupTimeout { timeout_secs },
+                    termination_deadline.as_mut(),
+                );
             }
             () = &mut drain_deadline, if cli_status.is_some() => {
                 log_warn!(

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -67,6 +67,7 @@ pub(super) enum TerminationReason {
     PostResult,
     InitialPromptStdin,
     StuckTool,
+    CodexResumeStartupTimeout,
     HeartbeatError,
     HeartbeatPanic,
     EventDelivery,
@@ -79,6 +80,7 @@ impl TerminationReason {
             TerminationReason::PostResult => "post-result reap",
             TerminationReason::InitialPromptStdin => "initial-prompt stdin",
             TerminationReason::StuckTool => "stuck-tool watchdog",
+            TerminationReason::CodexResumeStartupTimeout => "Codex resume startup timeout",
             TerminationReason::HeartbeatError => "heartbeat error",
             TerminationReason::HeartbeatPanic => "heartbeat panic",
             TerminationReason::EventDelivery => "event delivery",
@@ -223,6 +225,7 @@ pub(super) enum ControlTerminationLog {
     ClaudeStdinWriterFailed { error: String },
     ClaudeStdinWriterTaskFailed { error: String },
     StuckTool { name: String, elapsed: u64 },
+    CodexResumeStartupTimeout { timeout_secs: u64 },
     HeartbeatFailed,
     HeartbeatTaskPanicked,
     HeartbeatStoppedBeforeStatus,
@@ -249,6 +252,12 @@ impl ControlTerminationLog {
                 log_warn!(
                     LOG_TAG,
                     "Tool timeout: {name} stuck for {elapsed}s, SIGTERM pgid={pgid}"
+                );
+            }
+            Self::CodexResumeStartupTimeout { timeout_secs } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Codex resume emitted no turn lifecycle event within {timeout_secs}s after thread.started, SIGTERM pgid={pgid}"
                 );
             }
             Self::HeartbeatFailed => {
@@ -576,6 +585,9 @@ fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTermina
         TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
         TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
         TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,
+        TerminationReason::CodexResumeStartupTimeout => {
+            DiagnosticTerminationReason::CodexResumeStartupTimeout
+        }
         TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
         TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
         TerminationReason::EventDelivery => DiagnosticTerminationReason::EventDelivery,

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -34,6 +34,11 @@ pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 300;
 /// How often (in seconds) to check for stuck tools in the select loop.
 pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;
 
+/// Maximum time a resumed ordinary Codex execution may remain between its
+/// synthetic `thread.started` record and the first real turn lifecycle event.
+/// Once real lifecycle output begins, long-running turns are unrestricted.
+pub const CODEX_RESUME_STARTUP_TIMEOUT_SECS: u64 = 60;
+
 /// After the CLI process exits, continue reading stdout for this many seconds.
 /// If EOF is not received within this deadline, break the loop to prevent
 /// hanging on orphaned child processes that inherited the stdout fd.

--- a/crates/guest-agent/tests/codex_resume_startup_timeout.rs
+++ b/crates/guest-agent/tests/codex_resume_startup_timeout.rs
@@ -1,0 +1,265 @@
+//! Ordinary Codex resumes must not remain alive after emitting only the
+//! synthetic `thread.started` startup record.
+
+mod common;
+
+use guest_agent::active_input::ActiveInputRuntime;
+use guest_agent::masker::SecretMasker;
+use guest_agent::run_context::GuestRuntime;
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const RESUME_THREAD_ID: &str = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+const FIXTURE_READY: &str = "codex-resume-fixture-ready";
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::test]
+async fn resumed_codex_without_real_lifecycle_is_reaped_without_retry() -> TestResult {
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let mock = executable_script(root.path(), "stalled-codex", &stalled_script())?;
+    let runtime = build_runtime(root.path(), &mock, "stalled-resume", true)?;
+    let agent_log = runtime.paths.agent_log_file().to_string();
+    let execution = spawn_execution(runtime);
+
+    common::wait_for_file_contains(Path::new(&agent_log), FIXTURE_READY, Duration::from_secs(5))
+        .await?;
+
+    tokio::time::pause();
+    advance_until_finished(&execution, 70).await;
+    tokio::time::resume();
+
+    let result = await_execution(execution).await?;
+    let error = result
+        .control_error
+        .as_ref()
+        .ok_or("stalled Codex resume should return a control error")?;
+    assert!(
+        error.to_string().contains(
+            "Codex resume startup timeout: no turn lifecycle event received within 60 seconds after thread.started"
+        ),
+        "unexpected control error: {error}"
+    );
+
+    let termination = result
+        .cli_termination
+        .ok_or("stalled Codex resume should record controlled termination")?;
+    assert_eq!(
+        termination.reason,
+        CliTerminationReason::CodexResumeStartupTimeout
+    );
+    assert!(matches!(
+        termination.signal_sent,
+        Some(CliTerminationSignal::Sigterm | CliTerminationSignal::Sigkill)
+    ));
+
+    let invocations = std::fs::read_to_string(root.path().join("invocations"))?;
+    assert_eq!(
+        invocations.lines().count(),
+        1,
+        "the stalled turn must fail without starting a retry"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn resumed_codex_real_lifecycle_disarms_startup_timeout() -> TestResult {
+    for (name, lifecycle_event) in [
+        ("turn-started", r#"{"type":"turn.started"}"#),
+        ("item-started", r#"{"type":"item.started"}"#),
+    ] {
+        let root = tempfile::tempdir()?;
+        common::ensure_canonical_workspace_for_test()?;
+        let mock = executable_script(
+            root.path(),
+            "healthy-codex",
+            &waiting_script(Some(lifecycle_event)),
+        )?;
+        let runtime = build_runtime(root.path(), &mock, name, true)?;
+        let agent_log = runtime.paths.agent_log_file().to_string();
+        let execution = spawn_execution(runtime);
+
+        common::wait_for_file_contains(
+            Path::new(&agent_log),
+            FIXTURE_READY,
+            Duration::from_secs(5),
+        )
+        .await?;
+
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(61)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !execution.is_finished(),
+            "real lifecycle event {name} should permanently disarm the startup timeout"
+        );
+        std::fs::write(root.path().join("release"), "")?;
+        tokio::time::resume();
+
+        let result = await_execution(execution).await?;
+        assert_eq!(result.exit_code, common::CLEAN_EXIT);
+        assert!(result.control_error.is_none());
+        assert!(result.cli_termination.is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn fresh_codex_does_not_arm_resume_startup_timeout() -> TestResult {
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let mock = executable_script(root.path(), "fresh-codex", &waiting_script(None))?;
+    let runtime = build_runtime(root.path(), &mock, "fresh-codex", false)?;
+    let agent_log = runtime.paths.agent_log_file().to_string();
+    let execution = spawn_execution(runtime);
+
+    common::wait_for_file_contains(Path::new(&agent_log), FIXTURE_READY, Duration::from_secs(5))
+        .await?;
+
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !execution.is_finished(),
+        "fresh Codex executions must not use the resume-only startup timeout"
+    );
+    std::fs::write(root.path().join("release"), "")?;
+    tokio::time::resume();
+
+    let result = await_execution(execution).await?;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.control_error.is_none());
+    assert!(result.cli_termination.is_none());
+    Ok(())
+}
+
+fn build_runtime(
+    root: &Path,
+    mock_path: &Path,
+    run_id: &str,
+    resume: bool,
+) -> TestResult<GuestRuntime> {
+    let home = root.join("home");
+    let runtime_dir = home.join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "test prompt".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+    let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
+        run_id: run_id.to_string(),
+        api_url: "http://127.0.0.1:1".to_string(),
+        api_token: String::new(),
+        sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
+        sandbox_reuse_result: "reused".to_string(),
+        resume_session_id: if resume {
+            RESUME_THREAD_ID.to_string()
+        } else {
+            String::new()
+        },
+        use_mock_codex: "true".to_string(),
+        mock_codex_path: Some(mock_path.to_string_lossy().into_owned()),
+        cli_agent_type: "codex".to_string(),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+        home: Some(home.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir.clone()),
+        ..guest_agent::env::GuestConfigRaw::default()
+    })
+    .map_err(std::io::Error::other)?;
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
+    std::fs::create_dir_all(
+        Path::new(paths.agent_log_file())
+            .parent()
+            .ok_or("agent log path should have a parent")?,
+    )?;
+    let http = guest_agent::http::HttpClient::for_config(&config)?;
+    Ok(GuestRuntime {
+        config,
+        paths,
+        http,
+    })
+}
+
+fn spawn_execution(
+    runtime: GuestRuntime,
+) -> tokio::task::JoinHandle<
+    Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError>,
+> {
+    tokio::spawn(async move {
+        let active_input = ActiveInputRuntime::new_with_initial_prompt(
+            &runtime.config.run_id,
+            false,
+            &runtime.config.prompt,
+        );
+        guest_agent::cli::execute_cli_with_active_input_for_config(
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+            runtime.http.clone(),
+            active_input.into_writer(),
+            &runtime.config,
+            &runtime.paths,
+        )
+        .await
+    })
+}
+
+async fn advance_until_finished<T>(execution: &tokio::task::JoinHandle<T>, seconds: u64) {
+    for _ in 0..seconds {
+        if execution.is_finished() {
+            return;
+        }
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn await_execution(
+    execution: tokio::task::JoinHandle<
+        Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError>,
+    >,
+) -> TestResult<guest_agent::cli::CliExecutionResult> {
+    let joined = tokio::time::timeout(Duration::from_secs(10), execution)
+        .await
+        .map_err(|_| std::io::Error::other("ordinary Codex fixture did not exit"))?;
+    let executed = joined.map_err(std::io::Error::other)?;
+    Ok(executed?)
+}
+
+fn stalled_script() -> String {
+    let mut script = script_prelude();
+    script.push_str("printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"0199a213-81c0-7800-8aa1-bbab2a035a53\"}'\n");
+    script.push_str(&format!("printf '%s\\n' '{FIXTURE_READY}'\n"));
+    script.push_str("while :; do sleep 1; done\n");
+    script
+}
+
+fn waiting_script(lifecycle_event: Option<&str>) -> String {
+    let mut script = script_prelude();
+    script.push_str("printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"0199a213-81c0-7800-8aa1-bbab2a035a53\"}'\n");
+    if let Some(lifecycle_event) = lifecycle_event {
+        script.push_str(&format!("printf '%s\\n' '{lifecycle_event}'\n"));
+    }
+    script.push_str(&format!("printf '%s\\n' '{FIXTURE_READY}'\n"));
+    script.push_str("while [ ! -f \"$script_dir/release\" ]; do sleep 0.05; done\n");
+    script
+}
+
+fn script_prelude() -> String {
+    "#!/bin/sh\nset -eu\nscript_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\nprintf '%s\\n' \"$$\" >> \"$script_dir/invocations\"\n".to_string()
+}
+
+fn executable_script(root: &Path, name: &str, contents: &str) -> TestResult<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = root.join(name);
+    std::fs::write(&path, contents)?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -327,6 +327,8 @@ pub enum CliTerminationReason {
     PostResultReap,
     /// The stuck-tool watchdog terminated the process.
     StuckToolWatchdog,
+    /// A resumed Codex process did not begin emitting real turn lifecycle events.
+    CodexResumeStartupTimeout,
     /// Heartbeat handling failed and required termination.
     HeartbeatError,
     /// Heartbeat handling panicked and required termination.
@@ -346,6 +348,7 @@ impl CliTerminationReason {
         match self {
             Self::PostResultReap => "post_result_reap",
             Self::StuckToolWatchdog => "stuck_tool_watchdog",
+            Self::CodexResumeStartupTimeout => "codex_resume_startup_timeout",
             Self::HeartbeatError => "heartbeat_error",
             Self::HeartbeatPanic => "heartbeat_panic",
             Self::InitialPromptStdin => "initial_prompt_stdin",
@@ -701,6 +704,23 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<CliTerminationReason>(serde_json::json!("stdout_ingestion"))
                 .unwrap(),
+            reason
+        );
+    }
+
+    #[test]
+    fn codex_resume_startup_timeout_reason_has_stable_serialization() {
+        let reason = CliTerminationReason::CodexResumeStartupTimeout;
+        assert_eq!(reason.as_str(), "codex_resume_startup_timeout");
+        assert_eq!(
+            serde_json::to_value(reason).unwrap(),
+            serde_json::json!("codex_resume_startup_timeout")
+        );
+        assert_eq!(
+            serde_json::from_value::<CliTerminationReason>(serde_json::json!(
+                "codex_resume_startup_timeout"
+            ))
+            .unwrap(),
             reason
         );
     }


### PR DESCRIPTION
## Summary

- bound the startup transition for ordinary resumed Codex runs after `thread.started`
- terminate a resume with a structured diagnostic when no real turn lifecycle event arrives within 60 seconds
- permanently disarm the guard after the first turn or item lifecycle event so long-running healthy turns remain unrestricted
- cover stalled resumes, healthy resumes, fresh runs, and no-retry behavior with entry-point integration tests

## Scope

- applies only to ordinary Codex executions with a non-empty resume session ID
- reuses the existing process-group termination path and records `codex_resume_startup_timeout`
- does not retry automatically
- does not change initial Codex runs, the experimental app-server path, APIs, schemas, or persisted data

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p guest-agent --test codex_resume_startup_timeout`
- `cargo test -p guest-contracts`
- `cargo test -p guest-agent --lib`
- `cargo test --workspace --all-features`

Closes #22552
