### PR TITLE
test: restore paid onboarding playwright coverage

### DIFF
--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -14,8 +14,7 @@ import {
 import { fillStripeCheckout } from "../lib/stripe-checkout";
 import { deriveAppUrl } from "../playwright.config";
 
-// TODO: Re-enable when staging Stripe webhook delivery is restored.
-test.skip("paid onboarding completes through the video workflow", async ({
+test("paid onboarding completes through the video workflow", async ({
   page,
 }) => {
   test.setTimeout(240_000);


### PR DESCRIPTION
## Summary

- re-enable the paid onboarding Playwright test that was temporarily skipped in #22563
- exercise the current App onboarding, Stripe Checkout, webhook, tier upgrade, and chat handoff path
- validate the flow through the PR preview's dedicated Stripe listener before restoring coverage on `main`

## Verification

- `cd e2e && pnpm check-types`
- browser E2E intentionally left to the PR pipeline and its deployed preview infrastructure

No product behavior changes are included.
