### PR TITLE
fix(chat): structure automatic user-message sends

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/action-callback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/action-callback.ts
@@ -1,8 +1,11 @@
 import { command, computed } from "ccstate";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { searchParams$ } from "../route.ts";
+import { textToMessageDocument } from "../zero-page/user-message-document-codec.ts";
 
 export interface ChatActionCallback {
   readonly callbackPrompt: string | null;
@@ -35,6 +38,15 @@ export const runChatActionCallback$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(chatMessagesContract);
+    const features = get(featureSwitch$);
+    const structuredPromptEnabled =
+      features[FeatureSwitchKey.StructuredPrompt] ?? false;
+    const structuredPrompt = structuredPromptEnabled
+      ? textToMessageDocument(args.callbackPrompt)
+      : undefined;
+    if (structuredPromptEnabled && !structuredPrompt) {
+      throw new Error("Failed to serialize structured callback prompt");
+    }
     await accept(
       client.send({
         body: {
@@ -42,6 +54,7 @@ export const runChatActionCallback$ = command(
           threadId: args.threadId,
           prompt: args.callbackPrompt,
           hasTextContent: true,
+          ...(structuredPrompt ? { structuredPrompt } : {}),
           clientMessageId: crypto.randomUUID(),
           chatThreadSortEventId: crypto.randomUUID(),
         },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -132,6 +132,7 @@ import type {
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
 import { createMailDraftCardSignalsRegistry } from "./mail-draft.ts";
 import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
+import { textToMessageDocument } from "../zero-page/user-message-document-codec.ts";
 
 type ChatThreadRemote = ReturnType<typeof createRemoteChatThreadDataSource>;
 
@@ -3073,22 +3074,26 @@ function prepareTextOnlyUserMessage(
 
 function structuredPromptForSend({
   enabled,
+  prompt,
   editorDocument,
   generationTemplate,
   attachments,
 }: {
   readonly enabled: boolean;
+  readonly prompt: string;
   readonly editorDocument: SendMessageOptions["editorDocument"];
   readonly generationTemplate: GenerationTemplateRequest | undefined;
   readonly attachments: PagedChatMessage["attachFiles"];
 }): UserMessageDocument | undefined {
-  if (!enabled || !editorDocument) {
+  if (!enabled) {
     return undefined;
   }
-  const structuredPrompt = editorDocument.toMessageDocument({
-    generationTemplate,
-    attachments,
-  });
+  const structuredPrompt = editorDocument
+    ? editorDocument.toMessageDocument({
+        generationTemplate,
+        attachments,
+      })
+    : textToMessageDocument(prompt);
   if (!structuredPrompt) {
     throw new Error("Failed to serialize structured prompt");
   }
@@ -3102,6 +3107,7 @@ function queueStructured(
 ): UserMessageDocument | undefined {
   return structuredPromptForSend({
     enabled: features[FeatureSwitchKey.StructuredPrompt] ?? false,
+    prompt: result.prompt,
     editorDocument: options.editorDocument,
     generationTemplate: options.generationTemplate,
     attachments: result.attachments,
@@ -3379,6 +3385,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
       const features = get(featureSwitch$);
       const structuredPrompt = structuredPromptForSend({
         enabled: features[FeatureSwitchKey.StructuredPrompt] ?? false,
+        prompt: result.prompt,
         editorDocument: request.options?.editorDocument,
         generationTemplate,
         attachments: result.attachments,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -51,7 +51,10 @@ import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing
 import { chatPageModelSelection$ } from "../zero-page/zero-chat-page.ts";
 import { selectedModelAvailable$ } from "../zero-page/model-first-personal-oauth.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import type { EditorDocumentSnapshot } from "../zero-page/user-message-document-codec.ts";
+import {
+  textToMessageDocument,
+  type EditorDocumentSnapshot,
+} from "../zero-page/user-message-document-codec.ts";
 
 export type NewChatThreadPane = "main" | "sidebar";
 
@@ -67,6 +70,7 @@ interface SendNewThreadMessageRequest {
   agentId: string;
   prompt: string;
   generationTemplate: GenerationTemplateRequest | undefined;
+  generationTemplateTitleSnapshot?: string;
   editorDocument?: EditorDocumentSnapshot;
   computerUseHostId?: string | null;
   routeSearchParams?: URLSearchParams;
@@ -82,6 +86,42 @@ interface PreparedNewThreadPayload {
   attachFiles: AttachFile[] | undefined;
   attachments: PagedChatMessage["attachFiles"];
   hasTextContent: boolean;
+}
+
+function structuredPromptForNewThread(
+  enabled: boolean,
+  request: SendNewThreadMessageRequest,
+  prepared: PreparedNewThreadPayload,
+): UserMessageDocument | undefined {
+  if (!enabled) {
+    return undefined;
+  }
+  const generationTemplate = request.generationTemplate;
+  if (
+    generationTemplate &&
+    !request.editorDocument &&
+    !request.generationTemplateTitleSnapshot
+  ) {
+    throw new Error("Structured template title snapshot is required");
+  }
+  const structuredPrompt = request.editorDocument
+    ? request.editorDocument.toMessageDocument({
+        generationTemplate,
+        attachments: prepared.attachments,
+      })
+    : textToMessageDocument(
+        prepared.prompt,
+        generationTemplate && request.generationTemplateTitleSnapshot
+          ? {
+              titleSnapshot: request.generationTemplateTitleSnapshot,
+              template: generationTemplate,
+            }
+          : undefined,
+      );
+  if (!structuredPrompt) {
+    throw new Error("Failed to serialize structured prompt");
+  }
+  return structuredPrompt;
 }
 
 function createNewThreadOptimisticMessageEntry({
@@ -465,20 +505,11 @@ const sendNewThreadMessage$ = command(
     const features = get(featureSwitch$);
     const structuredPromptEnabled =
       features[FeatureSwitchKey.StructuredPrompt] ?? false;
-    const structuredPrompt =
-      structuredPromptEnabled && request.editorDocument
-        ? request.editorDocument.toMessageDocument({
-            generationTemplate,
-            attachments: prepared.attachments,
-          })
-        : undefined;
-    if (
-      structuredPromptEnabled &&
-      request.editorDocument &&
-      !structuredPrompt
-    ) {
-      throw new Error("Failed to serialize structured prompt");
-    }
+    const structuredPrompt = structuredPromptForNewThread(
+      structuredPromptEnabled,
+      request,
+      prepared,
+    );
     const threadId = crypto.randomUUID();
     const clientMessageId = crypto.randomUUID();
     const chatThreadEventId = crypto.randomUUID();

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -23,6 +23,11 @@ import {
 } from "../zero-page/zero-chat-page.ts";
 import { withCleanup } from "../utils.ts";
 
+interface ResolvedGenerationTemplate {
+  readonly template: GenerationTemplateRequest;
+  readonly titleSnapshot: string;
+}
+
 function templateIdFromSearchParam(
   template: string | null,
 ): string | undefined {
@@ -35,35 +40,41 @@ function templateIdFromSearchParam(
 
 function websiteGenerationTemplateFromId(
   id: string,
-): GenerationTemplateRequest | undefined {
+): ResolvedGenerationTemplate | undefined {
   const websiteTemplate = findWebsiteTemplateItem(id);
   if (!websiteTemplate) {
     return undefined;
   }
   return {
-    type: "website",
-    selection: {
-      websiteTemplateId: websiteTemplate.id,
+    titleSnapshot: websiteTemplate.title,
+    template: {
+      type: "website",
+      selection: {
+        websiteTemplateId: websiteTemplate.id,
+      },
     },
   };
 }
 
 function videoGenerationTemplateFromId(
   id: string,
-): GenerationTemplateRequest | undefined {
+): ResolvedGenerationTemplate | undefined {
   const videoTemplate = findVideoTemplateItem(id);
   if (!videoTemplate) {
     return undefined;
   }
   return {
-    type: "video",
-    selection: { stylePresetId: videoTemplate.id },
+    titleSnapshot: videoTemplate.title,
+    template: {
+      type: "video",
+      selection: { stylePresetId: videoTemplate.id },
+    },
   };
 }
 
 function presentationGenerationTemplateFromId(
   id: string,
-): GenerationTemplateRequest | undefined {
+): ResolvedGenerationTemplate | undefined {
   const presentationTemplateId = id.replace(/^presentation-template:/, "");
   const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS.find(
     (item) => {
@@ -78,19 +89,22 @@ function presentationGenerationTemplateFromId(
     return undefined;
   }
   return {
-    type: "presentation",
-    selection: {
-      templateId: presentationTemplate.templateId,
-      colorSystemId:
-        presentationTemplate.colorSystemId ?? "color-system:warm-sand",
-      previewUrl: presentationTemplate.embedUrl,
+    titleSnapshot: presentationTemplate.title,
+    template: {
+      type: "presentation",
+      selection: {
+        templateId: presentationTemplate.templateId,
+        colorSystemId:
+          presentationTemplate.colorSystemId ?? "color-system:warm-sand",
+        previewUrl: presentationTemplate.embedUrl,
+      },
     },
   };
 }
 
 function illustrationGenerationTemplateFromId(
   id: string,
-): GenerationTemplateRequest | undefined {
+): ResolvedGenerationTemplate | undefined {
   const illustrationTemplateId = id
     .replace(/^illustration-template:/, "")
     .replace(/^image-template:/, "");
@@ -105,9 +119,12 @@ function illustrationGenerationTemplateFromId(
     return undefined;
   }
   return {
-    type: "illustration",
-    selection: {
-      illustrationStyleId: illustrationTemplate.illustrationStyleId,
+    titleSnapshot: illustrationTemplate.title,
+    template: {
+      type: "illustration",
+      selection: {
+        illustrationStyleId: illustrationTemplate.illustrationStyleId,
+      },
     },
   };
 }
@@ -121,15 +138,15 @@ const generationTemplateParsers = [
 
 function generationTemplateFromSearchParam(
   template: string | null,
-): GenerationTemplateRequest | undefined {
+): ResolvedGenerationTemplate | undefined {
   const id = templateIdFromSearchParam(template);
   if (!id) {
     return undefined;
   }
   for (const parse of generationTemplateParsers) {
-    const generationTemplate = parse(id);
-    if (generationTemplate) {
-      return generationTemplate;
+    const resolved = parse(id);
+    if (resolved) {
+      return resolved;
     }
   }
   return undefined;
@@ -151,7 +168,8 @@ export const setupPromptPage$ = command(
     const prompt = params.get("prompt")?.trim();
     const requestedModel = params.get("model")?.trim();
     const template = params.get("template");
-    const generationTemplate = generationTemplateFromSearchParam(template);
+    const resolvedGenerationTemplate =
+      generationTemplateFromSearchParam(template);
     if (!prompt) {
       set(detachedNavigateTo$, "/", { replace: true });
       return;
@@ -186,7 +204,9 @@ export const setupPromptPage$ = command(
         {
           agentId,
           prompt,
-          generationTemplate,
+          generationTemplate: resolvedGenerationTemplate?.template,
+          generationTemplateTitleSnapshot:
+            resolvedGenerationTemplate?.titleSnapshot,
           computerUseHostId: null,
           routeSearchParams: cleaned,
         },

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -25,6 +25,11 @@ export interface EditorDocumentSnapshot {
   ) => UserMessageDocument | null;
 }
 
+export interface TextMessageTemplateSnapshot {
+  readonly titleSnapshot: string;
+  readonly template: GenerationTemplateRequest;
+}
+
 function appendTextPart(parts: UserMessagePart[], text: string): void {
   if (text.length === 0) {
     return;
@@ -197,6 +202,24 @@ export function createEditorDocumentSnapshot(
       return editorDocToMessageDocument(document, context);
     },
   });
+}
+
+/** Creates the business document for sends that do not originate in Tiptap. */
+export function textToMessageDocument(
+  text: string,
+  template?: TextMessageTemplateSnapshot,
+): UserMessageDocument | null {
+  const parts: UserMessagePart[] = [];
+  if (template) {
+    parts.push({
+      type: "template",
+      titleSnapshot: template.titleSnapshot,
+      template: template.template,
+    });
+  }
+  appendTextPart(parts, text);
+  const parsed = userMessageDocumentSchema.safeParse({ version: 1, parts });
+  return parsed.success ? parsed.data : null;
 }
 
 function templateCategory(type: GenerationTemplateType): string {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1058,7 +1058,11 @@ describe("chat message action cards", () => {
     const threadId = `${THREAD_ID}-single-permission`;
     const callbackPrompt = "Re-check Slack access, then continue";
     const permissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=channels.read&action=allow&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
-    const sentPrompts: { prompt: string; threadId?: string }[] = [];
+    const sentPrompts: {
+      prompt: string;
+      threadId?: string;
+      structuredPrompt?: unknown;
+    }[] = [];
 
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
@@ -1116,14 +1120,19 @@ describe("chat message action cards", () => {
           createdAt: "2026-06-09T10:01:00Z",
         },
       ],
-      onSendRequest: ({ prompt, threadId: sentThreadId }) => {
-        sentPrompts.push({ prompt, threadId: sentThreadId });
+      onSendRequest: ({ prompt, threadId: sentThreadId, structuredPrompt }) => {
+        sentPrompts.push({
+          prompt,
+          threadId: sentThreadId,
+          structuredPrompt,
+        });
       },
     });
 
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -1134,6 +1143,10 @@ describe("chat message action cards", () => {
         {
           prompt: callbackPrompt,
           threadId,
+          structuredPrompt: {
+            version: 1,
+            parts: [{ type: "text", text: callbackPrompt }],
+          },
         },
       ]);
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -152,7 +152,10 @@ describe("chat lifecycle", () => {
     });
     expect(sentMessages[0]).toMatchObject({ prompt: followupPrompt });
     expect(sentMessages[0]?.revokesMessageId).toBeUndefined();
-    expect(sentMessages[0]?.structuredPrompt).toBeUndefined();
+    expect(sentMessages[0]?.structuredPrompt).toStrictEqual({
+      version: 1,
+      parts: [{ type: "text", text: followupPrompt }],
+    });
   });
 
   it("shows recommended follow-ups after a completed marker update event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -461,6 +461,7 @@ export function mockChatLifecycle(
       prompt: string;
       threadId?: string;
       clientThreadId?: string;
+      structuredPrompt?: UserMessageDocument;
       model?: string;
       modelSelection?: ModelSelectionRequest | null;
     }) => void;
@@ -928,6 +929,7 @@ export function mockChatLifecycle(
       prompt: body.prompt,
       threadId: body.threadId,
       clientThreadId: body.clientThreadId,
+      structuredPrompt: body.structuredPrompt,
       model: body.model,
       modelSelection: modelSelectionFromBody(body),
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -6,6 +6,7 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   WEBSITE_TEMPLATE_ITEMS,
 } from "@vm0/core";
+import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -89,7 +90,10 @@ describe("prompt query parameter injection", () => {
     await waitFor(() => {
       expect(screen.getByText("Build a launch recap")).toBeInTheDocument();
       expect(runPrompt).toBe("Build a launch recap");
-      expect(structuredPrompt).toBeUndefined();
+      expect(structuredPrompt).toStrictEqual({
+        version: 1,
+        parts: [{ type: "text", text: "Build a launch recap" }],
+      });
       expect(createdThreadModel).toBe("deepseek-v4-pro");
     });
   });
@@ -168,6 +172,7 @@ describe("prompt query parameter injection", () => {
     expect(presentationTemplate).toBeDefined();
 
     let runPrompt: string | undefined;
+    let structuredPrompt: UserMessageDocument | undefined;
     let selection:
       | {
           templateId: string;
@@ -178,6 +183,7 @@ describe("prompt query parameter injection", () => {
     mockChatLifecycle(context, {
       onRunCreate: (body) => {
         runPrompt = body.prompt;
+        structuredPrompt = body.structuredPrompt;
         selection =
           body.generationTemplate?.type === "presentation"
             ? body.generationTemplate.selection
@@ -188,6 +194,7 @@ describe("prompt query parameter injection", () => {
     detachedSetupPage({
       context,
       path: "/prompt?prompt=Make%20a%20launch%20deck&template=presentation-template%3Aplayful-launch-presentation",
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
     });
 
     await waitFor(() => {
@@ -197,6 +204,20 @@ describe("prompt query parameter injection", () => {
         colorSystemId: presentationTemplate?.colorSystemId,
         templateId: presentationTemplate?.templateId,
         previewUrl: presentationTemplate?.embedUrl,
+      });
+      expect(structuredPrompt).toStrictEqual({
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: presentationTemplate?.title,
+            template: {
+              type: "presentation",
+              selection,
+            },
+          },
+          { type: "text", text: "Make a launch deck" },
+        ],
       });
     });
   });


### PR DESCRIPTION
## Summary

- create UserMessageDocument snapshots for text sends that do not originate from the Tiptap composer
- cover recommended follow-ups, prompt-route auto-send, and connector or permission action callbacks behind the existing StructuredPrompt feature switch
- resolve prompt-route template titles alongside their generation request so template parts retain a stable titleSnapshot
- keep all legacy request behavior unchanged while the switch is disabled

## User-visible impact

Messages generated by automatic product entry points now follow the same structured source-of-truth path as composer messages when StructuredPrompt is enabled. Prompt-route template sends preserve both the selected template and user text in order.

## Verification

- app production and test type checks pass
- app lint passes with zero warnings
- targeted page tests: 3 files, 41 tests passed

Refs #22314