### PR TITLE
refactor(api): register connector skills from catalog metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -721,10 +721,15 @@ function setArtifactAuthMethods(
 function buildBundledSkill(
   connectorRef: string,
   versionId = "a".repeat(64),
-  digests: {
-    readonly manifest: string;
-    readonly archive: string;
-  } = { manifest: ZERO_DIGEST, archive: ZERO_DIGEST },
+  metadata: {
+    readonly size: number;
+    readonly archiveSize: number;
+    readonly fileCount: number;
+  } = {
+    size: Buffer.byteLength(`# ${connectorRef}\n`),
+    archiveSize: 321,
+    fileCount: 1,
+  },
 ): JsonRecord {
   const storageName = `connector-skill@${connectorRef}`;
   const prefix = `__system__/volume/${storageName}/${versionId}`;
@@ -732,24 +737,26 @@ function buildBundledSkill(
     kind: "bundled",
     storageName,
     versionId,
+    size: metadata.size,
+    archiveSize: metadata.archiveSize,
+    fileCount: metadata.fileCount,
     frontmatter: {
       name: `${connectorRef} skill`,
       description: `Use the ${connectorRef} connector`,
     },
     manifest: {
       key: `${prefix}/manifest.json`,
-      digest: digests.manifest,
+      digest: ZERO_DIGEST,
     },
     archive: {
       key: `${prefix}/archive.tar.gz`,
-      digest: digests.archive,
+      digest: ZERO_DIGEST,
     },
   };
 }
 
 interface BundledSkillFixture {
   readonly descriptor: JsonRecord;
-  readonly objects: ReadonlyMap<string, Buffer>;
   readonly storageName: string;
   readonly s3Prefix: string;
   readonly versionId: string;
@@ -759,33 +766,13 @@ interface BundledSkillFixture {
   readonly archiveKey: string;
 }
 
-interface BundledSkillFixtureOptions {
-  readonly manifest?: unknown;
-  readonly archive?: Buffer;
-  readonly manifestDigest?: string;
-  readonly archiveDigest?: string;
-}
-
 function buildBundledSkillFixture(
   connectorRef: string,
   versionId = "a".repeat(64),
-  options: BundledSkillFixtureOptions = {},
 ): BundledSkillFixture {
-  const content = Buffer.from(`# ${connectorRef}\n`);
-  const manifest = jsonBytes(
-    options.manifest ?? {
-      version: 1,
-      files: [
-        {
-          path: "SKILL.md",
-          hash: createHash("sha256").update(content).digest("hex"),
-          size: content.length,
-        },
-      ],
-      createdAt: "1970-01-01T00:00:00.000Z",
-    },
-  );
-  const archive = options.archive ?? Buffer.alloc(321, 1);
+  const contentSize = Buffer.byteLength(`# ${connectorRef}\n`);
+  const archiveSize = 321;
+  const fileCount = 1;
   const storageName = `connector-skill@${connectorRef}`;
   const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
   const versionPrefix = `${s3Prefix}/${versionId}`;
@@ -793,18 +780,15 @@ function buildBundledSkillFixture(
   const archiveKey = `${versionPrefix}/archive.tar.gz`;
   return {
     descriptor: buildBundledSkill(connectorRef, versionId, {
-      manifest: options.manifestDigest ?? digest(manifest),
-      archive: options.archiveDigest ?? digest(archive),
+      size: contentSize,
+      archiveSize,
+      fileCount,
     }),
-    objects: new Map([
-      [manifestKey, manifest],
-      [archiveKey, archive],
-    ]),
     storageName,
     s3Prefix,
     versionId,
-    contentSize: content.length,
-    archiveSize: archive.length,
+    contentSize,
+    archiveSize,
     manifestKey,
     archiveKey,
   };
@@ -2572,11 +2556,7 @@ describe("connector catalog valid lifecycle", () => {
         firstRecord(artifact.connectors, "connectors").skill = skill.descriptor;
       },
     });
-    const objects = new Map(catalogObjects([release], release));
-    for (const [key, bytes] of skill.objects) {
-      objects.set(key, bytes);
-    }
-    serveObjects(objects);
+    serveObjects(catalogObjects([release], release));
     await syncCatalog();
     mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
 
@@ -4023,11 +4003,7 @@ describe("connector catalog valid lifecycle", () => {
         connector.skill = skill.descriptor;
       },
     });
-    const objects = new Map(catalogObjects([release], release));
-    for (const [key, bytes] of skill.objects) {
-      objects.set(key, bytes);
-    }
-    serveObjects(objects);
+    serveObjects(catalogObjects([release], release));
 
     expect((await syncCatalog()).body).toMatchObject({
       outcome: "accepted",
@@ -4045,39 +4021,30 @@ describe("connector catalog valid lifecycle", () => {
       file_count: 1,
       head_version_id: skill.versionId,
     });
+    const requestedKeys = context.mocks.s3.send.mock.calls.map((call) => {
+      const input = commandInput(call[0]);
+      return typeof input.Key === "string" ? input.Key : null;
+    });
+    expect(requestedKeys).not.toContain(skill.manifestKey);
+    expect(requestedKeys).not.toContain(skill.archiveKey);
   });
 
-  it("rejects bundled skill objects that fail verification", async () => {
+  it("rejects incomplete or out-of-range bundled skill metadata", async () => {
     const cases = [
       {
-        expected: "source-unavailable",
-        includeObjects: false,
-        label: "missing",
-        options: {},
+        field: "size",
+        label: "missing-size",
+        value: undefined,
       },
       {
-        expected: "digest-mismatch",
-        includeObjects: true,
-        label: "digest",
-        options: { manifestDigest: ZERO_DIGEST },
+        field: "archiveSize",
+        label: "oversized-archive",
+        value: 2 * 1024 * 1024 + 1,
       },
       {
-        expected: "invalid-artifact",
-        includeObjects: true,
-        label: "manifest",
-        options: {
-          manifest: {
-            version: 1,
-            files: [],
-            createdAt: "1970-01-01T00:00:00.000Z",
-          },
-        },
-      },
-      {
-        expected: "object-too-large",
-        includeObjects: true,
-        label: "oversized",
-        options: { archive: Buffer.alloc(2 * 1024 * 1024 + 1, 1) },
+        field: "fileCount",
+        label: "empty-manifest",
+        value: 0,
       },
     ] as const;
 
@@ -4089,7 +4056,6 @@ describe("connector catalog valid lifecycle", () => {
         createHash("sha256")
           .update(`${testCase.label}:${randomUUID()}`)
           .digest("hex"),
-        testCase.options,
       );
       const previous = await readVolumeStorageState({
         orgId: SYSTEM_ORG_ID,
@@ -4106,24 +4072,23 @@ describe("connector catalog valid lifecycle", () => {
         version: `2026-07-22.skill-${testCase.label}-${randomUUID().slice(0, 8)}`,
         connectorRef,
         mutatePrivate: (artifact) => {
-          firstRecord(artifact.connectors, "connectors").skill =
-            skill.descriptor;
+          const descriptor = structuredClone(skill.descriptor);
+          if (testCase.value === undefined) {
+            delete descriptor[testCase.field];
+          } else {
+            descriptor[testCase.field] = testCase.value;
+          }
+          firstRecord(artifact.connectors, "connectors").skill = descriptor;
         },
       });
-      const objects = new Map(catalogObjects([release], release));
-      if (testCase.includeObjects) {
-        for (const [key, bytes] of skill.objects) {
-          objects.set(key, bytes);
-        }
-      }
-      serveObjects(objects);
+      serveObjects(catalogObjects([release], release));
 
       const response = await syncCatalog();
       expect(response.body).toMatchObject({
         outcome: "rejected",
         state: "never-synced",
         active: null,
-        lastAttempt: { failureCode: testCase.expected },
+        lastAttempt: { failureCode: "invalid-artifact" },
       });
       await expect(
         readVolumeStorageState({
@@ -4181,20 +4146,10 @@ describe("connector catalog valid lifecycle", () => {
       },
     });
 
-    const firstObjects = new Map(catalogObjects([firstRelease], firstRelease));
-    for (const [key, bytes] of firstSkill.objects) {
-      firstObjects.set(key, bytes);
-    }
-    serveObjects(firstObjects);
+    serveObjects(catalogObjects([firstRelease], firstRelease));
     expect((await syncCatalog()).body.outcome).toBe("accepted");
 
-    const secondObjects = new Map(
-      catalogObjects([firstRelease, secondRelease], secondRelease),
-    );
-    for (const [key, bytes] of secondSkill.objects) {
-      secondObjects.set(key, bytes);
-    }
-    serveObjects(secondObjects);
+    serveObjects(catalogObjects([firstRelease, secondRelease], secondRelease));
     expect((await syncCatalog()).body.outcome).toBe("accepted");
 
     context.mocks.s3.send.mockClear();
@@ -4310,12 +4265,7 @@ describe("connector catalog valid lifecycle", () => {
         connectors.push(conflictingConnector);
       },
     });
-    const objects = new Map(catalogObjects([release], release));
-    for (const skill of [firstSkill, conflictingSkill]) {
-      for (const [key, bytes] of skill.objects) {
-        objects.set(key, bytes);
-      }
-    }
+    const objects = catalogObjects([release], release);
     serveObjects(objects);
 
     expect((await syncCatalog()).body).toMatchObject({

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -60,9 +60,8 @@ export function connectorCatalogReleaseArtifactKeys(
 // These schema-v1 limits mirror vm0-connectors output. Changing them requires
 // a new connector catalog artifact schema generation in both repositories.
 const CONNECTOR_SKILL_MAX_FILES = 64;
-const CONNECTOR_SKILL_MAX_FILE_BYTES = 512 * 1024;
-export const CONNECTOR_SKILL_MAX_TOTAL_BYTES = 1024 * 1024;
-const CONNECTOR_SKILL_MAX_PATH_BYTES = 512;
+const CONNECTOR_SKILL_MAX_TOTAL_BYTES = 1024 * 1024;
+const CONNECTOR_SKILL_MAX_ARCHIVE_BYTES = CONNECTOR_SKILL_MAX_TOTAL_BYTES * 2;
 const CONNECTOR_SKILL_STORAGE_NAME_PREFIX = "connector-skill@";
 export const CONNECTOR_SKILL_STORAGE_PATH_PREFIX = "__system__/volume";
 
@@ -108,114 +107,6 @@ const privateSkillArchiveReferenceSchema = artifactReferenceSchema.refine(
 );
 
 const connectorSkillVersionIdSchema = z.string().regex(/^[a-f0-9]{64}$/u);
-
-const connectorSkillFilePathSchema = artifactKeySchema
-  .refine(
-    (filePath) => {
-      return filePath === filePath.normalize("NFC");
-    },
-    {
-      message: "Skill file paths must use NFC normalization",
-    },
-  )
-  .refine(
-    (filePath) => {
-      return !Array.from(filePath).some((character) => {
-        const codePoint = character.codePointAt(0);
-        return (
-          codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)
-        );
-      });
-    },
-    { message: "Skill file paths must not contain control characters" },
-  )
-  .refine(
-    (filePath) => {
-      return (
-        Buffer.byteLength(filePath, "utf8") <= CONNECTOR_SKILL_MAX_PATH_BYTES
-      );
-    },
-    {
-      message: `Skill file paths must not exceed ${CONNECTOR_SKILL_MAX_PATH_BYTES} UTF-8 bytes`,
-    },
-  );
-
-export const connectorSkillManifestSchema = z
-  .object({
-    version: z.literal(1),
-    files: z
-      .array(
-        z
-          .object({
-            path: connectorSkillFilePathSchema,
-            hash: z.string().regex(/^[a-f0-9]{64}$/u),
-            size: z
-              .number()
-              .int()
-              .nonnegative()
-              .max(CONNECTOR_SKILL_MAX_FILE_BYTES),
-          })
-          .strict(),
-      )
-      .min(1)
-      .max(CONNECTOR_SKILL_MAX_FILES),
-    createdAt: z.literal("1970-01-01T00:00:00.000Z"),
-  })
-  .strict()
-  .superRefine((manifest, context) => {
-    const paths = manifest.files.map((file) => {
-      return file.path;
-    });
-    const sortedPaths = [...paths].sort(compareStrings);
-    if (
-      paths.some((filePath, index) => {
-        return filePath !== sortedPaths[index];
-      })
-    ) {
-      context.addIssue({
-        code: "custom",
-        message: "Skill manifest files must be alphabetical",
-        path: ["files"],
-      });
-    }
-    if (new Set(paths).size !== paths.length) {
-      context.addIssue({
-        code: "custom",
-        message: "Skill manifest file paths must be unique",
-        path: ["files"],
-      });
-    }
-    if (
-      new Set(
-        paths.map((filePath) => {
-          return filePath.toLowerCase();
-        }),
-      ).size !== paths.length
-    ) {
-      context.addIssue({
-        code: "custom",
-        message: "Skill manifest file paths must not collide by case",
-        path: ["files"],
-      });
-    }
-    if (!paths.includes("SKILL.md")) {
-      context.addIssue({
-        code: "custom",
-        message: "Skill manifest requires root SKILL.md",
-        path: ["files"],
-      });
-    }
-    const totalSize = manifest.files.reduce((total, file) => {
-      return total + file.size;
-    }, 0);
-    if (totalSize > CONNECTOR_SKILL_MAX_TOTAL_BYTES) {
-      context.addIssue({
-        code: "custom",
-        message: `Skill manifest files must not exceed ${CONNECTOR_SKILL_MAX_TOTAL_BYTES} total bytes`,
-        path: ["files"],
-      });
-    }
-  });
 
 const connectorSkillFrontmatterSchema = z
   .object({
@@ -415,6 +306,13 @@ const privateConnectorSkillSchema = z.discriminatedUnion("kind", [
       kind: z.literal("bundled"),
       storageName: connectorSkillStorageNameSchema,
       versionId: connectorSkillVersionIdSchema,
+      size: z.number().int().nonnegative().max(CONNECTOR_SKILL_MAX_TOTAL_BYTES),
+      archiveSize: z
+        .number()
+        .int()
+        .positive()
+        .max(CONNECTOR_SKILL_MAX_ARCHIVE_BYTES),
+      fileCount: z.number().int().positive().max(CONNECTOR_SKILL_MAX_FILES),
       frontmatter: connectorSkillFrontmatterSchema,
       manifest: privateSkillManifestReferenceSchema,
       archive: privateSkillArchiveReferenceSchema,

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
 import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
@@ -7,19 +5,11 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
-import { S3ObjectSizeLimitError } from "../external/s3";
-import { safeJsonParse, safeSync, settle } from "../utils";
 import {
-  CONNECTOR_SKILL_MAX_TOTAL_BYTES,
   CONNECTOR_SKILL_STORAGE_PATH_PREFIX,
-  connectorSkillManifestSchema,
   type ConnectorCatalogPrivateArtifact,
 } from "./connector-catalog-artifacts/artifacts";
-import type { ConnectorCatalogArtifactReader } from "./connector-catalog-artifacts/loader";
 
-const CONNECTOR_SKILL_MANIFEST_MAX_BYTES = 128 * 1024;
-const CONNECTOR_SKILL_ARCHIVE_MAX_BYTES = CONNECTOR_SKILL_MAX_TOTAL_BYTES * 2;
-const CONNECTOR_SKILL_READ_CONCURRENCY = 8;
 const SYSTEM_STORAGE_CREATOR = "system";
 
 type PrivateConnector = ConnectorCatalogPrivateArtifact["connectors"][number];
@@ -57,7 +47,7 @@ interface ConnectorSkillIdentity {
 }
 
 export interface PreparedConnectorSkillRegistration {
-  readonly provenance: "existing" | "verified";
+  readonly provenance: "catalog" | "existing";
   readonly storageName: string;
   readonly versionId: string;
   readonly s3Prefix: string;
@@ -94,10 +84,6 @@ function fail(
   throw new ConnectorCatalogSkillError({ code, cacheable });
 }
 
-function digest(bytes: Uint8Array): string {
-  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
-}
-
 function skillIdentity(skill: BundledConnectorSkill): ConnectorSkillIdentity {
   const s3Prefix = `${CONNECTOR_SKILL_STORAGE_PATH_PREFIX}/${skill.storageName}`;
   return {
@@ -108,35 +94,35 @@ function skillIdentity(skill: BundledConnectorSkill): ConnectorSkillIdentity {
   };
 }
 
-function reusableExistingVersion(
-  existing: ExistingStorageVersion,
-  identity: ConnectorSkillIdentity,
-): PreparedConnectorSkillRegistration | undefined {
-  if (
-    existing.orgId !== SYSTEM_ORG_ID ||
-    existing.userId !== VOLUME_ORG_USER_ID ||
-    existing.name !== identity.storageName ||
-    existing.type !== "volume" ||
-    existing.s3Prefix !== identity.s3Prefix ||
-    existing.s3Key !== identity.s3Key ||
-    existing.message !== null ||
-    existing.createdBy !== SYSTEM_STORAGE_CREATOR ||
-    !Number.isSafeInteger(existing.size) ||
-    existing.size < 0 ||
-    !Number.isSafeInteger(existing.archiveSize) ||
-    existing.archiveSize <= 0 ||
-    !Number.isSafeInteger(existing.fileCount) ||
-    existing.fileCount <= 0
-  ) {
-    return undefined;
-  }
+function registrationFromSkill(
+  skill: BundledConnectorSkill,
+): PreparedConnectorSkillRegistration {
   return {
-    ...identity,
-    provenance: "existing",
-    size: existing.size,
-    archiveSize: existing.archiveSize,
-    fileCount: existing.fileCount,
+    ...skillIdentity(skill),
+    provenance: "catalog",
+    size: skill.size,
+    archiveSize: skill.archiveSize,
+    fileCount: skill.fileCount,
   };
+}
+
+function existingVersionMatchesRegistration(
+  existing: ExistingStorageVersion,
+  registration: PreparedConnectorSkillRegistration,
+): boolean {
+  return (
+    existing.orgId === SYSTEM_ORG_ID &&
+    existing.userId === VOLUME_ORG_USER_ID &&
+    existing.name === registration.storageName &&
+    existing.type === "volume" &&
+    existing.s3Prefix === registration.s3Prefix &&
+    existing.s3Key === registration.s3Key &&
+    existing.size === registration.size &&
+    existing.archiveSize === registration.archiveSize &&
+    existing.fileCount === registration.fileCount &&
+    existing.message === null &&
+    existing.createdBy === SYSTEM_STORAGE_CREATOR
+  );
 }
 
 async function readExistingVersions(
@@ -173,88 +159,8 @@ async function readExistingVersions(
   );
 }
 
-async function readSkillObject(
-  reader: ConnectorCatalogArtifactReader,
-  key: string,
-  maxBytes: number,
-  signal: AbortSignal,
-): Promise<Buffer> {
-  const result = await settle(reader.readArtifact(key, maxBytes), signal);
-  if (!result.ok) {
-    if (result.error instanceof S3ObjectSizeLimitError) {
-      fail("object-too-large", true);
-    }
-    fail("source-unavailable", false);
-  }
-  const bytes = Buffer.from(result.value);
-  if (bytes.length > maxBytes) {
-    fail("object-too-large", true);
-  }
-  return bytes;
-}
-
-function parseSkillManifest(bytes: Uint8Array) {
-  const decoded = safeSync(() => {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  });
-  if (!("ok" in decoded)) {
-    fail("invalid-json", true);
-  }
-  const value = safeJsonParse(decoded.ok);
-  if (value === undefined) {
-    fail("invalid-json", true);
-  }
-  const parsed = connectorSkillManifestSchema.safeParse(value);
-  if (!parsed.success) {
-    fail("invalid-artifact", true);
-  }
-  return parsed.data;
-}
-
-async function verifySkill(
-  reader: ConnectorCatalogArtifactReader,
-  skill: BundledConnectorSkill,
-  signal: AbortSignal,
-): Promise<PreparedConnectorSkillRegistration> {
-  const [manifestBytes, archiveBytes] = await Promise.all([
-    readSkillObject(
-      reader,
-      skill.manifest.key,
-      CONNECTOR_SKILL_MANIFEST_MAX_BYTES,
-      signal,
-    ),
-    readSkillObject(
-      reader,
-      skill.archive.key,
-      CONNECTOR_SKILL_ARCHIVE_MAX_BYTES,
-      signal,
-    ),
-  ]);
-  signal.throwIfAborted();
-  if (
-    digest(manifestBytes) !== skill.manifest.digest ||
-    digest(archiveBytes) !== skill.archive.digest
-  ) {
-    fail("digest-mismatch", true);
-  }
-  if (archiveBytes.length === 0) {
-    fail("invalid-artifact", true);
-  }
-  const manifest = parseSkillManifest(manifestBytes);
-  return {
-    ...skillIdentity(skill),
-    provenance: "verified",
-    size: manifest.files.reduce((total, file) => {
-      return total + file.size;
-    }, 0),
-    archiveSize: archiveBytes.length,
-    fileCount: manifest.files.length,
-  };
-}
-
 export async function prepareConnectorCatalogSkills(args: {
   readonly db: ReadonlyDb;
-  readonly reader: ConnectorCatalogArtifactReader;
   readonly privateArtifact: ConnectorCatalogPrivateArtifact;
   readonly signal: AbortSignal;
 }): Promise<readonly PreparedConnectorSkillRegistration[]> {
@@ -268,54 +174,17 @@ export async function prepareConnectorCatalogSkills(args: {
     }),
     args.signal,
   );
-  const prepared: PreparedConnectorSkillRegistration[] = [];
-  const skillsToVerify: BundledConnectorSkill[] = [];
-  for (const skill of bundledSkills) {
+  return bundledSkills.map((skill) => {
+    const registration = registrationFromSkill(skill);
     const existing = existingByVersion.get(skill.versionId);
-    if (existing) {
-      const reusable = reusableExistingVersion(existing, skillIdentity(skill));
-      if (!reusable) {
-        fail("invalid-reference", false);
-      }
-      prepared.push(reusable);
-      continue;
+    if (!existing) {
+      return registration;
     }
-    skillsToVerify.push(skill);
-  }
-  for (
-    let offset = 0;
-    offset < skillsToVerify.length;
-    offset += CONNECTOR_SKILL_READ_CONCURRENCY
-  ) {
-    prepared.push(
-      ...(await Promise.all(
-        skillsToVerify
-          .slice(offset, offset + CONNECTOR_SKILL_READ_CONCURRENCY)
-          .map(async (skill) => {
-            return await verifySkill(args.reader, skill, args.signal);
-          }),
-      )),
-    );
-  }
-  return prepared;
-}
-
-function existingVersionMatchesRegistration(
-  existing: ExistingStorageVersion,
-  registration: PreparedConnectorSkillRegistration,
-): boolean {
-  const reusable = reusableExistingVersion(existing, {
-    storageName: registration.storageName,
-    versionId: registration.versionId,
-    s3Prefix: registration.s3Prefix,
-    s3Key: registration.s3Key,
+    if (!existingVersionMatchesRegistration(existing, registration)) {
+      fail("invalid-reference", false);
+    }
+    return { ...registration, provenance: "existing" };
   });
-  return (
-    reusable !== undefined &&
-    reusable.size === registration.size &&
-    reusable.archiveSize === registration.archiveSize &&
-    reusable.fileCount === registration.fileCount
-  );
 }
 
 async function missingRegistrations(

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -793,7 +793,6 @@ async function prepareCandidateSkillsForSync(
   const prepared = await settle(
     prepareConnectorCatalogSkills({
       db: runtime.db,
-      reader: runtime.reader,
       privateArtifact: candidate.privateArtifact,
       signal: runtime.signal,
     }),


### PR DESCRIPTION
## Summary

- require producer-computed `size`, `archiveSize`, and `fileCount` on bundled connector skill descriptors
- register connector skill storage versions directly from the integrity-bound private catalog metadata
- stop downloading and reparsing skill manifests and archives during catalog synchronization
- preserve the existing two-stage database reconciliation, exact identity checks, deletion-race behavior, and head-update rules

## Compatibility

- the external catalog path remains opt-in; the default static source behavior is unchanged
- no legacy schema fallback is included because connector catalog schema v1 has not been published for production use
- skill object layout, runtime mounting, and publisher behavior are unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts` (91 passed)
- `pnpm -F api build`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run` (2319 passed; one unrelated shared local database state failure in `cron-summarize-memory.test.ts`)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts` (5 passed in isolation)

Closes #22600

Delivery parent: https://github.com/vm0-ai/vm0-connectors/issues/1
Producer dependency: https://github.com/vm0-ai/vm0-connectors/issues/21
