### PR TITLE
feat(ci): collapse production rollback dashboard entries

### DIFF
--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -115,6 +115,7 @@ PATH="${fake_bin}:$PATH" \
 
 grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
 grep -Fqx -- "<summary>07-23-2026 07:39:40 SGT</summary>" "$output_file"
+grep -Fqx -- "* RevertId: \`${target_commit}\`" "$output_file"
 grep -Fqx -- "* PDT 07-22-2026 16:39:40" "$output_file"
 grep -Fqx -- "### [app](https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0): \`0.618.0\`" "$output_file"
 grep -Fqx -- "### [api](https://github.com/vm0-ai/vm0/releases/tag/api-v1.303.0): \`1.303.0\`" "$output_file"
@@ -127,8 +128,15 @@ grep -Fqx -- "* api feature" "$output_file"
 grep -Fqx -- "* runner improvement" "$output_file"
 grep -Fqx -- "* zeta feature" "$output_file"
 grep -Fqx -- "<summary>07-22-2026 07:39:39 SGT</summary>" "$output_file"
+grep -Fqx -- "* RevertId: \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`" "$output_file"
 grep -Fqx -- "* PDT 07-21-2026 16:39:39" "$output_file"
 grep -Fqx -- "* retained fix" "$output_file"
+
+revert_id_line=$(grep -n -F "* RevertId: \`${target_commit}\`" "$output_file" | cut -d: -f1)
+pdt_line=$(grep -n -F "* PDT 07-22-2026 16:39:40" "$output_file" | cut -d: -f1)
+if ! [ "$revert_id_line" -lt "$pdt_line" ]; then
+  fail "RevertId should appear above Pacific time"
+fi
 
 app_line=$(grep -n '^### \[app\]' "$output_file" | cut -d: -f1)
 api_line=$(grep -n '^### \[api\]' "$output_file" | cut -d: -f1)

--- a/.github/scripts/tests/update-rollback-dashboard-body-test.sh
+++ b/.github/scripts/tests/update-rollback-dashboard-body-test.sh
@@ -35,6 +35,30 @@ This issue is automatically maintained by CI. Do not edit manually.
 ### legacy entry
 | Component | Version |
 | api | v1.0.0 |
+<!-- ROLLBACK_ENTRY_START aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->
+## 07-22-2026 07:39:39 Asia/Singapore · 07-21-2026 16:39:39 SF · RollbackId: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+
+### [legacy-app](https://example.test/legacy-app): `1.0.0`
+
+**Change Log**
+
+#### Dependencies
+
+* old dependency
+
+#### Bug Fixes
+
+* retained fix
+
+### [legacy-core](https://example.test/legacy-core): `2.0.0`
+
+**Change Log**
+
+#### Dependencies
+
+* trailing dependency
+
+<!-- ROLLBACK_ENTRY_END -->
 <!-- ROLLBACK_ENTRIES_END -->
 EOF
 
@@ -52,7 +76,7 @@ jq -n --arg target "$target_commit" '[
     target_commitish: $target,
     html_url: "https://github.com/vm0-ai/vm0/releases/tag/core-v8.452.0",
     published_at: "2026-07-22T23:39:31Z",
-    body: "## [8.452.0](https://example.test/core) (2026-07-22)\n\n### Bug Fixes\n\n* core fix"
+    body: "## [8.452.0](https://example.test/core) (2026-07-22)\n\n### Dependencies\n\n* core dependency"
   },
   {
     tag_name: "runner-rs-v0.147.2",
@@ -73,7 +97,7 @@ jq -n --arg target "$target_commit" '[
     target_commitish: $target,
     html_url: "https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0",
     published_at: "2026-07-22T23:39:34Z",
-    body: "## [0.618.0](https://example.test/app) (2026-07-22)\n\n### Features\n\n* app feature"
+    body: "## [0.618.0](https://example.test/app) (2026-07-22)\n\n### Features\n\n* app feature\n\n### Dependencies\n\n* app dependency"
   },
   {
     tag_name: "unrelated-v9.9.9",
@@ -90,7 +114,8 @@ PATH="${fake_bin}:$PATH" \
   "$TARGET" "$body_file" "$target_commit" "$rollback_url" >"$output_file"
 
 grep -Fqx -- "[Rollback](${rollback_url})" "$output_file"
-grep -Fqx -- "## 07-23-2026 07:39:40 Asia/Singapore · 07-22-2026 16:39:40 SF · RollbackId: \`${target_commit}\`" "$output_file"
+grep -Fqx -- "<summary>07-23-2026 07:39:40 SGT</summary>" "$output_file"
+grep -Fqx -- "* PDT 07-22-2026 16:39:40" "$output_file"
 grep -Fqx -- "### [app](https://github.com/vm0-ai/vm0/releases/tag/app-v0.618.0): \`0.618.0\`" "$output_file"
 grep -Fqx -- "### [api](https://github.com/vm0-ai/vm0/releases/tag/api-v1.303.0): \`1.303.0\`" "$output_file"
 grep -Fqx -- "### [runner-rs](https://github.com/vm0-ai/vm0/releases/tag/runner-rs-v0.147.2): \`0.147.2\`" "$output_file"
@@ -100,8 +125,10 @@ grep -Fqx -- "#### Features" "$output_file"
 grep -Fqx -- "* app feature" "$output_file"
 grep -Fqx -- "* api feature" "$output_file"
 grep -Fqx -- "* runner improvement" "$output_file"
-grep -Fqx -- "* core fix" "$output_file"
 grep -Fqx -- "* zeta feature" "$output_file"
+grep -Fqx -- "<summary>07-22-2026 07:39:39 SGT</summary>" "$output_file"
+grep -Fqx -- "* PDT 07-21-2026 16:39:39" "$output_file"
+grep -Fqx -- "* retained fix" "$output_file"
 
 app_line=$(grep -n '^### \[app\]' "$output_file" | cut -d: -f1)
 api_line=$(grep -n '^### \[api\]' "$output_file" | cut -d: -f1)
@@ -123,6 +150,28 @@ if grep -Fq 'must not appear' "$output_file"; then
 fi
 if grep -Fq '## [0.618.0]' "$output_file"; then
   fail "duplicate release title was not removed"
+fi
+if grep -Fq 'RollbackId:' "$output_file"; then
+  fail "rollback commit should not be visible in entry headings"
+fi
+if grep -Fq '#### Dependencies' "$output_file" || \
+  grep -Fq 'app dependency' "$output_file" || \
+  grep -Fq 'core dependency' "$output_file" || \
+  grep -Fq 'old dependency' "$output_file" || \
+  grep -Fq 'trailing dependency' "$output_file"; then
+  fail "dependency-only changelog sections were not removed"
+fi
+if sed -n '/^### \[core\]/,/^### \[zeta\]/p' "$output_file" |
+  grep -Fq '**Change Log**'; then
+  fail "dependency-only release retained an empty changelog heading"
+fi
+if grep -Eq '^<details[[:space:]]+open' "$output_file"; then
+  fail "rollback entries should be collapsed by default"
+fi
+initial_details_count=$(grep -c '^<details>$' "$output_file")
+initial_details_end_count=$(grep -c '^</details>$' "$output_file")
+if [ "$initial_details_count" -ne "$initial_details_end_count" ]; then
+  fail "legacy dashboard migration left an unclosed details block"
 fi
 
 write_single_release() {
@@ -159,6 +208,10 @@ done
 entry_count=$(grep -c '^<!-- ROLLBACK_ENTRY_START [0-9a-f]\{40\} -->$' "$output_file")
 if [ "$entry_count" -ne 7 ]; then
   fail "expected 7 dashboard entries, found $entry_count"
+fi
+details_count=$(grep -c '^<details>$' "$output_file")
+if [ "$details_count" -ne "$entry_count" ]; then
+  fail "expected every dashboard entry to be a collapsible details block"
 fi
 
 latest_commit=0000000000000000000000000000000000000008

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -97,6 +97,7 @@ new_entry_file="${entries_dir}/000.md"
   printf '<!-- ROLLBACK_ENTRY_START %s -->\n' "$target_commit"
   printf '<details>\n'
   printf '<summary>%s SGT</summary>\n\n' "$singapore_time"
+  printf '* RevertId: `%s`\n' "$target_commit"
   printf '* %s %s\n\n' "$sf_zone" "$sf_time"
 
   while IFS=$'\t' read -r artifact version url encoded_body; do
@@ -144,6 +145,13 @@ normalize_retained_entry() {
   local normalized_entry_file="${entry_file}.normalized"
 
   awk '
+    /^<!-- ROLLBACK_ENTRY_START [0-9a-f]+ -->$/ {
+      entry_commit = $0
+      sub(/^<!-- ROLLBACK_ENTRY_START /, "", entry_commit)
+      sub(/ -->$/, "", entry_commit)
+      print
+      next
+    }
     /^```/ {
       in_fence = !in_fence
       if (!skip_dependencies) {
@@ -168,6 +176,7 @@ normalize_retained_entry() {
       print "<details>"
       print "<summary>" singapore_time " SGT</summary>"
       print ""
+      print "* RevertId: `" entry_commit "`"
       print "* PDT " sf_time
       print ""
       converted = 1

--- a/.github/scripts/update-rollback-dashboard-body.sh
+++ b/.github/scripts/update-rollback-dashboard-body.sh
@@ -59,6 +59,7 @@ jq -ce --arg target "$target_commit" '
 published_at=$(jq -r 'map(.published_at) | max' "$normalized_releases_file")
 singapore_time=$(TZ=Asia/Singapore date -d "$published_at" '+%m-%d-%Y %H:%M:%S')
 sf_time=$(TZ=America/Los_Angeles date -d "$published_at" '+%m-%d-%Y %H:%M:%S')
+sf_zone=$(TZ=America/Los_Angeles date -d "$published_at" '+%Z')
 jq -r '.[] | [.artifact, .version, .url, (.body | @base64)] | @tsv' \
   "$normalized_releases_file" >"$release_rows_file"
 
@@ -72,9 +73,17 @@ format_changelog() {
     { skip_leading_blanks = 0 }
     /^```/ {
       in_fence = !in_fence
-      print
+      if (!skip_dependencies) print
       next
     }
+    !in_fence && /^###[[:space:]]+Dependencies[[:space:]]*$/ {
+      skip_dependencies = 1
+      next
+    }
+    !in_fence && skip_dependencies && /^###[[:space:]]+/ {
+      skip_dependencies = 0
+    }
+    skip_dependencies { next }
     !in_fence && /^#/ {
       print "#" $0
       next
@@ -86,24 +95,27 @@ format_changelog() {
 new_entry_file="${entries_dir}/000.md"
 {
   printf '<!-- ROLLBACK_ENTRY_START %s -->\n' "$target_commit"
-  printf '## %s Asia/Singapore · %s SF · RollbackId: `%s`\n\n' \
-    "$singapore_time" \
-    "$sf_time" \
-    "$target_commit"
+  printf '<details>\n'
+  printf '<summary>%s SGT</summary>\n\n' "$singapore_time"
+  printf '* %s %s\n\n' "$sf_zone" "$sf_time"
 
   while IFS=$'\t' read -r artifact version url encoded_body; do
-    printf '### [%s](%s): `%s`\n\n' "$artifact" "$url" "$version"
-    printf '**Change Log**\n\n'
+    printf '### [%s](%s): `%s`\n' "$artifact" "$url" "$version"
 
     changelog=$(printf '%s' "$encoded_body" | base64 --decode)
     if [ -n "$changelog" ]; then
-      printf '%s\n' "$changelog" | format_changelog
+      formatted_changelog=$(printf '%s\n' "$changelog" | format_changelog)
     else
-      printf '_No changelog provided._\n'
+      formatted_changelog='_No changelog provided._'
+    fi
+    if [ -n "$formatted_changelog" ]; then
+      printf '\n**Change Log**\n\n'
+      printf '%s\n' "$formatted_changelog"
     fi
     printf '\n'
   done <"$release_rows_file"
 
+  printf '</details>\n'
   printf '<!-- ROLLBACK_ENTRY_END -->\n'
 } >"$new_entry_file"
 
@@ -126,6 +138,90 @@ awk -v entries_dir="$entries_dir" -v target="$target_commit" '
     capture = 0
   }
 ' "$body_file"
+
+normalize_retained_entry() {
+  local entry_file=$1
+  local normalized_entry_file="${entry_file}.normalized"
+
+  awk '
+    /^```/ {
+      in_fence = !in_fence
+      if (!skip_dependencies) {
+        if (pending_changelog) {
+          print "**Change Log**"
+          print ""
+          pending_changelog = 0
+        }
+        print
+      }
+      next
+    }
+    !in_fence && /^## .* Asia\/Singapore · .* SF · RollbackId:/ {
+      singapore_time = $0
+      sub(/^## /, "", singapore_time)
+      sub(/ Asia\/Singapore ·.*$/, "", singapore_time)
+
+      sf_time = $0
+      sub(/^.* Asia\/Singapore · /, "", sf_time)
+      sub(/ SF · RollbackId:.*$/, "", sf_time)
+
+      print "<details>"
+      print "<summary>" singapore_time " SGT</summary>"
+      print ""
+      print "* PDT " sf_time
+      print ""
+      converted = 1
+      next
+    }
+    !in_fence && /^\*\*Change Log\*\*$/ {
+      pending_changelog = 1
+      next
+    }
+    !in_fence && pending_changelog && /^[[:space:]]*$/ { next }
+    !in_fence && /^####[[:space:]]+Dependencies[[:space:]]*$/ {
+      skip_dependencies = 1
+      next
+    }
+    !in_fence && skip_dependencies &&
+      (/^#[[:space:]]/ ||
+       /^##[[:space:]]/ ||
+       /^###[[:space:]]/ ||
+       /^####[[:space:]]/) {
+      skip_dependencies = 0
+    }
+    !in_fence && skip_dependencies &&
+      (/^<\/details>$/ ||
+       /^<!-- ROLLBACK_ENTRY_END -->$/) {
+      skip_dependencies = 0
+    }
+    skip_dependencies { next }
+    pending_changelog {
+      if (/^###[[:space:]]+\[/ ||
+          /^<\/details>$/ ||
+          /^<!-- ROLLBACK_ENTRY_END -->$/) {
+        pending_changelog = 0
+      } else {
+        print "**Change Log**"
+        print ""
+        pending_changelog = 0
+      }
+    }
+    /^<!-- ROLLBACK_ENTRY_END -->$/ {
+      if (converted) print "</details>"
+      print
+      next
+    }
+    { print }
+  ' "$entry_file" >"$normalized_entry_file"
+
+  mv "$normalized_entry_file" "$entry_file"
+}
+
+for entry_file in "$entries_dir"/[0-9][0-9][1-9].md; do
+  if [ -f "$entry_file" ]; then
+    normalize_retained_entry "$entry_file"
+  fi
+done
 
 render_body() {
   local output_file=$1


### PR DESCRIPTION
## Summary

- Render each production rollback entry as a collapsed details block labeled with SGT.
- Show RevertId first and Pacific time immediately below it inside the expanded entry.
- Remove Dependencies sections and omit empty Change Log headings.
- Migrate retained legacy entries to the collapsed format while preserving their revert commit IDs.

## User-visible impact

Issue #6792 will default to a compact list of release timestamps. Expanding an entry shows its RevertId, Pacific time, per-artifact versions, and non-dependency changelog details.

## Verification

- Ran Bash syntax checks for the generator and its integration test.
- Ran .github/scripts/tests/update-rollback-dashboard-body-test.sh.
- Generated a read-only preview from the current #6792 body and GitHub release metadata, including RevertId placement above PDT.