### PR TITLE
fix: remove vm0 auto model

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -182,7 +182,6 @@ runs:
         fi
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
-          add_env VM0_MODEL_PROXY_HOST "https://www.vm0.ai"
           add_env ENV "$deploy_env"
           if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
             add_secret CLOUDFLARE_BROWSER_RENDERING_API_TOKEN CLOUDFLARE_BROWSER_RENDERING_API_TOKEN
@@ -244,9 +243,6 @@ runs:
         add_secret ABLY_API_KEY ABLY_API_KEY
         add_secret OPENROUTER_API_KEY OPENROUTER_API_KEY
         add_secret OPENAI_API_KEY OPENAI_API_KEY
-        if [[ "$INPUT_APP" == "api" ]]; then
-          add_secret VM0_MODEL_PROXY_TOKEN VM0_MODEL_PROXY_TOKEN
-        fi
         add_secret FAL_KEY FAL_KEY
         add_secret BYTEPLUS_API_KEY BYTEPLUS_API_KEY
         add_secret BYTEPLUS_STT_API_KEY BYTEPLUS_STT_API_KEY

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -132,7 +132,7 @@ run_action() {
     INPUT_APP_URL="https://pr-123-app.vm0.test" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
     REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_BACKEND_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","ZERO_PRICE_PRO":"price_test_pro","ZERO_PRICE_TEAM":"price_test_team","ATOM_GRANT_PRICE":"price_test_atom_grant","ZERO_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","ZERO_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}' \
-    REPO_SECRETS_JSON='{"VM0_MODEL_PROXY_TOKEN":"github-vm0-model-proxy-token","GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","ZERO_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","ZERO_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret"}' \
+    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","ZERO_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","ZERO_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret"}' \
     DOPPLER_SECRETS_JSON="$doppler_secrets_json" \
     bash "$action_script"
 }
@@ -165,14 +165,12 @@ assert_env_value "$success_env_file" FINICITY_APP_KEY "github-finicity-app-key"
 assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-secret"
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
 assert_env_value "$success_env_file" UNSPLASH_ACCESS_KEY "github-unsplash-access-key"
-assert_env_value "$success_env_file" VM0_MODEL_PROXY_TOKEN "github-vm0-model-proxy-token"
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
 assert_env_value "$success_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_value "$success_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$success_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
-assert_env_value "$success_env_file" VM0_MODEL_PROXY_HOST "https://www.vm0.ai"
 assert_env_value "$success_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$success_env_file" "ONBOARDING_URL="
 assert_env_value "$success_env_file" ZERO_PRICE_PRO "price_test_pro"
@@ -209,8 +207,6 @@ assert_env_value "$production_web_env_file" ZERO_SCRAPE_FIRECRAWL_TOKEN "github-
 assert_env_value "$production_web_env_file" ZERO_WEB_SEARCH_PERPLEXITY_TOKEN "github-perplexity-token"
 assert_env_absent_value "$production_web_env_file" "github-cloudflare-browser-rendering-token"
 assert_env_absent_value "$production_web_env_file" "github-artifact-preview-waf-secret"
-assert_env_absent_value "$production_web_env_file" "VM0_MODEL_PROXY_TOKEN="
-assert_env_absent_value "$production_web_env_file" "VM0_MODEL_PROXY_HOST="
 
 production_api_dir="$(mktemp -d)"
 TEMP_DIRS+=("$production_api_dir")
@@ -218,7 +214,6 @@ production_api_output="$(run_action "$(build_doppler_secrets_json)" "$production
 production_api_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${production_api_dir}/github-output")"
 assert_contains "$production_api_output" "Rendered"
 assert_env_value "$production_api_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
-assert_env_value "$production_api_env_file" VM0_MODEL_PROXY_HOST "https://www.vm0.ai"
 assert_env_value "$production_api_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" ATOM_URL "https://atom.github.test"
 assert_env_value "$production_api_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
@@ -230,7 +225,6 @@ assert_env_value "$production_api_env_file" ZERO_WEB_SEARCH_PERPLEXITY_TOKEN "gi
 assert_env_absent_value "$production_api_env_file" "ONBOARDING_URL="
 assert_env_value "$production_api_env_file" CLOUDFLARE_BROWSER_RENDERING_API_TOKEN "github-cloudflare-browser-rendering-token"
 assert_env_value "$production_api_env_file" ARTIFACT_PREVIEW_WAF_SECRET "github-artifact-preview-waf-secret"
-assert_env_value "$production_api_env_file" VM0_MODEL_PROXY_TOKEN "github-vm0-model-proxy-token"
 
 missing_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_dir")

--- a/docs/model-usage-pricing-protocol.md
+++ b/docs/model-usage-pricing-protocol.md
@@ -4,11 +4,17 @@ This document is the source of truth for the signed model usage pricing
 response headers consumed by the runner mitm addon. It defines version 1 of the
 contract between:
 
-- the pricing producer, which handles a VM0 Model request and adds the private
-  pricing headers to its response;
+- the legacy pricing producer, which handled a VM0 Auto request and added the
+  private pricing headers to its response;
 - the runner mitm addon, which authenticates and consumes those headers; and
 - the sandbox client, which receives the response after the private headers
   have been removed.
+
+> **Retirement compatibility:** The Auto model no longer accepts new runs.
+> This protocol and its guest-agent, runner, and proxy compatibility paths
+> remain temporarily so runs claimed by a pre-retirement API deployment can
+> drain safely. Remove them after all pre-retirement API and runner versions
+> are no longer active or rollback-eligible.
 
 The implementation lives in
 `crates/runner/mitm-addon/src/model_usage_pricing.py`.

--- a/turbo/.gitignore
+++ b/turbo/.gitignore
@@ -53,7 +53,6 @@ yarn-error.log*
 .dev-process-pid
 .dev-server.log
 .dev-tunnel-url
-.dev-marketing-tunnel-url
 
 # SBOM
 sbom.json

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -83,10 +83,6 @@ CLAUDE_CODE_VERSION_URL=https://storage.googleapis.com/claude-code-dist-86c565f3
 # Required: OpenAI (voice-chat ephemeral token minting, STT, TTS)
 OPENAI_API_KEY=op://Development/openai/OPENAI_API_KEY
 
-# Optional: Auto proxy authentication (required to run vm0-model)
-VM0_MODEL_PROXY_TOKEN=op://Development/vm0/VM0_MODEL_PROXY_TOKEN
-VM0_MODEL_PROXY_HOST=
-
 # Optional: OpenRouter lightweight model calls
 OPENROUTER_API_KEY=op://Development/openrouter/Section_ak7dvythmldarvk4dodjs4ecyq/OPENROUTER_API_KEY
 

--- a/turbo/apps/api/scripts/dev.sh
+++ b/turbo/apps/api/scripts/dev.sh
@@ -14,7 +14,6 @@ ENV_LOCAL_FILE="$API_APP_DIR/.env.local"
 STRIPE_PIDFILE="/tmp/stripe-listen-api.pid"
 TUNNEL_PIDFILE="/tmp/cloudflared-${TUNNEL_PORT}.pid"
 LEGACY_API_TUNNEL_PIDFILE="/tmp/cloudflared-${API_PORT}.pid"
-LEGACY_MARKETING_TUNNEL_PIDFILE="/tmp/cloudflared-3042.pid"
 
 kill_stale() {
   local pidfile="$1" pattern="$2"
@@ -77,7 +76,6 @@ cleanup() {
   if [[ "${API_KEEP_TUNNEL_ON_EXIT:-}" != "1" ]]; then
     kill_stale "$TUNNEL_PIDFILE" ""
     kill_stale "$LEGACY_API_TUNNEL_PIDFILE" ""
-    kill_stale "$LEGACY_MARKETING_TUNNEL_PIDFILE" ""
   fi
 }
 trap cleanup EXIT INT TERM
@@ -125,13 +123,10 @@ start_api_tunnel() {
 }
 
 kill_stale "$LEGACY_API_TUNNEL_PIDFILE" ""
-kill_stale "$LEGACY_MARKETING_TUNNEL_PIDFILE" ""
 
 TUNNEL_URL="$(start_api_tunnel)"
 
 echo "[api:dev] Tunnel URL=${TUNNEL_URL}"
-update_env_value "VM0_MODEL_PROXY_HOST" "$TUNNEL_URL"
-echo "[api:dev] VM0_MODEL_PROXY_HOST=${TUNNEL_URL}"
 
 start_stripe_webhook_forwarding
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2765,57 +2765,6 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
-  it("resumes the CLI session when switching between GPT and Auto", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-    mockOptionalEnv("VM0_MODEL_PROXY_TOKEN", "vm0-model-proxy-token");
-    mockOptionalEnv("VM0_MODEL_PROXY_HOST", "https://www.vm0.test");
-    await seedVm0ManagedModelKey("gpt-5.5");
-    await chatCallbacks.updateOrgModelPolicies(actor, [
-      {
-        model: "gpt-5.5",
-        isDefault: true,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-        modelProviderId: null,
-      },
-      {
-        model: "vm0-model",
-        isDefault: false,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-        modelProviderId: null,
-      },
-    ]);
-
-    const first = await sendChatRun(actor, {
-      agentId,
-      prompt: "start on GPT before switching to Auto",
-      model: "gpt-5.5",
-    });
-    const firstClaim = await claimChatRun(runnerGroup, first.runId);
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders, {
-      cliAgentType: "codex",
-    });
-    await flushWaitUntilForTest();
-
-    await seedVm0ManagedModelKey("vm0-model");
-    const second = await sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      prompt: "continue on Auto in the same session",
-      model: "vm0-model",
-    });
-    const secondClaim = await claimChatRun(runnerGroup, second.runId);
-    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
-      `bdd-cli-${first.runId}`,
-    );
-    expect(claimEnvironment(secondClaim.claim).OPENAI_MODEL).toBe("vm0-model");
-
-    await cancelChatRun(actor, second.runId);
-  }, 90_000);
-
   it("re-resolves a sticky model through the current provider policy", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -2936,7 +2885,7 @@ describe("CHAT-02: run-level model overrides", () => {
 
     // Chat send only accepts supported run models.
     const vm0ThreadId = randomUUID();
-    const invalidVm0Model = await chat.requestSendMessage(
+    const invalidModel = await chat.requestSendMessage(
       actor,
       {
         agentId: agent.agentId,
@@ -2946,8 +2895,8 @@ describe("CHAT-02: run-level model overrides", () => {
       },
       [400],
     );
-    expectApiError(invalidVm0Model.body);
-    expect(invalidVm0Model.body.error.message).toBe(
+    expectApiError(invalidModel.body);
+    expect(invalidModel.body.error.message).toBe(
       "model: Invalid model selection",
     );
     await chat.requestReadThread(actor, vm0ThreadId, [404]);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   getModelProviderFirewall,
   getVm0ConcreteProviderType,
-  MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
@@ -4754,7 +4753,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(queue.body.concurrency.active).toBe(0);
   });
 
-  it("defaults limited-free runs to Luna, allows Terra and Auto, and rejects Sol", async () => {
+  it("defaults limited-free runs to Luna, allows Terra, rejects Sol, and normalizes retired Auto", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
@@ -4825,51 +4824,29 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(queue.body.queue).toHaveLength(0);
     expect(queue.body.concurrency.active).toBe(0);
 
-    const vm0Model = "vm0-model";
-    const proxyHost = "https://www.vm0.test";
-    const proxyBaseUrl = `${proxyHost}/api/internal/vm0-model/v1`;
-    mockOptionalEnv("VM0_MODEL_PROXY_TOKEN", "vm0-model-proxy-token");
-    mockOptionalEnv("VM0_MODEL_PROXY_HOST", proxyHost);
-    await seedVm0ManagedModelKey(vm0Model);
-    await api.updateOrgModelPolicies(actor, [
-      {
-        model: vm0Model,
-        isDefault: true,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-        modelProviderId: null,
-      },
-    ]);
-
-    const vm0Sent = await chat.requestSendMessage(
+    const retiredAuto = await chat.requestSendMessage(
       actor,
       {
         agentId,
-        prompt: "limited-free Auto run",
-        model: vm0Model,
+        prompt: "legacy Auto request",
+        model: "vm0-model",
       },
       [201],
     );
-    if (vm0Sent.status !== 201 || vm0Sent.body.runId === null) {
-      throw new Error("Expected Auto to create a limited-free run");
+    if (retiredAuto.status !== 201 || retiredAuto.body.runId === null) {
+      throw new Error("Expected retired Auto to normalize to Luna");
     }
     await api.heartbeatRunner(runnerGroup);
-    const vm0Claim = await api.claimRunnerJob(vm0Sent.body.runId);
-    expect(vm0Claim.environment).toMatchObject({
-      OPENAI_BASE_URL: proxyBaseUrl,
-      OPENAI_MODEL: vm0Model,
+    const retiredAutoClaim = await api.claimRunnerJob(retiredAuto.body.runId);
+    expect(retiredAutoClaim.environment).toMatchObject({
+      OPENAI_MODEL: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
     });
-    expect(vm0Claim.codexRuntimeConfig).toMatchObject({
-      providerId: vm0Model,
-      baseUrl: proxyBaseUrl,
-    });
-    expect(
-      vm0Claim.firewalls?.map((firewall) => {
-        return firewallEntryName(firewall);
-      }),
-    ).toContain("model-provider:vm0-model");
-    expect(vm0Claim.modelUsageProvider).toBe(vm0Model);
-    await api.requestCancelRun(actor, vm0Sent.body.runId, [200]);
+    expect(retiredAutoClaim.environment).not.toHaveProperty("OPENAI_BASE_URL");
+    expect(retiredAutoClaim.codexRuntimeConfig).toBeNull();
+    expect(retiredAutoClaim.modelUsageProvider).toBe(
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+    );
+    await api.requestCancelRun(actor, retiredAuto.body.runId, [200]);
   });
 
   it("claims vm0 runs with billable model firewall and usage provider", async () => {
@@ -4963,107 +4940,6 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     ).toContain("model-provider:openai-api-key");
     expect(claim.billableFirewalls).toContain("model-provider:openai-api-key");
     expect(claim.modelUsageProvider).toBe(selectedModel);
-
-    await api.requestCancelRun(actor, sent.body.runId, [200]);
-  });
-
-  it("routes vm0-model through the marketing tunnel and injects both managed credentials", async () => {
-    const api = createRunsApi(context);
-    const chat = createChatFilesBddApi(context);
-    const fw = createFirewallApi(context);
-    const selectedModel = "vm0-model";
-    const proxyHost = "https://tunnel-yuma-vm0-marketing.vm7.ai:8443";
-    const proxyBaseUrl = `${proxyHost}/api/internal/vm0-model/v1`;
-    const firewallName = "model-provider:vm0-model";
-    const proxyAuthHeaders = {
-      Authorization: `Bearer \${{ secrets.OPENAI_API_KEY }}`,
-      "X-VM0-Upstream-Authorization": `Bearer \${{ secrets.VM0_MODEL_UPSTREAM_API_KEY }}`,
-    } as const;
-    mockOptionalEnv("VM0_MODEL_PROXY_TOKEN", "vm0-model-proxy-token");
-    mockOptionalEnv("VM0_MODEL_PROXY_HOST", proxyHost);
-    await seedVm0ManagedModelKey(selectedModel);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
-
-    await api.updateOrgModelPolicies(actor, [
-      {
-        model: selectedModel,
-        isDefault: true,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-        modelProviderId: null,
-      },
-    ]);
-
-    const sent = await chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        prompt: "vm0 model proxy run",
-        model: selectedModel,
-      },
-      [201],
-    );
-    if (sent.status !== 201 || sent.body.runId === null) {
-      throw new Error("Expected Auto chat send to create a run");
-    }
-
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(sent.body.runId);
-
-    expect(claim.cliAgentType).toBe("codex");
-    expect(claim.environment).toMatchObject({
-      OPENAI_API_KEY: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
-      OPENAI_BASE_URL: proxyBaseUrl,
-      OPENAI_MODEL: selectedModel,
-    });
-    expect(claim.environment?.OPENAI_API_KEY).not.toBe("vm0-model-proxy-token");
-    expect(claim.codexRuntimeConfig).toMatchObject({
-      providerId: "vm0-model",
-      name: "Auto",
-      baseUrl: proxyBaseUrl,
-      envKey: "OPENAI_API_KEY",
-      wireApi: "responses",
-      supportsWebsockets: false,
-      modelCatalog: {
-        models: [expect.objectContaining({ slug: selectedModel })],
-      },
-    });
-    expect(
-      claim.firewalls?.map((firewall) => {
-        return firewallEntryName(firewall);
-      }),
-    ).toContain(firewallName);
-    expect(inlineFirewallApis(claim.firewalls, firewallName)).toStrictEqual([
-      {
-        base: `${proxyBaseUrl}/responses`,
-        auth: { headers: proxyAuthHeaders },
-        permissions: [],
-      },
-    ]);
-    expect(claim.billableFirewalls).toContain(firewallName);
-    expect(claim.modelUsageProvider).toBe(selectedModel);
-    expect(claim.encryptedSecrets).toBeTruthy();
-
-    const resolved = await fw.requestFirewallAuth(
-      { authorization: `Bearer ${claim.sandboxToken}` },
-      {
-        encryptedSecrets: claim.encryptedSecrets!,
-        authHeaders: proxyAuthHeaders,
-      },
-      [200],
-    );
-    if (resolved.status !== 200) {
-      throw new Error("Expected Auto firewall auth to resolve");
-    }
-    expect(resolved.body.headers).toStrictEqual({
-      Authorization: "Bearer vm0-model-proxy-token",
-      "X-VM0-Upstream-Authorization":
-        "Bearer vm0-key-run-lifecycle-bdd-default-model",
-    });
-    expect(resolved.body.resolvedSecrets).toStrictEqual([
-      "OPENAI_API_KEY",
-      "VM0_MODEL_UPSTREAM_API_KEY",
-    ]);
 
     await api.requestCancelRun(actor, sent.body.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -418,7 +418,7 @@ describe("AUTH-03 user model preference", () => {
     expectApiError(emptyBody.body);
     expect(emptyBody.body.error.code).toBe("BAD_REQUEST");
     expect(emptyBody.body.error.message).toContain(
-      "selectedModel: Invalid option",
+      "selectedModel: Invalid input",
     );
 
     const removedModel = await cfg.rawUpdateModelPreference(
@@ -429,7 +429,7 @@ describe("AUTH-03 user model preference", () => {
     expectApiError(removedModel.body);
     expect(removedModel.body.error.code).toBe("BAD_REQUEST");
     expect(removedModel.body.error.message).toContain(
-      "selectedModel: Invalid option",
+      "selectedModel: Invalid model selection",
     );
 
     const unauthenticated = await cfg.requestReadModelPreference(null, [401]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -346,6 +346,39 @@ describe("GET/PUT /api/zero/model-policies", () => {
     );
   });
 
+  it("normalizes retired Auto policy writes to Luna", async () => {
+    const fixture = await seedFixture();
+    useSession(fixture);
+
+    const response = await accept(
+      apiClient().update({
+        headers: authHeaders(),
+        body: {
+          policies: [
+            {
+              model: "vm0-model",
+              isDefault: true,
+              defaultProviderType: "vm0",
+              credentialScope: "org",
+              modelProviderId: null,
+            },
+          ],
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.workspaceDefaultModel).toBe(
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+    );
+    expect(response.body.policies).toHaveLength(1);
+    expect(response.body.policies[0]).toMatchObject({
+      model: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      isDefault: true,
+      defaultProviderType: "vm0",
+    });
+  });
+
   it("removes supported models omitted from an update", async () => {
     const fixture = await seedFixture();
     useSession(fixture);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -8,6 +8,7 @@ import {
   type GenerationTemplateRequest,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
@@ -133,7 +134,7 @@ interface NormalSendBody {
   readonly clientThreadId?: string;
   readonly chatThreadEventId?: string;
   readonly chatThreadSortEventId?: string;
-  readonly model?: string;
+  readonly model?: SupportedRunModel;
   readonly modelSelection?: {
     readonly modelProviderId: string;
     readonly selectedModel: string;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -21,8 +21,6 @@ import {
   getProviderRuntimeModel,
   getSecretNameForType,
   getSecretsForAuthMethod,
-  getVm0ModelCodexRuntimeConfig,
-  getVm0ModelProviderConfig,
   getVm0ConcreteProviderType,
   getVm0Vendor,
   hasAuthMethods,
@@ -1806,33 +1804,6 @@ async function vm0ModelProviderEnvironment(
   const secretName = getSecretNameForType(concreteType);
   if (!apiKey || !secretName) {
     return null;
-  }
-
-  if (selectedModel === "vm0-model") {
-    const proxyToken = optionalEnv("VM0_MODEL_PROXY_TOKEN")?.trim();
-    const proxyHost = optionalEnv("VM0_MODEL_PROXY_HOST")?.trim();
-    if (!proxyToken || !proxyHost) {
-      return null;
-    }
-    const vm0ModelConfig = getVm0ModelProviderConfig(proxyHost);
-    return {
-      id: null,
-      type: "vm0",
-      concreteType,
-      environment: {
-        OPENAI_API_KEY: `\${{ secrets.OPENAI_API_KEY }}`,
-        OPENAI_BASE_URL: vm0ModelConfig.baseUrl,
-        OPENAI_MODEL: selectedModel,
-      },
-      secrets: {
-        OPENAI_API_KEY: proxyToken,
-        VM0_MODEL_UPSTREAM_API_KEY: apiKey,
-      },
-      selectedModel,
-      codexRuntimeConfig: getVm0ModelCodexRuntimeConfig(vm0ModelConfig.baseUrl),
-      firewall: vm0ModelConfig.firewall,
-      inlineFirewall: true,
-    };
   }
 
   return {

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -27,18 +27,14 @@ function isKnownModelProvider(
  *
  * Model IDs may be provider-qualified (for example, anthropic/claude-opus),
  * while the session family is the first part of the canonical model ID
- * (claude, gpt, glm, ...). Auto is explicitly treated as part of the GPT
- * family. This intentionally treats model variants in one family as compatible
- * while keeping different families isolated.
+ * (claude, gpt, glm, ...). This intentionally treats model variants in one
+ * family as compatible while keeping different families isolated.
  */
 function chatSessionModelFamily(model: string): string {
   const normalized = normalizeRunModelId(model.trim()).toLowerCase();
   const modelName = normalized.includes("/")
     ? normalized.slice(normalized.lastIndexOf("/") + 1)
     : normalized;
-  if (modelName === "vm0-model") {
-    return "gpt";
-  }
   return modelName.split(/[-_.]/, 1)[0] ?? modelName;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -1140,40 +1140,6 @@ describe("chat composer models", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("keeps Auto available when VM0 models and BYOK are restricted", async () => {
-    const user = userEvent.setup({ delay: null });
-    mockBillingCapabilities({ supportByok: false, restrictedVm0Models: true });
-    context.mocks.data.orgModelPolicies([
-      buildModelPolicy({
-        id: "00000000-0000-4000-a000-000000000703",
-        model: "kimi-k2.7-code",
-        modelLabel: "Kimi K2.7 Code",
-        isDefault: true,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-      }),
-      buildModelPolicy({
-        id: "00000000-0000-4000-a000-000000000704",
-        model: "vm0-model",
-        modelLabel: "Auto",
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-      }),
-    ]);
-    mockAgent();
-
-    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
-
-    await expectComposerModel("Kimi K2.7 Code");
-    await user.click(screen.getByRole("combobox", { name: "Kimi K2.7 Code" }));
-    await user.click(await screen.findByRole("option", { name: /Auto/u }));
-
-    await expectComposerModel("Auto");
-    expect(
-      screen.queryByRole("heading", { name: "Compare plans" }),
-    ).not.toBeInTheDocument();
-  });
-
   it("opens the model picker directly to options and labels BYOK routes", async () => {
     const user = userEvent.setup({ delay: null });
     context.mocks.data.orgModelProviders([]);
@@ -2227,8 +2193,16 @@ describe("chat composer models", () => {
         }),
       ).toBeTruthy();
     });
-    await user.click(buttonContainingText("Deny", dialog));
-    await user.click(buttonContainingText("Apply", dialog));
+    await user.click(
+      await waitFor(() => {
+        return buttonContainingText("Deny", dialog);
+      }),
+    );
+    await user.click(
+      await waitFor(() => {
+        return buttonContainingText("Apply", dialog);
+      }),
+    );
 
     await waitFor(() => {
       expect(appliedPermissionAgentId).toBe(OTHER_AGENT_ID);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -9,7 +9,6 @@ import type {
   ModelProviderResponse,
   OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -218,16 +217,10 @@ function mockProCheckout(): void {
   });
 }
 
-async function openProvidersTab(options?: {
-  readonly vm0ModelEnabled?: boolean;
-}): Promise<void> {
+async function openProvidersTab(): Promise<void> {
   detachedSetupPage({
     context,
     path: "/?settings=model",
-    featureSwitches:
-      options?.vm0ModelEnabled === undefined
-        ? undefined
-        : { [FeatureSwitchKey.Vm0Model]: options.vm0ModelEnabled },
   });
   await waitFor(() => {
     expect(
@@ -304,7 +297,7 @@ describe("organization model providers settings", () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);
     context.mocks.data.orgModelPolicies([]);
-    await openProvidersTab({ vm0ModelEnabled: true });
+    await openProvidersTab();
 
     click(buttonByText("Add model"));
     const dialog = screen.getByRole("dialog", { name: "Add model" });
@@ -338,7 +331,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openProvidersTab({ vm0ModelEnabled: true });
+    await openProvidersTab();
 
     await expect(
       screen.findByTestId("org-model-policy-row-kimi-k2.7-code"),
@@ -366,7 +359,7 @@ describe("organization model providers settings", () => {
         true,
       ),
     ]);
-    await openProvidersTab({ vm0ModelEnabled: true });
+    await openProvidersTab();
 
     click(buttonByText("Add model"));
     await selectDialogModel("Claude Sonnet 5");

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -1140,53 +1140,46 @@ function ModelPolicyRouteDialog({
             </Select>
           </div>
 
-          {selectedModel === "vm0-model" ? (
-            <p className="text-sm text-muted-foreground">
-              VM0 automatically selects the right model for each task, balancing
-              capability, speed, and cost.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">
-                Provided by
-              </label>
-              <div
-                role="radiogroup"
-                aria-label="Provided by"
-                className="grid grid-cols-1 gap-3 md:grid-cols-3"
-              >
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-foreground">
+              Provided by
+            </label>
+            <div
+              role="radiogroup"
+              aria-label="Provided by"
+              className="grid grid-cols-1 gap-3 md:grid-cols-3"
+            >
+              <RouteChoiceButton
+                active={dialog.routeKind === "built-in"}
+                title="Built-in"
+                description="Workspace credits cover usage."
+                onClick={() => {
+                  chooseRoute("built-in");
+                }}
+              />
+              <RouteChoiceButton
+                active={dialog.routeKind === "api-key"}
+                disabled={apiTypes.length === 0}
+                pro={!modelCapabilities.supportByok}
+                title="API key"
+                description="A shared workspace key. Best when the team bills through one account."
+                onClick={() => {
+                  chooseRoute("api-key");
+                }}
+              />
+              {oauthTypes.length > 0 && (
                 <RouteChoiceButton
-                  active={dialog.routeKind === "built-in"}
-                  title="Built-in"
-                  description="Workspace credits cover usage."
-                  onClick={() => {
-                    chooseRoute("built-in");
-                  }}
-                />
-                <RouteChoiceButton
-                  active={dialog.routeKind === "api-key"}
-                  disabled={apiTypes.length === 0}
+                  active={dialog.routeKind === "oauth"}
                   pro={!modelCapabilities.supportByok}
-                  title="API key"
-                  description="A shared workspace key. Best when the team bills through one account."
+                  title={getOAuthRouteCopy(oauthTypes).title}
+                  description={getOAuthRouteCopy(oauthTypes).description}
                   onClick={() => {
-                    chooseRoute("api-key");
+                    chooseRoute("oauth");
                   }}
                 />
-                {oauthTypes.length > 0 && (
-                  <RouteChoiceButton
-                    active={dialog.routeKind === "oauth"}
-                    pro={!modelCapabilities.supportByok}
-                    title={getOAuthRouteCopy(oauthTypes).title}
-                    description={getOAuthRouteCopy(oauthTypes).description}
-                    onClick={() => {
-                      chooseRoute("oauth");
-                    }}
-                  />
-                )}
-              </div>
+              )}
             </div>
-          )}
+          </div>
 
           {dialog.routeKind === "api-key" && (
             <ApiKeyProviderSection

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -48,7 +48,6 @@ export function getUILabel(type: ModelProviderType): string {
 
 const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
   Object.freeze({
-    "vm0-model": "vm0",
     "claude-fable-5": "anthropic-api-key",
     "claude-opus-4-8": "anthropic-api-key",
     "claude-opus-4-7": "anthropic-api-key",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -29,7 +29,9 @@ import {
   getSecretsForAuthMethod,
   isLimitedFree1RestrictedRunModel,
   modelProviderCredentialScopeSchema,
+  requestedRunModelSchema,
   supportedRunModelSchema,
+  updateOrgModelPoliciesRequestSchema,
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
   CODEX_FAST_MODE_MODELS,
@@ -39,8 +41,6 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   MODEL_PROVIDER_TYPES,
-  getVm0ModelProviderConfig,
-  getVm0ModelCodexRuntimeConfig,
   modelProviderTypeSchema,
   modelProviderFrameworkSchema,
   type ModelProviderType,
@@ -87,7 +87,6 @@ describe("model-first canonical catalog", () => {
 
   it("exposes the curated flat model list only", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
-      "vm0-model",
       "claude-fable-5",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
@@ -112,7 +111,10 @@ describe("model-first canonical catalog", () => {
   });
 
   it("validates canonical models and credential scopes", () => {
-    expect(supportedRunModelSchema.safeParse("vm0-model").success).toBe(true);
+    expect(supportedRunModelSchema.safeParse("vm0-model").success).toBe(false);
+    expect(requestedRunModelSchema.parse("vm0-model")).toBe(
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+    );
     expect(supportedRunModelSchema.safeParse("gpt-5.6-sol").success).toBe(true);
     expect(supportedRunModelSchema.safeParse("gpt-5.6-terra").success).toBe(
       true,
@@ -156,8 +158,33 @@ describe("model-first canonical catalog", () => {
     ).toBe(false);
   });
 
+  it("replaces retired Auto policy requests with the default model", () => {
+    expect(
+      updateOrgModelPoliciesRequestSchema.parse({
+        policies: [
+          {
+            model: "vm0-model",
+            isDefault: true,
+            defaultProviderType: "vm0",
+            credentialScope: "org",
+            modelProviderId: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      policies: [
+        {
+          model: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+          isDefault: true,
+          defaultProviderType: "vm0",
+          credentialScope: "org",
+          modelProviderId: null,
+        },
+      ],
+    });
+  });
+
   it("identifies models blocked on limited-free-1", () => {
-    expect(isLimitedFree1RestrictedRunModel("vm0-model")).toBe(false);
     expect(isLimitedFree1RestrictedRunModel("gpt-5.6-sol")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("openai/gpt-5.6-sol")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("gpt-5.6-terra")).toBe(false);
@@ -198,7 +225,6 @@ describe("model-first canonical catalog", () => {
   });
 
   it("surfaces display labels for canonical models", () => {
-    expect(getCanonicalModelDisplayName("vm0-model")).toBe("Auto");
     expect(getCanonicalModelDisplayName("claude-opus-4-8")).toBe(
       "Claude Opus 4.8",
     );
@@ -252,7 +278,7 @@ describe("model-first canonical catalog", () => {
   });
 
   it("returns compatible provider types for canonical models", () => {
-    expect(getProvidersForModel("vm0-model")).toEqual(["vm0"]);
+    expect(getProvidersForModel("vm0-model")).toEqual([]);
     expect(getProvidersForModel("claude-fable-5")).toEqual([
       "vm0",
       "claude-code-oauth-token",
@@ -351,10 +377,6 @@ describe("model-first canonical catalog", () => {
   });
 
   it("checks model/provider compatibility", () => {
-    expect(isModelSupportedByProvider("vm0-model", "vm0")).toBe(true);
-    expect(isModelSupportedByProvider("vm0-model", "openai-api-key")).toBe(
-      false,
-    );
     expect(isModelSupportedByProvider("gpt-5.6-sol", "vm0")).toBe(true);
     expect(isModelSupportedByProvider("gpt-5.6-sol", "openai-api-key")).toBe(
       true,
@@ -502,7 +524,6 @@ describe("model-first canonical catalog", () => {
   it("exposes VM0 price tiers for built-in reasoning models", () => {
     expect(VM0_MODEL_PRICE_TIER).toEqual(
       expect.objectContaining({
-        "vm0-model": "$$",
         "claude-fable-5": "$$$$",
         "gpt-5.6-sol": "$$$",
         "gpt-5.6-terra": "$$",
@@ -519,7 +540,7 @@ describe("model-first canonical catalog", () => {
         "hy3-preview": "$",
       }),
     );
-    expect(getVm0ModelPriceTier("vm0-model")).toBe("$$");
+    expect(getVm0ModelPriceTier("vm0-model")).toBeUndefined();
     expect(getVm0ModelPriceTier("claude-fable-5")).toBe("$$$$");
     expect(getVm0ModelPriceTier("gpt-5.6-sol")).toBe("$$$");
     expect(getVm0ModelPriceTier("gpt-5.6-terra")).toBe("$$");
@@ -734,7 +755,7 @@ describe("model selection for Claude-compatible gateway providers", () => {
 describe("getVm0VisibleModels", () => {
   it("returns all VM0 managed models", () => {
     const models = getVm0VisibleModels();
-    expect(models).toContain("vm0-model");
+    expect(models).not.toContain("vm0-model");
     expect(models).toContain("claude-fable-5");
     expect(models).toContain("claude-opus-4-8");
     expect(models).toContain("kimi-k3");
@@ -919,55 +940,6 @@ describe("openai-api-key codex provider", () => {
 
   it("modelProviderFrameworkSchema accepts codex", () => {
     expect(modelProviderFrameworkSchema.safeParse("codex").success).toBe(true);
-  });
-});
-
-describe("vm0-model managed proxy", () => {
-  it("disables reasoning summaries by default", () => {
-    const config = getVm0ModelCodexRuntimeConfig("https://www.vm0.ai/v1");
-
-    expect(config).toMatchObject({
-      modelCatalog: {
-        models: [
-          {
-            slug: "vm0-model",
-            supports_reasoning_summaries: false,
-            default_reasoning_summary: "none",
-            context_window: 1_000_000,
-            max_context_window: 1_000_000,
-          },
-        ],
-      },
-    });
-  });
-
-  it("scopes both managed credentials to the configured web origin", () => {
-    const config = getVm0ModelProviderConfig(
-      "https://preview-www.vm0.test/workspace",
-    );
-
-    expect(config.baseUrl).toBe(
-      "https://preview-www.vm0.test/api/internal/vm0-model/v1",
-    );
-    expect(config.firewall).toMatchObject({
-      name: "model-provider:vm0-model",
-      apis: [
-        {
-          base: "https://preview-www.vm0.test/api/internal/vm0-model/v1/responses",
-          auth: {
-            headers: {
-              Authorization: "Bearer ${{ secrets.OPENAI_API_KEY }}",
-              "X-VM0-Upstream-Authorization":
-                "Bearer ${{ secrets.VM0_MODEL_UPSTREAM_API_KEY }}",
-            },
-          },
-        },
-      ],
-    });
-    expect(config.firewall.placeholders).toStrictEqual({
-      OPENAI_API_KEY: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
-      VM0_MODEL_UPSTREAM_API_KEY: expect.stringMatching(/^sk-vm0-upstream-/),
-    });
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -5,7 +5,7 @@ import { hostedArtifactKindSchema } from "./zero-host";
 import { runStatusSchema } from "./runs";
 import { zeroGoalEventSchema } from "./zero-goals";
 import { triggerSourceSchema } from "./logs";
-import { isSupportedRunModel } from "./model-providers";
+import { requestedRunModelSchema } from "./model-providers";
 
 const c = initContract();
 export const MODEL_FIRST_SELECTION_PROVIDER_ID =
@@ -431,17 +431,7 @@ const chatThreadDraftSchema = z.object({
   draftAttachments: z.array(persistedAttachmentSchema).nullable(),
 });
 
-const selectedModelRequestSchema = z
-  .string()
-  .min(1)
-  .superRefine((value, ctx) => {
-    if (!isSupportedRunModel(value)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid model selection",
-      });
-    }
-  });
+const selectedModelRequestSchema = requestedRunModelSchema;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -542,6 +542,7 @@ export {
   orgModelPoliciesResponseSchema,
   updateOrgModelPoliciesRequestSchema,
   supportedRunModelSchema,
+  requestedRunModelSchema,
   modelProviderCredentialScopeSchema,
   MODEL_PROVIDER_TYPES,
   SUPPORTED_RUN_MODELS,

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -5,7 +5,6 @@
  * without importing the full model provider contract schema.
  */
 export const SUPPORTED_RUN_MODELS = [
-  "vm0-model",
   "claude-fable-5",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
@@ -40,7 +39,6 @@ export type Vm0ModelPriceTier = "$" | "$$" | "$$$" | "$$$$";
 export const VM0_MODEL_PRICE_TIER = Object.freeze<
   Record<SupportedRunModel, Vm0ModelPriceTier>
 >({
-  "vm0-model": "$$",
   "claude-fable-5": "$$$$",
   "gpt-5.6-sol": "$$$",
   "gpt-5.6-terra": "$$",

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -48,51 +48,6 @@ export const MODEL_PROVIDER_ENV_PLACEHOLDERS = {
   CHATGPT_REFRESH_TOKEN: "rt_VM0_PLACEHOLDER_DO_NOT_TRUST",
 } as const;
 
-const VM0_MODEL_PROXY_PATH = "/api/internal/vm0-model/v1";
-
-const VM0_MODEL_UPSTREAM_API_KEY_PLACEHOLDER =
-  "sk-vm0-upstream-CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafe";
-
-export interface Vm0ModelProviderConfig {
-  readonly baseUrl: string;
-  readonly firewall: ExpandedFirewallConfig;
-}
-
-/**
- * Auto uses the public Responses shape while keeping both credentials in
- * firewall auth. Codex sees only the canonical OPENAI_API_KEY placeholder; the
- * firewall injects the proxy credential as Authorization and a managed OpenAI
- * credential in the internal upstream header consumed by the proxy.
- */
-export function getVm0ModelProviderConfig(
-  proxyHost: string,
-): Vm0ModelProviderConfig {
-  const baseUrl = new URL(VM0_MODEL_PROXY_PATH, proxyHost).toString();
-  return {
-    baseUrl,
-    firewall: {
-      name: "model-provider:vm0-model",
-      apis: [
-        {
-          base: `${baseUrl}/responses`,
-          auth: {
-            headers: {
-              Authorization: "Bearer ${{ secrets.OPENAI_API_KEY }}",
-              "X-VM0-Upstream-Authorization":
-                "Bearer ${{ secrets.VM0_MODEL_UPSTREAM_API_KEY }}",
-            },
-          },
-          permissions: [],
-        },
-      ],
-      placeholders: {
-        OPENAI_API_KEY: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
-        VM0_MODEL_UPSTREAM_API_KEY: VM0_MODEL_UPSTREAM_API_KEY_PLACEHOLDER,
-      },
-    },
-  };
-}
-
 const MODEL_PROVIDER_FIREWALL_PROVIDER_CONFIGS: Record<
   LegacySingleSecretProvider,
   SingleSecretFirewallProviderConfig

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -14,7 +14,6 @@ import {
 } from "./model-provider-types";
 export {
   getModelProviderFirewall,
-  getVm0ModelProviderConfig,
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
 } from "./model-provider-firewalls";
@@ -84,63 +83,6 @@ export type ModelProviderCodexRuntimeConfig = z.infer<
   typeof modelProviderCodexRuntimeConfigSchema
 >;
 
-export function getVm0ModelCodexRuntimeConfig(
-  baseUrl: string,
-): ModelProviderCodexRuntimeConfig {
-  return {
-    providerId: "vm0-model",
-    name: "Auto",
-    baseUrl,
-    envKey: "OPENAI_API_KEY",
-    wireApi: "responses",
-    supportsWebsockets: false,
-    modelCatalog: {
-      models: [
-        {
-          slug: "vm0-model",
-          display_name: "Auto",
-          description: "Automatically routes each task to a VM0 model.",
-          default_reasoning_level: null,
-          supported_reasoning_levels: [],
-          shell_type: "shell_command",
-          visibility: "list",
-          supported_in_api: true,
-          priority: 0,
-          additional_speed_tiers: [],
-          service_tiers: [],
-          default_service_tier: null,
-          availability_nux: null,
-          upgrade: null,
-          base_instructions: "",
-          model_messages: null,
-          include_skills_usage_instructions: false,
-          supports_reasoning_summaries: false,
-          default_reasoning_summary: "none",
-          support_verbosity: true,
-          default_verbosity: null,
-          apply_patch_tool_type: "freeform",
-          web_search_tool_type: "text_and_image",
-          truncation_policy: { mode: "tokens", limit: 10_000 },
-          supports_parallel_tool_calls: true,
-          supports_image_detail_original: true,
-          context_window: 1_000_000,
-          max_context_window: 1_000_000,
-          auto_compact_token_limit: null,
-          comp_hash: null,
-          effective_context_window_percent: 95,
-          experimental_supported_tools: [],
-          input_modalities: ["text", "image"],
-          supports_search_tool: true,
-          use_responses_lite: false,
-          auto_review_model_override: null,
-          tool_mode: null,
-          multi_agent_version: null,
-        },
-      ],
-    },
-  };
-}
-
 /**
  * The org slug authorized to use the VM0 managed provider.
  */
@@ -163,6 +105,25 @@ export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
 
 export const supportedRunModelSchema = z.enum(SUPPORTED_RUN_MODELS);
 
+const RETIRED_VM0_AUTO_MODEL = "vm0-model";
+
+export const requestedRunModelSchema = z
+  .string()
+  .min(1)
+  .superRefine((model, ctx) => {
+    if (model !== RETIRED_VM0_AUTO_MODEL && !isSupportedRunModel(model)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid model selection",
+      });
+    }
+  })
+  .transform((model): SupportedRunModel => {
+    return model === RETIRED_VM0_AUTO_MODEL
+      ? DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL
+      : supportedRunModelSchema.parse(model);
+  });
+
 export const modelProviderCredentialScopeSchema = z.enum(["org", "member"]);
 
 export type ModelProviderCredentialScope = z.infer<
@@ -178,7 +139,6 @@ export interface DefaultOrgModelPolicySeed {
 }
 
 const SUPPORTED_RUN_MODEL_LABELS: Record<SupportedRunModel, string> = {
-  "vm0-model": "Auto",
   "claude-fable-5": "Claude Fable 5",
   "claude-opus-4-8": "Claude Opus 4.8",
   "claude-opus-4-7": "Claude Opus 4.7",
@@ -283,10 +243,6 @@ interface Vm0ModelConfig {
 // `MODEL_PROVIDER_TYPES.vm0.models` is derived from it, which in turn drives
 // the order models appear in the Built-in model dropdown.
 export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
-  "vm0-model": {
-    concreteType: "openai-api-key",
-    vendor: "openai",
-  },
   "claude-fable-5": {
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
@@ -389,7 +345,6 @@ const VM0_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
   VM0_MODEL_ALIAS_TO_MODEL;
 
 const LIMITED_FREE1_ALLOWED_RUN_MODELS: ReadonlySet<string> = new Set([
-  "vm0-model",
   "claude-sonnet-5",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
@@ -971,7 +926,6 @@ export const MODEL_PROVIDER_TYPES = {
 } as const satisfies Record<ModelProviderType, unknown>;
 
 const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
-  "vm0-model": ["vm0"],
   "claude-fable-5": [
     "vm0",
     "claude-code-oauth-token",
@@ -1515,6 +1469,10 @@ export const updateOrgModelPolicySchema = z.object({
 
 export type UpdateOrgModelPolicy = z.infer<typeof updateOrgModelPolicySchema>;
 
+const requestedOrgModelPolicySchema = updateOrgModelPolicySchema.extend({
+  model: z.union([supportedRunModelSchema, z.literal(RETIRED_VM0_AUTO_MODEL)]),
+});
+
 export const orgModelPoliciesResponseSchema = z.object({
   policies: z.array(orgModelPolicySchema),
   workspaceDefaultModel: supportedRunModelSchema.nullable(),
@@ -1525,9 +1483,58 @@ export type OrgModelPoliciesResponse = z.infer<
   typeof orgModelPoliciesResponseSchema
 >;
 
-export const updateOrgModelPoliciesRequestSchema = z.object({
-  policies: z.array(updateOrgModelPolicySchema),
-});
+export const updateOrgModelPoliciesRequestSchema = z
+  .object({
+    policies: z.array(requestedOrgModelPolicySchema),
+  })
+  .transform(({ policies }) => {
+    const retiredDefault = policies.some((policy) => {
+      return (
+        policy.model === RETIRED_VM0_AUTO_MODEL && policy.isDefault === true
+      );
+    });
+    const activePolicies = policies.flatMap(
+      (policy): UpdateOrgModelPolicy[] => {
+        if (policy.model === RETIRED_VM0_AUTO_MODEL) {
+          return [];
+        }
+        return [
+          {
+            model: policy.model,
+            isDefault: policy.isDefault,
+            defaultProviderType: policy.defaultProviderType,
+            credentialScope: policy.credentialScope,
+            modelProviderId: policy.modelProviderId,
+          },
+        ];
+      },
+    );
+    if (!retiredDefault) {
+      return { policies: activePolicies };
+    }
+
+    const replacementExists = activePolicies.some((policy) => {
+      return policy.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+    });
+    const normalizedPolicies = activePolicies.map(
+      (policy): UpdateOrgModelPolicy => {
+        return {
+          ...policy,
+          isDefault: policy.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+        };
+      },
+    );
+    if (!replacementExists) {
+      normalizedPolicies.push({
+        model: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      });
+    }
+    return { policies: normalizedPolicies };
+  });
 
 export type UpdateOrgModelPoliciesRequest = z.infer<
   typeof updateOrgModelPoliciesRequestSchema

--- a/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { initContract, authHeadersSchema } from "./base";
 import { apiErrorSchema } from "./errors";
-import { supportedRunModelSchema } from "./model-providers";
+import {
+  requestedRunModelSchema,
+  supportedRunModelSchema,
+} from "./model-providers";
 
 const c = initContract();
 
@@ -15,7 +18,7 @@ export type UserModelPreferenceResponse = z.infer<
 >;
 
 export const updateUserModelPreferenceRequestSchema = z.object({
-  selectedModel: supportedRunModelSchema.nullable(),
+  selectedModel: requestedRunModelSchema.nullable(),
 });
 
 export type UpdateUserModelPreferenceRequest = z.infer<

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,7 +54,6 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "codexFastMode",
-  Vm0Model = "vm0Model",
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",
   StructuredPrompt = "structuredPrompt",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -315,11 +315,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.Vm0Model]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Show Auto in the workspace Add model selector.",
-    enabled: false,
-  },
   [FeatureSwitchKey.RealAgentInPreview]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -6,8 +6,8 @@
 	}
 }
 
-# Public dev tunnel ingress. Keep Auto on the same www authority as the
-# API while routing only its internal proxy path to vm0-marketing.
+# Public dev tunnel ingress. Retain the legacy Auto route temporarily for runs
+# claimed by pre-retirement API deployments.
 :3043 {
 	handle /api/internal/vm0-model/v1/* {
 		reverse_proxy localhost:3042

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -27,7 +27,7 @@ Marketing      App            API
 Cloudflare www tunnel
   ↓
 Caddy tunnel ingress (HTTP: 3043)
-  ├─ /api/internal/vm0-model/v1/* → Marketing (port 3042)
+  ├─ legacy Auto route → Marketing (port 3042)
   └─ all other paths                       → API (port 3001)
 ```
 
@@ -91,8 +91,8 @@ The `Caddyfile` defines:
 | api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)   |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443 |
 
-The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043. Caddy sends the Auto proxy path to vm0-marketing and preserves the
-API as the fallback for every other path.
+The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043. Caddy temporarily preserves the retired Auto proxy path for old API
+claims and uses the API as the fallback for every other path.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary

- retire Auto (`vm0-model`) from the supported model catalog, model policies, UI, feature switches, API run creation, and proxy credentials
- normalize legacy client selections to the current Luna default and reconcile legacy model-policy writes
- retain historical usage labels and temporary guest, runner, and proxy readers so rolling deployments can drain safely

## Testing

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- full Vitest suite: 598 files passed, 7,497 tests passed
- rebase verification: affected-workspace lint and type checks, plus 392 focused tests
- web API environment action shell test
- runtime API schema compatibility check