### PR TITLE
feat: gate onboarding run action on required connectors

### DIFF
--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -32,6 +32,38 @@ function connectorRefs(values: readonly string[]): ConnectorRef[] {
   });
 }
 
+export function useRequiredConnectorsState(connectorIds: readonly string[]): {
+  readonly loading: boolean;
+  readonly allConnected: boolean;
+  readonly missingLabels: readonly string[];
+} {
+  const refs = connectorRefs(connectorIds);
+  const connectorCatalogItemsLoadable = useLastLoadable(
+    allConnectorCatalogItems$,
+  );
+  const justConnectedRefs = useGet(justConnectedRefs$);
+  const items =
+    connectorCatalogItemsLoadable.state === "hasData"
+      ? connectorCatalogItemsLoadable.data
+      : [];
+  const missing = refs.filter((connectorRef) => {
+    const item = items.find((candidate) => {
+      return candidate.connectorRef === connectorRef;
+    });
+    return !(item?.connected === true || justConnectedRefs.has(connectorRef));
+  });
+  return {
+    loading: connectorCatalogItemsLoadable.state === "loading",
+    allConnected: missing.length === 0,
+    missingLabels: missing.map((connectorRef) => {
+      const item = items.find((candidate) => {
+        return candidate.connectorRef === connectorRef;
+      });
+      return item?.label ?? connectorRef;
+    }),
+  };
+}
+
 function promptHelpText(helpText: string | undefined): string {
   return (helpText ?? "Connect this account to continue")
     .replace(/^Connect your \w+ account to /u, "")

--- a/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
@@ -64,6 +64,7 @@ export interface OnboardingWorkflow {
   readonly description: string;
   readonly prompt: string;
   readonly connectors: readonly string[];
+  readonly required: readonly string[];
   readonly steps: readonly string[];
 }
 
@@ -303,6 +304,25 @@ function workflowSteps(promptGuidance: string): readonly string[] {
     .slice(0, 4);
 }
 
+// Derives the required connectors from the "Connectors: X required; Y optional"
+// line embedded in promptGuidance, so this stays the single source of truth with
+// the guidance text. Templates without that line resolve to no required connectors.
+function requiredConnectors(
+  promptGuidance: string,
+  connectors: readonly string[],
+): readonly string[] {
+  const match = promptGuidance.match(/Connectors:\s*([^.;\n]*?)\s+required/u);
+  const captured = match?.[1];
+  if (captured === undefined) {
+    return [];
+  }
+  const declared = captured
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return connectors.filter((connector) => declared.includes(connector));
+}
+
 function onboardingWorkflow(
   id: string,
   categoryId: OnboardingWorkflowCategoryId,
@@ -320,6 +340,7 @@ function onboardingWorkflow(
     description: WORKFLOW_DESCRIPTION_OVERRIDES[id] ?? template.description,
     prompt: template.promptGuidance,
     connectors: template.connectors,
+    required: requiredConnectors(template.promptGuidance, template.connectors),
     steps: workflowSteps(template.promptGuidance),
   };
 }

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -7,7 +7,10 @@ import {
   updateOnboardingUi$,
 } from "../../signals/onboarding/onboarding-state.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
-import { OnboardingConnectorSetup } from "./onboarding-connectors.tsx";
+import {
+  OnboardingConnectorSetup,
+  useRequiredConnectorsState,
+} from "./onboarding-connectors.tsx";
 import {
   buildCustomWorkflowPrompt,
   buildWorkflowPrompt,
@@ -22,6 +25,16 @@ import {
   WorkflowPreview,
 } from "./onboarding-workflow-picker-page.tsx";
 
+function formatConnectorList(labels: readonly string[]): string {
+  if (labels.length <= 1) {
+    return labels[0] ?? "";
+  }
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
+
 export function OnboardingWorkflowRunPage() {
   const draft = useGet(onboardingDraft$);
   const ui = useGet(onboardingUi$);
@@ -30,6 +43,9 @@ export function OnboardingWorkflowRunPage() {
   const { navigateTo } = useOnboardingNavigation();
   const custom = draft.workflowId === CUSTOM_WORKFLOW_ID;
   const workflow = findOnboardingWorkflow(draft.workflowId);
+  const requiredState = useRequiredConnectorsState(workflow?.required ?? []);
+  const requiredConnectorsMissing =
+    (workflow?.required.length ?? 0) > 0 && !requiredState.allConnected;
   const previewOpen = ui.workflowPreviewId === workflow?.id;
   const prompt = custom
     ? buildCustomWorkflowPrompt(draft.workflowNote)
@@ -62,7 +78,9 @@ export function OnboardingWorkflowRunPage() {
         footer={
           <OnboardingRunAction
             prompt={prompt}
-            disabled={custom && !draft.workflowNote.trim()}
+            disabled={
+              (custom && !draft.workflowNote.trim()) || requiredConnectorsMissing
+            }
             onBack={handleBack}
           />
         }
@@ -114,6 +132,11 @@ export function OnboardingWorkflowRunPage() {
             className="mt-[18px] min-h-[98px] w-full resize-y rounded-xl border border-border bg-background p-3 text-sm leading-5 outline-none focus:border-primary focus:ring-2 focus:ring-primary/15"
           />
         </OnboardingConnectorSetup>
+        {requiredConnectorsMissing && requiredState.missingLabels.length > 0 ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            {`Connect ${formatConnectorList(requiredState.missingLabels)} to run this workflow.`}
+          </p>
+        ) : null}
       </OnboardingShell>
       {workflow && previewOpen ? (
         <WorkflowPreview


### PR DESCRIPTION
## Summary

Builds on #22592. That PR marked which connectors each onboarding workflow template *requires* vs which are optional, but only in the prompt guidance handed to the agent. On the onboarding **workflow-run page** ("Connect your tools and customize your workflow"), the user could still hit **Run now** without connecting any required connector, and every connector — required or optional — was presented identically ("Connect the … to continue the workflow").

This PR makes the required connectors an actual precondition for running:

- **Run now is disabled until every *required* connector for the selected template is connected.** Optional connectors never block.
- Templates that declare **no** required connectors are **not** gated (fail-open), so the ~46 curated templates without a `Connectors: … required` line still run as before.
- A minimal hint under the connector list names what's still needed, e.g. *"Connect Exa and Slack to run this workflow."*, so the disabled button isn't unexplained.

Nothing else changes — no prompt-guidance text, titles, connector lists, or connector-row copy are touched.

## Implementation

- **`onboarding-data.ts`** — add a structured `required: readonly string[]` to `OnboardingWorkflow`, derived by `requiredConnectors()` from the existing `Connectors: X required; Y optional` line already embedded in `promptGuidance`. This keeps the guidance text the single source of truth and stays 1:1 with #22592's declarations (no per-template data duplicated). Templates without that line resolve to an empty required list.
- **`onboarding-connectors.tsx`** — add `useRequiredConnectorsState(connectorIds)`, which reuses the existing connector-catalog signals (`allConnectorCatalogItems$` / `justConnectedRefs$`) to report `allConnected` and the labels still missing.
- **`onboarding-workflow-run-page.tsx`** — compute the gate, pass `disabled` to the existing `OnboardingRunAction` (which already supports it), and render the hint.

## Notes

- Stacked on `feat/workflow-template-required-connectors` (#22592) so the diff is only the gating change; retarget to `main` after #22592 merges.
- Custom "Talk to Zero" card has no template/required, so it is never gated.
- Relying on the PR pipeline for lint / type-check / tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)