### PR TITLE
test(mitm-addon): cover malformed endpoint tuple types

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connection_endpoints.py
+++ b/crates/runner/mitm-addon/tests/test_connection_endpoints.py
@@ -1,0 +1,47 @@
+"""Connection endpoint shape contract tests."""
+
+import ipaddress
+
+import pytest
+
+import connection_endpoints
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        pytest.param(
+            (int(ipaddress.IPv4Address("203.0.113.10")), 443),
+            id="integer-host",
+        ),
+        pytest.param(
+            (ipaddress.IPv4Address("203.0.113.10").packed, 443),
+            id="packed-bytes-host",
+        ),
+        pytest.param(("203.0.113.10", "443"), id="string-port"),
+    ],
+)
+def test_address_pair_rejects_malformed_member_types(address: tuple[object, ...]) -> None:
+    assert connection_endpoints.address_pair(address) is None
+
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    [
+        pytest.param(
+            ("203.0.113.10", 443),
+            ("203.0.113.10", 443),
+            id="host-port-pair",
+        ),
+        pytest.param(
+            ("2001:db8::1", 443, 0, 2),
+            ("2001:db8::1", 443),
+            id="ipv6-extra-fields",
+        ),
+    ],
+)
+def test_address_pair_returns_host_port_pair(
+    address: tuple[object, ...],
+    expected: tuple[str, int],
+) -> None:
+    assert connection_endpoints.address_pair(address) == expected

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1197,7 +1197,14 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_without_endp
 @pytest.mark.parametrize(
     "client_sockname",
     [
-        pytest.param(cast(tuple[str, int], ("203.0.113.10",)), id="malformed"),
+        pytest.param(cast(tuple[str, int], ("203.0.113.10",)), id="short-tuple"),
+        pytest.param(
+            cast(
+                tuple[str, int],
+                (int(ipaddress.IPv4Address("203.0.113.10")), 443),
+            ),
+            id="integer-host",
+        ),
         pytest.param(("127.0.0.1", 443), id="loopback"),
         pytest.param((str(ipaddress.IPv4Address(0)), 443), id="unspecified-ipv4"),
         pytest.param(("::", 443), id="unspecified-ipv6"),

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -30,6 +30,7 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `test_addon_configuration.py`                           | Addon option registration and configuration updates                                                                  |
 | `test_builtin_host_policy_contract.py`                  | Cross-stage malformed built-in host policy contracts                                                                 |
+| `test_connection_endpoints.py`                          | Connection endpoint shape validation and IPv6 tuple normalization                                                     |
 | `test_request_handler_passthrough.py`                   | Request pass-through, auto-allow, and browser user-agent passthrough decisions                                       |
 | `test_request_handler_authority_validation.py`          | HTTPS authority validation before firewall auth                                                                      |
 | `test_request_handler_firewall_dispatch.py`             | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |


### PR DESCRIPTION
## Summary

- add a focused contract matrix for malformed connection endpoint member types
- prove an integer host cannot satisfy connector-auth destination binding
- document the new endpoint contract test responsibility

## Scope

This PR changes tests and test documentation only. It does not change production endpoint parsing, admission behavior, APIs, schemas, protocols, migrations, or deployment compatibility.

## Validation

- `.venv/bin/python -m pytest -q tests/test_connection_endpoints.py tests/test_request_handler_authority_validation.py::test_matching_sni_and_host_blocks_non_authoritative_connected_endpoint` — 10 passed
- in-process mutation checks confirmed the integer-host request test catches removal of the host guard and the string-port test catches removal of the port guard
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/ -v` — 4,175 passed

Closes #22627
