### PR TITLE
feat(api): register connector skills during catalog sync

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -721,6 +721,10 @@ function setArtifactAuthMethods(
 function buildBundledSkill(
   connectorRef: string,
   versionId = "a".repeat(64),
+  digests: {
+    readonly manifest: string;
+    readonly archive: string;
+  } = { manifest: ZERO_DIGEST, archive: ZERO_DIGEST },
 ): JsonRecord {
   const storageName = `connector-skill@${connectorRef}`;
   const prefix = `__system__/volume/${storageName}/${versionId}`;
@@ -734,12 +738,75 @@ function buildBundledSkill(
     },
     manifest: {
       key: `${prefix}/manifest.json`,
-      digest: ZERO_DIGEST,
+      digest: digests.manifest,
     },
     archive: {
       key: `${prefix}/archive.tar.gz`,
-      digest: ZERO_DIGEST,
+      digest: digests.archive,
     },
+  };
+}
+
+interface BundledSkillFixture {
+  readonly descriptor: JsonRecord;
+  readonly objects: ReadonlyMap<string, Buffer>;
+  readonly storageName: string;
+  readonly s3Prefix: string;
+  readonly versionId: string;
+  readonly contentSize: number;
+  readonly archiveSize: number;
+  readonly manifestKey: string;
+  readonly archiveKey: string;
+}
+
+interface BundledSkillFixtureOptions {
+  readonly manifest?: unknown;
+  readonly archive?: Buffer;
+  readonly manifestDigest?: string;
+  readonly archiveDigest?: string;
+}
+
+function buildBundledSkillFixture(
+  connectorRef: string,
+  versionId = "a".repeat(64),
+  options: BundledSkillFixtureOptions = {},
+): BundledSkillFixture {
+  const content = Buffer.from(`# ${connectorRef}\n`);
+  const manifest = jsonBytes(
+    options.manifest ?? {
+      version: 1,
+      files: [
+        {
+          path: "SKILL.md",
+          hash: createHash("sha256").update(content).digest("hex"),
+          size: content.length,
+        },
+      ],
+      createdAt: "1970-01-01T00:00:00.000Z",
+    },
+  );
+  const archive = options.archive ?? Buffer.alloc(321, 1);
+  const storageName = `connector-skill@${connectorRef}`;
+  const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
+  const versionPrefix = `${s3Prefix}/${versionId}`;
+  const manifestKey = `${versionPrefix}/manifest.json`;
+  const archiveKey = `${versionPrefix}/archive.tar.gz`;
+  return {
+    descriptor: buildBundledSkill(connectorRef, versionId, {
+      manifest: options.manifestDigest ?? digest(manifest),
+      archive: options.archiveDigest ?? digest(archive),
+    }),
+    objects: new Map([
+      [manifestKey, manifest],
+      [archiveKey, archive],
+    ]),
+    storageName,
+    s3Prefix,
+    versionId,
+    contentSize: content.length,
+    archiveSize: archive.length,
+    manifestKey,
+    archiveKey,
   };
 }
 
@@ -2481,7 +2548,6 @@ describe("connector catalog valid lifecycle", () => {
 
   it("mounts an external connector skill from its exact system version", async () => {
     const connectorRef = `external-skill-${randomUUID().slice(0, 8)}`;
-    const storageName = `connector-skill@${connectorRef}`;
     const selectedVersionId = createHash("sha256")
       .update(`selected:${randomUUID()}`)
       .digest("hex");
@@ -2491,18 +2557,26 @@ describe("connector catalog valid lifecycle", () => {
     const newerVersionId = createHash("sha256")
       .update(`newer:${randomUUID()}`)
       .digest("hex");
-    const canonicalPrefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
+    const skill = buildBundledSkillFixture(connectorRef, selectedVersionId);
+    const { storageName, s3Prefix: canonicalPrefix } = skill;
     configureSource();
+    const previousSystemState = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+    });
     const release = buildRelease({
       version: "2026-07-15.external-exact-skill",
       connectorRef,
       label: "External Exact Skill",
       mutatePrivate: (artifact) => {
-        firstRecord(artifact.connectors, "connectors").skill =
-          buildBundledSkill(connectorRef, selectedVersionId);
+        firstRecord(artifact.connectors, "connectors").skill = skill.descriptor;
       },
     });
-    serveObjects(catalogObjects([release], release));
+    const objects = new Map(catalogObjects([release], release));
+    for (const [key, bytes] of skill.objects) {
+      objects.set(key, bytes);
+    }
+    serveObjects(objects);
     await syncCatalog();
     mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
 
@@ -2512,10 +2586,6 @@ describe("connector catalog valid lifecycle", () => {
       throw new Error("Expected an organization-scoped test actor");
     }
     const runtimeOrgId = actor.orgId;
-    const previousSystemState = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
-    });
     const previousRuntimeState = await readVolumeStorageState({
       orgId: runtimeOrgId,
       storageName,
@@ -2581,6 +2651,50 @@ describe("connector catalog valid lifecycle", () => {
     };
 
     await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: newerVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/${newerVersionId}`,
+    });
+
+    const run = await createSkillRun();
+    successfulRunId = run.runId;
+    expect(run.status).not.toBe("failed");
+    await runs.heartbeatRunner(runnerGroup);
+    await expect
+      .poll(
+        async () => {
+          return (await runs.pollRunner(runnerGroup)).body.job?.runId;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(run.runId);
+    const claim = await runs.claimRunnerJob(run.runId);
+    const mountedSkills =
+      claim.storageManifest?.storages.filter((storage) => {
+        return (
+          storage.mountPath === `/home/user/.claude/skills/${connectorRef}`
+        );
+      }) ?? [];
+    expect(mountedSkills).toHaveLength(1);
+    expect(mountedSkills[0]).toMatchObject({
+      name: storageName,
+      mountPath: `/home/user/.claude/skills/${connectorRef}`,
+      vasStorageName: storageName,
+      vasVersionId: selectedVersionId,
+      archiveSize: 321,
+      archiveUrl: expect.any(String),
+    });
+    await runs.requestCancelRun(actor, run.runId, [200]);
+    successfulRunId = undefined;
+
+    await restoreVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      previous: previousSystemState,
+    });
+    await seedVolumeStorageVersion({
       orgId: runtimeOrgId,
       storageName,
       versionId: selectedVersionId,
@@ -2621,52 +2735,6 @@ describe("connector catalog valid lifecycle", () => {
       s3Key: `${canonicalPrefix}/wrong-${selectedVersionId}`,
     });
     await expectRegistrationFailure();
-
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
-      versionId: selectedVersionId,
-      s3Prefix: canonicalPrefix,
-      s3Key: `${canonicalPrefix}/${selectedVersionId}`,
-    });
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
-      versionId: newerVersionId,
-      s3Prefix: canonicalPrefix,
-      s3Key: `${canonicalPrefix}/${newerVersionId}`,
-    });
-
-    const run = await createSkillRun();
-    successfulRunId = run.runId;
-    expect(run.status).not.toBe("failed");
-    await runs.heartbeatRunner(runnerGroup);
-    await expect
-      .poll(
-        async () => {
-          return (await runs.pollRunner(runnerGroup)).body.job?.runId;
-        },
-        { timeout: 10_000 },
-      )
-      .toBe(run.runId);
-    const claim = await runs.claimRunnerJob(run.runId);
-    const mountedSkills =
-      claim.storageManifest?.storages.filter((storage) => {
-        return (
-          storage.mountPath === `/home/user/.claude/skills/${connectorRef}`
-        );
-      }) ?? [];
-    expect(mountedSkills).toHaveLength(1);
-    expect(mountedSkills[0]).toMatchObject({
-      name: storageName,
-      mountPath: `/home/user/.claude/skills/${connectorRef}`,
-      vasStorageName: storageName,
-      vasVersionId: selectedVersionId,
-      archiveSize: 321,
-      archiveUrl: expect.any(String),
-    });
-    await runs.requestCancelRun(actor, run.runId, [200]);
-    successfulRunId = undefined;
   }, 30_000);
 
   it("executes an external device grant with catalog-owned storage", async () => {
@@ -3936,20 +4004,428 @@ describe("connector catalog valid lifecycle", () => {
 
   it("accepts a complete bundled skill descriptor", async () => {
     configureSource();
+    const skill = buildBundledSkillFixture("external-test");
+    const previous = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: skill.storageName,
+    });
+    onTestFinished(async () => {
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: skill.storageName,
+        previous,
+      });
+    });
     const release = buildRelease({
       version: "2026-07-15.bundled-skill",
       mutatePrivate: (artifact) => {
         const connector = firstRecord(artifact.connectors, "connectors");
-        connector.skill = buildBundledSkill("external-test");
+        connector.skill = skill.descriptor;
       },
     });
-    serveObjects(catalogObjects([release], release));
+    const objects = new Map(catalogObjects([release], release));
+    for (const [key, bytes] of skill.objects) {
+      objects.set(key, bytes);
+    }
+    serveObjects(objects);
 
     expect((await syncCatalog()).body).toMatchObject({
       outcome: "accepted",
       state: "current",
       active: { catalogVersion: release.version },
     });
+    await expect(
+      readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: skill.storageName,
+      }),
+    ).resolves.toStrictEqual({
+      s3_prefix: skill.s3Prefix,
+      size: skill.contentSize,
+      file_count: 1,
+      head_version_id: skill.versionId,
+    });
+  });
+
+  it("rejects bundled skill objects that fail verification", async () => {
+    const cases = [
+      {
+        expected: "source-unavailable",
+        includeObjects: false,
+        label: "missing",
+        options: {},
+      },
+      {
+        expected: "digest-mismatch",
+        includeObjects: true,
+        label: "digest",
+        options: { manifestDigest: ZERO_DIGEST },
+      },
+      {
+        expected: "invalid-artifact",
+        includeObjects: true,
+        label: "manifest",
+        options: {
+          manifest: {
+            version: 1,
+            files: [],
+            createdAt: "1970-01-01T00:00:00.000Z",
+          },
+        },
+      },
+      {
+        expected: "object-too-large",
+        includeObjects: true,
+        label: "oversized",
+        options: { archive: Buffer.alloc(2 * 1024 * 1024 + 1, 1) },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      configureSource();
+      const connectorRef = `skill-${testCase.label}-${randomUUID().slice(0, 8)}`;
+      const skill = buildBundledSkillFixture(
+        connectorRef,
+        createHash("sha256")
+          .update(`${testCase.label}:${randomUUID()}`)
+          .digest("hex"),
+        testCase.options,
+      );
+      const previous = await readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: skill.storageName,
+      });
+      onTestFinished(async () => {
+        await restoreVolumeStorageState({
+          orgId: SYSTEM_ORG_ID,
+          storageName: skill.storageName,
+          previous,
+        });
+      });
+      const release = buildRelease({
+        version: `2026-07-22.skill-${testCase.label}-${randomUUID().slice(0, 8)}`,
+        connectorRef,
+        mutatePrivate: (artifact) => {
+          firstRecord(artifact.connectors, "connectors").skill =
+            skill.descriptor;
+        },
+      });
+      const objects = new Map(catalogObjects([release], release));
+      if (testCase.includeObjects) {
+        for (const [key, bytes] of skill.objects) {
+          objects.set(key, bytes);
+        }
+      }
+      serveObjects(objects);
+
+      const response = await syncCatalog();
+      expect(response.body).toMatchObject({
+        outcome: "rejected",
+        state: "never-synced",
+        active: null,
+        lastAttempt: { failureCode: testCase.expected },
+      });
+      await expect(
+        readVolumeStorageState({
+          orgId: SYSTEM_ORG_ID,
+          storageName: skill.storageName,
+        }),
+      ).resolves.toBeNull();
+    }
+  });
+
+  it("reuses immutable skill versions without regressing HEAD", async () => {
+    configureSource();
+    const connectorRef = `skill-cache-${randomUUID().slice(0, 8)}`;
+    const firstSkill = buildBundledSkillFixture(
+      connectorRef,
+      createHash("sha256").update(`first:${randomUUID()}`).digest("hex"),
+    );
+    const secondSkill = buildBundledSkillFixture(
+      connectorRef,
+      createHash("sha256").update(`second:${randomUUID()}`).digest("hex"),
+    );
+    const previous = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: firstSkill.storageName,
+    });
+    onTestFinished(async () => {
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: firstSkill.storageName,
+        previous,
+      });
+    });
+    const firstRelease = buildRelease({
+      version: `2026-07-22.skill-cache-first-${randomUUID().slice(0, 8)}`,
+      connectorRef,
+      mutatePrivate: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").skill =
+          firstSkill.descriptor;
+      },
+    });
+    const secondRelease = buildRelease({
+      version: `2026-07-22.skill-cache-second-${randomUUID().slice(0, 8)}`,
+      connectorRef,
+      mutatePrivate: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").skill =
+          secondSkill.descriptor;
+      },
+    });
+    const oldRetryRelease = buildRelease({
+      version: `2026-07-22.skill-cache-old-${randomUUID().slice(0, 8)}`,
+      connectorRef,
+      mutatePrivate: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").skill =
+          firstSkill.descriptor;
+      },
+    });
+
+    const firstObjects = new Map(catalogObjects([firstRelease], firstRelease));
+    for (const [key, bytes] of firstSkill.objects) {
+      firstObjects.set(key, bytes);
+    }
+    serveObjects(firstObjects);
+    expect((await syncCatalog()).body.outcome).toBe("accepted");
+
+    const secondObjects = new Map(
+      catalogObjects([firstRelease, secondRelease], secondRelease),
+    );
+    for (const [key, bytes] of secondSkill.objects) {
+      secondObjects.set(key, bytes);
+    }
+    serveObjects(secondObjects);
+    expect((await syncCatalog()).body.outcome).toBe("accepted");
+
+    context.mocks.s3.send.mockClear();
+    serveObjects(
+      catalogObjects(
+        [firstRelease, secondRelease, oldRetryRelease],
+        oldRetryRelease,
+      ),
+    );
+    expect((await syncCatalog()).body.outcome).toBe("accepted");
+    const requestedKeys = context.mocks.s3.send.mock.calls.map((call) => {
+      const input = commandInput(call[0]);
+      return typeof input.Key === "string" ? input.Key : null;
+    });
+    expect(requestedKeys).not.toContain(firstSkill.manifestKey);
+    expect(requestedKeys).not.toContain(firstSkill.archiveKey);
+    await expect(
+      readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: firstSkill.storageName,
+      }),
+    ).resolves.toMatchObject({
+      head_version_id: secondSkill.versionId,
+    });
+  });
+
+  it("rolls back all skill registrations and retries a repaired conflict", async () => {
+    configureSource();
+    const suffix = randomUUID().slice(0, 8);
+    const firstConnectorRef = `skill-atomic-a-${suffix}`;
+    const conflictingConnectorRef = `skill-atomic-b-${suffix}`;
+    const firstSkill = buildBundledSkillFixture(
+      firstConnectorRef,
+      createHash("sha256").update(`first:${randomUUID()}`).digest("hex"),
+    );
+    const conflictingSkill = buildBundledSkillFixture(
+      conflictingConnectorRef,
+      createHash("sha256").update(`conflict:${randomUUID()}`).digest("hex"),
+    );
+    const previousFirst = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: firstSkill.storageName,
+    });
+    const previousConflicting = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: conflictingSkill.storageName,
+    });
+    onTestFinished(async () => {
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: firstSkill.storageName,
+        previous: previousFirst,
+      });
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: conflictingSkill.storageName,
+        previous: previousConflicting,
+      });
+    });
+    const wrongPrefix = `${SYSTEM_ORG_ID}/volume/wrong-${conflictingSkill.storageName}`;
+    const existingVersionId = createHash("sha256")
+      .update(`existing:${randomUUID()}`)
+      .digest("hex");
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName: conflictingSkill.storageName,
+      versionId: existingVersionId,
+      s3Prefix: wrongPrefix,
+      s3Key: `${wrongPrefix}/${existingVersionId}`,
+    });
+    const conflictingIconBytes = Buffer.from(
+      `<svg>${conflictingConnectorRef}</svg>`,
+    );
+    const conflictingIconDigest = digest(conflictingIconBytes);
+    const release = buildRelease({
+      version: `2026-07-22.skill-conflict-${randomUUID().slice(0, 8)}`,
+      connectorRef: firstConnectorRef,
+      mutatePublic: (artifact) => {
+        arrayValue(artifact.connectors, "connectors").push(
+          buildPublicConnector({
+            connectorRef: conflictingConnectorRef,
+            label: "Conflicting Skill",
+            iconKey:
+              "platform/views/zero-page/components/settings/icons/" +
+              `${conflictingConnectorRef}-${conflictingIconDigest.slice("sha256:".length, 19)}.svg`,
+            iconDigest: conflictingIconDigest,
+          }),
+        );
+      },
+      mutatePrivate: (artifact) => {
+        const connectors = arrayValue(artifact.connectors, "connectors");
+        firstRecord(connectors, "connectors").skill = firstSkill.descriptor;
+        const conflictingConnector = buildPrivateConnector(
+          conflictingConnectorRef,
+        );
+        const conflictingPrivateName = "ATOMIC_SKILL_B_TOKEN";
+        const conflictingMethod = firstRecord(
+          conflictingConnector.authMethods,
+          "authMethods",
+        );
+        recordValue(conflictingMethod.storage, "storage").secrets = [
+          conflictingPrivateName,
+        ];
+        firstRecord(
+          recordValue(conflictingMethod.grant, "grant").fields,
+          "grant.fields",
+        ).privateName = conflictingPrivateName;
+        recordValue(
+          recordValue(conflictingMethod.access, "access").envBindings,
+          "envBindings",
+        ).SERVICE_TOKEN = `$secrets.${conflictingPrivateName}`;
+        conflictingConnector.skill = conflictingSkill.descriptor;
+        connectors.push(conflictingConnector);
+      },
+    });
+    const objects = new Map(catalogObjects([release], release));
+    for (const skill of [firstSkill, conflictingSkill]) {
+      for (const [key, bytes] of skill.objects) {
+        objects.set(key, bytes);
+      }
+    }
+    serveObjects(objects);
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      active: null,
+      lastAttempt: { failureCode: "invalid-reference" },
+    });
+    await expect(
+      readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: firstSkill.storageName,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: conflictingSkill.storageName,
+      }),
+    ).resolves.toStrictEqual({
+      s3_prefix: wrongPrefix,
+      size: 1,
+      file_count: 1,
+      head_version_id: existingVersionId,
+    });
+
+    await restoreVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: conflictingSkill.storageName,
+      previous: previousConflicting,
+    });
+    serveObjects(objects);
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      active: { catalogVersion: release.version },
+    });
+    for (const skill of [firstSkill, conflictingSkill]) {
+      await expect(
+        readVolumeStorageState({
+          orgId: SYSTEM_ORG_ID,
+          storageName: skill.storageName,
+        }),
+      ).resolves.toMatchObject({
+        s3_prefix: skill.s3Prefix,
+        head_version_id: skill.versionId,
+      });
+    }
+  });
+
+  it("rejects a connector skill version owned by another storage", async () => {
+    configureSource();
+    const connectorRef = `skill-owner-${randomUUID().slice(0, 8)}`;
+    const skill = buildBundledSkillFixture(
+      connectorRef,
+      createHash("sha256").update(`shared:${randomUUID()}`).digest("hex"),
+    );
+    const ownerStorageName = `connector-skill@owner-${randomUUID().slice(0, 8)}`;
+    const ownerPrefix = `${SYSTEM_ORG_ID}/volume/${ownerStorageName}`;
+    const previousOwner = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: ownerStorageName,
+    });
+    const previousCandidate = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName: skill.storageName,
+    });
+    onTestFinished(async () => {
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: ownerStorageName,
+        previous: previousOwner,
+      });
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: skill.storageName,
+        previous: previousCandidate,
+      });
+    });
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName: ownerStorageName,
+      versionId: skill.versionId,
+      s3Prefix: ownerPrefix,
+      s3Key: `${ownerPrefix}/${skill.versionId}`,
+    });
+    const release = buildRelease({
+      version: `2026-07-22.skill-owner-${randomUUID().slice(0, 8)}`,
+      connectorRef,
+      mutatePrivate: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").skill = skill.descriptor;
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      active: null,
+      lastAttempt: { failureCode: "invalid-reference" },
+    });
+    await expect(
+      readVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName: skill.storageName,
+      }),
+    ).resolves.toBeNull();
+    const requestedKeys = context.mocks.s3.send.mock.calls.map((call) => {
+      const input = commandInput(call[0]);
+      return typeof input.Key === "string" ? input.Key : null;
+    });
+    expect(requestedKeys).not.toContain(skill.manifestKey);
+    expect(requestedKeys).not.toContain(skill.archiveKey);
   });
 
   it("accepts source identities and platform requirements without local support", async () => {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -57,8 +57,12 @@ export function connectorCatalogReleaseArtifactKeys(
   };
 }
 
+const CONNECTOR_SKILL_MAX_FILES = 64;
+const CONNECTOR_SKILL_MAX_FILE_BYTES = 512 * 1024;
+export const CONNECTOR_SKILL_MAX_TOTAL_BYTES = 1024 * 1024;
+const CONNECTOR_SKILL_MAX_PATH_BYTES = 512;
 const CONNECTOR_SKILL_STORAGE_NAME_PREFIX = "connector-skill@";
-const CONNECTOR_SKILL_STORAGE_PATH_PREFIX = "__system__/volume";
+export const CONNECTOR_SKILL_STORAGE_PATH_PREFIX = "__system__/volume";
 
 const artifactHeaderShape = Object.freeze({
   artifactSchemaVersion: z.literal(SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION),
@@ -102,6 +106,114 @@ const privateSkillArchiveReferenceSchema = artifactReferenceSchema.refine(
 );
 
 const connectorSkillVersionIdSchema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+const connectorSkillFilePathSchema = artifactKeySchema
+  .refine(
+    (filePath) => {
+      return filePath === filePath.normalize("NFC");
+    },
+    {
+      message: "Skill file paths must use NFC normalization",
+    },
+  )
+  .refine(
+    (filePath) => {
+      return !Array.from(filePath).some((character) => {
+        const codePoint = character.codePointAt(0);
+        return (
+          codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)
+        );
+      });
+    },
+    { message: "Skill file paths must not contain control characters" },
+  )
+  .refine(
+    (filePath) => {
+      return (
+        Buffer.byteLength(filePath, "utf8") <= CONNECTOR_SKILL_MAX_PATH_BYTES
+      );
+    },
+    {
+      message: `Skill file paths must not exceed ${CONNECTOR_SKILL_MAX_PATH_BYTES} UTF-8 bytes`,
+    },
+  );
+
+export const connectorSkillManifestSchema = z
+  .object({
+    version: z.literal(1),
+    files: z
+      .array(
+        z
+          .object({
+            path: connectorSkillFilePathSchema,
+            hash: z.string().regex(/^[a-f0-9]{64}$/u),
+            size: z
+              .number()
+              .int()
+              .nonnegative()
+              .max(CONNECTOR_SKILL_MAX_FILE_BYTES),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(CONNECTOR_SKILL_MAX_FILES),
+    createdAt: z.literal("1970-01-01T00:00:00.000Z"),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const paths = manifest.files.map((file) => {
+      return file.path;
+    });
+    const sortedPaths = [...paths].sort(compareStrings);
+    if (
+      paths.some((filePath, index) => {
+        return filePath !== sortedPaths[index];
+      })
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill manifest files must be alphabetical",
+        path: ["files"],
+      });
+    }
+    if (new Set(paths).size !== paths.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill manifest file paths must be unique",
+        path: ["files"],
+      });
+    }
+    if (
+      new Set(
+        paths.map((filePath) => {
+          return filePath.toLowerCase();
+        }),
+      ).size !== paths.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill manifest file paths must not collide by case",
+        path: ["files"],
+      });
+    }
+    if (!paths.includes("SKILL.md")) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill manifest requires root SKILL.md",
+        path: ["files"],
+      });
+    }
+    const totalSize = manifest.files.reduce((total, file) => {
+      return total + file.size;
+    }, 0);
+    if (totalSize > CONNECTOR_SKILL_MAX_TOTAL_BYTES) {
+      context.addIssue({
+        code: "custom",
+        message: `Skill manifest files must not exceed ${CONNECTOR_SKILL_MAX_TOTAL_BYTES} total bytes`,
+        path: ["files"],
+      });
+    }
+  });
 
 const connectorSkillFrontmatterSchema = z
   .object({

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -57,6 +57,8 @@ export function connectorCatalogReleaseArtifactKeys(
   };
 }
 
+// These schema-v1 limits mirror vm0-connectors output. Changing them requires
+// a new connector catalog artifact schema generation in both repositories.
 const CONNECTOR_SKILL_MAX_FILES = 64;
 const CONNECTOR_SKILL_MAX_FILE_BYTES = 512 * 1024;
 export const CONNECTOR_SKILL_MAX_TOTAL_BYTES = 1024 * 1024;

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -58,6 +58,7 @@ export interface ConnectorCatalogReleaseIdentity {
 
 export interface ValidatedConnectorCatalogCandidate {
   readonly identity: ConnectorCatalogReleaseIdentity;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
   readonly publicCatalogText: string;
   readonly privateCatalogText: string;
   readonly privateFirewallsText: string;
@@ -413,6 +414,7 @@ export async function loadConnectorCatalogCandidate(args: {
   validateCatalogViews(views, integrity);
   return {
     identity: releaseIdentity(args.pointer, integrity),
+    privateArtifact: views.privateArtifact,
     publicCatalogText: views.publicCatalogText,
     privateCatalogText: views.privateCatalogText,
     privateFirewallsText: views.privateFirewallsText,

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -1,0 +1,420 @@
+import { createHash } from "node:crypto";
+
+import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
+import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import type { Db, ReadonlyDb } from "../external/db";
+import { S3ObjectSizeLimitError } from "../external/s3";
+import { safeJsonParse, safeSync, settle } from "../utils";
+import {
+  CONNECTOR_SKILL_MAX_TOTAL_BYTES,
+  CONNECTOR_SKILL_STORAGE_PATH_PREFIX,
+  connectorSkillManifestSchema,
+  type ConnectorCatalogPrivateArtifact,
+} from "./connector-catalog-artifacts/artifacts";
+import type { ConnectorCatalogArtifactReader } from "./connector-catalog-artifacts/loader";
+
+const CONNECTOR_SKILL_MANIFEST_MAX_BYTES = 128 * 1024;
+const CONNECTOR_SKILL_ARCHIVE_MAX_BYTES = CONNECTOR_SKILL_MAX_TOTAL_BYTES * 2;
+const SYSTEM_STORAGE_CREATOR = "system";
+
+type PrivateConnector = ConnectorCatalogPrivateArtifact["connectors"][number];
+type BundledConnectorSkill = Extract<
+  PrivateConnector["skill"],
+  { readonly kind: "bundled" }
+>;
+
+interface ExistingStorageVersion {
+  readonly id: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly type: string;
+  readonly s3Prefix: string;
+  readonly s3Key: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+  readonly message: string | null;
+  readonly createdBy: string;
+}
+
+interface StorageIdentity {
+  readonly id: string;
+  readonly s3Prefix: string;
+}
+
+interface ConnectorSkillIdentity {
+  readonly storageName: string;
+  readonly versionId: string;
+  readonly s3Prefix: string;
+  readonly s3Key: string;
+}
+
+export interface PreparedConnectorSkillRegistration {
+  readonly storageName: string;
+  readonly versionId: string;
+  readonly s3Prefix: string;
+  readonly s3Key: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+}
+
+export interface ConnectorCatalogSkillFailure {
+  readonly code: ConnectorCatalogSyncFailureCode;
+  readonly cacheable: boolean;
+}
+
+class ConnectorCatalogSkillError extends Error {
+  constructor(readonly failure: ConnectorCatalogSkillFailure) {
+    super(failure.code);
+    this.name = "ConnectorCatalogSkillError";
+  }
+}
+
+export function connectorCatalogSkillFailure(
+  error: unknown,
+): ConnectorCatalogSkillFailure | undefined {
+  return error instanceof ConnectorCatalogSkillError
+    ? error.failure
+    : undefined;
+}
+
+function fail(
+  code: ConnectorCatalogSyncFailureCode,
+  cacheable: boolean,
+): never {
+  throw new ConnectorCatalogSkillError({ code, cacheable });
+}
+
+function digest(bytes: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function skillIdentity(skill: BundledConnectorSkill): ConnectorSkillIdentity {
+  const s3Prefix = `${CONNECTOR_SKILL_STORAGE_PATH_PREFIX}/${skill.storageName}`;
+  return {
+    storageName: skill.storageName,
+    versionId: skill.versionId,
+    s3Prefix,
+    s3Key: `${s3Prefix}/${skill.versionId}`,
+  };
+}
+
+function reusableExistingVersion(
+  existing: ExistingStorageVersion,
+  identity: ConnectorSkillIdentity,
+): PreparedConnectorSkillRegistration | undefined {
+  if (
+    existing.orgId !== SYSTEM_ORG_ID ||
+    existing.userId !== VOLUME_ORG_USER_ID ||
+    existing.name !== identity.storageName ||
+    existing.type !== "volume" ||
+    existing.s3Prefix !== identity.s3Prefix ||
+    existing.s3Key !== identity.s3Key ||
+    existing.message !== null ||
+    existing.createdBy !== SYSTEM_STORAGE_CREATOR
+  ) {
+    return undefined;
+  }
+  return {
+    ...identity,
+    size: existing.size,
+    archiveSize: existing.archiveSize,
+    fileCount: existing.fileCount,
+  };
+}
+
+async function readExistingVersions(
+  db: ReadonlyDb,
+  versionIds: readonly string[],
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, ExistingStorageVersion>> {
+  if (versionIds.length === 0) {
+    return new Map();
+  }
+  const rows = await db
+    .select({
+      id: storageVersions.id,
+      orgId: storages.orgId,
+      userId: storages.userId,
+      name: storages.name,
+      type: storages.type,
+      s3Prefix: storages.s3Prefix,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    })
+    .from(storageVersions)
+    .innerJoin(storages, eq(storageVersions.storageId, storages.id))
+    .where(inArray(storageVersions.id, [...new Set(versionIds)]));
+  signal.throwIfAborted();
+  return new Map(
+    rows.map((row) => {
+      return [row.id, row] as const;
+    }),
+  );
+}
+
+async function readSkillObject(
+  reader: ConnectorCatalogArtifactReader,
+  key: string,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const result = await settle(reader.readArtifact(key, maxBytes), signal);
+  if (!result.ok) {
+    if (result.error instanceof S3ObjectSizeLimitError) {
+      fail("object-too-large", true);
+    }
+    fail("source-unavailable", false);
+  }
+  const bytes = Buffer.from(result.value);
+  if (bytes.length > maxBytes) {
+    fail("object-too-large", true);
+  }
+  return bytes;
+}
+
+function parseSkillManifest(bytes: Uint8Array) {
+  const decoded = safeSync(() => {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  });
+  if (!("ok" in decoded)) {
+    fail("invalid-json", true);
+  }
+  const value = safeJsonParse(decoded.ok);
+  if (value === undefined) {
+    fail("invalid-json", true);
+  }
+  const parsed = connectorSkillManifestSchema.safeParse(value);
+  if (!parsed.success) {
+    fail("invalid-artifact", true);
+  }
+  return parsed.data;
+}
+
+async function verifySkill(
+  reader: ConnectorCatalogArtifactReader,
+  skill: BundledConnectorSkill,
+  signal: AbortSignal,
+): Promise<PreparedConnectorSkillRegistration> {
+  const [manifestBytes, archiveBytes] = await Promise.all([
+    readSkillObject(
+      reader,
+      skill.manifest.key,
+      CONNECTOR_SKILL_MANIFEST_MAX_BYTES,
+      signal,
+    ),
+    readSkillObject(
+      reader,
+      skill.archive.key,
+      CONNECTOR_SKILL_ARCHIVE_MAX_BYTES,
+      signal,
+    ),
+  ]);
+  signal.throwIfAborted();
+  if (
+    digest(manifestBytes) !== skill.manifest.digest ||
+    digest(archiveBytes) !== skill.archive.digest
+  ) {
+    fail("digest-mismatch", true);
+  }
+  if (archiveBytes.length === 0) {
+    fail("invalid-artifact", true);
+  }
+  const manifest = parseSkillManifest(manifestBytes);
+  return {
+    ...skillIdentity(skill),
+    size: manifest.files.reduce((total, file) => {
+      return total + file.size;
+    }, 0),
+    archiveSize: archiveBytes.length,
+    fileCount: manifest.files.length,
+  };
+}
+
+export async function prepareConnectorCatalogSkills(args: {
+  readonly db: ReadonlyDb;
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly signal: AbortSignal;
+}): Promise<readonly PreparedConnectorSkillRegistration[]> {
+  const bundledSkills = args.privateArtifact.connectors.flatMap((connector) => {
+    return connector.skill.kind === "bundled" ? [connector.skill] : [];
+  });
+  const existingByVersion = await readExistingVersions(
+    args.db,
+    bundledSkills.map((skill) => {
+      return skill.versionId;
+    }),
+    args.signal,
+  );
+  const prepared: PreparedConnectorSkillRegistration[] = [];
+  for (const skill of bundledSkills) {
+    const existing = existingByVersion.get(skill.versionId);
+    if (existing) {
+      const reusable = reusableExistingVersion(existing, skillIdentity(skill));
+      if (!reusable) {
+        fail("invalid-reference", false);
+      }
+      prepared.push(reusable);
+      continue;
+    }
+    prepared.push(await verifySkill(args.reader, skill, args.signal));
+  }
+  return prepared;
+}
+
+async function readStorageVersion(
+  db: Db,
+  versionId: string,
+  signal: AbortSignal,
+): Promise<ExistingStorageVersion | undefined> {
+  const versions = await readExistingVersions(db, [versionId], signal);
+  return versions.get(versionId);
+}
+
+async function loadOrCreateStorage(
+  db: Db,
+  registration: PreparedConnectorSkillRegistration,
+  signal: AbortSignal,
+): Promise<StorageIdentity> {
+  const [created] = await db
+    .insert(storages)
+    .values({
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      name: registration.storageName,
+      type: "volume",
+      s3Prefix: registration.s3Prefix,
+      size: registration.size,
+      fileCount: registration.fileCount,
+    })
+    .onConflictDoNothing()
+    .returning({ id: storages.id, s3Prefix: storages.s3Prefix });
+  signal.throwIfAborted();
+  if (created) {
+    return created;
+  }
+
+  const [storage] = await db
+    .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, SYSTEM_ORG_ID),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, registration.storageName),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!storage) {
+    throw new Error("Connector skill storage was not created");
+  }
+  return storage;
+}
+
+function existingVersionMatchesRegistration(
+  existing: ExistingStorageVersion,
+  registration: PreparedConnectorSkillRegistration,
+): boolean {
+  const reusable = reusableExistingVersion(existing, {
+    storageName: registration.storageName,
+    versionId: registration.versionId,
+    s3Prefix: registration.s3Prefix,
+    s3Key: registration.s3Key,
+  });
+  return (
+    reusable !== undefined &&
+    reusable.size === registration.size &&
+    reusable.archiveSize === registration.archiveSize &&
+    reusable.fileCount === registration.fileCount
+  );
+}
+
+async function insertStorageVersion(
+  db: Db,
+  storageId: string,
+  registration: PreparedConnectorSkillRegistration,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const [inserted] = await db
+    .insert(storageVersions)
+    .values({
+      id: registration.versionId,
+      storageId,
+      s3Key: registration.s3Key,
+      size: registration.size,
+      archiveSize: registration.archiveSize,
+      fileCount: registration.fileCount,
+      message: null,
+      createdBy: SYSTEM_STORAGE_CREATOR,
+    })
+    .onConflictDoNothing()
+    .returning({ id: storageVersions.id });
+  signal.throwIfAborted();
+  return inserted !== undefined;
+}
+
+async function registerConnectorCatalogSkill(
+  db: Db,
+  registration: PreparedConnectorSkillRegistration,
+  signal: AbortSignal,
+): Promise<void> {
+  const existing = await readStorageVersion(db, registration.versionId, signal);
+  if (existing) {
+    if (!existingVersionMatchesRegistration(existing, registration)) {
+      fail("invalid-reference", false);
+    }
+    return;
+  }
+
+  const storage = await loadOrCreateStorage(db, registration, signal);
+  if (storage.s3Prefix !== registration.s3Prefix) {
+    fail("invalid-reference", false);
+  }
+  const inserted = await insertStorageVersion(
+    db,
+    storage.id,
+    registration,
+    signal,
+  );
+  if (!inserted) {
+    const raced = await readStorageVersion(db, registration.versionId, signal);
+    if (!raced || !existingVersionMatchesRegistration(raced, registration)) {
+      fail("invalid-reference", false);
+    }
+    return;
+  }
+
+  await db
+    .update(storages)
+    .set({
+      headVersionId: registration.versionId,
+      size: registration.size,
+      fileCount: registration.fileCount,
+      updatedAt: nowDate(),
+    })
+    .where(eq(storages.id, storage.id));
+  signal.throwIfAborted();
+}
+
+export async function registerPreparedConnectorCatalogSkills(args: {
+  readonly db: Db;
+  readonly registrations: readonly PreparedConnectorSkillRegistration[];
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  for (const registration of args.registrations) {
+    await registerConnectorCatalogSkill(args.db, registration, args.signal);
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
 import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
@@ -19,6 +19,7 @@ import type { ConnectorCatalogArtifactReader } from "./connector-catalog-artifac
 
 const CONNECTOR_SKILL_MANIFEST_MAX_BYTES = 128 * 1024;
 const CONNECTOR_SKILL_ARCHIVE_MAX_BYTES = CONNECTOR_SKILL_MAX_TOTAL_BYTES * 2;
+const CONNECTOR_SKILL_READ_CONCURRENCY = 8;
 const SYSTEM_STORAGE_CREATOR = "system";
 
 type PrivateConnector = ConnectorCatalogPrivateArtifact["connectors"][number];
@@ -42,8 +43,9 @@ interface ExistingStorageVersion {
   readonly createdBy: string;
 }
 
-interface StorageIdentity {
+interface CanonicalStorage {
   readonly id: string;
+  readonly name: string;
   readonly s3Prefix: string;
 }
 
@@ -55,6 +57,7 @@ interface ConnectorSkillIdentity {
 }
 
 export interface PreparedConnectorSkillRegistration {
+  readonly provenance: "existing" | "verified";
   readonly storageName: string;
   readonly versionId: string;
   readonly s3Prefix: string;
@@ -117,12 +120,19 @@ function reusableExistingVersion(
     existing.s3Prefix !== identity.s3Prefix ||
     existing.s3Key !== identity.s3Key ||
     existing.message !== null ||
-    existing.createdBy !== SYSTEM_STORAGE_CREATOR
+    existing.createdBy !== SYSTEM_STORAGE_CREATOR ||
+    !Number.isSafeInteger(existing.size) ||
+    existing.size < 0 ||
+    !Number.isSafeInteger(existing.archiveSize) ||
+    existing.archiveSize <= 0 ||
+    !Number.isSafeInteger(existing.fileCount) ||
+    existing.fileCount <= 0
   ) {
     return undefined;
   }
   return {
     ...identity,
+    provenance: "existing",
     size: existing.size,
     archiveSize: existing.archiveSize,
     fileCount: existing.fileCount,
@@ -233,6 +243,7 @@ async function verifySkill(
   const manifest = parseSkillManifest(manifestBytes);
   return {
     ...skillIdentity(skill),
+    provenance: "verified",
     size: manifest.files.reduce((total, file) => {
       return total + file.size;
     }, 0),
@@ -258,6 +269,7 @@ export async function prepareConnectorCatalogSkills(args: {
     args.signal,
   );
   const prepared: PreparedConnectorSkillRegistration[] = [];
+  const skillsToVerify: BundledConnectorSkill[] = [];
   for (const skill of bundledSkills) {
     const existing = existingByVersion.get(skill.versionId);
     if (existing) {
@@ -268,60 +280,24 @@ export async function prepareConnectorCatalogSkills(args: {
       prepared.push(reusable);
       continue;
     }
-    prepared.push(await verifySkill(args.reader, skill, args.signal));
+    skillsToVerify.push(skill);
+  }
+  for (
+    let offset = 0;
+    offset < skillsToVerify.length;
+    offset += CONNECTOR_SKILL_READ_CONCURRENCY
+  ) {
+    prepared.push(
+      ...(await Promise.all(
+        skillsToVerify
+          .slice(offset, offset + CONNECTOR_SKILL_READ_CONCURRENCY)
+          .map(async (skill) => {
+            return await verifySkill(args.reader, skill, args.signal);
+          }),
+      )),
+    );
   }
   return prepared;
-}
-
-async function readStorageVersion(
-  db: Db,
-  versionId: string,
-  signal: AbortSignal,
-): Promise<ExistingStorageVersion | undefined> {
-  const versions = await readExistingVersions(db, [versionId], signal);
-  return versions.get(versionId);
-}
-
-async function loadOrCreateStorage(
-  db: Db,
-  registration: PreparedConnectorSkillRegistration,
-  signal: AbortSignal,
-): Promise<StorageIdentity> {
-  const [created] = await db
-    .insert(storages)
-    .values({
-      orgId: SYSTEM_ORG_ID,
-      userId: VOLUME_ORG_USER_ID,
-      name: registration.storageName,
-      type: "volume",
-      s3Prefix: registration.s3Prefix,
-      size: registration.size,
-      fileCount: registration.fileCount,
-    })
-    .onConflictDoNothing()
-    .returning({ id: storages.id, s3Prefix: storages.s3Prefix });
-  signal.throwIfAborted();
-  if (created) {
-    return created;
-  }
-
-  const [storage] = await db
-    .select({ id: storages.id, s3Prefix: storages.s3Prefix })
-    .from(storages)
-    .where(
-      and(
-        eq(storages.orgId, SYSTEM_ORG_ID),
-        eq(storages.userId, VOLUME_ORG_USER_ID),
-        eq(storages.name, registration.storageName),
-        eq(storages.type, "volume"),
-      ),
-    )
-    .limit(1);
-  signal.throwIfAborted();
-  if (!storage) {
-    throw new Error("Connector skill storage was not created");
-  }
-  return storage;
 }
 
 function existingVersionMatchesRegistration(
@@ -342,71 +318,215 @@ function existingVersionMatchesRegistration(
   );
 }
 
-async function insertStorageVersion(
+async function missingRegistrations(
   db: Db,
-  storageId: string,
-  registration: PreparedConnectorSkillRegistration,
+  registrations: readonly PreparedConnectorSkillRegistration[],
   signal: AbortSignal,
-): Promise<boolean> {
-  const [inserted] = await db
-    .insert(storageVersions)
-    .values({
-      id: registration.versionId,
-      storageId,
-      s3Key: registration.s3Key,
-      size: registration.size,
-      archiveSize: registration.archiveSize,
-      fileCount: registration.fileCount,
-      message: null,
-      createdBy: SYSTEM_STORAGE_CREATOR,
+): Promise<readonly PreparedConnectorSkillRegistration[]> {
+  const existingByVersion = await readExistingVersions(
+    db,
+    registrations.map((registration) => {
+      return registration.versionId;
+    }),
+    signal,
+  );
+  const missing: PreparedConnectorSkillRegistration[] = [];
+  for (const registration of registrations) {
+    const existing = existingByVersion.get(registration.versionId);
+    if (existing) {
+      if (!existingVersionMatchesRegistration(existing, registration)) {
+        fail("invalid-reference", false);
+      }
+      continue;
+    }
+    if (registration.provenance === "existing") {
+      fail("invalid-reference", false);
+    }
+    missing.push(registration);
+  }
+  return missing;
+}
+
+async function createAndReadCanonicalStorages(
+  db: Db,
+  registrations: readonly PreparedConnectorSkillRegistration[],
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, CanonicalStorage>> {
+  await db
+    .insert(storages)
+    .values(
+      registrations.map((registration) => {
+        return {
+          orgId: SYSTEM_ORG_ID,
+          userId: VOLUME_ORG_USER_ID,
+          name: registration.storageName,
+          type: "volume",
+          s3Prefix: registration.s3Prefix,
+          size: registration.size,
+          fileCount: registration.fileCount,
+        };
+      }),
+    )
+    .onConflictDoNothing();
+  signal.throwIfAborted();
+
+  const rows = await db
+    .select({
+      id: storages.id,
+      name: storages.name,
+      s3Prefix: storages.s3Prefix,
     })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, SYSTEM_ORG_ID),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.type, "volume"),
+        inArray(
+          storages.name,
+          registrations.map((registration) => {
+            return registration.storageName;
+          }),
+        ),
+      ),
+    );
+  signal.throwIfAborted();
+  const byName = new Map(
+    rows.map((row) => {
+      return [row.name, row] as const;
+    }),
+  );
+  for (const registration of registrations) {
+    const storage = byName.get(registration.storageName);
+    if (!storage) {
+      throw new Error("Connector skill storage was not created");
+    }
+    if (storage.s3Prefix !== registration.s3Prefix) {
+      fail("invalid-reference", false);
+    }
+  }
+  return byName;
+}
+
+async function insertAndValidateStorageVersions(
+  db: Db,
+  registrations: readonly PreparedConnectorSkillRegistration[],
+  storageByName: ReadonlyMap<string, CanonicalStorage>,
+  signal: AbortSignal,
+): Promise<ReadonlySet<string>> {
+  const inserted = await db
+    .insert(storageVersions)
+    .values(
+      registrations.map((registration) => {
+        const storage = storageByName.get(registration.storageName);
+        if (!storage) {
+          throw new Error("Connector skill storage is unavailable");
+        }
+        return {
+          id: registration.versionId,
+          storageId: storage.id,
+          s3Key: registration.s3Key,
+          size: registration.size,
+          archiveSize: registration.archiveSize,
+          fileCount: registration.fileCount,
+          message: null,
+          createdBy: SYSTEM_STORAGE_CREATOR,
+        };
+      }),
+    )
     .onConflictDoNothing()
     .returning({ id: storageVersions.id });
   signal.throwIfAborted();
-  return inserted !== undefined;
-}
-
-async function registerConnectorCatalogSkill(
-  db: Db,
-  registration: PreparedConnectorSkillRegistration,
-  signal: AbortSignal,
-): Promise<void> {
-  const existing = await readStorageVersion(db, registration.versionId, signal);
-  if (existing) {
-    if (!existingVersionMatchesRegistration(existing, registration)) {
-      fail("invalid-reference", false);
-    }
-    return;
-  }
-
-  const storage = await loadOrCreateStorage(db, registration, signal);
-  if (storage.s3Prefix !== registration.s3Prefix) {
-    fail("invalid-reference", false);
-  }
-  const inserted = await insertStorageVersion(
+  const existingByVersion = await readExistingVersions(
     db,
-    storage.id,
-    registration,
+    registrations.map((registration) => {
+      return registration.versionId;
+    }),
     signal,
   );
-  if (!inserted) {
-    const raced = await readStorageVersion(db, registration.versionId, signal);
-    if (!raced || !existingVersionMatchesRegistration(raced, registration)) {
+  for (const registration of registrations) {
+    const existing = existingByVersion.get(registration.versionId);
+    if (
+      !existing ||
+      !existingVersionMatchesRegistration(existing, registration)
+    ) {
       fail("invalid-reference", false);
     }
+  }
+  return new Set(
+    inserted.map((row) => {
+      return row.id;
+    }),
+  );
+}
+
+async function updateNewStorageHeads(
+  db: Db,
+  registrations: readonly PreparedConnectorSkillRegistration[],
+  signal: AbortSignal,
+): Promise<void> {
+  const updatedAt = nowDate();
+  const updated = await db
+    .insert(storages)
+    .values(
+      registrations.map((registration) => {
+        return {
+          orgId: SYSTEM_ORG_ID,
+          userId: VOLUME_ORG_USER_ID,
+          name: registration.storageName,
+          type: "volume",
+          s3Prefix: registration.s3Prefix,
+          size: registration.size,
+          fileCount: registration.fileCount,
+          headVersionId: registration.versionId,
+          updatedAt,
+        };
+      }),
+    )
+    .onConflictDoUpdate({
+      target: [storages.orgId, storages.userId, storages.name, storages.type],
+      set: {
+        headVersionId: sql`excluded.head_version_id`,
+        size: sql`excluded.size`,
+        fileCount: sql`excluded.file_count`,
+        updatedAt: sql`excluded.updated_at`,
+      },
+      setWhere: eq(storages.s3Prefix, sql`excluded.s3_prefix`),
+    })
+    .returning({ name: storages.name });
+  signal.throwIfAborted();
+  if (updated.length !== registrations.length) {
+    fail("invalid-reference", false);
+  }
+}
+
+async function registerConnectorCatalogSkills(
+  db: Db,
+  registrations: readonly PreparedConnectorSkillRegistration[],
+  signal: AbortSignal,
+): Promise<void> {
+  const missing = await missingRegistrations(db, registrations, signal);
+  if (missing.length === 0) {
     return;
   }
-
-  await db
-    .update(storages)
-    .set({
-      headVersionId: registration.versionId,
-      size: registration.size,
-      fileCount: registration.fileCount,
-      updatedAt: nowDate(),
-    })
-    .where(eq(storages.id, storage.id));
-  signal.throwIfAborted();
+  const storageByName = await createAndReadCanonicalStorages(
+    db,
+    missing,
+    signal,
+  );
+  const insertedVersionIds = await insertAndValidateStorageVersions(
+    db,
+    missing,
+    storageByName,
+    signal,
+  );
+  const newHeads = missing.filter((registration) => {
+    return insertedVersionIds.has(registration.versionId);
+  });
+  if (newHeads.length === 0) {
+    return;
+  }
+  await updateNewStorageHeads(db, newHeads, signal);
 }
 
 export async function registerPreparedConnectorCatalogSkills(args: {
@@ -414,7 +534,12 @@ export async function registerPreparedConnectorCatalogSkills(args: {
   readonly registrations: readonly PreparedConnectorSkillRegistration[];
   readonly signal: AbortSignal;
 }): Promise<void> {
-  for (const registration of args.registrations) {
-    await registerConnectorCatalogSkill(args.db, registration, args.signal);
+  if (args.registrations.length === 0) {
+    return;
   }
+  await registerConnectorCatalogSkills(
+    args.db,
+    args.registrations,
+    args.signal,
+  );
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -36,6 +36,13 @@ import {
   type ConnectorCatalogArtifactReader,
   type ValidatedConnectorCatalogCandidate,
 } from "./connector-catalog-artifacts/loader";
+import {
+  connectorCatalogSkillFailure,
+  prepareConnectorCatalogSkills,
+  registerPreparedConnectorCatalogSkills,
+  type ConnectorCatalogSkillFailure,
+  type PreparedConnectorSkillRegistration,
+} from "./connector-catalog-skill-registration.service";
 
 const log = logger("connector-catalog:sync");
 
@@ -82,7 +89,13 @@ interface RejectedCandidate {
   readonly failureCode: ConnectorCatalogSyncFailureCode;
 }
 
-type CandidateCommitResult = "accepted" | "retry";
+type CandidateCommitResult =
+  | "accepted"
+  | "retry"
+  | {
+      readonly kind: "rejected";
+      readonly failure: ConnectorCatalogSkillFailure;
+    };
 
 class CandidateCommitRetry extends Error {}
 
@@ -493,11 +506,18 @@ async function commitCandidate(args: {
   readonly sourceId: string;
   readonly baseline: SyncStateSnapshot | undefined;
   readonly candidate: ValidatedConnectorCatalogCandidate;
+  readonly skillRegistrations: readonly PreparedConnectorSkillRegistration[];
   readonly pointerObservation: PointerObservation;
   readonly attemptedAt: Date;
+  readonly signal: AbortSignal;
 }): Promise<CandidateCommitResult> {
   const result = await settle(
     args.db.transaction(async (tx) => {
+      await registerPreparedConnectorCatalogSkills({
+        db: tx,
+        registrations: args.skillRegistrations,
+        signal: args.signal,
+      });
       await activateCandidate({ ...args, db: tx });
       return "accepted" as const;
     }),
@@ -507,6 +527,10 @@ async function commitCandidate(args: {
   }
   if (result.error instanceof CandidateCommitRetry) {
     return "retry";
+  }
+  const skillFailure = connectorCatalogSkillFailure(result.error);
+  if (skillFailure) {
+    return { kind: "rejected", failure: skillFailure };
   }
   throw new ConnectorCatalogPersistenceError();
 }
@@ -595,16 +619,16 @@ async function rejectSyncAttempt(
   baseline: SyncStateSnapshot | undefined,
   failureCode: ConnectorCatalogSyncFailureCode,
   pointerObservation?: PointerObservation,
+  cacheable = true,
 ): Promise<SyncAttemptResult> {
   const response = await rejectCandidate({
     db: runtime.db,
     source: runtime.source,
     baseline,
     failureCode,
-    rejectedCandidate: cacheableRejectedCandidate(
-      pointerObservation,
-      failureCode,
-    ),
+    rejectedCandidate: cacheable
+      ? cacheableRejectedCandidate(pointerObservation, failureCode)
+      : undefined,
     pointerObservation,
   });
   runtime.signal.throwIfAborted();
@@ -711,6 +735,7 @@ async function commitValidatedCandidate(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot | undefined,
   candidate: ValidatedConnectorCatalogCandidate,
+  skillRegistrations: readonly PreparedConnectorSkillRegistration[],
   pointerObservation: PointerObservation,
 ): Promise<SyncAttemptResult> {
   const outcome = await commitCandidate({
@@ -718,12 +743,23 @@ async function commitValidatedCandidate(
     sourceId: runtime.source.sourceId,
     baseline,
     candidate,
+    skillRegistrations,
     pointerObservation,
     attemptedAt: nowDate(),
+    signal: runtime.signal,
   });
   runtime.signal.throwIfAborted();
   if (outcome === "retry") {
     return { kind: "retry" };
+  }
+  if (typeof outcome !== "string") {
+    return await rejectSyncAttempt(
+      runtime,
+      baseline,
+      outcome.failure.code,
+      pointerObservation,
+      outcome.failure.cacheable,
+    );
   }
   log.debug("Connector catalog sync completed", {
     sourceId: runtime.source.sourceId,
@@ -739,6 +775,44 @@ async function commitValidatedCandidate(
   });
   runtime.signal.throwIfAborted();
   return { kind: "complete", response };
+}
+
+type CandidateSkillPreparationResult =
+  | SyncAttemptResult
+  | {
+      readonly kind: "prepared";
+      readonly registrations: readonly PreparedConnectorSkillRegistration[];
+    };
+
+async function prepareCandidateSkillsForSync(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot | undefined,
+  candidate: ValidatedConnectorCatalogCandidate,
+  pointerObservation: PointerObservation,
+): Promise<CandidateSkillPreparationResult> {
+  const prepared = await settle(
+    prepareConnectorCatalogSkills({
+      db: runtime.db,
+      reader: runtime.reader,
+      privateArtifact: candidate.privateArtifact,
+      signal: runtime.signal,
+    }),
+    runtime.signal,
+  );
+  if (prepared.ok) {
+    return { kind: "prepared", registrations: prepared.value };
+  }
+  const failure = connectorCatalogSkillFailure(prepared.error);
+  if (!failure) {
+    throw prepared.error;
+  }
+  return await rejectSyncAttempt(
+    runtime,
+    baseline,
+    failure.code,
+    pointerObservation,
+    failure.cacheable,
+  );
 }
 
 async function syncConnectorCatalogAttempt(
@@ -803,10 +877,20 @@ async function syncConnectorCatalogAttempt(
   if (candidateResult.kind !== "loaded") {
     return candidateResult;
   }
+  const skillPreparation = await prepareCandidateSkillsForSync(
+    runtime,
+    baseline,
+    candidateResult.candidate,
+    pointerObservation,
+  );
+  if (skillPreparation.kind !== "prepared") {
+    return skillPreparation;
+  }
   return await commitValidatedCandidate(
     runtime,
     baseline,
     candidateResult.candidate,
+    skillPreparation.registrations,
     pointerObservation,
   );
 }


### PR DESCRIPTION
## Summary

- verify manifest and archive objects referenced by bundled connector skills during catalog sync
- create or reuse canonical system-owned storage versions in the same transaction as snapshot activation
- retain historical versions, avoid redundant R2 reads, and reject invalid or conflicting candidates without partial registration
- bound first-sync R2 concurrency and batch database reconciliation for the complete connector inventory

## Architecture

`vm0-connectors` remains the publisher: it uploads immutable connector and skill objects directly to `R2_USER_STORAGES_BUCKET_NAME` and writes `active.json` last. vm0 does not expose a publisher callback or shared publisher credential. Instead, vm0 verifies missing bundled skill objects while consuming a candidate release and atomically reconciles the database records its runtime already requires.

This PR does not change publisher upload paths, the active-pointer format, runtime storage manifests, frontend routes, runner protocols, source-mode defaults, or model-provider behavior. It adds no environment variable or database migration.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --maxWorkers=1 --silent=passed-only` (91 tests)

Closes #22529

Parent context: https://github.com/vm0-ai/vm0-connectors/issues/1
