### PR TITLE
fix(sandbox-fc): bridge netns pool locks into private runtime

### DIFF
--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -91,7 +91,8 @@ REAL_IPTABLES_RESTORE=$(command -v iptables-restore)
 REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
 REAL_IP6TABLES_RESTORE=$(command -v ip6tables-restore)
 
-# Reserve four pool indexes before the runner starts. Two become clean
+# Reserve four legacy-only pool indexes before the runner starts, modeling the
+# runner version deployed before the private-lock bridge. Two become clean
 # historical indexes, one owns a synthetic firewall-only orphan, and one
 # remains active throughout reconciliation. The first three locks are released
 # during own-index cleanup, after the runner has captured their resources and
@@ -171,7 +172,7 @@ find_own_pool_hex() {
   for fd in /proc/"$PPID"/fd/*; do
     target=$(readlink "$fd" 2>/dev/null || true)
     case "$target" in
-      */vm0-netns-pool-*.lock)
+      /var/lock/vm0-netns-pool-*.lock)
         index=${target##*/vm0-netns-pool-}
         index=${index%.lock}
         case "$index" in
@@ -378,6 +379,14 @@ assert_reconcile_count() {
     || fail "expected $expected reconciliation $name call(s), found $actual"
 }
 
+assert_pool_lock_held() {
+  local path=$1
+  sudo test -f "$path" || fail "pool lock does not exist: $path"
+  if sudo flock -n "$path" true; then
+    fail "runner does not hold pool lock: $path"
+  fi
+}
+
 # Pause the runner at the cross-pool mutation boundary. This keeps later
 # warm-up or namespace failure cleanup from being mistaken for another startup
 # discovery pass while also proving that the target pool lock is still held.
@@ -388,6 +397,12 @@ for _ in $(seq 1 1200); do
 done
 [ -e "$RECONCILE_FIREWALL_DELETE_STARTED" ] \
   || fail "startup reconciliation did not reach the firewall cleanup checkpoint"
+
+OWN_POOL_HEX=$(<"$RECONCILE_COUNT_DIR/own-pool")
+OWN_POOL_INDEX=$((16#$OWN_POOL_HEX))
+assert_pool_lock_held "/var/lock/vm0-netns-pool-${OWN_POOL_INDEX}.lock"
+assert_pool_lock_held "/run/vm0/netns-locks/vm0-netns-pool-${OWN_POOL_INDEX}.lock"
+echo "PASS: runner holds the complete legacy/private pool lock bridge"
 
 echo "--- Test: startup reconciliation uses one host snapshot ---"
 # Failed snapshot sources stay abandoned instead of triggering a per-namespace

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::fmt::Write as _;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
@@ -99,6 +100,8 @@ enum Warning {
     NoDnsmasq { port: u16, base_dir: PathBuf },
     /// A network namespace whose pool lock is not held by any process.
     OrphanNamespace { ns_name: String, pool_idx: u32 },
+    /// A pool whose ownership cannot be verified without trusting unsafe state.
+    NetnsPoolLockUnverifiable { pool_idx: u32, error: String },
     /// An NBD device whose recorded owner task has exited and whose lock is free.
     OrphanNbdDevice { device_index: u32, pid: u32 },
     /// The NBD orphan scan task panicked (bug in find_nbd_orphans).
@@ -162,6 +165,12 @@ impl fmt::Display for Warning {
             }
             Self::OrphanNamespace { ns_name, .. } => {
                 write!(f, "orphan namespace {ns_name} (pool lock not held)")
+            }
+            Self::NetnsPoolLockUnverifiable { pool_idx, error } => {
+                write!(
+                    f,
+                    "netns pool {pool_idx} lock ownership is unverifiable: {error}"
+                )
             }
             Self::OrphanNbdDevice { device_index, pid } => {
                 write!(
@@ -285,8 +294,10 @@ impl Warning {
                 pid_exists(*pid) && process::is_orphan(*pid, runner_pids).await
             }
             Self::OrphanNamespace { pool_idx, .. } => {
-                let lock_path = format!("/var/lock/vm0-netns-pool-{pool_idx}.lock");
-                is_lock_free(&lock_path).await
+                netns_lock_anomaly_persists(probe_netns_pool_lock_status(*pool_idx).await)
+            }
+            Self::NetnsPoolLockUnverifiable { pool_idx, .. } => {
+                netns_lock_anomaly_persists(probe_netns_pool_lock_status(*pool_idx).await)
             }
             Self::OrphanNbdDevice { device_index, pid } => {
                 let idx = *device_index;
@@ -1087,30 +1098,67 @@ async fn detect_orphan_firecrackers(
 
 /// List `vm0-ns-*` namespaces and check if their pool locks are held.
 async fn detect_orphan_namespaces() -> Vec<Warning> {
-    let mut warnings = Vec::new();
-
     let output = match tokio::process::Command::new("ip")
         .args(["netns", "list"])
         .output()
         .await
     {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
-        _ => return warnings,
+        _ => return Vec::new(),
     };
 
-    for line in output.lines() {
-        if let Some((ns_name, pool_idx)) = parse_netns_list_line(line) {
-            let lock_path = format!("/var/lock/vm0-netns-pool-{pool_idx}.lock");
-            if is_lock_free(&lock_path).await {
-                warnings.push(Warning::OrphanNamespace {
-                    ns_name: ns_name.to_string(),
-                    pool_idx,
-                });
-            }
+    let mut pools: Vec<(u32, Vec<String>)> = Vec::new();
+    for (name, index) in output.lines().filter_map(parse_netns_list_line) {
+        if let Some((_, names)) = pools
+            .iter_mut()
+            .find(|(pool_index, _)| *pool_index == index)
+        {
+            names.push(name.to_string());
+        } else {
+            pools.push((index, vec![name.to_string()]));
         }
     }
 
+    let mut warnings = Vec::new();
+    for (index, names) in pools {
+        let observation = match probe_netns_pool_lock_status(index).await {
+            Ok(sandbox_fc::NetnsPoolLockStatus::Active) => NetnsPoolLockObservation::Active,
+            Ok(sandbox_fc::NetnsPoolLockStatus::Idle) => NetnsPoolLockObservation::Idle,
+            Err(error) => NetnsPoolLockObservation::Unverifiable(error.to_string()),
+        };
+        warnings.extend(classify_namespace_lock_observation(
+            index,
+            &names,
+            observation,
+        ));
+    }
     warnings
+}
+
+enum NetnsPoolLockObservation {
+    Active,
+    Idle,
+    Unverifiable(String),
+}
+
+fn classify_namespace_lock_observation(
+    pool_idx: u32,
+    namespaces: &[String],
+    observation: NetnsPoolLockObservation,
+) -> Vec<Warning> {
+    match observation {
+        NetnsPoolLockObservation::Active => Vec::new(),
+        NetnsPoolLockObservation::Idle => namespaces
+            .iter()
+            .map(|ns_name| Warning::OrphanNamespace {
+                ns_name: ns_name.clone(),
+                pool_idx,
+            })
+            .collect(),
+        NetnsPoolLockObservation::Unverifiable(error) => {
+            vec![Warning::NetnsPoolLockUnverifiable { pool_idx, error }]
+        }
+    }
 }
 
 /// Parse `ip netns list` output line and return the namespace plus pool index.
@@ -1137,27 +1185,16 @@ async fn detect_nbd_orphans() -> Vec<Warning> {
         .collect()
 }
 
-/// Try non-blocking flock to check if a lock file is free (not held by anyone).
-async fn is_lock_free(lock_path: &str) -> bool {
-    let lock_path = lock_path.to_string();
-    tokio::task::spawn_blocking(move || {
-        use std::fs::File;
-        let file = match File::open(&lock_path) {
-            Ok(f) => f,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
-            Err(e) => {
-                tracing::warn!("cannot open lock file {lock_path}: {e}, assuming held");
-                return false;
-            }
-        };
-        // Try exclusive lock without blocking
-        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
-            Ok(_lock) => true, // lock acquired → was free → orphaned
-            Err(_) => false,   // lock held → pool is active
-        }
-    })
-    .await
-    .unwrap_or(false) // if task panics, assume lock is held (don't false-positive)
+async fn probe_netns_pool_lock_status(
+    pool_idx: u32,
+) -> io::Result<sandbox_fc::NetnsPoolLockStatus> {
+    tokio::task::spawn_blocking(move || sandbox_fc::probe_netns_pool_lock(pool_idx))
+        .await
+        .map_err(|error| io::Error::other(format!("netns pool lock probe panicked: {error}")))?
+}
+
+fn netns_lock_anomaly_persists(result: io::Result<sandbox_fc::NetnsPoolLockStatus>) -> bool {
+    !matches!(result, Ok(sandbox_fc::NetnsPoolLockStatus::Active))
 }
 
 // ---------------------------------------------------------------------------
@@ -2317,6 +2354,15 @@ mod tests {
             "stale mitmproxy PID 555 on port 32821 (runner stopped)"
         );
 
+        let w = Warning::NetnsPoolLockUnverifiable {
+            pool_idx: 7,
+            error: "unsafe path".into(),
+        };
+        assert_eq!(
+            w.to_string(),
+            "netns pool 7 lock ownership is unverifiable: unsafe path"
+        );
+
         let w = Warning::OrphanNbdDevice {
             device_index: 3,
             pid: 12345,
@@ -3165,29 +3211,56 @@ mod tests {
         assert!(!is_test_tld("https://example.com?q=.test"));
     }
 
-    #[tokio::test]
-    async fn is_lock_free_returns_true_when_file_not_found() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("no-such-file.lock");
-        assert!(super::is_lock_free(path.to_str().unwrap()).await);
+    #[test]
+    fn namespace_lock_warnings_distinguish_and_deduplicate_states() {
+        assert!(
+            classify_namespace_lock_observation(
+                0,
+                &["vm0-ns-00-00".to_string()],
+                NetnsPoolLockObservation::Active,
+            )
+            .is_empty()
+        );
+
+        let warnings = classify_namespace_lock_observation(
+            1,
+            &["vm0-ns-01-00".to_string()],
+            NetnsPoolLockObservation::Idle,
+        );
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            Warning::OrphanNamespace {
+                ns_name,
+                pool_idx: 1
+            } if ns_name == "vm0-ns-01-00"
+        ));
+
+        let warnings = classify_namespace_lock_observation(
+            2,
+            &["vm0-ns-02-00".to_string(), "vm0-ns-02-01".to_string()],
+            NetnsPoolLockObservation::Unverifiable("unsafe lock".to_string()),
+        );
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            Warning::NetnsPoolLockUnverifiable {
+                pool_idx: 2,
+                error
+            } if error == "unsafe lock"
+        ));
     }
 
-    #[tokio::test]
-    async fn is_lock_free_returns_true_when_lock_not_held() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("free.lock");
-        std::fs::File::create(&path).unwrap();
-        assert!(super::is_lock_free(path.to_str().unwrap()).await);
-    }
-
-    #[tokio::test]
-    async fn is_lock_free_returns_false_when_lock_held() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("held.lock");
-        let file = std::fs::File::create(&path).unwrap();
-        // Hold an exclusive lock for the duration of the test.
-        let _lock = nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock)
-            .expect("failed to acquire test lock");
-        assert!(!super::is_lock_free(path.to_str().unwrap()).await);
+    #[test]
+    fn namespace_lock_warning_rechecks_remain_conservative() {
+        assert!(!netns_lock_anomaly_persists(Ok(
+            sandbox_fc::NetnsPoolLockStatus::Active
+        )));
+        assert!(netns_lock_anomaly_persists(Ok(
+            sandbox_fc::NetnsPoolLockStatus::Idle
+        )));
+        assert!(netns_lock_anomaly_persists(Err(io::Error::other(
+            "unsafe lock"
+        ))));
     }
 }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -58,7 +58,8 @@ pub use control::FirecrackerControl;
 pub use factory::{PREWARM_SCRIPT, config_hash};
 pub use network::{
     DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4, NetnsInfo, NetnsLease,
-    NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+    NetnsPool, NetnsPoolConfig, NetnsPoolLockStatus, ParsedNetnsName, parse_netns_name,
+    probe_netns_pool_lock,
 };
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,

--- a/crates/sandbox-fc/src/network/error.rs
+++ b/crates/sandbox-fc/src/network/error.rs
@@ -43,9 +43,9 @@ pub enum NetworkError {
     #[error("failed to detect default network interface from: {0}")]
     NoDefaultInterface(String),
 
-    /// A lock file needed for namespace pool coordination could not be opened.
-    #[error("failed to open lock file: {0}")]
-    LockOpen(String),
+    /// A lock file needed for namespace pool coordination was unsafe or failed.
+    #[error("pool index lock error: {0}")]
+    PoolLock(String),
 
     /// A required host or network prerequisite failed while preparing namespaces.
     #[error("prerequisite check failed: {0}")]

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -6,7 +6,8 @@ mod readiness;
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
 pub use pool::{
-    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, NetnsPoolLockStatus, ParsedNetnsName,
+    parse_netns_name, probe_netns_pool_lock,
 };
 pub(crate) use pool::{NetnsPoolHandle, make_pool_dns_filter_comment};
 pub(crate) use readiness::probe_namespace_dns_diagnostic;

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -34,17 +34,20 @@
 //!   pool, or creates one on-demand as fallback
 //! - [`NetnsPool::release`] takes `&mut Option<NetnsLease>` so cancellation
 //!   before the final commit point leaves cleanup ownership with the caller
-//! - Pool index (0–63) is auto-allocated via flock on `/var/lock`
+//! - Pool index (0–63) is auto-allocated through a temporary dual-lock bridge:
+//!   the legacy `/var/lock` path plus an owner-only `/run/vm0` path
 //! - Orphans from abnormally-exited prior runners (SIGKILL, panic, OOM,
 //!   power loss, aborted in-flight creation tasks) are reconciled at
 //!   startup via flock-based liveness probe.
 
 mod completion;
 mod host;
+mod lock;
 mod naming;
 mod state;
 mod types;
 
+pub use lock::{NetnsPoolLockStatus, probe_netns_pool_lock};
 pub(crate) use naming::make_pool_dns_filter_comment;
 pub use naming::{ParsedNetnsName, parse_netns_name};
 pub use state::NetnsPool;

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fs::File;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
@@ -7,7 +6,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use nix::fcntl::{Flock, FlockArg};
 use tracing::{error, info, warn};
 
 use crate::command::{
@@ -18,6 +16,7 @@ use crate::paths::LockPaths;
 
 use super::super::error::{NetworkError, Result};
 use super::super::{GUEST_NETWORK, GuestNetwork};
+use super::lock::{PoolIndexLock, try_claim_reconciliation_lock};
 use super::naming::{
     MAX_NAMESPACES, MAX_POOLS, NS_PREFIX, format_hex_index, generate_veth_ip_pair,
     make_host_device, make_host_device_iptables_pattern, make_ns_name,
@@ -705,53 +704,6 @@ fn conntrack_command_missing(src: IgnoredCommandOutcome, dst: IgnoredCommandOutc
 }
 
 // ---------------------------------------------------------------------------
-// Pool index lock
-// ---------------------------------------------------------------------------
-
-/// Try to acquire an exclusive flock on a pool index file (0..MAX_POOLS).
-///
-/// Returns the first successfully locked `(index, Flock<File>)`. The lock is
-/// held for the lifetime of the returned `Flock` — when the process exits or
-/// the `Flock` is dropped, the OS releases the lock automatically.
-pub(super) fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
-    for index in 0..MAX_POOLS {
-        let path = locks.netns_pool(index);
-        // Open for writing without O_CREAT first, fall back to create.
-        // This avoids EACCES from fs.protected_regular=2 on sticky-bit
-        // directories (/var/lock) when the file is owned by another user.
-        let file = match File::options().write(true).open(&path).or_else(|_| {
-            File::options()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .open(&path)
-        }) {
-            Ok(f) => f,
-            Err(e) => {
-                // Skip indices whose lock file is inaccessible (e.g. owned by
-                // another user under fs.protected_regular=2).
-                warn!(index, %e, "cannot open pool lock, skipping index");
-                continue;
-            }
-        };
-        match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
-            Ok(lock) => {
-                info!(index, "acquired pool index lock");
-                return Ok((index, lock));
-            }
-            Err((_, errno)) => {
-                if errno != nix::errno::Errno::EWOULDBLOCK {
-                    warn!(index, %errno, "unexpected flock error, skipping index");
-                }
-                continue;
-            }
-        }
-    }
-
-    Err(NetworkError::NoPoolIndexAvailable)
-}
-
-// ---------------------------------------------------------------------------
 // Namespace creation
 // ---------------------------------------------------------------------------
 
@@ -1291,14 +1243,11 @@ async fn cleanup_namespaces_from_snapshot(
 /// acquired index before reuse. Captured resources under other indexes are
 /// deleted only after their flock proves that they have no active owner.
 ///
-/// `_own_lock` is a borrow witness — taking it proves the caller holds a
-/// pool-index flock, which is the permission required to do kernel-side
-/// cleanup on `own_index` without first re-flocking it.
-pub(super) async fn reconcile_orphan_namespaces(
-    locks: &LockPaths,
-    own_index: u32,
-    _own_lock: &Flock<File>,
-) {
+/// `own_lock` is both the index source and a borrow witness: taking it proves
+/// the caller holds the complete bridge claim required to do kernel-side
+/// cleanup on that index without first re-flocking it.
+pub(super) async fn reconcile_orphan_namespaces(locks: &LockPaths, own_lock: &PoolIndexLock) {
+    let own_index = own_lock.index();
     let snapshot = ReconciliationSnapshot::capture().await;
     let candidate_indexes = snapshot.candidate_pool_indexes(own_index);
     let candidate_count = candidate_indexes.len();
@@ -1316,15 +1265,24 @@ pub(super) async fn reconcile_orphan_namespaces(
     // authority to mutate resources for an index. A missed or failed cleanup
     // is retried when a future runner directly acquires that index.
     let mut reconciled = 1_usize;
-    let mut skipped = 0_usize;
+    let mut active = 0_usize;
+    let mut unsafe_locks = 0_usize;
     let mut abandoned = usize::from(matches!(own_outcome, NamespaceDeleteOutcome::Abandoned));
     for index in candidate_indexes {
         if index == own_index {
             continue;
         }
-        let Some(_guard) = try_claim_idle_pool_lock(locks, index) else {
-            skipped += 1;
-            continue;
+        let _guard = match try_claim_reconciliation_lock(locks, index) {
+            Ok(Some(guard)) => guard,
+            Ok(None) => {
+                active += 1;
+                continue;
+            }
+            Err(error) => {
+                unsafe_locks += 1;
+                warn!(index, %error, "cannot safely claim orphaned pool index");
+                continue;
+            }
         };
         info!(index, "reconciling orphaned namespaces from idle pool");
         let outcome = cleanup_namespaces_from_snapshot(&snapshot, index).await;
@@ -1337,24 +1295,11 @@ pub(super) async fn reconcile_orphan_namespaces(
         own_index,
         candidate_count,
         reconciled,
-        skipped,
+        active,
+        unsafe_locks,
         abandoned,
         "startup namespace reconciliation complete"
     );
-}
-
-/// Try to acquire a non-blocking flock on an existing pool lock file.
-///
-/// Returns `None` when the file is missing (index never used, no orphans
-/// possible) or when the lock is held by another runner (active owner,
-/// off-limits). Returns `Some(guard)` otherwise; dropping the guard
-/// releases the lock.
-fn try_claim_idle_pool_lock(locks: &LockPaths, index: u32) -> Option<Flock<File>> {
-    let path = locks.netns_pool(index);
-    // Do NOT create the file — a missing lock file means this index was
-    // never used, so there is nothing to reconcile.
-    let file = File::options().write(true).open(&path).ok()?;
-    Flock::lock(file, FlockArg::LockExclusiveNonblock).ok()
 }
 
 #[cfg(test)]
@@ -1790,93 +1735,5 @@ touch "{}"
                 "trusted right-side outcome: {outcome:?}"
             );
         }
-    }
-
-    #[test]
-    fn acquire_pool_lock_returns_first_available() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        let (index, _lock) = acquire_pool_lock(&locks).unwrap();
-        assert_eq!(index, 0);
-    }
-
-    #[test]
-    fn acquire_pool_lock_skips_held_indices() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        let (i0, _hold0) = acquire_pool_lock(&locks).unwrap();
-        let (i1, _hold1) = acquire_pool_lock(&locks).unwrap();
-        let (i2, _hold2) = acquire_pool_lock(&locks).unwrap();
-
-        assert_eq!(i0, 0);
-        assert_eq!(i1, 1);
-        assert_eq!(i2, 2);
-    }
-
-    #[test]
-    fn acquire_pool_lock_reuses_released_index() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        let (i0, hold0) = acquire_pool_lock(&locks).unwrap();
-        let (i1, _hold1) = acquire_pool_lock(&locks).unwrap();
-        assert_eq!(i0, 0);
-        assert_eq!(i1, 1);
-
-        // Drop lock 0 → index 0 becomes available again.
-        drop(hold0);
-
-        let (reused, _hold) = acquire_pool_lock(&locks).unwrap();
-        assert_eq!(reused, 0);
-    }
-
-    #[test]
-    fn try_claim_idle_pool_lock_returns_none_when_file_missing() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-        // No lock file has ever been created for index 0.
-        assert!(try_claim_idle_pool_lock(&locks, 0).is_none());
-    }
-
-    #[test]
-    fn try_claim_idle_pool_lock_returns_none_when_held() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        let (idx, _held) = acquire_pool_lock(&locks).unwrap();
-        assert!(try_claim_idle_pool_lock(&locks, idx).is_none());
-    }
-
-    #[test]
-    fn try_claim_idle_pool_lock_returns_some_when_idle() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        // Create the lock file by acquiring then releasing — simulates a
-        // prior runner that exited.
-        let (idx, held) = acquire_pool_lock(&locks).unwrap();
-        drop(held);
-
-        let claimed = try_claim_idle_pool_lock(&locks, idx);
-        assert!(claimed.is_some());
-    }
-
-    #[test]
-    fn acquire_pool_lock_exhausted() {
-        let dir = tempfile::tempdir().unwrap();
-        let locks = LockPaths::with_dir(dir.path().to_path_buf());
-
-        // Hold all 64 slots.
-        let _locks: Vec<_> = (0..MAX_POOLS)
-            .map(|_| acquire_pool_lock(&locks).unwrap())
-            .collect();
-
-        let err = acquire_pool_lock(&locks).unwrap_err();
-        assert!(
-            matches!(err, NetworkError::NoPoolIndexAvailable),
-            "expected NoPoolIndexAvailable, got: {err}"
-        );
     }
 }

--- a/crates/sandbox-fc/src/network/pool/lock.rs
+++ b/crates/sandbox-fc/src/network/pool/lock.rs
@@ -1,0 +1,862 @@
+//! Netns pool index ownership during the private-lock migration.
+//!
+//! A bridge runner acquires the legacy `/var/lock` file first and the matching
+//! owner-only runtime file second. Holding both claims keeps it mutually
+//! exclusive with deployed legacy-only runners and with the future
+//! private-only release. The legacy half must not be removed until #22632's
+//! rollout gate confirms that legacy-only rollback is no longer supported.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+
+use nix::fcntl::{Flock, FlockArg};
+use tracing::{info, warn};
+
+use crate::paths::LockPaths;
+use crate::runtime_dirs::{
+    ensure_private_runtime_dir, ensure_traversable_runtime_dir, validate_private_runtime_dir,
+    validate_traversable_runtime_dir,
+};
+
+use super::super::error::{NetworkError, Result};
+use super::naming::MAX_POOLS;
+
+const MAX_STALE_INODE_RETRIES: usize = 16;
+const PRIVATE_FILE_MODE: u32 = 0o600;
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
+
+/// Observable ownership state for one netns pool index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetnsPoolLockStatus {
+    /// At least one side of the migration bridge is held by a current owner.
+    Active,
+    /// Neither side of the migration bridge is currently held.
+    Idle,
+}
+
+/// Complete ownership claim for one netns pool index.
+///
+/// Dropping this value releases both flocks. The field order is not relied on
+/// for release ordering; acquisition is always legacy first, private second.
+#[derive(Debug)]
+pub(super) struct PoolIndexLock {
+    index: u32,
+    _legacy_lock: Flock<File>,
+    _private_lock: Flock<File>,
+}
+
+impl PoolIndexLock {
+    pub(super) fn index(&self) -> u32 {
+        self.index
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(index: u32) -> Self {
+        let legacy_file = tempfile::tempfile().expect("create legacy test lock file");
+        let private_file = tempfile::tempfile().expect("create private test lock file");
+        let legacy_lock = Flock::lock(legacy_file, FlockArg::LockExclusiveNonblock)
+            .unwrap_or_else(|(_, error)| panic!("lock legacy test file: {error}"));
+        let private_lock = Flock::lock(private_file, FlockArg::LockExclusiveNonblock)
+            .unwrap_or_else(|(_, error)| panic!("lock private test file: {error}"));
+        Self {
+            index,
+            _legacy_lock: legacy_lock,
+            _private_lock: private_lock,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum FileClaim {
+    Acquired(Flock<File>),
+    Busy,
+    Missing,
+}
+
+enum BridgeClaim {
+    Acquired(PoolIndexLock),
+    Busy,
+}
+
+#[derive(Clone, Copy)]
+struct OpenPolicy {
+    create: bool,
+    tighten_mode: bool,
+}
+
+impl OpenPolicy {
+    const CLAIM: Self = Self {
+        create: true,
+        tighten_mode: true,
+    };
+    const PROBE: Self = Self {
+        create: false,
+        tighten_mode: false,
+    };
+}
+
+/// Acquire the first safe, idle pool index and retain both bridge locks.
+pub(super) fn acquire_pool_lock(paths: &LockPaths) -> Result<PoolIndexLock> {
+    prepare_private_lock_dir(paths).map_err(pool_lock_error)?;
+
+    let mut first_error = None;
+    let mut error_count = 0_usize;
+    for index in 0..MAX_POOLS {
+        match try_claim_complete(paths, index) {
+            Ok(BridgeClaim::Acquired(claim)) => {
+                info!(index, "acquired pool index lock bridge");
+                return Ok(claim);
+            }
+            Ok(BridgeClaim::Busy) => {}
+            Err(error) => {
+                warn!(index, %error, "cannot safely claim pool index, skipping index");
+                error_count += 1;
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+
+    match first_error {
+        Some(error) => Err(NetworkError::PoolLock(format!(
+            "{error} ({error_count} unsafe or failed pool indexes)"
+        ))),
+        None => Err(NetworkError::NoPoolIndexAvailable),
+    }
+}
+
+/// Try to claim an index discovered from captured host resources.
+///
+/// Missing lock files are created because captured namespaces or firewall
+/// rules are evidence that the index needs ownership-aware reconciliation.
+pub(super) fn try_claim_reconciliation_lock(
+    paths: &LockPaths,
+    index: u32,
+) -> io::Result<Option<PoolIndexLock>> {
+    match try_claim_complete(paths, index)? {
+        BridgeClaim::Acquired(claim) => Ok(Some(claim)),
+        BridgeClaim::Busy => Ok(None),
+    }
+}
+
+/// Probe whether a production netns pool index has a current owner.
+///
+/// The probe never creates lock files or runtime directories and never changes
+/// file modes. Unsafe files, unstable pathnames, and invalid private runtime
+/// directories are returned as errors so diagnostics cannot misclassify them
+/// as orphaned resources.
+pub fn probe_netns_pool_lock(index: u32) -> io::Result<NetnsPoolLockStatus> {
+    probe_netns_pool_lock_with_paths(&LockPaths::new(), index)
+}
+
+pub(crate) fn probe_netns_pool_lock_with_paths(
+    paths: &LockPaths,
+    index: u32,
+) -> io::Result<NetnsPoolLockStatus> {
+    let legacy_path = paths.netns_pool(index);
+    let legacy_lock = match try_lock_file(&legacy_path, OpenPolicy::PROBE)? {
+        FileClaim::Acquired(lock) => Some(lock),
+        FileClaim::Busy => return Ok(NetnsPoolLockStatus::Active),
+        FileClaim::Missing => None,
+    };
+
+    validate_private_lock_dir_if_present(paths)?;
+    let private_path = paths.private_netns_pool(index);
+    let status = match try_lock_file(&private_path, OpenPolicy::PROBE)? {
+        FileClaim::Busy => NetnsPoolLockStatus::Active,
+        FileClaim::Acquired(_) | FileClaim::Missing => NetnsPoolLockStatus::Idle,
+    };
+    drop(legacy_lock);
+    Ok(status)
+}
+
+fn try_claim_complete(paths: &LockPaths, index: u32) -> io::Result<BridgeClaim> {
+    let legacy_path = paths.netns_pool(index);
+    let legacy_lock = match try_lock_file(&legacy_path, OpenPolicy::CLAIM)? {
+        FileClaim::Acquired(lock) => lock,
+        FileClaim::Busy => return Ok(BridgeClaim::Busy),
+        FileClaim::Missing => {
+            return Err(io::Error::other(format!(
+                "legacy pool lock disappeared while creating {}",
+                legacy_path.display()
+            )));
+        }
+    };
+
+    let private_path = paths.private_netns_pool(index);
+    let private_lock = match try_lock_file(&private_path, OpenPolicy::CLAIM)? {
+        FileClaim::Acquired(lock) => lock,
+        FileClaim::Busy => return Ok(BridgeClaim::Busy),
+        FileClaim::Missing => {
+            return Err(io::Error::other(format!(
+                "private pool lock disappeared while creating {}",
+                private_path.display()
+            )));
+        }
+    };
+
+    Ok(BridgeClaim::Acquired(PoolIndexLock {
+        index,
+        _legacy_lock: legacy_lock,
+        _private_lock: private_lock,
+    }))
+}
+
+fn prepare_private_lock_dir(paths: &LockPaths) -> io::Result<()> {
+    ensure_traversable_runtime_dir(paths.runtime_base())?;
+    ensure_private_runtime_dir(paths.private_base())
+}
+
+fn validate_private_lock_dir_if_present(paths: &LockPaths) -> io::Result<()> {
+    match std::fs::symlink_metadata(paths.runtime_base()) {
+        Ok(_) => validate_traversable_runtime_dir(paths.runtime_base())?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(path_error(
+                "stat runtime lock parent",
+                paths.runtime_base(),
+                error,
+            ));
+        }
+    }
+
+    match std::fs::symlink_metadata(paths.private_base()) {
+        Ok(_) => validate_private_runtime_dir(paths.private_base()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(path_error(
+            "stat private lock directory",
+            paths.private_base(),
+            error,
+        )),
+    }
+}
+
+fn try_lock_file(path: &Path, policy: OpenPolicy) -> io::Result<FileClaim> {
+    try_lock_file_with(path, policy, |_, _| {})
+}
+
+fn try_lock_file_with(
+    path: &Path,
+    policy: OpenPolicy,
+    mut after_flock: impl FnMut(usize, &Path),
+) -> io::Result<FileClaim> {
+    for attempt in 0..MAX_STALE_INODE_RETRIES {
+        let Some(file) = open_lock_file(path, policy)? else {
+            return Ok(FileClaim::Missing);
+        };
+        match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+            Ok(lock) => {
+                after_flock(attempt, path);
+                if lock_inode_is_current(&lock, path)? {
+                    return Ok(FileClaim::Acquired(lock));
+                }
+            }
+            Err((file, error)) if error == nix::errno::Errno::EWOULDBLOCK => {
+                after_flock(attempt, path);
+                if file_inode_is_current(&file, path)? {
+                    return Ok(FileClaim::Busy);
+                }
+            }
+            Err((_file, error)) => {
+                return Err(path_error(
+                    "flock pool lock",
+                    path,
+                    io::Error::from_raw_os_error(error as i32),
+                ));
+            }
+        }
+    }
+
+    Err(io::Error::other(format!(
+        "pool lock path {} changed during {MAX_STALE_INODE_RETRIES} acquisition attempts",
+        path.display()
+    )))
+}
+
+fn open_lock_file(path: &Path, policy: OpenPolicy) -> io::Result<Option<File>> {
+    match open_existing_lock_file(path, policy.tighten_mode) {
+        Ok(file) => Ok(Some(file)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound && !policy.create => Ok(None),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            create_lock_file(path, policy.tighten_mode).map(Some)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn base_open_options() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    options
+}
+
+fn open_existing_lock_file(path: &Path, tighten_mode: bool) -> io::Result<File> {
+    let file = base_open_options()
+        .open(path)
+        .map_err(|error| path_error("open pool lock", path, error))?;
+    validate_lock_file(&file, path, tighten_mode)?;
+    Ok(file)
+}
+
+fn create_lock_file(path: &Path, tighten_mode: bool) -> io::Result<File> {
+    let mut options = base_open_options();
+    let file = options
+        .create(true)
+        .truncate(false)
+        .mode(PRIVATE_FILE_MODE)
+        .open(path)
+        .map_err(|error| path_error("create pool lock", path, error))?;
+    validate_lock_file(&file, path, tighten_mode)?;
+    Ok(file)
+}
+
+fn validate_lock_file(file: &File, path: &Path, tighten_mode: bool) -> io::Result<()> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| path_error("stat opened pool lock", path, error))?;
+    if !metadata.is_file() {
+        return Err(permission_denied(format!(
+            "{} is not a regular pool lock file",
+            path.display()
+        )));
+    }
+
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    if !lock_file_owner_is_trusted(metadata.uid(), expected_uid) {
+        return Err(permission_denied(format!(
+            "{} is owned by uid {}, but current euid is {expected_uid}",
+            path.display(),
+            metadata.uid()
+        )));
+    }
+
+    if metadata.nlink() != 1 {
+        return Err(permission_denied(format!(
+            "{} has {} hard links",
+            path.display(),
+            metadata.nlink()
+        )));
+    }
+
+    let mode = metadata.mode() & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+        return Err(permission_denied(format!(
+            "{} is group/other writable",
+            path.display()
+        )));
+    }
+    if tighten_mode && mode != PRIVATE_FILE_MODE {
+        chmod_lock_file(file, path)?;
+    }
+    Ok(())
+}
+
+fn lock_file_owner_is_trusted(owner_uid: u32, effective_uid: u32) -> bool {
+    owner_uid == effective_uid
+}
+
+fn chmod_lock_file(file: &File, path: &Path) -> io::Result<()> {
+    // SAFETY: `fchmod` operates on this live descriptor and does not affect
+    // Rust memory or aliasing.
+    let result = unsafe { libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(path_error(
+            "chmod pool lock",
+            path,
+            io::Error::last_os_error(),
+        ))
+    }
+}
+
+fn metadata_inode_is_current(metadata: std::fs::Metadata, path: &Path) -> io::Result<bool> {
+    let path_metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(path_error("stat pool lock path", path, error)),
+    };
+    Ok(metadata.dev() == path_metadata.dev() && metadata.ino() == path_metadata.ino())
+}
+
+fn lock_inode_is_current(lock: &Flock<File>, path: &Path) -> io::Result<bool> {
+    metadata_inode_is_current(
+        lock.metadata()
+            .map_err(|error| path_error("stat flocked pool lock", path, error))?,
+        path,
+    )
+}
+
+fn file_inode_is_current(file: &File, path: &Path) -> io::Result<bool> {
+    metadata_inode_is_current(
+        file.metadata()
+            .map_err(|error| path_error("stat contended pool lock", path, error))?,
+        path,
+    )
+}
+
+fn permission_denied(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, message)
+}
+
+fn path_error(action: &str, path: &Path, error: io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!("{action} {}: {error}", path.display()),
+    )
+}
+
+fn pool_lock_error(error: io::Error) -> NetworkError {
+    NetworkError::PoolLock(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::Permissions;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    use nix::sys::stat::Mode;
+    use nix::unistd::mkfifo;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    struct Fixture {
+        _dir: TempDir,
+        paths: LockPaths,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let fixture = Self::unprepared();
+            prepare_private_lock_dir(&fixture.paths).unwrap();
+            fixture
+        }
+
+        fn unprepared() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let legacy = dir.path().join("legacy");
+            let runtime = dir.path().join("runtime");
+            std::fs::create_dir(&legacy).unwrap();
+            let paths = LockPaths::with_dirs(legacy, runtime);
+            Self { _dir: dir, paths }
+        }
+
+        fn create_lock(&self, path: &Path) -> File {
+            let file = base_open_options()
+                .create(true)
+                .truncate(false)
+                .mode(PRIVATE_FILE_MODE)
+                .open(path)
+                .unwrap();
+            std::fs::set_permissions(path, Permissions::from_mode(PRIVATE_FILE_MODE)).unwrap();
+            file
+        }
+    }
+
+    fn flock(file: File) -> Flock<File> {
+        Flock::lock(file, FlockArg::LockExclusiveNonblock)
+            .unwrap_or_else(|(_, error)| panic!("lock test file: {error}"))
+    }
+
+    #[test]
+    fn acquisition_creates_private_files_and_reuses_released_index() {
+        let fixture = Fixture::new();
+        let first = acquire_pool_lock(&fixture.paths).unwrap();
+        assert_eq!(first.index(), 0);
+        assert_eq!(
+            std::fs::metadata(fixture.paths.netns_pool(0))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            PRIVATE_FILE_MODE
+        );
+        assert_eq!(
+            std::fs::metadata(fixture.paths.private_netns_pool(0))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            PRIVATE_FILE_MODE
+        );
+        assert_eq!(
+            std::fs::metadata(fixture.paths.runtime_base())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o711
+        );
+        assert_eq!(
+            std::fs::metadata(fixture.paths.private_base())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+
+        let second = acquire_pool_lock(&fixture.paths).unwrap();
+        assert_eq!(second.index(), 1);
+        drop(first);
+        assert_eq!(acquire_pool_lock(&fixture.paths).unwrap().index(), 0);
+    }
+
+    #[test]
+    fn private_contention_releases_partial_legacy_claim() {
+        let fixture = Fixture::new();
+        let private_path = fixture.paths.private_netns_pool(0);
+        let _private_holder = flock(fixture.create_lock(&private_path));
+
+        assert!(matches!(
+            try_claim_complete(&fixture.paths, 0).unwrap(),
+            BridgeClaim::Busy
+        ));
+        assert!(matches!(
+            try_lock_file(&fixture.paths.netns_pool(0), OpenPolicy::CLAIM).unwrap(),
+            FileClaim::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn legacy_contention_does_not_create_private_counterpart() {
+        let fixture = Fixture::new();
+        let legacy_path = fixture.paths.netns_pool(0);
+        let _legacy_holder = flock(fixture.create_lock(&legacy_path));
+
+        assert!(matches!(
+            try_claim_complete(&fixture.paths, 0).unwrap(),
+            BridgeClaim::Busy
+        ));
+        assert!(!fixture.paths.private_netns_pool(0).exists());
+    }
+
+    #[test]
+    fn compatible_legacy_mode_is_tightened_even_while_contended() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        let file = fixture.create_lock(&path);
+        std::fs::set_permissions(&path, Permissions::from_mode(0o644)).unwrap();
+        let _holder = flock(file);
+
+        assert!(matches!(
+            try_claim_complete(&fixture.paths, 0).unwrap(),
+            BridgeClaim::Busy
+        ));
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            PRIVATE_FILE_MODE
+        );
+    }
+
+    #[test]
+    fn captured_candidate_creates_both_missing_locks() {
+        let fixture = Fixture::new();
+        let claim = try_claim_reconciliation_lock(&fixture.paths, 7)
+            .unwrap()
+            .expect("candidate should be claimable");
+        assert_eq!(claim.index(), 7);
+        assert!(fixture.paths.netns_pool(7).is_file());
+        assert!(fixture.paths.private_netns_pool(7).is_file());
+    }
+
+    #[test]
+    fn captured_candidate_creates_a_missing_private_counterpart() {
+        let fixture = Fixture::new();
+        fixture.create_lock(&fixture.paths.netns_pool(8));
+
+        let claim = try_claim_reconciliation_lock(&fixture.paths, 8)
+            .unwrap()
+            .expect("candidate should be claimable");
+        assert_eq!(claim.index(), 8);
+        assert!(fixture.paths.private_netns_pool(8).is_file());
+    }
+
+    #[test]
+    fn only_one_concurrent_candidate_claim_wins() {
+        let fixture = Fixture::new();
+        let paths = Arc::new(fixture.paths);
+        let start = Arc::new(Barrier::new(3));
+        let finish = Arc::new(Barrier::new(3));
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                let paths = Arc::clone(&paths);
+                let start = Arc::clone(&start);
+                let finish = Arc::clone(&finish);
+                thread::spawn(move || {
+                    start.wait();
+                    let claim = try_claim_reconciliation_lock(&paths, 3).unwrap();
+                    let acquired = claim.is_some();
+                    finish.wait();
+                    acquired
+                })
+            })
+            .collect();
+        start.wait();
+        finish.wait();
+        let acquired = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .filter(|acquired| *acquired)
+            .count();
+        assert_eq!(acquired, 1);
+    }
+
+    #[test]
+    fn rejects_symlink_fifo_directory_hard_link_and_unsafe_mode() {
+        let fixture = Fixture::new();
+
+        let target = fixture.paths.netns_pool(63);
+        fixture.create_lock(&target);
+        symlink(&target, fixture.paths.netns_pool(0)).unwrap();
+        assert!(try_claim_complete(&fixture.paths, 0).is_err());
+
+        mkfifo(&fixture.paths.netns_pool(1), Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+        assert!(try_claim_complete(&fixture.paths, 1).is_err());
+
+        std::fs::create_dir(fixture.paths.netns_pool(2)).unwrap();
+        assert!(try_claim_complete(&fixture.paths, 2).is_err());
+
+        let hard_link_source = fixture.paths.netns_pool(61);
+        fixture.create_lock(&hard_link_source);
+        std::fs::hard_link(&hard_link_source, fixture.paths.netns_pool(3)).unwrap();
+        assert!(try_claim_complete(&fixture.paths, 3).is_err());
+
+        let unsafe_mode = fixture.paths.netns_pool(4);
+        fixture.create_lock(&unsafe_mode);
+        std::fs::set_permissions(&unsafe_mode, Permissions::from_mode(0o620)).unwrap();
+        assert!(try_claim_complete(&fixture.paths, 4).is_err());
+    }
+
+    #[test]
+    fn retries_replaced_path_before_accepting_claim() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        fixture.create_lock(&path);
+        let mut replaced = false;
+
+        let claim = try_lock_file_with(&path, OpenPolicy::CLAIM, |_, path| {
+            if !replaced {
+                std::fs::remove_file(path).unwrap();
+                let replacement = base_open_options()
+                    .create(true)
+                    .truncate(false)
+                    .mode(PRIVATE_FILE_MODE)
+                    .open(path)
+                    .unwrap();
+                drop(replacement);
+                replaced = true;
+            }
+        })
+        .unwrap();
+        assert!(matches!(claim, FileClaim::Acquired(_)));
+    }
+
+    #[test]
+    fn retries_replaced_contended_path_instead_of_reporting_busy() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        let _holder = flock(fixture.create_lock(&path));
+        let mut replaced = false;
+
+        let claim = try_lock_file_with(&path, OpenPolicy::CLAIM, |_, path| {
+            if !replaced {
+                std::fs::remove_file(path).unwrap();
+                let replacement = base_open_options()
+                    .create(true)
+                    .truncate(false)
+                    .mode(PRIVATE_FILE_MODE)
+                    .open(path)
+                    .unwrap();
+                drop(replacement);
+                replaced = true;
+            }
+        })
+        .unwrap();
+        assert!(matches!(claim, FileClaim::Acquired(_)));
+    }
+
+    #[test]
+    fn replacement_retries_are_bounded() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        fixture.create_lock(&path);
+        let mut replacements = 0;
+
+        let error = try_lock_file_with(&path, OpenPolicy::CLAIM, |_, path| {
+            std::fs::remove_file(path).unwrap();
+            let replacement = base_open_options()
+                .create(true)
+                .truncate(false)
+                .mode(PRIVATE_FILE_MODE)
+                .open(path)
+                .unwrap();
+            drop(replacement);
+            replacements += 1;
+        })
+        .unwrap_err();
+        assert_eq!(replacements, MAX_STALE_INODE_RETRIES);
+        assert!(error.to_string().contains("changed during"));
+    }
+
+    #[test]
+    fn allocation_skips_unsafe_index_but_preserves_terminal_error() {
+        let fixture = Fixture::new();
+        let target = fixture.paths.netns_pool(63);
+        fixture.create_lock(&target);
+        symlink(&target, fixture.paths.netns_pool(0)).unwrap();
+
+        let mut claims = Vec::new();
+        for expected in 1..MAX_POOLS {
+            let claim = acquire_pool_lock(&fixture.paths).unwrap();
+            assert_eq!(claim.index(), expected);
+            claims.push(claim);
+        }
+        assert!(matches!(
+            acquire_pool_lock(&fixture.paths),
+            Err(NetworkError::PoolLock(_))
+        ));
+    }
+
+    #[test]
+    fn ordinary_contention_returns_pool_exhaustion() {
+        let fixture = Fixture::new();
+        let claims: Vec<_> = (0..MAX_POOLS)
+            .map(|_| acquire_pool_lock(&fixture.paths).unwrap())
+            .collect();
+        assert_eq!(claims.len(), MAX_POOLS as usize);
+        assert!(matches!(
+            acquire_pool_lock(&fixture.paths),
+            Err(NetworkError::NoPoolIndexAvailable)
+        ));
+    }
+
+    #[test]
+    fn probe_distinguishes_idle_legacy_and_private_owners() {
+        let fixture = Fixture::new();
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Idle
+        );
+        assert!(!fixture.paths.netns_pool(0).exists());
+        assert!(!fixture.paths.private_netns_pool(0).exists());
+
+        let legacy_path = fixture.paths.netns_pool(0);
+        let legacy_holder = flock(fixture.create_lock(&legacy_path));
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Active
+        );
+        drop(legacy_holder);
+        std::fs::remove_file(legacy_path).unwrap();
+
+        let private_path = fixture.paths.private_netns_pool(0);
+        let _private_holder = flock(fixture.create_lock(&private_path));
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Active
+        );
+    }
+
+    #[test]
+    fn idle_probe_does_not_create_runtime_namespace() {
+        let fixture = Fixture::unprepared();
+
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Idle
+        );
+        assert!(!fixture.paths.runtime_base().exists());
+        assert!(!fixture.paths.private_base().exists());
+    }
+
+    #[test]
+    fn probe_reports_unsafe_file_without_changing_it() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        fixture.create_lock(&path);
+        std::fs::set_permissions(&path, Permissions::from_mode(0o622)).unwrap();
+
+        assert!(probe_netns_pool_lock_with_paths(&fixture.paths, 0).is_err());
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o622
+        );
+    }
+
+    #[test]
+    fn probe_does_not_tighten_compatible_legacy_mode() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.netns_pool(0);
+        fixture.create_lock(&path);
+        std::fs::set_permissions(&path, Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Idle
+        );
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_private_lock_file() {
+        let fixture = Fixture::new();
+        let path = fixture.paths.private_netns_pool(0);
+        fixture.create_lock(&path);
+        std::fs::set_permissions(&path, Permissions::from_mode(0o602)).unwrap();
+
+        assert!(try_claim_complete(&fixture.paths, 0).is_err());
+        assert!(matches!(
+            try_lock_file(&fixture.paths.netns_pool(0), OpenPolicy::CLAIM).unwrap(),
+            FileClaim::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn probe_rejects_invalid_private_directory_without_repairing_it() {
+        let fixture = Fixture::new();
+        std::fs::set_permissions(fixture.paths.private_base(), Permissions::from_mode(0o755))
+            .unwrap();
+
+        assert!(probe_netns_pool_lock_with_paths(&fixture.paths, 0).is_err());
+        assert_eq!(
+            std::fs::metadata(fixture.paths.private_base())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn legacy_owner_is_active_without_requiring_private_directory() {
+        let fixture = Fixture::new();
+        let legacy_path = fixture.paths.netns_pool(0);
+        let _legacy_holder = flock(fixture.create_lock(&legacy_path));
+        std::fs::set_permissions(fixture.paths.private_base(), Permissions::from_mode(0o755))
+            .unwrap();
+
+        assert_eq!(
+            probe_netns_pool_lock_with_paths(&fixture.paths, 0).unwrap(),
+            NetnsPoolLockStatus::Active
+        );
+    }
+
+    #[test]
+    fn owner_policy_rejects_a_different_uid() {
+        assert!(lock_file_owner_is_trusted(1000, 1000));
+        assert!(!lock_file_owner_is_trusted(1001, 1000));
+    }
+}

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashSet, VecDeque};
-use std::fs::File;
 #[cfg(test)]
 use std::future::Future;
 use std::sync::Arc;
@@ -7,9 +6,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::future::join_all;
-use nix::fcntl::Flock;
-#[cfg(test)]
-use nix::fcntl::FlockArg;
 use tokio::sync::watch;
 use tracing::{error, info, warn};
 
@@ -29,10 +25,10 @@ use super::completion::{
 #[cfg(test)]
 use super::host::ConntrackFlushOutcome;
 use super::host::{
-    NamespaceDeleteOutcome, NetnsLifecycleOps, acquire_pool_lock, create_single_namespace,
-    enable_host_ip_forwarding, get_default_interface, reconcile_orphan_namespaces,
-    setup_dns_input_filter,
+    NamespaceDeleteOutcome, NetnsLifecycleOps, create_single_namespace, enable_host_ip_forwarding,
+    get_default_interface, reconcile_orphan_namespaces, setup_dns_input_filter,
 };
+use super::lock::{PoolIndexLock, acquire_pool_lock};
 use super::naming::{MAX_NAMESPACES, format_hex_index, make_host_device_dnsmasq_pattern};
 use super::types::{
     CheckedNetnsPoolConfig, NetnsInfo, NetnsLease, NetnsPoolConfig, NetnsReleaseOutcome,
@@ -152,17 +148,13 @@ struct NetnsPoolState {
     #[cfg(test)]
     acquire_waiting_notify: Option<Arc<tokio::sync::Notify>>,
     /// Held for the lifetime of the pool to reserve the pool index.
-    _lock: Flock<File>,
+    _lock: PoolIndexLock,
 }
 
 impl NetnsPoolState {
     #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
-        let file = tempfile::tempfile().expect("create test netns pool lock file");
-        let lock = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
-            Ok(lock) => lock,
-            Err((_, errno)) => panic!("lock test netns pool file: {errno}"),
-        };
+        let lock = PoolIndexLock::for_test(0);
         Self {
             active: false,
             plain_queue: VecDeque::new(),
@@ -206,7 +198,8 @@ impl NetnsPoolState {
     async fn create_checked(config: CheckedNetnsPoolConfig) -> Result<Self> {
         let config = config.inner;
         let lock_paths = LockPaths::new();
-        let (index, lock) = acquire_pool_lock(&lock_paths)?;
+        let lock = acquire_pool_lock(&lock_paths)?;
+        let index = lock.index();
 
         info!(index, buffer = BUFFER_SIZE, "initializing namespace pool");
 
@@ -217,7 +210,7 @@ impl NetnsPoolState {
         // This is the correctness guarantee for kernel-side cleanup —
         // `NetnsPool::cleanup` is best-effort and cannot survive SIGKILL,
         // panic, OOM, or aborted in-flight creation tasks (issue #10625).
-        reconcile_orphan_namespaces(&lock_paths, index, &lock).await;
+        reconcile_orphan_namespaces(&lock_paths, &lock).await;
 
         let default_iface = get_default_interface().await?;
         let dns_input_filter_comment = match config.dns_port {

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -51,11 +51,16 @@ impl RuntimePaths {
     }
 }
 
-/// Lock file paths under `/var/lock` for flock-based coordination.
+/// Lock file paths for flock-based host coordination.
 ///
-/// `/var/lock` is the FHS-standard location for lock files (mode 1777).
+/// Netns pool ownership temporarily bridges the legacy shared `/var/lock`
+/// namespace and the owner-only `/run/vm0/netns-locks` namespace. Both paths
+/// are required until every rollback-eligible runner understands the private
+/// namespace.
 pub struct LockPaths {
-    base_dir: PathBuf,
+    legacy_base_dir: PathBuf,
+    runtime_base_dir: PathBuf,
+    private_base_dir: PathBuf,
 }
 
 impl Default for LockPaths {
@@ -65,24 +70,45 @@ impl Default for LockPaths {
 }
 
 impl LockPaths {
-    /// Creates lock path helpers rooted at `/var/lock`.
+    /// Creates legacy and private netns lock path helpers.
     ///
-    /// This only records the lock root; it does not create, validate, or
-    /// canonicalize filesystem entries.
+    /// This only records the `/var/lock` and `/run/vm0/netns-locks` roots; it
+    /// does not create, validate, or canonicalize filesystem entries.
     pub fn new() -> Self {
+        let runtime_base_dir = PathBuf::from(RUNTIME_DIR);
         Self {
-            base_dir: PathBuf::from("/var/lock"),
+            legacy_base_dir: PathBuf::from("/var/lock"),
+            private_base_dir: runtime_base_dir.join("netns-locks"),
+            runtime_base_dir,
         }
     }
 
     #[cfg(test)]
-    pub fn with_dir(base_dir: PathBuf) -> Self {
-        Self { base_dir }
+    pub(crate) fn with_dirs(legacy_base_dir: PathBuf, runtime_base_dir: PathBuf) -> Self {
+        Self {
+            legacy_base_dir,
+            private_base_dir: runtime_base_dir.join("netns-locks"),
+            runtime_base_dir,
+        }
     }
 
-    /// Lock file for netns pool index allocation.
+    /// Legacy lock file for netns pool index allocation.
     pub fn netns_pool(&self, index: u32) -> PathBuf {
-        self.base_dir.join(format!("vm0-netns-pool-{index}.lock"))
+        self.legacy_base_dir
+            .join(format!("vm0-netns-pool-{index}.lock"))
+    }
+
+    pub(crate) fn private_netns_pool(&self, index: u32) -> PathBuf {
+        self.private_base_dir
+            .join(format!("vm0-netns-pool-{index}.lock"))
+    }
+
+    pub(crate) fn runtime_base(&self) -> &Path {
+        &self.runtime_base_dir
+    }
+
+    pub(crate) fn private_base(&self) -> &Path {
+        &self.private_base_dir
     }
 }
 

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -35,6 +35,14 @@ pub(crate) fn ensure_traversable_runtime_dir(path: &Path) -> io::Result<()> {
     ensure_runtime_dir_with_mode(path, TRAVERSABLE_RUNTIME_DIR_MODE)
 }
 
+pub(crate) fn validate_private_runtime_dir(path: &Path) -> io::Result<()> {
+    validate_runtime_dir(path, PRIVATE_RUNTIME_DIR_MODE, false)
+}
+
+pub(crate) fn validate_traversable_runtime_dir(path: &Path) -> io::Result<()> {
+    validate_runtime_dir(path, TRAVERSABLE_RUNTIME_DIR_MODE, false)
+}
+
 pub(crate) fn prepare_runtime_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
     ensure_traversable_runtime_dir(sock_paths.dir())?;
     ensure_private_runtime_dir(&sock_paths.vsock_dir())
@@ -116,7 +124,7 @@ fn invalid_vsock_dir_shape(sock_base: &Path, vsock_bind_dir: &Path) -> io::Error
 
 fn ensure_runtime_dir_with_mode(path: &Path, mode: u32) -> io::Result<()> {
     create_runtime_dir_if_missing(path, mode)?;
-    validate_runtime_dir(path, mode)
+    validate_runtime_dir(path, mode, true)
 }
 
 fn create_runtime_dir_if_missing(path: &Path, mode: u32) -> io::Result<()> {
@@ -132,7 +140,7 @@ fn create_runtime_dir_if_missing(path: &Path, mode: u32) -> io::Result<()> {
     }
 }
 
-fn validate_runtime_dir(path: &Path, expected_mode: u32) -> io::Result<()> {
+fn validate_runtime_dir(path: &Path, expected_mode: u32, normalize_mode: bool) -> io::Result<()> {
     let metadata = std::fs::symlink_metadata(path).map_err(|e| {
         io::Error::new(
             e.kind(),
@@ -163,7 +171,7 @@ fn validate_runtime_dir(path: &Path, expected_mode: u32) -> io::Result<()> {
     }
 
     let mode = metadata.permissions().mode() & 0o7777;
-    if mode != expected_mode {
+    if mode != expected_mode && normalize_mode {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(expected_mode)).map_err(
             |e| {
                 io::Error::new(
@@ -176,6 +184,14 @@ fn validate_runtime_dir(path: &Path, expected_mode: u32) -> io::Result<()> {
                 )
             },
         )?;
+    } else if mode != expected_mode {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "runtime dir {} has mode {mode:04o}, expected {expected_mode:04o}",
+                path.display()
+            ),
+        ));
     }
 
     eaccess(path, AccessFlags::W_OK | AccessFlags::X_OK).map_err(|e| {

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -196,6 +196,29 @@ the canonical shape immediately while the guest reader temporarily accepts both
 representations. Remove the legacy readers and the capability only after the
 canonical API output has been stable across the fully upgraded Runner fleet.
 
+### Netns pool lock migration
+
+Netns pool indexes temporarily use a two-file ownership bridge. Bridge runners
+acquire the legacy `/var/lock/vm0-netns-pool-<index>.lock` first, then acquire
+the matching owner-only
+`/run/vm0/netns-locks/vm0-netns-pool-<index>.lock`, and retain both flocks for
+the pool lifetime. Allocation and orphan reconciliation never proceed with a
+partial claim.
+
+The bridge supports these deployment pairs:
+
+- legacy-only and bridge runners coordinate through the legacy lock;
+- bridge runners coordinate through both locks; and
+- bridge and private-only runners coordinate through the private lock after the
+  cleanup gate is satisfied.
+
+Legacy-only and private-only runners have no common authority and must never be
+active together. Do not remove the legacy side or permit rollback to a
+legacy-only release until the bridge is healthy in production, no active runner
+is legacy-only, and every version retained by `runner gc --keep-latest 6` plus
+every manually supported rollback target contains the bridge. The private-only
+cleanup is tracked by #22632.
+
 ### Firewall hostname policy
 
 The backend is the single owner of firewall configuration hostname policy.


### PR DESCRIPTION
## Summary

- add a hardened legacy-first dual-lock guard for netns pool ownership, retaining matching `/var/lock` and owner-only `/run/vm0/netns-locks` flocks for the pool lifetime
- require the complete bridge for allocation and captured-resource reconciliation, with stable-inode checks, private modes, bounded retries, partial-claim release, and separate contention versus unsafe-state diagnostics
- move `runner doctor` to the shared sandbox-fc ownership probe and report unverifiable lock state conservatively
- extend the privileged cancellation behavior test for legacy-only overlap and complete bridge ownership, and document the rollout/rollback gate

## Compatibility

This is the bridge release from parent #22626. It preserves coordination with deployed legacy-only runners and establishes coordination with the later private-only release. It intentionally does not remove legacy acquisition or add a cleanup switch; private-only cleanup remains gated in #22632.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc --all-features` (770 passed)
- `cargo test -p runner --all-targets --all-features` (2797 passed, 13 ignored)
- `bash -n .github/scripts/runner-behavior-cancel.sh`
- `shellcheck .github/scripts/runner-behavior-cancel.sh`

Closes #22631

Parent: #22626
