### PR TITLE
feat(ci): add release details to the production rollback dashboard

### DIFF
--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -6,9 +6,27 @@ TARGET="${SCRIPT_DIR}/../update-rollback-dashboard-body.sh"
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
+fake_bin="${tmp_dir}/bin"
+mkdir -p "$fake_bin"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+cat >"${fake_bin}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "api" ]
+[ "${2:-}" = "repos/vm0-ai/vm0/releases?per_page=100" ]
+jq . "$MOCK_RELEASES_FILE"
+SH
+chmod +x "${fake_bin}/gh"
 
 body_file="${tmp_dir}/body.md"
 output_file="${tmp_dir}/output.md"
+releases_file="${tmp_dir}/releases.json"
+rollback_url=https://github.com/vm0-ai/vm0/actions/workflows/rollback-production.yml
 
 cat >"$body_file" <<'EOF'
 This issue is automatically maintained by CI. Do not edit manually.
@@ -21,40 +39,187 @@ This issue is automatically maintained by CI. Do not edit manually.
 EOF
 
 target_commit=1111111111111111111111111111111111111111
-rollback_url=https://github.com/vm0-ai/vm0/actions/workflows/rollback-production.yml
+jq -n --arg target "$target_commit" '[
+  {
+    tag_name: "zeta-v2.0.0",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/zeta-v2.0.0",
+    published_at: "2026-07-22T23:39:32Z",
+    body: "## [2.0.0](https://example.test/zeta) (2026-07-22)\n\n### Features\n\n* zeta feature"
+  },
+  {
+    tag_name: "core-v8.452.0",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/core-v8.452.0",
+    published_at: "2026-07-22T23:39:31Z",
+    body: "## [8.452.0](https://example.test/core) (2026-07-22)\n\n### Bug Fixes\n\n* core fix"
+  },
+  {
+    tag_name: "runner-rs-v0.147.2",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/runner-rs-v0.147.2",
+    published_at: "2026-07-22T23:39:40Z",
+    body: "## [0.147.2](https://example.test/runner) (2026-07-22)\n\n### Performance Improvements\n\n* runner improvement"
+  },
+  {
+    tag_name: "api-v1.303.0",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/api-v1.303.0",
+    published_at: "2026-07-22T23:39:33Z",
+    body: "## [1.303.0](https://example.test/api) (2026-07-22)\n\n### Features\n\n* api feature"
+  },
+  {
+    tag_name: "app-v0.618.0",
+    target_commitish: $target,
+    html_url: "https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0",
+    published_at: "2026-07-22T23:39:34Z",
+    body: "## [0.618.0](https://example.test/app) (2026-07-22)\n\n### Features\n\n* app feature"
+  },
+  {
+    tag_name: "unrelated-v9.9.9",
+    target_commitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    html_url: "https://example.test/unrelated",
+    published_at: "2026-07-22T23:39:59Z",
+    body: "must not appear"
+  }
+]' >"$releases_file"
 
-"$TARGET" "$body_file" "$target_commit" "$rollback_url" >"$output_file"
+PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_RELEASES_FILE="$releases_file" \
+  "$TARGET" "$body_file" "$target_commit" "$rollback_url" >"$output_file"
 
-grep -Fqx -- "- \`${target_commit}\` — [Rollback production](${rollback_url})" "$output_file"
-if grep -Fq 'legacy entry' "$output_file"; then
-  echo "legacy dashboard entries were not removed" >&2
-  exit 1
+grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
+grep -Fqx -- "## 07-23-2026 07:39:40 Asia/Singapore · 07-22-2026 16:39:40 SF · RollbackId: \`${target_commit}\`" "$output_file"
+grep -Fqx -- "### [app](https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0): \`0.618.0\`" "$output_file"
+grep -Fqx -- "### [api](https://github.com/vm0-ai/vm0/releases/tag/api-v1.303.0): \`1.303.0\`" "$output_file"
+grep -Fqx -- "### [runner-rs](https://github.com/vm0-ai/vm0/releases/tag/runner-rs-v0.147.2): \`0.147.2\`" "$output_file"
+grep -Fqx -- "### [core](https://github.com/vm0-ai/vm0/releases/tag/core-v8.452.0): \`8.452.0\`" "$output_file"
+grep -Fqx -- "### [zeta](https://github.com/vm0-ai/vm0/releases/tag/zeta-v2.0.0): \`2.0.0\`" "$output_file"
+grep -Fqx -- "#### Features" "$output_file"
+grep -Fqx -- "* app feature" "$output_file"
+grep -Fqx -- "* api feature" "$output_file"
+grep -Fqx -- "* runner improvement" "$output_file"
+grep -Fqx -- "* core fix" "$output_file"
+grep -Fqx -- "* zeta feature" "$output_file"
+
+app_line=$(grep -n '^### \[app\]' "$output_file" | cut -d: -f1)
+api_line=$(grep -n '^### \[api\]' "$output_file" | cut -d: -f1)
+runner_line=$(grep -n '^### \[runner-rs\]' "$output_file" | cut -d: -f1)
+core_line=$(grep -n '^### \[core\]' "$output_file" | cut -d: -f1)
+zeta_line=$(grep -n '^### \[zeta\]' "$output_file" | cut -d: -f1)
+if ! [ "$app_line" -lt "$api_line" ] || \
+  ! [ "$api_line" -lt "$runner_line" ] || \
+  ! [ "$runner_line" -lt "$core_line" ] || \
+  ! [ "$core_line" -lt "$zeta_line" ]; then
+  fail "release artifacts are not ordered by production priority"
 fi
 
-for digit in 1 2 3 4 5 6 7; do
+if grep -Fq 'legacy entry' "$output_file"; then
+  fail "legacy dashboard entries were not removed"
+fi
+if grep -Fq 'must not appear' "$output_file"; then
+  fail "release from another target was included"
+fi
+if grep -Fq '## [0.618.0]' "$output_file"; then
+  fail "duplicate release title was not removed"
+fi
+
+write_single_release() {
+  local commit=$1
+  local published_at=$2
+  local body_size=${3:-0}
+
+  jq -n \
+    --arg target "$commit" \
+    --arg published_at "$published_at" \
+    --argjson body_size "$body_size" \
+    '[{
+      tag_name: "app-v1.2.3",
+      target_commitish: $target,
+      html_url: "https://example.test/app-v1.2.3",
+      published_at: $published_at,
+      body: (
+        "## [1.2.3](https://example.test/app) (2026-07-22)\n\n### Features\n\n* "
+        + ("x" * $body_size)
+      )
+    }]' >"$releases_file"
+}
+
+for digit in 2 3 4 5 6 7 8; do
   commit=$(printf '%040d' "$digit")
-  "$TARGET" "$output_file" "$commit" "$rollback_url" >"${output_file}.next"
+  write_single_release "$commit" "2026-07-22T23:39:4${digit}Z"
+  PATH="${fake_bin}:$PATH" \
+    GITHUB_REPOSITORY=vm0-ai/vm0 \
+    MOCK_RELEASES_FILE="$releases_file" \
+    "$TARGET" "$output_file" "$commit" "$rollback_url" >"${output_file}.next"
   mv "${output_file}.next" "$output_file"
 done
 
-entry_count=$(grep -c "^- \`[0-9a-f]\\{40\\}\` — \\[Rollback production\\]" "$output_file")
+entry_count=$(grep -c '^<!-- ROLLBACK_ENTRY_START [0-9a-f]\{40\} -->$' "$output_file")
 if [ "$entry_count" -ne 7 ]; then
-  echo "expected 7 dashboard entries, found $entry_count" >&2
-  exit 1
+  fail "expected 7 dashboard entries, found $entry_count"
 fi
 
-latest_commit=0000000000000000000000000000000000000007
-grep -Fqx -- "- \`${latest_commit}\` — [Rollback production](${rollback_url})" "$output_file"
+latest_commit=0000000000000000000000000000000000000008
+grep -Fq -- "<!-- ROLLBACK_ENTRY_START ${latest_commit} -->" "$output_file"
 if grep -Fq "$target_commit" "$output_file"; then
-  echo "oldest dashboard entry was not trimmed" >&2
-  exit 1
+  fail "oldest dashboard entry was not trimmed"
 fi
 
-"$TARGET" "$output_file" "$latest_commit" "$rollback_url" >"${output_file}.next"
-duplicate_count=$(grep -c "$latest_commit" "${output_file}.next")
+write_single_release "$latest_commit" "2026-07-22T23:39:48Z"
+PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_RELEASES_FILE="$releases_file" \
+  "$TARGET" "$output_file" "$latest_commit" "$rollback_url" >"${output_file}.next"
+duplicate_count=$(grep -c "ROLLBACK_ENTRY_START ${latest_commit}" "${output_file}.next")
 if [ "$duplicate_count" -ne 1 ]; then
-  echo "duplicate target commit was not collapsed" >&2
-  exit 1
+  fail "duplicate target commit was not collapsed"
 fi
+
+printf '%s\n' \
+  'This issue is automatically maintained by CI. Do not edit manually.' \
+  '<!-- ROLLBACK_ENTRIES_START -->' \
+  '<!-- ROLLBACK_ENTRIES_END -->' >"$body_file"
+for digit in 1 2 3 4 5 6 7; do
+  commit=$(printf '%040d' "$digit")
+  write_single_release "$commit" "2026-07-22T23:40:0${digit}Z" 15000
+  PATH="${fake_bin}:$PATH" \
+    GITHUB_REPOSITORY=vm0-ai/vm0 \
+    MOCK_RELEASES_FILE="$releases_file" \
+    "$TARGET" "$body_file" "$commit" "$rollback_url" >"${body_file}.next"
+  mv "${body_file}.next" "$body_file"
+done
+
+body_bytes=$(wc -c <"$body_file")
+if [ "$body_bytes" -gt 65000 ]; then
+  fail "dashboard body exceeded the safe GitHub issue size"
+fi
+entry_count=$(grep -c '^<!-- ROLLBACK_ENTRY_START ' "$body_file")
+if [ "$entry_count" -ge 7 ]; then
+  fail "old entries were not removed to satisfy the body size limit"
+fi
+start_count=$entry_count
+end_count=$(grep -c '^<!-- ROLLBACK_ENTRY_END -->$' "$body_file")
+if [ "$start_count" -ne "$end_count" ]; then
+  fail "dashboard size trimming removed a partial entry"
+fi
+grep -Fq 'ROLLBACK_ENTRY_START 0000000000000000000000000000000000000007' "$body_file"
+
+jq -n '[{
+  tag_name: "app-v1.2.3",
+  target_commitish: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  html_url: "https://example.test/app-v1.2.3",
+  published_at: "2026-07-22T23:40:00Z",
+  body: "other target"
+}]' >"$releases_file"
+if PATH="${fake_bin}:$PATH" \
+  GITHUB_REPOSITORY=vm0-ai/vm0 \
+  MOCK_RELEASES_FILE="$releases_file" \
+  "$TARGET" "$body_file" "$target_commit" "$rollback_url" \
+  >"${tmp_dir}/missing.out" 2>"${tmp_dir}/missing.err"; then
+  fail "missing release artifacts should fail"
+fi
+grep -Fq "No release artifacts found for target ${target_commit}" "${tmp_dir}/missing.err"
 
 echo "update-rollback-dashboard-body tests passed"

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -15,36 +15,149 @@ if [[ ! "$target_commit" =~ ^[0-9a-f]{40}$ ]]; then
   exit 2
 fi
 
-entries_file=$(mktemp)
-filtered_entries_file=$(mktemp)
-trap 'rm -f "$entries_file" "$filtered_entries_file"' EXIT
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
-printf -- "- \`%s\` — [Rollback production](%s)\n" \
-  "$target_commit" \
-  "$rollback_url" >"$entries_file"
+work_dir=$(mktemp -d)
+entries_dir="${work_dir}/entries"
+releases_file="${work_dir}/releases.json"
+normalized_releases_file="${work_dir}/normalized-releases.json"
+release_rows_file="${work_dir}/release-rows.tsv"
+rendered_body_file="${work_dir}/body.md"
+mkdir -p "$entries_dir"
+trap 'rm -rf "$work_dir"' EXIT
 
-awk '
-  /<!-- ROLLBACK_ENTRIES_START -->/ { in_entries=1; next }
-  /<!-- ROLLBACK_ENTRIES_END -->/ { in_entries=0; next }
-  in_entries && /^- `[0-9a-f]{40}` — \[Rollback production\]\(.*\)$/ { print }
-' "$body_file" \
-  | awk -v target="\`${target_commit}\`" 'index($0, target) == 0' \
-  >>"$entries_file"
+gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"$releases_file"
 
-head -n 7 "$entries_file" >"$filtered_entries_file"
+jq -ce --arg target "$target_commit" '
+  [
+    .[]
+    | select(.target_commitish == $target)
+    | select(.tag_name | test("^.+-v[0-9]"))
+    | (.tag_name | capture("^(?<artifact>.+)-v(?<version>[0-9].*)$")) as $tag
+    | {
+        artifact: $tag.artifact,
+        version: $tag.version,
+        url: .html_url,
+        published_at: .published_at,
+        body: (.body // ""),
+        priority: (
+          if $tag.artifact == "app" then 0
+          elif $tag.artifact == "api" then 1
+          elif $tag.artifact == "runner-rs" then 2
+          else 3
+          end
+        )
+      }
+  ]
+  | if length == 0 then
+      error("No release artifacts found for target " + $target)
+    else
+      sort_by([.priority, .artifact])
+    end
+' "$releases_file" >"$normalized_releases_file"
 
-awk -v entries_file="$filtered_entries_file" '
-  /<!-- ROLLBACK_ENTRIES_START -->/ {
-    print
-    while ((getline line < entries_file) > 0) print line
-    close(entries_file)
-    in_entries=1
+published_at=$(jq -r 'map(.published_at) | max' "$normalized_releases_file")
+singapore_time=$(TZ=Asia/Singapore date -d "$published_at" '+%m-%d-%Y %H:%M:%S')
+sf_time=$(TZ=America/Los_Angeles date -d "$published_at" '+%m-%d-%Y %H:%M:%S')
+jq -r '.[] | [.artifact, .version, .url, (.body | @base64)] | @tsv' \
+  "$normalized_releases_file" >"$release_rows_file"
+
+format_changelog() {
+  awk '
+    NR == 1 && /^## \[/ {
+      skip_leading_blanks = 1
+      next
+    }
+    skip_leading_blanks && /^[[:space:]]*$/ { next }
+    { skip_leading_blanks = 0 }
+    /^```/ {
+      in_fence = !in_fence
+      print
+      next
+    }
+    !in_fence && /^#/ {
+      print "#" $0
+      next
+    }
+    { print }
+  '
+}
+
+new_entry_file="${entries_dir}/000.md"
+{
+  printf '<!-- ROLLBACK_ENTRY_START %s -->\n' "$target_commit"
+  printf '## %s Asia/Singapore · %s SF · RollbackId: `%s`\n\n' \
+    "$singapore_time" \
+    "$sf_time" \
+    "$target_commit"
+
+  while IFS=$'\t' read -r artifact version url encoded_body; do
+    printf '### [%s](%s): `%s`\n\n' "$artifact" "$url" "$version"
+    printf '**Change Log**\n\n'
+
+    changelog=$(printf '%s' "$encoded_body" | base64 --decode)
+    if [ -n "$changelog" ]; then
+      printf '%s\n' "$changelog" | format_changelog
+    else
+      printf '_No changelog provided._\n'
+    fi
+    printf '\n'
+  done <"$release_rows_file"
+
+  printf '<!-- ROLLBACK_ENTRY_END -->\n'
+} >"$new_entry_file"
+
+awk -v entries_dir="$entries_dir" -v target="$target_commit" '
+  /^<!-- ROLLBACK_ENTRY_START [0-9a-f]+ -->$/ {
+    commit = $0
+    sub(/^<!-- ROLLBACK_ENTRY_START /, "", commit)
+    sub(/ -->$/, "", commit)
+    capture = commit != target && kept < 6
+    if (capture) {
+      kept++
+      entry_file = sprintf("%s/%03d.md", entries_dir, kept)
+      print > entry_file
+    }
     next
   }
-  /<!-- ROLLBACK_ENTRIES_END -->/ {
-    in_entries=0
-    print
-    next
+  capture { print >> entry_file }
+  /^<!-- ROLLBACK_ENTRY_END -->$/ {
+    if (capture) close(entry_file)
+    capture = 0
   }
-  !in_entries { print }
 ' "$body_file"
+
+render_body() {
+  local output_file=$1
+  local entry_file
+
+  {
+    printf 'This issue is automatically maintained by CI. Do not edit manually.\n\n'
+    printf '[Rollback](%s)\n\n' "$rollback_url"
+    printf '<!-- ROLLBACK_ENTRIES_START -->\n'
+    for entry_file in "$entries_dir"/*.md; do
+      command cat "$entry_file"
+      printf '\n'
+    done
+    printf '<!-- ROLLBACK_ENTRIES_END -->\n'
+  } >"$output_file"
+}
+
+max_body_bytes=65000
+while true; do
+  render_body "$rendered_body_file"
+  body_bytes=$(wc -c <"$rendered_body_file")
+  if [ "$body_bytes" -le "$max_body_bytes" ]; then
+    break
+  fi
+
+  entry_files=("$entries_dir"/*.md)
+  entry_count=${#entry_files[@]}
+  if [ "$entry_count" -eq 1 ]; then
+    echo "latest rollback dashboard entry exceeds ${max_body_bytes} bytes" >&2
+    exit 1
+  fi
+  rm -f "${entry_files[$((entry_count - 1))]}"
+done
+
+command cat "$rendered_body_file"


### PR DESCRIPTION
## Summary

- replace commit-only rollback dashboard rows with timestamped release batches showing both Asia/Singapore and SF time alongside the rollback commit
- list every release-please artifact for the target commit with a linked version and its complete changelog, ordered with App, API, and Runner first
- retain up to seven batches while removing the oldest complete batches before the GitHub Issue body reaches 65 KB, and migrate the legacy row format on the next release

## Verification

- `bash -n .github/scripts/update-rollback-dashboard-body.sh .github/scripts/tests/update-rollback-dashboard-body-test.sh`
- `bash .github/scripts/tests/update-rollback-dashboard-body-test.sh`
- `git diff --check`
- read-only render using Issue #6792 and release commit `b186ced9115854a9266daf344deb98955a4a54da`: 11 artifacts, 7,730-byte body

Full Vitest and a local development server were not run because this change only touches the release dashboard shell script and its integration test.
