### PR TITLE
fix: expose org switcher in top-left of onboarding page

### DIFF
--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -163,6 +163,32 @@ function chooseTemplate(
 }
 
 describe("onboarding flow", () => {
+  it("exposes the workspace switcher in the onboarding shell", async () => {
+    mockOnboardingNeeded();
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      org: {
+        activeOrg: { id: "org_switcher", name: "Acme Workspace", slug: "acme" },
+        memberships: [{ id: "org_switcher" }],
+      },
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "What do you want to make first",
+      }),
+    ).resolves.toBeInTheDocument();
+
+    // The compact switcher (mobile layout) is wired into the onboarding shell.
+    expect(buttonByAriaLabel("Switch workspace")).toBeInTheDocument();
+
+    // The desktop switcher shows the active workspace name in the top-left.
+    await waitFor(() => {
+      expect(queryButtonByText("Acme Workspace")).not.toBeNull();
+    });
+  });
+
   it("renders workflow connector marks from catalog metadata", async () => {
     mockGithubCatalogItem({
       url: "https://icons.example.test/onboarding-github.svg",

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import { AccountDropdown } from "../zero-page/zero-sidebar.tsx";
+import { ZeroOrgSwitcherCompact } from "../zero-page/zero-org-switcher.tsx";
 import { SettingsDialog } from "../zero-page/components/settings/settings-dialog.tsx";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
@@ -179,6 +180,9 @@ export function OnboardingShell({
           }
         }}
       />
+      <div className="fixed left-4 top-4 z-20 sm:left-6 sm:top-6">
+        <ZeroOrgSwitcherCompact />
+      </div>
       <div className="fixed bottom-6 left-4 z-20 hidden w-60 sm:block">
         <OnboardingAccount collapsed={false} />
       </div>

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -8,7 +8,10 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import { AccountDropdown } from "../zero-page/zero-sidebar.tsx";
-import { ZeroOrgSwitcherCompact } from "../zero-page/zero-org-switcher.tsx";
+import {
+  ZeroOrgSwitcher,
+  ZeroOrgSwitcherCompact,
+} from "../zero-page/zero-org-switcher.tsx";
 import { SettingsDialog } from "../zero-page/components/settings/settings-dialog.tsx";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
@@ -180,7 +183,10 @@ export function OnboardingShell({
           }
         }}
       />
-      <div className="fixed left-4 top-4 z-20 sm:left-6 sm:top-6">
+      <div className="fixed left-4 top-4 z-20 hidden w-60 sm:left-6 sm:top-6 sm:block">
+        <ZeroOrgSwitcher />
+      </div>
+      <div className="fixed left-4 top-4 z-20 sm:hidden">
         <ZeroOrgSwitcherCompact />
       </div>
       <div className="fixed bottom-6 left-4 z-20 hidden w-60 sm:block">


### PR DESCRIPTION
## Problem

The org switcher was not exposed in the top-left corner of the onboarding page. In the main app the workspace/org switcher lives at the top of the nav rail (`ZeroOrgSwitcherCompact`), but the onboarding shell only rendered the account dropdown (bottom-left), leaving the top-left empty. Users had no way to switch organizations while onboarding.

Closes #22571

## Change

Render `ZeroOrgSwitcherCompact` fixed to the top-left of `OnboardingShell`, mirroring how `OnboardingAccount` is fixed to the bottom-left. Because every onboarding step composes `OnboardingShell`, the switcher now appears consistently across the whole flow. It reuses the existing compact switcher component, so the workspace list, pending-invitation badge, and 'Create workspace' behavior match the rest of the app.

## User-visible impact

- The org/workspace switcher avatar now shows in the top-left on every onboarding step (positioned at `top-4 left-4`, `sm:top-6 left-6`).
- Users can switch organizations, see pending invitations, and create a workspace directly from onboarding.

## Verification

Relies on the PR pipeline for lint/type-check/tests.