### PR TITLE
refactor(platform): batch paged chat state updates

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1355,42 +1355,54 @@ function registerChatMessage(
   return { message, blocks };
 }
 
-function createWritePersistentMessages(
+function createMergePersistentMessages(
   threadId: string,
   persistentMessages$: PersistentChatMessages$,
   registerBodyBlocks: BodyBlocksRenderer,
 ) {
+  return command(({ get, set }, msgs: PagedChatMessage[]): void => {
+    if (msgs.length === 0) {
+      return;
+    }
+    const reportedCompletedRunIds = new Set(
+      completedRunIdsFromMessages(
+        get(persistentMessages$).map((entry) => {
+          return entry.message;
+        }),
+      ),
+    );
+    const newlyCompletedRunIds = completedRunIdsFromMessages(msgs).filter(
+      (runId) => {
+        return !reportedCompletedRunIds.has(runId);
+      },
+    );
+    for (const _ of newlyCompletedRunIds) {
+      captureTaskCompletedSuccessfully();
+    }
+    const registeredMessages = msgs.map((message) => {
+      return registerChatMessage(message, registerBodyBlocks);
+    });
+    set(persistentMessages$, (prev) => {
+      return mergeRegisteredMessages([prev, registeredMessages]);
+    });
+    set(reconcileOptimisticChatMessages$, { threadId, messages: msgs });
+  });
+}
+
+function createWritePersistentMessages(
+  threadId: string,
+  mergePersistentMessages$: Command<void, [PagedChatMessage[]]>,
+) {
   return command(
     async (
-      { get, set },
+      { set },
       msgs: PagedChatMessage[],
       signal: AbortSignal,
     ): Promise<void> => {
       if (msgs.length === 0) {
         return;
       }
-      const reportedCompletedRunIds = new Set(
-        completedRunIdsFromMessages(
-          get(persistentMessages$).map((entry) => {
-            return entry.message;
-          }),
-        ),
-      );
-      const newlyCompletedRunIds = completedRunIdsFromMessages(msgs).filter(
-        (runId) => {
-          return !reportedCompletedRunIds.has(runId);
-        },
-      );
-      for (const _ of newlyCompletedRunIds) {
-        captureTaskCompletedSuccessfully();
-      }
-      const registeredMessages = msgs.map((message) => {
-        return registerChatMessage(message, registerBodyBlocks);
-      });
-      set(persistentMessages$, (prev) => {
-        return mergeRegisteredMessages([prev, registeredMessages]);
-      });
-      set(reconcileOptimisticChatMessages$, { threadId, messages: msgs });
+      set(mergePersistentMessages$, msgs);
       await set(writeIndexedDbChatMessages$, threadId, msgs, signal);
       signal.throwIfAborted();
     },
@@ -2099,28 +2111,24 @@ function createSyncRemoteMessagesCommand({
   threadId,
   persistentMessages$,
   hasReachedOldestMessage$,
-  writePersistentMessages$,
+  mergePersistentMessages$,
   dataSource,
 }: {
   threadId: string;
   persistentMessages$: PersistentChatMessages$;
   hasReachedOldestMessage$: State<boolean>;
-  writePersistentMessages$: Command<
-    Promise<void>,
-    [PagedChatMessage[], AbortSignal]
-  >;
+  mergePersistentMessages$: Command<void, [PagedChatMessage[]]>;
   dataSource: ChatThreadRemote;
 }): Command<Promise<void>, [AbortSignal]> {
-  const sinceId$ = computed((get): string | undefined => {
-    return get(persistentMessages$).at(-1)?.message.id;
-  });
-
   return command(async ({ get, set }, signal: AbortSignal) => {
-    const startedWithoutCursor = get(sinceId$) === undefined;
+    const persistentMessages = get(persistentMessages$);
+    const accumulatedMessages: PagedChatMessage[] = [];
+    let sinceId = persistentMessages.at(-1)?.message.id;
+    const startedWithoutCursor = sinceId === undefined;
     let initialHasHistoryBefore: boolean | undefined;
 
     async function syncMessagesAfter(): Promise<void> {
-      const requestedSinceId = get(sinceId$);
+      const requestedSinceId = sinceId;
       const result = await set(
         dataSource.listMessagesAfter$,
         { threadId, sinceId: requestedSinceId },
@@ -2141,56 +2149,65 @@ function createSyncRemoteMessagesCommand({
         return;
       }
 
-      await set(writePersistentMessages$, result.messages, signal);
+      accumulatedMessages.push(...result.messages);
+      await set(writeIndexedDbChatMessages$, threadId, result.messages, signal);
       signal.throwIfAborted();
+      sinceId = result.messages.at(-1)!.id;
 
       return syncMessagesAfter();
     }
     await syncMessagesAfter();
     signal.throwIfAborted();
 
-    if (get(hasReachedOldestMessage$)) {
-      return;
-    }
-
-    if (
-      (startedWithoutCursor && initialHasHistoryBefore === false) ||
-      get(persistentMessages$).length === 0
-    ) {
-      set(hasReachedOldestMessage$, true);
-      return;
-    }
-
-    let beforeId = get(persistentMessages$)[0]!.message.id;
-    async function syncMessagesBefore(): Promise<void> {
-      const result = await set(
-        dataSource.listMessagesBefore$,
-        { threadId, beforeId },
-        signal,
-      );
-      signal.throwIfAborted();
-      L.debug("syncRemoteMessages$ listMessagesBefore result", {
-        threadId,
-        beforeId,
-        gotCount: result.messages.length,
-        hasHistoryBefore: result.hasHistoryBefore,
-      });
-
-      if (result.messages.length > 0) {
-        await set(writePersistentMessages$, result.messages, signal);
-        signal.throwIfAborted();
-      }
-
-      if (!result.hasHistoryBefore) {
+    if (!get(hasReachedOldestMessage$)) {
+      const oldestMessageId =
+        persistentMessages[0]?.message.id ?? accumulatedMessages[0]?.id;
+      if (
+        (startedWithoutCursor && initialHasHistoryBefore === false) ||
+        oldestMessageId === undefined
+      ) {
         set(hasReachedOldestMessage$, true);
-        return;
+      } else {
+        let beforeId = oldestMessageId;
+        async function syncMessagesBefore(): Promise<void> {
+          const result = await set(
+            dataSource.listMessagesBefore$,
+            { threadId, beforeId },
+            signal,
+          );
+          signal.throwIfAborted();
+          L.debug("syncRemoteMessages$ listMessagesBefore result", {
+            threadId,
+            beforeId,
+            gotCount: result.messages.length,
+            hasHistoryBefore: result.hasHistoryBefore,
+          });
+
+          if (result.messages.length > 0) {
+            accumulatedMessages.push(...result.messages);
+            await set(
+              writeIndexedDbChatMessages$,
+              threadId,
+              result.messages,
+              signal,
+            );
+            signal.throwIfAborted();
+          }
+
+          if (!result.hasHistoryBefore) {
+            set(hasReachedOldestMessage$, true);
+            return;
+          }
+
+          beforeId = result.messages[0]!.id;
+
+          return syncMessagesBefore();
+        }
+        await syncMessagesBefore();
       }
-
-      beforeId = result.messages[0]!.id;
-
-      return syncMessagesBefore();
     }
-    await syncMessagesBefore();
+    signal.throwIfAborted();
+    set(mergePersistentMessages$, accumulatedMessages);
   });
 }
 
@@ -2430,10 +2447,14 @@ function createPagedMessages(
     return mailDraftCardSignals.entries();
   });
 
-  const writePersistentMessages$ = createWritePersistentMessages(
+  const mergePersistentMessages$ = createMergePersistentMessages(
     threadId,
     persistentChatMessages$,
     registerBodyBlocks,
+  );
+  const writePersistentMessages$ = createWritePersistentMessages(
+    threadId,
+    mergePersistentMessages$,
   );
 
   const mergeIndexedDbMessages$ = command(
@@ -2465,7 +2486,7 @@ function createPagedMessages(
     threadId,
     persistentMessages$: persistentChatMessages$,
     hasReachedOldestMessage$,
-    writePersistentMessages$,
+    mergePersistentMessages$,
     dataSource,
   });
   const syncRemoteMessages$ = createTrackedMessageSyncCommand(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -43,7 +43,7 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 describe("chat lifecycle", () => {
-  it("loads older pages after a delayed initial remote message page", async () => {
+  it("publishes initial and older pages together after full history sync", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000730";
     const messages = Array.from({ length: 60 }, (_, index) => {
       const itemNumber = index + 1;
@@ -55,6 +55,7 @@ describe("chat lifecycle", () => {
       } satisfies PagedChatMessage;
     });
     const initialPageGate = context.mocks.deferred<void>();
+    const beforePageGate = context.mocks.deferred<void>();
     let initialPageRequested = false;
     const beforeIds: string[] = [];
     const sinceIds: string[] = [];
@@ -75,6 +76,7 @@ describe("chat lifecycle", () => {
       async ({ query, respond }) => {
         if (query.beforeId) {
           beforeIds.push(query.beforeId);
+          await beforePageGate.promise;
           return respond(200, {
             messages: messages.slice(0, 10),
             hasHistoryBefore: false,
@@ -110,9 +112,18 @@ describe("chat lifecycle", () => {
       await waitFor(() => {
         expect(beforeIds).toStrictEqual([messages[10]!.id]);
       });
+      expect(
+        screen.queryByText("Delayed history reply 60"),
+      ).not.toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
+
+      beforePageGate.resolve();
     } finally {
       if (!initialPageGate.settled()) {
         initialPageGate.resolve();
+      }
+      if (!beforePageGate.settled()) {
+        beforePageGate.resolve();
       }
     }
 
@@ -136,14 +147,18 @@ describe("chat lifecycle", () => {
     expect(beforeIds).toStrictEqual([messages[10]!.id]);
   });
 
-  it("automatically loads older chat history after rendering latest messages", async () => {
+  it("automatically loads older chat history before publishing messages", async () => {
     const olderReply = "Earlier launch notes from last week.";
     const beforeHistoryGate = context.mocks.deferred<void>();
+    let initialPageReturned = false;
 
     mockChatLifecycle(context, {
       threadId: HISTORY_THREAD_ID,
       threadTitle: "History review",
       beforeHistoryGate: beforeHistoryGate.promise,
+      afterInitialMessagesList: () => {
+        initialPageReturned = true;
+      },
       historyMessages: [
         {
           role: "assistant",
@@ -168,18 +183,28 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({ context, path: `/chats/${HISTORY_THREAD_ID}` });
 
-    await waitFor(() => {
+    try {
+      await waitFor(() => {
+        expect(initialPageReturned).toBeTruthy();
+      });
       expect(
-        screen.getByText("Current launch risks are ready."),
-      ).toBeInTheDocument();
-    });
-    expect(queryButtonByText("Load history")).toBeNull();
-    expect(screen.queryByText(olderReply)).not.toBeInTheDocument();
+        screen.queryByText("Current launch risks are ready."),
+      ).not.toBeInTheDocument();
+      expect(queryButtonByText("Load history")).toBeNull();
+      expect(screen.queryByText(olderReply)).not.toBeInTheDocument();
 
-    beforeHistoryGate.resolve();
+      beforeHistoryGate.resolve();
+    } finally {
+      if (!beforeHistoryGate.settled()) {
+        beforeHistoryGate.resolve();
+      }
+    }
 
     await waitFor(() => {
       expect(screen.getByText(olderReply)).toBeInTheDocument();
+      expect(
+        screen.getByText("Current launch risks are ready."),
+      ).toBeInTheDocument();
       expect(queryButtonByText("Load history")).toBeNull();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1223,8 +1223,10 @@ describe("chat lifecycle", () => {
     const burstMessages = Array.from({ length: 120 }, (_, index) => {
       return makeMessage(`burst-${index}`, `Burst ${index}`);
     });
+    const terminalPageGate = context.mocks.deferred<void>();
+    let burstEnabled = false;
     let page = 0;
-    let emptyForwardPageRequested = false;
+    let terminalForwardPageRequested = false;
     const sinceIds: string[] = [];
 
     mockSubagentThread(context, threadId);
@@ -1235,24 +1237,29 @@ describe("chat lifecycle", () => {
         codexServiceTier: null,
       });
     });
-    context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
-      if (!query.sinceId) {
-        return respond(200, {
-          messages: baselineMessages,
-          hasHistoryBefore: false,
-        });
-      }
-      sinceIds.push(query.sinceId);
-      const startIndex = page * 50;
-      page += 1;
-      const messages = burstMessages.slice(startIndex, startIndex + 50);
-      if (messages.length === 0) {
-        emptyForwardPageRequested = true;
-      }
-      return respond(200, {
-        messages,
-      });
-    });
+    context.mocks.api(
+      chatThreadMessagesContract.list,
+      async ({ query, respond }) => {
+        if (!query.sinceId) {
+          return respond(200, {
+            messages: baselineMessages,
+            hasHistoryBefore: false,
+          });
+        }
+        sinceIds.push(query.sinceId);
+        if (!burstEnabled) {
+          return respond(200, { messages: [] });
+        }
+        const startIndex = page * 50;
+        page += 1;
+        const messages = burstMessages.slice(startIndex, startIndex + 50);
+        if (messages.length === 0) {
+          terminalForwardPageRequested = true;
+          await terminalPageGate.promise;
+        }
+        return respond(200, { messages });
+      },
+    );
     context.mocks.api(chatThreadMarkReadContract.markRead, ({ respond }) => {
       return respond(200, {
         lastReadAt: null,
@@ -1260,15 +1267,35 @@ describe("chat lifecycle", () => {
       });
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    try {
+      detachedSetupPage({ context, path: `/chats/${threadId}` });
 
-    await waitFor(() => {
-      expect(screen.getByText("Baseline 0")).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(screen.getByText("Burst 119")).toBeInTheDocument();
-      expect(emptyForwardPageRequested).toBeTruthy();
-    });
+      await waitFor(() => {
+        expect(screen.getByText("Baseline 0")).toBeInTheDocument();
+        expect(
+          context.mocks.ably.hasSubscription(
+            `chatThreadMessageCreated:${threadId}`,
+          ),
+        ).toBeTruthy();
+      });
+      sinceIds.length = 0;
+      burstEnabled = true;
+      context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`, {});
+
+      await waitFor(() => {
+        expect(terminalForwardPageRequested).toBeTruthy();
+      });
+      expect(screen.queryByText("Burst 119")).not.toBeInTheDocument();
+
+      terminalPageGate.resolve();
+      await waitFor(() => {
+        expect(screen.getByText("Burst 119")).toBeInTheDocument();
+      });
+    } finally {
+      if (!terminalPageGate.settled()) {
+        terminalPageGate.resolve();
+      }
+    }
     expect(sinceIds).toStrictEqual([
       baselineMessages.at(-1)!.id,
       burstMessages[49]!.id,


### PR DESCRIPTION
## Summary

- persist every forward and backward message page to IndexedDB as soon as it arrives
- advance pagination with local cursors while accumulating the fetched messages
- merge all accumulated messages into persistent chat state once, after the complete forward and backward sync

## User-visible impact

Long chat histories no longer re-render after every 50-message page. The visible persistent transcript updates once after the entire remote sync, avoiding repeated page jitter while retaining per-page IndexedDB recovery.

## Implementation notes

- separates the state-only persistent merge from the immediate state-and-IndexedDB write used by non-pagination paths
- preserves immediate updates for queued, recalled, cancelled, and individually refreshed messages
- keeps the existing failure and abort behavior without adding retries, locks, or concurrency handling

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-navigation.test.tsx` (27 tests passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx` (19 tests passed)
