### PR TITLE
perf(sandbox-fc): batch firewall mutations

### DIFF
--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -87,7 +87,9 @@ mkdir -p "$RECONCILE_BIN_DIR" "$RECONCILE_COUNT_DIR"
 REAL_IP=$(command -v ip)
 REAL_IPTABLES=$(command -v iptables)
 REAL_IPTABLES_SAVE=$(command -v iptables-save)
+REAL_IPTABLES_RESTORE=$(command -v iptables-restore)
 REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
+REAL_IP6TABLES_RESTORE=$(command -v ip6tables-restore)
 
 # Reserve four pool indexes before the runner starts. Two become clean
 # historical indexes, one owns a synthetic firewall-only orphan, and one
@@ -233,15 +235,20 @@ case "$COMMAND_NAME" in
     fi
     exit "$STATUS"
     ;;
-  iptables)
-    OWN_POOL_HEX=$(<"$VM0_RECONCILE_COUNT_DIR/own-pool")
-    if contains_argument VM0-RECONCILE-OWN "$@" \
-      && contains_argument "vm0-ns-${OWN_POOL_HEX}-fd" "$@"; then
-      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.own-delete"
-      exit 0
+  iptables-restore | ip6tables-restore)
+    RESTORE_FILE=${!#}
+    if [ "$COMMAND_NAME" = "iptables-restore" ]; then
+      REAL_COMMAND=$VM0_RECONCILE_REAL_IPTABLES_RESTORE
+    else
+      REAL_COMMAND=$VM0_RECONCILE_REAL_IP6TABLES_RESTORE
     fi
-    if contains_argument VM0-RECONCILE-IDLE "$@" \
-      && contains_argument "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" "$@"; then
+
+    if grep -F -- "vm0-ns-$(<"$VM0_RECONCILE_COUNT_DIR/own-pool")-fd" \
+      "$RESTORE_FILE" >/dev/null; then
+      printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.own-delete"
+    fi
+    if grep -F -- "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns" \
+      "$RESTORE_FILE" >/dev/null; then
       if flock -n "/var/lock/vm0-netns-pool-${VM0_RECONCILE_FIREWALL_POOL_INDEX}.lock" true; then
         printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.firewall-only-unlocked"
       fi
@@ -252,12 +259,29 @@ case "$COMMAND_NAME" in
         sleep 0.05
       done
       [ -e "$VM0_RECONCILE_FIREWALL_DELETE_RELEASE" ] || exit 1
-      exit 0
     fi
-    if contains_argument VM0-RECONCILE-DECOY "$@"; then
+    if grep -F -- "vm0-ns-${VM0_RECONCILE_FIREWALL_POOL_HEX}-dns-extra" \
+      "$RESTORE_FILE" >/dev/null; then
       printf '1\n' >>"$VM0_RECONCILE_COUNT_DIR/iptables.decoy-delete"
-      exit 0
     fi
+
+    SANITIZED_RESTORE_FILE=$(mktemp "$VM0_RECONCILE_COUNT_DIR/restore.XXXXXX")
+    grep -F -v \
+      -e 'VM0-RECONCILE-OWN' \
+      -e 'VM0-RECONCILE-IDLE' \
+      -e 'VM0-RECONCILE-DECOY' \
+      "$RESTORE_FILE" >"$SANITIZED_RESTORE_FILE"
+    RESTORE_ARGS=("$@")
+    RESTORE_ARGS[$((${#RESTORE_ARGS[@]} - 1))]=$SANITIZED_RESTORE_FILE
+    if "$REAL_COMMAND" "${RESTORE_ARGS[@]}"; then
+      STATUS=0
+    else
+      STATUS=$?
+    fi
+    rm -f "$SANITIZED_RESTORE_FILE"
+    exit "$STATUS"
+    ;;
+  iptables)
     exec "$VM0_RECONCILE_REAL_IPTABLES" "$@"
     ;;
   ip)
@@ -313,7 +337,13 @@ esac
 exit 127
 NETWORK_COMMAND
 chmod 755 "$RECONCILE_BIN_DIR/network-command"
-for command in ip iptables iptables-save ip6tables-save; do
+for command in \
+  ip \
+  iptables \
+  iptables-save \
+  iptables-restore \
+  ip6tables-save \
+  ip6tables-restore; do
   ln -s network-command "$RECONCILE_BIN_DIR/$command"
 done
 
@@ -328,7 +358,9 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --env "VM0_RECONCILE_REAL_IP=$REAL_IP" \
   --env "VM0_RECONCILE_REAL_IPTABLES=$REAL_IPTABLES" \
   --env "VM0_RECONCILE_REAL_IPTABLES_SAVE=$REAL_IPTABLES_SAVE" \
+  --env "VM0_RECONCILE_REAL_IPTABLES_RESTORE=$REAL_IPTABLES_RESTORE" \
   --env "VM0_RECONCILE_REAL_IP6TABLES_SAVE=$REAL_IP6TABLES_SAVE" \
+  --env "VM0_RECONCILE_REAL_IP6TABLES_RESTORE=$REAL_IP6TABLES_RESTORE" \
   --env "VM0_RECONCILE_FIREWALL_POOL_INDEX=${RECONCILE_POOL_INDEXES[2]}" \
   --env "VM0_RECONCILE_FIREWALL_POOL_HEX=$RECONCILE_FIREWALL_POOL_HEX" \
   --env "VM0_RECONCILE_FIREWALL_DELETE_STARTED=$RECONCILE_FIREWALL_DELETE_STARTED" \
@@ -346,15 +378,6 @@ assert_reconcile_count() {
     || fail "expected $expected reconciliation $name call(s), found $actual"
 }
 
-assert_reconcile_count_at_least() {
-  local name=$1 minimum=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0
-  if [ -f "$path" ]; then
-    actual=$(wc -l <"$path")
-  fi
-  [ "$actual" -ge "$minimum" ] \
-    || fail "expected at least $minimum reconciliation $name call(s), found $actual"
-}
-
 # Pause the runner at the cross-pool mutation boundary. This keeps later
 # warm-up or namespace failure cleanup from being mistaken for another startup
 # discovery pass while also proving that the target pool lock is still held.
@@ -367,29 +390,11 @@ done
   || fail "startup reconciliation did not reach the firewall cleanup checkpoint"
 
 echo "--- Test: startup reconciliation uses one host snapshot ---"
-# A fully captured snapshot must read every table exactly once. If a source was
-# abandoned, the preserved targeted fallback may re-read IPv4 tables for the
-# synthetic own-index namespace. The unique IPv6 and namespace cardinalities
-# still reject the historical per-index discovery loop in that failure path.
-FIREWALL_SNAPSHOT_SUCCEEDED=true
-for source in \
-  iptables-save.raw \
-  iptables-save.nat \
-  iptables-save.filter \
-  ip6tables-save.filter; do
-  if [ ! -e "$RECONCILE_COUNT_DIR/snapshot-${source}/succeeded" ]; then
-    FIREWALL_SNAPSHOT_SUCCEEDED=false
-  fi
-done
-if [ "$FIREWALL_SNAPSHOT_SUCCEEDED" = true ]; then
-  assert_reconcile_count iptables-save.raw 1
-  assert_reconcile_count iptables-save.nat 1
-  assert_reconcile_count iptables-save.filter 1
-else
-  assert_reconcile_count_at_least iptables-save.raw 1
-  assert_reconcile_count_at_least iptables-save.nat 1
-  assert_reconcile_count_at_least iptables-save.filter 1
-fi
+# Failed snapshot sources stay abandoned instead of triggering a per-namespace
+# fallback that repeats whole-table reads.
+assert_reconcile_count iptables-save.raw 1
+assert_reconcile_count iptables-save.nat 1
+assert_reconcile_count iptables-save.filter 1
 assert_reconcile_count ip6tables-save.filter 1
 assert_reconcile_count ip.netns-list 1
 assert_reconcile_count iptables.own-delete 1

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -34,12 +34,14 @@ const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
-const START_SYSTEM_DEPENDENCIES: [&str; 9] = [
+const START_SYSTEM_DEPENDENCIES: [&str; 11] = [
     "ip",
     "iptables",
     "iptables-save",
+    "iptables-restore",
     "ip6tables",
     "ip6tables-save",
+    "ip6tables-restore",
     "sysctl",
     "dnsmasq",
     "mkfs.ext4",
@@ -1230,7 +1232,14 @@ mod tests {
 
     #[test]
     fn runner_start_dependencies_include_dual_stack_firewall_tools() {
-        for dependency in ["iptables", "iptables-save", "ip6tables", "ip6tables-save"] {
+        for dependency in [
+            "iptables",
+            "iptables-save",
+            "iptables-restore",
+            "ip6tables",
+            "ip6tables-save",
+            "ip6tables-restore",
+        ] {
             assert!(START_SYSTEM_DEPENDENCIES.contains(&dependency));
         }
     }

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 hex.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["process", "fs", "rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
@@ -28,7 +29,6 @@ which.workspace = true
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
-tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test-support.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/sandbox-fc/src/network/pool/completion.rs
+++ b/crates/sandbox-fc/src/network/pool/completion.rs
@@ -100,7 +100,10 @@ impl CreationNotifier {
                         host_device = %ns.host_device,
                         "namespace creation completed after pool receiver dropped; deleting"
                     );
-                    let outcome = (self.ops.delete_namespace)(ns.clone()).await;
+                    let outcome = self
+                        .ops
+                        .delete_network_resources(vec![ns.clone()], None)
+                        .await;
                     if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
                         warn!(
                             name = %ns.name,

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::future::Future;
+use std::io::Write;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,13 +31,14 @@ static CONNTRACK_NOT_FOUND_LOGGED: AtomicBool = AtomicBool::new(false);
 const PEER_DEVICE: &str = "veth0";
 
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+type DeleteNetworkResourcesFn =
+    dyn Fn(Vec<NetnsInfo>, Option<String>) -> BoxFuture<NamespaceDeleteOutcome> + Send + Sync;
 
 #[derive(Clone)]
 pub(super) struct NetnsLifecycleOps {
     pub(super) flush_conntrack:
         Arc<dyn Fn(String) -> BoxFuture<ConntrackFlushOutcome> + Send + Sync>,
-    pub(super) delete_namespace:
-        Arc<dyn Fn(NetnsInfo) -> BoxFuture<NamespaceDeleteOutcome> + Send + Sync>,
+    pub(super) delete_network_resources: Arc<DeleteNetworkResourcesFn>,
 }
 
 impl Default for NetnsLifecycleOps {
@@ -45,10 +47,22 @@ impl Default for NetnsLifecycleOps {
             flush_conntrack: Arc::new(|peer_ip| {
                 Box::pin(async move { flush_conntrack(&peer_ip).await })
             }),
-            delete_namespace: Arc::new(|ns| {
-                Box::pin(async move { delete_namespace_resources(&ns.name, &ns.host_device).await })
+            delete_network_resources: Arc::new(|namespaces, dns_input_filter_comment| {
+                Box::pin(async move {
+                    delete_network_resources(namespaces, dns_input_filter_comment).await
+                })
             }),
         }
+    }
+}
+
+impl NetnsLifecycleOps {
+    pub(super) async fn delete_network_resources(
+        &self,
+        namespaces: Vec<NetnsInfo>,
+        dns_input_filter_comment: Option<String>,
+    ) -> NamespaceDeleteOutcome {
+        (self.delete_network_resources)(namespaces, dns_input_filter_comment).await
     }
 }
 
@@ -57,7 +71,9 @@ impl NetnsLifecycleOps {
     pub(super) fn trusted_for_test() -> Self {
         Self {
             flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
-            delete_namespace: Arc::new(|_| Box::pin(async { NamespaceDeleteOutcome::Deleted })),
+            delete_network_resources: Arc::new(|_, _| {
+                Box::pin(async { NamespaceDeleteOutcome::Deleted })
+            }),
         }
     }
 }
@@ -119,6 +135,7 @@ async fn exec_xtables_status_with_timeout(
     exec_status_with_timeout(program, &args, timeout).await
 }
 
+#[cfg(test)]
 async fn exec_xtables_ignore_errors_with_timeout(
     program: &str,
     args: &[&str],
@@ -126,12 +143,6 @@ async fn exec_xtables_ignore_errors_with_timeout(
 ) -> IgnoredCommandOutcome {
     let args = xtables_args(args);
     exec_ignore_errors_with_timeout(program, &args, timeout).await
-}
-
-/// Shorthand: run a bounded mutating `iptables` command and discard stdout.
-async fn exec_iptables(args: &[&str]) -> Result<()> {
-    exec_xtables_status_with_timeout("iptables", args, NETNS_COMMAND_TIMEOUT).await?;
-    Ok(())
 }
 
 /// Restrict the runner-managed DNS port to this pool's VM-facing veths.
@@ -146,43 +157,31 @@ pub(super) async fn setup_dns_input_filter(pool_index: u32, dns_port: u16) -> Re
     let pool_idx = format_hex_index(pool_index);
     let interface = make_host_device_iptables_pattern(&pool_idx);
     let comment = format!("{NS_PREFIX}{pool_idx}-dns");
-    let port = dns_port.to_string();
-
-    for program in ["iptables", "ip6tables"] {
-        for protocol in ["udp", "tcp"] {
-            let args = [
-                "-I",
-                "INPUT",
-                "1",
-                "!",
-                "-i",
-                &interface,
-                "-p",
-                protocol,
-                "--dport",
-                &port,
-                "-m",
-                "comment",
-                "--comment",
-                &comment,
-                "-j",
-                "REJECT",
-            ];
-            if let Err(error) =
-                exec_xtables_status_with_timeout(program, &args, NETNS_COMMAND_TIMEOUT).await
-            {
-                if matches!(
-                    delete_pool_firewall_rules_by_comment(&comment).await,
-                    NamespaceDeleteOutcome::Abandoned
-                ) {
-                    warn!(
-                        comment,
-                        "failed to roll back partial DNS input filter; startup orphan reconciliation will retry"
-                    );
-                }
-                return Err(error.into());
-            }
+    let firewall = vec![FirewallRestoreTable {
+        table: "filter",
+        rules: ["udp", "tcp"]
+            .map(|protocol| {
+                format!(
+                    "-I INPUT 1 ! -i {interface} -p {protocol} --dport {dns_port} -m comment --comment {comment} -j REJECT"
+                )
+            })
+            .into(),
+    }];
+    let (ipv4, ipv6) = tokio::join!(
+        apply_firewall_rules_with_restore("iptables-restore", &firewall),
+        apply_firewall_rules_with_restore("ip6tables-restore", &firewall),
+    );
+    if let Err(error) = ipv4.and(ipv6) {
+        if matches!(
+            delete_pool_firewall_rules_by_comment(&comment).await,
+            NamespaceDeleteOutcome::Abandoned
+        ) {
+            warn!(
+                comment,
+                "failed to roll back partial DNS input filter; startup orphan reconciliation will retry"
+            );
         }
+        return Err(error);
     }
 
     info!(dns_port, interface, comment, "DNS input filter installed");
@@ -324,257 +323,93 @@ async fn setup_namespace_routing(
     Ok(())
 }
 
-/// Add host-side source validation and forwarding rules.
-///
-/// The raw PREROUTING guard establishes the namespace's peer IP as a trusted
-/// identity before conntrack and NAT redirects can attribute the packet. This
-/// must remain independent of host reverse-path-filter configuration.
-async fn setup_host_iptables(
+/// Build the complete host firewall transaction for one namespace.
+#[derive(Clone, Copy)]
+struct NamespaceFirewallConfig<'a> {
+    default_iface: &'a str,
+    proxy_port: Option<u16>,
+    dns_port: Option<u16>,
+}
+
+fn namespace_firewall_restore_tables(
     name: &str,
     host_device: &str,
     peer_ip: &str,
-    default_iface: &str,
-) -> Result<()> {
+    config: NamespaceFirewallConfig<'_>,
+) -> Vec<FirewallRestoreTable> {
+    let NamespaceFirewallConfig {
+        default_iface,
+        proxy_port,
+        dns_port,
+    } = config;
     let peer = format!("{peer_ip}/32");
-    exec_iptables(&[
-        "-t",
-        "raw",
-        "-I",
-        "PREROUTING",
-        "1",
-        "-i",
-        host_device,
-        "!",
-        "-s",
-        &peer,
-        "-m",
-        "comment",
-        "--comment",
-        name,
-        "-j",
-        "DROP",
-    ])
-    .await?;
-    exec_iptables(&[
-        "-t",
-        "nat",
-        "-A",
-        "POSTROUTING",
-        "-s",
-        &peer,
-        "-o",
-        default_iface,
-        "-j",
-        "MASQUERADE",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    exec_iptables(&[
-        "-A",
-        "FORWARD",
-        "-i",
-        host_device,
-        "-s",
-        &peer,
-        "-o",
-        default_iface,
-        "-j",
-        "ACCEPT",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    exec_iptables(&[
-        "-A",
-        "FORWARD",
-        "-i",
-        default_iface,
-        "-o",
-        host_device,
-        "-d",
-        &peer,
-        "-m",
-        "state",
-        "--state",
-        "RELATED,ESTABLISHED",
-        "-j",
-        "ACCEPT",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    Ok(())
-}
 
-/// Add a proxy REDIRECT rule for outbound TCP traffic in PREROUTING.
-///
-/// This rule redirects outbound TCP traffic from the namespace's veth peer IP
-/// to the specified proxy port on the host. When the DNS proxy is enabled,
-/// standard DNS (53) and DNS-over-TLS (853) are excluded so their dedicated
-/// rules cannot be bypassed by mitmproxy's raw TCP passthrough. Without a DNS
-/// proxy, all TCP traffic keeps the existing mitmproxy behavior.
-async fn add_proxy_redirect_rule(
-    name: &str,
-    host_device: &str,
-    peer_ip: &str,
-    proxy_port: u16,
-    dns_proxy_enabled: bool,
-) -> Result<()> {
-    let src = format!("{peer_ip}/32");
-    let port_str = proxy_port.to_string();
-    let mut args: Vec<&str> = vec![
-        "-t",
-        "nat",
-        "-A",
-        "PREROUTING",
-        "-i",
-        host_device,
-        "-s",
-        &src,
-        "-p",
-        "tcp",
+    // Reject forged source addresses before conntrack and NAT attribute them
+    // to this namespace. This remains independent of host rp_filter settings.
+    let raw = vec![format!(
+        "-I PREROUTING 1 -i {host_device} ! -s {peer} -m comment --comment {name} -j DROP"
+    )];
+
+    // Establish the base outbound and return paths before inserting the
+    // optional logging and DNS guards ahead of the terminating ACCEPT rules.
+    let mut nat = vec![format!(
+        "-A POSTROUTING -s {peer} -o {default_iface} -j MASQUERADE -m comment --comment {name}"
+    )];
+    let mut filter = vec![
+        format!(
+            "-A FORWARD -i {host_device} -s {peer} -o {default_iface} -j ACCEPT -m comment --comment {name}"
+        ),
+        format!(
+            "-A FORWARD -i {default_iface} -o {host_device} -d {peer} -m state --state RELATED,ESTABLISHED -j ACCEPT -m comment --comment {name}"
+        ),
     ];
-    if dns_proxy_enabled {
-        args.extend(["-m", "multiport", "!", "--dports", "53,853"]);
-    }
-    args.extend([
-        "-j",
-        "REDIRECT",
-        "--to-port",
-        &port_str,
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ]);
-    exec_iptables(&args).await?;
-    Ok(())
-}
 
-/// Add LOG rule for all non-TCP outbound traffic in FORWARD chain.
-///
-/// Logs packet metadata (src/dst IP, port, protocol, size) to the kernel
-/// log with a `VM0:<peer_ip>:` prefix so the runner can match entries to
-/// VMs and write them to the per-run network JSONL file.
-///
-/// Uses `-I FORWARD 1` (insert at top) instead of `-A` (append) because
-/// the ACCEPT rules from [`setup_host_iptables`] are already in the chain.
-/// LOG is a non-terminating target (packet continues to the next rule),
-/// so it must come before ACCEPT to fire.
-async fn add_non_tcp_log_rule(name: &str, host_device: &str, peer_ip: &str) -> Result<()> {
-    let src = format!("{peer_ip}/32");
-    let prefix = format!("VM0:{peer_ip}:");
-    exec_iptables(&[
-        "-I",
-        "FORWARD",
-        "1",
-        "-i",
-        host_device,
-        "-s",
-        &src,
-        "!",
-        "-p",
-        "tcp",
-        "-m",
-        "limit",
-        "--limit",
-        "10/sec",
-        "--limit-burst",
-        "50",
-        "-j",
-        "LOG",
-        "--log-prefix",
-        &prefix,
-        "--log-level",
-        "4",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    Ok(())
-}
-
-/// Redirect standard outbound DNS (UDP/TCP 53) to the local dnsmasq port.
-///
-/// VM resolv.conf points to an external nameserver as a dummy target.
-/// These PREROUTING REDIRECT rules intercept packets before FORWARD/MASQUERADE,
-/// preserving the original source IP (peer veth) for per-VM log routing. TCP
-/// support covers explicit DNS-over-TCP and fallback after truncated UDP
-/// responses.
-async fn add_dns_redirect_rules(
-    name: &str,
-    host_device: &str,
-    peer_ip: &str,
-    dns_port: u16,
-) -> Result<()> {
-    let src = format!("{peer_ip}/32");
-    let port_str = dns_port.to_string();
-    for protocol in ["udp", "tcp"] {
-        exec_iptables(&[
-            "-t",
-            "nat",
-            "-A",
-            "PREROUTING",
-            "-i",
-            host_device,
-            "-s",
-            &src,
-            "-p",
-            protocol,
-            "--dport",
-            "53",
-            "-j",
-            "REDIRECT",
-            "--to-port",
-            &port_str,
-            "-m",
-            "comment",
-            "--comment",
-            name,
-        ])
-        .await?;
+    if let Some(port) = proxy_port {
+        // The dedicated DNS rules own ports 53 and 853 when DNS proxying is
+        // enabled; otherwise all outbound TCP keeps the proxy behavior.
+        let dns_exclusions = if dns_port.is_some() {
+            " -m multiport ! --dports 53,853"
+        } else {
+            ""
+        };
+        nat.push(format!(
+            "-A PREROUTING -i {host_device} -s {peer} -p tcp{dns_exclusions} -j REDIRECT --to-port {port} -m comment --comment {name}"
+        ));
+        // LOG is non-terminating and must precede the ACCEPT rules.
+        filter.push(format!(
+            "-I FORWARD 1 -i {host_device} -s {peer} ! -p tcp -m limit --limit 10/sec --limit-burst 50 -j LOG --log-prefix VM0:{peer_ip}: --log-level 4 -m comment --comment {name}"
+        ));
     }
-    Ok(())
-}
 
-/// Drop external DNS traffic that bypasses the REDIRECT rule.
-///
-/// Blocks UDP/TCP 53 and TCP 853 (DNS over TLS) in FORWARD chain.
-/// DNS over HTTPS (TCP 443) is handled by mitmproxy at HTTP level.
-async fn add_dns_drop_rules(name: &str, host_device: &str, peer_ip: &str) -> Result<()> {
-    let src = format!("{peer_ip}/32");
-    for (protocol, port) in [("udp", "53"), ("tcp", "53"), ("tcp", "853")] {
-        exec_iptables(&[
-            "-I",
-            "FORWARD",
-            "1",
-            "-i",
-            host_device,
-            "-s",
-            &src,
-            "-p",
-            protocol,
-            "--dport",
-            port,
-            "-j",
-            "DROP",
-            "-m",
-            "comment",
-            "--comment",
-            name,
-        ])
-        .await?;
+    if let Some(port) = dns_port {
+        // Redirect standard DNS to dnsmasq, then block attempts to bypass it
+        // over external DNS and DNS-over-TLS forwarding paths.
+        for protocol in ["udp", "tcp"] {
+            nat.push(format!(
+                "-A PREROUTING -i {host_device} -s {peer} -p {protocol} --dport 53 -j REDIRECT --to-port {port} -m comment --comment {name}"
+            ));
+        }
+        for (protocol, port) in [("udp", "53"), ("tcp", "53"), ("tcp", "853")] {
+            filter.push(format!(
+                "-I FORWARD 1 -i {host_device} -s {peer} -p {protocol} --dport {port} -j DROP -m comment --comment {name}"
+            ));
+        }
     }
-    Ok(())
+
+    vec![
+        FirewallRestoreTable {
+            table: "raw",
+            rules: raw,
+        },
+        FirewallRestoreTable {
+            table: "nat",
+            rules: nat,
+        },
+        FirewallRestoreTable {
+            table: "filter",
+            rules: filter,
+        },
+    ]
 }
 
 pub(super) async fn get_default_interface() -> Result<String> {
@@ -589,82 +424,20 @@ pub(super) async fn get_default_interface() -> Result<String> {
     Ok(iface)
 }
 
-/// Delete IPv4 iptables rules that contain `comment`.
+/// Delete IPv4 iptables rules with the exact `comment`.
 async fn delete_iptables_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
-    let (raw, nat, filter) = tokio::join!(
-        delete_firewall_rules_from_table("iptables", "iptables-save", "raw", comment),
-        delete_firewall_rules_from_table("iptables", "iptables-save", "nat", comment),
-        delete_firewall_rules_from_table("iptables", "iptables-save", "filter", comment),
-    );
-    if matches!(raw, NamespaceDeleteOutcome::Deleted)
-        && matches!(nat, NamespaceDeleteOutcome::Deleted)
-        && matches!(filter, NamespaceDeleteOutcome::Deleted)
-    {
-        NamespaceDeleteOutcome::Deleted
-    } else {
-        NamespaceDeleteOutcome::Abandoned
-    }
+    Ipv4FirewallSnapshot::capture()
+        .await
+        .delete_rules_with_comments(&BTreeSet::from([comment.to_string()]))
+        .await
 }
 
-/// Delete pool-scoped IPv4 and IPv6 firewall rules that contain `comment`.
+/// Delete pool-scoped IPv4 and IPv6 firewall rules with the exact `comment`.
 pub(super) async fn delete_pool_firewall_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
-    let (ipv4, ipv6_filter) = tokio::join!(
-        delete_iptables_rules_by_comment(comment),
-        delete_firewall_rules_from_table("ip6tables", "ip6tables-save", "filter", comment),
-    );
-    if matches!(ipv4, NamespaceDeleteOutcome::Deleted)
-        && matches!(ipv6_filter, NamespaceDeleteOutcome::Deleted)
-    {
-        NamespaceDeleteOutcome::Deleted
-    } else {
-        NamespaceDeleteOutcome::Abandoned
-    }
-}
-
-async fn delete_firewall_rules_from_table(
-    command: &str,
-    save_command: &str,
-    table: &str,
-    comment: &str,
-) -> NamespaceDeleteOutcome {
-    let output = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT).await
-    {
-        Ok(output) => output,
-        Err(e) => {
-            warn!(save_command, table, error = %e, "failed to read firewall rules, skipping cleanup");
-            return NamespaceDeleteOutcome::Abandoned;
-        }
-    };
-    delete_firewall_rule_lines(
-        command,
-        table,
-        output
-            .lines()
-            .filter(|line| line.starts_with("-A ") && line.contains(comment)),
-    )
-    .await
-}
-
-async fn delete_firewall_rule_lines<'a>(
-    command: &str,
-    table: &str,
-    rules: impl Iterator<Item = &'a str>,
-) -> NamespaceDeleteOutcome {
-    // Sequential: the legacy xtables lock serializes writes to the same table anyway.
-    // Note: split_whitespace + trim_matches('"') is safe because namespace
-    // comment values (e.g. "vm0-ns-00-0a") never contain spaces. If they
-    // did, iptables-save would quote them as `--comment "foo bar"` and the
-    // split would incorrectly break the value into separate arguments.
-    let mut outcomes = Vec::new();
-    for line in rules {
-        let rule = line.replacen("-A ", "-D ", 1);
-        let mut args: Vec<&str> = vec!["-t", table];
-        args.extend(rule.split_whitespace().map(|t| t.trim_matches('"')));
-        outcomes.push(
-            exec_xtables_ignore_errors_with_timeout(command, &args, NETNS_COMMAND_TIMEOUT).await,
-        );
-    }
-    NamespaceDeleteOutcome::from_best_effort(outcomes)
+    FirewallSnapshot::capture()
+        .await
+        .delete_rules_with_comments(&BTreeSet::from([comment.to_string()]))
+        .await
 }
 
 /// Delete a namespace's network resources (iptables, veth, netns).
@@ -685,6 +458,60 @@ async fn delete_namespace_resources(ns_name: &str, host_device: &str) -> Namespa
         );
         NamespaceDeleteOutcome::Abandoned
     }
+}
+
+/// Delete a known batch of namespace resources from one firewall snapshot.
+///
+/// Pool shutdown reaches this path with every currently queued namespace, so
+/// reading each complete firewall table once avoids multiplying host-wide
+/// discovery by the pool size. The optional DNS comment is captured and
+/// deleted in the same pass once no namespace creation remains pending.
+async fn delete_network_resources(
+    namespaces: Vec<NetnsInfo>,
+    dns_input_filter_comment: Option<String>,
+) -> NamespaceDeleteOutcome {
+    if namespaces.is_empty() && dns_input_filter_comment.is_none() {
+        return NamespaceDeleteOutcome::Deleted;
+    }
+
+    let mut comments: BTreeSet<String> = namespaces
+        .iter()
+        .map(|namespace| namespace.name.clone())
+        .collect();
+    let includes_ipv6 = dns_input_filter_comment.is_some();
+    if let Some(comment) = dns_input_filter_comment {
+        comments.insert(comment);
+    }
+
+    let firewall = if includes_ipv6 {
+        FirewallSnapshot::capture()
+            .await
+            .delete_rules_with_comments(&comments)
+            .await
+    } else {
+        Ipv4FirewallSnapshot::capture()
+            .await
+            .delete_rules_with_comments(&comments)
+            .await
+    };
+
+    let mut outcome = firewall;
+    for namespace in namespaces {
+        info!(name = %namespace.name, "deleting namespace");
+        let namespace_outcome =
+            delete_namespace_link_and_netns(&namespace.name, &namespace.host_device).await;
+        if matches!(namespace_outcome, NamespaceDeleteOutcome::Deleted) {
+            info!(name = %namespace.name, "namespace deleted");
+        } else {
+            warn!(
+                name = %namespace.name,
+                host_device = %namespace.host_device,
+                "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
+            );
+            outcome = NamespaceDeleteOutcome::Abandoned;
+        }
+    }
+    outcome
 }
 
 /// Delete the host veth and netns only; callers handle host iptables separately.
@@ -836,45 +663,16 @@ pub(super) async fn create_single_namespace(
         &host_ip,
         &peer_ip,
         sn,
-        &default_iface,
+        NamespaceFirewallConfig {
+            default_iface: &default_iface,
+            proxy_port,
+            dns_port,
+        },
     )
     .await;
 
     match result {
         Ok(()) => {
-            if let Some(port) = proxy_port {
-                if let Err(e) = add_proxy_redirect_rule(
-                    &ns_name,
-                    &host_device,
-                    &peer_ip,
-                    port,
-                    dns_port.is_some(),
-                )
-                .await
-                {
-                    error!(name = %ns_name, error = %e, "failed to add proxy rules, cleaning up");
-                    delete_namespace_resources(&ns_name, &host_device).await;
-                    return Err(e);
-                }
-                if let Err(e) = add_non_tcp_log_rule(&ns_name, &host_device, &peer_ip).await {
-                    error!(name = %ns_name, error = %e, "failed to add non-TCP log rule, cleaning up");
-                    delete_namespace_resources(&ns_name, &host_device).await;
-                    return Err(e);
-                }
-            }
-            if let Some(port) = dns_port {
-                if let Err(e) = add_dns_redirect_rules(&ns_name, &host_device, &peer_ip, port).await
-                {
-                    error!(name = %ns_name, error = %e, "failed to add DNS redirect rules, cleaning up");
-                    delete_namespace_resources(&ns_name, &host_device).await;
-                    return Err(e);
-                }
-                if let Err(e) = add_dns_drop_rules(&ns_name, &host_device, &peer_ip).await {
-                    error!(name = %ns_name, error = %e, "failed to add DNS drop rules, cleaning up");
-                    delete_namespace_resources(&ns_name, &host_device).await;
-                    return Err(e);
-                }
-            }
             info!(name = %ns_name, "namespace created");
             Ok(NetnsInfo::new(ns_name, host_device, peer_ip))
         }
@@ -893,13 +691,14 @@ async fn create_namespace_inner(
     host_ip: &str,
     peer_ip: &str,
     sn: &GuestNetwork,
-    default_iface: &str,
+    firewall_config: NamespaceFirewallConfig<'_>,
 ) -> Result<()> {
     let gw_with_prefix = format!("{}/{}", sn.gateway_ip, sn.prefix_len);
     create_netns_with_tap(name, sn.tap_name, sn.tap_mac, &gw_with_prefix).await?;
     setup_veth_pair(name, host_device, host_ip, peer_ip).await?;
     setup_namespace_routing(name, host_ip, sn.gateway_ip, sn.prefix_len).await?;
-    setup_host_iptables(name, host_device, peer_ip, default_iface).await?;
+    let firewall = namespace_firewall_restore_tables(name, host_device, peer_ip, firewall_config);
+    apply_firewall_rules_with_restore("iptables-restore", &firewall).await?;
 
     Ok(())
 }
@@ -912,9 +711,110 @@ enum SnapshotSource<T> {
 
 #[derive(Debug)]
 struct FirewallTableSnapshot {
-    command: &'static str,
     table: &'static str,
     rules_by_pool: SnapshotSource<BTreeMap<u32, Vec<String>>>,
+}
+
+#[derive(Clone, Debug)]
+struct FirewallRestoreTable {
+    table: &'static str,
+    rules: Vec<String>,
+}
+
+struct FirewallRestoreSelection {
+    tables: Vec<FirewallRestoreTable>,
+    sources_complete: bool,
+}
+
+#[derive(Clone, Copy)]
+enum FirewallRestoreMode {
+    Apply,
+    Delete,
+}
+
+#[derive(Debug)]
+struct Ipv4FirewallSnapshot {
+    raw: FirewallTableSnapshot,
+    nat: FirewallTableSnapshot,
+    filter: FirewallTableSnapshot,
+}
+
+impl Ipv4FirewallSnapshot {
+    async fn capture() -> Self {
+        let (raw, nat, filter) = tokio::join!(
+            capture_firewall_table("iptables-save", "raw"),
+            capture_firewall_table("iptables-save", "nat"),
+            capture_firewall_table("iptables-save", "filter"),
+        );
+        Self { raw, nat, filter }
+    }
+
+    fn extend_candidate_pool_indexes(&self, indexes: &mut BTreeSet<u32>) {
+        for table in [&self.raw, &self.nat, &self.filter] {
+            extend_candidate_pool_indexes(table, indexes);
+        }
+    }
+
+    async fn delete_pool_rules(&self, pool_index: u32) -> NamespaceDeleteOutcome {
+        delete_firewall_restore_selection(
+            "iptables-restore",
+            firewall_restore_tables_for_pool([&self.raw, &self.nat, &self.filter], pool_index),
+        )
+        .await
+    }
+
+    async fn delete_rules_with_comments(
+        &self,
+        comments: &BTreeSet<String>,
+    ) -> NamespaceDeleteOutcome {
+        delete_firewall_restore_selection(
+            "iptables-restore",
+            firewall_restore_tables_with_comments([&self.raw, &self.nat, &self.filter], comments),
+        )
+        .await
+    }
+}
+
+#[derive(Debug)]
+struct FirewallSnapshot {
+    ipv4: Ipv4FirewallSnapshot,
+    ipv6_filter: FirewallTableSnapshot,
+}
+
+impl FirewallSnapshot {
+    async fn capture() -> Self {
+        let (ipv4, ipv6_filter) = tokio::join!(
+            Ipv4FirewallSnapshot::capture(),
+            capture_firewall_table("ip6tables-save", "filter"),
+        );
+        Self { ipv4, ipv6_filter }
+    }
+
+    fn extend_candidate_pool_indexes(&self, indexes: &mut BTreeSet<u32>) {
+        self.ipv4.extend_candidate_pool_indexes(indexes);
+        extend_candidate_pool_indexes(&self.ipv6_filter, indexes);
+    }
+
+    async fn delete_pool_rules(&self, pool_index: u32) -> NamespaceDeleteOutcome {
+        let ipv6 = firewall_restore_tables_for_pool([&self.ipv6_filter], pool_index);
+        let (ipv4, ipv6_filter) = tokio::join!(
+            self.ipv4.delete_pool_rules(pool_index),
+            delete_firewall_restore_selection("ip6tables-restore", ipv6),
+        );
+        combine_namespace_delete_outcomes([ipv4, ipv6_filter])
+    }
+
+    async fn delete_rules_with_comments(
+        &self,
+        comments: &BTreeSet<String>,
+    ) -> NamespaceDeleteOutcome {
+        let ipv6 = firewall_restore_tables_with_comments([&self.ipv6_filter], comments);
+        let (ipv4, ipv6_filter) = tokio::join!(
+            self.ipv4.delete_rules_with_comments(comments),
+            delete_firewall_restore_selection("ip6tables-restore", ipv6),
+        );
+        combine_namespace_delete_outcomes([ipv4, ipv6_filter])
+    }
 }
 
 #[derive(Debug)]
@@ -925,43 +825,23 @@ struct CapturedNamespace {
 
 #[derive(Debug)]
 struct ReconciliationSnapshot {
-    ipv4_raw: FirewallTableSnapshot,
-    ipv4_nat: FirewallTableSnapshot,
-    ipv4_filter: FirewallTableSnapshot,
-    ipv6_filter: FirewallTableSnapshot,
+    firewall: FirewallSnapshot,
     namespaces_by_pool: SnapshotSource<BTreeMap<u32, Vec<CapturedNamespace>>>,
 }
 
 impl ReconciliationSnapshot {
     async fn capture() -> Self {
-        let (ipv4_raw, ipv4_nat, ipv4_filter, ipv6_filter, namespaces) = tokio::join!(
-            capture_firewall_table("iptables", "iptables-save", "raw"),
-            capture_firewall_table("iptables", "iptables-save", "nat"),
-            capture_firewall_table("iptables", "iptables-save", "filter"),
-            capture_firewall_table("ip6tables", "ip6tables-save", "filter"),
-            capture_namespaces(),
-        );
+        let (firewall, namespaces) =
+            tokio::join!(FirewallSnapshot::capture(), capture_namespaces());
         Self {
-            ipv4_raw,
-            ipv4_nat,
-            ipv4_filter,
-            ipv6_filter,
+            firewall,
             namespaces_by_pool: namespaces,
         }
     }
 
     fn candidate_pool_indexes(&self, own_index: u32) -> BTreeSet<u32> {
         let mut indexes = BTreeSet::from([own_index]);
-        for table in [
-            &self.ipv4_raw,
-            &self.ipv4_nat,
-            &self.ipv4_filter,
-            &self.ipv6_filter,
-        ] {
-            if let SnapshotSource::Captured(rules_by_pool) = &table.rules_by_pool {
-                indexes.extend(rules_by_pool.keys().copied());
-            }
-        }
+        self.firewall.extend_candidate_pool_indexes(&mut indexes);
         if let SnapshotSource::Captured(namespaces_by_pool) = &self.namespaces_by_pool {
             indexes.extend(namespaces_by_pool.keys().copied());
         }
@@ -970,38 +850,39 @@ impl ReconciliationSnapshot {
 }
 
 async fn capture_firewall_table(
-    command: &'static str,
     save_command: &'static str,
     table: &'static str,
 ) -> FirewallTableSnapshot {
-    let rules_by_pool = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT)
-        .await
-    {
-        Ok(output) => {
-            let mut rules_by_pool: BTreeMap<u32, Vec<String>> = BTreeMap::new();
-            for line in output.lines() {
-                if let Some(pool_index) = firewall_rule_pool_index(line) {
-                    rules_by_pool
-                        .entry(pool_index)
-                        .or_default()
-                        .push(line.to_string());
+    let rules_by_pool =
+        match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT).await {
+            Ok(output) => {
+                let mut rules_by_pool: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+                for line in output.lines() {
+                    if let Some(pool_index) = firewall_rule_pool_index(line) {
+                        rules_by_pool
+                            .entry(pool_index)
+                            .or_default()
+                            .push(line.to_string());
+                    }
                 }
+                SnapshotSource::Captured(rules_by_pool)
             }
-            SnapshotSource::Captured(rules_by_pool)
-        }
-        Err(error) => {
-            warn!(save_command, table, %error, "failed to capture firewall rules for startup reconciliation");
-            SnapshotSource::Abandoned
-        }
-    };
+            Err(error) => {
+                warn!(save_command, table, %error, "failed to capture firewall rules for cleanup");
+                SnapshotSource::Abandoned
+            }
+        };
     FirewallTableSnapshot {
-        command,
         table,
         rules_by_pool,
     }
 }
 
 fn firewall_rule_pool_index(line: &str) -> Option<u32> {
+    firewall_rule_comment(line).and_then(pool_index_from_comment)
+}
+
+fn firewall_rule_comment(line: &str) -> Option<&str> {
     if !line.starts_with("-A ") {
         return None;
     }
@@ -1009,10 +890,7 @@ fn firewall_rule_pool_index(line: &str) -> Option<u32> {
     let mut tokens = line.split_whitespace();
     while let Some(token) = tokens.next() {
         if token == "--comment" {
-            return tokens
-                .next()
-                .map(|comment| comment.trim_matches('"'))
-                .and_then(pool_index_from_comment);
+            return tokens.next().map(|comment| comment.trim_matches('"'));
         }
     }
     None
@@ -1059,36 +937,16 @@ async fn capture_namespaces() -> SnapshotSource<BTreeMap<u32, Vec<CapturedNamesp
     SnapshotSource::Captured(namespaces_by_pool)
 }
 
-async fn delete_firewall_rules_from_snapshot(
-    snapshot: &FirewallTableSnapshot,
-    pool_index: u32,
-) -> NamespaceDeleteOutcome {
-    let SnapshotSource::Captured(rules_by_pool) = &snapshot.rules_by_pool else {
-        return NamespaceDeleteOutcome::Abandoned;
-    };
-    let Some(rules) = rules_by_pool.get(&pool_index) else {
-        return NamespaceDeleteOutcome::Deleted;
-    };
-
-    delete_firewall_rule_lines(
-        snapshot.command,
-        snapshot.table,
-        rules.iter().map(String::as_str),
-    )
-    .await
+fn extend_candidate_pool_indexes(snapshot: &FirewallTableSnapshot, indexes: &mut BTreeSet<u32>) {
+    if let SnapshotSource::Captured(rules_by_pool) = &snapshot.rules_by_pool {
+        indexes.extend(rules_by_pool.keys().copied());
+    }
 }
 
-async fn delete_pool_firewall_rules_from_snapshot(
-    snapshot: &ReconciliationSnapshot,
-    pool_index: u32,
+fn combine_namespace_delete_outcomes(
+    outcomes: impl IntoIterator<Item = NamespaceDeleteOutcome>,
 ) -> NamespaceDeleteOutcome {
-    let (raw, nat, filter, ipv6_filter) = tokio::join!(
-        delete_firewall_rules_from_snapshot(&snapshot.ipv4_raw, pool_index),
-        delete_firewall_rules_from_snapshot(&snapshot.ipv4_nat, pool_index),
-        delete_firewall_rules_from_snapshot(&snapshot.ipv4_filter, pool_index),
-        delete_firewall_rules_from_snapshot(&snapshot.ipv6_filter, pool_index),
-    );
-    if [raw, nat, filter, ipv6_filter]
+    if outcomes
         .into_iter()
         .all(|outcome| matches!(outcome, NamespaceDeleteOutcome::Deleted))
     {
@@ -1098,16 +956,182 @@ async fn delete_pool_firewall_rules_from_snapshot(
     }
 }
 
+fn firewall_restore_tables_for_pool<'a>(
+    snapshots: impl IntoIterator<Item = &'a FirewallTableSnapshot>,
+    pool_index: u32,
+) -> FirewallRestoreSelection {
+    select_firewall_restore_tables(snapshots, |rules_by_pool| {
+        rules_by_pool
+            .get(&pool_index)
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect()
+    })
+}
+
+fn firewall_restore_tables_with_comments<'a>(
+    snapshots: impl IntoIterator<Item = &'a FirewallTableSnapshot>,
+    comments: &BTreeSet<String>,
+) -> FirewallRestoreSelection {
+    select_firewall_restore_tables(snapshots, |rules_by_pool| {
+        rules_by_pool
+            .values()
+            .flatten()
+            .filter(|line| {
+                firewall_rule_comment(line).is_some_and(|comment| comments.contains(comment))
+            })
+            .cloned()
+            .collect()
+    })
+}
+
+fn select_firewall_restore_tables<'a>(
+    snapshots: impl IntoIterator<Item = &'a FirewallTableSnapshot>,
+    select_rules: impl Fn(&BTreeMap<u32, Vec<String>>) -> Vec<String>,
+) -> FirewallRestoreSelection {
+    let mut selection = FirewallRestoreSelection {
+        tables: Vec::new(),
+        sources_complete: true,
+    };
+    for snapshot in snapshots {
+        match &snapshot.rules_by_pool {
+            SnapshotSource::Captured(rules_by_pool) => {
+                selection.tables.push(FirewallRestoreTable {
+                    table: snapshot.table,
+                    rules: select_rules(rules_by_pool),
+                });
+            }
+            SnapshotSource::Abandoned => selection.sources_complete = false,
+        }
+    }
+    selection
+}
+
+fn firewall_restore_payload(
+    tables: &[FirewallRestoreTable],
+    mode: FirewallRestoreMode,
+) -> std::result::Result<String, &'static str> {
+    let mut payload = String::new();
+    for table in tables {
+        if table.rules.is_empty() {
+            continue;
+        }
+        payload.push('*');
+        payload.push_str(table.table);
+        payload.push('\n');
+        for rule in &table.rules {
+            match mode {
+                FirewallRestoreMode::Apply => payload.push_str(rule),
+                FirewallRestoreMode::Delete => {
+                    payload.push_str("-D ");
+                    payload.push_str(
+                        rule.strip_prefix("-A ")
+                            .ok_or("captured firewall rule has an invalid append form")?,
+                    );
+                }
+            }
+            payload.push('\n');
+        }
+        payload.push_str("COMMIT\n");
+    }
+    Ok(payload)
+}
+
+async fn delete_firewall_restore_selection(
+    command: &str,
+    selection: FirewallRestoreSelection,
+) -> NamespaceDeleteOutcome {
+    let outcome = delete_firewall_rules_with_restore(command, selection.tables).await;
+    combine_namespace_delete_outcomes([
+        outcome,
+        if selection.sources_complete {
+            NamespaceDeleteOutcome::Deleted
+        } else {
+            NamespaceDeleteOutcome::Abandoned
+        },
+    ])
+}
+
+async fn delete_firewall_rules_with_restore(
+    command: &str,
+    tables: Vec<FirewallRestoreTable>,
+) -> NamespaceDeleteOutcome {
+    let payload = match firewall_restore_payload(&tables, FirewallRestoreMode::Delete) {
+        Ok(payload) => payload,
+        Err(error) => {
+            warn!(command, error, "failed to build firewall restore input");
+            return NamespaceDeleteOutcome::Abandoned;
+        }
+    };
+    if payload.is_empty() {
+        return NamespaceDeleteOutcome::Deleted;
+    }
+
+    match run_firewall_restore(command, &payload).await {
+        Ok(()) => NamespaceDeleteOutcome::Deleted,
+        Err(error) => {
+            warn!(command, %error, "firewall restore did not complete cleanly");
+            NamespaceDeleteOutcome::Abandoned
+        }
+    }
+}
+
+async fn apply_firewall_rules_with_restore(
+    command: &str,
+    tables: &[FirewallRestoreTable],
+) -> Result<()> {
+    let payload = firewall_restore_payload(tables, FirewallRestoreMode::Apply)
+        .map_err(|error| NetworkError::Prerequisite(error.into()))?;
+    if payload.is_empty() {
+        return Ok(());
+    }
+    run_firewall_restore(command, &payload).await?;
+    Ok(())
+}
+
+async fn run_firewall_restore(
+    command: &str,
+    payload: &str,
+) -> std::result::Result<(), CommandError> {
+    let mut file = match tempfile::NamedTempFile::new() {
+        Ok(file) => file,
+        Err(error) => {
+            return Err(CommandError {
+                command: command.to_string(),
+                detail: format!("failed to create firewall restore input: {error}"),
+            });
+        }
+    };
+    if let Err(error) = file.write_all(payload.as_bytes()) {
+        return Err(CommandError {
+            command: command.to_string(),
+            detail: format!("failed to write firewall restore input: {error}"),
+        });
+    }
+    let Some(path) = file.path().to_str() else {
+        return Err(CommandError {
+            command: command.to_string(),
+            detail: format!(
+                "firewall restore input path is not UTF-8: {}",
+                file.path().display()
+            ),
+        });
+    };
+
+    exec_xtables_status_with_timeout(command, &["--noflush", path], NETNS_COMMAND_TIMEOUT).await
+}
+
 /// Clean up all captured resources matching a given pool index.
 ///
 /// Deletes orphaned host firewall rules first, then deletes captured
-/// namespaces and their veth devices. If snapshot-backed firewall cleanup is
-/// abandoned, each namespace retains the existing fresh-discovery fallback.
+/// namespaces and their veth devices. An abandoned snapshot remains abandoned;
+/// cleanup never expands one failed host read into per-namespace table scans.
 async fn cleanup_namespaces_from_snapshot(
     snapshot: &ReconciliationSnapshot,
     index: u32,
 ) -> NamespaceDeleteOutcome {
-    let firewall = delete_pool_firewall_rules_from_snapshot(snapshot, index).await;
+    let firewall = snapshot.firewall.delete_pool_rules(index).await;
     let SnapshotSource::Captured(namespaces_by_pool) = &snapshot.namespaces_by_pool else {
         return NamespaceDeleteOutcome::Abandoned;
     };
@@ -1122,25 +1146,18 @@ async fn cleanup_namespaces_from_snapshot(
         let ns_name = namespace.name.clone();
         let host_device = namespace.host_device.clone();
         set.spawn(async move {
-            match firewall {
-                NamespaceDeleteOutcome::Deleted => {
-                    info!(name = %ns_name, "deleting namespace");
-                    let outcome = delete_namespace_link_and_netns(&ns_name, &host_device).await;
-                    if matches!(outcome, NamespaceDeleteOutcome::Deleted) {
-                        info!(name = %ns_name, "namespace deleted");
-                    } else {
-                        warn!(
-                            name = %ns_name,
-                            host_device,
-                            "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
-                        );
-                    }
-                    outcome
-                }
-                NamespaceDeleteOutcome::Abandoned => {
-                    delete_namespace_resources(&ns_name, &host_device).await
-                }
+            info!(name = %ns_name, "deleting namespace");
+            let outcome = delete_namespace_link_and_netns(&ns_name, &host_device).await;
+            if matches!(outcome, NamespaceDeleteOutcome::Deleted) {
+                info!(name = %ns_name, "namespace deleted");
+            } else {
+                warn!(
+                    name = %ns_name,
+                    host_device,
+                    "namespace cleanup did not complete cleanly; startup orphan reconciliation will retry"
+                );
             }
+            outcome
         });
     }
 
@@ -1266,6 +1283,152 @@ mod tests {
             NamespaceDeleteOutcome::from_best_effort([outcome]),
             NamespaceDeleteOutcome::Abandoned
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn firewall_restore_applies_insert_and_append_rules_in_one_waiting_mutation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let command = dir.path().join("verify-restore");
+        std::fs::write(
+            &command,
+            r#"#!/bin/sh
+[ "$1" = "--wait" ] || exit 2
+[ "$2" = "--noflush" ] || exit 3
+EXPECTED='*raw
+-I PREROUTING 1 -m comment --comment vm0-ns-00-00 -j DROP
+COMMIT
+*filter
+-A FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT
+COMMIT'
+[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        apply_firewall_rules_with_restore(
+            command.to_str().unwrap(),
+            &[
+                FirewallRestoreTable {
+                    table: "raw",
+                    rules: vec!["-I PREROUTING 1 -m comment --comment vm0-ns-00-00 -j DROP".into()],
+                },
+                FirewallRestoreTable {
+                    table: "filter",
+                    rules: vec!["-A FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT".into()],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn firewall_restore_batches_tables_in_one_waiting_mutation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let command = dir.path().join("verify-restore");
+        std::fs::write(
+            &command,
+            r#"#!/bin/sh
+[ "$1" = "--wait" ] || exit 2
+[ "$2" = "--noflush" ] || exit 3
+EXPECTED='*raw
+-D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP
+COMMIT
+*filter
+-D FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT
+COMMIT'
+[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let outcome = delete_firewall_rules_with_restore(
+            command.to_str().unwrap(),
+            vec![
+                FirewallRestoreTable {
+                    table: "raw",
+                    rules: vec!["-A PREROUTING -m comment --comment vm0-ns-00-00 -j DROP".into()],
+                },
+                FirewallRestoreTable {
+                    table: "nat",
+                    rules: Vec::new(),
+                },
+                FirewallRestoreTable {
+                    table: "filter",
+                    rules: vec!["-A FORWARD -m comment --comment vm0-ns-00-00 -j ACCEPT".into()],
+                },
+            ],
+        )
+        .await;
+
+        assert_eq!(outcome, NamespaceDeleteOutcome::Deleted);
+    }
+
+    #[tokio::test]
+    async fn firewall_restore_nonzero_is_abandoned() {
+        let outcome = delete_firewall_rules_with_restore(
+            "false",
+            vec![FirewallRestoreTable {
+                table: "raw",
+                rules: vec!["-A PREROUTING -j DROP".into()],
+            }],
+        )
+        .await;
+
+        assert_eq!(outcome, NamespaceDeleteOutcome::Abandoned);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn incomplete_snapshot_deletes_captured_rules_and_remains_abandoned() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let command = dir.path().join("verify-restore");
+        let called = dir.path().join("called");
+        std::fs::write(
+            &command,
+            format!(
+                r#"#!/bin/sh
+[ "$1" = "--wait" ] || exit 2
+[ "$2" = "--noflush" ] || exit 3
+EXPECTED='*raw
+-D PREROUTING -m comment --comment vm0-ns-00-00 -j DROP
+COMMIT'
+[ "$(cat "$3")" = "$EXPECTED" ] || exit 4
+touch "{}"
+"#,
+                called.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let captured = FirewallTableSnapshot {
+            table: "raw",
+            rules_by_pool: SnapshotSource::Captured(BTreeMap::from([(
+                0,
+                vec!["-A PREROUTING -m comment --comment vm0-ns-00-00 -j DROP".into()],
+            )])),
+        };
+        let abandoned = FirewallTableSnapshot {
+            table: "filter",
+            rules_by_pool: SnapshotSource::Abandoned,
+        };
+        let selection = firewall_restore_tables_for_pool([&captured, &abandoned], 0);
+
+        let outcome = delete_firewall_restore_selection(command.to_str().unwrap(), selection).await;
+
+        assert!(called.exists());
+        assert_eq!(outcome, NamespaceDeleteOutcome::Abandoned);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -30,8 +30,8 @@ use super::completion::{
 use super::host::ConntrackFlushOutcome;
 use super::host::{
     NamespaceDeleteOutcome, NetnsLifecycleOps, acquire_pool_lock, create_single_namespace,
-    delete_pool_firewall_rules_by_comment, enable_host_ip_forwarding, get_default_interface,
-    reconcile_orphan_namespaces, setup_dns_input_filter,
+    enable_host_ip_forwarding, get_default_interface, reconcile_orphan_namespaces,
+    setup_dns_input_filter,
 };
 use super::naming::{MAX_NAMESPACES, format_hex_index, make_host_device_dnsmasq_pattern};
 use super::types::{
@@ -878,7 +878,7 @@ impl NetnsPoolState {
                 .chain(self.proxy_queue.iter())
                 .cloned(),
         );
-        let dns_input_filter_comment = if namespaces.is_empty() && wait_for_pending.is_none() {
+        let dns_input_filter_comment = if wait_for_pending.is_none() {
             self.dns_input_filter_comment.clone()
         } else {
             None
@@ -1039,7 +1039,10 @@ impl NetnsPoolInner {
             }
         }
 
-        let delete = (plan.ops.delete_namespace)(plan.info.clone()).await;
+        let delete = plan
+            .ops
+            .delete_network_resources(vec![plan.info.clone()], None)
+            .await;
         let mut state = self.state.lock().await;
         state.commit_release_delete(lease, &plan, delete)
     }
@@ -1056,22 +1059,27 @@ impl NetnsPoolInner {
             }
 
             let names = cleanup_namespace_names(&plan.namespaces);
-            delete_namespaces_with_ops(plan.ops, plan.namespaces).await;
+            let dns_input_filter_comment = plan.dns_input_filter_comment;
+            let outcome = delete_network_resources_with_ops(
+                plan.ops,
+                plan.namespaces,
+                dns_input_filter_comment.clone(),
+            )
+            .await;
+            if let Some(comment) = &dns_input_filter_comment
+                && matches!(outcome, NamespaceDeleteOutcome::Abandoned)
+            {
+                warn!(
+                    comment,
+                    "DNS input filter cleanup did not complete cleanly; startup orphan reconciliation will retry"
+                );
+            }
             {
                 let mut state = self.state.lock().await;
                 state.remove_queued_namespaces(&names);
-            }
-
-            if let Some(comment) = plan.dns_input_filter_comment {
-                let outcome = delete_pool_firewall_rules_by_comment(&comment).await;
-                if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
-                    warn!(
-                        comment,
-                        "DNS input filter cleanup did not complete cleanly; startup orphan reconciliation will retry"
-                    );
+                if let Some(comment) = &dns_input_filter_comment {
+                    state.commit_dns_input_filter_cleanup(comment);
                 }
-                let mut state = self.state.lock().await;
-                state.commit_dns_input_filter_cleanup(&comment);
             }
 
             if let Some(mut waiter) = plan.wait_for_pending
@@ -1301,20 +1309,35 @@ where
 }
 
 async fn delete_namespaces_with_ops(ops: NetnsLifecycleOps, namespaces: Vec<NetnsInfo>) {
+    delete_network_resources_with_ops(ops, namespaces, None).await;
+}
+
+async fn delete_network_resources_with_ops(
+    ops: NetnsLifecycleOps,
+    namespaces: Vec<NetnsInfo>,
+    dns_input_filter_comment: Option<String>,
+) -> NamespaceDeleteOutcome {
     let count = namespaces.len();
     if count > 0 {
         info!(count, "cleaning up namespace pool entries");
     }
-    for ns in namespaces {
-        let outcome = (ops.delete_namespace)(ns.clone()).await;
-        if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+    let namespace_metadata: Vec<_> = namespaces
+        .iter()
+        .map(|namespace| (namespace.name.clone(), namespace.host_device.clone()))
+        .collect();
+    let outcome = ops
+        .delete_network_resources(namespaces, dns_input_filter_comment)
+        .await;
+    if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+        for (name, host_device) in namespace_metadata {
             warn!(
-                name = %ns.name,
-                host_device = %ns.host_device,
+                name,
+                host_device,
                 "namespace cleanup was abandoned; startup orphan reconciliation will retry"
             );
         }
     }
+    outcome
 }
 
 fn cleanup_namespace_names(namespaces: &[NetnsInfo]) -> HashSet<String> {
@@ -1325,8 +1348,8 @@ fn cleanup_namespace_names(namespaces: &[NetnsInfo]) -> HashSet<String> {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     const TEST_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -1458,10 +1481,11 @@ mod tests {
                         flush_outcome
                     })
                 }),
-                delete_namespace: Arc::new(move |_| {
+                delete_network_resources: Arc::new(move |namespaces, _| {
                     let delete_count = Arc::clone(&delete_count_for_ops);
+                    let count = namespaces.len();
                     Box::pin(async move {
-                        delete_count.fetch_add(1, Ordering::SeqCst);
+                        delete_count.fetch_add(count, Ordering::SeqCst);
                         delete_outcome
                     })
                 }),
@@ -1485,7 +1509,9 @@ mod tests {
                     ConntrackFlushOutcome::Trusted
                 })
             }),
-            delete_namespace: Arc::new(|_| Box::pin(async { NamespaceDeleteOutcome::Deleted })),
+            delete_network_resources: Arc::new(|_, _| {
+                Box::pin(async { NamespaceDeleteOutcome::Deleted })
+            }),
         };
         let probe = probe_for_test(move |namespace| {
             let phase = Arc::clone(&phase_for_probe);
@@ -1557,7 +1583,9 @@ mod tests {
                         ConntrackFlushOutcome::Trusted
                     })
                 }),
-                delete_namespace: Arc::new(|_| Box::pin(async { NamespaceDeleteOutcome::Deleted })),
+                delete_network_resources: Arc::new(|_, _| {
+                    Box::pin(async { NamespaceDeleteOutcome::Deleted })
+                }),
             },
             entered,
             release,
@@ -1582,10 +1610,11 @@ mod tests {
                         ConntrackFlushOutcome::Trusted
                     })
                 }),
-                delete_namespace: Arc::new(move |_| {
+                delete_network_resources: Arc::new(move |namespaces, _| {
                     let delete_count = Arc::clone(&delete_count_for_ops);
+                    let count = namespaces.len();
                     Box::pin(async move {
-                        delete_count.fetch_add(1, Ordering::SeqCst);
+                        delete_count.fetch_add(count, Ordering::SeqCst);
                         NamespaceDeleteOutcome::Deleted
                     })
                 }),
@@ -1620,10 +1649,11 @@ mod tests {
                         ConntrackFlushOutcome::Trusted
                     })
                 }),
-                delete_namespace: Arc::new(move |_| {
+                delete_network_resources: Arc::new(move |namespaces, _| {
                     let delete_count = Arc::clone(&delete_count_for_ops);
+                    let count = namespaces.len();
                     Box::pin(async move {
-                        delete_count.fetch_add(1, Ordering::SeqCst);
+                        delete_count.fetch_add(count, Ordering::SeqCst);
                         NamespaceDeleteOutcome::Deleted
                     })
                 }),
@@ -1645,12 +1675,13 @@ mod tests {
         BlockingDeleteLifecycle {
             ops: NetnsLifecycleOps {
                 flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
-                delete_namespace: Arc::new(move |_| {
+                delete_network_resources: Arc::new(move |namespaces, _| {
                     let entered = Arc::clone(&entered_for_ops);
                     let release = Arc::clone(&release_for_ops);
                     let delete_count = Arc::clone(&delete_count_for_ops);
+                    let count = namespaces.len();
                     Box::pin(async move {
-                        let attempt = delete_count.fetch_add(1, Ordering::SeqCst);
+                        let attempt = delete_count.fetch_add(count, Ordering::SeqCst);
                         if attempt == 0 {
                             entered.notify_one();
                             release.notified().await;
@@ -1683,12 +1714,13 @@ mod tests {
                         ConntrackFlushOutcome::Untrusted
                     })
                 }),
-                delete_namespace: Arc::new(move |_| {
+                delete_network_resources: Arc::new(move |namespaces, _| {
                     let delete_count = Arc::clone(&delete_count_for_ops);
                     let entered = Arc::clone(&entered_for_ops);
                     let release = Arc::clone(&release_for_ops);
+                    let count = namespaces.len();
                     Box::pin(async move {
-                        let attempt = delete_count.fetch_add(1, Ordering::SeqCst);
+                        let attempt = delete_count.fetch_add(count, Ordering::SeqCst);
                         if attempt == 0 {
                             entered.notify_one();
                             release.notified().await;
@@ -3050,6 +3082,42 @@ mod tests {
         let pool = pool.inner.state.lock().await;
         assert!(!pool.active);
         assert!(pool.plain_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_batches_queued_namespaces_and_dns_filter() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let calls_for_ops = Arc::clone(&calls);
+        let ops = NetnsLifecycleOps {
+            flush_conntrack: Arc::new(|_| Box::pin(async { ConntrackFlushOutcome::Trusted })),
+            delete_network_resources: Arc::new(move |namespaces, dns_comment| {
+                let calls = Arc::clone(&calls_for_ops);
+                Box::pin(async move {
+                    calls.lock().unwrap().push((
+                        namespaces
+                            .into_iter()
+                            .map(|namespace| namespace.name)
+                            .collect::<Vec<_>>(),
+                        dns_comment,
+                    ));
+                    NamespaceDeleteOutcome::Deleted
+                })
+            }),
+        };
+        let mut state = NetnsPoolState::inactive_for_test();
+        state.active = true;
+        state.plain_queue.push_back(test_info("plain-ns"));
+        state.proxy_queue.push_back(test_info("proxy-ns"));
+        state.dns_input_filter_comment = Some("vm0-ns-00-dns".into());
+        state.ops = ops;
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        pool.cleanup().await.unwrap();
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, ["plain-ns", "proxy-ns"]);
+        assert_eq!(calls[0].1.as_deref(), Some("vm0-ns-00-dns"));
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -60,8 +60,14 @@ const SNAPSHOT_CREATE_COMMAND_GROUPS: &[&[&str]] = &[
     SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
 ];
 
-const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
-const DNS_INPUT_FILTER_COMMANDS: &[&str] = &["ip6tables", "ip6tables-save"];
+const NETWORK_COMMANDS: &[&str] = &[
+    "ip",
+    "iptables",
+    "iptables-save",
+    "iptables-restore",
+    "sysctl",
+];
+const DNS_INPUT_FILTER_COMMANDS: &[&str] = &["ip6tables", "ip6tables-save", "ip6tables-restore"];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
 const COW_POOL_SNAPSHOT_RESTORE_COMMANDS: &[&str] = &["cp"];
@@ -540,7 +546,14 @@ mod tests {
         let mode = PrerequisiteMode::FactoryFresh;
         assert_eq!(
             required_commands(&mode),
-            vec!["ip", "iptables", "iptables-save", "sysctl", "mkfs.ext4"]
+            vec![
+                "ip",
+                "iptables",
+                "iptables-save",
+                "iptables-restore",
+                "sysctl",
+                "mkfs.ext4"
+            ]
         );
     }
 
@@ -555,6 +568,7 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
+                "iptables-restore",
                 "sysctl",
                 "cp",
                 "mkfs.ext4",
@@ -577,6 +591,7 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
+                "iptables-restore",
                 "sysctl",
                 "mkfs.ext4",
                 "unshare",
@@ -622,7 +637,13 @@ mod tests {
     fn network_prerequisites_only_require_ipv6_tools_for_dns_filter() {
         assert_eq!(
             network_commands(false),
-            vec!["ip", "iptables", "iptables-save", "sysctl"]
+            vec![
+                "ip",
+                "iptables",
+                "iptables-save",
+                "iptables-restore",
+                "sysctl"
+            ]
         );
         assert_eq!(
             network_commands(true),
@@ -630,9 +651,11 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
+                "iptables-restore",
                 "sysctl",
                 "ip6tables",
                 "ip6tables-save",
+                "ip6tables-restore",
             ]
         );
     }


### PR DESCRIPTION
## Summary

- apply each namespace's host firewall rules through one waiting `iptables-restore --noflush` transaction instead of up to eleven separate mutations
- clean queued namespaces and the pool DNS filter from one firewall snapshot and one restore transaction per address family
- batch snapshot-backed orphan deletion while preserving exact comment matching, partial-source best-effort cleanup, bounded waits, and abandoned outcomes
- require the restore binaries at runner startup and cover restore-backed reconciliation in the real runner behavior script

## Motivation

Waiting for the legacy xtables lock made mutations reliable, but namespace creation and teardown still acquired that host-wide lock once per rule. A single-snapshot startup reconciler removed repeated discovery, yet normal warm-up, shutdown, and snapshot-backed deletion could still spend multiple timeout windows competing for the same lock.

This change removes those repeated mutation processes without changing firewall rule content or final ordering.

## Scope

- no API, persisted-state, queue, runner protocol, or guest contract changes
- no firewall policy or resource naming changes
- failed snapshot sources do not trigger repeated full-table scans; rules from successfully captured sources are still reclaimed and the aggregate outcome remains abandoned

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `cargo test -p sandbox-fc --all-targets --all-features` (744 passed)
- `cargo test -p runner --all-targets --all-features` (2787 passed, 13 ignored; guest inventory integration passed)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `bash -n .github/scripts/runner-behavior-cancel.sh`
- `shellcheck .github/scripts/runner-behavior-cancel.sh`
- `git diff --check`
