### PR TITLE
feat(connectors): improve app oauth completion flow

### DIFF
--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -54,10 +54,12 @@ function resultFromPath(
 }
 
 function callbackPageElement(
+  connectorRef: ConnectorRef | null,
   label: string,
   result: ConnectorCallbackPageResult,
 ): React.JSX.Element {
   return createElement(ZeroConnectorCallbackPage, {
+    connectorRef,
     connectorLabel: label,
     status: result.status,
     username: result.status === "success" ? result.username : null,
@@ -102,7 +104,7 @@ export const setupConnectorCallbackPage$ = command(
     );
 
     if (pathResult) {
-      set(updatePage$, callbackPageElement(label, pathResult));
+      set(updatePage$, callbackPageElement(connectorRef, label, pathResult));
       set(updateDocumentTitle$, `Connect ${label}`);
       await set(hideAppSkeleton$, signal);
       return;
@@ -111,7 +113,7 @@ export const setupConnectorCallbackPage$ = command(
     if (!connectorRef) {
       set(
         updatePage$,
-        callbackPageElement(label, {
+        callbackPageElement(connectorRef, label, {
           status: "error",
           message: "Invalid connector callback URL.",
         }),
@@ -121,7 +123,10 @@ export const setupConnectorCallbackPage$ = command(
       return;
     }
 
-    set(updatePage$, callbackPageElement(label, { status: "loading" }));
+    set(
+      updatePage$,
+      callbackPageElement(connectorRef, label, { status: "loading" }),
+    );
     set(updateDocumentTitle$, `Connect ${label}`);
     await set(hideAppSkeleton$, signal);
 
@@ -131,7 +136,7 @@ export const setupConnectorCallbackPage$ = command(
       Object.fromEntries(searchParams),
       signal,
     );
-    set(updatePage$, callbackPageElement(label, result));
+    set(updatePage$, callbackPageElement(connectorRef, label, result));
 
     const resultSearchParams = new URLSearchParams();
     if (result.status === "success" && result.username) {

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -3,6 +3,11 @@ import {
   type ConnectorOauthCallbackResult,
 } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
+  publicConnectorCatalogIconSchema,
+  type PublicConnectorCatalogIcon,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@vm0/connectors/app-oauth-callback";
+import {
   connectorRefSchema,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -13,13 +18,20 @@ import { ZeroConnectorCallbackPage } from "../../views/zero-page/zero-connector-
 import { zeroClient$ } from "../api-client.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
 import { updatePage$ } from "../react-router.ts";
 import { pathParams$, replacePathSilently$, searchParams$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
+import { jsonParseOr } from "../utils.ts";
 
 type ConnectorCallbackPageResult =
   | { readonly status: "loading" }
   | ConnectorOauthCallbackResult;
+
+const {
+  get$: connectorAppOauthCallbackMetadataRaw$,
+  clear$: clearConnectorAppOauthCallbackMetadata$,
+} = localStorageSignals(CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY);
 
 function connectorRefFromPath(value: string | undefined): ConnectorRef | null {
   const parsed = connectorRefSchema.safeParse(value?.toLowerCase());
@@ -31,6 +43,71 @@ function connectorLabel(connectorRef: ConnectorRef | null): string {
     return "Connector";
   }
   return connectorRef === "github" ? "GitHub" : connectorRef.toUpperCase();
+}
+
+function connectorIconFromSearchParams(
+  searchParams: URLSearchParams,
+): PublicConnectorCatalogIcon | undefined {
+  const url = searchParams.get("iconUrl");
+  const invertInDarkMode = searchParams.get("iconInvertInDarkMode");
+  if (!url || (invertInDarkMode !== "true" && invertInDarkMode !== "false")) {
+    return undefined;
+  }
+  const scale = searchParams.get("iconScale");
+  const parsed = publicConnectorCatalogIconSchema.safeParse({
+    url,
+    invertInDarkMode: invertInDarkMode === "true",
+    ...(scale === null ? {} : { scale: Number(scale) }),
+  });
+  return parsed.success ? parsed.data : undefined;
+}
+
+function addConnectorIconSearchParams(
+  searchParams: URLSearchParams,
+  icon: PublicConnectorCatalogIcon | undefined,
+): void {
+  if (!icon) {
+    return;
+  }
+  searchParams.set("iconUrl", icon.url);
+  searchParams.set("iconInvertInDarkMode", String(icon.invertInDarkMode));
+  if (icon.scale !== undefined) {
+    searchParams.set("iconScale", String(icon.scale));
+  }
+}
+
+function connectorCallbackMetadataFromStorage(
+  raw: string | null,
+  connectorRef: ConnectorRef | null,
+): {
+  readonly connectorRef: ConnectorRef;
+  readonly icon: PublicConnectorCatalogIcon;
+} | null {
+  if (!raw || !connectorRef) {
+    return null;
+  }
+  const value = jsonParseOr<unknown>(raw, null);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("connectorRef" in value) ||
+    !("icon" in value)
+  ) {
+    return null;
+  }
+  const parsedConnectorRef = connectorRefSchema.safeParse(value.connectorRef);
+  const parsedIcon = publicConnectorCatalogIconSchema.safeParse(value.icon);
+  if (
+    !parsedConnectorRef.success ||
+    parsedConnectorRef.data !== connectorRef ||
+    !parsedIcon.success
+  ) {
+    return null;
+  }
+  return {
+    connectorRef: parsedConnectorRef.data,
+    icon: parsedIcon.data,
+  };
 }
 
 function resultFromPath(
@@ -54,12 +131,12 @@ function resultFromPath(
 }
 
 function callbackPageElement(
-  connectorRef: ConnectorRef | null,
+  connectorIcon: PublicConnectorCatalogIcon | undefined,
   label: string,
   result: ConnectorCallbackPageResult,
 ): React.JSX.Element {
   return createElement(ZeroConnectorCallbackPage, {
-    connectorRef,
+    connectorIcon,
     connectorLabel: label,
     status: result.status,
     username: result.status === "success" ? result.username : null,
@@ -98,13 +175,19 @@ export const setupConnectorCallbackPage$ = command(
     );
     const label = connectorLabel(connectorRef);
     const searchParams = get(searchParams$);
+    const storedMetadata = connectorCallbackMetadataFromStorage(
+      get(connectorAppOauthCallbackMetadataRaw$),
+      connectorRef,
+    );
+    const connectorIcon =
+      connectorIconFromSearchParams(searchParams) ?? storedMetadata?.icon;
     const pathResult = resultFromPath(
       typeof params?.status === "string" ? params.status : undefined,
       searchParams,
     );
 
     if (pathResult) {
-      set(updatePage$, callbackPageElement(connectorRef, label, pathResult));
+      set(updatePage$, callbackPageElement(connectorIcon, label, pathResult));
       set(updateDocumentTitle$, `Connect ${label}`);
       await set(hideAppSkeleton$, signal);
       return;
@@ -113,7 +196,7 @@ export const setupConnectorCallbackPage$ = command(
     if (!connectorRef) {
       set(
         updatePage$,
-        callbackPageElement(connectorRef, label, {
+        callbackPageElement(connectorIcon, label, {
           status: "error",
           message: "Invalid connector callback URL.",
         }),
@@ -125,7 +208,7 @@ export const setupConnectorCallbackPage$ = command(
 
     set(
       updatePage$,
-      callbackPageElement(connectorRef, label, { status: "loading" }),
+      callbackPageElement(connectorIcon, label, { status: "loading" }),
     );
     set(updateDocumentTitle$, `Connect ${label}`);
     await set(hideAppSkeleton$, signal);
@@ -136,7 +219,7 @@ export const setupConnectorCallbackPage$ = command(
       Object.fromEntries(searchParams),
       signal,
     );
-    set(updatePage$, callbackPageElement(connectorRef, label, result));
+    set(updatePage$, callbackPageElement(connectorIcon, label, result));
 
     const resultSearchParams = new URLSearchParams();
     if (result.status === "success" && result.username) {
@@ -145,11 +228,15 @@ export const setupConnectorCallbackPage$ = command(
     if (result.status === "error") {
       resultSearchParams.set("message", result.message);
     }
+    addConnectorIconSearchParams(resultSearchParams, connectorIcon);
     set(
       replacePathSilently$,
       ROUTES.connectorCallbackResult,
       { type: connectorRef, status: result.status },
       resultSearchParams,
     );
+    if (storedMetadata) {
+      set(clearConnectorAppOauthCallbackMetadata$);
+    }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -5,7 +5,10 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
-import { isConnectorAppOauthCallbackEnabled } from "@vm0/connectors/app-oauth-callback";
+import {
+  CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
+  isConnectorAppOauthCallbackEnabled,
+} from "@vm0/connectors/app-oauth-callback";
 import {
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
@@ -70,6 +73,9 @@ const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 
 const { get$: hiddenConnectorRefsRaw$, set$: setHiddenConnectorRefs$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
+const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
+  CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
+);
 type PostConnectOptions = {
   readonly authorizeVisibleAgents?: boolean;
   readonly connectorLabel?: string;
@@ -2099,7 +2105,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
 
 const openConnectorOAuthAuthCodeWindow$ = command(
   async (
-    { get },
+    { get, set },
     args: {
       readonly connectorRef: ConnectorRef;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
@@ -2111,6 +2117,15 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     signal: AbortSignal,
   ) => {
     const standalone = isStandaloneMode();
+    if (isConnectorAppOauthCallbackEnabled(args.connectorRef)) {
+      set(
+        setConnectorAppOauthCallbackMetadata$,
+        JSON.stringify({
+          connectorRef: args.connectorRef,
+          icon: args.connectorIcon,
+        }),
+      );
+    }
 
     // In standalone (PWA) mode, omit popup features so iOS Safari opens the
     // URL in the external browser instead of blocking it as a popup.

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -60,6 +60,7 @@ import {
 } from "../../utils.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
+import { subagents$ } from "../../agent.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
 import { sanitizeTokenInputRecord } from "./token-input.ts";
 import { IN_VITEST } from "../../../env.ts";
@@ -70,6 +71,7 @@ const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 const { get$: hiddenConnectorRefsRaw$, set$: setHiddenConnectorRefs$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
 type PostConnectOptions = {
+  readonly authorizeVisibleAgents?: boolean;
   readonly connectorLabel?: string;
   readonly agentId?: string;
 };
@@ -829,12 +831,46 @@ type FinishConnectorConnectionOptions = PostConnectOptions & {
   readonly toastMessage?: string | null;
 };
 
-const finishConnectorConnection$ = command(
-  (
+const authorizeConnectorForVisibleAgents$ = command(
+  async (
     { get, set },
     connectorRef: ConnectorRef,
-    options: FinishConnectorConnectionOptions = {},
-  ): boolean => {
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const visibleSubagents = await get(subagents$);
+    signal.throwIfAborted();
+    const client = get(zeroClient$)(zeroUserConnectorsContract);
+    await withCleanup(
+      Promise.all(
+        visibleSubagents.map(async (agent) => {
+          await accept(
+            client.update({
+              params: { id: agent.id },
+              body: { enabledTypes: [connectorRef], operation: "add" },
+              fetchOptions: { signal },
+            }),
+            [200, 404],
+          );
+        }),
+      ),
+      () => {
+        set(reloadAgentConnectorAuthorizations$);
+      },
+    );
+    signal.throwIfAborted();
+  },
+);
+
+const finishConnectorConnection$ = command(
+  async (
+    { get, set },
+    connectorRef: ConnectorRef,
+    options: FinishConnectorConnectionOptions,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (options.authorizeVisibleAgents) {
+      await set(authorizeConnectorForVisibleAgents$, connectorRef, signal);
+    }
     set(internalJustConnectedRefs$, (prev) => {
       return new Set([...prev, connectorRef]);
     });
@@ -915,11 +951,16 @@ export const submitManualGrant$ = command(
         );
         connectorStateChanged = true;
         signal.throwIfAborted();
-        set(finishConnectorConnection$, connectorRef, {
-          ...options,
-          reloadConnectors: false,
-          toastMessage: `${options.connectorLabel ?? connectorRef} connected successfully`,
-        });
+        await set(
+          finishConnectorConnection$,
+          connectorRef,
+          {
+            ...options,
+            reloadConnectors: false,
+            toastMessage: `${options.connectorLabel ?? connectorRef} connected successfully`,
+          },
+          signal,
+        );
         return true;
       })(),
       () => {
@@ -982,11 +1023,16 @@ export const connectConnectorNoAuth$ = command(
         );
         connectorStateChanged = true;
         signal.throwIfAborted();
-        set(finishConnectorConnection$, connectorRef, {
-          ...options,
-          reloadConnectors: false,
-          toastMessage: `${options.connectorLabel ?? connectorRef} enabled successfully`,
-        });
+        await set(
+          finishConnectorConnection$,
+          connectorRef,
+          {
+            ...options,
+            reloadConnectors: false,
+            toastMessage: `${options.connectorLabel ?? connectorRef} enabled successfully`,
+          },
+          signal,
+        );
         return true;
       })(),
       () => {
@@ -1336,11 +1382,16 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
 
         if (pollResult.status === "complete") {
           signal.throwIfAborted();
-          set(finishConnectorConnection$, connectorRef, {
-            ...options,
-            clearSelectedConnector: true,
-            reloadConnectors: false,
-          });
+          await set(
+            finishConnectorConnection$,
+            connectorRef,
+            {
+              ...options,
+              clearSelectedConnector: true,
+              reloadConnectors: false,
+            },
+            signal,
+          );
           set(
             internalConnectorOAuthDeviceAuthState$,
             createIdleConnectorOAuthDeviceAuthState(),
@@ -1892,11 +1943,16 @@ const completeConnectorExternalCode$ = command(
           return false;
         }
 
-        set(finishConnectorConnection$, connectorRef, {
-          ...options,
-          clearSelectedConnector: true,
-          reloadConnectors: false,
-        });
+        await set(
+          finishConnectorConnection$,
+          connectorRef,
+          {
+            ...options,
+            clearSelectedConnector: true,
+            reloadConnectors: false,
+          },
+          flowSignal,
+        );
         set(
           internalConnectorExternalCodeState$,
           createIdleConnectorExternalCodeState(),
@@ -2265,12 +2321,17 @@ export const connectConnectorOAuthAuthCode$ = command(
           return connectorMatchesAuthMethod(c, connectorRef, method.id);
         });
         if (isConnected) {
-          set(finishConnectorConnection$, connectorRef, {
-            ...options,
-            clearSelectedConnector: true,
-            reloadConnectors: false,
-            toastMessage: null,
-          });
+          await set(
+            finishConnectorConnection$,
+            connectorRef,
+            {
+              ...options,
+              clearSelectedConnector: true,
+              reloadConnectors: false,
+              toastMessage: null,
+            },
+            signal,
+          );
         }
         return isConnected;
       })(),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -1,4 +1,5 @@
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
+import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -34,6 +35,10 @@ describe("connector callback page", () => {
         name: "GitHub connected",
       }),
     ).resolves.toBeInTheDocument();
+    expect(document.querySelector("img")).toHaveAttribute(
+      "src",
+      getStaticConnectorIconMetadata("github").url,
+    );
     expect(screen.getByText("octocat")).toBeInTheDocument();
     expect(screen.getByText(/You can close this window\./)).toBeInTheDocument();
     expect(observedQuery).toMatchObject({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -1,15 +1,25 @@
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
+import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@vm0/connectors/app-oauth-callback";
 import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { pathname, search } from "../../../signals/location.ts";
 
 const context = testContext();
+const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
+  CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
+);
 
 describe("connector callback page", () => {
   it("forwards provider parameters and renders a durable success page", async () => {
+    const githubIcon = getStaticConnectorIconMetadata("github");
+    context.store.set(
+      setConnectorAppOauthCallbackMetadata$,
+      JSON.stringify({ connectorRef: "github", icon: githubIcon }),
+    );
     let observedQuery: Readonly<Record<string, string | undefined>> = {};
     context.mocks.api(
       connectorsTypeCallbackContract.callback,
@@ -30,15 +40,14 @@ describe("connector callback page", () => {
       session: null,
     });
 
-    await expect(
-      screen.findByRole("heading", {
-        name: "GitHub connected",
-      }),
-    ).resolves.toBeInTheDocument();
-    expect(document.querySelector("img")).toHaveAttribute(
-      "src",
-      getStaticConnectorIconMetadata("github").url,
-    );
+    const heading = await screen.findByRole("heading", {
+      name: "GitHub connected",
+    });
+    const connectorIcon = heading.parentElement?.querySelector("img");
+    if (!(connectorIcon instanceof HTMLImageElement)) {
+      throw new Error("GitHub connector icon not found");
+    }
+    expect(connectorIcon).toHaveAttribute("src", githubIcon.url);
     expect(screen.getByText("octocat")).toBeInTheDocument();
     expect(screen.getByText(/You can close this window\./)).toBeInTheDocument();
     expect(observedQuery).toMatchObject({
@@ -49,7 +58,15 @@ describe("connector callback page", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/connectors/github/callback/success");
     });
-    expect(search()).toBe("?username=octocat");
+    const resultSearchParams = new URLSearchParams(search());
+    expect(resultSearchParams.get("username")).toBe("octocat");
+    expect(resultSearchParams.get("iconUrl")).toBe(githubIcon.url);
+    expect(resultSearchParams.get("iconInvertInDarkMode")).toBe(
+      String(githubIcon.invertInDarkMode),
+    );
+    expect(resultSearchParams.get("iconScale")).toBe(
+      githubIcon.scale === undefined ? null : String(githubIcon.scale),
+    );
   });
 
   it("renders the API failure result without retaining OAuth parameters", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1817,8 +1817,14 @@ describe("connectors page", () => {
     });
   });
 
-  it("enables a no-auth connector for the default agent without dialogs", async () => {
+  it("enables a no-auth connector for all visible agents without dialogs", async () => {
+    const defaultAgentId = "c0000000-0000-4000-a000-000000000001";
+    const researchAgentId = "c0000000-0000-4000-a000-000000000002";
     mockConnectors([]);
+    context.mocks.data.team([
+      teamAgent(defaultAgentId, "Zero"),
+      teamAgent(researchAgentId, "Research Agent"),
+    ]);
     mockPublicConnectorStatus([
       publicStatusItem({
         connectorRef: "stripe",
@@ -1863,6 +1869,14 @@ describe("connectors page", () => {
         });
       },
     );
+    const authorizedAgentIds: string[] = [];
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ params, respond }) => {
+        authorizedAgentIds.push(params.id);
+        return respond(200, { enabledTypes: ["stripe"] });
+      },
+    );
 
     detachedSetupPage({ context, path: "/connectors" });
 
@@ -1871,6 +1885,7 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       expect(connectCount).toBe(1);
+      expect(authorizedAgentIds).toStrictEqual([researchAgentId]);
     });
     expect(openMock.calls).toHaveLength(0);
     expect(
@@ -2609,8 +2624,14 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not issue a client-side authorization update after connecting", async () => {
+  it("authorizes every visible non-default agent after connecting", async () => {
+    const defaultAgentId = "c0000000-0000-4000-a000-000000000001";
+    const researchAgentId = "c0000000-0000-4000-a000-000000000002";
     mockConnectors([]);
+    context.mocks.data.team([
+      teamAgent(defaultAgentId, "Zero"),
+      teamAgent(researchAgentId, "Research Agent"),
+    ]);
     mockPublicConnectorStatus([
       publicStatusItem({
         connectorRef: "axiom",
@@ -2657,16 +2678,18 @@ describe("connectors page", () => {
     context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
       return respond(200, { enabledTypes: [] });
     });
-    let authorizationUpdateCount = 0;
-    context.mocks.api(zeroUserConnectorsContract.update, ({ respond }) => {
-      authorizationUpdateCount += 1;
-      return respond(400, {
-        error: {
-          code: "CONNECTOR_ACCESS_UPDATE_FAILED",
-          message: "Could not update connector access",
-        },
-      });
-    });
+    const authorizedAgentIds: string[] = [];
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ body, params, respond }) => {
+        authorizedAgentIds.push(params.id);
+        expect(body).toStrictEqual({
+          enabledTypes: ["axiom"],
+          operation: "add",
+        });
+        return respond(200, { enabledTypes: ["axiom"] });
+      },
+    );
 
     detachedSetupPage({ context, path: "/connectors" });
 
@@ -2685,15 +2708,14 @@ describe("connectors page", () => {
       expect(
         screen.getByText("Public Axiom connected successfully"),
       ).toBeInTheDocument();
+      expect(authorizedAgentIds).toStrictEqual([researchAgentId]);
     });
     expect(
       within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
     ).toBeInTheDocument();
-    expect(authorizationUpdateCount).toBe(0);
     expect(
       screen.queryByText("You've successfully connected with Public Axiom!"),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Could not update connector access")).toBeNull();
     expect(
       screen.queryByText("Public Axiom enabled for 1 agent"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1742,8 +1742,14 @@ describe("connectors page", () => {
     });
   });
 
-  it("starts Stripe OAuth from the connect dialog", async () => {
+  it("connects Stripe OAuth from the dialog for all visible agents", async () => {
+    const defaultAgentId = "c0000000-0000-4000-a000-000000000001";
+    const researchAgentId = "c0000000-0000-4000-a000-000000000002";
     mockConnectors([]);
+    context.mocks.data.team([
+      teamAgent(defaultAgentId, "Zero"),
+      teamAgent(researchAgentId, "Research Agent"),
+    ]);
     mockPublicConnectorStatus([
       publicStatusItem({
         connectorRef: "stripe",
@@ -1793,6 +1799,14 @@ describe("connectors page", () => {
         });
       },
     );
+    const authorizedAgentIds: string[] = [];
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ params, respond }) => {
+        authorizedAgentIds.push(params.id);
+        return respond(200, { enabledTypes: ["stripe"] });
+      },
+    );
 
     detachedSetupPage({
       context,
@@ -1814,6 +1828,16 @@ describe("connectors page", () => {
       expect(authWindow.location.href).toBe(
         "https://oauth.test/stripe/authorize",
       );
+      expect(
+        context.mocks.ably.hasSubscription("connector:changed"),
+      ).toBeTruthy();
+    });
+
+    mockConnectors([{ type: "stripe", authMethod: "oauth" }]);
+    context.mocks.ably.trigger("connector:changed");
+
+    await waitFor(() => {
+      expect(authorizedAgentIds).toStrictEqual([researchAgentId]);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -417,6 +417,7 @@ function OAuthAuthCodeConnectMethodContent(props: ConnectMethodContentProps) {
       item={props.item}
       method={props.method}
       onSuccess={props.onSuccess}
+      authorizeVisibleAgentsOnConnect={props.authorizeVisibleAgentsOnConnect}
       connectOAuthAuthCodeAndSettle={props.connectOAuthAuthCodeAndSettle}
       signal={props.signal}
     />
@@ -944,9 +945,7 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
       authMethod={props.authMethod}
       method={props.method}
       onSuccess={props.onSuccess}
-      authorizeVisibleAgentsOnConnect={
-        props.authorizeVisibleAgentsOnConnect
-      }
+      authorizeVisibleAgentsOnConnect={props.authorizeVisibleAgentsOnConnect}
       agentId={props.agentId}
       submit={props.submitManualGrant}
       submitting={props.manualGrantSubmitting}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -91,6 +91,7 @@ function connectedStatusText(item: PublicConnectorCatalogStatusItem): string {
 }
 
 type PostConnectOptions = {
+  readonly authorizeVisibleAgents?: boolean;
   readonly connectorLabel?: string;
   readonly agentId?: string;
 };
@@ -158,6 +159,7 @@ type ConnectModalContentProps = {
   item: PublicConnectorCatalogStatusItem;
   agentId?: string;
   onSuccess: () => void | Promise<void>;
+  authorizeVisibleAgentsOnConnect: boolean;
 };
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
@@ -244,6 +246,7 @@ function ManualGrantForm({
   authMethod,
   method,
   onSuccess,
+  authorizeVisibleAgentsOnConnect,
   agentId,
   submit,
   submitting,
@@ -253,6 +256,7 @@ function ManualGrantForm({
   authMethod: ConnectorAuthMethodId;
   method: PublicConnectorCatalogAuthMethodDetail;
   onSuccess: () => void | Promise<void>;
+  authorizeVisibleAgentsOnConnect: boolean;
   agentId?: string;
   submit: SubmitManualGrantFn;
   submitting: boolean;
@@ -278,6 +282,7 @@ function ManualGrantForm({
         authMethod,
         manualGrantInputValuesForMethod(method, fieldValues),
         {
+          authorizeVisibleAgents: authorizeVisibleAgentsOnConnect,
           connectorLabel,
           ...(agentId ? { agentId } : {}),
         },
@@ -370,6 +375,7 @@ function OAuthAuthCodeConnectButton({
   item,
   method,
   onSuccess,
+  authorizeVisibleAgentsOnConnect,
   agentId,
   connectOAuthAuthCodeAndSettle,
   signal,
@@ -388,6 +394,7 @@ function OAuthAuthCodeConnectButton({
             method,
             onSuccess,
             {
+              authorizeVisibleAgents: authorizeVisibleAgentsOnConnect,
               connectorLabel: item.label,
               connectorIcon: item.icon,
               ...(agentId ? { agentId } : {}),
@@ -644,6 +651,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
+          authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
         },
@@ -877,6 +885,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
+          authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
         },
@@ -935,6 +944,9 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
       authMethod={props.authMethod}
       method={props.method}
       onSuccess={props.onSuccess}
+      authorizeVisibleAgentsOnConnect={
+        props.authorizeVisibleAgentsOnConnect
+      }
       agentId={props.agentId}
       submit={props.submitManualGrant}
       submitting={props.manualGrantSubmitting}
@@ -950,6 +962,7 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
         authMethod: props.authMethod,
         onSuccess: props.onSuccess,
         options: {
+          authorizeVisibleAgents: props.authorizeVisibleAgentsOnConnect,
           connectorLabel: props.item.label,
           ...(props.agentId ? { agentId: props.agentId } : {}),
         },
@@ -1087,6 +1100,7 @@ function StandardConnectMethodsContent({
   item,
   agentId,
   onSuccess,
+  authorizeVisibleAgentsOnConnect,
   connectOAuthAuthCodeAndSettle,
   connectOAuthDeviceAuthAndSettle,
   connectExternalCode,
@@ -1120,6 +1134,7 @@ function StandardConnectMethodsContent({
           item,
           agentId,
           onSuccess,
+          authorizeVisibleAgentsOnConnect,
           connectOAuthAuthCodeAndSettle,
           connectOAuthDeviceAuthAndSettle,
           connectExternalCode,
@@ -1140,6 +1155,7 @@ function ConnectModalContent({
   item,
   agentId,
   onSuccess,
+  authorizeVisibleAgentsOnConnect,
 }: ConnectModalContentProps) {
   const [settleLoadable, connectOAuthAuthCodeAndSettleCommand] = useLoadableSet(
     connectConnectorOAuthAuthCodeAndSettle$,
@@ -1243,6 +1259,7 @@ function ConnectModalContent({
       item={item}
       agentId={agentId}
       onSuccess={onConnectSuccess}
+      authorizeVisibleAgentsOnConnect={authorizeVisibleAgentsOnConnect}
       connectOAuthAuthCodeAndSettle={connectOAuthAuthCodeAndSettle}
       connectOAuthDeviceAuthAndSettle={connectOAuthDeviceAuthAndSettleCommandFn}
       connectExternalCode={connectExternalCode}
@@ -1265,11 +1282,13 @@ function ConnectModalContent({
 export function ConnectModal({
   onClose,
   onSuccess,
+  authorizeVisibleAgentsOnConnect = false,
   selectedConnectorRef: selectedConnectorRefOverride,
   agentId,
 }: {
   onClose: () => void;
   onSuccess?: () => void | Promise<void>;
+  authorizeVisibleAgentsOnConnect?: boolean;
   selectedConnectorRef?: ConnectorRef | null;
   agentId?: string;
 }) {
@@ -1344,6 +1363,7 @@ export function ConnectModal({
         <ConnectModalContent
           item={item}
           agentId={agentId}
+          authorizeVisibleAgentsOnConnect={authorizeVisibleAgentsOnConnect}
           onSuccess={async () => {
             await onSuccess?.();
             clearConnectorOAuthDeviceAuth();

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,20 +1,30 @@
 import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
+import {
+  getStaticConnectorIconMetadata,
+  isStaticConnectorIconType,
+} from "@vm0/connectors/static-connector-icons";
 import { Button } from "@vm0/ui/components/ui/button";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 type ConnectorCallbackPageStatus = "loading" | "success" | "error";
 
 export function ZeroConnectorCallbackPage({
+  connectorRef,
   connectorLabel,
   status,
   username,
   errorMessage,
 }: {
+  readonly connectorRef: string | null;
   readonly connectorLabel: string;
   readonly status: ConnectorCallbackPageStatus;
   readonly username: string | null;
   readonly errorMessage: string | null;
 }): React.JSX.Element {
+  const connectorIcon =
+    connectorRef && isStaticConnectorIconType(connectorRef)
+      ? getStaticConnectorIconMetadata(connectorRef)
+      : undefined;
   const title =
     status === "success"
       ? `${connectorLabel} connected`
@@ -41,7 +51,7 @@ export function ZeroConnectorCallbackPage({
 
   return (
     <ZeroConnectorFlowCard
-      connectorIcon={undefined}
+      connectorIcon={connectorIcon}
       title={title}
       description={description}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,30 +1,23 @@
 import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  getStaticConnectorIconMetadata,
-  isStaticConnectorIconType,
-} from "@vm0/connectors/static-connector-icons";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 type ConnectorCallbackPageStatus = "loading" | "success" | "error";
 
 export function ZeroConnectorCallbackPage({
-  connectorRef,
+  connectorIcon,
   connectorLabel,
   status,
   username,
   errorMessage,
 }: {
-  readonly connectorRef: string | null;
+  readonly connectorIcon: PublicConnectorCatalogIcon | undefined;
   readonly connectorLabel: string;
   readonly status: ConnectorCallbackPageStatus;
   readonly username: string | null;
   readonly errorMessage: string | null;
 }): React.JSX.Element {
-  const connectorIcon =
-    connectorRef && isStaticConnectorIconType(connectorRef)
-      ? getStaticConnectorIconMetadata(connectorRef)
-      : undefined;
   const title =
     status === "success"
       ? `${connectorLabel} connected`

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -983,7 +983,11 @@ export function ZeroConnectorsPage() {
         return connect(
           connectorRef,
           authMethod,
-          { connectorLabel: ct.label, connectorIcon: ct.icon },
+          {
+            authorizeVisibleAgents: true,
+            connectorLabel: ct.label,
+            connectorIcon: ct.icon,
+          },
           signal,
         );
       },
@@ -992,7 +996,10 @@ export function ZeroConnectorsPage() {
           {
             connectorRef,
             authMethod,
-            options: { connectorLabel: ct.label },
+            options: {
+              authorizeVisibleAgents: true,
+              connectorLabel: ct.label,
+            },
           },
           signal,
         );
@@ -1131,6 +1138,7 @@ export function ZeroConnectorsPage() {
 
       {selectedConnectorRef && (
         <ConnectModal
+          authorizeVisibleAgentsOnConnect
           onClose={() => {
             return setSelected(null);
           }}
@@ -1176,6 +1184,7 @@ export function ZeroConnectorsPage() {
                 connectorRef,
                 authMethod,
                 {
+                  authorizeVisibleAgents: true,
                   connectorLabel: connector.label,
                   connectorIcon: connector.icon,
                 },

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -1,4 +1,7 @@
 // Add a connector only after its OAuth app accepts the App callback URL.
+export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
+  "vm0.connector.appOauthCallbackMetadata";
+
 const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
   "github",
   "gmail",

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -15,6 +15,7 @@ const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
   "google-search-console",
   "google-sheets",
   "stripe",
+  "x",
   "youtube",
 ]);
 


### PR DESCRIPTION
## Summary

- enable App OAuth callbacks for X while keeping Cloudflare on its existing API callback
- show each connector’s real icon on OAuth callback result pages
- authorize newly connected connectors for every agent visible to the user when connecting from the connector list
- keep directed connector flows scoped to their existing target agent behavior

## Test plan

- added integration coverage for callback icons and visible-agent authorization
- not run locally per request; CI will validate the changes