### PR TITLE
refactor: reduce fallback slop in log search

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -789,7 +789,7 @@ async function getSearchRunMetadata(
       agentComposeVersions,
       eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
     )
-    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
     .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(
       and(
@@ -801,7 +801,7 @@ async function getSearchRunMetadata(
 
   for (const row of rows) {
     result.set(row.runId, {
-      agentName: row.displayName ?? row.composeId ?? "unknown",
+      agentName: row.displayName ?? row.composeId,
       framework: extractFramework(row.composeContent),
     });
   }


### PR DESCRIPTION
## Summary

Log search now expresses the database invariant that every agent run has a session, then uses the session compose ID directly when an agent display name is unavailable. This removes an unreachable `"unknown"` identity fallback that could conceal corrupted run/session state.

## Scan

- Timestamp: `2026-07-22T20:02:27.794Z`
- Base commit: `3d56c192c04c3ae7f66dfb63919ba05f841452f6`
- Files scanned: 4,282
- Scanner high-confidence production actionable matches: 224
- Scanner suggested 5% budget: 12
- Manual `actionable_total`: 1
- Adjusted `edit_budget`: 1
- Candidates changed: 1 unique candidate (2 overlapping scanner matches)

Total matches by category:

```text
nullish: 6000
nullish-chain: 129
field-fallback-chain: 105
optional-prop: 5895
zod-optional: 2336
zod-loose-optional: 2
loose-record: 1057
loose-index-signature: 3
as-any: 0
as-unknown-as: 32
empty-fallback: 724
string-fallback: 770
null-undefined-fallback: 1569
empty-catch: 3
promise-catch-swallow: 14
rust-unwrap-or: 644
rust-ok-discard: 140
```

## Files changed

- `turbo/apps/api/src/signals/services/zero-logs.service.ts`: use an inner join for the required run-to-session relationship and remove the terminal `"unknown"` agent-name fallback. This is safe because `agent_runs.session_id` is a non-null foreign key and `agent_sessions.agent_compose_id` is non-null; valid log-search behavior is unchanged.

## Verification

- `git diff --check`
- Re-ran the repository scanner after the edit: high-confidence production matches decreased from 224 to 222 because the single source candidate matched both `nullish-chain` and `field-fallback-chain`; `string-fallback` decreased from 770 to 769.
- Existing integration coverage in `run-reads.bdd.test.ts` exercises log-search identity fallback to the session compose ID.
- Package lint, typecheck, and targeted Vitest were not run because this fresh clone has no installed dependencies; the PR pipeline will run the full required checks.

This workflow intentionally leaves the remaining candidates for later daily runs.
