### PR TITLE
docs(nbd-cow): clarify request length semantics

### DIFF
--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -63,8 +63,18 @@ pub(crate) struct NbdRequest {
     /// Byte offset into the device where the operation applies (Read /
     /// Write / Trim). Ignored for Flush and Disconnect.
     pub(crate) offset: u64,
-    /// Payload length in bytes. Requests exceeding the server's
-    /// `MAX_REQUEST_LENGTH` (see `server.rs`) are rejected with `EIO`.
+    /// Command-specific byte count:
+    ///
+    /// - [`Command::Read`]: bytes requested from the device and returned in a
+    ///   successful reply.
+    /// - [`Command::Write`]: payload bytes following the request header.
+    /// - [`Command::Trim`]: bytes in the affected range; no payload follows.
+    ///
+    /// For [`Command::Flush`] and [`Command::Disconnect`], the protocol
+    /// requires this field to be zero and the current dispatcher does not
+    /// inspect it. This server rejects Read and Write lengths above
+    /// `MAX_REQUEST_LENGTH` (see `server.rs`) with `EIO`; it does not apply
+    /// that limit to Trim.
     pub(crate) length: u32,
 }
 


### PR DESCRIPTION
## Summary

- document the command-specific meaning of `NbdRequest::length` for Read, Write, and Trim
- distinguish the protocol's zero requirement for Flush and Disconnect from the current dispatcher's behavior
- scope `MAX_REQUEST_LENGTH` and `EIO` enforcement to the Read and Write handlers

## Scope

Documentation only. This does not change the NBD wire format, parsing, dispatch, limits, errors, or runtime behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo doc -p nbd-cow --all-features --no-deps`
- `cargo test -p nbd-cow --all-features`
- pre-commit workspace Rust formatting, Clippy, and rustdoc checks
- `git diff --check`

Closes #22624
