### PR TITLE
fix(connectors): redirect oauth directly to providers

### DIFF
--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -242,31 +242,13 @@ connect_test_oauth_via_authorization_code() {
         return 1
     }
 
-    local handoff_headers="$BATS_FILE_TMPDIR/test-oauth-handoff.headers"
-    local handoff_body="$BATS_FILE_TMPDIR/test-oauth-handoff.body"
-    local curl_args=(-sS -D "$handoff_headers" -o "$handoff_body" -w "%{http_code}")
-    append_test_oauth_bypass_headers curl_args
-    local handoff_status
-    handoff_status=$(curl "${curl_args[@]}" "$authorization_url")
-    if [[ "$handoff_status" != "307" ]]; then
-        echo "# test-oauth handoff returned HTTP $handoff_status"
-        cat "$handoff_body"
-        return 1
-    fi
-
-    authorization_url=$(header_location "$handoff_headers")
-    [ -n "$authorization_url" ] || {
-        echo "# Missing provider Location from test-oauth handoff"
-        cat "$handoff_headers"
-        return 1
-    }
     if [[ -n "$scenario" ]]; then
         authorization_url="${authorization_url}&scenario=${scenario}"
     fi
 
     local authorize_headers="$BATS_FILE_TMPDIR/test-oauth-authorize.headers"
     local authorize_body="$BATS_FILE_TMPDIR/test-oauth-authorize.body"
-    curl_args=(-sS -D "$authorize_headers" -o "$authorize_body" -w "%{http_code}")
+    local curl_args=(-sS -D "$authorize_headers" -o "$authorize_body" -w "%{http_code}")
     append_test_oauth_bypass_headers curl_args
     local authorize_status
     authorize_status=$(curl "${curl_args[@]}" "$authorization_url")

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -333,10 +333,7 @@ describe("CONN-02: OAuth start and callback", () => {
     if (startResponse.status !== 200) {
       throw new Error(`Unexpected OAuth start status ${startResponse.status}`);
     }
-    const authorizationUrl = await connectorsApi.continueOauth(
-      "github",
-      startResponse.body.authorizationUrl,
-    );
+    const authorizationUrl = new URL(startResponse.body.authorizationUrl);
     expect(
       new URL(authorizationUrl.searchParams.get("redirect_uri") ?? "").pathname,
     ).toBe("/connectors/github/callback");
@@ -381,8 +378,7 @@ describe("CONN-02: OAuth start and callback", () => {
         `Unexpected OAuth start status ${failedStartResponse.status}`,
       );
     }
-    const failedAuthorizationUrl = await connectorsApi.continueOauth(
-      "github",
+    const failedAuthorizationUrl = new URL(
       failedStartResponse.body.authorizationUrl,
     );
     const failedState = stateFromAuthorizationUrl(
@@ -414,10 +410,7 @@ describe("CONN-02: OAuth start and callback", () => {
     const actor = bdd.user();
 
     const start = await connectorsApi.startOauth(actor, "github", "oauth");
-    const authorizationUrl = await connectorsApi.continueOauth(
-      "github",
-      start.authorizationUrl,
-    );
+    const authorizationUrl = new URL(start.authorizationUrl);
     expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
       "https://github.com/login/oauth/authorize",
     );
@@ -494,10 +487,7 @@ describe("CONN-02: OAuth start and callback", () => {
     });
 
     const start = await connectorsApi.startOauth(actor, "datadog", "oauth");
-    const authorizationUrl = await connectorsApi.continueOauth(
-      "datadog",
-      start.authorizationUrl,
-    );
+    const authorizationUrl = new URL(start.authorizationUrl);
     expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
       "S256",
     );
@@ -2609,10 +2599,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       "oauth",
       agent.agentId,
     );
-    const authorizationUrl = await connectorsApi.continueOauth(
-      "test-oauth",
-      start.authorizationUrl,
-    );
+    const authorizationUrl = new URL(start.authorizationUrl);
     expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
       "http://localhost:3000/api/test/oauth-provider/authorize",
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -38,7 +38,6 @@ import {
   zeroConnectorManualGrantContract,
   zeroConnectorExternalCodeSessionContract,
   zeroConnectorOauthDeviceAuthSessionContract,
-  zeroConnectorOauthContinueContract,
   zeroConnectorOauthStartContract,
   zeroConnectorScopeDiffContract,
   zeroConnectorsByTypeContract,
@@ -1306,28 +1305,6 @@ export function createConnectorBddApi(context: TestContext) {
       });
       expectStatus(response, 200);
       return response.body;
-    },
-
-    async continueOauth(
-      type: ConnectorRef,
-      continuationUrl: string,
-    ): Promise<URL> {
-      const state = new URL(continuationUrl).searchParams.get("state");
-      if (!state) {
-        throw new Error(
-          "Expected connector OAuth handoff URL to include state",
-        );
-      }
-      const client = setupApp({ context })(zeroConnectorOauthContinueContract);
-      const response = await accept(
-        client.continue({ params: { type }, query: { state } }),
-        [307],
-      );
-      const location = response.headers.get("location");
-      if (!location) {
-        throw new Error("Expected connector OAuth handoff to redirect");
-      }
-      return new URL(location);
     },
 
     async completeOauthCallback(type: string, query: CallbackQuery) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -123,7 +123,7 @@ async function requestOauthStart(
   });
 }
 
-async function continuationUrlFromResponse(response: Response): Promise<URL> {
+async function authorizationUrlFromResponse(response: Response): Promise<URL> {
   const body = connectorOauthStartResponseSchema.parse(await response.json());
   return new URL(body.authorizationUrl);
 }
@@ -146,16 +146,22 @@ async function requestOauthContinuation(
   return await app.request(continuationUrl.toString());
 }
 
-async function authorizationUrlFromResponse(response: Response): Promise<URL> {
-  return await providerAuthorizationUrl(
-    await continuationUrlFromResponse(response),
-  );
-}
-
 function expectOauthState(authorizationUrl: URL): string {
   const state = authorizationUrl.searchParams.get("state");
   expect(state).toMatch(/^[0-9a-f]{64}$/);
   return state!;
+}
+
+function legacyContinuationUrl(
+  connectorType: string,
+  authorizationUrl: URL,
+): URL {
+  const continuationUrl = new URL(
+    `/api/zero/connectors/${connectorType}/oauth/continue`,
+    API_ORIGIN,
+  );
+  continuationUrl.searchParams.set("state", expectOauthState(authorizationUrl));
+  return continuationUrl;
 }
 
 async function rejectProviderAuthorization(
@@ -264,7 +270,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("returns an API OAuth handoff that redirects to the provider authorization URL", async () => {
+  it("returns the provider authorization URL without an API redirect", async () => {
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("github", {
@@ -273,13 +279,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
 
     expect(response.status).toBe(200);
-    const continuationUrl = await continuationUrlFromResponse(response);
-    expect(`${continuationUrl.origin}${continuationUrl.pathname}`).toBe(
-      `${API_ORIGIN}/api/zero/connectors/github/oauth/continue`,
-    );
-    const state = expectOauthState(continuationUrl);
-
-    const authorizationUrl = await providerAuthorizationUrl(continuationUrl);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
     expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
       "https://github.com/login/oauth/authorize",
     );
@@ -289,8 +289,25 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
       `${WEB_ORIGIN}/api/connectors/github/callback`,
     );
-    expect(authorizationUrl.searchParams.get("state")).toBe(state);
+    expectOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("continues OAuth handoff URLs issued before deployment", async () => {
+    const response = await requestOauthStart("github", {
+      authenticated: true,
+      origin: API_ORIGIN,
+    });
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+
+    const redirectedAuthorizationUrl = await providerAuthorizationUrl(
+      legacyContinuationUrl("github", authorizationUrl),
+    );
+
+    expect(redirectedAuthorizationUrl.toString()).toBe(
+      authorizationUrl.toString(),
+    );
   });
 
   it("rejects an OAuth handoff whose state does not exist", async () => {
@@ -318,11 +335,8 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       origin: API_ORIGIN,
     });
     expect(response.status).toBe(200);
-    const continuationUrl = await continuationUrlFromResponse(response);
-    continuationUrl.pathname = continuationUrl.pathname.replace(
-      "/github/",
-      "/notion/",
-    );
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    const continuationUrl = legacyContinuationUrl("notion", authorizationUrl);
 
     const continueResponse = await requestOauthContinuation(continuationUrl);
 
@@ -343,7 +357,8 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       origin: API_ORIGIN,
     });
     expect(response.status).toBe(200);
-    const continuationUrl = await continuationUrlFromResponse(response);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    const continuationUrl = legacyContinuationUrl("github", authorizationUrl);
     mockNow(new Date(startedAt.getTime() + 15 * 60 * 1000));
 
     const continueResponse = await requestOauthContinuation(continuationUrl);
@@ -363,8 +378,8 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
       origin: API_ORIGIN,
     });
     expect(response.status).toBe(200);
-    const continuationUrl = await continuationUrlFromResponse(response);
-    const authorizationUrl = await providerAuthorizationUrl(continuationUrl);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    const continuationUrl = legacyContinuationUrl("github", authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
 
     const continueResponse = await requestOauthContinuation(continuationUrl);

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -64,7 +64,6 @@ import {
   buildConnectorOpenIdAuthUrlWithMethod,
   prepareConnectorOpenIdAuthStartWithMethod,
 } from "./connector-openid-auth-start";
-import { getOAuthApiOrigin } from "./oauth-web-origin";
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -557,16 +556,10 @@ const startConnectorOauthInner$ = command(
     });
     signal.throwIfAborted();
 
-    const continuationUrl = new URL(
-      `/api/zero/connectors/${resolved.connectorRef}/oauth/continue`,
-      getOAuthApiOrigin(request),
-    );
-    continuationUrl.searchParams.set("state", prepared.state);
-
     return {
       status: 200 as const,
       body: {
-        authorizationUrl: continuationUrl.toString(),
+        authorizationUrl: authResult.url,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -565,6 +565,9 @@ const startConnectorOauthInner$ = command(
   },
 );
 
+// Compatibility for handoff URLs issued before direct provider redirects.
+// Remove after the previous API is no longer rollback-eligible and every state
+// issued with CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS has expired.
 const continueConnectorOauthInner$ = command(
   async ({ get }, signal: AbortSignal) => {
     const params = get(

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -13,7 +13,11 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
-import type { ConnectorRedirectingStatus } from "./connector-redirecting.ts";
+import {
+  resetConnectorRedirectingMobileWarning$,
+  showConnectorRedirectingMobileWarningAfterDelay$,
+  type ConnectorRedirectingStatus,
+} from "./connector-redirecting.ts";
 
 function connectorTypeFromPath(value: string | undefined): ConnectorRef | null {
   const parsed = connectorRefSchema.safeParse(value?.toLowerCase());
@@ -50,6 +54,7 @@ export const setupConnectorRedirectingPage$ = command(
       searchParams.get("status") === "error" ? "error" : "redirecting";
     const connectorIcon = connectorIconFromSearchParams(searchParams);
 
+    set(resetConnectorRedirectingMobileWarning$);
     set(
       updatePage$,
       createElement(ZeroConnectorRedirectingPage, {
@@ -60,5 +65,8 @@ export const setupConnectorRedirectingPage$ = command(
     );
     set(updateDocumentTitle$, `Connect ${connectorLabel}`);
     await set(hideAppSkeleton$, signal);
+    if (status === "redirecting") {
+      await set(showConnectorRedirectingMobileWarningAfterDelay$, signal);
+    }
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -29,6 +29,7 @@ export const showConnectorRedirectingMobileWarningAfterDelay$ = command(
     }
 
     await delay(MOBILE_REDIRECT_WARNING_DELAY_MS, { signal });
+    signal.throwIfAborted();
     set(internalMobileWarningVisible$, true);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -1,9 +1,37 @@
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { command, computed, state } from "ccstate";
+import { delay } from "signal-timers";
+import { IN_VITEST } from "../../env.ts";
 import { generateRouterPath } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 
 export type ConnectorRedirectingStatus = "redirecting" | "error";
+
+const MOBILE_REDIRECT_WARNING_DELAY_MS = IN_VITEST ? 100 : 2000;
+const internalMobileWarningVisible$ = state(false);
+
+export const connectorRedirectingMobileWarningVisible$ = computed((get) => {
+  return get(internalMobileWarningVisible$);
+});
+
+export const resetConnectorRedirectingMobileWarning$ = command(({ set }) => {
+  set(internalMobileWarningVisible$, false);
+});
+
+export const showConnectorRedirectingMobileWarningAfterDelay$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const mobileDevice =
+      /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent) ||
+      (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1);
+    if (!mobileDevice) {
+      return;
+    }
+
+    await delay(MOBILE_REDIRECT_WARNING_DELAY_MS, { signal });
+    set(internalMobileWarningVisible$, true);
+  },
+);
 
 export function connectorRedirectingPath(args: {
   readonly type: ConnectorRef;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -1,12 +1,29 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+const MOBILE_WARNING =
+  "The GitHub app may not support this OAuth link. Please complete this connection in the VM0 web app on a computer.";
+const IPHONE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
+
+function backToVm0Link(): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.trim() === "Back to VM0";
+  });
+  if (!link) {
+    throw new Error("Back to VM0 link not found");
+  }
+  return link;
+}
 
 describe("connector redirecting page", () => {
-  it("renders the provider handoff without an authenticated user", async () => {
+  it("renders the provider redirect page without an authenticated user", async () => {
     detachedSetupPage({
       context,
       path: "/connectors/github/redirecting?label=GitHub",
@@ -26,6 +43,26 @@ describe("connector redirecting page", () => {
     expect(
       screen.getByLabelText("Connector icon unavailable"),
     ).toBeInTheDocument();
+    expect(backToVm0Link()).toHaveAttribute("href", "/");
+    expect(screen.queryByText(MOBILE_WARNING)).not.toBeInTheDocument();
+  });
+
+  it("warns mobile users when the provider redirect does not leave the page", async () => {
+    context.mocks.browser.userAgent(IPHONE_USER_AGENT);
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/redirecting?label=GitHub",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Redirecting to GitHub…" }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText(MOBILE_WARNING)).not.toBeInTheDocument();
+
+    const warning = await screen.findByText(MOBILE_WARNING);
+    expect(warning).toHaveClass("text-amber-600");
   });
 
   it("renders a validated catalog icon for an unknown server connector ref", async () => {
@@ -81,6 +118,6 @@ describe("connector redirecting page", () => {
     expect(
       screen.getByText("Return to VM0 and try connecting again."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Close window")).toBeInTheDocument();
+    expect(backToVm0Link()).toHaveAttribute("href", "/");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,7 +1,17 @@
-import { IconAlertCircle, IconLoader2 } from "@tabler/icons-react";
+import {
+  IconAlertCircle,
+  IconArrowLeft,
+  IconLoader2,
+} from "@tabler/icons-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
-import type { ConnectorRedirectingStatus } from "../../signals/connectors-page/connector-redirecting.ts";
+import { useGet } from "ccstate-react";
+import {
+  connectorRedirectingMobileWarningVisible$,
+  type ConnectorRedirectingStatus,
+} from "../../signals/connectors-page/connector-redirecting.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
+import { Link } from "../router/link.tsx";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 export function ZeroConnectorRedirectingPage({
@@ -14,6 +24,7 @@ export function ZeroConnectorRedirectingPage({
   readonly status: ConnectorRedirectingStatus;
 }) {
   const hasError = status === "error";
+  const showMobileWarning = useGet(connectorRedirectingMobileWarningVisible$);
 
   return (
     <ZeroConnectorFlowCard
@@ -29,27 +40,35 @@ export function ZeroConnectorRedirectingPage({
           : `You’ll continue on ${connectorLabel} to authorize VM0.`
       }
     >
-      {hasError ? (
-        <div className="flex flex-col items-center gap-4">
+      <div className="flex flex-col items-center gap-4">
+        {hasError ? (
           <div className="flex items-center gap-2 text-sm text-destructive">
             <IconAlertCircle size={16} aria-hidden="true" />
             <span>Unable to start the connection</span>
           </div>
-          <Button
-            variant="outline"
-            onClick={() => {
-              window.close();
-            }}
-          >
-            Close window
-          </Button>
-        </div>
-      ) : (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
-          <span>Preparing a secure connection</span>
-        </div>
-      )}
+        ) : (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <IconLoader2
+              size={16}
+              className="animate-spin"
+              aria-hidden="true"
+            />
+            <span>Preparing a secure connection</span>
+          </div>
+        )}
+        {!hasError && showMobileWarning && (
+          <p className="w-72 max-w-full text-sm text-amber-600 dark:text-amber-400">
+            The {connectorLabel} app may not support this OAuth link. Please
+            complete this connection in the VM0 web app on a computer.
+          </p>
+        )}
+        <Button variant="outline" asChild>
+          <Link pathname={ROUTES.home}>
+            <IconArrowLeft size={16} aria-hidden="true" />
+            Back to VM0
+          </Link>
+        </Button>
+      </div>
     </ZeroConnectorFlowCard>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -110,7 +110,7 @@ export const zeroConnectorOauthStartContract = c.router({
       403: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Create connector OAuth handoff and authorization URL",
+    summary: "Create connector OAuth authorization URL",
   },
 });
 


### PR DESCRIPTION
## Summary

- return provider authorization URLs directly from connector OAuth start, bypassing the `api.vm0.ai` continuation redirect in new flows
- keep the existing continuation endpoint for links issued before deployment compatibility windows close
- show a delayed amber warning when a mobile user remains on the redirect page
- provide a Back to VM0 button that returns to the app home page

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/api-contracts test`
- affected workspace lint and type checks
- full Knip and repository type checks through the pre-commit hook
