### PR TITLE
test(api): isolate telegram state cache identity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -542,11 +542,13 @@ describe("POST /api/test/telegram-state", () => {
     const orgId = uniqueId("org");
     const botId = uniqueId("bot");
     const telegramUserId = uniqueId("telegram");
+    const email = `${userId}@example.test`;
     mockClerkTestUser({ userId, orgId });
 
     const first = await postTelegramState({
       bot_id: botId,
       telegram_user_id: telegramUserId,
+      email,
     });
     expect(first.status).toBe(200);
     const firstBody = await readJson<TestTelegramStateSeedResponse>(first);
@@ -563,6 +565,7 @@ describe("POST /api/test/telegram-state", () => {
     const second = await postTelegramState({
       bot_id: botId,
       telegram_user_id: telegramUserId,
+      email,
       seed_link: false,
     });
     expect(second.status).toBe(200);


### PR DESCRIPTION
## Summary

- give the Telegram state idempotency test an invocation-specific email
- reuse that email across both POST requests so the scenario still exercises one identity
- keep the route, fallback email, user cache, and fixture cleanup behavior unchanged

## Scope

This is a test-only isolation fix. It does not change API contracts, production code, database schema, persisted production data, or deployment compatibility.

## Validation

- focused Telegram idempotency test passed twice sequentially against the same database
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-state.test.ts --maxWorkers=1 --silent=passed-only` (15 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks, including full Turbo type checking and cached full-workspace Knip

Closes #22548
