### PR TITLE
test(api): stabilize cron skill sync tests against registry growth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_SKILLS_REPO,
 } from "@vm0/core/github-url";
 import { getSkillStorageName, SYSTEM_ORG_ID } from "@vm0/core/storage-names";
-import { getSeedSkillNames, SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { cronSyncSkillsContract } from "@vm0/api-contracts/contracts/cron";
 import { http, HttpResponse } from "msw";
 import { create as createTar } from "tar";
@@ -36,7 +36,9 @@ const context = testContext();
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
 const TEST_SKILL_PREFIX = "api-test-skill";
-const ALL_SEED_SKILL_NAMES = getSeedSkillNames();
+// The service validates SEED_SKILLS; alpha and beta cover arbitrary repository
+// entries without coupling these route tests to the connector registry size.
+const REQUIRED_SEED_SKILL_NAMES = SEED_SKILLS;
 const STALE_PRESEEDED_COMMIT_SHA = "0".repeat(40);
 
 interface MockSkillEntry {
@@ -216,7 +218,7 @@ function memoizedTarballBuilder(): (
 const createMockTarball = memoizedTarballBuilder();
 
 function seedSkillEntries(): MockSkillEntry[] {
-  return ALL_SEED_SKILL_NAMES.map((name) => {
+  return REQUIRED_SEED_SKILL_NAMES.map((name) => {
     return {
       name,
       files: [
@@ -500,7 +502,7 @@ describe("GET /api/cron/sync-skills", () => {
       [200],
     );
 
-    expect(response.body.total).toBe(ALL_SEED_SKILL_NAMES.length + 2);
+    expect(response.body.total).toBe(REQUIRED_SEED_SKILL_NAMES.length + 2);
     await expect(
       findSkillByUrl(testSkillUrl(nonSkillDirectory.name)),
     ).resolves.toBeNull();
@@ -678,7 +680,7 @@ describe("GET /api/cron/sync-skills", () => {
     mockEnv("AXIOM_DATASET_SUFFIX", "dev");
     const omittedSkills = SEED_SKILLS.slice(0, 2);
     const omittedSkillSet = new Set(omittedSkills);
-    const keptSkills = ALL_SEED_SKILL_NAMES.filter((name) => {
+    const keptSkills = REQUIRED_SEED_SKILL_NAMES.filter((name) => {
       return !omittedSkillSet.has(name);
     });
     const commitSha = newCommitSha();


### PR DESCRIPTION
## Summary

- Limit the cron skill sync route fixture to the required `SEED_SKILLS` instead of every dynamically registered connector skill.
- Keep `alpha` and `beta` fixtures so arbitrary repository skill entries still exercise the real route, database, tarball, and incremental sync paths.
- Remove registry-size-dependent CI timing without raising timeouts or adding retries, sleeps, skips, or manual cleanup.

## Context

The failed Turbo run timed out two tests at 5,004 ms and 5,020 ms while the whole file slowed from about 8.4 seconds to 27.6 seconds. At the current registry size, `getSeedSkillNames()` expands this route fixture from 36 required seed skills to 321 entries, even though the service validates only `SEED_SKILLS`. The same commit and adjacent main commits passed under normal runner load, and the failure log contained no unhandled promise, abort, or teardown warnings.

Failed run: https://github.com/vm0-ai/vm0/actions/runs/29919954928

## Verification

- Target file passed 5 consecutive runs: 50/50 tests, with test phases between 1.23s and 2.12s.
- Target file passed again on the latest main commit: 10/10 tests in 1.27s.
- The exact CI shard executed the target file successfully: 10/10 tests in 1.17s. The full local shard had unrelated queue, usage, and catalog environment failures.
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- Prettier and `git diff --check`

## Product behavior

No production code or sync behavior changes. The test continues to cover required seed validation, generic repository skills, incremental updates, malformed frontmatter, orphan removal, and S3 cleanup failures.