### PR TITLE
refactor(api): convert active run lookups to drizzle builders

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -182,6 +182,7 @@ export default [
       "api/no-store-in-params": "error",
       "api/no-unsafe-sql-interpolation": "error",
       "api/prefer-drizzle-apis": "error",
+      "api/prefer-drizzle-query-builder": "error",
       "api/require-execute-row-schema": "error",
       "api/require-sql-result-mapping": "error",
       "api/signal-check-await": "error",

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -9,7 +9,6 @@ import {
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { agentSessions } from "@vm0/db/schema/agent-session";
-import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import {
@@ -54,7 +53,6 @@ import {
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
 import {
@@ -103,6 +101,7 @@ import {
   updateChatMessage,
 } from "../services/zero-chat-message.service";
 import { loadWebChatIncompleteContext } from "../services/zero-chat-incomplete-context.service";
+import { activeChatRunExists } from "../services/zero-chat-active-run.service";
 import { projectStructuredUserMessage } from "../services/zero-chat-structured-message.service";
 import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-marker.service";
 import {
@@ -363,7 +362,6 @@ const sendBody$ = bodyResultOf(chatMessagesContract.send);
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
-const idRowSchema = z.object({ id: z.string() });
 const replacementChatMessage = alias(chatMessages, "replacement_chat_message");
 const replacementAgentRun = alias(agentRuns, "replacement_agent_run");
 
@@ -832,7 +830,7 @@ async function latestSessionForThread(
     // mirrored in latestSessionForThreadFromDb
     // (internal-chat-run-callback.service.ts) and latestSessionIdForThread
     // (zero-goal-continuation.service.ts) — keep them in sync. This is a
-    // continuity filter ONLY; it must NOT be copied into activeRunExistsForThread.
+    // continuity filter ONLY; it must NOT be copied into activeChatRunExists.
     .where(
       and(
         eq(zeroRuns.chatThreadId, threadId),
@@ -936,40 +934,6 @@ async function getLatestRunsByThreadId(
       messages: messagesByRunId.get(run.runId) ?? [],
     };
   });
-}
-
-async function activeRunExistsForThread(
-  db: Db,
-  threadId: string,
-): Promise<boolean> {
-  const runs = await executeRawRows(
-    db,
-    sql`
-      SELECT ${zeroRuns.id} AS "id"
-      FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
-      WHERE ${eq(zeroRuns.chatThreadId, threadId)}
-        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-        AND (
-          NOT EXISTS (
-            SELECT 1
-            FROM ${agentRunCallbacks}
-            WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
-              AND ${agentRunCallbacks.internalKind} = 'chat'
-              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-          )
-          OR EXISTS (
-            SELECT 1
-            FROM ${chatMessages}
-            WHERE ${eq(chatMessages.runId, zeroRuns.id)}
-              AND ${chatMessages.role} = 'user'
-          )
-        )
-      LIMIT 1
-    `,
-    idRowSchema,
-  );
-  return runs[0] !== undefined;
 }
 
 async function resolveClientMessageSend(params: {
@@ -3284,10 +3248,9 @@ const sendNormalMessage$ = command(
       "api_dispatch_pre_create_zero_web_chat_check_active_run",
       "nested",
       async () => {
-        return await activeRunExistsForThread(
-          prepared.db,
-          prepared.thread.threadId,
-        );
+        return await activeChatRunExists(prepared.db, {
+          threadId: prepared.thread.threadId,
+        });
       },
     );
     signal.throwIfAborted();
@@ -3346,7 +3309,7 @@ const sendQueueFirstNormalMessage$ = command(
       "api_dispatch_pre_create_zero_web_chat_queue_first_check_dispatchable",
       "nested",
       async (): Promise<"self" | "wait" | "drain"> => {
-        if (await activeRunExistsForThread(prepared.db, threadId)) {
+        if (await activeChatRunExists(prepared.db, { threadId })) {
           return "wait";
         }
         const head = await loadNextUnclaimedQueuedUserMessage(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -27,14 +27,12 @@ import {
   isNotNull,
   lte,
   max,
-  ne,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
 
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { nullableDriverValueDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -69,6 +67,7 @@ import {
 } from "./zero-chat-message-shared.service";
 import { insertChatMessage } from "./zero-chat-message.service";
 import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
+import { activeChatRunExists } from "./zero-chat-active-run.service";
 import { projectStructuredUserMessage } from "./zero-chat-structured-message.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { recommendedFollowupsMessageIdForRun } from "./assistant-message-id";
@@ -101,8 +100,6 @@ const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
-const idRowSchema = z.object({ id: z.string() });
-
 type ChatCallbackPreCreateTimingSpanKind = "top_level" | "nested";
 
 type ChatCallbackPreCreateTimingActionType =
@@ -1685,40 +1682,6 @@ async function loadAgentForAutoSend(
   return agent ?? null;
 }
 
-async function activeChatRunExistsForThread(
-  db: Db,
-  threadId: string,
-): Promise<boolean> {
-  const runs = await executeRawRows(
-    db,
-    sql`
-      SELECT ${zeroRuns.id} AS "id"
-      FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
-      WHERE ${eq(zeroRuns.chatThreadId, threadId)}
-        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-        AND (
-          NOT EXISTS (
-            SELECT 1
-            FROM ${agentRunCallbacks}
-            WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
-              AND ${agentRunCallbacks.internalKind} = 'chat'
-              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-          )
-          OR EXISTS (
-            SELECT 1
-            FROM ${chatMessages}
-            WHERE ${eq(chatMessages.runId, zeroRuns.id)}
-              AND ${chatMessages.role} = 'user'
-          )
-        )
-      LIMIT 1
-    `,
-    idRowSchema,
-  );
-  return runs[0] !== undefined;
-}
-
 async function chatThreadExists(db: Db, threadId: string): Promise<boolean> {
   const [thread] = await db
     .select({ id: chatThreads.id })
@@ -2081,35 +2044,11 @@ async function claimQueuedUserMessageForDispatch(args: {
     // message. Concurrent drains may insert more than one candidate before
     // reaching this serialized gate; ignoring those unclaimed candidates lets
     // one claim win while the others cancel before dispatch.
-    const competingRuns = await executeRawRows(
-      tx,
-      sql`
-        SELECT ${zeroRuns.id} AS "id"
-        FROM ${zeroRuns}
-        INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
-        WHERE ${eq(zeroRuns.chatThreadId, args.threadId)}
-          AND ${ne(zeroRuns.id, args.runId)}
-          AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-          AND (
-            NOT EXISTS (
-              SELECT 1
-              FROM ${agentRunCallbacks}
-              WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
-                AND ${agentRunCallbacks.internalKind} = 'chat'
-                AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM ${chatMessages}
-              WHERE ${eq(chatMessages.runId, zeroRuns.id)}
-                AND ${chatMessages.role} = 'user'
-            )
-          )
-        LIMIT 1
-      `,
-      idRowSchema,
-    );
-    if (competingRuns[0]) {
+    const competingRunExists = await activeChatRunExists(tx, {
+      threadId: args.threadId,
+      excludeRunId: args.runId,
+    });
+    if (competingRunExists) {
       return null;
     }
 
@@ -2330,7 +2269,7 @@ async function autoSendQueuedMessageForThread(args: {
     "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run",
     "nested",
     () => {
-      return activeChatRunExistsForThread(args.db, threadId);
+      return activeChatRunExists(args.db, { threadId });
     },
   );
   if (activeRunExists) {

--- a/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
@@ -1,0 +1,71 @@
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  and,
+  eq,
+  exists,
+  inArray,
+  isNotNull,
+  ne,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+const ACTIVE_CHAT_RUN_STATUSES = ["queued", "pending", "running"] as const;
+
+export async function activeChatRunExists(
+  db: Pick<Db, "select">,
+  args: {
+    readonly threadId: string;
+    readonly excludeRunId?: string;
+  },
+): Promise<boolean> {
+  const [run] = await db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, args.threadId),
+        args.excludeRunId === undefined
+          ? undefined
+          : ne(zeroRuns.id, args.excludeRunId),
+        inArray(agentRuns.status, ACTIVE_CHAT_RUN_STATUSES),
+        or(
+          notExists(
+            db
+              .select({ id: agentRunCallbacks.id })
+              .from(agentRunCallbacks)
+              .where(
+                and(
+                  eq(agentRunCallbacks.runId, zeroRuns.id),
+                  eq(agentRunCallbacks.internalKind, "chat"),
+                  isNotNull(
+                    sql`${agentRunCallbacks.payload}->>'queuedMessageId'`,
+                  ),
+                ),
+              ),
+          ),
+          exists(
+            db
+              .select({ id: chatMessages.id })
+              .from(chatMessages)
+              .where(
+                and(
+                  eq(chatMessages.runId, zeroRuns.id),
+                  eq(chatMessages.role, "user"),
+                ),
+              ),
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+
+  return run !== undefined;
+}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -1,0 +1,296 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, it } from "vitest";
+
+import { preferDrizzleQueryBuilder } from "../rules/prefer-drizzle-query-builder.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+const rawRowsImport = `
+  import { executeRawRows } from "./lib/db-raw-rows";
+`;
+
+const schemaPreamble = `
+  import { integer, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+
+  const runs = pgTable("runs", {
+    id: integer("id").notNull(),
+    threadId: integer("thread_id").notNull(),
+  });
+  const runStates = pgTable("run_states", {
+    id: integer("id").notNull(),
+    status: text("status").notNull(),
+  });
+  const callbacks = pgTable("callbacks", {
+    id: integer("id").notNull(),
+    runId: integer("run_id").notNull(),
+    payload: jsonb("payload").notNull(),
+  });
+  declare const db: never;
+  declare const rowSchema: never;
+  declare const threadId: number;
+  declare const excludedRunId: number;
+`;
+
+const directQuery = `
+  sql\`
+    SELECT \${runs.id} AS "id"
+    FROM \${runs}
+    INNER JOIN \${runStates} ON \${eq(runStates.id, runs.id)}
+    WHERE \${eq(runs.threadId, threadId)}
+      AND \${runStates.status} IN ('queued', 'pending', 'running')
+      AND (
+        NOT EXISTS (
+          SELECT 1 FROM \${callbacks}
+          WHERE \${eq(callbacks.runId, runs.id)}
+            AND \${callbacks.payload}->>'queuedMessageId' IS NOT NULL
+        )
+        OR \${eq(runs.id, excludedRunId)}
+      )
+    LIMIT 1
+  \`
+`;
+
+ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
+  valid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        import { integer, pgTable } from "drizzle-orm/pg-core";
+        const users = pgTable("users", { id: integer("id").notNull() });
+        sql\`\${users.id}\`;
+      `,
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        async function executeRawRows(...args: unknown[]) { return args; }
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "./other/db-raw-rows";
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        const query = ${directQuery};
+        await executeRawRows(db, query, rowSchema);
+      `,
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
+        function runLocal(
+          decodeRows: (...args: unknown[]) => unknown,
+        ) {
+          return decodeRows(db, ${directQuery}, rowSchema);
+        }
+        runLocal(() => undefined);
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const eq = (...values: unknown[]) => values;
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT 1 FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id}, \${runs.threadId} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM runs WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} LEFT JOIN \${runStates} ON \${eq(runStates.id, runs.id)} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} INNER JOIN \${runStates} ON \${1} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} ORDER BY \${runs.id} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} FOR UPDATE LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT \${1}\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 2\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)}\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`WITH candidate AS (SELECT 1) SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} LIMIT 1\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql as query } from "drizzle-orm";
+        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
+        await decodeRows(
+          db,
+          query\`select \${runs.id} from \${runs} inner join \${runStates} on \${eq(runStates.id, runs.id)} where \${eq(runs.threadId, threadId)} and \${eq(runs.id, excludedRunId)} limit 1;\`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${schemaPreamble}
+        import * as drizzle from "drizzle-orm";
+        import * as rawRows from "./lib/db-raw-rows";
+        await rawRows.executeRawRows(
+          db,
+          drizzle.sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            INNER JOIN \${runStates}
+              ON \${drizzle.eq(runStates.id, runs.id)}
+            WHERE \${drizzle.eq(runs.threadId, threadId)}
+              AND $$ORDER BY ignored$$ = $$ORDER BY ignored$$
+              /* GROUP BY ignored /* nested ORDER BY */ */
+              AND (SELECT 1 FROM ignored ORDER BY ignored LIMIT 1) = 1
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -9,6 +9,7 @@ import { noSqlRaw } from "./rules/no-sql-raw.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
 import { noUnsafeSqlInterpolation } from "./rules/no-unsafe-sql-interpolation.ts";
 import { preferDrizzleApis } from "./rules/prefer-drizzle-apis.ts";
+import { preferDrizzleQueryBuilder } from "./rules/prefer-drizzle-query-builder.ts";
 import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
 import { requireSqlResultMapping } from "./rules/require-sql-result-mapping.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
@@ -30,6 +31,7 @@ export const apiLintPlugin = {
     "no-test-vi-mocks": noTestViMocks,
     "no-unsafe-sql-interpolation": noUnsafeSqlInterpolation,
     "prefer-drizzle-apis": preferDrizzleApis,
+    "prefer-drizzle-query-builder": preferDrizzleQueryBuilder,
     "require-execute-row-schema": requireExecuteRowSchema,
     "require-sql-result-mapping": requireSqlResultMapping,
     "signal-check-await": signalCheckAwait,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -39,6 +39,10 @@ import {
   isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
+import {
+  SQL_TEMPLATE_EXPRESSION_BOUNDARY,
+  sqlCodeMask,
+} from "../sql-lexing.ts";
 import { createRule } from "../utils.ts";
 
 type BinaryLeftOperand = "array" | "pattern" | "wrapper";
@@ -51,8 +55,6 @@ interface BinaryHelper {
   readonly right: BinaryRightOperand;
   readonly rightBoundary: BinaryRightBoundary;
 }
-
-const TEMPLATE_EXPRESSION_BOUNDARY = "\u0000";
 
 const BINARY_HELPERS = new Map<string, BinaryHelper>([
   [
@@ -335,7 +337,7 @@ function hasSqlIdentifierPrefix(source: string, start: number): boolean {
   return (
     isSqlIdentifierCharacter(source[start - 1]) ||
     previous === "." ||
-    previous === TEMPLATE_EXPRESSION_BOUNDARY
+    previous === SQL_TEMPLATE_EXPRESSION_BOUNDARY
   );
 }
 
@@ -412,137 +414,6 @@ function rangeMatch(
     return { helper: "between" };
   }
   return operator === "NOT BETWEEN" ? { helper: "notBetween" } : undefined;
-}
-
-type SqlLexicalState =
-  | { readonly kind: "block-comment"; readonly depth: number }
-  | { readonly kind: "code" }
-  | { readonly kind: "dollar-quote"; readonly delimiter: string }
-  | { readonly kind: "double-quote" }
-  | { readonly kind: "line-comment" }
-  | { readonly kind: "single-quote" };
-
-function sqlCodeMask(source: string): string {
-  const mask = source.split("");
-  let state: SqlLexicalState = { kind: "code" };
-  let offset = 0;
-  while (offset < source.length) {
-    if (source[offset] === TEMPLATE_EXPRESSION_BOUNDARY) {
-      mask[offset] = TEMPLATE_EXPRESSION_BOUNDARY;
-      offset += 1;
-      continue;
-    }
-    if (state.kind === "code") {
-      const pair = source.slice(offset, offset + 2);
-      if (pair === "--") {
-        mask[offset] = " ";
-        mask[offset + 1] = " ";
-        state = { kind: "line-comment" };
-        offset += 2;
-        continue;
-      }
-      if (pair === "/*") {
-        mask[offset] = " ";
-        mask[offset + 1] = " ";
-        state = { kind: "block-comment", depth: 1 };
-        offset += 2;
-        continue;
-      }
-      const character = source[offset];
-      if (character === "'") {
-        mask[offset] = " ";
-        state = { kind: "single-quote" };
-        offset += 1;
-        continue;
-      }
-      if (character === '"') {
-        mask[offset] = " ";
-        state = { kind: "double-quote" };
-        offset += 1;
-        continue;
-      }
-      if (character === "$") {
-        const delimiter = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/.exec(
-          source.slice(offset),
-        )?.[0];
-        if (delimiter !== undefined) {
-          for (let index = 0; index < delimiter.length; index += 1) {
-            mask[offset + index] = " ";
-          }
-          state = { kind: "dollar-quote", delimiter };
-          offset += delimiter.length;
-          continue;
-        }
-      }
-      offset += 1;
-      continue;
-    }
-
-    const character = source[offset];
-    mask[offset] = character === "\n" ? "\n" : " ";
-    if (state.kind === "line-comment") {
-      if (character === "\n") {
-        state = { kind: "code" };
-      }
-      offset += 1;
-      continue;
-    }
-    if (state.kind === "block-comment") {
-      const pair = source.slice(offset, offset + 2);
-      if (pair === "/*") {
-        mask[offset + 1] = " ";
-        state = { kind: "block-comment", depth: state.depth + 1 };
-        offset += 2;
-        continue;
-      }
-      if (pair === "*/") {
-        mask[offset + 1] = " ";
-        const depth: number = state.depth - 1;
-        state =
-          depth === 0 ? { kind: "code" } : { kind: "block-comment", depth };
-        offset += 2;
-        continue;
-      }
-      offset += 1;
-      continue;
-    }
-    if (state.kind === "dollar-quote") {
-      if (source.startsWith(state.delimiter, offset)) {
-        for (let index = 0; index < state.delimiter.length; index += 1) {
-          mask[offset + index] = " ";
-        }
-        offset += state.delimiter.length;
-        state = { kind: "code" };
-      } else {
-        offset += 1;
-      }
-      continue;
-    }
-
-    const quote = state.kind === "single-quote" ? "'" : '"';
-    if (character !== quote) {
-      offset += 1;
-      continue;
-    }
-    if (source[offset + 1] === quote) {
-      mask[offset + 1] = " ";
-      offset += 2;
-      continue;
-    }
-    let backslashes = 0;
-    for (
-      let index = offset - 1;
-      index >= 0 && source[index] === "\\";
-      index -= 1
-    ) {
-      backslashes += 1;
-    }
-    if (backslashes % 2 === 0) {
-      state = { kind: "code" };
-    }
-    offset += 1;
-  }
-  return mask.join("");
 }
 
 function skipSqlWhitespace(source: string, start: number): number {
@@ -1375,9 +1246,11 @@ export const preferDrizzleApis = createRule({
 
         const quasis = node.quasi.quasis.map(quasiText);
         const syntaxSource = sqlCodeMask(
-          quasis.join(TEMPLATE_EXPRESSION_BOUNDARY),
+          quasis.join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
         );
-        const syntaxQuasis = syntaxSource.split(TEMPLATE_EXPRESSION_BOUNDARY);
+        const syntaxQuasis = syntaxSource.split(
+          SQL_TEMPLATE_EXPRESSION_BOUNDARY,
+        );
         const expressions = node.quasi.expressions;
         if (
           expressions.length === 0 &&
@@ -1530,7 +1403,9 @@ export const preferDrizzleApis = createRule({
 
           const aggregate = aggregateMatch(prefix);
           const aggregateSuffix = aggregateRemainder(
-            syntaxQuasis.slice(index + 1).join(TEMPLATE_EXPRESSION_BOUNDARY),
+            syntaxQuasis
+              .slice(index + 1)
+              .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
           );
           if (
             aggregate === undefined ||

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -1,0 +1,493 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  isImportDeclaration,
+  isImportSpecifier,
+  isNamespaceImport,
+  isStringLiteral,
+  type Node,
+} from "typescript";
+
+import {
+  isDrizzleColumnType,
+  isDrizzleSqlTag,
+  isDrizzleTableType,
+  isDrizzleWrapperType,
+} from "../drizzle.ts";
+import {
+  SQL_TEMPLATE_EXPRESSION_BOUNDARY,
+  sqlCodeMask,
+} from "../sql-lexing.ts";
+import { createRule } from "../utils.ts";
+
+interface SqlTokenBase {
+  readonly end: number;
+  readonly start: number;
+}
+
+interface ExpressionToken extends SqlTokenBase {
+  readonly expressionIndex: number;
+  readonly kind: "expression";
+}
+
+interface NumberToken extends SqlTokenBase {
+  readonly kind: "number";
+  readonly value: string;
+}
+
+interface PunctuationToken extends SqlTokenBase {
+  readonly kind: "punctuation";
+  readonly value: "(" | ")" | "," | ";";
+}
+
+interface WordToken extends SqlTokenBase {
+  readonly kind: "word";
+  readonly value: string;
+}
+
+type SqlToken = ExpressionToken | NumberToken | PunctuationToken | WordToken;
+
+interface SimpleSelectMatch {
+  readonly joinConditionExpressionIndexes: readonly number[];
+  readonly joinTableExpressionIndexes: readonly number[];
+  readonly selectedColumnExpressionIndex: number;
+  readonly sourceTableExpressionIndex: number;
+}
+
+const UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS = new Set([
+  "EXCEPT",
+  "FETCH",
+  "FOR",
+  "GROUP",
+  "HAVING",
+  "INTERSECT",
+  "LIMIT",
+  "OFFSET",
+  "ORDER",
+  "QUALIFY",
+  "UNION",
+  "WINDOW",
+]);
+
+function quasiText(node: TSESTree.TemplateElement): string {
+  return node.value.cooked ?? node.value.raw;
+}
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function importSource(node: Node): string | undefined {
+  let current: Node | undefined = node;
+  while (current !== undefined && !isImportDeclaration(current)) {
+    current = current.parent;
+  }
+  return current !== undefined && isStringLiteral(current.moduleSpecifier)
+    ? current.moduleSpecifier.text.replaceAll("\\", "/")
+    : undefined;
+}
+
+function isRawRowsModule(source: string | undefined): boolean {
+  return (
+    source !== undefined &&
+    /(?:^|\/)lib\/db-raw-rows(?:\.[cm]?[jt]s)?$/.test(source)
+  );
+}
+
+function topLevelTokens(source: string): readonly SqlToken[] | undefined {
+  const tokens: SqlToken[] = [];
+  let depth = 0;
+  let expressionIndex = 0;
+  let offset = 0;
+
+  while (offset < source.length) {
+    const character = source[offset];
+    if (character === SQL_TEMPLATE_EXPRESSION_BOUNDARY) {
+      if (depth === 0) {
+        tokens.push({
+          kind: "expression",
+          expressionIndex,
+          start: offset,
+          end: offset + 1,
+        });
+      }
+      expressionIndex += 1;
+      offset += 1;
+      continue;
+    }
+    if (character === "(") {
+      if (depth === 0) {
+        tokens.push({
+          kind: "punctuation",
+          value: "(",
+          start: offset,
+          end: offset + 1,
+        });
+      }
+      depth += 1;
+      offset += 1;
+      continue;
+    }
+    if (character === ")") {
+      if (depth === 0) {
+        return undefined;
+      }
+      depth -= 1;
+      if (depth === 0) {
+        tokens.push({
+          kind: "punctuation",
+          value: ")",
+          start: offset,
+          end: offset + 1,
+        });
+      }
+      offset += 1;
+      continue;
+    }
+    if (depth !== 0 || /\s/.test(character ?? "")) {
+      offset += 1;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(character ?? "")) {
+      const start = offset;
+      offset += 1;
+      while (/[A-Za-z0-9_$]/.test(source[offset] ?? "")) {
+        offset += 1;
+      }
+      tokens.push({
+        kind: "word",
+        value: source.slice(start, offset).toUpperCase(),
+        start,
+        end: offset,
+      });
+      continue;
+    }
+    if (/[0-9]/.test(character ?? "")) {
+      const start = offset;
+      offset += 1;
+      while (/[0-9]/.test(source[offset] ?? "")) {
+        offset += 1;
+      }
+      tokens.push({
+        kind: "number",
+        value: source.slice(start, offset),
+        start,
+        end: offset,
+      });
+      continue;
+    }
+    if (character === "," || character === ";") {
+      tokens.push({
+        kind: "punctuation",
+        value: character,
+        start: offset,
+        end: offset + 1,
+      });
+    }
+    offset += 1;
+  }
+
+  return depth === 0 ? tokens : undefined;
+}
+
+function isWord(token: SqlToken | undefined, value: string): boolean {
+  return token?.kind === "word" && token.value === value;
+}
+
+function expressionIndex(token: SqlToken | undefined): number | undefined {
+  return token?.kind === "expression" ? token.expressionIndex : undefined;
+}
+
+function simpleSelectMatch(
+  source: string,
+  syntaxSource: string,
+): SimpleSelectMatch | undefined {
+  const tokens = topLevelTokens(syntaxSource);
+  if (tokens === undefined) {
+    return undefined;
+  }
+
+  let cursor = 0;
+  if (!isWord(tokens[cursor], "SELECT")) {
+    return undefined;
+  }
+  cursor += 1;
+  const selectedColumnExpressionIndex = expressionIndex(tokens[cursor]);
+  if (selectedColumnExpressionIndex === undefined) {
+    return undefined;
+  }
+  cursor += 1;
+
+  if (isWord(tokens[cursor], "AS")) {
+    const aliasKeyword = tokens[cursor];
+    cursor += 1;
+    if (tokens[cursor]?.kind === "word" && !isWord(tokens[cursor], "FROM")) {
+      cursor += 1;
+    } else {
+      const from = tokens[cursor];
+      if (
+        aliasKeyword === undefined ||
+        from === undefined ||
+        !isWord(from, "FROM") ||
+        !/^"(?:[^"]|"")+"$/s.test(
+          source.slice(aliasKeyword.end, from.start).trim(),
+        )
+      ) {
+        return undefined;
+      }
+    }
+  }
+
+  if (!isWord(tokens[cursor], "FROM")) {
+    return undefined;
+  }
+  cursor += 1;
+  const sourceTableExpressionIndex = expressionIndex(tokens[cursor]);
+  if (sourceTableExpressionIndex === undefined) {
+    return undefined;
+  }
+  cursor += 1;
+
+  const joinTableExpressionIndexes: number[] = [];
+  const joinConditionExpressionIndexes: number[] = [];
+  while (isWord(tokens[cursor], "INNER")) {
+    cursor += 1;
+    if (!isWord(tokens[cursor], "JOIN")) {
+      return undefined;
+    }
+    cursor += 1;
+    const joinTableIndex = expressionIndex(tokens[cursor]);
+    if (joinTableIndex === undefined) {
+      return undefined;
+    }
+    joinTableExpressionIndexes.push(joinTableIndex);
+    cursor += 1;
+    if (!isWord(tokens[cursor], "ON")) {
+      return undefined;
+    }
+    cursor += 1;
+    const joinConditionIndex = expressionIndex(tokens[cursor]);
+    if (joinConditionIndex === undefined) {
+      return undefined;
+    }
+    joinConditionExpressionIndexes.push(joinConditionIndex);
+    cursor += 1;
+  }
+
+  if (!isWord(tokens[cursor], "WHERE")) {
+    return undefined;
+  }
+  cursor += 1;
+
+  let end = tokens.length;
+  const trailingToken = tokens[end - 1];
+  if (trailingToken?.kind === "punctuation" && trailingToken.value === ";") {
+    end -= 1;
+  }
+  const limitKeywordIndex = end - 2;
+  const limitValue = tokens[limitKeywordIndex + 1];
+  if (
+    cursor >= limitKeywordIndex ||
+    !isWord(tokens[limitKeywordIndex], "LIMIT") ||
+    limitValue?.kind !== "number" ||
+    limitValue.value !== "1"
+  ) {
+    return undefined;
+  }
+  for (let index = cursor; index < limitKeywordIndex; index += 1) {
+    const token = tokens[index];
+    if (
+      token === undefined ||
+      (token.kind === "word" &&
+        UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS.has(token.value)) ||
+      (token.kind === "punctuation" && token.value === ";")
+    ) {
+      return undefined;
+    }
+  }
+
+  return {
+    joinConditionExpressionIndexes,
+    joinTableExpressionIndexes,
+    selectedColumnExpressionIndex,
+    sourceTableExpressionIndex,
+  };
+}
+
+export const preferDrizzleQueryBuilder = createRule({
+  name: "prefer-drizzle-query-builder",
+  defaultOptions: [],
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer Drizzle query builders for complete schema-backed simple selects",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      queryBuilder:
+        "Use a Drizzle select builder for this complete schema-backed query.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const directRawRowsBindings = new Set<string>();
+    const rawRowsNamespaces = new Set<string>();
+
+    for (const statement of context.sourceCode.ast.body) {
+      if (
+        statement.type !== AST_NODE_TYPES.ImportDeclaration ||
+        typeof statement.source.value !== "string" ||
+        !isRawRowsModule(statement.source.value)
+      ) {
+        continue;
+      }
+      for (const specifier of statement.specifiers) {
+        if (
+          specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+          ((specifier.imported.type === AST_NODE_TYPES.Identifier &&
+            specifier.imported.name === "executeRawRows") ||
+            (specifier.imported.type === AST_NODE_TYPES.Literal &&
+              specifier.imported.value === "executeRawRows"))
+        ) {
+          directRawRowsBindings.add(specifier.local.name);
+        } else if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+          rawRowsNamespaces.add(specifier.local.name);
+        }
+      }
+    }
+
+    function isExecuteRawRowsCallee(node: TSESTree.Expression): boolean {
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        if (!directRawRowsBindings.has(node.name)) {
+          return false;
+        }
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        const symbol = checker.getSymbolAtLocation(tsNode);
+        return (
+          symbol?.declarations?.some((declaration) => {
+            return (
+              isImportSpecifier(declaration) &&
+              (declaration.propertyName?.text ?? declaration.name.text) ===
+                "executeRawRows" &&
+              isRawRowsModule(importSource(declaration))
+            );
+          }) === true
+        );
+      }
+      if (
+        node.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node) !== "executeRawRows" ||
+        node.object.type !== AST_NODE_TYPES.Identifier ||
+        !rawRowsNamespaces.has(node.object.name)
+      ) {
+        return false;
+      }
+      const tsObject = services.esTreeNodeToTSNodeMap.get(node.object);
+      const symbol = checker.getSymbolAtLocation(tsObject);
+      return (
+        symbol?.declarations?.some((declaration) => {
+          return (
+            isNamespaceImport(declaration) &&
+            isRawRowsModule(importSource(declaration))
+          );
+        }) === true
+      );
+    }
+
+    function expressionType(node: TSESTree.Expression) {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return {
+        location: tsNode,
+        type: checker.getTypeAtLocation(tsNode),
+      };
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (
+          !isExecuteRawRowsCallee(node.callee) ||
+          node.arguments.length !== 3 ||
+          node.arguments.some((argument) => {
+            return argument.type === AST_NODE_TYPES.SpreadElement;
+          })
+        ) {
+          return;
+        }
+        const query = node.arguments[1];
+        if (
+          query === undefined ||
+          query.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+          !isDrizzleSqlTag(checker, services, query.tag)
+        ) {
+          return;
+        }
+
+        const source = query.quasi.quasis
+          .map(quasiText)
+          .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
+        const match = simpleSelectMatch(source, sqlCodeMask(source));
+        if (match === undefined) {
+          return;
+        }
+
+        const selectedColumn =
+          query.quasi.expressions[match.selectedColumnExpressionIndex];
+        const sourceTable =
+          query.quasi.expressions[match.sourceTableExpressionIndex];
+        if (selectedColumn === undefined || sourceTable === undefined) {
+          return;
+        }
+        const selectedColumnType = expressionType(selectedColumn);
+        const sourceTableType = expressionType(sourceTable);
+        if (
+          !isDrizzleColumnType(
+            checker,
+            selectedColumnType.type,
+            selectedColumnType.location,
+          ) ||
+          !isDrizzleTableType(
+            checker,
+            sourceTableType.type,
+            sourceTableType.location,
+          ) ||
+          !match.joinTableExpressionIndexes.every((index) => {
+            const expression = query.quasi.expressions[index];
+            if (expression === undefined) {
+              return false;
+            }
+            const expressionValue = expressionType(expression);
+            return isDrizzleTableType(
+              checker,
+              expressionValue.type,
+              expressionValue.location,
+            );
+          }) ||
+          !match.joinConditionExpressionIndexes.every((index) => {
+            const expression = query.quasi.expressions[index];
+            return (
+              expression !== undefined &&
+              isDrizzleWrapperType(checker, expressionType(expression).type)
+            );
+          })
+        ) {
+          return;
+        }
+
+        context.report({ node: query, messageId: "queryBuilder" });
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/sql-lexing.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-lexing.ts
@@ -1,0 +1,132 @@
+export const SQL_TEMPLATE_EXPRESSION_BOUNDARY = "\u0000";
+
+type SqlLexicalState =
+  | { readonly kind: "block-comment"; readonly depth: number }
+  | { readonly kind: "code" }
+  | { readonly kind: "dollar-quote"; readonly delimiter: string }
+  | { readonly kind: "double-quote" }
+  | { readonly kind: "line-comment" }
+  | { readonly kind: "single-quote" };
+
+export function sqlCodeMask(source: string): string {
+  const mask = source.split("");
+  let state: SqlLexicalState = { kind: "code" };
+  let offset = 0;
+  while (offset < source.length) {
+    if (source[offset] === SQL_TEMPLATE_EXPRESSION_BOUNDARY) {
+      mask[offset] = SQL_TEMPLATE_EXPRESSION_BOUNDARY;
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "code") {
+      const pair = source.slice(offset, offset + 2);
+      if (pair === "--") {
+        mask[offset] = " ";
+        mask[offset + 1] = " ";
+        state = { kind: "line-comment" };
+        offset += 2;
+        continue;
+      }
+      if (pair === "/*") {
+        mask[offset] = " ";
+        mask[offset + 1] = " ";
+        state = { kind: "block-comment", depth: 1 };
+        offset += 2;
+        continue;
+      }
+      const character = source[offset];
+      if (character === "'") {
+        mask[offset] = " ";
+        state = { kind: "single-quote" };
+        offset += 1;
+        continue;
+      }
+      if (character === '"') {
+        mask[offset] = " ";
+        state = { kind: "double-quote" };
+        offset += 1;
+        continue;
+      }
+      if (character === "$") {
+        const delimiter = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/.exec(
+          source.slice(offset),
+        )?.[0];
+        if (delimiter !== undefined) {
+          for (let index = 0; index < delimiter.length; index += 1) {
+            mask[offset + index] = " ";
+          }
+          state = { kind: "dollar-quote", delimiter };
+          offset += delimiter.length;
+          continue;
+        }
+      }
+      offset += 1;
+      continue;
+    }
+
+    const character = source[offset];
+    mask[offset] = character === "\n" ? "\n" : " ";
+    if (state.kind === "line-comment") {
+      if (character === "\n") {
+        state = { kind: "code" };
+      }
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "block-comment") {
+      const pair = source.slice(offset, offset + 2);
+      if (pair === "/*") {
+        mask[offset + 1] = " ";
+        state = { kind: "block-comment", depth: state.depth + 1 };
+        offset += 2;
+        continue;
+      }
+      if (pair === "*/") {
+        mask[offset + 1] = " ";
+        const depth: number = state.depth - 1;
+        state =
+          depth === 0 ? { kind: "code" } : { kind: "block-comment", depth };
+        offset += 2;
+        continue;
+      }
+      offset += 1;
+      continue;
+    }
+    if (state.kind === "dollar-quote") {
+      if (source.startsWith(state.delimiter, offset)) {
+        for (let index = 0; index < state.delimiter.length; index += 1) {
+          mask[offset + index] = " ";
+        }
+        offset += state.delimiter.length;
+        state = { kind: "code" };
+      } else {
+        offset += 1;
+      }
+      continue;
+    }
+
+    const quote = state.kind === "single-quote" ? "'" : '"';
+    if (character !== quote) {
+      offset += 1;
+      continue;
+    }
+    if (source[offset + 1] === quote) {
+      mask[offset + 1] = " ";
+      offset += 2;
+      continue;
+    }
+    let backslashes = 0;
+    for (
+      let index = offset - 1;
+      index >= 0 && source[index] === "\\";
+      index -= 1
+    ) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) {
+      state = { kind: "code" };
+    }
+    offset += 1;
+  }
+  return mask.join("");
+}


### PR DESCRIPTION
## Summary

- replace the three raw active/competing chat-run lookups with one schema-aware Drizzle query
- preserve the existing database or transaction receiver, current-run exclusion, lock placement, and one-row Boolean result
- add a conservative type-aware lint rule for complete schema-backed `executeRawRows(...)` simple selects, reusing the existing SQL lexical masking

## Behavior and performance

- the only retained raw SQL is the PostgreSQL JSON text-extraction leaf for `queuedMessageId`
- rendered SQL preserves every correlation and predicate; status, callback kind, role, and limit values become parameters
- matching, non-matching, and excluded-run `EXPLAIN (ANALYZE, BUFFERS)` plans retained the same nodes, costs, indexes, rows/loops, and buffers with no sort or materialization
- the new rule used 81 ms (0.4% of measured API ESLint rule time)

## Scope

- no schema, migration, persisted-data, API, protocol, feature-switch, or rollout change
- other raw statement families remain deferred under #22439

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules exec vitest run --maxWorkers=1` (47 files, 704 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only` (2 files, 65 tests)
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/eslint-rules`
- `pnpm check-types`
- `git diff --check`

Closes #22565

Parent context: #22439
