### PR TITLE
fix(platform): refresh connector state from ably

### DIFF
--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -5,6 +5,7 @@ import {
   subscribeThreadListChanged$,
 } from "./chat-thread-list-reload.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
+import { subscribeConnectorChanged$ } from "./connector-reload.ts";
 import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
 import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
 import { setupRealtime$ } from "./realtime.ts";
@@ -24,6 +25,7 @@ export const setupAuthenticatedDaemons$ = command(
       set(subscribeThreadListChanged$, signal),
       set(subscribeChatThreadReadCursorUpdated$, signal),
       set(subscribeEventDrivenChatThreads$, signal),
+      set(subscribeConnectorChanged$, signal),
       set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),
       set(reloadFeatureSwitch$, signal),

--- a/turbo/apps/platform/src/signals/connector-reload.ts
+++ b/turbo/apps/platform/src/signals/connector-reload.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { reloadConnectors$ } from "./external/connectors.ts";
+import { setAblyLoop$ } from "./realtime.ts";
+import { reloadAgentConnectorAuthorizations$ } from "./zero-page/agent-connector-authorizations.ts";
+
+export const subscribeConnectorChanged$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const onChanged$ = command(({ set }) => {
+      set(reloadConnectors$);
+      set(reloadAgentConnectorAuthorizations$);
+      return false;
+    });
+    await set(
+      setAblyLoop$,
+      { topic: "connector:changed", loopCommand$: onChanged$ },
+      signal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/connector-reload.ts
+++ b/turbo/apps/platform/src/signals/connector-reload.ts
@@ -12,7 +12,11 @@ export const subscribeConnectorChanged$ = command(
     });
     await set(
       setAblyLoop$,
-      { topic: "connector:changed", loopCommand$: onChanged$ },
+      {
+        topic: "connector:changed",
+        loopCommand$: onChanged$,
+        options: { runOnSubscribe: true },
+      },
       signal,
     );
   },

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-ref.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-ref.ts
@@ -52,8 +52,13 @@ export const agentEnabledTypes$ = computed(async (get) => {
   if (!agentId) {
     return { agentId: null, enabledTypes: [] };
   }
-  const authorizations = await get(agentConnectorAuthorizations({ agentId }));
-  return { agentId, enabledTypes: [...authorizations.enabledTypes] };
+  const authorizations = await get(
+    agentConnectorAuthorizations({ agentId, missing: "null" }),
+  );
+  return {
+    agentId,
+    enabledTypes: [...(authorizations?.enabledTypes ?? [])],
+  };
 });
 
 export type DirectedAuthorizeConnectModalKey = {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -19,6 +19,7 @@ import {
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
@@ -39,6 +40,7 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { now } from "../../../lib/time.ts";
 import { search } from "../../../signals/location.ts";
 import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
@@ -1032,6 +1034,64 @@ describe("connectors page", () => {
     context.mocks.ably.trigger("connector:changed");
 
     await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Asana")).toBeInTheDocument();
+      expect(
+        within(connectorCardByLabel("Asana")).getByText("Connected"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("catches connector changes when the Ably subscription attaches", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000010";
+    const realtimeReady = Promise.withResolvers<void>();
+    let enabledTypes = ["github"];
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([teamAgent(agentId, "Research Agent", "preset:0")]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+      return respond(200, {
+        enabledTypes: params.id === agentId ? enabledTypes : [],
+      });
+    });
+    context.mocks.api(
+      platformRealtimeTokenContract.create,
+      async ({ respond }) => {
+        await realtimeReady.promise;
+        return respond(200, {
+          keyName: "mock-key",
+          clientId: "test-user-123",
+          timestamp: now(),
+          capability: '{"*":["*"]}',
+          nonce: "mock-nonce",
+          mac: "mock-mac",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors?connection=agent:${agentId}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+      expect(
+        context.mocks.ably.hasSubscription("connector:changed"),
+      ).toBeFalsy();
+    });
+
+    enabledTypes = ["github", "asana"];
+    mockConnectors([
+      { type: "github", externalUsername: "octocat" },
+      { type: "asana" },
+    ]);
+    realtimeReady.resolve();
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("connector:changed"),
+      ).toBeTruthy();
       expect(screen.getByText("GitHub")).toBeInTheDocument();
       expect(screen.getByText("Asana")).toBeInTheDocument();
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -45,7 +45,6 @@ import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { resetSignalScope } from "../../../signals/utils.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { reloadAgentConnectorAuthorizations$ } from "../../../signals/zero-page/agent-connector-authorizations.ts";
 import { submitManualGrant$ } from "../../../signals/zero-page/settings/connectors.ts";
 
 const context = testContext();
@@ -1001,7 +1000,7 @@ describe("connectors page", () => {
     expect(search()).toContain(agentId);
   });
 
-  it("refreshes agent-filtered connectors when authorizations reload", async () => {
+  it("refreshes connector and agent authorization state after an Ably update", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000010";
     let enabledTypes = ["github"];
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
@@ -1020,14 +1019,24 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
       expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+      expect(
+        context.mocks.ably.hasSubscription("connector:changed"),
+      ).toBeTruthy();
     });
 
     enabledTypes = ["github", "asana"];
-    await context.store.set(reloadAgentConnectorAuthorizations$);
+    mockConnectors([
+      { type: "github", externalUsername: "octocat" },
+      { type: "asana" },
+    ]);
+    context.mocks.ably.trigger("connector:changed");
 
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
       expect(screen.getByText("Asana")).toBeInTheDocument();
+      expect(
+        within(connectorCardByLabel("Asana")).getByText("Connected"),
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- subscribe authenticated app sessions to `connector:changed` Ably events
- invalidate both connector catalog and agent connector authorization state
- verify connector status and agent-filtered UI refresh through a page integration test

## Testing

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only` (112 files, 1139 tests)
- `pnpm -F @vm0/app build`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx` after rebasing onto latest `main` (50 tests)
