### PR TITLE
fix(ci): prevent connector test cleanup race

### DIFF
--- a/.github/scripts/tests/check-connector-source-freeze-test.sh
+++ b/.github/scripts/tests/check-connector-source-freeze-test.sh
@@ -55,6 +55,7 @@ firewall_dir="${repo}/turbo/packages/firewalls-generator/src"
 git init -q -b main "$repo"
 git -C "$repo" config user.email test@example.com
 git -C "$repo" config user.name Test
+git -C "$repo" config maintenance.auto false
 mkdir -p "$connector_dir" "$firewall_dir"
 printf 'export const connector = "base";\n' > "${connector_dir}/example.ts"
 printf 'export const runtime = "base";\n' > "${connector_runtime_dir}/runtime.ts"

--- a/.github/scripts/tests/check-connector-source-freeze-test.sh
+++ b/.github/scripts/tests/check-connector-source-freeze-test.sh
@@ -55,6 +55,7 @@ firewall_dir="${repo}/turbo/packages/firewalls-generator/src"
 git init -q -b main "$repo"
 git -C "$repo" config user.email test@example.com
 git -C "$repo" config user.name Test
+# Prevent detached Git maintenance from racing temporary repository cleanup.
 git -C "$repo" config maintenance.auto false
 mkdir -p "$connector_dir" "$firewall_dir"
 printf 'export const connector = "base";\n' > "${connector_dir}/example.ts"


### PR DESCRIPTION
## Summary

- disable automatic Git maintenance in the connector source freeze test's ephemeral repository
- prevent Git 2.54 detached maintenance from racing temporary repository cleanup
- document why the test-specific maintenance setting must be preserved

## Scope

- test setup only; connector source freeze behavior is unchanged
- no production or runtime changes

## Validation

- `bash -n .github/scripts/tests/check-connector-source-freeze-test.sh`
- `shellcheck .github/scripts/tests/check-connector-source-freeze-test.sh`
- `bash .github/scripts/tests/check-connector-source-freeze-test.sh`
- Git 2.43 and Git 2.54 traces confirmed zero detached maintenance launches
- Git 2.54 stress run passed 100/100 iterations on the current head
