### PR TITLE
refactor(ci): remove redundant runner binary cache plumbing

### DIFF
--- a/.github/scripts/runner-binary-cache-plan.sh
+++ b/.github/scripts/runner-binary-cache-plan.sh
@@ -201,7 +201,7 @@ emit "compile-matrix" "$miss_matrix"
 emit "hit-targets" "$hit_targets"
 emit "hit-count" "$hit_count"
 emit "miss-count" "$miss_count"
-emit "resolution-json" "$resolution_json"
+printf 'resolution-json=%s\n' "$resolution_json"
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -465,11 +465,12 @@ publish() {
     ' > "$manifest_tmp"
   mv -f "$manifest_tmp" "${OUTPUT_DIR}/manifest.json"
 
-  MANIFEST_PATH="${OUTPUT_DIR}/manifest.json" \
-  EXPECTED_TARGET="$FRESH_TARGET" \
-  EXPECTED_BINARY_INPUT_DIGEST="$FRESH_BINARY_INPUT_DIGEST" \
-  EXPECTED_REPOSITORY="$PRODUCER_REPOSITORY" \
-  EXPECTED_WORKFLOW_PATH="${PRODUCER_WORKFLOW_PATH:-$RUNNER_BINARY_WORKFLOW_PATH}" \
+  env GITHUB_OUTPUT= \
+    MANIFEST_PATH="${OUTPUT_DIR}/manifest.json" \
+    EXPECTED_TARGET="$FRESH_TARGET" \
+    EXPECTED_BINARY_INPUT_DIGEST="$FRESH_BINARY_INPUT_DIGEST" \
+    EXPECTED_REPOSITORY="$PRODUCER_REPOSITORY" \
+    EXPECTED_WORKFLOW_PATH="${PRODUCER_WORKFLOW_PATH:-$RUNNER_BINARY_WORKFLOW_PATH}" \
     "$0" manifest-validate >/dev/null
 
   emit "published" "true"
@@ -518,7 +519,6 @@ validate_resolution_context() {
 
 collect_trusted_candidates() {
   local expected_target=$1 expected_digest=$2 output_dir=$3
-  validate_resolution_context
   mkdir -p "$output_dir"
 
   local artifact_name_value artifacts_json
@@ -602,7 +602,6 @@ collect_trusted_candidates() {
   while IFS=$'\t' read -r rank artifact_created artifact_id artifact_run_id source artifact_head_sha; do
     [ -n "$artifact_run_id" ] || continue
     if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ]; then
-      limit_reached=true
       break
     fi
     inspected=$((inspected + 1))
@@ -657,7 +656,8 @@ collect_trusted_candidates() {
       continue
     fi
     manifest_path="${manifest_candidates[0]}"
-    if ! MANIFEST_PATH="$manifest_path" \
+    if ! env GITHUB_OUTPUT= \
+      MANIFEST_PATH="$manifest_path" \
       EXPECTED_TARGET="$expected_target" \
       EXPECTED_BINARY_INPUT_DIGEST="$expected_digest" \
       EXPECTED_REPOSITORY="$REPO" \
@@ -740,6 +740,7 @@ shadow_resolve() {
     exit 2
   fi
   mkdir -p "$SHADOW_OUTPUT_DIR"
+  validate_resolution_context
 
   if ! collect_trusted_candidates \
     "$FRESH_TARGET" "$FRESH_BINARY_INPUT_DIGEST" "$SHADOW_OUTPUT_DIR"; then
@@ -881,14 +882,14 @@ active_resolve() {
     runnerSizeBytes: .runner.sizeBytes,
     guestSha256: .guests
   }' "$TRUSTED_MANIFEST_PATH" > "${transport_dir}/metadata.json"
-  FRESH_METADATA_PATH="${transport_dir}/metadata.json" \
-  RUNNER_PATH="${transport_dir}/runner" \
-  EXPECTED_TARGET="$EXPECTED_TARGET" \
-  EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
+  env GITHUB_OUTPUT= \
+    FRESH_METADATA_PATH="${transport_dir}/metadata.json" \
+    RUNNER_PATH="${transport_dir}/runner" \
+    EXPECTED_TARGET="$EXPECTED_TARGET" \
+    EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
     "$0" fresh-validate >/dev/null
   mv "$transport_dir" "$RESOLVE_OUTPUT_DIR"
 
-  emit "binary-input-digest" "$EXPECTED_BINARY_INPUT_DIGEST"
   emit "runner-size-bytes" "$runner_size"
   emit "object-size-bytes" "$object_size"
   resolve_result "hit" "$TRUSTED_SOURCE" "validated" "$TRUSTED_RUN_ID"

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -196,10 +196,21 @@ run_plan() {
 }
 
 : > "${TMPDIR}/gh.log"
-all_hit=$(run_plan all-hit "${TMPDIR}/all-hit")
+plan_output="${TMPDIR}/plan.output"
+plan_summary="${TMPDIR}/plan.summary"
+all_hit=$(GITHUB_OUTPUT="$plan_output" \
+  GITHUB_STEP_SUMMARY="$plan_summary" \
+  run_plan all-hit "${TMPDIR}/all-hit")
 assert_contains "$all_hit" 'compile-matrix=[]'
 assert_contains "$all_hit" 'hit-count=2'
 assert_contains "$all_hit" 'miss-count=0'
+assert_contains "$all_hit" 'resolution-json=['
+plan_output_keys=$(cut -d= -f1 "$plan_output" | LC_ALL=C sort -u | paste -sd, -)
+[ "$plan_output_keys" = "compile-matrix,hit-count,hit-targets,miss-count" ] ||
+  fail "unexpected plan output keys: ${plan_output_keys}"
+grep -qF '### Runner binary cache plan' "$plan_summary" || fail "expected plan summary"
+grep -qF "\`${arm_target}\`" "$plan_summary" || fail "expected arm target in plan summary"
+grep -qF "\`${x86_target}\`" "$plan_summary" || fail "expected x86 target in plan summary"
 cmp -s "$runner" "${TMPDIR}/all-hit/${arm_target}/runner" || fail "arm hit bytes were not staged"
 cmp -s "$runner" "${TMPDIR}/all-hit/${x86_target}/runner" || fail "x86 hit bytes were not staged"
 

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -17,6 +17,13 @@ assert_contains() {
   grep -qF "$expected" <<<"$output" || fail "expected '${expected}' in: ${output}"
 }
 
+assert_output_keys() {
+  local file=$1 expected=$2 actual
+  actual=$(cut -d= -f1 "$file" | LC_ALL=C sort -u | paste -sd, -)
+  [ "$actual" = "$expected" ] ||
+    fail "expected output keys '${expected}', got '${actual}'"
+}
+
 assert_fails() {
   local name=$1
   shift
@@ -179,9 +186,12 @@ run_publish() {
 }
 
 : > "${TMPDIR}/aws.log"
-publish_out=$(run_publish "${TMPDIR}/published")
+publish_output="${TMPDIR}/publish.output"
+publish_out=$(GITHUB_OUTPUT="$publish_output" run_publish "${TMPDIR}/published")
 assert_contains "$publish_out" "published=true"
 assert_contains "$publish_out" "publish-reason=uploaded"
+assert_output_keys "$publish_output" \
+  "manifest-path,object-key,object-size-bytes,publish-reason,published"
 [ -f "${TMPDIR}/published/manifest.json" ] || fail "expected reusable manifest"
 zstd -q -d -c "${TMPDIR}/store/object.zst" > "${TMPDIR}/stored-runner"
 cmp -s "$runner" "${TMPDIR}/stored-runner" || fail "R2 object must contain the fresh runner"
@@ -493,13 +503,24 @@ run_shadow() {
 }
 
 : > "${TMPDIR}/gh.log"
-pr_shadow=$(run_shadow pull_request rank "${TMPDIR}/shadow-pr")
+shadow_output="${TMPDIR}/shadow.output"
+pr_shadow=$(GITHUB_OUTPUT="$shadow_output" run_shadow pull_request rank "${TMPDIR}/shadow-pr")
 assert_contains "$pr_shadow" "shadow-outcome=hit"
 assert_contains "$pr_shadow" "shadow-source=protected-main"
 assert_contains "$pr_shadow" "shadow-producer-run-id=20"
+assert_output_keys "$shadow_output" \
+  "shadow-outcome,shadow-producer-run-id,shadow-reason,shadow-source"
 if grep -qE 'actions/runs/(99|30)([^0-9]|$)' "${TMPDIR}/gh.log"; then
   fail "shadow resolution queried current or unrelated producer runs"
 fi
+
+if run_shadow unsupported rank "${TMPDIR}/shadow-invalid-context" \
+  > "${TMPDIR}/shadow-invalid-context.out" \
+  2> "${TMPDIR}/shadow-invalid-context.err"; then
+  fail "shadow resolution accepted an unsupported current event"
+fi
+grep -qF 'unsupported current event: unsupported' \
+  "${TMPDIR}/shadow-invalid-context.err" || fail "expected shadow context diagnostic"
 
 merge_shadow=$(run_shadow merge_group rank "${TMPDIR}/shadow-merge")
 assert_contains "$merge_shadow" "shadow-outcome=hit"
@@ -574,10 +595,13 @@ run_active() {
 
 zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
 : > "${TMPDIR}/gh.log"
-active_hit=$(run_active pull_request rank "${TMPDIR}/active-hit")
+active_output="${TMPDIR}/active.output"
+active_hit=$(GITHUB_OUTPUT="$active_output" run_active pull_request rank "${TMPDIR}/active-hit")
 assert_contains "$active_hit" "resolve-outcome=hit"
 assert_contains "$active_hit" "resolve-source=protected-main"
 assert_contains "$active_hit" "resolve-producer-run-id=20"
+assert_output_keys "$active_output" \
+  "candidate-inspections,object-size-bytes,resolve-outcome,resolve-producer-run-id,resolve-reason,resolve-source,runner-size-bytes"
 cmp -s "$runner" "${TMPDIR}/active-hit/runner" || fail "active hit must materialize verified runner bytes"
 FRESH_METADATA_PATH="${TMPDIR}/active-hit/metadata.json" \
 RUNNER_PATH="${TMPDIR}/active-hit/runner" \
@@ -596,6 +620,17 @@ force_miss=$(RUNNER_BINARY_CACHE_FORCE_MISS=true \
   run_active pull_request rank "${TMPDIR}/active-force")
 assert_contains "$force_miss" "resolve-reason=force-miss"
 [ ! -s "${TMPDIR}/gh.log" ] || fail "force miss must bypass candidate lookup"
+
+: > "${TMPDIR}/gh.log"
+if RUNNER_BINARY_CACHE_FORCE_MISS=true \
+  run_active unsupported rank "${TMPDIR}/active-invalid-context" \
+  > "${TMPDIR}/active-invalid-context.out" \
+  2> "${TMPDIR}/active-invalid-context.err"; then
+  fail "active force miss accepted an unsupported current event"
+fi
+grep -qF 'unsupported current event: unsupported' \
+  "${TMPDIR}/active-invalid-context.err" || fail "expected active context diagnostic"
+[ ! -s "${TMPDIR}/gh.log" ] || fail "invalid active context must fail before candidate lookup"
 
 api_miss=$(run_active pull_request api-fail "${TMPDIR}/active-api-fail")
 assert_contains "$api_miss" "resolve-outcome=miss"

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -18,6 +18,8 @@ jq -e '
   (.jobs.prepare | has("container") | not) and
   .jobs.prepare.permissions.actions == "read" and
   .jobs.prepare.outputs["runner-binary-compile-matrix"] == "${{ steps.binary-plan.outputs.compile-matrix }}" and
+  (.jobs.prepare.outputs | has("runner-binary-hit-count") | not) and
+  (.jobs.prepare.outputs | has("runner-binary-resolution-json") | not) and
   any(.jobs.prepare.steps[];
     .id == "binary-plan" and
     .run == ".github/scripts/runner-binary-cache-plan.sh" and
@@ -26,6 +28,7 @@ jq -e '
   any(.jobs.prepare.steps[];
     .uses == "actions/upload-artifact@v7" and
     .with.name == "runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}" and
+    .if == "steps.binary-plan.outputs.hit-count != '\''0'\''" and
     .with["compression-level"] == 1 and
     (. | has("continue-on-error") | not)
   )
@@ -91,6 +94,19 @@ jq -e '
   any(.jobs.asset.steps[];
     .name == "Download compiled runner binary" and
     .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}"
+  ) and
+  any(.jobs.asset.steps[];
+    .name == "Validate fresh runner binary" and
+    (. | has("if") | not) and
+    (. | has("continue-on-error") | not)
+  ) and
+  any(.jobs.asset.steps[];
+    .name == "Resolve reusable candidate in shadow mode" and
+    (. | has("if") | not)
+  ) and
+  any(.jobs.asset.steps[];
+    .name == "Publish runner binary cache object" and
+    (. | has("if") | not)
   )
 ' <<<"$workflow_json" >/dev/null || fail "reusable publication must run only for compiled misses"
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -38,9 +38,7 @@ jobs:
       runner-host-groups-configured: ${{ steps.host-group-presence.outputs.configured }}
       runner-binary-compile-matrix: ${{ steps.binary-plan.outputs.compile-matrix }}
       runner-binary-hit-targets: ${{ steps.binary-plan.outputs.hit-targets }}
-      runner-binary-hit-count: ${{ steps.binary-plan.outputs.hit-count }}
       runner-binary-miss-count: ${{ steps.binary-plan.outputs.miss-count }}
-      runner-binary-resolution-json: ${{ steps.binary-plan.outputs.resolution-json }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -519,7 +517,6 @@ jobs:
 
       - name: Resolve reusable candidate in shadow mode
         id: shadow
-        if: steps.fresh.outcome == 'success'
         env:
           CURRENT_EVENT: ${{ github.event_name }}
           CURRENT_PR_HEAD_REF: ${{ needs.prepare.outputs.pr-head-ref }}
@@ -540,7 +537,6 @@ jobs:
 
       - name: Publish runner binary cache object
         id: publish
-        if: steps.fresh.outcome == 'success'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: auto


### PR DESCRIPTION
## Summary

- remove unused runner binary cache job and step output plumbing while retaining the live hit-count gate, stdout resolution diagnostics, and job summary
- make active and shadow resolution own one context validation each, and prevent internal validator outputs from leaking into enclosing command outputs
- rely on equivalent default successful-step gating and the existing post-loop candidate-limit derivation
- cover public output contracts, invalid context, summary diagnostics, and workflow structure at the shell entry points

## Compatibility and exclusions

- unchanged cache key, hit/miss selection, forced-build behavior, and fallback-to-compile contract
- unchanged artifact, manifest, producer provenance, R2, publish read-back, transport, and remote-host validations
- no runner runtime, API, protocol, schema, persisted-data, migration, rollout, or feature-switch change

## Validation

- `bash -n .github/scripts/runner-binary-cache.sh .github/scripts/runner-binary-cache-plan.sh .github/scripts/tests/runner-binary-cache-test.sh .github/scripts/tests/runner-binary-cache-plan-test.sh .github/scripts/tests/runner-image-workflow-test.sh`
- `shellcheck --severity=warning .github/scripts/runner-binary-cache.sh .github/scripts/runner-binary-cache-plan.sh .github/scripts/tests/runner-binary-cache-test.sh .github/scripts/tests/runner-binary-cache-plan-test.sh .github/scripts/tests/runner-image-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint .github/workflows/runner-image.yml`
- `.github/scripts/tests/runner-binary-cache-test.sh`
- `.github/scripts/tests/runner-binary-cache-plan-test.sh`
- `.github/scripts/tests/runner-image-workflow-test.sh`
- `git diff --check`
- `lefthook run pre-commit`

Closes #22530
