### PR TITLE
perf(runner): move reused mount validation to idle admission

### DIFF
--- a/.github/scripts/runner-behavior-keep-alive.sh
+++ b/.github/scripts/runner-behavior-keep-alive.sh
@@ -188,7 +188,10 @@ done
 echo "--- Starting independently owned runner exec ---"
 sudo timeout 90 "$BIN_DIR/runner" exec --timeout 80 \
   --sandbox "$OVERLAP_SANDBOX_ID" -- sh -c \
-  'touch /tmp/keepalive-overlap-exec-ready; sleep 60' &
+  'rm -f /tmp/keepalive-overlap-exec-release
+mkfifo /tmp/keepalive-overlap-exec-release
+touch /tmp/keepalive-overlap-exec-ready
+cat /tmp/keepalive-overlap-exec-release >/dev/null' &
 OVERLAP_EXEC_PID=$!
 
 EXEC_READY=false

--- a/.github/scripts/runner-behavior-keep-alive.sh
+++ b/.github/scripts/runner-behavior-keep-alive.sh
@@ -45,6 +45,8 @@ set -euo pipefail
 BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
 UNIT="vm0-runner-${SVC}.service"
 SESSION_ID="e2e-keepalive-test-session"
+OVERLAP_SUBMIT_PID=""
+OVERLAP_EXEC_PID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 wait_for_unit_inactive() {
@@ -59,6 +61,14 @@ wait_for_unit_inactive() {
 
 cleanup() {
   echo "--- Cleanup ---"
+  if [ -n "$OVERLAP_EXEC_PID" ]; then
+    kill "$OVERLAP_EXEC_PID" 2>/dev/null || true
+    wait "$OVERLAP_EXEC_PID" 2>/dev/null || true
+  fi
+  if [ -n "$OVERLAP_SUBMIT_PID" ]; then
+    kill "$OVERLAP_SUBMIT_PID" 2>/dev/null || true
+    wait "$OVERLAP_SUBMIT_PID" 2>/dev/null || true
+  fi
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   wait_for_unit_inactive
   sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
@@ -75,6 +85,15 @@ sudo rm -rf "$GROUP_DIR"
 echo "--- Starting runner ---"
 sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+
+INVOCATION_ID=""
+for _ in $(seq 1 30); do
+  INVOCATION_ID=$(sudo systemctl show "$UNIT" \
+    --property=InvocationID --value 2>/dev/null) || true
+  [ -n "$INVOCATION_ID" ] && break
+  sleep 1
+done
+[ -n "$INVOCATION_ID" ] || fail "runner invocation ID unavailable"
 
 # Turn 1: submit job with session ID and sandboxReuse flag — creates a marker file in guest
 echo "--- Turn 1: create marker file ---"
@@ -104,6 +123,132 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --prompt 'test ! -f /tmp/keepalive-marker' \
   || fail "Turn 3: marker file found — session isolation broken"
 echo "PASS: Turn 3 completed (new VM for different session)"
+
+# A privileged guest can stack an unrelated mount over the canonical workspace
+# after a turn starts. Idle admission must reject that sandbox, so the next turn
+# receives a fresh VM whose workspace is backed by /dev/vdb.
+TAMPER_SESSION_ID="e2e-keepalive-tampered-mount"
+echo "--- Tamper turn 1: replace canonical workspace mount before idle admission ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$TAMPER_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'set -eu
+touch /tmp/keepalive-tampered-mount-marker
+cd /tmp
+sudo mount -t tmpfs -o size=1m tmpfs /home/user/workspace' \
+  || fail "Tamper turn 1 failed"
+
+echo "--- Tamper turn 2: rejected sandbox is replaced with a valid fresh mount ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$TAMPER_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'set -eu
+test ! -f /tmp/keepalive-tampered-mount-marker
+source=$(findmnt -rn -o SOURCE --target /home/user/workspace)
+test "$(readlink -f "$source")" = /dev/vdb' \
+  || fail "Tamper turn 2 reused an unsafe sandbox or exposed the wrong workspace device"
+echo "PASS: tampered workspace mount was rejected before reuse"
+
+# Hold an independently owned runner-exec normal operation while the supervised
+# turn completes. The atomic final-operation reservation must fail busy, and the
+# sandbox must be destroyed instead of entering the idle pool.
+OVERLAP_SESSION_ID="e2e-keepalive-overlapping-exec"
+echo "--- Overlap turn 1: hold supervised turn open ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$OVERLAP_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'set -eu
+touch /tmp/keepalive-overlap-marker
+rm -f /tmp/keepalive-overlap-release
+mkfifo /tmp/keepalive-overlap-release
+cat /tmp/keepalive-overlap-release >/dev/null' &
+OVERLAP_SUBMIT_PID=$!
+
+OVERLAP_SANDBOX_ID=""
+OVERLAP_READY=false
+for _ in $(seq 1 60); do
+  if ! kill -0 "$OVERLAP_SUBMIT_PID" 2>/dev/null; then
+    wait "$OVERLAP_SUBMIT_PID" 2>/dev/null || true
+    OVERLAP_SUBMIT_PID=""
+    fail "Overlap turn 1 exited before setup completed"
+  fi
+  OVERLAP_SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
+    "$RUNNER_DIR/status.json" 2>/dev/null || true)
+  if [ -n "$OVERLAP_SANDBOX_ID" ] \
+    && sudo timeout 3 "$BIN_DIR/runner" exec --timeout 2 \
+      --sandbox "$OVERLAP_SANDBOX_ID" -- test -p /tmp/keepalive-overlap-release \
+      2>/dev/null; then
+    OVERLAP_READY=true
+    break
+  fi
+  sleep 1
+done
+[ "$OVERLAP_READY" = true ] || fail "Overlap turn sandbox was not ready after 60s"
+
+echo "--- Starting independently owned runner exec ---"
+sudo timeout 90 "$BIN_DIR/runner" exec --timeout 80 \
+  --sandbox "$OVERLAP_SANDBOX_ID" -- sh -c \
+  'touch /tmp/keepalive-overlap-exec-ready; sleep 60' &
+OVERLAP_EXEC_PID=$!
+
+EXEC_READY=false
+for _ in $(seq 1 30); do
+  if ! kill -0 "$OVERLAP_EXEC_PID" 2>/dev/null; then
+    wait "$OVERLAP_EXEC_PID" 2>/dev/null || true
+    OVERLAP_EXEC_PID=""
+    fail "Independent runner exec exited before idle admission"
+  fi
+  if sudo timeout 3 "$BIN_DIR/runner" exec --timeout 2 \
+    --sandbox "$OVERLAP_SANDBOX_ID" -- test -f /tmp/keepalive-overlap-exec-ready \
+    2>/dev/null; then
+    EXEC_READY=true
+    break
+  fi
+  sleep 1
+done
+[ "$EXEC_READY" = true ] || fail "Independent runner exec did not become active"
+
+sudo timeout 20 "$BIN_DIR/runner" exec --timeout 15 \
+  --sandbox "$OVERLAP_SANDBOX_ID" -- sh -c \
+  'printf release > /tmp/keepalive-overlap-release' \
+  || fail "Failed to release overlap turn"
+if ! wait "$OVERLAP_SUBMIT_PID"; then
+  OVERLAP_SUBMIT_PID=""
+  fail "Overlap turn 1 failed"
+fi
+OVERLAP_SUBMIT_PID=""
+
+for _ in $(seq 1 20); do
+  if ! kill -0 "$OVERLAP_EXEC_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+if kill -0 "$OVERLAP_EXEC_PID" 2>/dev/null; then
+  kill "$OVERLAP_EXEC_PID" 2>/dev/null || true
+  wait "$OVERLAP_EXEC_PID" 2>/dev/null || true
+  OVERLAP_EXEC_PID=""
+  fail "Independent runner exec remained alive after rejected sandbox destruction"
+fi
+wait "$OVERLAP_EXEC_PID" 2>/dev/null || true
+OVERLAP_EXEC_PID=""
+
+OVERLAP_LOGS=$(sudo journalctl --no-pager \
+  "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+  || fail "failed to read overlap runner logs"
+grep -F 'normal operations busy while preparing park' <<<"$OVERLAP_LOGS" >/dev/null \
+  || fail "overlapping runner exec did not reject idle admission as busy"
+
+echo "--- Overlap turn 2: busy sandbox was not reused ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$OVERLAP_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'set -eu
+test ! -f /tmp/keepalive-overlap-marker
+source=$(findmnt -rn -o SOURCE --target /home/user/workspace)
+test "$(readlink -f "$source")" = /dev/vdb' \
+  || fail "Overlap turn 2 reused the sandbox rejected by the final-operation fence"
+echo "PASS: overlapping runner exec could not produce a reusable sandbox"
 
 # Regression gate for sandbox_id/run_id conflation (#9552):
 # at this point the runner has parked idle VMs whose FC workspace

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -23,8 +23,8 @@ use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::idle_pool::{
-    DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkRequest, IdleParkRequestParts,
-    ParkResult, ParkingGate,
+    DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest,
+    IdleParkRequestParts, ParkResult, ParkingGate,
 };
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -203,54 +203,97 @@ pub(super) async fn finalize_sandbox_for_completion(
         });
         let park_outcome = match park_request.park_for_idle().await {
             Ok(outcome) => outcome,
-            Err(failure) => {
-                let failure = failure.into_active_parts();
-                let IdleParkActiveParts {
-                    sandbox,
-                    factory: failure_factory,
-                    budget_lease,
-                    workspace_promotion,
-                } = failure.active;
-                warn!(
-                    run_id = %run_id,
-                    session_id = %cli_agent_session_id,
-                    reason = failure.reason,
-                    error = %failure.error,
-                    "sandbox idle admission failed, destroying instead of parking"
-                );
-                let destroy_result = stop_and_destroy_sandbox(
-                    sandbox,
-                    &**failure_factory,
-                    workspace_promotion,
-                    ActiveCleanupContext {
+            Err(failure) => match failure.into_parts() {
+                IdleParkFailureParts::Active {
+                    active,
+                    reason,
+                    error,
+                } => {
+                    let IdleParkActiveParts {
+                        sandbox,
+                        factory: failure_factory,
+                        budget_lease,
+                        workspace_promotion,
+                    } = active;
+                    warn!(
+                        run_id = %run_id,
+                        session_id = %cli_agent_session_id,
+                        reason,
+                        error,
+                        "sandbox idle admission failed, destroying instead of parking"
+                    );
+                    let destroy_result = stop_and_destroy_sandbox(
+                        sandbox,
+                        &**failure_factory,
+                        workspace_promotion,
+                        ActiveCleanupContext {
+                            run_id,
+                            sandbox_id,
+                            profile_name: &profile_name,
+                            cli_agent_session_id: Some(&cli_agent_session_id),
+                            reason,
+                            network_log_session: network_log_session.take(),
+                            network_log_drain: network_log_drain.clone(),
+                        },
+                    )
+                    .await;
+                    let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                        &held_session_snapshot,
+                        Some(&cli_agent_session_id),
+                        &profile_name,
+                        &completed_at,
+                        destroy_result.workspace_cache_promoted,
+                    );
+                    record_destroy_result(destroy_result.outcome, destroy_bookkeeping);
+                    return mark_session_affinity_refresh(
+                        CompletionReady::new(
+                            completion_payload,
+                            BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(
+                                budget_lease,
+                            )),
+                        ),
+                        workspace_cache_promoted,
+                    );
+                }
+                IdleParkFailureParts::Parked {
+                    rejected,
+                    reason,
+                    error,
+                } => {
+                    warn!(
+                        run_id = %run_id,
+                        session_id = %cli_agent_session_id,
+                        reason,
+                        error,
+                        "parked sandbox failed idle admission, destroying instead of reusing"
+                    );
+                    close_network_log_session(
                         run_id,
-                        sandbox_id,
-                        profile_name: &profile_name,
-                        cli_agent_session_id: Some(&cli_agent_session_id),
-                        reason: failure.reason,
-                        network_log_session: network_log_session.take(),
-                        network_log_drain: network_log_drain.clone(),
-                    },
-                )
-                .await;
-                let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
-                    &held_session_snapshot,
-                    Some(&cli_agent_session_id),
-                    &profile_name,
-                    &completed_at,
-                    destroy_result.workspace_cache_promoted,
-                );
-                record_destroy_result(destroy_result.outcome, destroy_bookkeeping);
-                return mark_session_affinity_refresh(
-                    CompletionReady::new(
-                        completion_payload,
-                        BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(
-                            budget_lease,
-                        )),
-                    ),
-                    workspace_cache_promoted,
-                );
-            }
+                        network_log_session.take(),
+                        &network_log_drain,
+                    )
+                    .await;
+                    let (payload, budget_lease) = rejected.into_active_destroy_parts();
+                    let destroy_result = destroy_active_owned_idle_payload(
+                        payload,
+                        budget_lease,
+                        reason,
+                        destroy_bookkeeping,
+                    )
+                    .await;
+                    let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                        &held_session_snapshot,
+                        Some(&cli_agent_session_id),
+                        &profile_name,
+                        &completed_at,
+                        destroy_result.workspace_cache_promoted,
+                    );
+                    return mark_session_affinity_refresh(
+                        CompletionReady::new(completion_payload, destroy_result.budget),
+                        workspace_cache_promoted,
+                    );
+                }
+            },
         };
         let (candidate, non_reusable_reason) = park_outcome.into_parts();
         if cancel.is_cancelled() {
@@ -1010,7 +1053,8 @@ mod tests {
         .await;
 
         assert_eq!(completion_ready.result_for_test(), (0, None));
-        assert_eq!(overrides.park_call_count(), 0);
+        assert_eq!(overrides.park_call_count(), 1);
+        assert_eq!(overrides.unpark_call_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(fixture.idle_pool.lock().await.len(), 0);
         let cache_states = cache.held_session_states().await;
@@ -1784,7 +1828,7 @@ mod tests {
         .park_for_idle()
         .await
         .unwrap_or_else(|failure| {
-            let error = failure.into_active_parts().error;
+            let error = failure.into_error();
             panic!("existing sandbox should park: {error}");
         })
         .expect_reusable()

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1160,40 +1160,6 @@ pub(super) async fn execute_reused_sandbox(
         }
     };
 
-    let mount_started = Instant::now();
-    if let Err(e) = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await {
-        telemetry.record(
-            "workspace_drive_mount",
-            mount_started.elapsed(),
-            false,
-            Some(&e.to_string()),
-        );
-        if let Err(unregister_error) =
-            unregister_proxy_registry(config, &source_ip, context.run_id).await
-        {
-            warn!(
-                run_id = %context.run_id,
-                error = %unregister_error,
-                "failed to unregister VM from proxy after reused sandbox mount failure"
-            );
-        }
-        telemetry.record(
-            "runner_reused_sandbox_prepare",
-            prepare_started.elapsed(),
-            false,
-            Some(&e.to_string()),
-        );
-        return ExecuteOutcome {
-            failure: Some(ExecutionFailure::from_error(e.to_string())),
-            sandbox: Some(sandbox),
-            source_ip,
-            network_log_session: Some(network_log_session),
-            workspace_image: None,
-            discovered_cli_agent_session_id: None,
-            restored_session_identity: None,
-        };
-    }
-    telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
     telemetry.record(
         "runner_reused_sandbox_prepare",
         prepare_started.elapsed(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -222,9 +222,8 @@ async fn execute_job_reuse_guest_state_restore_exec_failure_returns_sandbox() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
 
-    // First exec mounts the workspace drive, second exec restores guest state.
+    // The guest state restore transport fails.
     let sandbox = MockSandbox::new("reuse-clock-fail");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
 
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -258,10 +257,8 @@ async fn execute_job_reuse_reseed_failure_returns_sandbox() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
 
-    // Workspace mount succeeds, then the combined guest state restore reports a
-    // guest-reseed failure.
+    // The combined guest state restore reports a guest-reseed failure.
     let sandbox = MockSandbox::new("reuse-reseed-fail");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         Vec::new(),
@@ -289,20 +286,15 @@ async fn execute_job_reuse_reseed_failure_returns_sandbox() {
 }
 
 #[tokio::test]
-async fn execute_job_reuse_workspace_mount_failure_returns_sandbox() {
+async fn execute_job_reuse_skips_workspace_mount_validation() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-
-    let sandbox = MockSandbox::new("reuse-mount-fail");
-    sandbox.push_exec_result(Ok(ExecResult::new(
-        64,
-        Vec::new(),
-        b"mount denied".to_vec(),
-    )));
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =
-        make_reusable_idle_sandbox(Box::new(sandbox), "10.0.0.1".into(), "sess-1").await;
+        make_reusable_idle_sandbox(sandbox, "10.0.0.1".into(), "sess-1").await;
     let (outcome, _telemetry) = execute_job_reuse(
         idle_sandbox,
         minimal_context(),
@@ -312,22 +304,16 @@ async fn execute_job_reuse_workspace_mount_failure_returns_sandbox() {
     )
     .await;
 
-    assert_eq!(outcome.exit_code(), 1);
-    let error = outcome.error().unwrap();
+    assert_eq!(outcome.exit_code(), 0);
+    assert!(outcome.error().is_none());
+    assert!(outcome.sandbox.is_some());
     assert!(
-        error.contains("mount workspace drive failed"),
-        "got: {error}"
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("workspace_device=")),
+        "reused execution must rely on the idle-admission mount proof"
     );
-    assert!(error.contains("mount denied"), "got: {error}");
-    assert!(
-        outcome.sandbox.is_some(),
-        "sandbox must be returned on workspace mount failure"
-    );
-    assert!(
-        outcome.network_log_session.is_some(),
-        "network log session must be returned so finalization can close it"
-    );
-    assert_proxy_registry_empty(dir.path()).await;
 }
 
 /// Verify that session restore failure during reuse still returns the sandbox.

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1016,7 +1016,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     .park_for_idle()
     .await
     .unwrap_or_else(|failure| {
-        let error = failure.into_active_parts().error;
+        let error = failure.into_error();
         panic!("test sandbox should park: {error}");
     })
     .expect_reusable()
@@ -1127,7 +1127,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
     .park_for_idle()
     .await
     .unwrap_or_else(|failure| {
-        let error = failure.into_active_parts().error;
+        let error = failure.into_error();
         panic!("test sandbox should park: {error}");
     })
     .expect_reusable()

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError,
-    SandboxFactory, SandboxInitializationPhase, SandboxOperation, SandboxOperationReason,
-    StartProcessRequest,
+    SandboxFactory, SandboxFinalExecParkOutcome, SandboxInitializationPhase, SandboxOperation,
+    SandboxOperationReason, StartProcessRequest,
 };
 use sandbox_mock::MockSandboxFactory;
 
@@ -217,6 +217,16 @@ impl Sandbox for OperationGateSandbox {
         self.inner.park().await
     }
 
+    async fn final_exec_and_park(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        self.inner
+            .final_exec_and_park(request, diagnostic_label)
+            .await
+    }
+
     async fn unpark(&mut self) -> sandbox::Result<()> {
         self.inner.unpark().await
     }
@@ -300,6 +310,16 @@ impl Sandbox for CancelAtProcessBoundarySandbox {
 
     async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
+    }
+
+    async fn final_exec_and_park(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        self.inner
+            .final_exec_and_park(request, diagnostic_label)
+            .await
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
@@ -418,6 +438,16 @@ impl Sandbox for QueuedCopyFileSandbox {
 
     async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
+    }
+
+    async fn final_exec_and_park(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        self.inner
+            .final_exec_and_park(request, diagnostic_label)
+            .await
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -920,7 +920,6 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         "runner_agent_env_build",
         "runner_agent_start_process",
         "sandbox_reuse_hit",
-        "workspace_drive_mount",
         "agent_execute",
     ] {
         assert_has_action(&telemetry, action);
@@ -934,6 +933,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_proxy_register");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
     assert_lacks_action(&telemetry, "runner_guest_timezone_sync");
+    assert_lacks_action(&telemetry, "workspace_drive_mount");
 }
 
 #[tokio::test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -13,7 +13,7 @@ use sandbox::{
     SandboxParkOutcome,
 };
 
-use crate::idle_reuse_preparation::prepare_sandbox_for_idle_reuse;
+use crate::idle_reuse_preparation::IdleReusePreparation;
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
@@ -245,10 +245,19 @@ pub(crate) enum IdleParkOutcome {
 
 #[must_use = "idle park failures must be explicitly destroyed or otherwise handled"]
 pub(crate) struct IdleParkFailure {
-    resources: IdleSandboxResources,
-    budget_lease: BudgetLease,
+    ownership: IdleParkFailureOwnership,
     reason: &'static str,
     error: String,
+}
+
+enum IdleParkFailureOwnership {
+    Active {
+        resources: IdleSandboxResources,
+        budget_lease: BudgetLease,
+    },
+    Parked {
+        rejected: RejectedParkedIdleCandidate,
+    },
 }
 
 #[must_use = "active idle-park parts still own a sandbox and budget lease"]
@@ -260,10 +269,17 @@ pub(crate) struct IdleParkActiveParts {
 }
 
 #[must_use = "idle park failure parts must be logged and cleaned up"]
-pub(crate) struct IdleParkFailureParts {
-    pub(crate) active: IdleParkActiveParts,
-    pub(crate) reason: &'static str,
-    pub(crate) error: String,
+pub(crate) enum IdleParkFailureParts {
+    Active {
+        active: IdleParkActiveParts,
+        reason: &'static str,
+        error: String,
+    },
+    Parked {
+        rejected: RejectedParkedIdleCandidate,
+        reason: &'static str,
+        error: String,
+    },
 }
 
 impl IdleParkRequest {
@@ -328,37 +344,50 @@ impl IdleParkRequest {
             )
             .await;
             return Err(IdleParkFailure {
-                resources: IdleSandboxResources {
-                    sandbox,
-                    factory,
-                    workspace_promotion: None,
+                ownership: IdleParkFailureOwnership::Active {
+                    resources: IdleSandboxResources {
+                        sandbox,
+                        factory,
+                        workspace_promotion: None,
+                    },
+                    budget_lease,
                 },
-                budget_lease,
                 reason: "promotion_identity_mismatch",
                 error: format!("workspace promotion identity mismatch: {mismatch}"),
             });
         }
 
-        if let Err(error) = prepare_sandbox_for_idle_reuse(
-            sandbox.as_ref(),
+        let preparation = match IdleReusePreparation::new(
+            sandbox.id(),
             run_id,
             retained_runtime_dir.as_deref(),
-        )
-        .await
-        {
-            return Err(IdleParkFailure {
-                resources: IdleSandboxResources {
-                    sandbox,
-                    factory,
-                    workspace_promotion,
-                },
-                budget_lease,
-                reason: "reuse_preparation_failed",
-                error: error.to_string(),
-            });
-        }
+        ) {
+            Ok(preparation) => preparation,
+            Err(error) => {
+                return Err(IdleParkFailure {
+                    ownership: IdleParkFailureOwnership::Active {
+                        resources: IdleSandboxResources {
+                            sandbox,
+                            factory,
+                            workspace_promotion,
+                        },
+                        budget_lease,
+                    },
+                    reason: "reuse_preparation_failed",
+                    error: error.to_string(),
+                });
+            }
+        };
 
-        match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
+        let final_exec_and_park = {
+            let request = preparation.exec_request();
+            AssertUnwindSafe(
+                sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
+            )
+            .catch_unwind()
+            .await
+        };
+        match final_exec_and_park {
             Ok(Ok(outcome)) => {
                 let candidate = ParkedIdleCandidate {
                     resources: IdleSandboxResources {
@@ -369,7 +398,16 @@ impl IdleParkRequest {
                     metadata,
                     budget_lease,
                 };
-                Ok(match outcome {
+                if let Err(error) = preparation.validate_result(&outcome.exec_result) {
+                    return Err(IdleParkFailure {
+                        ownership: IdleParkFailureOwnership::Parked {
+                            rejected: candidate.into_rejected(),
+                        },
+                        reason: "reuse_preparation_failed",
+                        error: error.to_string(),
+                    });
+                }
+                Ok(match outcome.park_outcome {
                     SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
                     SandboxParkOutcome::NonReusable(reason) => {
                         IdleParkOutcome::NonReusable { candidate, reason }
@@ -377,12 +415,14 @@ impl IdleParkRequest {
                 })
             }
             Ok(Err(e)) => Err(IdleParkFailure {
-                resources: IdleSandboxResources {
-                    sandbox,
-                    factory,
-                    workspace_promotion,
+                ownership: IdleParkFailureOwnership::Active {
+                    resources: IdleSandboxResources {
+                        sandbox,
+                        factory,
+                        workspace_promotion,
+                    },
+                    budget_lease,
                 },
-                budget_lease,
                 reason: "park_failed",
                 error: e.to_string(),
             }),
@@ -391,12 +431,14 @@ impl IdleParkRequest {
                 // the sandbox, but do not publish a workspace cache image.
                 abandon_unpublished_workspace_promotion(workspace_promotion, "park_panicked").await;
                 Err(IdleParkFailure {
-                    resources: IdleSandboxResources {
-                        sandbox,
-                        factory,
-                        workspace_promotion: None,
+                    ownership: IdleParkFailureOwnership::Active {
+                        resources: IdleSandboxResources {
+                            sandbox,
+                            factory,
+                            workspace_promotion: None,
+                        },
+                        budget_lease,
                     },
-                    budget_lease,
                     reason: "park_panicked",
                     error: "sandbox park panicked".into(),
                 })
@@ -428,27 +470,46 @@ impl IdleParkOutcome {
 }
 
 impl IdleParkFailure {
-    pub(crate) fn into_active_parts(self) -> IdleParkFailureParts {
+    pub(crate) fn into_parts(self) -> IdleParkFailureParts {
         let Self {
-            resources,
-            budget_lease,
+            ownership,
             reason,
             error,
         } = self;
-        let IdleSandboxResources {
-            sandbox,
-            factory,
-            workspace_promotion,
-        } = resources;
-        IdleParkFailureParts {
-            active: IdleParkActiveParts {
-                sandbox,
-                factory,
+        match ownership {
+            IdleParkFailureOwnership::Active {
+                resources,
                 budget_lease,
-                workspace_promotion,
+            } => {
+                let IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion,
+                } = resources;
+                IdleParkFailureParts::Active {
+                    active: IdleParkActiveParts {
+                        sandbox,
+                        factory,
+                        budget_lease,
+                        workspace_promotion,
+                    },
+                    reason,
+                    error,
+                }
+            }
+            IdleParkFailureOwnership::Parked { rejected } => IdleParkFailureParts::Parked {
+                rejected,
+                reason,
+                error,
             },
-            reason,
-            error,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_error(self) -> String {
+        match self.into_parts() {
+            IdleParkFailureParts::Active { error, .. }
+            | IdleParkFailureParts::Parked { error, .. } => error,
         }
     }
 }
@@ -1387,6 +1448,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idle_park_request_semantic_rejection_returns_parked_ownership() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+            pattern: "prepare-for-reuse".into(),
+            exit_code: 0,
+            stdout: b"not-json".to_vec(),
+            stderr: Vec::new(),
+        });
+        let request = make_idle_park_request(
+            Arc::clone(&overrides),
+            "session-invalid-report",
+            make_budget_lease(2, 2048),
+        )
+        .await;
+
+        let failure = match request.park_for_idle().await {
+            Ok(_) => panic!("invalid report must reject idle admission"),
+            Err(failure) => failure,
+        };
+        let IdleParkFailureParts::Parked {
+            rejected,
+            reason,
+            error,
+        } = failure.into_parts()
+        else {
+            panic!("semantic rejection after park must retain parked ownership");
+        };
+
+        assert_eq!(overrides.park_call_count(), 1);
+        assert_eq!(reason, "reuse_preparation_failed");
+        assert!(error.contains("invalid report"));
+        let (payload, budget_lease) = rejected.into_active_destroy_parts();
+        assert_eq!(budget_lease.vcpu(), 2);
+        assert_eq!(budget_lease.memory_mb(), 2048);
+        assert_eq!(payload.stop_and_destroy().await, DestroyOutcome::Completed);
+        assert_eq!(overrides.destroy_call_count(), 1);
+    }
+
+    #[tokio::test]
     async fn idle_park_request_protects_retained_identity_runtime_directory() {
         let overrides = Arc::new(MockSandboxOverrides::new());
         let session_id = "session-retained-runtime";
@@ -1563,12 +1663,14 @@ mod tests {
             Ok(_) => panic!("park should fail"),
             Err(failure) => failure,
         };
-        let failure = failure.into_active_parts();
+        let IdleParkFailureParts::Active { active, error, .. } = failure.into_parts() else {
+            panic!("park operation errors must retain active ownership");
+        };
 
         assert_eq!(overrides.park_call_count(), 1);
-        assert!(failure.error.contains("simulated park error"));
-        assert_eq!(failure.active.budget_lease.vcpu(), 2);
-        assert_eq!(failure.active.budget_lease.memory_mb(), 2048);
+        assert!(error.contains("simulated park error"));
+        assert_eq!(active.budget_lease.vcpu(), 2);
+        assert_eq!(active.budget_lease.memory_mb(), 2048);
     }
 
     #[tokio::test]
@@ -1586,12 +1688,14 @@ mod tests {
             Ok(_) => panic!("park should panic"),
             Err(failure) => failure,
         };
-        let failure = failure.into_active_parts();
+        let IdleParkFailureParts::Active { active, error, .. } = failure.into_parts() else {
+            panic!("park panics must retain active ownership");
+        };
 
         assert_eq!(overrides.park_call_count(), 1);
-        assert_eq!(failure.error, "sandbox park panicked");
-        assert_eq!(failure.active.budget_lease.vcpu(), 2);
-        assert_eq!(failure.active.budget_lease.memory_mb(), 2048);
+        assert_eq!(error, "sandbox park panicked");
+        assert_eq!(active.budget_lease.vcpu(), 2);
+        assert_eq!(active.budget_lease.memory_mb(), 2048);
     }
 
     #[test]

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -8,7 +8,7 @@ use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
     ReusePreparationReport, ReusePreparationRequest,
 };
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecResult, ExecTermination, Sandbox};
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecResult, ExecTermination};
 use tracing::{info, warn};
 
 use crate::helper_exec::{
@@ -16,10 +16,12 @@ use crate::helper_exec::{
 };
 use crate::ids::RunId;
 use crate::paths::guest;
+use crate::workspace_mount::{WORKSPACE_MOUNT_TIMEOUT, workspace_mount_command};
 
 const REUSE_PREPARATION_TIMEOUT: Duration = Duration::from_secs(10);
 const MIN_REUSE_ROOTFS_AVAILABLE_BYTES: u64 = 128 * 1024 * 1024;
 const MIN_REUSE_ROOTFS_AVAILABLE_INODES: u64 = 1024;
+const REUSE_PREPARATION_EXIT_WORKSPACE_MOUNT_FAILED: i32 = 6;
 
 #[derive(Clone, Copy)]
 enum ReuseRejectionReason {
@@ -27,6 +29,7 @@ enum ReuseRejectionReason {
     InspectionFailed,
     CleanupFailed,
     ContainmentFailed,
+    WorkspaceMountFailed,
     HelperFailed,
     InvalidReport,
     LowBytes,
@@ -41,6 +44,7 @@ impl ReuseRejectionReason {
             Self::InspectionFailed => "inspection_failed",
             Self::CleanupFailed => "cleanup_failed",
             Self::ContainmentFailed => "containment_failed",
+            Self::WorkspaceMountFailed => "workspace_mount_failed",
             Self::HelperFailed => "helper_failed",
             Self::InvalidReport => "invalid_report",
             Self::LowBytes => "low_bytes",
@@ -61,103 +65,125 @@ impl std::fmt::Display for IdleReusePreparationFailure {
     }
 }
 
-pub(crate) async fn prepare_sandbox_for_idle_reuse(
-    sandbox: &dyn Sandbox,
+pub(crate) struct IdleReusePreparation {
     run_id: RunId,
-    retained_runtime_dir: Option<&str>,
-) -> Result<(), IdleReusePreparationFailure> {
-    let current_runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(
-        CANONICAL_GUEST_HOME_DIR,
-        &run_id.to_string(),
-    )
-    .map_err(|error| {
-        reject_without_exec(
-            sandbox,
-            run_id,
-            ReuseRejectionReason::InvalidRequest,
-            format!("resolve current runtime directory: {error}"),
+    sandbox_id: String,
+    command: String,
+    request_bytes: Vec<u8>,
+}
+
+impl IdleReusePreparation {
+    pub(crate) fn new(
+        sandbox_id: &str,
+        run_id: RunId,
+        retained_runtime_dir: Option<&str>,
+    ) -> Result<Self, IdleReusePreparationFailure> {
+        let current_runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(
+            CANONICAL_GUEST_HOME_DIR,
+            &run_id.to_string(),
         )
-    })?
-    .to_string_lossy()
-    .into_owned();
-    let request = ReusePreparationRequest {
-        current_runtime_dir,
-        retained_runtime_dir: retained_runtime_dir.map(str::to_owned),
-    };
-    let request_bytes = serde_json::to_vec(&request).map_err(|error| {
-        reject_without_exec(
-            sandbox,
-            run_id,
-            ReuseRejectionReason::InvalidRequest,
-            format!("serialize reuse-preparation request: {error}"),
-        )
-    })?;
-    let command = format!("{} prepare-for-reuse", guest::RUN_AGENT);
-    let result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &command,
-                timeout: REUSE_PREPARATION_TIMEOUT,
-                env: &[],
-                sudo: true,
-                expected_exit_codes: &[],
-                stdin_bytes: Some(&request_bytes),
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "idle-reuse-preparation",
-        )
-        .await
         .map_err(|error| {
             reject_without_exec(
-                sandbox,
+                sandbox_id,
                 run_id,
-                ReuseRejectionReason::HelperFailed,
-                format!("reuse-preparation exec failed: {error}"),
+                ReuseRejectionReason::InvalidRequest,
+                format!("resolve current runtime directory: {error}"),
             )
-        })?;
-
-    if !helper_exec_succeeded(&result) {
-        let reason = helper_failure_reason(&result);
-        return Err(reject_with_result(
-            sandbox,
-            run_id,
-            reason,
-            &result,
-            format_helper_exec_failure("reuse preparation", &result),
-        ));
-    }
-
-    let report =
-        serde_json::from_slice::<ReusePreparationReport>(&result.stdout).map_err(|error| {
-            reject_with_result(
-                sandbox,
-                run_id,
-                ReuseRejectionReason::InvalidReport,
-                &result,
-                format!("reuse preparation returned an invalid report: {error}"),
-            )
-        })?;
-    let low_bytes = report.after.available_bytes < MIN_REUSE_ROOTFS_AVAILABLE_BYTES;
-    let low_inodes = report.after.available_inodes < MIN_REUSE_ROOTFS_AVAILABLE_INODES;
-    if low_bytes || low_inodes {
-        let reason = if low_bytes && low_inodes {
-            ReuseRejectionReason::LowBytesAndInodes
-        } else if low_bytes {
-            ReuseRejectionReason::LowBytes
-        } else {
-            ReuseRejectionReason::LowInodes
+        })?
+        .to_string_lossy()
+        .into_owned();
+        let request = ReusePreparationRequest {
+            current_runtime_dir,
+            retained_runtime_dir: retained_runtime_dir.map(str::to_owned),
         };
-        log_report(sandbox, run_id, reason.as_str(), &result, report, false);
-        return Err(IdleReusePreparationFailure {
-            error: format!(
-                "guest rootfs below reuse reserve: {} bytes and {} inodes available",
-                report.after.available_bytes, report.after.available_inodes
-            ),
-        });
+        let request_bytes = serde_json::to_vec(&request).map_err(|error| {
+            reject_without_exec(
+                sandbox_id,
+                run_id,
+                ReuseRejectionReason::InvalidRequest,
+                format!("serialize reuse-preparation request: {error}"),
+            )
+        })?;
+        let mount_command = workspace_mount_command();
+        let command = format!(
+            "set -e\n{} prepare-for-reuse\nset +e\n(\nset -eu\n{}\n) >/dev/null\nmount_status=$?\nset -e\nif [ \"$mount_status\" -ne 0 ]; then\n  exit {REUSE_PREPARATION_EXIT_WORKSPACE_MOUNT_FAILED}\nfi",
+            guest::RUN_AGENT,
+            mount_command
+        );
+        Ok(Self {
+            run_id,
+            sandbox_id: sandbox_id.to_owned(),
+            command,
+            request_bytes,
+        })
     }
 
-    log_report(sandbox, run_id, "ready", &result, report, true);
-    Ok(())
+    pub(crate) fn exec_request(&self) -> ExecRequest<'_> {
+        ExecRequest {
+            cmd: &self.command,
+            timeout: REUSE_PREPARATION_TIMEOUT + WORKSPACE_MOUNT_TIMEOUT,
+            env: &[],
+            sudo: true,
+            expected_exit_codes: &[],
+            stdin_bytes: Some(&self.request_bytes),
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        }
+    }
+
+    pub(crate) fn validate_result(
+        &self,
+        result: &ExecResult,
+    ) -> Result<(), IdleReusePreparationFailure> {
+        if !helper_exec_succeeded(result) {
+            let reason = helper_failure_reason(result);
+            return Err(reject_with_result(
+                &self.sandbox_id,
+                self.run_id,
+                reason,
+                result,
+                format_helper_exec_failure("reuse preparation", result),
+            ));
+        }
+
+        let report =
+            serde_json::from_slice::<ReusePreparationReport>(&result.stdout).map_err(|error| {
+                reject_with_result(
+                    &self.sandbox_id,
+                    self.run_id,
+                    ReuseRejectionReason::InvalidReport,
+                    result,
+                    format!("reuse preparation returned an invalid report: {error}"),
+                )
+            })?;
+        let low_bytes = report.after.available_bytes < MIN_REUSE_ROOTFS_AVAILABLE_BYTES;
+        let low_inodes = report.after.available_inodes < MIN_REUSE_ROOTFS_AVAILABLE_INODES;
+        if low_bytes || low_inodes {
+            let reason = if low_bytes && low_inodes {
+                ReuseRejectionReason::LowBytesAndInodes
+            } else if low_bytes {
+                ReuseRejectionReason::LowBytes
+            } else {
+                ReuseRejectionReason::LowInodes
+            };
+            log_report(
+                &self.sandbox_id,
+                self.run_id,
+                reason.as_str(),
+                result,
+                report,
+                false,
+            );
+            return Err(IdleReusePreparationFailure {
+                error: format!(
+                    "guest rootfs below reuse reserve: {} bytes and {} inodes available",
+                    report.after.available_bytes, report.after.available_inodes
+                ),
+            });
+        }
+
+        log_report(&self.sandbox_id, self.run_id, "ready", result, report, true);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -212,6 +238,9 @@ fn helper_failure_reason(result: &ExecResult) -> ReuseRejectionReason {
         ExecTermination::Exited {
             exit_code: REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
         } => ReuseRejectionReason::ContainmentFailed,
+        ExecTermination::Exited {
+            exit_code: REUSE_PREPARATION_EXIT_WORKSPACE_MOUNT_FAILED,
+        } => ReuseRejectionReason::WorkspaceMountFailed,
         ExecTermination::Exited { .. }
         | ExecTermination::TimedOut
         | ExecTermination::Cancelled
@@ -221,14 +250,14 @@ fn helper_failure_reason(result: &ExecResult) -> ReuseRejectionReason {
 }
 
 fn reject_without_exec(
-    sandbox: &dyn Sandbox,
+    sandbox_id: &str,
     run_id: RunId,
     reason: ReuseRejectionReason,
     error: String,
 ) -> IdleReusePreparationFailure {
     warn!(
         run_id = %run_id,
-        sandbox_id = %sandbox.id(),
+        sandbox_id,
         reason = reason.as_str(),
         error = %error,
         "sandbox rejected from idle reuse"
@@ -237,7 +266,7 @@ fn reject_without_exec(
 }
 
 fn reject_with_result(
-    sandbox: &dyn Sandbox,
+    sandbox_id: &str,
     run_id: RunId,
     reason: ReuseRejectionReason,
     result: &ExecResult,
@@ -245,7 +274,7 @@ fn reject_with_result(
 ) -> IdleReusePreparationFailure {
     warn!(
         run_id = %run_id,
-        sandbox_id = %sandbox.id(),
+        sandbox_id,
         reason = reason.as_str(),
         helper_termination = helper_exec_termination_label(result),
         helper_stdout_len = result.stdout.len(),
@@ -259,7 +288,7 @@ fn reject_with_result(
 }
 
 fn log_report(
-    sandbox: &dyn Sandbox,
+    sandbox_id: &str,
     run_id: RunId,
     reason: &'static str,
     result: &ExecResult,
@@ -277,7 +306,7 @@ fn log_report(
     if ready {
         info!(
             run_id = %run_id,
-            sandbox_id = %sandbox.id(),
+            sandbox_id,
             reason,
             helper_termination = helper_exec_termination_label(result),
             removed_entries = report.removed_entries,
@@ -292,7 +321,7 @@ fn log_report(
     } else {
         warn!(
             run_id = %run_id,
-            sandbox_id = %sandbox.id(),
+            sandbox_id,
             reason,
             helper_termination = helper_exec_termination_label(result),
             removed_entries = report.removed_entries,
@@ -311,7 +340,7 @@ fn log_report(
 mod tests {
     use super::*;
 
-    use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
+    use sandbox::{Sandbox, SandboxError, SandboxOperation, SandboxOperationReason};
     use sandbox_mock::MockSandbox;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -345,9 +374,29 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         let guard = tracing::subscriber::set_default(subscriber);
         tracing::callsite::rebuild_interest_cache();
-        let result = prepare_sandbox_for_idle_reuse(sandbox, run_id, None).await;
+        let result = execute_preparation(sandbox, run_id, None).await;
         drop(guard);
         (result, captured.entries())
+    }
+
+    async fn execute_preparation(
+        sandbox: &MockSandbox,
+        run_id: RunId,
+        retained_runtime_dir: Option<&str>,
+    ) -> Result<(), IdleReusePreparationFailure> {
+        let preparation = IdleReusePreparation::new(sandbox.id(), run_id, retained_runtime_dir)?;
+        let result = sandbox
+            .exec_with_diagnostic_label(&preparation.exec_request(), "idle-reuse-preparation")
+            .await
+            .map_err(|error| {
+                reject_without_exec(
+                    sandbox.id(),
+                    run_id,
+                    ReuseRejectionReason::HelperFailed,
+                    format!("reuse-preparation exec failed: {error}"),
+                )
+            })?;
+        preparation.validate_result(&result)
     }
 
     fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
@@ -373,14 +422,22 @@ mod tests {
         let run_id = RunId::new_v4();
         let retained = "/home/user/.vm0/guest-agent/runs/previous";
 
-        prepare_sandbox_for_idle_reuse(&sandbox, run_id, Some(retained))
+        execute_preparation(&sandbox, run_id, Some(retained))
             .await
             .expect("healthy guest should be prepared");
 
         let calls = sandbox.exec_calls();
         assert_eq!(calls.len(), 1);
         assert!(calls[0].sudo);
-        assert!(calls[0].cmd.ends_with("guest-agent prepare-for-reuse"));
+        let helper_position = calls[0]
+            .cmd
+            .find("guest-agent prepare-for-reuse")
+            .expect("reuse helper command");
+        let mount_position = calls[0]
+            .cmd
+            .find("workspace_device=")
+            .expect("workspace mount command");
+        assert!(helper_position < mount_position);
         let request: ReusePreparationRequest = serde_json::from_slice(
             calls[0]
                 .stdin_bytes
@@ -491,6 +548,27 @@ mod tests {
                 Some(expected_reason)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn preparation_distinguishes_workspace_mount_failure() {
+        let sandbox = MockSandbox::new("workspace-mount-failure");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            REUSE_PREPARATION_EXIT_WORKSPACE_MOUNT_FAILED,
+            serde_json::to_vec(&healthy_reuse_preparation_report()).unwrap(),
+            b"workspace mount failed".to_vec(),
+        )));
+
+        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse")
+                .fields
+                .get("reason")
+                .map(String::as_str),
+            Some("workspace_mount_failed")
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -19,7 +19,7 @@ use shell_quote::quote_shell_arg;
 use crate::error::{RunnerError, RunnerResult};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 
-const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_FREEZE_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
 const WORKSPACE_MOUNT_SCRIPT: &str = include_str!("../scripts/mount-workspace-drive.sh");
@@ -87,7 +87,7 @@ async fn run_workspace_drive_command(
     Err(RunnerError::Internal(message))
 }
 
-fn workspace_mount_command() -> String {
+pub(crate) fn workspace_mount_command() -> String {
     workspace_command(WORKSPACE_MOUNT_SCRIPT)
 }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -11,17 +11,17 @@ use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessCancelHandle,
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
-    SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver,
-    SandboxStartStage, StartProcessRequest, WriteFileEntry,
+    SandboxError, SandboxFinalExecParkOutcome, SandboxIdleTransition, SandboxInvalidStateContext,
+    SandboxOperation, SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome,
+    SandboxStartObserver, SandboxStartStage, StartProcessRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
 use vsock_host::{
-    ExecOutputEvent, ExecOwnedCapturedOutput, NormalOperationFence, NormalOperationFenceRejection,
-    SupervisedExecControl, SupervisedExecRequest, VsockHost,
+    ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, NormalOperationFence,
+    NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest, VsockHost,
 };
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
 
@@ -1955,6 +1955,90 @@ impl Sandbox for FirecrackerSandbox {
         Ok(outcome)
     }
 
+    async fn final_exec_and_park(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+        if self.is_parked {
+            return Err(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "final guest exec cannot run on an already parked sandbox",
+            ));
+        }
+
+        let operation = SandboxOperation::Exec;
+        Self::validate_exec_env_keys(operation, request.env)?;
+        let timeout_ms = request.timeout_ms();
+        validate_exec_capture_timeout(timeout_ms)
+            .map_err(|error| Self::operation_error(operation, error, self.has_backend_crashed()))?;
+
+        let coordinator = self.park_coordinator.clone();
+        let guest = Arc::clone(&self.guest);
+        let final_exec_guest = Arc::clone(&guest);
+        let id = self.id.clone();
+        let api_sock = self.sock_paths.api_sock();
+        let final_exec_request = exec_capture_request(request, timeout_ms, diagnostic_label);
+        let (normal_operations_fence, park_outcome, exec_result) =
+            park_with_ready_for_park_and_preparation(
+                &id,
+                &coordinator,
+                || async move {
+                    let guest =
+                        final_exec_guest
+                            .lock()
+                            .await
+                            .as_ref()
+                            .cloned()
+                            .ok_or_else(|| {
+                                ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
+                                    io::ErrorKind::NotConnected,
+                                    "guest connection missing during final park operation",
+                                ))
+                            })?;
+                    let (result, fence) = guest
+                        .exec_operation_capture_with_fence(final_exec_request)
+                        .await
+                        .map_err(|error| match error {
+                            FencedExecError::FenceRejected(error) => {
+                                ParkNormalOperationFenceError::Rejected(error)
+                            }
+                            FencedExecError::Operation(error) => {
+                                ParkNormalOperationFenceError::FinalOperation(error)
+                            }
+                        })?;
+                    let result = exec_result_from_operation_result(result)
+                        .map_err(ParkNormalOperationFenceError::FinalOperation)?;
+                    Ok((fence, result))
+                },
+                || async move {
+                    let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotConnected,
+                            "guest connection missing during park quiesce",
+                        )
+                    })?;
+                    guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
+                },
+                || {
+                    park_inner(
+                        &mut self.is_parked,
+                        self.config.resources.memory_mb,
+                        self.runtime.balloon_mut(),
+                        &api_sock,
+                        &id,
+                    )
+                },
+            )
+            .await?;
+        self.park_fence = Some(normal_operations_fence);
+        self.park_outcome = Some(park_outcome);
+        Ok(SandboxFinalExecParkOutcome {
+            exec_result,
+            park_outcome,
+        })
+    }
+
     async fn unpark(&mut self) -> sandbox::Result<()> {
         if !self.is_parked {
             if self.park_fence.is_some() {
@@ -2273,6 +2357,7 @@ enum ParkBoundaryGuardState {
 enum ParkNormalOperationFenceError {
     GuestUnavailable(io::Error),
     Rejected(NormalOperationFenceRejection),
+    FinalOperation(io::Error),
 }
 
 struct ParkBoundaryGuard<Fence> {
@@ -2441,6 +2526,42 @@ where
     P: FnOnce() -> PF,
     PF: Future<Output = sandbox::Result<Outcome>>,
 {
+    let (fence, outcome, ()) = park_with_ready_for_park_and_preparation(
+        log_id,
+        coordinator,
+        || async move { fence_normal_operations().await.map(|fence| (fence, ())) },
+        quiesce_guest,
+        park_firecracker,
+    )
+    .await?;
+    Ok((fence, outcome))
+}
+
+async fn park_with_ready_for_park_and_preparation<
+    Fence,
+    Outcome,
+    Preparation,
+    F,
+    FF,
+    Q,
+    QF,
+    P,
+    PF,
+>(
+    log_id: &str,
+    coordinator: &ParkCoordinator,
+    fence_and_prepare: F,
+    quiesce_guest: Q,
+    park_firecracker: P,
+) -> sandbox::Result<(Fence, Outcome, Preparation)>
+where
+    F: FnOnce() -> FF,
+    FF: Future<Output = Result<(Fence, Preparation), ParkNormalOperationFenceError>>,
+    Q: FnOnce() -> QF,
+    QF: Future<Output = io::Result<()>>,
+    P: FnOnce() -> PF,
+    PF: Future<Output = sandbox::Result<Outcome>>,
+{
     info!(
         id = %log_id,
         transition = "park",
@@ -2480,9 +2601,10 @@ where
         phase = "normal_operations_fence",
         "sandbox park lifecycle normal-operation fence started"
     );
-    match fence_normal_operations().await {
-        Ok(fence) => {
+    let preparation = match fence_and_prepare().await {
+        Ok((fence, preparation)) => {
             guard.mark_normal_operations_fenced(fence);
+            preparation
         }
         Err(ParkNormalOperationFenceError::Rejected(NormalOperationFenceRejection::Busy)) => {
             warn!(
@@ -2526,7 +2648,20 @@ where
             guard.mark_dirty(message.clone());
             return Err(idle_transition_error(SandboxIdleTransition::Park, message));
         }
-    }
+        Err(ParkNormalOperationFenceError::FinalOperation(error)) => {
+            let message = format!("final guest operation failed while preparing park: {error}");
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "final_guest_operation",
+                reason_kind = "protocol_or_transport",
+                error = %error,
+                "sandbox park lifecycle final guest operation failed"
+            );
+            guard.mark_dirty(message.clone());
+            return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+        }
+    };
 
     info!(
         id = %log_id,
@@ -2619,7 +2754,7 @@ where
         phase = "parked",
         "sandbox park lifecycle marked parked"
     );
-    Ok((normal_operations_fence, outcome))
+    Ok((normal_operations_fence, outcome, preparation))
 }
 
 async fn unpark_with_ready_for_operations<U, UF, R, RF, F>(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -871,6 +871,84 @@ async fn ready_for_park_boundary_preserves_non_reusable_outcome() {
 }
 
 #[tokio::test]
+async fn final_preparation_runs_after_operation_admission_closes() {
+    let coordinator = ParkCoordinator::new();
+    let guest = Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>));
+    let operation_gate = GuestOperationStartGate::new(guest, coordinator.clone());
+    let (preparation_entered_tx, preparation_entered_rx) = tokio::sync::oneshot::channel();
+    let (release_preparation_tx, release_preparation_rx) = tokio::sync::oneshot::channel();
+
+    let transition = super::park_with_ready_for_park_and_preparation(
+        "test-sandbox",
+        &coordinator,
+        || async move {
+            preparation_entered_tx.send(()).unwrap();
+            release_preparation_rx.await.unwrap();
+            Ok((TestNormalOperationFence, "prepared"))
+        },
+        || async { Ok(()) },
+        || async { Ok(SandboxParkOutcome::Reusable) },
+    );
+    tokio::pin!(transition);
+
+    tokio::select! {
+        _ = &mut transition => panic!("park completed before final preparation was released"),
+        result = preparation_entered_rx => result.unwrap(),
+    }
+
+    assert!(matches!(
+        operation_gate
+            .begin_sandbox_operation(|| SandboxState::Running)
+            .await,
+        Err(GuestOperationStartError::GateClosed { .. })
+    ));
+    assert!(matches!(
+        operation_gate.begin_control_operation().await,
+        Err(GuestOperationStartError::GateClosed { .. })
+    ));
+
+    release_preparation_tx.send(()).unwrap();
+    let (_fence, outcome, preparation) = transition.await.unwrap();
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(preparation, "prepared");
+    assert!(matches!(coordinator.state(), CoordinatorState::Parked));
+}
+
+#[tokio::test]
+async fn final_preparation_transport_failure_marks_dirty_without_quiesce_or_pause() {
+    let coordinator = ParkCoordinator::new();
+    let events = event_log();
+    let quiesce_events = Arc::clone(&events);
+    let park_events = Arc::clone(&events);
+
+    let result = super::park_with_ready_for_park_and_preparation(
+        "test-sandbox",
+        &coordinator,
+        || async {
+            Err::<(TestNormalOperationFence, ()), _>(ParkNormalOperationFenceError::FinalOperation(
+                io::Error::new(io::ErrorKind::ConnectionReset, "final exec disconnected"),
+            ))
+        },
+        || async move {
+            quiesce_events.lock().unwrap().push("guest_quiesce");
+            Ok(())
+        },
+        || async move {
+            park_events.lock().unwrap().push("firecracker_park");
+            Ok(SandboxParkOutcome::Reusable)
+        },
+    )
+    .await;
+
+    assert_idle_transition(result.map(drop), SandboxIdleTransition::Park);
+    assert!(logged_events(&events).is_empty());
+    assert!(matches!(
+        coordinator.state(),
+        CoordinatorState::Dirty { .. }
+    ));
+}
+
+#[tokio::test]
 async fn ready_for_park_boundary_fences_before_quiesce_and_holds_until_returned() {
     let coordinator = ParkCoordinator::new();
     let events = event_log();

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -319,6 +319,21 @@ impl Sandbox for MockSandbox {
             .next_result(SandboxParkOutcome::Reusable)
     }
 
+    async fn final_exec_and_park(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+    ) -> Result<SandboxFinalExecParkOutcome> {
+        let exec_result = self
+            .exec_with_diagnostic_label(request, diagnostic_label)
+            .await?;
+        let park_outcome = self.park().await?;
+        Ok(SandboxFinalExecParkOutcome {
+            exec_result,
+            park_outcome,
+        })
+    }
+
     /// Mock unpark: counter + queued-result semantics mirror [`park`]
     /// exactly. See [`park`] for details.
     ///

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -42,8 +42,8 @@ pub use factory::{
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::{
-    Sandbox, SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver,
-    SandboxStartStage,
+    Sandbox, SandboxFinalExecParkOutcome, SandboxParkNonReusableReason, SandboxParkOutcome,
+    SandboxStartObserver, SandboxStartStage,
 };
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::error::Result;
+use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
     StartProcessRequest, WriteFileEntry,
@@ -17,6 +17,18 @@ pub enum SandboxParkOutcome {
     Reusable,
     /// The sandbox is validly parked but must be destroyed instead of reused.
     NonReusable(SandboxParkNonReusableReason),
+}
+
+/// Completed final guest exec together with the resulting parked state.
+///
+/// The exec result is transport-complete but may still be semantically
+/// unacceptable to the lifecycle owner. The sandbox is validly parked in
+/// either case and must be admitted or destroyed through a parked cleanup path.
+pub struct SandboxFinalExecParkOutcome {
+    /// Terminal result of the lifecycle-owned final guest exec.
+    pub exec_result: ExecResult,
+    /// Eligibility reported after the sandbox reached the parked state.
+    pub park_outcome: SandboxParkOutcome,
 }
 
 /// Stable reason why a validly parked sandbox cannot be reused.
@@ -231,6 +243,35 @@ pub trait Sandbox: Send + Sync + Any {
     /// when the implementation documents that retry as safe.
     async fn park(&mut self) -> Result<SandboxParkOutcome> {
         Ok(SandboxParkOutcome::Reusable)
+    }
+
+    /// Run one final normal guest exec and park without reopening operation
+    /// admission between the exec and pause.
+    ///
+    /// Implementations must close admission to new normal/control operations
+    /// before atomically ordering `request` after every previously admitted
+    /// normal operation. A successful exec must remain fenced through guest
+    /// quiesce and the completed park transition. A competing earlier operation
+    /// may reject this transition, but it must not run after the final exec and
+    /// still allow this method to succeed.
+    ///
+    /// A completed non-zero or otherwise semantically unacceptable exec result
+    /// may still be returned after a valid park; the lifecycle owner decides
+    /// whether to admit or destroy that parked sandbox. On `Err`, callers must
+    /// not dispatch further work and should destroy the sandbox.
+    ///
+    /// Unlike [`park`](Self::park), this operation is not idempotent because its
+    /// final exec must run exactly once on an active sandbox.
+    async fn final_exec_and_park(
+        &mut self,
+        _request: &ExecRequest<'_>,
+        _diagnostic_label: &'static str,
+    ) -> Result<SandboxFinalExecParkOutcome> {
+        Err(SandboxError::IdleTransition {
+            transition: SandboxIdleTransition::Park,
+            message: "final guest exec during park is not supported by this sandbox provider"
+                .to_string(),
+        })
     }
 
     /// Transition the sandbox back to the active state.

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -153,7 +153,8 @@ pub struct NormalOperationFence {
     _inner: operation_tracker::NormalOperationFence,
 }
 
-/// Reason why [`VsockHost::try_fence_normal_operations`] could not acquire a
+/// Reason why [`VsockHost::try_fence_normal_operations`] or
+/// [`VsockHost::exec_operation_capture_with_fence`] could not acquire a
 /// [`NormalOperationFence`].
 ///
 /// The variants identify caller-visible recovery paths for normal-operation
@@ -186,6 +187,36 @@ impl From<TrackerNormalOperationFenceRejection> for NormalOperationFenceRejectio
             TrackerNormalOperationFenceRejection::AlreadyFenced => Self::AlreadyFenced,
             TrackerNormalOperationFenceRejection::NotParkable => Self::NotParkable,
             TrackerNormalOperationFenceRejection::Closed => Self::Closed,
+        }
+    }
+}
+
+/// Failure while atomically fencing normal operations and running one final
+/// capture exec.
+#[derive(Debug)]
+pub enum FencedExecError {
+    /// The connection could not enter the fenced final-operation state.
+    FenceRejected(NormalOperationFenceRejection),
+    /// The reserved capture exec did not produce a trustworthy terminal result.
+    Operation(io::Error),
+}
+
+impl std::fmt::Display for FencedExecError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FenceRejected(reason) => {
+                write!(formatter, "normal-operation fence rejected: {reason:?}")
+            }
+            Self::Operation(error) => write!(formatter, "fenced exec failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for FencedExecError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::FenceRejected(_) => None,
+            Self::Operation(error) => Some(error),
         }
     }
 }
@@ -441,6 +472,39 @@ impl CompositeNormalOperation {
             Ok(()) | Err(NormalOperationTransitionError::UnknownOperation { .. }) => Ok(()),
             Err(error) => Err(normal_operation_transition_error(error)),
         }
+    }
+}
+
+struct FencedNormalOperationGuard {
+    normal_operation: Option<CompositeNormalOperation>,
+    fence: Option<NormalOperationFence>,
+}
+
+impl FencedNormalOperationGuard {
+    fn complete(mut self) -> io::Result<NormalOperationFence> {
+        let normal_operation = self.normal_operation.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fenced normal operation already completed",
+            )
+        })?;
+        normal_operation.complete()?;
+        self.fence.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fenced normal operation is missing its fence",
+            )
+        })
+    }
+}
+
+impl Drop for FencedNormalOperationGuard {
+    fn drop(&mut self) {
+        // Release the operation token before the fence. If a request may have
+        // reached the guest, dropping the token first makes the tracker
+        // NotParkable before the fence can consider reopening it.
+        drop(self.normal_operation.take());
+        drop(self.fence.take());
     }
 }
 
@@ -1177,6 +1241,50 @@ impl VsockHost {
         request: ExecCaptureRequest<'_>,
     ) -> io::Result<ExecOperationResult> {
         exec_operation::exec_operation_capture_on_shared(&self.shared, request).await
+    }
+
+    /// Atomically reserve one final normal operation and fence every competing
+    /// normal operation while running a capture exec.
+    ///
+    /// Reservation succeeds only when the normal-operation tracker is open and
+    /// idle. The returned fence remains held after the exec reaches a terminal
+    /// result, allowing a lifecycle owner to quiesce and pause the guest without
+    /// reopening normal-operation admission in between.
+    ///
+    /// Dropping this future or losing terminal proof releases the operation
+    /// token before the fence. If the request may have reached the guest, that
+    /// ordering leaves the connection not parkable rather than reopening it.
+    pub async fn exec_operation_capture_with_fence(
+        &self,
+        request: ExecCaptureRequest<'_>,
+    ) -> Result<(ExecOperationResult, NormalOperationFence), FencedExecError> {
+        let (normal_operation, fence) = self
+            .shared
+            .normal_operations
+            .try_reserve_and_fence()
+            .map_err(|error| FencedExecError::FenceRejected(error.into()))?;
+        let mut guard = FencedNormalOperationGuard {
+            normal_operation: Some(CompositeNormalOperation {
+                normal_operation: Some(normal_operation),
+            }),
+            fence: Some(NormalOperationFence { _inner: fence }),
+        };
+        let normal_operation = guard.normal_operation.as_mut().ok_or_else(|| {
+            FencedExecError::Operation(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fenced normal operation is unavailable",
+            ))
+        })?;
+        let result = exec_operation::exec_operation_capture_with_composite_on_shared_and_observer(
+            &self.shared,
+            request,
+            normal_operation,
+            FrameWriteObserver::default(),
+        )
+        .await
+        .map_err(FencedExecError::Operation)?;
+        let fence = guard.complete().map_err(FencedExecError::Operation)?;
+        Ok((result, fence))
     }
 
     /// Start a streaming exec operation with a bounded output event receiver.

--- a/crates/vsock-host/src/operation_tracker.rs
+++ b/crates/vsock-host/src/operation_tracker.rs
@@ -63,6 +63,39 @@ impl NormalOperationTracker {
         }
     }
 
+    pub(crate) fn try_reserve_and_fence(
+        &self,
+    ) -> Result<(NormalOperationToken, NormalOperationFence), NormalOperationFenceRejection> {
+        let mut inner = self.inner();
+        match inner.state {
+            TrackerState::Open if inner.operations.is_empty() => {
+                let operation_id = NormalOperationId(inner.next_operation_id);
+                inner.next_operation_id += 1;
+                let fence_id = NormalOperationFenceId(inner.next_fence_id);
+                inner.next_fence_id += 1;
+                inner
+                    .operations
+                    .insert(operation_id, OperationPhase::ReservedBeforeWrite);
+                inner.state = TrackerState::Fenced { id: fence_id };
+                Ok((
+                    NormalOperationToken {
+                        id: operation_id,
+                        inner: Arc::clone(&self.inner),
+                        released: false,
+                    },
+                    NormalOperationFence {
+                        id: fence_id,
+                        inner: Arc::clone(&self.inner),
+                    },
+                ))
+            }
+            TrackerState::Open => Err(NormalOperationFenceRejection::Busy),
+            TrackerState::Fenced { .. } => Err(NormalOperationFenceRejection::AlreadyFenced),
+            TrackerState::NotParkable => Err(NormalOperationFenceRejection::NotParkable),
+            TrackerState::Closed => Err(NormalOperationFenceRejection::Closed),
+        }
+    }
+
     pub(crate) fn mark_not_parkable(&self) {
         let mut inner = self.inner();
         inner.state = TrackerState::NotParkable;
@@ -473,6 +506,55 @@ mod tests {
             tracker.reserve(),
             Err(NormalOperationRejection::Fenced)
         ));
+    }
+
+    #[test]
+    fn reserved_operation_and_fence_are_acquired_atomically() {
+        let tracker = NormalOperationTracker::new();
+
+        let (token, fence) = tracker
+            .try_reserve_and_fence()
+            .expect("idle tracker should reserve and fence");
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Fenced);
+        assert!(matches!(
+            tracker.reserve(),
+            Err(NormalOperationRejection::Fenced)
+        ));
+        token
+            .complete()
+            .expect("reserved operation should complete");
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Fenced);
+
+        drop(fence);
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::Idle);
+    }
+
+    #[test]
+    fn reserved_operation_and_fence_reject_busy_tracker() {
+        let tracker = NormalOperationTracker::new();
+        let _token = reserve(&tracker);
+
+        assert!(matches!(
+            tracker.try_reserve_and_fence(),
+            Err(NormalOperationFenceRejection::Busy)
+        ));
+    }
+
+    #[test]
+    fn uncertain_reserved_and_fenced_write_remains_not_parkable() {
+        let tracker = NormalOperationTracker::new();
+        let (mut token, fence) = tracker
+            .try_reserve_and_fence()
+            .expect("idle tracker should reserve and fence");
+        token
+            .mark_possible_guest_write_started()
+            .expect("mark write started");
+
+        drop(token);
+        drop(fence);
+
+        assert_eq!(tracker.readiness(), NormalOperationReadiness::NotParkable);
     }
 
     #[test]

--- a/crates/vsock-host/src/tests/exec_operation/capture.rs
+++ b/crates/vsock-host/src/tests/exec_operation/capture.rs
@@ -8,11 +8,31 @@ use vsock_proto::{
 };
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, is_connected, operation_count, read_guest_message,
-    read_guest_messages, send_exec_result, send_raw_exec_result, setup_host_and_guest,
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    operation_count, read_guest_message, read_guest_messages, send_exec_result,
+    send_raw_exec_result, setup_host_and_guest,
 };
 use super::start_capture_operation;
-use crate::{ExecCaptureRequest, ExecOperationRequest, ExecOwnedCapturedOutput};
+use crate::operation_tracker::NormalOperationReadiness;
+use crate::{
+    ExecCaptureRequest, ExecOperationRequest, ExecOwnedCapturedOutput, FencedExecError,
+    NormalOperationFenceRejection,
+};
+
+fn fenced_capture_request() -> ExecCaptureRequest<'static> {
+    ExecCaptureRequest {
+        timeout_ms: 5000,
+        command: "final-preparation",
+        env: &[],
+        sudo: true,
+        label: "fenced-capture",
+        stdout_limit_bytes: 1024,
+        stderr_limit_bytes: 1024,
+        expected_exit_codes: &[],
+        stdin_bytes: None,
+        wait_timeout: Duration::from_secs(5),
+    }
+}
 
 #[tokio::test]
 async fn exec_operation_capture_sends_start_and_receives_result() {
@@ -81,6 +101,112 @@ async fn exec_operation_capture_sends_start_and_receives_result() {
         }
     );
     assert_eq!(operation_count(&host), 0);
+}
+
+#[tokio::test]
+async fn fenced_capture_excludes_normal_operations_until_fence_drops() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.exec_operation_capture_with_fence(fenced_capture_request())
+                .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Fenced
+    );
+    let error = match host
+        .start_exec_operation(ExecOperationRequest {
+            timeout_ms: 5000,
+            command: "competing-operation",
+            env: &[],
+            sudo: false,
+            label: "competing-operation",
+            stdout: ExecOutputPolicy::Capture { limit_bytes: 16 },
+            stderr: ExecOutputPolicy::Capture { limit_bytes: 16 },
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            stream_queue_capacity: None,
+        })
+        .await
+    {
+        Ok(_) => panic!("competing operation should be fenced"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+
+    send_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"ready",
+        b"",
+    )
+    .await;
+    let (result, fence) = task.await.unwrap().unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Fenced
+    );
+
+    drop(fence);
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn fenced_capture_rejects_an_existing_normal_operation() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let handle = start_capture_operation(&host, "existing-operation").await;
+    let msg = read_guest_message(&mut guest).await;
+
+    let error = host
+        .exec_operation_capture_with_fence(fenced_capture_request())
+        .await
+        .expect_err("busy normal-operation tracker should reject fencing");
+    assert!(matches!(
+        error,
+        FencedExecError::FenceRejected(NormalOperationFenceRejection::Busy)
+    ));
+
+    send_exec_result(
+        &mut guest,
+        msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn dropping_fenced_capture_after_write_is_not_parkable() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.exec_operation_capture_with_fence(fenced_capture_request())
+                .await
+        })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    task.abort();
+    let _ = task.await;
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reserve one lifecycle-owned final guest exec and the retained normal-operation fence atomically before Firecracker park
- run idle cleanup and workspace mount validation in that final exec, then distinguish active transition failures from semantically rejected parked sandboxes
- remove the redundant workspace mount exec from reused spawn while preserving fresh, benchmark, and workspace-promotion mount behavior
- extend runner metal behavior coverage for mount tampering, `/dev/vdb` identity, and an independently owned `runner exec` overlapping idle admission

## Compatibility

- no schema, persisted state, API, queue payload, image format, guest wire message, or feature switch changes
- idle entries remain process-local, so mixed runner versions drain their own proof state without compatibility cleanup

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-host -p sandbox -p sandbox-fc -p sandbox-mock -p runner --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host -p sandbox -p sandbox-fc -p sandbox-mock --all-targets --all-features`
- `shellcheck .github/scripts/runner-behavior-keep-alive.sh`
- `bash -n .github/scripts/runner-behavior-keep-alive.sh`

Closes #22605
