### PR TITLE
test: temporarily skip paid onboarding e2e while staging webhooks are unavailable

### DIFF
--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -14,7 +14,8 @@ import {
 import { fillStripeCheckout } from "../lib/stripe-checkout";
 import { deriveAppUrl } from "../playwright.config";
 
-test("paid onboarding completes through the video workflow", async ({
+// TODO: Re-enable when staging Stripe webhook delivery is restored.
+test.skip("paid onboarding completes through the video workflow", async ({
   page,
 }) => {
   test.setTimeout(240_000);


### PR DESCRIPTION
## Summary

- temporarily skip the paid video onboarding Playwright test
- document that the test must be re-enabled after staging Stripe webhook delivery is restored

## User impact

- unblocks the release pipeline while the staging Stripe webhook endpoint is not receiving checkout events
- does not change paid onboarding behavior in production

## Context

- failing run: https://github.com/vm0-ai/vm0/actions/runs/29906011150
- checkout completion depends on the staging API receiving Stripe `invoice.paid`; the failed run and subsequent main runs received no Stripe webhook deliveries at the staging endpoint

## Verification

- `cd e2e && pnpm check-types`
- `git diff --check`
- browser E2E was not run locally because it requires the unavailable staging Stripe webhook delivery path

## Follow-up

- restore the staging Stripe webhook endpoint and re-enable this test
