### PR TITLE
feat(platform): simplify gmail automation match conditions

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -61,6 +61,18 @@ export interface WorkflowCopyFormState {
   readonly removeOriginal: boolean;
 }
 
+export type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
+export type GmailTextOperator = "contains" | "doesNotContain";
+export interface GmailMatchCondition {
+  readonly field: GmailTextField;
+  readonly operator: GmailTextOperator;
+  readonly value: string;
+}
+
+function defaultGmailMatchConditions(): readonly GmailMatchCondition[] {
+  return [{ field: "from", operator: "contains", value: "" }];
+}
+
 function defaultWorkflowCopyForm(): WorkflowCopyFormState {
   return {
     selectedAgentId: null,
@@ -217,6 +229,12 @@ const internalRevealWebhookSecretAutomationId$ = state<string | null>(null);
 const internalCreateGithubLabelActor$ = state<WorkflowGithubLabelActor>("me");
 const internalEditingGithubLabelActors$ = state<
   Record<string, WorkflowGithubLabelActor>
+>({});
+const internalCreateGmailMatchConditions$ = state<
+  readonly GmailMatchCondition[]
+>(defaultGmailMatchConditions());
+const internalEditingGmailMatchConditions$ = state<
+  Readonly<Record<string, readonly GmailMatchCondition[]>>
 >({});
 const internalCreateScheduleCronFields$ = state<WorkflowCronFields>(
   defaultWorkflowCronFields(),
@@ -421,6 +439,8 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
   set(internalCreatedWorkflowWebhookAutomation$, null);
   set(internalCreateGithubLabelActor$, "me");
   set(internalEditingGithubLabelActors$, {});
+  set(internalCreateGmailMatchConditions$, defaultGmailMatchConditions());
+  set(internalEditingGmailMatchConditions$, {});
   set(internalCreateScheduleCronFields$, defaultWorkflowCronFields());
   set(internalEditingScheduleCronFields$, defaultWorkflowCronFields());
   set(internalWorkflowConnectorReadiness$, null);
@@ -459,6 +479,7 @@ export const setEditingWorkflowAutomationId$ = command(
     set(internalEditingWorkflowAutomationId$, automationId);
     if (!automationId) {
       set(internalEditingGithubLabelActors$, {});
+      set(internalEditingGmailMatchConditions$, {});
     }
   },
 );
@@ -498,6 +519,9 @@ export const setWorkflowAutomationCreateDialog$ = command(
     }
     if (dialog === "github-label") {
       set(internalCreateGithubLabelActor$, "me");
+    }
+    if (dialog === "gmail") {
+      set(internalCreateGmailMatchConditions$, defaultGmailMatchConditions());
     }
     if (dialog === "notion-page-content-updated") {
       set(internalCreateNotionPageContentUpdatedScope$, "page");
@@ -573,6 +597,34 @@ export const setEditingGithubLabelActor$ = command(
   ) => {
     set(internalEditingGithubLabelActors$, (actors) => {
       return { ...actors, [input.automationId]: input.actor };
+    });
+  },
+);
+
+export const createGmailMatchConditions$ = computed((get) => {
+  return get(internalCreateGmailMatchConditions$);
+});
+
+export const setCreateGmailMatchConditions$ = command(
+  ({ set }, conditions: readonly GmailMatchCondition[]) => {
+    set(internalCreateGmailMatchConditions$, conditions);
+  },
+);
+
+export const editingGmailMatchConditions$ = computed((get) => {
+  return get(internalEditingGmailMatchConditions$);
+});
+
+export const setEditingGmailMatchConditions$ = command(
+  (
+    { set },
+    input: {
+      readonly automationId: string;
+      readonly conditions: readonly GmailMatchCondition[];
+    },
+  ) => {
+    set(internalEditingGmailMatchConditions$, {
+      [input.automationId]: input.conditions,
     });
   },
 );

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2236,9 +2236,30 @@ describe("workflow detail page", () => {
     const createAutomationForm = await screen.findByRole("form", {
       name: "Add Gmail automation",
     });
+    expect(within(createAutomationForm).getAllByRole("textbox")).toHaveLength(
+      1,
+    );
+    expect(
+      buttonByText("Remove condition 1", createAutomationForm),
+    ).toBeDisabled();
     await fill(
       within(createAutomationForm).getByLabelText("From contains"),
       "@acme.com",
+    );
+    click(buttonByText("Add condition", createAutomationForm));
+    expect(within(createAutomationForm).getAllByRole("textbox")).toHaveLength(
+      2,
+    );
+    click(buttonByText("Remove condition 2", createAutomationForm));
+    expect(within(createAutomationForm).getAllByRole("textbox")).toHaveLength(
+      1,
+    );
+    click(buttonByText("Add condition", createAutomationForm));
+    selectOptionByLabel("Condition 2 field", "Subject", createAutomationForm);
+    selectOptionByLabel(
+      "Condition 2 operator",
+      "Does not contain",
+      createAutomationForm,
     );
     await fill(
       within(createAutomationForm).getByLabelText("Subject does not contain"),
@@ -2929,10 +2950,16 @@ describe("workflow detail page", () => {
     const updateAutomationForm = screen.getByRole("form", {
       name: "Update Gmail new message automation",
     });
+    expect(
+      within(updateAutomationForm).getByLabelText("Subject does not contain"),
+    ).toHaveValue("newsletter");
+    click(buttonByText("Add condition", updateAutomationForm));
     await fill(
       within(updateAutomationForm).getByLabelText("From contains"),
       "@acme.com",
     );
+    click(buttonByText("Add condition", updateAutomationForm));
+    selectOptionByLabel("Condition 3 field", "Body", updateAutomationForm);
     await fill(
       within(updateAutomationForm).getByLabelText("Body contains"),
       "invoice",

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -50,6 +50,7 @@ import {
   IconExternalLink,
   IconPlugConnected,
   IconVideo,
+  IconX,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -94,6 +95,7 @@ import {
   createWorkflowGoogleMeetTranscriptGeneratedAutomation$,
   createWorkflowGmailLabelAppliedAutomation$,
   createWorkflowGmailNewMessageAutomation$,
+  createGmailMatchConditions$,
   createWorkflowNotionChildPageAutomation$,
   createWorkflowNotionDatabaseItemAutomation$,
   createWorkflowNotionPageContentUpdatedAutomation$,
@@ -109,6 +111,7 @@ import {
   deleteWorkflowAutomation$,
   editingScheduleCronFields$,
   editingGithubLabelActors$,
+  editingGmailMatchConditions$,
   editingWorkflowAutomationId$,
   patchWorkflowMetadataForm$,
   openWorkflowChat$,
@@ -120,10 +123,12 @@ import {
   runWorkflowAutomationNow$,
   selectedWorkflowFilePath$,
   setCreateGithubLabelActor$,
+  setCreateGmailMatchConditions$,
   setCreateNotionPageContentUpdatedScope$,
   setCreateScheduleCronFields$,
   setCreatedWorkflowWebhookAutomation$,
   setEditingGithubLabelActor$,
+  setEditingGmailMatchConditions$,
   setEditingScheduleCronFields$,
   setEditingWorkflowAutomationId$,
   setRevealWebhookSecretAutomationId$,
@@ -158,6 +163,9 @@ import {
   type WorkflowDetailTab,
   type WorkflowAutomationCreateDialog,
   type NotionPageContentUpdatedScopeMode,
+  type GmailMatchCondition,
+  type GmailTextField,
+  type GmailTextOperator,
   workflowMetadataPatch$,
   workflowConnectorReadiness$,
 } from "../../signals/workflows-page/workflows-signals.ts";
@@ -223,7 +231,6 @@ const AUTOMATION_TIMEZONE = "UTC";
 
 type GmailMatchRules = NonNullable<GmailNewMessageEventConfig["match"]>;
 type GmailTextMatcher = NonNullable<GmailMatchRules["from"]>;
-type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
 type GmailWorkflowAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   {
@@ -252,6 +259,14 @@ const GMAIL_TEXT_FIELDS: readonly {
   { field: "body", label: "Body" },
   { field: "to", label: "To" },
   { field: "cc", label: "Cc" },
+];
+
+const GMAIL_TEXT_OPERATORS: readonly {
+  readonly operator: GmailTextOperator;
+  readonly label: string;
+}[] = [
+  { operator: "contains", label: "Contains" },
+  { operator: "doesNotContain", label: "Does not contain" },
 ];
 
 const GITHUB_SUBJECT_OPTIONS: readonly {
@@ -2558,6 +2573,63 @@ function buildGmailNewMessageEventConfig(
     : { provider: "gmail", event: "new_message" };
 }
 
+function gmailMatchConditions(
+  config?: GmailNewMessageEventConfig,
+): GmailMatchCondition[] {
+  const conditions: GmailMatchCondition[] = [];
+  for (const { field } of GMAIL_TEXT_FIELDS) {
+    for (const { operator } of GMAIL_TEXT_OPERATORS) {
+      const value = config?.match?.[field]?.[operator];
+      if (value) {
+        conditions.push({ field, operator, value });
+      }
+    }
+  }
+  return conditions.length > 0
+    ? conditions
+    : [{ field: "from", operator: "contains", value: "" }];
+}
+
+function nextGmailMatchCondition(
+  conditions: readonly GmailMatchCondition[],
+): GmailMatchCondition | null {
+  for (const { operator } of GMAIL_TEXT_OPERATORS) {
+    for (const { field } of GMAIL_TEXT_FIELDS) {
+      const used = conditions.some((condition) => {
+        return condition.field === field && condition.operator === operator;
+      });
+      if (!used) {
+        return { field, operator, value: "" };
+      }
+    }
+  }
+  return null;
+}
+
+function gmailTextFieldOption(
+  value: string,
+): (typeof GMAIL_TEXT_FIELDS)[number] {
+  const option = GMAIL_TEXT_FIELDS.find((candidate) => {
+    return candidate.field === value;
+  });
+  if (!option) {
+    throw new Error(`Unknown Gmail text field: ${value}`);
+  }
+  return option;
+}
+
+function gmailTextOperatorOption(
+  value: string,
+): (typeof GMAIL_TEXT_OPERATORS)[number] {
+  const option = GMAIL_TEXT_OPERATORS.find((candidate) => {
+    return candidate.operator === value;
+  });
+  if (!option) {
+    throw new Error(`Unknown Gmail text operator: ${value}`);
+  }
+  return option;
+}
+
 function buildGmailLabelAppliedEventConfig(
   form: FormData,
 ): GmailLabelAppliedEventConfig | null {
@@ -2761,14 +2833,6 @@ function workflowAutomationSummary(
     return title ? `Database ${quote(title)}` : "Configured database";
   }
   return null;
-}
-
-function gmailMatcherDefaultValue(
-  config: GmailNewMessageEventConfig,
-  field: GmailTextField,
-  key: "contains" | "doesNotContain",
-): string {
-  return config.match?.[field]?.[key] ?? "";
 }
 
 type AutomationCreateDialogKind =
@@ -4426,6 +4490,187 @@ function WorkflowDayOfWeekPicker({
   );
 }
 
+function updateGmailMatchCondition(
+  conditions: readonly GmailMatchCondition[],
+  index: number,
+  update: Partial<GmailMatchCondition>,
+): readonly GmailMatchCondition[] {
+  return conditions.map((condition, conditionIndex) => {
+    return conditionIndex === index ? { ...condition, ...update } : condition;
+  });
+}
+
+function gmailMatchConditionUsed(
+  conditions: readonly GmailMatchCondition[],
+  index: number,
+  field: GmailTextField,
+  operator: GmailTextOperator,
+): boolean {
+  return conditions.some((condition, conditionIndex) => {
+    return (
+      conditionIndex !== index &&
+      condition.field === field &&
+      condition.operator === operator
+    );
+  });
+}
+
+function GmailMatchConditionRow({
+  condition,
+  conditions,
+  index,
+  disabled,
+  onChange,
+}: {
+  readonly condition: GmailMatchCondition;
+  readonly conditions: readonly GmailMatchCondition[];
+  readonly index: number;
+  readonly disabled: boolean;
+  readonly onChange: (conditions: readonly GmailMatchCondition[]) => void;
+}) {
+  const fieldLabel = gmailTextFieldOption(condition.field).label;
+  const operatorLabel = gmailTextOperatorOption(condition.operator).label;
+  const updateCondition = (update: Partial<GmailMatchCondition>) => {
+    onChange(updateGmailMatchCondition(conditions, index, update));
+  };
+
+  return (
+    <div className="group grid grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_2.25rem] items-center gap-2 sm:grid-cols-[minmax(0,0.85fr)_minmax(0,1.35fr)_minmax(0,2fr)_2.25rem]">
+      <Select
+        value={condition.field}
+        disabled={disabled}
+        onValueChange={(value) => {
+          updateCondition({ field: gmailTextFieldOption(value).field });
+        }}
+      >
+        <SelectTrigger aria-label={`Condition ${index + 1} field`}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {GMAIL_TEXT_FIELDS.map((option) => {
+            return (
+              <SelectItem
+                key={option.field}
+                value={option.field}
+                disabled={gmailMatchConditionUsed(
+                  conditions,
+                  index,
+                  option.field,
+                  condition.operator,
+                )}
+              >
+                {option.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      <Select
+        value={condition.operator}
+        disabled={disabled}
+        onValueChange={(value) => {
+          updateCondition({
+            operator: gmailTextOperatorOption(value).operator,
+          });
+        }}
+      >
+        <SelectTrigger aria-label={`Condition ${index + 1} operator`}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {GMAIL_TEXT_OPERATORS.map((option) => {
+            return (
+              <SelectItem
+                key={option.operator}
+                value={option.operator}
+                disabled={gmailMatchConditionUsed(
+                  conditions,
+                  index,
+                  condition.field,
+                  option.operator,
+                )}
+              >
+                {option.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      <Input
+        name={`${condition.field}${condition.operator === "contains" ? "Contains" : "DoesNotContain"}`}
+        aria-label={`${fieldLabel} ${operatorLabel.toLowerCase()}`}
+        value={condition.value}
+        disabled={disabled}
+        placeholder="Enter a value"
+        className="col-span-2 row-start-2 sm:col-auto sm:row-auto"
+        onChange={(event) => {
+          updateCondition({ value: event.currentTarget.value });
+        }}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={`Remove condition ${index + 1}`}
+        disabled={disabled || conditions.length === 1}
+        className="col-start-3 row-start-1 h-9 w-9 shrink-0 text-muted-foreground hover:bg-gray-50 hover:text-foreground sm:col-auto sm:row-auto [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100"
+        onClick={() => {
+          onChange(
+            conditions.filter((_, conditionIndex) => {
+              return conditionIndex !== index;
+            }),
+          );
+        }}
+      >
+        <IconX size={16} stroke={1.5} />
+      </Button>
+    </div>
+  );
+}
+
+function GmailMatchConditionsEditor({
+  conditions,
+  disabled,
+  onChange,
+}: {
+  readonly conditions: readonly GmailMatchCondition[];
+  readonly disabled: boolean;
+  readonly onChange: (conditions: readonly GmailMatchCondition[]) => void;
+}) {
+  const nextCondition = nextGmailMatchCondition(conditions);
+  return (
+    <div className="flex flex-col gap-2">
+      {conditions.map((condition, index) => {
+        return (
+          <GmailMatchConditionRow
+            key={`${condition.field}-${condition.operator}`}
+            condition={condition}
+            conditions={conditions}
+            index={index}
+            disabled={disabled}
+            onChange={onChange}
+          />
+        );
+      })}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={disabled || !nextCondition}
+        className="-ml-2 w-fit px-2 font-normal"
+        onClick={() => {
+          if (nextCondition) {
+            onChange([...conditions, nextCondition]);
+          }
+        }}
+      >
+        <IconPlus size={14} stroke={1.5} />
+        Add condition
+      </Button>
+    </div>
+  );
+}
+
 function CreateGmailNewMessageAutomationDialog({
   workflowId,
   open,
@@ -4439,6 +4684,8 @@ function CreateGmailNewMessageAutomationDialog({
   const [createLoadable, createGmailAutomation] = useLoadableSet(
     createWorkflowGmailNewMessageAutomation$,
   );
+  const matchConditions = useGet(createGmailMatchConditions$);
+  const setMatchConditions = useSet(setCreateGmailMatchConditions$);
   const creating = createLoadable.state === "loading";
 
   return (
@@ -4471,28 +4718,11 @@ function CreateGmailNewMessageAutomationDialog({
             );
           }}
         >
-          <div className="grid gap-3 sm:grid-cols-2">
-            {GMAIL_TEXT_FIELDS.map(({ field, label }) => {
-              return (
-                <div key={field} className="grid grid-cols-2 gap-2">
-                  <input
-                    name={`${field}Contains`}
-                    aria-label={`${label} contains`}
-                    disabled={creating}
-                    placeholder={`${label} contains`}
-                    className={FIELD_CLASS}
-                  />
-                  <input
-                    name={`${field}DoesNotContain`}
-                    aria-label={`${label} does not contain`}
-                    disabled={creating}
-                    placeholder={`${label} does not contain`}
-                    className={FIELD_CLASS}
-                  />
-                </div>
-              );
-            })}
-          </div>
+          <GmailMatchConditionsEditor
+            conditions={matchConditions}
+            disabled={creating}
+            onChange={setMatchConditions}
+          />
           <DialogFooter>
             <Button
               type="button"
@@ -5545,7 +5775,6 @@ function AutomationControls({
   );
   const [runNowLoadable, runNow] = useLoadableSet(runWorkflowAutomationNow$);
   const busy = runNowLoadable.state === "loading";
-  const running = busy;
   const canEdit = canEditWorkflowAutomation(automation);
   const revealWebhookSecretOpen =
     revealWebhookSecretAutomationId === automation.id &&
@@ -5577,7 +5806,7 @@ function AutomationControls({
                   );
                 }}
               >
-                {running ? (
+                {busy ? (
                   <IconLoader2 size={14} className="animate-spin" />
                 ) : (
                   <IconPlayerPlay size={14} stroke={1.5} />
@@ -5908,6 +6137,11 @@ function UpdateGmailNewMessageAutomationForm({
   const [updateLoadable, updateGmailAutomation] = useLoadableSet(
     updateWorkflowGmailNewMessageAutomation$,
   );
+  const matchConditionsByAutomationId = useGet(editingGmailMatchConditions$);
+  const setMatchConditions = useSet(setEditingGmailMatchConditions$);
+  const matchConditions =
+    matchConditionsByAutomationId[automation.id] ??
+    gmailMatchConditions(automation.eventConfig);
   const saving = updateLoadable.state === "loading";
 
   return (
@@ -5935,38 +6169,13 @@ function UpdateGmailNewMessageAutomationForm({
         );
       }}
     >
-      <div className="grid gap-2 sm:grid-cols-2">
-        {GMAIL_TEXT_FIELDS.map(({ field, label }) => {
-          return (
-            <div key={field} className="grid grid-cols-2 gap-1.5">
-              <input
-                name={`${field}Contains`}
-                aria-label={`${label} contains`}
-                defaultValue={gmailMatcherDefaultValue(
-                  automation.eventConfig,
-                  field,
-                  "contains",
-                )}
-                disabled={saving}
-                placeholder={`${label} contains`}
-                className={AUTOMATION_FIELD_CLASS}
-              />
-              <input
-                name={`${field}DoesNotContain`}
-                aria-label={`${label} does not contain`}
-                defaultValue={gmailMatcherDefaultValue(
-                  automation.eventConfig,
-                  field,
-                  "doesNotContain",
-                )}
-                disabled={saving}
-                placeholder={`${label} does not contain`}
-                className={AUTOMATION_FIELD_CLASS}
-              />
-            </div>
-          );
-        })}
-      </div>
+      <GmailMatchConditionsEditor
+        conditions={matchConditions}
+        disabled={saving}
+        onChange={(conditions) => {
+          setMatchConditions({ automationId: automation.id, conditions });
+        }}
+      />
       <DialogFooter>
         <Button
           type="button"


### PR DESCRIPTION
## Summary

- Replace the ten fixed Gmail matcher inputs with compact field, operator, and value condition rows in both create and edit dialogs
- Support adding and removing conditions while preventing duplicate field/operator pairs
- Keep the existing Gmail event-config payload and preserve legacy `containsAny` and `doesNotContainAny` matchers when editing
- Wrap each condition cleanly on small screens while keeping the desktop layout on one line

## Preview walkthrough

- PASS: default state shows one `From` / `Contains` / value row with the only remove action disabled
- PASS: field options are `From`, `Subject`, `Body`, `To`, and `Cc`; operator options are `Contains` and `Does not contain`
- PASS: add, remove, and re-add condition interactions work with compact stacked rows
- PASS: desktop layout and 390 x 844 mobile layout render without horizontal overflow
- BLOCKED: create/edit persistence could not be completed because the PR API preview is missing `GMAIL_PUBSUB_TOPIC_NAME`; the real submit request reaches the API and returns that environment error

![Desktop default state](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/024a0fe3-2628-4e41-86e2-3c35bc437add/pr-22596-dialog-diagnostic.png)

![Desktop multi-condition state](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/6f9d91b7-79e4-4201-b74e-abeda2d54d1b/pr-22596-gmail-multi-condition.png)

![Mobile multi-condition state](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/e2a36f91-aa05-45ed-af07-16512f1cc154/pr-22596-gmail-mobile.png)

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/workflows-page/workflows-signals.ts apps/platform/src/views/workflows-page/workflow-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm --filter @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t "Gmail new message automation"` (3 passed)
- PR pipeline: all required checks passed

Local dev server was not started per the vm0 PR verification policy; visual verification used the PR preview.
