### PR TITLE
chore(api): enforce structured scalar query builders

### DIFF
--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -75,7 +75,7 @@ const scalarQuery = `
   sql\`(
     SELECT "message"."id"
     FROM "messages" AS "message"
-    WHERE "message"."user_id" = \${users.id}
+    WHERE "message"."user_id" = "users"."id"
     LIMIT 1
   )\`
 `;
@@ -305,6 +305,9 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         db.select({ value: sql\`(SELECT 1 WHERE true LIMIT 1)\` });
         db.select({ value: sql\`(SELECT 1 FROM messages LIMIT 1)\` });
         db.select({ value: sql\`(SELECT 1 FROM messages WHERE true)\` });
+        db.select({
+          value: sql\`(SELECT 1 FROM messages WHERE true LIMIT \${1})\`,
+        });
         db.select({
           value: sql\`(
             SELECT "message"."id"

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -325,6 +325,7 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         db.select({
           value: users.id,
         }).from(users).where(${scalarQuery});
+        db.selectDistinctOn([${scalarQuery}], { value: users.id });
       `,
     },
     {
@@ -478,7 +479,7 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         import { sql } from "drizzle-orm";
         const fields = {
           value: ${mappedScalarQuery},
-        } as const;
+        } satisfies Record<string, unknown>;
         db.select(fields);
         db.select({ ...fields });
       `,

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -344,9 +344,66 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
     {
       code: `${structuredSelectionPreamble}
         import { sql } from "drizzle-orm";
+        const adapter = {
+          select(fields: unknown) {
+            void fields;
+            return db.select({ id: users.id });
+          },
+          returning(fields: unknown) {
+            void fields;
+            return db.update(users).set({ name: "updated" });
+          },
+        };
+        adapter.select({ value: ${mappedScalarQuery} });
+        adapter.returning({ value: ${mappedScalarQuery} });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare const useDatabase: boolean;
+        const adapter = {
+          select(fields: unknown) {
+            void fields;
+            return db.select({ id: users.id });
+          },
+        };
+        const consumer = useDatabase ? db : adapter;
+        consumer.select({ value: ${mappedScalarQuery} });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
         let fields = { value: ${mappedScalarQuery} };
         db.select(fields);
         fields = { value: sql\`1\`.mapWith(messages.id) };
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const fields = { value: ${mappedScalarQuery} };
+        fields.value = sql\`1\`.mapWith(messages.id);
+        db.select(fields);
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const fields = { value: ${mappedScalarQuery} };
+        const alias = fields;
+        alias.value = sql\`1\`.mapWith(messages.id);
+        db.select(fields);
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare function inspect(fields: object): void;
+        const fields = { value: ${mappedScalarQuery} };
+        inspect(fields);
+        db.select(fields);
       `,
     },
     {
@@ -360,6 +417,36 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           return { value: sql\`1\`.mapWith(messages.id) };
         }
         db.select(fields());
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        function fields() {
+          return { value: ${mappedScalarQuery} };
+        }
+        fields = () => ({ value: sql\`1\`.mapWith(messages.id) });
+        db.select(fields());
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const selection = { value: ${mappedScalarQuery} };
+        function fields() {
+          return selection;
+        }
+        fields().value = sql\`1\`.mapWith(messages.id);
+        db.select(fields());
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        export const fields = { value: ${mappedScalarQuery} };
+        export function selectedFields() {
+          return db.select(fields);
+        }
       `,
     },
     {
@@ -424,6 +511,36 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       code: `${structuredSelectionPreamble}
         import { sql } from "drizzle-orm";
         db.select({ value: ${scalarQuery} }).from(users);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare const selectedDb: Pick<DrizzleDatabase, "select">;
+        selectedDb.select({ value: ${mappedScalarQuery} }).from(users);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare const selectedDb: {
+          select: DrizzleDatabase["select"] & { readonly kind: "select" };
+        };
+        selectedDb.select({ value: ${mappedScalarQuery} }).from(users);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const usersCte = db.$with("users_cte").as(
+          db.select({ id: users.id }).from(users),
+        );
+        db.with(usersCte)
+          .select({ value: ${mappedScalarQuery} })
+          .from(usersCte);
       `,
       errors: [{ messageId: "structuredScalarQuery" }],
     },

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -52,6 +52,36 @@ const schemaPreamble = `
   declare const excludedRunId: number;
 `;
 
+const structuredSelectionPreamble = `
+  import { integer, pgTable, text } from "drizzle-orm/pg-core";
+
+  const users = pgTable("users", {
+    id: integer("id").notNull(),
+    name: text("name").notNull(),
+  });
+  const messages = pgTable("messages", {
+    id: integer("id").notNull(),
+    userId: integer("user_id").notNull(),
+  });
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      users: typeof users;
+      messages: typeof messages;
+    }>;
+  declare const db: DrizzleDatabase;
+`;
+
+const scalarQuery = `
+  sql\`(
+    SELECT "message"."id"
+    FROM "messages" AS "message"
+    WHERE "message"."user_id" = \${users.id}
+    LIMIT 1
+  )\`
+`;
+
+const mappedScalarQuery = `${scalarQuery}.mapWith(messages.id)`;
+
 const directQuery = `
   sql\`
     SELECT \${runs.id} AS "id"
@@ -249,6 +279,100 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`;
       `,
     },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const query = ${mappedScalarQuery};
+        void query;
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`coalesce((
+            SELECT "message"."id"
+            FROM "messages" AS "message"
+            WHERE "message"."user_id" = \${users.id}
+            LIMIT 1
+          ), 0)\`.mapWith(messages.id),
+        });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.select({ value: sql\`(SELECT 1 WHERE true LIMIT 1)\` });
+        db.select({ value: sql\`(SELECT 1 FROM messages LIMIT 1)\` });
+        db.select({ value: sql\`(SELECT 1 FROM messages WHERE true)\` });
+        db.select({
+          value: sql\`(
+            SELECT "message"."id"
+            FROM "messages" AS "message"
+            WHERE "message"."user_id" = \${users.id}
+            ORDER BY "message"."id"
+            LIMIT 1
+          )\`.mapWith(messages.id),
+        });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: users.id,
+        }).from(users).where(${scalarQuery});
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const builder = {
+          select(fields: unknown) {
+            return fields;
+          },
+        };
+        builder.select({ value: ${scalarQuery} });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        let fields = { value: ${mappedScalarQuery} };
+        db.select(fields);
+        fields = { value: sql\`1\`.mapWith(messages.id) };
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare const chooseFirst: boolean;
+        function fields() {
+          if (chooseFirst) {
+            return { value: ${mappedScalarQuery} };
+          }
+          return { value: sql\`1\`.mapWith(messages.id) };
+        }
+        db.select(fields());
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        function value() {
+          return ${mappedScalarQuery};
+        }
+        db.select({ value: value() });
+      `,
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.insert(users).select(${scalarQuery});
+      `,
+    },
   ],
   invalid: [
     {
@@ -291,6 +415,86 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         );
       `,
       errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.select({ value: ${scalarQuery} }).from(users);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql as query } from "drizzle-orm";
+        db.select({
+          value: query\`(
+            SELECT "message"."id"
+            FROM "messages" AS "message"
+            WHERE "message"."user_id" = \${users.id}
+            LIMIT 1
+          )\`.mapWith(messages.id).as("value"),
+        });
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import * as drizzle from "drizzle-orm";
+        db.select({
+          nested: {
+            value: drizzle.sql\`(
+              SELECT "message"."id"
+              FROM "messages" AS "message"
+              WHERE "message"."user_id" = \${users.id}
+              LIMIT 1
+            )\`.mapWith(messages.id),
+          },
+        });
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const messageColumns = {
+          lastMessageId: ${mappedScalarQuery},
+        } as const;
+        function selectedMessageColumns(database: DrizzleDatabase) {
+          return {
+            name: users.name,
+            ...messageColumns,
+          } as const;
+        }
+        db.select(selectedMessageColumns(db)).from(users);
+        db.select(selectedMessageColumns(db)).from(users);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        const fields = {
+          value: ${mappedScalarQuery},
+        } as const;
+        db.select(fields);
+        db.select({ ...fields });
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        db.selectDistinct({ value: ${mappedScalarQuery} });
+        db.selectDistinctOn([users.id], { value: ${mappedScalarQuery} });
+        db.update(users)
+          .set({ name: "updated" })
+          .returning({ value: ${mappedScalarQuery} });
+      `,
+      errors: [
+        { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+      ],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -578,7 +578,32 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       code: `${structuredSelectionPreamble}
         import { sql } from "drizzle-orm";
         const messageColumns = {
-          lastMessageId: ${mappedScalarQuery},
+          workflowAutomationBrief: sql\`(
+            SELECT COALESCE(
+              "zero_runs"."trigger_brief",
+              CASE
+                WHEN "zero_workflow_automations"."kind" = 'event'
+                  THEN 'Webhook received'
+                ELSE NULL
+              END
+            )
+            FROM "zero_runs"
+            INNER JOIN "zero_workflow_automations"
+              ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
+            WHERE "zero_runs"."id" = "chat_messages"."run_id"
+            LIMIT 1
+          )\`.mapWith(users.name),
+          workflowAutomationUserTimezone: sql\`(
+            SELECT "org_members_metadata"."timezone"
+            FROM "zero_runs"
+            INNER JOIN "zero_workflow_automations"
+              ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
+            LEFT JOIN "org_members_metadata"
+              ON "org_members_metadata"."org_id" = "zero_workflow_automations"."org_id"
+              AND "org_members_metadata"."user_id" = "zero_workflow_automations"."owner_user_id"
+            WHERE "zero_runs"."id" = "chat_messages"."run_id"
+            LIMIT 1
+          )\`.mapWith(users.name),
         } as const;
         function selectedMessageColumns(database: DrizzleDatabase) {
           return {
@@ -589,7 +614,10 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         db.select(selectedMessageColumns(db)).from(users);
         db.select(selectedMessageColumns(db)).from(users);
       `,
-      errors: [{ messageId: "structuredScalarQuery" }],
+      errors: [
+        { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+      ],
     },
     {
       code: `${structuredSelectionPreamble}

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -454,6 +454,8 @@ export const preferDrizzleQueryBuilder = createRule({
     const checker = services.program.getTypeChecker();
     const directRawRowsBindings = new Set<string>();
     const rawRowsNamespaces = new Set<string>();
+    // Keep the type-aware consumer traversal out of files with no matching
+    // syntax. The API baseline has hundreds of result calls but zero targets.
     const scalarQueryCandidates = new Set<TSESTree.TaggedTemplateExpression>();
     const structuredSelectionCalls: TSESTree.CallExpression[] = [];
     const reportedScalarQueries = new Set<TSESTree.TaggedTemplateExpression>();
@@ -615,6 +617,8 @@ export const preferDrizzleQueryBuilder = createRule({
     }
 
     function localSingleReturn(node: TSESTree.Node): TSESTree.Node | null {
+      // This intentionally covers only the historical local factory shape.
+      // Parameter substitution and broader call flow remain opaque.
       if (
         node.type !== AST_NODE_TYPES.CallExpression ||
         node.callee.type !== AST_NODE_TYPES.Identifier ||

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -2,8 +2,11 @@ import {
   AST_NODE_TYPES,
   ESLintUtils,
   type TSESTree,
+  type TSESLint,
 } from "@typescript-eslint/utils";
 import {
+  canHaveModifiers,
+  getModifiers,
   isFunctionDeclaration,
   isImportDeclaration,
   isImportSpecifier,
@@ -13,6 +16,7 @@ import {
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
+  SyntaxKind,
   type Node,
   type Type,
   type VariableDeclaration,
@@ -20,10 +24,12 @@ import {
 
 import {
   isDrizzleColumnType,
+  isDrizzleDeclaration,
   isDrizzleSqlTag,
   isDrizzleSymbol,
   isDrizzleTableType,
   isDrizzleWrapperType,
+  isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
 import {
@@ -459,8 +465,13 @@ export const preferDrizzleQueryBuilder = createRule({
     const scalarQueryCandidates = new Set<TSESTree.TaggedTemplateExpression>();
     const structuredSelectionCalls: TSESTree.CallExpression[] = [];
     const reportedScalarQueries = new Set<TSESTree.TaggedTemplateExpression>();
-    const selectMethodTypes = new Map<Type, boolean>();
-    const returningMethodTypes = new Map<Type, boolean>();
+    const resultPropertyTypes: Record<
+      "execute" | "from",
+      Map<Type, boolean>
+    > = {
+      execute: new Map<Type, boolean>(),
+      from: new Map<Type, boolean>(),
+    };
 
     for (const statement of context.sourceCode.ast.body) {
       if (
@@ -540,21 +551,57 @@ export const preferDrizzleQueryBuilder = createRule({
       type: Type,
       property: "execute" | "from",
     ): boolean {
-      const cache =
-        property === "from" ? selectMethodTypes : returningMethodTypes;
+      const cache = resultPropertyTypes[property];
       const cached = cache.get(type);
       if (cached !== undefined) {
         return cached;
       }
-      const result = type.getCallSignatures().some((signature) => {
-        const returnType = checker.getReturnTypeOfSignature(signature);
-        return isDrizzleSymbol(
-          checker,
-          checker.getPropertyOfType(returnType, property),
-        );
-      });
+      let result: boolean;
+      if (type.isUnion()) {
+        result = type.types.every((member) => {
+          return methodReturnsDrizzleProperty(member, property);
+        });
+      } else {
+        const signatures = type.getCallSignatures();
+        result =
+          signatures.length > 0 &&
+          signatures.every((signature) => {
+            const returnType = checker.getReturnTypeOfSignature(signature);
+            return isDrizzleSymbol(
+              checker,
+              checker.getPropertyOfType(returnType, property),
+            );
+          });
+      }
       cache.set(type, result);
       return result;
+    }
+
+    function hasOnlyDrizzleDeclarations(node: TSESTree.Node): boolean {
+      const declarations = resolvedSymbol(
+        checker,
+        symbolAt(node),
+      )?.declarations;
+      return (
+        declarations !== undefined &&
+        declarations.length > 0 &&
+        declarations.every(isDrizzleDeclaration)
+      );
+    }
+
+    function hasOnlyNamedDrizzleSignatures(type: Type, name: string): boolean {
+      if (type.isUnion()) {
+        return type.types.every((member) => {
+          return hasOnlyNamedDrizzleSignatures(member, name);
+        });
+      }
+      const signatures = type.getCallSignatures();
+      return (
+        signatures.length > 0 &&
+        signatures.every((signature) => {
+          return isNamedDrizzleSignature(signature, name);
+        })
+      );
     }
 
     function structuredResultMethod(
@@ -566,13 +613,16 @@ export const preferDrizzleQueryBuilder = createRule({
       }
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
       const type = checker.getTypeAtLocation(tsNode);
-      if (name === "returning") {
-        return isDrizzleSymbol(checker, symbolAt(node.property)) ||
-          methodReturnsDrizzleProperty(type, "execute")
-          ? name
-          : null;
-      }
-      return methodReturnsDrizzleProperty(type, "from") ? name : null;
+      const hasDrizzleIdentity =
+        hasOnlyDrizzleDeclarations(node.property) ||
+        hasOnlyNamedDrizzleSignatures(type, name);
+      return hasDrizzleIdentity &&
+        methodReturnsDrizzleProperty(
+          type,
+          name === "returning" ? "execute" : "from",
+        )
+        ? name
+        : null;
     }
 
     function transparentExpression(node: TSESTree.Node): TSESTree.Node | null {
@@ -586,6 +636,91 @@ export const preferDrizzleQueryBuilder = createRule({
         return node.expression;
       }
       return null;
+    }
+
+    function variableInScope(
+      node: TSESTree.Identifier,
+    ): TSESLint.Scope.Variable | null {
+      let scope: TSESLint.Scope.Scope | null =
+        context.sourceCode.getScope(node);
+      while (scope !== null) {
+        const variable = scope.variables.find((candidate) => {
+          return candidate.name === node.name;
+        });
+        if (variable !== undefined) {
+          return variable;
+        }
+        scope = scope.upper;
+      }
+      return null;
+    }
+
+    function outerTransparentExpression(node: TSESTree.Node): TSESTree.Node {
+      let current = node;
+      while (
+        current.parent !== undefined &&
+        transparentExpression(current.parent) === current
+      ) {
+        current = current.parent;
+      }
+      return current;
+    }
+
+    function isStructuredResultArgument(node: TSESTree.Node): boolean {
+      const use = outerTransparentExpression(node);
+      const parent = use.parent;
+      if (
+        parent === undefined ||
+        parent.type !== AST_NODE_TYPES.CallExpression ||
+        parent.callee.type !== AST_NODE_TYPES.MemberExpression
+      ) {
+        return false;
+      }
+      const method = structuredResultMethod(parent.callee);
+      const argumentIndex =
+        method === null ? undefined : RESULT_FIELD_ARGUMENT.get(method);
+      return (
+        argumentIndex !== undefined && parent.arguments[argumentIndex] === use
+      );
+    }
+
+    function isSafeConstReference(
+      identifier: TSESTree.Identifier,
+      currentReference: TSESTree.Identifier,
+    ): boolean {
+      return (
+        identifier === currentReference ||
+        isStructuredResultArgument(identifier)
+      );
+    }
+
+    function hasExportModifier(node: Node): boolean {
+      return (
+        canHaveModifiers(node) &&
+        getModifiers(node)?.some((modifier) => {
+          return modifier.kind === SyntaxKind.ExportKeyword;
+        }) === true
+      );
+    }
+
+    function variableIsExported(declaration: VariableDeclaration): boolean {
+      return hasExportModifier(declaration.parent.parent);
+    }
+
+    function hasOnlySafeConstReferences(node: TSESTree.Identifier): boolean {
+      // const freezes the binding, not the selected object. Stop when another
+      // use could mutate or expose it outside a proven Drizzle result read.
+      const variable = variableInScope(node);
+      return (
+        variable !== null &&
+        variable.references.every((reference) => {
+          return (
+            reference.init === true ||
+            (reference.identifier.type === AST_NODE_TYPES.Identifier &&
+              isSafeConstReference(reference.identifier, node))
+          );
+        })
+      );
     }
 
     function localConstInitializer(node: TSESTree.Node): TSESTree.Node | null {
@@ -602,7 +737,9 @@ export const preferDrizzleQueryBuilder = createRule({
         !isVariableDeclaration(declaration) ||
         declaration.getSourceFile() !== tsNode.getSourceFile() ||
         !isConstVariable(declaration) ||
-        declaration.initializer === undefined
+        variableIsExported(declaration) ||
+        declaration.initializer === undefined ||
+        !hasOnlySafeConstReferences(node)
       ) {
         return null;
       }
@@ -613,6 +750,37 @@ export const preferDrizzleQueryBuilder = createRule({
       return (
         isVariableDeclarationList(declaration.parent) &&
         (declaration.parent.flags & NodeFlags.Const) !== 0
+      );
+    }
+
+    function isSafeFunctionReference(
+      identifier: TSESTree.Identifier,
+      currentReference: TSESTree.Identifier,
+    ): boolean {
+      if (identifier === currentReference) {
+        return true;
+      }
+      const callee = outerTransparentExpression(identifier);
+      const call = callee.parent;
+      return (
+        call !== undefined &&
+        call.type === AST_NODE_TYPES.CallExpression &&
+        call.callee === callee &&
+        isStructuredResultArgument(call)
+      );
+    }
+
+    function hasOnlySafeFunctionReferences(node: TSESTree.Identifier): boolean {
+      const variable = variableInScope(node);
+      return (
+        variable !== null &&
+        variable.references.every((reference) => {
+          return (
+            reference.init === true ||
+            (reference.identifier.type === AST_NODE_TYPES.Identifier &&
+              isSafeFunctionReference(reference.identifier, node))
+          );
+        })
       );
     }
 
@@ -638,7 +806,9 @@ export const preferDrizzleQueryBuilder = createRule({
         !isFunctionDeclaration(declaration) ||
         declaration.getSourceFile() !== tsCallee.getSourceFile() ||
         declaration.body === undefined ||
-        declaration.body.statements.length !== 1
+        declaration.body.statements.length !== 1 ||
+        hasExportModifier(declaration) ||
+        !hasOnlySafeFunctionReferences(node.callee)
       ) {
         return null;
       }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -4,18 +4,27 @@ import {
   type TSESTree,
 } from "@typescript-eslint/utils";
 import {
+  isFunctionDeclaration,
   isImportDeclaration,
   isImportSpecifier,
   isNamespaceImport,
+  isReturnStatement,
   isStringLiteral,
+  isVariableDeclaration,
+  isVariableDeclarationList,
+  NodeFlags,
   type Node,
+  type Type,
+  type VariableDeclaration,
 } from "typescript";
 
 import {
   isDrizzleColumnType,
   isDrizzleSqlTag,
+  isDrizzleSymbol,
   isDrizzleTableType,
   isDrizzleWrapperType,
+  resolvedSymbol,
 } from "../drizzle.ts";
 import {
   SQL_TEMPLATE_EXPRESSION_BOUNDARY,
@@ -57,6 +66,13 @@ interface SimpleSelectMatch {
   readonly sourceTableExpressionIndex: number;
 }
 
+const RESULT_FIELD_ARGUMENT = new Map<string, number>([
+  ["returning", 0],
+  ["select", 0],
+  ["selectDistinct", 0],
+  ["selectDistinctOn", 1],
+]);
+
 const UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS = new Set([
   "EXCEPT",
   "FETCH",
@@ -70,6 +86,12 @@ const UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS = new Set([
   "QUALIFY",
   "UNION",
   "WINDOW",
+]);
+
+const UNSUPPORTED_SCALAR_QUERY_KEYWORDS = new Set([
+  ...UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS,
+  "INTO",
+  "OVER",
 ]);
 
 function quasiText(node: TSESTree.TemplateElement): string {
@@ -323,6 +345,91 @@ function simpleSelectMatch(
   };
 }
 
+function parenthesizedScalarSelect(
+  source: string,
+  syntaxSource: string,
+): boolean {
+  let start = 0;
+  while (/\s/.test(syntaxSource[start] ?? "")) {
+    start += 1;
+  }
+  let end = syntaxSource.length - 1;
+  while (end >= start && /\s/.test(syntaxSource[end] ?? "")) {
+    end -= 1;
+  }
+  if (syntaxSource[start] !== "(" || syntaxSource[end] !== ")") {
+    return false;
+  }
+
+  let depth = 0;
+  for (let offset = start; offset <= end; offset += 1) {
+    const character = syntaxSource[offset];
+    if (character === "(") {
+      depth += 1;
+    } else if (character === ")") {
+      depth -= 1;
+      if (depth < 0 || (depth === 0 && offset !== end)) {
+        return false;
+      }
+    }
+  }
+  if (depth !== 0) {
+    return false;
+  }
+
+  const innerSource = source.slice(start + 1, end);
+  const innerSyntaxSource = syntaxSource.slice(start + 1, end);
+  const tokens = topLevelTokens(innerSyntaxSource);
+  if (tokens === undefined || !isWord(tokens[0], "SELECT")) {
+    return false;
+  }
+  if (
+    tokens.some((token, index) => {
+      return (
+        (token.kind === "punctuation" && token.value === ";") ||
+        (token.kind === "word" &&
+          UNSUPPORTED_SCALAR_QUERY_KEYWORDS.has(token.value) &&
+          !(token.value === "LIMIT" && index === tokens.length - 2))
+      );
+    })
+  ) {
+    return false;
+  }
+
+  const fromIndex = tokens.findIndex((token, index) => {
+    return index > 0 && isWord(token, "FROM");
+  });
+  const whereIndex = tokens.findIndex((token, index) => {
+    return index > fromIndex && isWord(token, "WHERE");
+  });
+  const limitIndex = tokens.length - 2;
+  const limitKeyword = tokens[limitIndex];
+  const limitValue = tokens[limitIndex + 1];
+  const selectKeyword = tokens[0];
+  const fromKeyword = tokens[fromIndex];
+  const whereKeyword = tokens[whereIndex];
+  if (
+    fromIndex <= 0 ||
+    whereIndex <= fromIndex ||
+    limitIndex <= whereIndex ||
+    !isWord(limitKeyword, "LIMIT") ||
+    limitValue?.kind !== "number" ||
+    limitValue.value !== "1" ||
+    selectKeyword === undefined ||
+    fromKeyword === undefined ||
+    whereKeyword === undefined ||
+    innerSource.slice(selectKeyword.end, fromKeyword.start).trim() === "" ||
+    innerSource.slice(fromKeyword.end, whereKeyword.start).trim() === "" ||
+    innerSource.slice(whereKeyword.end, limitKeyword.start).trim() === "" ||
+    innerSyntaxSource.slice(limitKeyword.end, limitValue.start).trim() !== "" ||
+    innerSyntaxSource.slice(limitValue.end).trim() !== ""
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export const preferDrizzleQueryBuilder = createRule({
   name: "prefer-drizzle-query-builder",
   defaultOptions: [],
@@ -330,7 +437,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete schema-backed simple selects",
+        "Prefer Drizzle query builders for complete simple selects and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -338,6 +445,8 @@ export const preferDrizzleQueryBuilder = createRule({
     messages: {
       queryBuilder:
         "Use a Drizzle select builder for this complete schema-backed query.",
+      structuredScalarQuery:
+        "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
   },
   create(context) {
@@ -345,6 +454,11 @@ export const preferDrizzleQueryBuilder = createRule({
     const checker = services.program.getTypeChecker();
     const directRawRowsBindings = new Set<string>();
     const rawRowsNamespaces = new Set<string>();
+    const scalarQueryCandidates = new Set<TSESTree.TaggedTemplateExpression>();
+    const structuredSelectionCalls: TSESTree.CallExpression[] = [];
+    const reportedScalarQueries = new Set<TSESTree.TaggedTemplateExpression>();
+    const selectMethodTypes = new Map<Type, boolean>();
+    const returningMethodTypes = new Map<Type, boolean>();
 
     for (const statement of context.sourceCode.ast.body) {
       if (
@@ -415,8 +529,257 @@ export const preferDrizzleQueryBuilder = createRule({
       };
     }
 
+    function symbolAt(node: TSESTree.Node) {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return checker.getSymbolAtLocation(tsNode);
+    }
+
+    function methodReturnsDrizzleProperty(
+      type: Type,
+      property: "execute" | "from",
+    ): boolean {
+      const cache =
+        property === "from" ? selectMethodTypes : returningMethodTypes;
+      const cached = cache.get(type);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const result = type.getCallSignatures().some((signature) => {
+        const returnType = checker.getReturnTypeOfSignature(signature);
+        return isDrizzleSymbol(
+          checker,
+          checker.getPropertyOfType(returnType, property),
+        );
+      });
+      cache.set(type, result);
+      return result;
+    }
+
+    function structuredResultMethod(
+      node: TSESTree.MemberExpression,
+    ): string | null {
+      const name = memberName(node);
+      if (name === null || !RESULT_FIELD_ARGUMENT.has(name)) {
+        return null;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const type = checker.getTypeAtLocation(tsNode);
+      if (name === "returning") {
+        return isDrizzleSymbol(checker, symbolAt(node.property)) ||
+          methodReturnsDrizzleProperty(type, "execute")
+          ? name
+          : null;
+      }
+      return methodReturnsDrizzleProperty(type, "from") ? name : null;
+    }
+
+    function transparentExpression(node: TSESTree.Node): TSESTree.Node | null {
+      if (
+        node.type === AST_NODE_TYPES.TSAsExpression ||
+        node.type === AST_NODE_TYPES.TSTypeAssertion ||
+        node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        node.type === AST_NODE_TYPES.TSNonNullExpression ||
+        node.type === AST_NODE_TYPES.ChainExpression
+      ) {
+        return node.expression;
+      }
+      return null;
+    }
+
+    function localConstInitializer(node: TSESTree.Node): TSESTree.Node | null {
+      if (node.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const declaration = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(tsNode),
+      )?.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isVariableDeclaration(declaration) ||
+        declaration.getSourceFile() !== tsNode.getSourceFile() ||
+        !isConstVariable(declaration) ||
+        declaration.initializer === undefined
+      ) {
+        return null;
+      }
+      return services.tsNodeToESTreeNodeMap.get(declaration.initializer);
+    }
+
+    function isConstVariable(declaration: VariableDeclaration): boolean {
+      return (
+        isVariableDeclarationList(declaration.parent) &&
+        (declaration.parent.flags & NodeFlags.Const) !== 0
+      );
+    }
+
+    function localSingleReturn(node: TSESTree.Node): TSESTree.Node | null {
+      if (
+        node.type !== AST_NODE_TYPES.CallExpression ||
+        node.callee.type !== AST_NODE_TYPES.Identifier ||
+        node.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        })
+      ) {
+        return null;
+      }
+      const tsCallee = services.esTreeNodeToTSNodeMap.get(node.callee);
+      const declaration = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(tsCallee),
+      )?.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isFunctionDeclaration(declaration) ||
+        declaration.getSourceFile() !== tsCallee.getSourceFile() ||
+        declaration.body === undefined ||
+        declaration.body.statements.length !== 1
+      ) {
+        return null;
+      }
+      const statement = declaration.body.statements[0];
+      if (
+        statement === undefined ||
+        !isReturnStatement(statement) ||
+        statement.expression === undefined
+      ) {
+        return null;
+      }
+      return services.tsNodeToESTreeNodeMap.get(statement.expression);
+    }
+
+    function isDrizzleResultWrapper(node: TSESTree.CallExpression): boolean {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        node.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        })
+      ) {
+        return false;
+      }
+      const name = memberName(node.callee);
+      if (
+        (name !== "mapWith" && name !== "as") ||
+        node.arguments.length !== 1
+      ) {
+        return false;
+      }
+      return isDrizzleSymbol(checker, symbolAt(node.callee.property));
+    }
+
+    function reportScalarQuery(node: TSESTree.TaggedTemplateExpression): void {
+      if (
+        !scalarQueryCandidates.has(node) ||
+        reportedScalarQueries.has(node) ||
+        !isDrizzleSqlTag(checker, services, node.tag)
+      ) {
+        return;
+      }
+      reportedScalarQueries.add(node);
+      context.report({ node, messageId: "structuredScalarQuery" });
+    }
+
+    function inspectSelectedValue(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): void {
+      if (visited.has(node)) {
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ObjectExpression) {
+        inspectSelectionContainer(node, visited);
+        return;
+      }
+      visited.add(node);
+
+      const transparent = transparentExpression(node);
+      if (transparent !== null) {
+        inspectSelectedValue(transparent, visited);
+        return;
+      }
+      const initializer = localConstInitializer(node);
+      if (initializer !== null) {
+        inspectSelectedValue(initializer, visited);
+        return;
+      }
+      if (
+        node.type === AST_NODE_TYPES.CallExpression &&
+        node.callee.type === AST_NODE_TYPES.MemberExpression &&
+        isDrizzleResultWrapper(node)
+      ) {
+        inspectSelectedValue(node.callee.object, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        reportScalarQuery(node);
+      }
+    }
+
+    function inspectSelectionContainer(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): void {
+      if (visited.has(node)) {
+        return;
+      }
+      visited.add(node);
+
+      const transparent = transparentExpression(node);
+      if (transparent !== null) {
+        inspectSelectionContainer(transparent, visited);
+        return;
+      }
+      const initializer = localConstInitializer(node);
+      if (initializer !== null) {
+        inspectSelectionContainer(initializer, visited);
+        return;
+      }
+      const returned = localSingleReturn(node);
+      if (returned !== null) {
+        inspectSelectionContainer(returned, visited);
+        return;
+      }
+      if (node.type !== AST_NODE_TYPES.ObjectExpression) {
+        return;
+      }
+      for (const property of node.properties) {
+        if (property.type === AST_NODE_TYPES.SpreadElement) {
+          inspectSelectionContainer(property.argument, visited);
+        } else {
+          inspectSelectedValue(property.value, visited);
+        }
+      }
+    }
+
+    function inspectStructuredSelection(node: TSESTree.CallExpression): void {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return;
+      }
+      const method = structuredResultMethod(node.callee);
+      if (method === null) {
+        return;
+      }
+      const argumentIndex = RESULT_FIELD_ARGUMENT.get(method);
+      const fields =
+        argumentIndex === undefined ? undefined : node.arguments[argumentIndex];
+      if (
+        fields === undefined ||
+        fields.type === AST_NODE_TYPES.SpreadElement
+      ) {
+        return;
+      }
+      inspectSelectionContainer(fields, new Set<TSESTree.Node>());
+    }
+
     return {
       CallExpression(node: TSESTree.CallExpression): void {
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          RESULT_FIELD_ARGUMENT.has(memberName(node.callee) ?? "")
+        ) {
+          structuredSelectionCalls.push(node);
+        }
         if (
           !isExecuteRawRowsCallee(node.callee) ||
           node.arguments.length !== 3 ||
@@ -487,6 +850,22 @@ export const preferDrizzleQueryBuilder = createRule({
         }
 
         context.report({ node: query, messageId: "queryBuilder" });
+      },
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
+        const source = node.quasi.quasis
+          .map(quasiText)
+          .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
+        if (parenthesizedScalarSelect(source, sqlCodeMask(source))) {
+          scalarQueryCandidates.add(node);
+        }
+      },
+      "Program:exit"(): void {
+        if (scalarQueryCandidates.size === 0) {
+          return;
+        }
+        for (const call of structuredSelectionCalls) {
+          inspectStructuredSelection(call);
+        }
       },
     };
   },


### PR DESCRIPTION
## Summary

- extend `api/prefer-drizzle-query-builder` to reject complete parenthesized raw scalar queries used as structured Drizzle result fields
- require real Drizzle method identity across every possible consumer branch instead of inferring identity from a returned builder shape
- follow only bounded, private, locally proven selection composition; mutation, aliasing, opaque escape, export, function reassignment, and unproven call sites stop traversal
- gate type-aware consumer traversal behind a syntax-only candidate pass so the zero-candidate production baseline keeps negligible lint cost
- cover the actual pre-#22604 factory/constant/spread path, including `COALESCE`/`CASE`, `INNER JOIN`, and `LEFT JOIN` scalar-query variants
- cover direct, projected, CTE-backed, and branded Drizzle methods; direct, aliased, and namespace SQL tags; source-tag deduplication; and conservative near misses

## Scope

This PR changes only the ESLint rule and its type-aware regression tests. It does not change runtime queries, database schema or persisted data, API contracts, query plans, or deployment behavior. It intentionally does not detect equivalent typed correlated subqueries or attempt general SQL parsing/interprocedural data flow.

Closes #22609

Parent context: #22439

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-query-builder.test.ts --maxWorkers=1` (48 passed)
- `pnpm -F @vm0/eslint-rules exec vitest run --maxWorkers=1` (47 files, 730 tests passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm knip --workspace @vm0/eslint-rules`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `TIMING=100 pnpm -F api exec eslint . --max-warnings 0`
- `git diff --check`
- pre-commit repository Knip and all 13 Turbo type-check tasks

The final rule timing samples were 36.244 ms, 39.669 ms, and 57.207 ms (0.4–0.6% of measured rule time), versus pre-change samples of 28.487 ms and 22.556 ms. An initial unconditional traversal measured 7,074.821 ms and was replaced before submission by the candidate-gated two-phase design.
