### PR TITLE
test(api): remove retired vercel app cases

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -840,18 +840,6 @@ describe("createApp", () => {
       expect(response.headers.get("access-control-allow-origin")).toBeNull();
     });
 
-    it("does not allow retired Vercel app preview origins", async () => {
-      mockEnv("ENV", "preview");
-      const app = createApp({ signal: context.signal });
-      const response = await app.request("/health", {
-        method: "GET",
-        headers: { origin: "https://pr-22085-app.vm6.ai" },
-      });
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("access-control-allow-origin")).toBeNull();
-    });
-
     it("rejects disallowed origins by omitting the allow-origin header", async () => {
       mockEnv("ENV", "production");
       const app = createApp({ signal: context.signal });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-portal.test.ts
@@ -168,7 +168,6 @@ describe("POST /api/zero/billing/portal", () => {
   it.each([
     "https://evil.example.com/settings/billing",
     "https://okou.ai.evil.example/settings/billing",
-    "https://pr-22085-app.vm6.ai/settings/billing",
   ])("returns 400 for the disallowed origin in %s", async (returnUrl) => {
     mockEnv("APP_URL", APP_ORIGIN);
     mocks.clerk.session(


### PR DESCRIPTION
## Summary

- remove the dedicated CORS assertion for the retired Vercel App preview origin
- remove the retired Vercel App billing return URL from the disallowed-origin matrix
- retain generic malicious-origin and lookalike-origin coverage

## User impact

Removes obsolete Vercel App references from the API test suite after the Cloudflare-only migration, without changing runtime behavior or the remaining generic origin-validation coverage.

## Verification

- `git diff --check origin/main...HEAD`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (13/13 tasks passed)
- pre-commit hooks: Prettier, Knip, and check-types passed
- confirmed no `app.vm6.ai` references remain in the repository
- local Vitest was not run per vm0 PR policy; the PR pipeline will validate the change
