### PR TITLE
perf(api): consolidate chat message metadata lookups

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -700,9 +700,16 @@ describe("zero workflow automation scheduler", () => {
     expect(read.nextRunAt).toBeNull();
   });
 
-  it("cascade-deletes a workflow's automations when the workflow is removed", async () => {
+  it("preserves run messages when workflow deletion removes automation provenance", async () => {
     const scenario = await setup();
     const automation = await createDueLoopAutomation(scenario, 300);
+
+    await executeDueWorkflowAutomations();
+    const run = await onlyWorkflowRunMessage(automation.threadId);
+    expect(run.workflowSnapshot).toMatchObject({
+      id: scenario.workflowId,
+      automationId: automation.automationId,
+    });
 
     // Under the hard 1:N model a workflow belongs to exactly one agent; removing
     // the workflow cascade-deletes its automations (FK onDelete: cascade).
@@ -715,5 +722,17 @@ describe("zero workflow automation scheduler", () => {
       }),
       [404],
     );
+
+    const historicalRuns = await workflowRunMessages(automation.threadId);
+    expect(historicalRuns).toStrictEqual([
+      {
+        runId: run.runId,
+        triggerSource: "workflow-schedule",
+        automationId: undefined,
+        hasLegacyTriggerId: false,
+        triggerBrief: undefined,
+        workflowSnapshot: undefined,
+      },
+    ]);
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -40,12 +40,16 @@ import {
   type ChatMessageGoalSnapshot,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { userArtifactFavorites } from "@vm0/db/schema/user-artifact-favorite";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import {
+  zeroWorkflowAutomations,
+  zeroWorkflows,
+} from "@vm0/db/schema/zero-workflow";
 import { alias } from "drizzle-orm/pg-core";
 import {
   and,
@@ -102,10 +106,6 @@ const nullableTriggerSourceDecoder = nullableDriverValueDecoder(
   zodEnumDriverValueDecoder(triggerSourceSchema),
 );
 const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
-const nullableIntegerDecoder = nullableDriverValueDecoder(pgIntegerDecoder);
-const nullableTimestampDecoder = nullableDriverValueDecoder(
-  zeroWorkflowAutomations.atTime,
-);
 const TERMINAL_MESSAGE_ORDER_SEQUENCE = 2_147_483_647;
 const matchedChatMessage = alias(chatMessages, "matched_chat_message");
 const hostedRunUploadedFiles = alias(runUploadedFiles, "hosted_files");
@@ -237,12 +237,6 @@ const messageColumns = {
   thinking: chatMessages.thinking,
   runId: effectiveChatMessageRunId(),
   runGroupId: chatMessages.runGroupId,
-  triggerSource: sql`(
-    SELECT "zero_runs"."trigger_source"
-    FROM "zero_runs"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTriggerSourceDecoder),
   usagePayload: chatMessages.usagePayload,
   runEventId: chatMessages.runEventId,
   goalEvent: chatMessages.goalEvent,
@@ -257,168 +251,121 @@ const messageColumns = {
   recommendedFollowups: chatMessages.recommendedFollowups,
   revokesMessageId: chatMessages.revokesMessageId,
   interruptsRunId: chatMessages.interruptsRunId,
-  workflowId: sql`(
-    SELECT "zero_workflows"."id"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    INNER JOIN "zero_workflows"
-      ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAgentId: sql`(
-    SELECT "zero_workflows"."agent_id"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    INNER JOIN "zero_workflows"
-      ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowName: sql`(
-    SELECT "zero_workflows"."name"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    INNER JOIN "zero_workflows"
-      ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowDisplayName: sql`(
-    SELECT "zero_workflows"."display_name"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    INNER JOIN "zero_workflows"
-      ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowDescription: sql`(
-    SELECT "zero_workflows"."description"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    INNER JOIN "zero_workflows"
-      ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationId: sql`(
-    SELECT "zero_workflow_automations"."id"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationBrief: sql`(
-    SELECT COALESCE(
-      "zero_runs"."trigger_brief",
-      CASE
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'gmail-label-applied'
-          THEN 'Gmail label applied'
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'gmail-new-message'
-          THEN 'Gmail new message'
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'google-calendar-event-created'
-          THEN 'Google Calendar event created'
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'google-calendar-event-updated'
-          THEN 'Google Calendar event updated'
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'google-calendar-event-cancelled'
-          THEN 'Google Calendar event cancelled'
-        WHEN "zero_workflow_automations"."kind" = 'event'
-          AND "zero_workflow_automations"."event_type" = 'webhook-received'
-          THEN 'Webhook received'
-        ELSE NULL
-      END
-    )
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationKind: sql`(
-    SELECT "zero_workflow_automations"."kind"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationScheduleType: sql`(
-    SELECT "zero_workflow_automations"."schedule_type"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationCronExpression: sql`(
-    SELECT "zero_workflow_automations"."cron_expression"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationIntervalSeconds: sql`(
-    SELECT "zero_workflow_automations"."interval_seconds"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableIntegerDecoder),
-  workflowAutomationAtTime: sql`(
-    SELECT "zero_workflow_automations"."at_time"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTimestampDecoder),
-  workflowAutomationTimezone: sql`(
-    SELECT "zero_workflow_automations"."timezone"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
-  workflowAutomationUserTimezone: sql`(
-    SELECT "org_members_metadata"."timezone"
-    FROM "zero_runs"
-    INNER JOIN "zero_workflow_automations"
-      ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
-    LEFT JOIN "org_members_metadata"
-      ON "org_members_metadata"."org_id" = "zero_workflow_automations"."org_id"
-      AND "org_members_metadata"."user_id" = "zero_workflow_automations"."owner_user_id"
-    WHERE "zero_runs"."id" = "chat_messages"."run_id"
-    LIMIT 1
-  )`.mapWith(nullableTextDecoder),
 } as const;
 
-function selectedMessageColumns(db: Pick<Db, "select">) {
-  return {
-    ...messageColumns,
-    isGoalRun: exists(
-      db
-        .select({ id: zeroRuns.id })
-        .from(zeroRuns)
-        .where(
-          and(eq(zeroRuns.id, chatMessages.runId), isNotNull(zeroRuns.goalId)),
-        ),
-    ).mapWith(pgBooleanDecoder),
-  } as const;
+function chatMessageMetadataSubquery(db: Pick<Db, "select">) {
+  return db
+    .select({
+      triggerSource: sql`${zeroRuns.triggerSource}`
+        .mapWith(nullableTriggerSourceDecoder)
+        .as("trigger_source"),
+      workflowId: sql`${zeroWorkflows.id}`
+        .mapWith(zeroWorkflows.id)
+        .as("workflow_id"),
+      workflowAgentId: zeroWorkflows.agentId,
+      workflowName: zeroWorkflows.name,
+      workflowDisplayName: zeroWorkflows.displayName,
+      workflowDescription: zeroWorkflows.description,
+      workflowAutomationId: sql`${zeroWorkflowAutomations.id}`
+        .mapWith(zeroWorkflowAutomations.id)
+        .as("workflow_automation_id"),
+      workflowAutomationBrief: sql`CASE
+        WHEN ${isNull(zeroWorkflowAutomations.id)} THEN NULL
+        ELSE COALESCE(
+          ${zeroRuns.triggerBrief},
+          CASE
+            WHEN ${eq(zeroWorkflowAutomations.kind, "event")} THEN CASE
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "gmail-label-applied",
+              )} THEN 'Gmail label applied'
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "gmail-new-message",
+              )} THEN 'Gmail new message'
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "google-calendar-event-created",
+              )} THEN 'Google Calendar event created'
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "google-calendar-event-updated",
+              )} THEN 'Google Calendar event updated'
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "google-calendar-event-cancelled",
+              )} THEN 'Google Calendar event cancelled'
+              WHEN ${eq(
+                zeroWorkflowAutomations.eventType,
+                "webhook-received",
+              )} THEN 'Webhook received'
+              ELSE NULL
+            END
+            ELSE NULL
+          END
+        )
+      END`
+        .mapWith(nullableTextDecoder)
+        .as("workflow_automation_brief"),
+      workflowAutomationKind: zeroWorkflowAutomations.kind,
+      workflowAutomationScheduleType: zeroWorkflowAutomations.scheduleType,
+      workflowAutomationCronExpression: zeroWorkflowAutomations.cronExpression,
+      workflowAutomationIntervalSeconds:
+        zeroWorkflowAutomations.intervalSeconds,
+      workflowAutomationAtTime: zeroWorkflowAutomations.atTime,
+      workflowAutomationTimezone: zeroWorkflowAutomations.timezone,
+      workflowAutomationUserTimezone: sql`${orgMembersMetadata.timezone}`
+        .mapWith(orgMembersMetadata.timezone)
+        .as("workflow_automation_user_timezone"),
+      goalId: zeroRuns.goalId,
+    })
+    .from(zeroRuns)
+    .leftJoin(
+      zeroWorkflowAutomations,
+      eq(zeroWorkflowAutomations.id, zeroRuns.workflowAutomationId),
+    )
+    .leftJoin(
+      zeroWorkflows,
+      eq(zeroWorkflows.id, zeroWorkflowAutomations.workflowId),
+    )
+    .leftJoin(
+      orgMembersMetadata,
+      and(
+        eq(orgMembersMetadata.orgId, zeroWorkflowAutomations.orgId),
+        eq(orgMembersMetadata.userId, zeroWorkflowAutomations.ownerUserId),
+      ),
+    )
+    .where(eq(zeroRuns.id, chatMessages.runId))
+    .limit(1)
+    .as("chat_message_metadata");
+}
+
+function selectChatMessagesWithMetadata(db: Pick<Db, "select">) {
+  const metadata = chatMessageMetadataSubquery(db);
+  return db
+    .select({
+      ...messageColumns,
+      triggerSource: metadata.triggerSource,
+      workflowId: metadata.workflowId,
+      workflowAgentId: metadata.workflowAgentId,
+      workflowName: metadata.workflowName,
+      workflowDisplayName: metadata.workflowDisplayName,
+      workflowDescription: metadata.workflowDescription,
+      workflowAutomationId: metadata.workflowAutomationId,
+      workflowAutomationBrief: metadata.workflowAutomationBrief,
+      workflowAutomationKind: metadata.workflowAutomationKind,
+      workflowAutomationScheduleType: metadata.workflowAutomationScheduleType,
+      workflowAutomationCronExpression:
+        metadata.workflowAutomationCronExpression,
+      workflowAutomationIntervalSeconds:
+        metadata.workflowAutomationIntervalSeconds,
+      workflowAutomationAtTime: metadata.workflowAutomationAtTime,
+      workflowAutomationTimezone: metadata.workflowAutomationTimezone,
+      workflowAutomationUserTimezone: metadata.workflowAutomationUserTimezone,
+      isGoalRun: isNotNull(metadata.goalId).mapWith(pgBooleanDecoder),
+    })
+    .from(chatMessages)
+    .leftJoinLateral(metadata, sql`true`);
 }
 
 const searchMessageColumns = {
@@ -1800,9 +1747,7 @@ export function zeroChatThreadMessagesPage(args: {
     let hasHistoryBefore = false;
 
     if (args.sinceId === undefined && args.beforeId === undefined) {
-      const latestRows = await db
-        .select(selectedMessageColumns(db))
-        .from(chatMessages)
+      const latestRows = await selectChatMessagesWithMetadata(db)
         .where(threadFilter)
         .orderBy(
           desc(chatMessages.createdAt),
@@ -1843,9 +1788,7 @@ export function zeroChatThreadMessagesPage(args: {
       )`;
 
       if (args.sinceId !== undefined) {
-        rows = await db
-          .select(selectedMessageColumns(db))
-          .from(chatMessages)
+        rows = await selectChatMessagesWithMetadata(db)
           .where(and(threadFilter, cursorAfterCondition))
           .orderBy(
             asc(chatMessages.createdAt),
@@ -1854,9 +1797,7 @@ export function zeroChatThreadMessagesPage(args: {
           )
           .limit(args.limit);
       } else {
-        const previousRows = await db
-          .select(selectedMessageColumns(db))
-          .from(chatMessages)
+        const previousRows = await selectChatMessagesWithMetadata(db)
           .where(and(threadFilter, cursorBeforeCondition))
           .orderBy(
             desc(chatMessages.createdAt),
@@ -1892,9 +1833,7 @@ export function zeroChatThreadMessageById(args: {
     }
 
     const db = get(db$);
-    const [row] = await db
-      .select(selectedMessageColumns(db))
-      .from(chatMessages)
+    const [row] = await selectChatMessagesWithMetadata(db)
       .where(
         and(
           eq(chatMessages.id, args.messageId),


### PR DESCRIPTION
## Summary

- replace 15 correlated chat-message metadata scalar subqueries and the goal-run `EXISTS` with one typed, zero-or-one `LEFT JOIN LATERAL` metadata graph
- keep all four latest, `sinceId`, `beforeId`, and single-message reads on the same shared query prefix while preserving their visible predicates, ordering, and limits
- use schema columns and their decoders for workflow metadata, retain runtime validation for `triggerSource`, and preserve the automation-missing null semantics of the trigger brief
- cover historical run messages after workflow deletion removes their automation provenance

## Performance and equivalence

A full local comparison covered 9,852 chat messages and found zero row-count or metadata-value differences across all 16 projected values.

Representative warm `EXPLAIN (ANALYZE, BUFFERS)` observations:

| Shape | Baseline | Replacement |
| --- | --- | --- |
| Latest 51-row page | 904 buffers, 1.384 ms | 106 buffers, 0.201 ms |
| `sinceId` (35 rows) | 1,144 buffers, 0.810 ms | 81 buffers, 0.146 ms |
| `beforeId` (36 rows) | 1,104 buffers, 0.681 ms | 79 buffers, 0.106 ms |
| Single message | 51 buffers, 0.233 ms | 6 buffers, 0.031 ms |

The latest page retains the backward message index, incremental sort, and 52-row read needed to return 51 rows. PostgreSQL chose small in-memory quicksorts for the two cursor samples; forced index-path diagnostics showed the original index plus incremental-sort shape remains available, but used more buffers than the default replacement plans. No optimizer hint or query-shape complication was added.

The final Drizzle SQL for every path contains one statement and one lateral metadata relation, with no independent scalar metadata subplans.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts src/signals/routes/__tests__/webhooks-gmail.test.ts src/signals/routes/__tests__/webhooks-notion.test.ts --maxWorkers=4 --silent=passed-only` (116 passed)
- `pnpm knip --workspace api`
- `pnpm knip`
- pre-commit hook: Prettier, full Knip, and repository-wide Turbo type checks passed

## Scope

No schema, migration, persisted-data, API-contract, protocol, feature-switch, compatibility fallback, or lint-rule change is included. A safe global AST boundary for this historical hardcoded scalar family was not proven, so lint classification remains with the final parent audit.

Closes #22602

Parent context: #22439
