### PR TITLE
refactor(platform): let ccstate own model and chat resource lifetimes

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -173,6 +173,12 @@ export function clearMockedAuth() {
 
 const clerkListeners: (() => void)[] = [];
 
+export function emitMockedClerkEvent(): void {
+  for (const listener of clerkListeners) {
+    listener();
+  }
+}
+
 type GetTokenImpl = (options?: {
   skipCache?: boolean;
 }) => Promise<string | null>;

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
@@ -1,8 +1,7 @@
 import type { DBSchema, IDBPDatabase, OpenDBCallbacks, openDB } from "idb";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import { CHAT_IDB_VERSION, CHAT_MESSAGES_STORE } from "./chat-idb-schema.ts";
-import { createChatIdbStore } from "./chat-idb-store.ts";
-import { createDeferredPromise } from "../utils.ts";
+import { createChatIdbOpener } from "./chat-idb-store.ts";
 
 type VersionChangeListener = (event: IDBVersionChangeEvent) => void;
 
@@ -109,8 +108,8 @@ function setupSubject(dbs: readonly FakeDb[]) {
   const reload = vi.fn(() => {
     return undefined;
   });
-  const subject = createChatIdbStore({ openDatabase, reload });
-  return { calls, openDatabaseMock, reload, subject };
+  const subject = createChatIdbOpener({ openDatabase, reload });
+  return { calls, reload, subject };
 }
 
 afterEach(() => {
@@ -118,26 +117,22 @@ afterEach(() => {
 });
 
 describe("openChatIdb", () => {
-  it("reuses the same open promise for the same user and org", async () => {
+  it("opens the database scoped to the user and organization", async () => {
     const db = fakeDb();
     const { calls, subject } = setupSubject([db]);
 
-    const first = subject.openChatIdb("user_1", "org_1");
-    const second = subject.openChatIdb("user_1", "org_1");
-
-    expect(first).toBe(second);
-    await expect(first).resolves.toBe(db.db);
+    await expect(subject.openChatIdb("user_1", "org_1")).resolves.toBe(db.db);
     expect(calls).toHaveLength(1);
     expect(calls[0]?.name).toBe("vm0-chat-user_1-org_1");
   });
 
-  it("closes the previous connection before opening a different chat database", async () => {
+  it("does not cache connections outside the ccstate computed", async () => {
     const firstDb = fakeDb();
     const secondDb = fakeDb();
     const { calls, subject } = setupSubject([firstDb, secondDb]);
 
     const first = subject.openChatIdb("user_1", "org_1");
-    const second = subject.openChatIdb("user_1", "org_2");
+    const second = subject.openChatIdb("user_1", "org_1");
 
     expect(first).not.toBe(second);
     await expect(first).resolves.toBe(firstDb.db);
@@ -146,35 +141,9 @@ describe("openChatIdb", () => {
       calls.map((call) => {
         return call.name;
       }),
-    ).toEqual(["vm0-chat-user_1-org_1", "vm0-chat-user_1-org_2"]);
-    expect(firstDb.close).toHaveBeenCalledTimes(1);
-    expect(secondDb.close).not.toHaveBeenCalled();
-  });
-
-  it("opens a different chat database while the previous open is pending", async () => {
-    const firstDb = fakeDb();
-    const secondDb = fakeDb();
-    const { openDatabaseMock, subject } = setupSubject([secondDb]);
-    const pendingFirst = createDeferredPromise<IDBPDatabase>(
-      AbortSignal.any([]),
-    );
-    openDatabaseMock.mockReturnValueOnce(pendingFirst.promise);
-
-    const first = subject.openChatIdb("user_1", "org_1");
-    const second = subject.openChatIdb("user_1", "org_2");
-
-    await expect(second).resolves.toBe(secondDb.db);
-    expect(openDatabaseMock).toHaveBeenCalledTimes(2);
-    expect(
-      openDatabaseMock.mock.calls.map(([name]) => {
-        return name;
-      }),
-    ).toEqual(["vm0-chat-user_1-org_1", "vm0-chat-user_1-org_2"]);
+    ).toEqual(["vm0-chat-user_1-org_1", "vm0-chat-user_1-org_1"]);
     expect(firstDb.close).not.toHaveBeenCalled();
-
-    pendingFirst.resolve(firstDb.db);
-    await expect(first).resolves.toBe(firstDb.db);
-    expect(firstDb.close).toHaveBeenCalledTimes(1);
+    expect(secondDb.close).not.toHaveBeenCalled();
   });
 
   it("registers the shared upgrade callback", async () => {
@@ -207,46 +176,19 @@ describe("openChatIdb", () => {
     );
   });
 
-  it("closes, invalidates, reloads once, and prevents stale reopen after version change", async () => {
-    const firstDb = fakeDb();
-    const { openDatabaseMock, reload, subject } = setupSubject([firstDb]);
+  it("closes the connection and reloads after a version change", async () => {
+    const db = fakeDb();
+    const { reload, subject } = setupSubject([db]);
 
     await subject.openChatIdb("user_1", "org_1");
 
-    expect(firstDb.versionChangeListeners).toHaveLength(1);
-    firstDb.versionChangeListeners[0]?.(
-      versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
-    );
-    firstDb.versionChangeListeners[0]?.(
+    expect(db.versionChangeListeners).toHaveLength(1);
+    db.versionChangeListeners[0]?.(
       versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
     );
 
-    expect(firstDb.close).toHaveBeenCalledTimes(2);
+    expect(db.close).toHaveBeenCalledTimes(1);
     expect(reload).toHaveBeenCalledTimes(1);
-    await expect(subject.openChatIdb("user_1", "org_1")).rejects.toThrow(
-      "Chat IndexedDB is closing for a page reload",
-    );
-    expect(openDatabaseMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("invalidates the current connection after the identity changes", async () => {
-    const firstDb = fakeDb();
-    const secondDb = fakeDb();
-    const { openDatabaseMock, subject } = setupSubject([firstDb, secondDb]);
-
-    await subject.openChatIdb("user_1", "org_1");
-    await subject.openChatIdb("user_1", "org_2");
-
-    secondDb.versionChangeListeners[0]?.(
-      versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
-    );
-
-    await expect(subject.openChatIdb("user_1", "org_2")).rejects.toThrow(
-      "Chat IndexedDB is closing for a page reload",
-    );
-    expect(openDatabaseMock).toHaveBeenCalledTimes(2);
-    expect(firstDb.close).toHaveBeenCalledTimes(1);
-    expect(secondDb.close).toHaveBeenCalledTimes(1);
   });
 
   it("does not close or reload when this open request is blocked", async () => {

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.ts
@@ -17,19 +17,12 @@ type OpenChatIdbDatabase = <DBTypes extends DBSchema | unknown = unknown>(
   callbacks?: OpenDBCallbacks<DBTypes>,
 ) => Promise<IDBPDatabase<DBTypes>>;
 
-interface ChatIdbStoreState {
-  dbName: string | null;
-  dbPromise: Promise<IDBPDatabase> | null;
-  previousClosePromise: Promise<void> | null;
-  reloadTriggered: boolean;
-}
-
-interface ChatIdbStoreOptions {
+interface ChatIdbOpenerOptions {
   readonly openDatabase?: OpenChatIdbDatabase;
   readonly reload?: () => void;
 }
 
-interface ChatIdbStore {
+interface ChatIdbOpener {
   readonly openChatIdb: (
     userId: string,
     orgId: string,
@@ -40,99 +33,50 @@ function chatIdbName(userId: string, orgId: string): string {
   return `vm0-chat-${userId}-${orgId}`;
 }
 
-export function createChatIdbStore(
-  options: ChatIdbStoreOptions = {},
-): ChatIdbStore {
+export function createChatIdbOpener(
+  options: ChatIdbOpenerOptions = {},
+): ChatIdbOpener {
   const openDatabase = options.openDatabase ?? openDB;
   const reload =
     options.reload ??
     (() => {
       window.location.reload();
     });
-  const state: ChatIdbStoreState = {
-    dbName: null,
-    dbPromise: null,
-    previousClosePromise: null,
-    reloadTriggered: false,
-  };
-
-  function handleVersionChange(
-    dbName: string,
-    db: IDBPDatabase,
-    event: IDBVersionChangeEvent,
-  ): void {
-    L.warn("versionchange", {
-      dbName,
-      currentVersion: event.oldVersion,
-      nextVersion: event.newVersion,
-    });
-    db.close();
-    if (state.dbName === dbName) {
-      state.dbName = null;
-      state.dbPromise = null;
-    }
-
-    if (state.reloadTriggered) {
-      return;
-    }
-    state.reloadTriggered = true;
-    reload();
-  }
-
-  async function openChatIdbConnection(dbName: string): Promise<IDBPDatabase> {
-    const db = await openDatabase(dbName, CHAT_IDB_VERSION, {
-      upgrade(db, oldVersion) {
-        L.debug("openDB:upgrade", { dbName });
-        upgradeChatIdb(db, oldVersion);
-      },
-      blocked(currentVersion, blockedVersion) {
-        L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
-      },
-    });
-    db.addEventListener("versionchange", (event) => {
-      handleVersionChange(dbName, db, event);
-    });
-    return db;
-  }
-
-  async function closeChatIdbAfterOpen(
-    promise: Promise<IDBPDatabase>,
-  ): Promise<void> {
-    const [result] = await Promise.allSettled([promise]);
-    if (result?.status === "fulfilled") {
-      result.value.close();
-    }
-  }
 
   return {
-    openChatIdb(userId, orgId) {
-      if (state.reloadTriggered) {
-        return Promise.reject(
-          new Error("Chat IndexedDB is closing for a page reload"),
-        );
-      }
-
+    async openChatIdb(userId, orgId) {
       const dbName = chatIdbName(userId, orgId);
-      if (state.dbName === dbName && state.dbPromise !== null) {
-        return state.dbPromise;
-      }
-
       L.debug("openDB", { dbName });
-      const previous = state.dbPromise;
-      const promise = openChatIdbConnection(dbName);
-      state.dbName = dbName;
-      state.dbPromise = promise;
-      if (previous !== null) {
-        state.previousClosePromise = closeChatIdbAfterOpen(previous);
-      }
-      return promise;
+      const db = await openDatabase(dbName, CHAT_IDB_VERSION, {
+        upgrade(db, oldVersion) {
+          L.debug("openDB:upgrade", { dbName });
+          upgradeChatIdb(db, oldVersion);
+        },
+        blocked(currentVersion, blockedVersion) {
+          L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
+        },
+      });
+      db.addEventListener(
+        "versionchange",
+        (event) => {
+          L.warn("versionchange", {
+            dbName,
+            currentVersion: event.oldVersion,
+            nextVersion: event.newVersion,
+          });
+          db.close();
+          reload();
+        },
+        { once: true },
+      );
+      return db;
     },
   };
 }
 
-const defaultChatIdbStore = createChatIdbStore();
+const defaultChatIdbOpener = createChatIdbOpener();
 
-export const openChatIdb = defaultChatIdbStore.openChatIdb;
+export const openChatIdb = defaultChatIdbOpener.openChatIdb;
 
 export const chatIdb$ = computed(async (get): Promise<IDBPDatabase> => {
   const { userId, orgId } = await get(authenticatedIdentity$);

--- a/turbo/apps/platform/src/signals/external/org-model-policies.ts
+++ b/turbo/apps/platform/src/signals/external/org-model-policies.ts
@@ -1,23 +1,11 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
-import type {
-  OrgModelPoliciesResponse,
-  UpdateOrgModelPolicy,
-} from "@vm0/api-contracts/contracts/model-providers";
+import type { UpdateOrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
-import { currentOrgInfo$ } from "../auth.ts";
 
 const internalReloadOrgModelPolicies$ = state(0);
-
-interface OrgModelPoliciesSnapshot {
-  orgId: string | null;
-  response: OrgModelPoliciesResponse;
-}
-
-const internalOrgModelPoliciesSnapshot$ =
-  state<OrgModelPoliciesSnapshot | null>(null);
 
 interface UpdateOrgModelPoliciesParams {
   policies: UpdateOrgModelPolicy[];
@@ -26,12 +14,6 @@ interface UpdateOrgModelPoliciesParams {
 
 export const orgModelPolicies$ = computed(async (get) => {
   get(internalReloadOrgModelPolicies$);
-  const org = await get(currentOrgInfo$);
-  const orgId = org?.id ?? null;
-  const snapshot = get(internalOrgModelPoliciesSnapshot$);
-  if (snapshot?.orgId === orgId) {
-    return snapshot.response;
-  }
   const createClient = get(zeroClient$);
   const client = createClient(zeroModelPoliciesMainContract, {
     apiBase: "api",
@@ -42,18 +24,11 @@ export const orgModelPolicies$ = computed(async (get) => {
 
 export const refreshOrgModelPolicies$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(internalOrgModelPoliciesSnapshot$, null);
     set(internalReloadOrgModelPolicies$, (value) => {
       return value + 1;
     });
     const response = await get(orgModelPolicies$);
     signal.throwIfAborted();
-    const org = await get(currentOrgInfo$);
-    signal.throwIfAborted();
-    set(internalOrgModelPoliciesSnapshot$, {
-      orgId: org?.id ?? null,
-      response,
-    });
     return response;
   },
 );
@@ -76,11 +51,8 @@ export const updateOrgModelPolicies$ = command(
       [200],
     );
     signal.throwIfAborted();
-    const org = await get(currentOrgInfo$);
-    signal.throwIfAborted();
-    set(internalOrgModelPoliciesSnapshot$, {
-      orgId: org?.id ?? null,
-      response: result.body,
+    set(internalReloadOrgModelPolicies$, (value) => {
+      return value + 1;
     });
     if (params.toast !== false) {
       toast.success("Model provider settings updated");

--- a/turbo/apps/platform/src/signals/external/user-model-preference.ts
+++ b/turbo/apps/platform/src/signals/external/user-model-preference.ts
@@ -5,27 +5,12 @@ import {
   zeroUserModelPreferenceContract,
 } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { zeroClient$ } from "../api-client.ts";
-import { currentOrgInfo$ } from "../auth.ts";
 import { accept } from "../../lib/accept.ts";
 
-interface UserModelPreferenceSnapshot {
-  orgId: string | null;
-  response: UserModelPreferenceResponse;
-}
-
-const internalUserModelPreferenceSnapshot$ =
-  state<UserModelPreferenceSnapshot | null>(null);
 const internalReloadUserModelPreference$ = state(0);
 
 export const userModelPreference$ = computed(async (get) => {
   get(internalReloadUserModelPreference$);
-  const org = await get(currentOrgInfo$);
-  const orgId = org?.id ?? null;
-  const snapshot = get(internalUserModelPreferenceSnapshot$);
-  if (snapshot?.orgId === orgId) {
-    return snapshot.response;
-  }
-
   const createClient = get(zeroClient$);
   const client = createClient(zeroUserModelPreferenceContract, {
     apiBase: "api",
@@ -52,20 +37,15 @@ export const updateUserModelPreference$ = command(
       [200],
     );
     signal.throwIfAborted();
-    const org = await get(currentOrgInfo$);
-    signal.throwIfAborted();
-    set(internalUserModelPreferenceSnapshot$, {
-      orgId: org?.id ?? null,
-      response: result.body,
+    set(internalReloadUserModelPreference$, (value) => {
+      return value + 1;
     });
     return result.body;
   },
 );
 
-export const reloadUserModelPreference$ = command(({ get, set }) => {
-  set(internalUserModelPreferenceSnapshot$, null);
-  set(
-    internalReloadUserModelPreference$,
-    get(internalReloadUserModelPreference$) + 1,
-  );
+export const reloadUserModelPreference$ = command(({ set }) => {
+  set(internalReloadUserModelPreference$, (value) => {
+    return value + 1;
+  });
 });

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -478,26 +478,40 @@ function resolvedChatIdb(db: Awaited<ReturnType<typeof openChatIdb>>) {
   };
 }
 
+async function withChatIdb<T>(
+  scope: TestAuthScope,
+  operation: (db: Awaited<ReturnType<typeof openChatIdb>>) => Promise<T>,
+): Promise<T> {
+  const db = await openChatIdb(scope.userId, scope.orgId);
+  try {
+    return await operation(db);
+  } finally {
+    db.close();
+  }
+}
+
 async function seedCachedArtifacts(
   scope: TestAuthScope,
   artifacts: readonly ArtifactItem[],
 ): Promise<void> {
-  const db = await openChatIdb(scope.userId, scope.orgId);
-  const stores = createArtifactItemCacheStores(resolvedChatIdb(db));
-  await stores.writeStore.replaceItems(artifacts);
-  const seeded = await stores.readStore.readRecent({ limit: 10_000 });
-  if (seeded.length !== artifacts.length) {
-    throw new Error("Expected artifact cache seed to be readable");
-  }
+  await withChatIdb(scope, async (db) => {
+    const stores = createArtifactItemCacheStores(resolvedChatIdb(db));
+    await stores.writeStore.replaceItems(artifacts);
+    const seeded = await stores.readStore.readRecent({ limit: 10_000 });
+    if (seeded.length !== artifacts.length) {
+      throw new Error("Expected artifact cache seed to be readable");
+    }
+  });
 }
 
 async function cachedArtifactIds(scope: TestAuthScope): Promise<string[]> {
-  const db = await openChatIdb(scope.userId, scope.orgId);
-  const artifacts = await createArtifactItemCacheStores(
-    resolvedChatIdb(db),
-  ).readStore.readRecent({ limit: 10_000 });
-  return artifacts.map((artifact) => {
-    return artifact.artifactItemId;
+  return await withChatIdb(scope, async (db) => {
+    const artifacts = await createArtifactItemCacheStores(
+      resolvedChatIdb(db),
+    ).readStore.readRecent({ limit: 10_000 });
+    return artifacts.map((artifact) => {
+      return artifact.artifactItemId;
+    });
   });
 }
 
@@ -1520,10 +1534,11 @@ describe("artifacts page", () => {
         artifact.artifactItemId,
       ]);
     });
-    const db = await openChatIdb(scope.userId, scope.orgId);
-    const cached = await createArtifactItemCacheStores(
-      resolvedChatIdb(db),
-    ).readStore.readRecent({ limit: 10_000 });
+    const cached = await withChatIdb(scope, async (db) => {
+      return await createArtifactItemCacheStores(
+        resolvedChatIdb(db),
+      ).readStore.readRecent({ limit: 10_000 });
+    });
     expect(cached).toStrictEqual([artifact]);
     expect(cached[0]).not.toHaveProperty("isFavorited");
   });
@@ -1580,10 +1595,11 @@ describe("artifacts page", () => {
 
     await screen.findByText("legacy-remote.html");
     await waitFor(async () => {
-      const db = await openChatIdb(scope.userId, scope.orgId);
-      const cached = await createArtifactItemCacheStores(
-        resolvedChatIdb(db),
-      ).readStore.readRecent({ limit: 10_000 });
+      const cached = await withChatIdb(scope, async (db) => {
+        return await createArtifactItemCacheStores(
+          resolvedChatIdb(db),
+        ).readStore.readRecent({ limit: 10_000 });
+      });
       expect(cached).toHaveLength(1);
       expect(cached[0]?.size).toBe(0);
     });
@@ -1629,11 +1645,12 @@ describe("artifacts page", () => {
         staleArtifact.artifactItemId,
       ]);
     });
-    const db = await openChatIdb(scope.userId, scope.orgId);
     await expect(
-      createArtifactItemCacheStores(
-        resolvedChatIdb(db),
-      ).readStore.readLastSyncedAt(),
+      withChatIdb(scope, async (db) => {
+        return await createArtifactItemCacheStores(
+          resolvedChatIdb(db),
+        ).readStore.readLastSyncedAt();
+      }),
     ).resolves.toBe("2026-01-04T00:00:00.000Z");
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -22,7 +22,12 @@ import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/ze
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it } from "vitest";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
-import { reloadUserModelPreference$ } from "../../../signals/external/user-model-preference.ts";
+import { emitMockedClerkEvent } from "../../../__tests__/mock-auth.ts";
+import { orgModelPolicies$ } from "../../../signals/external/org-model-policies.ts";
+import {
+  reloadUserModelPreference$,
+  userModelPreference$,
+} from "../../../signals/external/user-model-preference.ts";
 import { codexFastModeLocalDefault$ } from "../../../signals/zero-page/codex-fast-local-default.ts";
 import {
   resetChatPageModelSelection$,
@@ -74,6 +79,52 @@ beforeEach(() => {
 });
 
 describe("chat composer models", () => {
+  it("keeps model resources cached across Clerk profile events", async () => {
+    const policy = buildModelPolicy({
+      id: "00000000-0000-4000-a000-000000000205",
+      model: "kimi-k2.7-code",
+      modelLabel: "Kimi K2.7 Code",
+      isDefault: true,
+      defaultProviderType: "moonshot-api-key",
+      credentialScope: "org",
+      modelProviderId: MOONSHOT_PROVIDER_ID,
+    });
+    let policiesRequestCount = 0;
+    let preferenceRequestCount = 0;
+
+    mockOrgModelRoutes("kimi-k2.7-code");
+    context.mocks.api(zeroModelPoliciesMainContract.list, ({ respond }) => {
+      policiesRequestCount += 1;
+      return respond(200, {
+        policies: [policy],
+        workspaceDefaultModel: policy.model,
+        workspaceDefaultPolicyId: policy.id,
+      });
+    });
+    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+      preferenceRequestCount += 1;
+      return respond(200, { selectedModel: null, updatedAt: null });
+    });
+    mockAgent();
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await expectComposerModel("Kimi K2.7 Code");
+    await waitFor(() => {
+      expect(policiesRequestCount).toBe(1);
+      expect(preferenceRequestCount).toBe(1);
+    });
+
+    await act(async () => {
+      emitMockedClerkEvent();
+      await context.store.get(orgModelPolicies$);
+      await context.store.get(userModelPreference$);
+    });
+
+    expect(policiesRequestCount).toBe(1);
+    expect(preferenceRequestCount).toBe(1);
+  });
+
   it("resolves workspace, user, and thread model choices in the visible picker", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
@@ -7,10 +7,14 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
+import { mockOrganization, mockUser } from "../../../__tests__/mock-auth.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { CHAT_MESSAGES_STORE } from "../../../signals/external/chat-idb-schema.ts";
-import { openChatIdb } from "../../../signals/external/chat-idb-store.ts";
+import {
+  chatIdb$,
+  openChatIdb,
+} from "../../../signals/external/chat-idb-store.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 vi.mock("idb", async () => {
@@ -52,7 +56,15 @@ async function findThreadLink(title: string): Promise<HTMLAnchorElement> {
 
 describe("chat message persistence", () => {
   it("round-trips structured and legacy messages through IndexedDB on thread re-entry", async () => {
-    const testDb = await openChatIdb("idb-reentry-user", "idb-reentry-org");
+    mockUser(
+      { id: "idb-reentry-user", fullName: "IndexedDB Test User" },
+      { token: "test-token" },
+    );
+    mockOrganization({
+      activeOrg: { id: "idb-reentry-org", name: "IndexedDB Test Org" },
+      memberships: [{ id: "idb-reentry-org" }],
+    });
+    const appDb = await context.store.get(chatIdb$);
     const structuredPrompt = structuredPromptFixture();
     const user = userEvent.setup({ delay: null });
     const blockedRemote = context.mocks.deferred<void>();
@@ -153,24 +165,29 @@ describe("chat message persistence", () => {
       });
       expect(screen.queryByText(STRUCTURED_MESSAGE)).not.toBeInTheDocument();
       await waitFor(async () => {
-        const structuredMessage: unknown = await testDb.get(
-          CHAT_MESSAGES_STORE,
-          STRUCTURED_MESSAGE_ID,
-        );
-        expect(structuredMessage).toMatchObject({
-          content: STRUCTURED_MESSAGE,
-          structuredPrompt,
-          threadId: FIRST_THREAD_ID,
-        });
-        const persistedMessage: unknown = await testDb.get(
-          CHAT_MESSAGES_STORE,
-          FIRST_MESSAGE_ID,
-        );
-        expect(persistedMessage).toMatchObject({
-          content: FIRST_MESSAGE,
-          threadId: FIRST_THREAD_ID,
-        });
-        expect(persistedMessage).not.toHaveProperty("structuredPrompt");
+        const testDb = await openChatIdb("idb-reentry-user", "idb-reentry-org");
+        try {
+          const structuredMessage: unknown = await testDb.get(
+            CHAT_MESSAGES_STORE,
+            STRUCTURED_MESSAGE_ID,
+          );
+          expect(structuredMessage).toMatchObject({
+            content: STRUCTURED_MESSAGE,
+            structuredPrompt,
+            threadId: FIRST_THREAD_ID,
+          });
+          const persistedMessage: unknown = await testDb.get(
+            CHAT_MESSAGES_STORE,
+            FIRST_MESSAGE_ID,
+          );
+          expect(persistedMessage).toMatchObject({
+            content: FIRST_MESSAGE,
+            threadId: FIRST_THREAD_ID,
+          });
+          expect(persistedMessage).not.toHaveProperty("structuredPrompt");
+        } finally {
+          testDb.close();
+        }
       });
 
       await user.click(await findThreadLink("IndexedDB other thread"));
@@ -193,7 +210,7 @@ describe("chat message persistence", () => {
       });
     } finally {
       blockedRemote.resolve();
-      testDb.close();
+      appDb.close();
     }
   });
 
@@ -205,15 +222,28 @@ describe("chat message persistence", () => {
     const cachedMessage = "Invalid cached structured message";
     const remoteMessagesCaughtUp = context.mocks.deferred<void>();
     const testDb = await openChatIdb(userId, orgId);
-    await testDb.put(CHAT_MESSAGES_STORE, {
-      id: "00000000-0000-4000-8000-000000000734",
-      role: "user",
-      content: cachedMessage,
-      structuredPrompt: { version: 1, parts: [] },
-      createdAt: "2026-06-09T10:00:00Z",
-      threadId,
-      orderSequence: -1,
+    try {
+      await testDb.put(CHAT_MESSAGES_STORE, {
+        id: "00000000-0000-4000-8000-000000000734",
+        role: "user",
+        content: cachedMessage,
+        structuredPrompt: { version: 1, parts: [] },
+        createdAt: "2026-06-09T10:00:00Z",
+        threadId,
+        orderSequence: -1,
+      });
+    } finally {
+      testDb.close();
+    }
+    mockUser(
+      { id: userId, fullName: "Invalid IndexedDB Test User" },
+      { token: "test-token" },
+    );
+    mockOrganization({
+      activeOrg: { id: orgId, name: "Invalid IndexedDB Test Org" },
+      memberships: [{ id: orgId }],
     });
+    const appDb = await context.store.get(chatIdb$);
 
     mockChatLifecycle(context, {
       threadId,
@@ -256,7 +286,7 @@ describe("chat message persistence", () => {
       ).resolves.toBeInTheDocument();
       expect(screen.queryByText(cachedMessage)).not.toBeInTheDocument();
     } finally {
-      testDb.close();
+      appDb.close();
     }
   });
 });


### PR DESCRIPTION
## Summary

- keep organization model policies and user model preference response data exclusively in ccstate computed values, with state used only as an explicit reload version
- remove `currentOrgInfo$` and `orgId` snapshot ownership so Clerk profile or token events do not invalidate these model resources
- move chat IndexedDB connection caching to `chatIdb$` while preserving user and organization database naming plus upgrade, blocked, and version-change behavior
- update IndexedDB integration helpers to use short-lived direct connections and add Clerk-event regression coverage

## User impact

- chat no longer refetches `/api/zero/model-policies` or `/api/zero/user-model-preference` solely because Clerk emits a profile or token event
- organization-scoped IndexedDB data remains physically separated without a second module-level identity owner

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm --dir apps/platform exec vitest run src/signals/external/chat-idb-store.test.ts src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx src/views/artifacts-page/__tests__/artifacts-page.test.tsx src/views/zero-page/__tests__/chat-message-persistence.test.tsx` (75 tests passed)
