### PR TITLE
fix(chat): cap long composer drafts at a responsive height

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -13,7 +13,7 @@ async function elementHeight(locator: Locator): Promise<number> {
   return bounds.height;
 }
 
-test("send a chat message and preserve composer height with a template", async ({
+test("send a chat message, cap long drafts, and preserve template height", async ({
   page,
 }) => {
   // Navigate to chat page (default agent)
@@ -48,6 +48,34 @@ test("send a chat message and preserve composer height with a template", async (
 
   // The completed run leaves us on a chat-thread composer, whose responsive
   // minimum height is compact on mobile and three lines on desktop.
+  await expect.poll(() => elementHeight(composer)).toBe(96);
+
+  const longDraft = Array.from(
+    { length: 40 },
+    (_, index) => `draft line ${index + 1}`,
+  ).join("\n");
+  await page.setViewportSize({ width: 1280, height: 1000 });
+  await composer.fill(longDraft);
+  await expect.poll(() => elementHeight(composer)).toBe(320);
+  await expect
+    .poll(() =>
+      composer.evaluate(
+        (element) => element.scrollHeight > element.clientHeight,
+      ),
+    )
+    .toBe(true);
+  await composer.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect
+    .poll(() => composer.evaluate((element) => element.scrollTop > 0))
+    .toBe(true);
+
+  await page.setViewportSize({ width: 390, height: 600 });
+  await expect.poll(() => elementHeight(composer)).toBe(240);
+
+  await composer.fill("");
+  await page.setViewportSize({ width: 1280, height: 720 });
   await expect.poll(() => elementHeight(composer)).toBe(96);
 
   await page.getByRole("button", { name: "Template", exact: true }).click();

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -52,10 +52,9 @@ import {
 } from "./template-preview-runtime.ts";
 
 const EDITOR_CONTENT_CLASS =
-  // The editor grows with its content instead of scrolling inside a fixed
-  // 200px box: a nested scroll region felt cramped once queued references and
-  // typed text stacked up. Overflow is delegated to the surrounding page.
-  "w-full whitespace-pre-wrap " +
+  // Let the editor grow to 40% of the viewport, capped at 320px, then scroll
+  // before it crowds out the chat message history.
+  "w-full max-h-[min(40vh,320px)] overflow-y-auto whitespace-pre-wrap " +
   "break-words px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground " +
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -61,7 +61,7 @@ describe("chat composer models", () => {
     expect(editor).not.toHaveClass("min-h-[44px]");
   });
 
-  it("uses the mobile single-line height in chat thread composers", async () => {
+  it("bounds chat thread composers between mobile and responsive heights", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -72,7 +72,12 @@ describe("chat composer models", () => {
     });
 
     const editor = await findComposerEditor();
-    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+    expect(editor).toHaveClass(
+      "min-h-[44px]",
+      "md:min-h-[96px]",
+      "max-h-[min(40vh,320px)]",
+      "overflow-y-auto",
+    );
   });
 
   it("keeps the agent chat slash composer at three-line height", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -61,7 +61,7 @@ describe("chat composer models", () => {
     expect(editor).not.toHaveClass("min-h-[44px]");
   });
 
-  it("bounds chat thread composers between mobile and responsive heights", async () => {
+  it("uses the mobile single-line height in chat thread composers", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -72,12 +72,7 @@ describe("chat composer models", () => {
     });
 
     const editor = await findComposerEditor();
-    expect(editor).toHaveClass(
-      "min-h-[44px]",
-      "md:min-h-[96px]",
-      "max-h-[min(40vh,320px)]",
-      "overflow-y-auto",
-    );
+    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
   });
 
   it("keeps the agent chat slash composer at three-line height", async () => {


### PR DESCRIPTION
## Summary

- let the TipTap composer grow to `min(40vh, 320px)` before scrolling internally
- keep more chat history visible while providing substantially more room than the previous 200px cap
- cover the rendered height caps and internal scrolling with the existing Playwright webchat flow instead of asserting Tailwind class names

Closes #22459

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped` — 12/12 tasks passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` — 13/13 tasks passed
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx` — 17 passed
- `cd e2e && pnpm check-types`
- Playwright browser execution not run locally, following the repository PR verification preference; the PR pipeline will run it against the deployed preview
