### PR TITLE
perf(api): overlap storage manifest and execution context preparation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -32,6 +32,7 @@ import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import {
   deleteUsagePricingRows,
   seedOrgMetadata,
@@ -1225,6 +1226,73 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         return run.prompt === suspendedPrompt;
       }),
     ).toHaveLength(0);
+  });
+
+  it("overlaps storage presigning with context encryption while preserving storage errors", async () => {
+    const api = createRunsApi(context);
+    const storages = createStoragesBddApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const storageName = `bdd-overlap-${randomUUID().slice(0, 8)}`;
+    const storageFile = storageTextFile(
+      "overlap.txt",
+      `overlap payload ${storageName}`,
+    );
+    const prepared = await storages.prepareStorage(actor, {
+      storageName,
+      storageType: "volume",
+      files: [storageFile],
+    });
+    await storages.commitStorage(actor, {
+      storageName,
+      storageType: "volume",
+      versionId: prepared.versionId,
+      files: [storageFile],
+    });
+
+    const kmsStarted = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!kmsStarted.settled()) {
+        kmsStarted.resolve(undefined);
+      }
+    });
+    const storageError = new Error("storage manifest presign failed");
+    context.mocks.s3.getSignedUrl.mockImplementation(async () => {
+      await kmsStarted.promise;
+      throw storageError;
+    });
+    useSecretKmsClientForTests({
+      failAfterGenerateDataKeys: 0,
+      onGenerateDataKey: () => {
+        if (!kmsStarted.settled()) {
+          kmsStarted.resolve(undefined);
+        }
+      },
+    });
+
+    const failed = await api.createRun(actor, {
+      agentId,
+      prompt: "storage and context preparation should overlap",
+      modelProvider: "anthropic-api-key",
+      additionalVolumes: [
+        {
+          name: storageName,
+          version: prepared.versionId,
+          mountPath: "/overlap",
+        },
+      ],
+    });
+
+    expect(kmsStarted.settled()).toBeTruthy();
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe(storageError.message);
+    const stored = await api.readRun(actor, failed.runId);
+    expect(stored.status).toBe("failed");
+    expect(stored.error).toBe(storageError.message);
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).not.toContainEqual(
+      expect.objectContaining({ runId: failed.runId }),
+    );
+    await api.requestClaimRunnerJob(true, failed.runId, [404]);
   });
 
   it("emits bucketed storage manifest shape dimensions without leaking storage identifiers", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -547,6 +547,13 @@ interface BuiltStoredExecutionContext {
   readonly secretValues: readonly string[];
 }
 
+type BuiltStoredExecutionContextDraft = Omit<
+  BuiltStoredExecutionContext,
+  "context"
+> & {
+  readonly context: Omit<StoredExecutionContext, "storageManifest">;
+};
+
 type ApiErrorResponse<Status extends number, Code extends string> = {
   readonly status: Status;
   readonly body: {
@@ -4902,7 +4909,7 @@ async function insertQueuedRunRecord(
   return run;
 }
 
-async function buildStoredExecutionContext(args: {
+async function buildStoredExecutionContextDraft(args: {
   readonly runId: string;
   readonly userId: string;
   readonly orgId: string;
@@ -4917,12 +4924,11 @@ async function buildStoredExecutionContext(args: {
   readonly billableFirewalls: readonly string[];
   readonly modelUsageProvider: string | undefined;
   readonly apiStartTime: number;
-  readonly storageManifest: StorageManifest;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly extraEnvironment: Record<string, string> | undefined;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
-}): Promise<BuiltStoredExecutionContext> {
+}): Promise<BuiltStoredExecutionContextDraft> {
   const permissions = args.permissionManifest;
   const executionSecrets = buildStoredExecutionSecrets({
     connectorContext: args.connectorContext,
@@ -4963,7 +4969,6 @@ async function buildStoredExecutionContext(args: {
 
   return {
     context: {
-      storageManifest: args.storageManifest,
       environment,
       secretValueEnvironmentKeys,
       vars: args.connectorContext.vars ?? null,
@@ -4992,6 +4997,30 @@ async function buildStoredExecutionContext(args: {
     },
     secretNames,
     secretValues,
+  };
+}
+
+async function resolveBuiltStoredExecutionContext(
+  storageManifestPromise: Promise<StorageManifest>,
+  builtContextDraftPromise: Promise<BuiltStoredExecutionContextDraft>,
+): Promise<BuiltStoredExecutionContext> {
+  const [storageManifestResult, builtContextDraftResult] =
+    await Promise.allSettled([
+      storageManifestPromise,
+      builtContextDraftPromise,
+    ]);
+  if (storageManifestResult.status === "rejected") {
+    throw storageManifestResult.reason;
+  }
+  if (builtContextDraftResult.status === "rejected") {
+    throw builtContextDraftResult.reason;
+  }
+  return {
+    ...builtContextDraftResult.value,
+    context: {
+      ...builtContextDraftResult.value.context,
+      storageManifest: storageManifestResult.value,
+    },
   };
 }
 
@@ -5408,7 +5437,7 @@ function buildRunnerJobPayload(
     const storageManifestStats = args.timing
       ? new StorageManifestBuildStats()
       : undefined;
-    const storageManifest = await measureApiDispatchTiming(
+    const storageManifestPromise = measureApiDispatchTiming(
       args.timing,
       "api_dispatch_prepare_storage_manifest",
       "nested",
@@ -5435,21 +5464,21 @@ function buildRunnerJobPayload(
         return storageManifestStats?.overallDimensions();
       },
     );
-    const builtContext = await measureApiDispatchTiming(
+    const builtContextDraftPromise = measureApiDispatchTiming(
       args.timing,
       "api_dispatch_build_stored_execution_context",
       "nested",
       async () => {
-        return await buildStoredExecutionContext({
+        return await buildStoredExecutionContextDraft({
           ...args,
           body,
           runId: args.run.id,
-          chatThreadId: args.chatThreadId,
-          storageManifest,
-          userTimezone: args.userTimezone,
-          featureSwitchContext: args.featureSwitchContext,
         });
       },
+    );
+    const builtContext = await resolveBuiltStoredExecutionContext(
+      storageManifestPromise,
+      builtContextDraftPromise,
     );
     const runContextSnapshot = buildRunContextSnapshot({
       runId: args.run.id,


### PR DESCRIPTION
## Summary

- prepare the storage manifest and manifest-independent execution-context draft concurrently
- preserve storage-first failure selection, AbortError propagation, existing timing span semantics, and the final runner payload shape
- add a route integration barrier that proves KMS starts before blocked storage presigning and verifies dual-failure queue behavior

## Compatibility

- no database schema or migration changes
- no public API, persisted execution-context, queue payload, runner protocol, or guest protocol changes
- payload-build failures retain the existing failed-run audit row without creating runnable queue state

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only`

Closes #22570

Parent context: #21674
