### PR TITLE
feat: prefetch chat thread messages from realtime events

### DIFF
--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -36,6 +36,7 @@ type FailedStateChange = { reason?: { message?: string } };
 type ConnectionEventListener = (stateChange?: FailedStateChange) => void;
 
 const subscriptions = new Map<string, Set<Callback>>();
+const channelSubscriptions = new Set<Callback>();
 
 let capturedAuthCallback: AuthCallback | null = null;
 let tokenBodies: AuthCallbackToken[] = [];
@@ -51,11 +52,15 @@ let nextSubscribeError: Error | null = null;
  * to simulate a server-side Ably publish.
  */
 export function triggerAblyEvent(topic: string, data: unknown = null): void {
+  const message = { name: topic, data };
   const cbs = subscriptions.get(topic);
   if (cbs) {
     for (const cb of cbs) {
-      cb({ name: topic, data });
+      cb(message);
     }
+  }
+  for (const cb of channelSubscriptions) {
+    cb(message);
   }
 }
 
@@ -81,6 +86,7 @@ export function getAuthTokenHistory(): readonly AuthCallbackToken[] {
 /** Reset all subscriptions and captured auth state between tests. */
 export function resetAblySubscriptions(): void {
   subscriptions.clear();
+  channelSubscriptions.clear();
   capturedAuthCallback = null;
   tokenBodies = [];
   connectedListener = null;
@@ -96,6 +102,11 @@ export function resetAblySubscriptions(): void {
 export function hasSubscription(topic: string): boolean {
   const cbs = subscriptions.get(topic);
   return cbs !== undefined && cbs.size > 0;
+}
+
+/** Debug: check if the user channel has an active catch-all subscription. */
+export function hasChannelSubscription(): boolean {
+  return channelSubscriptions.size > 0;
 }
 
 /**
@@ -120,6 +131,7 @@ const connectedListeners = new Set<ConnectionListener>();
 export function triggerAblyConnectionClosed(): void {
   connectionClosed = true;
   subscriptions.clear();
+  channelSubscriptions.clear();
 }
 
 export function rejectNextAblySubscribe(message: string): void {
@@ -144,13 +156,20 @@ function invokeAuthCallback(cb: AuthCallback): Promise<AuthCallbackToken> {
 const fakeChannel = {
   // Mirror real Ably: subscribe registers the callback synchronously before
   // waiting for the channel attach to complete.
-  async subscribe(topic: string, callback: Callback): Promise<void> {
-    let cbs = subscriptions.get(topic);
-    if (!cbs) {
-      cbs = new Set();
-      subscriptions.set(topic, cbs);
+  async subscribe(
+    topicOrCallback: string | Callback,
+    callback?: Callback,
+  ): Promise<void> {
+    if (typeof topicOrCallback === "function") {
+      channelSubscriptions.add(topicOrCallback);
+    } else if (callback) {
+      let cbs = subscriptions.get(topicOrCallback);
+      if (!cbs) {
+        cbs = new Set();
+        subscriptions.set(topicOrCallback, cbs);
+      }
+      cbs.add(callback);
     }
-    cbs.add(callback);
     await Promise.resolve();
     if (connectionClosed) {
       throw new Error("Connection closed");
@@ -161,10 +180,13 @@ const fakeChannel = {
       throw error;
     }
   },
-  unsubscribe(topic: string, callback: Callback): void {
-    const cbs = subscriptions.get(topic);
-    if (cbs) {
-      cbs.delete(callback);
+  unsubscribe(topicOrCallback: string | Callback, callback?: Callback): void {
+    if (typeof topicOrCallback === "function") {
+      channelSubscriptions.delete(topicOrCallback);
+      return;
+    }
+    if (callback) {
+      subscriptions.get(topicOrCallback)?.delete(callback);
     }
   },
 };

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   setupRealtime$,
   setAblyLoop$,
+  setAblyMessageLoop$,
   setAblyPayloadLoop$,
 } from "../realtime.ts";
 import type { ChatThread } from "../agent-chat.ts";
@@ -503,6 +504,66 @@ describe("realtime signals", () => {
 
     subscriber.abort(abortError("test done"));
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("serializes user-channel messages received while the handler is in flight", async () => {
+    mockSignedInUser();
+    const subscriber = new AbortController();
+    const firstRunCanFinish = context.mocks.deferred<void>();
+    const handledNames: (string | undefined)[] = [];
+    let activeHandlers = 0;
+    let maxActiveHandlers = 0;
+    const loop$ = command(
+      async (_ctx, message: unknown, signal: AbortSignal): Promise<boolean> => {
+        activeHandlers += 1;
+        maxActiveHandlers = Math.max(maxActiveHandlers, activeHandlers);
+        handledNames.push(
+          typeof message === "object" &&
+            message !== null &&
+            "name" in message &&
+            typeof message.name === "string"
+            ? message.name
+            : undefined,
+        );
+        if (handledNames.length === 1) {
+          await firstRunCanFinish.promise;
+          signal.throwIfAborted();
+        }
+        activeHandlers -= 1;
+        return false;
+      },
+    );
+
+    await context.store.set(setupRealtime$, context.signal);
+    const loopPromise = context.store.set(
+      setAblyMessageLoop$,
+      { loopCommand$: loop$ },
+      subscriber.signal,
+    );
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+    });
+    context.mocks.ably.trigger("chatThreadMessageCreated:thread-1");
+    await waitFor(() => {
+      expect(handledNames).toStrictEqual(["chatThreadMessageCreated:thread-1"]);
+    });
+
+    context.mocks.ably.trigger("chatThreadMessageCreated:thread-2");
+    expect(handledNames).toStrictEqual(["chatThreadMessageCreated:thread-1"]);
+    firstRunCanFinish.resolve();
+
+    await waitFor(() => {
+      expect(handledNames).toStrictEqual([
+        "chatThreadMessageCreated:thread-1",
+        "chatThreadMessageCreated:thread-2",
+      ]);
+    });
+    expect(maxActiveHandlers).toBe(1);
+
+    subscriber.abort(abortError("test done"));
+    await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(context.mocks.ably.hasChannelSubscription()).toBeFalsy();
   });
 
   it("retries a payload notification after a transient handler error", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 
 import {
   getAuthTokenHistory,
+  hasChannelSubscription,
   hasSubscription,
   rejectNextAblySubscribe,
   triggerAblyConnectionClosed,
@@ -273,6 +274,7 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       triggerReauth: triggerAblyReauth,
       triggerConnectionClosed: triggerAblyConnectionClosed,
       rejectNextSubscribe: rejectNextAblySubscribe,
+      hasChannelSubscription,
       hasSubscription,
       getAuthTokenHistory,
     },

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -5,8 +5,8 @@ import {
   subscribeThreadListChanged$,
 } from "./chat-thread-list-reload.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
+import { setupChatMessageBackgroundSync$ } from "./chat-page/chat-message-background-sync.ts";
 import { subscribeConnectorChanged$ } from "./connector-reload.ts";
-import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
 import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
 import { setupRealtime$ } from "./realtime.ts";
 import { setupBillingRealtime$ } from "./zero-page/billing.ts";
@@ -28,7 +28,7 @@ export const setupAuthenticatedDaemons$ = command(
       set(subscribeConnectorChanged$, signal),
       set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),
-      set(reloadFeatureSwitch$, signal),
+      set(setupChatMessageBackgroundSync$, signal),
     ]);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
@@ -1,0 +1,196 @@
+import { waitFor } from "@testing-library/react";
+import {
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearMockedAuth,
+  mockOrganization,
+  mockUser,
+} from "../../../__tests__/mock-auth.ts";
+import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { CHAT_MESSAGES_STORE } from "../../external/chat-idb-schema.ts";
+import { chatIdb$ } from "../../external/chat-idb-store.ts";
+import { setupRealtime$ } from "../../realtime.ts";
+import { resetSignalScope } from "../../utils.ts";
+import { writeIndexedDbChatMessages$ } from "../chat-message-indexed-db.ts";
+import { setupChatMessageBackgroundSync$ } from "../chat-message-background-sync.ts";
+
+vi.mock("idb", async () => {
+  return await vi.importActual<typeof import("idb")>("idb-real");
+});
+
+const context = testContext();
+const resetSubscriberSignal$ = resetSignalScope();
+
+const USER_ID = "background-sync-user";
+const ORG_ID = "background-sync-org";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000801";
+const OLD_MESSAGE_ID = "00000000-0000-4000-8000-000000000801";
+const FIRST_CACHED_MESSAGE_ID = "00000000-0000-4000-8000-000000000802";
+const LAST_CACHED_MESSAGE_ID = "00000000-0000-4000-8000-000000000803";
+const NEW_MESSAGE_ID = "00000000-0000-4000-8000-000000000804";
+
+function assistantMessage(
+  id: string,
+  content: string,
+  createdAt: string,
+): PagedChatMessage {
+  return {
+    id,
+    role: "assistant",
+    content,
+    createdAt,
+  };
+}
+
+const oldMessage = assistantMessage(
+  OLD_MESSAGE_ID,
+  "Older remote message",
+  "2026-07-23T10:00:00.000Z",
+);
+const firstCachedMessage = assistantMessage(
+  FIRST_CACHED_MESSAGE_ID,
+  "First cached message",
+  "2026-07-23T10:01:00.000Z",
+);
+const lastCachedMessage = assistantMessage(
+  LAST_CACHED_MESSAGE_ID,
+  "Last cached message",
+  "2026-07-23T10:02:00.000Z",
+);
+const newMessage = assistantMessage(
+  NEW_MESSAGE_ID,
+  "New remote message",
+  "2026-07-23T10:03:00.000Z",
+);
+
+function mockSignedInUser(): void {
+  mockUser(
+    {
+      id: USER_ID,
+      fullName: "Background Sync User",
+      email: "background-sync@example.com",
+    },
+    { token: "test-token" },
+  );
+  mockOrganization({
+    activeOrg: { id: ORG_ID, name: "Background Sync Org" },
+    memberships: [{ id: ORG_ID }],
+  });
+}
+
+function abortError(message: string): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+describe("chat message background sync", () => {
+  afterEach(() => {
+    clearMockedAuth();
+  });
+
+  it("does not subscribe when the feature switch is disabled", async () => {
+    mockSignedInUser();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: false,
+    });
+
+    await context.store.set(setupChatMessageBackgroundSync$, context.signal);
+
+    expect(context.mocks.ably.hasChannelSubscription()).toBeFalsy();
+  });
+
+  it("fills missing messages before and after the cached thread bounds", async () => {
+    mockSignedInUser();
+    setMockFeatureSwitches({
+      [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: true,
+    });
+    const appDb = await context.store.get(chatIdb$);
+    await context.store.set(
+      writeIndexedDbChatMessages$,
+      THREAD_ID,
+      [firstCachedMessage, lastCachedMessage],
+      context.signal,
+    );
+
+    const requests: {
+      readonly sinceId: string | undefined;
+      readonly beforeId: string | undefined;
+    }[] = [];
+    context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
+      requests.push({
+        sinceId: query.sinceId,
+        beforeId: query.beforeId,
+      });
+      if (query.sinceId === LAST_CACHED_MESSAGE_ID) {
+        return respond(200, {
+          messages: [newMessage],
+          hasHistoryBefore: false,
+        });
+      }
+      if (query.sinceId === NEW_MESSAGE_ID) {
+        return respond(200, {
+          messages: [],
+          hasHistoryBefore: false,
+        });
+      }
+      if (query.beforeId === FIRST_CACHED_MESSAGE_ID) {
+        return respond(200, {
+          messages: [oldMessage],
+          hasHistoryBefore: false,
+        });
+      }
+      throw new Error(`Unexpected message cursor: ${JSON.stringify(query)}`);
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const subscriber = context.store.set(
+      resetSubscriberSignal$,
+      context.signal,
+    );
+    const subscription = context.store.set(
+      setupChatMessageBackgroundSync$,
+      subscriber.signal,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+
+      context.mocks.ably.trigger("threadListChanged");
+      context.mocks.ably.trigger(`chatThreadMessageCreated:${THREAD_ID}`);
+
+      await waitFor(async () => {
+        await expect(
+          appDb.get(CHAT_MESSAGES_STORE, OLD_MESSAGE_ID),
+        ).resolves.toMatchObject({
+          id: OLD_MESSAGE_ID,
+          threadId: THREAD_ID,
+        });
+        await expect(
+          appDb.get(CHAT_MESSAGES_STORE, NEW_MESSAGE_ID),
+        ).resolves.toMatchObject({
+          id: NEW_MESSAGE_ID,
+          threadId: THREAD_ID,
+        });
+      });
+
+      expect(requests).toStrictEqual([
+        { sinceId: LAST_CACHED_MESSAGE_ID, beforeId: undefined },
+        { sinceId: NEW_MESSAGE_ID, beforeId: undefined },
+        { sinceId: undefined, beforeId: FIRST_CACHED_MESSAGE_ID },
+      ]);
+    } finally {
+      subscriber.abort(abortError("test done"));
+      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
+      appDb.close();
+    }
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
@@ -1,0 +1,152 @@
+import { command } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  featureSwitch$,
+  reloadFeatureSwitch$,
+} from "../external/feature-switch.ts";
+import { setAblyMessageLoop$ } from "../realtime.ts";
+import {
+  loadIndexedDbChatMessageBounds$,
+  writeIndexedDbChatMessages$,
+} from "./chat-message-indexed-db.ts";
+import {
+  listMessagesAfter$,
+  listMessagesBefore$,
+} from "./remote-chat-thread-data-source.ts";
+import { logger } from "../log.ts";
+
+const L = logger("ChatMessageBackgroundSync");
+const CHAT_THREAD_MESSAGE_CREATED_PREFIX = "chatThreadMessageCreated:";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function createdMessageThreadId(message: unknown): string | null {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("name" in message) ||
+    typeof message.name !== "string" ||
+    !message.name.startsWith(CHAT_THREAD_MESSAGE_CREATED_PREFIX)
+  ) {
+    return null;
+  }
+  const threadId = message.name.slice(
+    CHAT_THREAD_MESSAGE_CREATED_PREFIX.length,
+  );
+  return UUID_PATTERN.test(threadId) ? threadId : null;
+}
+
+export const syncChatThreadMessagesToIndexedDb$ = command(
+  async ({ set }, threadId: string, signal: AbortSignal): Promise<void> => {
+    const bounds = await set(loadIndexedDbChatMessageBounds$, threadId, signal);
+    signal.throwIfAborted();
+
+    let sinceId = bounds.last?.id;
+    const startedWithoutCursor = sinceId === undefined;
+    let initialHasHistoryBefore: boolean | undefined;
+    let firstFetchedMessageId: string | undefined;
+
+    async function syncMessagesAfter(): Promise<void> {
+      const requestedSinceId = sinceId;
+      const result = await set(
+        listMessagesAfter$,
+        { threadId, sinceId: requestedSinceId },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      if (requestedSinceId === undefined) {
+        initialHasHistoryBefore = result.hasHistoryBefore;
+      }
+      firstFetchedMessageId ??= result.messages[0]?.id;
+
+      if (result.messages.length === 0) {
+        return;
+      }
+
+      await set(writeIndexedDbChatMessages$, threadId, result.messages, signal);
+      signal.throwIfAborted();
+      sinceId = result.messages.at(-1)!.id;
+      await syncMessagesAfter();
+    }
+
+    await syncMessagesAfter();
+    signal.throwIfAborted();
+
+    const oldestMessageId = bounds.first?.id ?? firstFetchedMessageId;
+    if (
+      oldestMessageId === undefined ||
+      (startedWithoutCursor && initialHasHistoryBefore === false)
+    ) {
+      return;
+    }
+
+    let beforeId = oldestMessageId;
+    async function syncMessagesBefore(): Promise<void> {
+      const result = await set(
+        listMessagesBefore$,
+        { threadId, beforeId },
+        signal,
+      );
+      signal.throwIfAborted();
+
+      if (result.messages.length > 0) {
+        await set(
+          writeIndexedDbChatMessages$,
+          threadId,
+          result.messages,
+          signal,
+        );
+        signal.throwIfAborted();
+      }
+
+      if (!result.hasHistoryBefore) {
+        return;
+      }
+
+      beforeId = result.messages[0]!.id;
+      await syncMessagesBefore();
+    }
+
+    await syncMessagesBefore();
+    signal.throwIfAborted();
+    L.debug("synced chat messages to IndexedDB", { threadId });
+  },
+);
+
+const handleUserChannelMessage$ = command(
+  async ({ set }, message: unknown, signal: AbortSignal): Promise<boolean> => {
+    const threadId = createdMessageThreadId(message);
+    if (!threadId) {
+      return false;
+    }
+
+    await set(syncChatThreadMessagesToIndexedDb$, threadId, signal);
+    signal.throwIfAborted();
+    return false;
+  },
+);
+
+export const subscribeChatMessageBackgroundSync$ = command(
+  async ({ set }, signal: AbortSignal): Promise<void> => {
+    await set(
+      setAblyMessageLoop$,
+      { loopCommand$: handleUserChannelMessage$ },
+      signal,
+    );
+  },
+);
+
+export const setupChatMessageBackgroundSync$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    await set(reloadFeatureSwitch$, signal);
+    signal.throwIfAborted();
+    if (
+      !get(featureSwitch$)[FeatureSwitchKey.ChatThreadMessageBackgroundSync]
+    ) {
+      return;
+    }
+
+    await set(subscribeChatMessageBackgroundSync$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/chat-message-indexed-db.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message-indexed-db.ts
@@ -4,7 +4,10 @@ import {
   chatIdbReadOr,
   chatIdbWriteBestEffort,
 } from "../external/chat-idb-safe.ts";
-import { createIdbMessageStores } from "../external/idb-message-store.ts";
+import {
+  createIdbMessageStores,
+  type ChatMessageBounds,
+} from "../external/idb-message-store.ts";
 import { chatIdb$ } from "../external/chat-idb-store.ts";
 import { logger } from "../log.ts";
 
@@ -34,6 +37,28 @@ export const loadIndexedDbChatMessages$ = command(
     signal.throwIfAborted();
     L.debug("loadIndexedDbMessages", { threadId, count: messages.length });
     return messages;
+  },
+);
+
+export const loadIndexedDbChatMessageBounds$ = command(
+  async ({ get }, threadId: string, signal: AbortSignal) => {
+    const stores = await get(chatMessageStores$);
+    signal.throwIfAborted();
+    const bounds = await chatIdbReadOr<ChatMessageBounds>(
+      "indexedDbMessages:readBounds",
+      () => {
+        return stores.readStore.readBounds(threadId, signal);
+      },
+      { first: null, last: null },
+      signal,
+    );
+    signal.throwIfAborted();
+    L.debug("loadIndexedDbMessageBounds", {
+      threadId,
+      firstId: bounds.first?.id ?? null,
+      lastId: bounds.last?.id ?? null,
+    });
+    return bounds;
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -225,7 +225,7 @@ const recallMessage$ = command(
   },
 );
 
-const listMessagesAfter$ = command(
+export const listMessagesAfter$ = command(
   async (
     { get },
     { threadId, sinceId }: ListMessagesAfterArgs,
@@ -264,7 +264,7 @@ const listMessagesAfter$ = command(
   },
 );
 
-const listMessagesBefore$ = command(
+export const listMessagesBefore$ = command(
   async (
     { get },
     { threadId, beforeId }: ListMessagesBeforeArgs,

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -23,10 +23,19 @@ type StoredPagedChatMessage = PagedChatMessage & {
 };
 
 interface ChatMessageReadStore {
+  readBounds(
+    threadId: string,
+    signal?: AbortSignal,
+  ): Promise<ChatMessageBounds>;
   readLatest(
     threadId: string,
     signal?: AbortSignal,
   ): Promise<PagedChatMessage[]>;
+}
+
+export interface ChatMessageBounds {
+  readonly first: PagedChatMessage | null;
+  readonly last: PagedChatMessage | null;
 }
 
 interface ChatMessageWriteStore {
@@ -85,6 +94,29 @@ function createMessageReadStore(
   getDb: GetDb,
 ): ChatMessageReadStore {
   return {
+    async readBounds(threadId, signal) {
+      L.debug("readBounds:start", { threadId });
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const tx = db.transaction(storeName, "readonly");
+      const index = tx.store.index(CHAT_MESSAGES_ORDER_INDEX);
+      const range = threadOrderRange(threadId);
+      const [firstCursor, lastCursor] = await Promise.all([
+        index.openCursor(range, "next"),
+        index.openCursor(range, "prev"),
+      ]);
+      signal?.throwIfAborted();
+      const bounds = {
+        first: firstCursor ? validateMessage(firstCursor.value) : null,
+        last: lastCursor ? validateMessage(lastCursor.value) : null,
+      };
+      L.debug("readBounds:done", {
+        threadId,
+        firstId: bounds.first?.id ?? null,
+        lastId: bounds.last?.id ?? null,
+      });
+      return bounds;
+    },
     async readLatest(threadId, signal) {
       L.debug("readLatest:start", { threadId });
       const db = await getDb();

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -39,7 +39,8 @@ interface RealtimeLoopArgs {
 
 interface RealtimePayloadLoopArgs {
   readonly channel: RealtimeChannel;
-  readonly topic: string;
+  readonly topic: string | null;
+  readonly passMessage?: boolean;
   readonly loopCommand$: Command<
     Promise<boolean> | boolean,
     [unknown, AbortSignal]
@@ -60,6 +61,13 @@ interface SetAblyPayloadLoopArgs {
     [unknown, AbortSignal]
   >;
   readonly options?: RealtimeSubscribeOptions;
+}
+
+interface SetAblyMessageLoopArgs {
+  readonly loopCommand$: Command<
+    Promise<boolean> | boolean,
+    [unknown, AbortSignal]
+  >;
 }
 
 function errorMessage(error: unknown): string | undefined {
@@ -218,10 +226,12 @@ const runWithChannel$ = command(
 const runWithChannelPayload$ = command(
   async (
     { set },
-    { channel, topic, loopCommand$, options }: RealtimePayloadLoopArgs,
+    args: RealtimePayloadLoopArgs,
     signal: AbortSignal,
   ): Promise<void> => {
+    const { channel, topic, passMessage, loopCommand$, options } = args;
     signal.throwIfAborted();
+    const subscriptionLabel = topic ?? "all user channel messages";
     let deferred = createDeferredPromise(signal);
     let poked = false;
     let transientRetryCount = 0;
@@ -239,15 +249,15 @@ const runWithChannelPayload$ = command(
       if (signal.aborted) {
         return;
       }
-      L.debug("got payload message from topic", topic, message);
-      pendingPayloads.push(message.data);
+      L.debug("got queued message from topic", subscriptionLabel, message);
+      pendingPayloads.push(passMessage ? message : message.data);
       pokeLoop();
     };
     const onVisibilityChange = () => {
       if (document.visibilityState !== "visible") {
         return;
       }
-      L.debug("tab visible, poking payload loop", topic);
+      L.debug("tab visible, poking payload loop", subscriptionLabel);
       pokeLoop();
     };
     let registeredPoke = false;
@@ -263,7 +273,11 @@ const runWithChannelPayload$ = command(
       });
       registeredPoke = false;
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      channel.unsubscribe(topic, callback);
+      if (topic === null) {
+        channel.unsubscribe(callback);
+      } else {
+        channel.unsubscribe(topic, callback);
+      }
     };
 
     document.addEventListener("visibilitychange", onVisibilityChange, {
@@ -279,10 +293,14 @@ const runWithChannelPayload$ = command(
 
     // eslint-disable-next-line no-restricted-syntax -- Ably can close during app teardown while a channel attach is in flight; suppress only that terminal close race.
     try {
-      await channel.subscribe(topic, callback);
+      if (topic === null) {
+        await channel.subscribe(callback);
+      } else {
+        await channel.subscribe(topic, callback);
+      }
       signal.throwIfAborted();
       options?.onSubscribed?.();
-      L.debug("subscribed to payload topic: " + topic);
+      L.debug("subscribed to payload topic: " + subscriptionLabel);
 
       await setLoop(
         async (loopSignal) => {
@@ -332,7 +350,7 @@ const runWithChannelPayload$ = command(
         L.debug(
           "Ably connection closed before payload subscription completed",
           {
-            topic,
+            topic: subscriptionLabel,
           },
         );
         return;
@@ -513,6 +531,27 @@ export const setAblyPayloadLoop$ = command(
     await set(
       runWithChannelPayload$,
       { channel, topic, loopCommand$, options },
+      signal,
+    );
+    signal.throwIfAborted();
+  },
+);
+
+export const setAblyMessageLoop$ = command(
+  async (
+    { set },
+    { loopCommand$ }: SetAblyMessageLoopArgs,
+    signal: AbortSignal,
+  ) => {
+    const channel = await set(
+      userChannel$,
+      "all user channel messages",
+      signal,
+    );
+    signal.throwIfAborted();
+    await set(
+      runWithChannelPayload$,
+      { channel, topic: null, passMessage: true, loopCommand$ },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -65,6 +65,7 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   DesktopX64Download = "desktopX64Download",
   AgentUnreadIndicators = "agentUnreadIndicators",
+  ChatThreadMessageBackgroundSync = "chatThreadMessageBackgroundSync",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ComposerChatThreadSuggestions = "composerChatThreadSuggestions",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -380,6 +380,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Prefetch chat thread messages into IndexedDB when message-created realtime events arrive outside the focused thread.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Add a catch-all subscriber on the authenticated user Ably channel and reuse the existing chatThreadMessageCreated:{threadId} notification without backend changes.
- Await a background REST sync for every matching notification, using the first and last IndexedDB messages as cursors and writing missing pages back to IndexedDB.
- Start the subscriber from authenticated bootstrap only when ChatThreadMessageBackgroundSync is enabled; the switch is disabled globally and enabled for staff organizations.
- Keep the existing focused-thread subscription unchanged as the fallback path. This first version intentionally has no debounce or navigation gate.

## User impact

For staff evaluation, messages for threads that are not currently focused can be prefetched silently. Opening those threads can render current IndexedDB data immediately, while any missed or unfinished prefetch still falls back to the existing foreground sync.

## Verification

- pnpm format
- pnpm turbo run lint --log-order grouped
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts (17 tests)
- pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-message-background-sync.test.ts (2 tests)
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts (23 tests)
- Full workspace type checking passed for 12 packages; the API check exceeded the default 2 GB Node heap, then the same API tsc --noEmit passed with a 4 GB heap.