### PR TITLE
test(api): deterministically order chat claim and recall race

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -60,7 +60,7 @@ import { createDeferredPromise } from "../../utils";
 import {
   deleteBddVm0ApiKeys,
   hasVm0ApiKeyLabel,
-  holdChatMessageWritesFixture,
+  holdChatMessageQueueItemFixture,
   holdOrgAdmissionLockFixture,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
@@ -4230,55 +4230,79 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(queued.body).toMatchObject({ runId: null });
 
-    // Stop the terminal drain at run admission until its preceding message
-    // writes are complete, then pause only the replacement insert. The claim
-    // holds the queue row while recall reaches the competing queue deletion.
+    // Pin the terminal drain ahead of the callback drain at run admission,
+    // then make the claim and recall queue behind the exact message row in a
+    // test-owned order.
     const admissionLock = await holdOrgAdmissionLockFixture({
       orgId: actor.orgId,
       signal: context.signal,
     });
-    onTestFinished(async () => {
-      admissionLock.release();
-      await admissionLock.done;
-    });
-
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
-    // The first waiter is the completion-triggered org run-queue drain; the
-    // second proves the callback's chat-message drain has finished its prior
-    // writes and is blocked at run admission before we pause its claim insert.
-    await expect.poll(admissionLock.waiterCount).toBe(2);
-
-    const messageWritesLock = await holdChatMessageWritesFixture({
+    const messageQueueLock = await holdChatMessageQueueItemFixture({
+      threadId: anchor.threadId,
+      messageId,
       signal: context.signal,
     });
+
+    const callbackQueryStarted = createDeferredPromise<void>(context.signal);
+    const releaseCallbackQuery = createDeferredPromise<void>(context.signal);
     onTestFinished(async () => {
-      messageWritesLock.release();
-      await messageWritesLock.done;
+      if (!releaseCallbackQuery.settled()) {
+        releaseCallbackQuery.resolve(undefined);
+      }
+      admissionLock.release();
+      messageQueueLock.release();
+      await Promise.all([admissionLock.done, messageQueueLock.done]);
     });
+
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (!apl.includes("['agent-run-events']")) {
+        return Promise.resolve([]);
+      }
+      if (!callbackQueryStarted.settled()) {
+        callbackQueryStarted.resolve(undefined);
+      }
+      return releaseCallbackQuery.promise.then(() => {
+        return [assistantEvent(0, "recall claim race complete")];
+      });
+    });
+
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await callbackQueryStarted.promise;
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    releaseCallbackQuery.resolve(undefined);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
     admissionLock.release();
     await admissionLock.done;
-    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(1);
+    await expect.poll(messageQueueLock.blockedWaiterCount).toBe(1);
 
-    const recall = chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        revokesMessageId: messageId,
-        clientMessageId: randomUUID(),
-      },
-      [400],
-    );
-    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(2);
-    messageWritesLock.release();
+    const recall = Promise.allSettled([
+      chat.requestSendMessage(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          revokesMessageId: messageId,
+          clientMessageId: randomUUID(),
+        },
+        [400],
+      ),
+    ]);
+    await expect.poll(messageQueueLock.blockedWaiterCount).toBe(2);
+    messageQueueLock.release();
 
-    const recalled = await recall;
+    const [recallResult] = await recall;
+    if (recallResult.status === "rejected") {
+      throw recallResult.reason;
+    }
+    const recalled = recallResult.value;
     expectApiError(recalled.body);
     expect(recalled.body.error.message).toBe(
       "Only queued user messages can be recalled",
     );
-    await messageWritesLock.done;
+    await messageQueueLock.done;
     await flushWaitUntilForTest();
 
     const messages = await waitForThreadMessages(

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,5 +1,5 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
-import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { and, count, eq, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
@@ -178,11 +178,13 @@ export async function holdOrgAdmissionLockFixture(args: {
 }
 
 /**
- * Holds a table lock that permits row selection but pauses chat-message writes.
- * This is a timing-only boundary exception for proving queue claim races through
- * the product API; the transaction neither creates nor changes product rows.
+ * Holds one queued user-message row so a claim and recall can reach the same
+ * product lock in a test-owned order. This timing-only boundary neither creates
+ * nor changes product rows and cannot block unrelated queue items.
  */
-export async function holdChatMessageWritesFixture(args: {
+export async function holdChatMessageQueueItemFixture(args: {
+  readonly threadId: string;
+  readonly messageId: string;
   readonly signal: AbortSignal;
 }): Promise<{
   readonly release: () => void;
@@ -192,17 +194,31 @@ export async function holdChatMessageWritesFixture(args: {
   const started = createDeferredPromise<number>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
   const done = db().transaction(async (tx) => {
-    await tx.execute(sql`LOCK TABLE ${chatMessages} IN SHARE MODE`);
-    const rows = await executeRawRows(
+    const rows = await tx
+      .select({ id: chatMessageQueue.id })
+      .from(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.chatThreadId, args.threadId),
+          eq(chatMessageQueue.chatMessageId, args.messageId),
+          eq(chatMessageQueue.itemType, "user_message"),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!rows[0]) {
+      throw new Error("Expected the queued chat message row");
+    }
+    const pidRows = await executeRawRows(
       tx,
       sql`
         SELECT pg_backend_pid() AS "pid"
       `,
       databasePidRowSchema,
     );
-    const holderPid = rows[0]?.pid;
+    const holderPid = pidRows[0]?.pid;
     if (!holderPid) {
-      throw new Error("Expected the chat-message lock holder pid");
+      throw new Error("Expected the chat-message queue lock holder pid");
     }
     started.resolve(holderPid);
     await released.promise;


### PR DESCRIPTION
## Summary

- deterministically stage the completion-triggered and callback-triggered drains before exercising the claim/recall race
- replace the shard-wide `chat_messages` table lock with a timing fixture that locks only the target `chat_message_queue` row
- keep the public API assertions for the rejected recall and preserved claimed replacement while owning the concurrent recall rejection immediately

## Root cause

The test previously observed two aggregate advisory-lock waiters without fixing their arrival order. After releasing the lock, scheduler order could put the wrong drain first, while the table-lock fixture recursively counted the resulting transitive blocking chain. That made the expected waiter count change from `1` to `2` even though the product behavior was unchanged.

This change uses the existing deferred Axiom boundary to establish drain order, then queues claim before recall on the exact queue item that decides the race. Unrelated chat-message writers in the same Vitest shard are no longer blocked.

Failed CI example: https://github.com/vm0-ai/vm0/actions/runs/29889321336/job/88826467213

## Verification

- `pnpm exec prettier --check apps/api/src/test-fixtures/chat-messages.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- targeted Oxlint and ESLint on both changed files
- `git diff --check`
- full API lint did not complete locally: its type-aware `tsgolint` subprocess was killed by the runtime memory limit after reporting no diagnostics
- API type-check did not complete locally: TypeScript exhausted both the default 2 GB heap and a 2.6 GB heap without reporting diagnostics
- Vitest not run locally; the PR pipeline will exercise the API test against its PostgreSQL service, following the repository PR verification preference
