### PR TITLE
fix(runner): restore sandbox codex cli to 0.144.6

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -114,7 +114,7 @@ CACHE_TMP_TAR=""
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
 CLAUDE_CODE_VERSION="2.1.217"
-CODEX_CLI_VERSION="0.145.0"
+CODEX_CLI_VERSION="0.144.6"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.32.3"


### PR DESCRIPTION
## Summary

- Restore the Codex CLI preinstalled in sandbox rootfs templates from `0.145.0` to `0.144.6`.
- Keep all other pinned rootfs package versions unchanged.
- Let the existing script hash invalidate the template cache so the next template build installs the restored version.

## Scope

- This PR only changes the pinned `@openai/codex` version.
- It does not rebuild or deploy a sandbox image.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- `npm view @openai/codex@0.144.6 version --json` returned `"0.144.6"`
