### PR TITLE
fix(chat): use structured prompts in incomplete-round context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -7,9 +7,14 @@ import type {
   AttachFile,
   GenerationTemplateRequest,
   PagedChatMessage,
+  UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
-import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_PICKER_ITEMS,
+} from "@vm0/core";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
@@ -161,6 +166,8 @@ async function startChatRun(
     readonly threadId?: string;
     readonly selectedModel?: string;
     readonly attachFiles?: readonly AttachFile[];
+    readonly generationTemplate?: GenerationTemplateRequest;
+    readonly structuredPrompt?: UserMessageDocument;
   },
 ): Promise<{
   readonly runId: string;
@@ -176,6 +183,12 @@ async function startChatRun(
     ...(body.attachFiles === undefined
       ? {}
       : { attachFiles: body.attachFiles }),
+    ...(body.generationTemplate === undefined
+      ? {}
+      : { generationTemplate: body.generationTemplate }),
+    ...(body.structuredPrompt === undefined
+      ? {}
+      : { structuredPrompt: body.structuredPrompt }),
     ...(body.selectedModel === undefined
       ? body.threadId === undefined
         ? { model: "claude-sonnet-4-6" }
@@ -2286,6 +2299,125 @@ describe("CHAT-02: failed chat callbacks", () => {
 });
 
 describe("CHAT-02: auto-send after failures", () => {
+  it("uses structured failed messages for normal and queued incomplete-round context", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.StructuredPrompt]: true },
+    );
+
+    const anchor = await startChatRun(actor, {
+      agentId,
+      prompt: "successful structured context anchor",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorHeaders);
+    await flushWaitUntilForTest();
+
+    const style = ILLUSTRATION_TEMPLATE_ITEMS[0];
+    if (!style) {
+      throw new Error("Expected a registered illustration style");
+    }
+    const generationTemplate: GenerationTemplateRequest = {
+      type: "illustration",
+      selection: { illustrationStyleId: style.illustrationStyleId },
+    };
+    const structuredPrompt: UserMessageDocument = {
+      version: 1,
+      parts: [
+        {
+          type: "template",
+          titleSnapshot: style.title,
+          template: generationTemplate,
+        },
+        { type: "text", text: "structured failed request" },
+      ],
+    };
+    const templatePrompt = `Select ${style.title} illustration template`;
+
+    const failedForNormal = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "stale failed legacy request",
+      generationTemplate,
+      structuredPrompt,
+    });
+    const failedForNormalHeaders = await claimChatRun(
+      runnerGroup,
+      failedForNormal.runId,
+    );
+    await failChatRun(
+      failedForNormal.runId,
+      failedForNormalHeaders,
+      "structured normal context failure",
+    );
+    await flushWaitUntilForTest();
+
+    const normal = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "normal incomplete context probe",
+    });
+    const normalContext = await waitForRunContext(actor, normal.runId);
+    expect(normalContext.body.appendSystemPrompt).toContain(templatePrompt);
+    await api.requestCancelRun(actor, normal.runId, [200]);
+    await waitForRunStatus(actor, normal.runId, "cancelled");
+    await flushWaitUntilForTest();
+
+    const failedForQueue = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "second stale failed legacy request",
+      generationTemplate,
+      structuredPrompt,
+    });
+    const failedForQueueHeaders = await claimChatRun(
+      runnerGroup,
+      failedForQueue.runId,
+    );
+    const queuedPrompt = "queued incomplete context probe";
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: queuedPrompt,
+    });
+    await failChatRun(
+      failedForQueue.runId,
+      failedForQueueHeaders,
+      "structured queued context failure",
+    );
+
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.content === queuedPrompt && message.runId !== undefined
+          );
+        });
+      },
+    );
+    const promoted = userMessages(messages.messages).find((message) => {
+      return message.content === queuedPrompt && message.runId !== undefined;
+    });
+    if (!promoted?.runId) {
+      throw new Error("Expected the queued probe to be promoted");
+    }
+    const queuedContext = await waitForRunContext(actor, promoted.runId);
+    expect(queuedContext.body.appendSystemPrompt).toContain(templatePrompt);
+
+    await api.requestCancelRun(actor, promoted.runId, [200]);
+    await waitForRunStatus(actor, promoted.runId, "cancelled");
+  }, 90_000);
+
   it("auto-sends the queued message after a failure, carrying attachments, incomplete-round context, and the continued session", async () => {
     const { actor, agentId, runnerGroup, storage } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1388,6 +1388,7 @@ async function resolveThread(params: {
   readonly requestedCodexServiceTier: CodexServiceTier | undefined;
   readonly persistRequestedCodexServiceTier: boolean;
   readonly codexFastModeEnabled: boolean;
+  readonly structuredPromptEnabled: boolean;
 }): Promise<ResolvedThreadAndRunConfiguration | NormalSendFailure> {
   if (!params.existingThreadId) {
     if (!params.explicitRunConfiguration) {
@@ -1462,7 +1463,11 @@ async function resolveThread(params: {
 
   const [latestSession, incompleteContext] = await Promise.all([
     latestSessionForThread(params.db, thread.id),
-    loadWebChatIncompleteContext(params.db, thread.id),
+    loadWebChatIncompleteContext(
+      params.db,
+      thread.id,
+      params.structuredPromptEnabled,
+    ),
   ]);
   const startNewSession = shouldStartNewChatSession({
     latestModel: latestSession?.selectedModel,
@@ -2178,6 +2183,7 @@ function resolveTimedThread(
           args.body.modelSelection !== undefined ||
           args.body.runOptions !== undefined,
         codexFastModeEnabled: featureSwitches.codexFastModeEnabled,
+        structuredPromptEnabled: featureSwitches.structuredPromptEnabled,
       });
     },
   );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1872,18 +1872,28 @@ function loadQueuedMessageSessionState(args: CreateQueuedChatRunInputArgs) {
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
     "nested",
-    () => {
-      return Promise.all([
+    async () => {
+      const [latestSession, featureSwitchContext] = await Promise.all([
         latestSessionForThreadFromDb(
           args.db,
           args.threadId,
           args.queuedMessage.triggerSource,
         ),
-        args.queuedMessage.triggerSource === "web"
-          ? loadWebChatIncompleteContext(args.db, args.threadId)
-          : Promise.resolve(""),
         loadUserFeatureSwitchContext(args.db, args.agent.orgId, args.userId),
       ]);
+      const structuredPromptEnabled = isFeatureEnabled(
+        FeatureSwitchKey.StructuredPrompt,
+        featureSwitchContext,
+      );
+      const incompleteContext =
+        args.queuedMessage.triggerSource === "web"
+          ? await loadWebChatIncompleteContext(
+              args.db,
+              args.threadId,
+              structuredPromptEnabled,
+            )
+          : "";
+      return [latestSession, incompleteContext, featureSwitchContext] as const;
     },
   );
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,11 +1,13 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
+import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
 import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
 import type { Db } from "../external/db";
 import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
+import { projectStructuredUserMessage } from "./zero-chat-structured-message.service";
 
 const INCOMPLETE_ROUND_LIMIT = 20;
 const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
@@ -20,6 +22,7 @@ interface IncompleteRoundSelection {
 interface IncompleteRoundMessage {
   readonly role: "user" | "assistant";
   readonly content: string | null;
+  readonly structuredPrompt: UserMessageDocument | null;
   readonly attachFiles: readonly string[] | null;
 }
 
@@ -168,6 +171,7 @@ async function loadSelectedIncompleteRounds(
       runId: chatMessages.runId,
       role: chatMessages.role,
       content: chatMessages.content,
+      structuredPrompt: chatMessages.structuredPrompt,
       attachFiles: chatMessages.attachFiles,
     })
     .from(chatMessages)
@@ -209,6 +213,7 @@ async function loadSelectedIncompleteRounds(
     round.messages.push({
       role: row.role,
       content: row.content,
+      structuredPrompt: row.structuredPrompt,
       attachFiles: row.attachFiles,
     });
   }
@@ -236,7 +241,20 @@ function truncateIncomplete(value: string): string {
   return `${value.slice(0, INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
 }
 
-function formatIncompleteMessage(message: IncompleteRoundMessage): string {
+function formatIncompleteMessage(
+  message: IncompleteRoundMessage,
+  structuredPromptEnabled: boolean,
+): string {
+  if (
+    message.role === "user" &&
+    structuredPromptEnabled &&
+    message.structuredPrompt
+  ) {
+    const prompt = projectStructuredUserMessage(
+      message.structuredPrompt,
+    ).agentPrompt;
+    return `User: ${truncateIncomplete(prompt) || "[empty message]"}`;
+  }
   const attach = formatAttachFileIds(message.attachFiles);
   if (message.role === "user") {
     const body =
@@ -253,6 +271,7 @@ function formatIncompleteMessage(message: IncompleteRoundMessage): string {
 
 function buildWebChatIncompleteContext(
   rounds: readonly IncompleteRound[],
+  structuredPromptEnabled: boolean,
 ): string {
   if (rounds.length === 0) {
     return "";
@@ -260,7 +279,9 @@ function buildWebChatIncompleteContext(
   const total = rounds.length;
   const blocks = rounds.map((round, index) => {
     const relativeIndex = index - total + 1;
-    const rendered = round.messages.map(formatIncompleteMessage);
+    const rendered = round.messages.map((message) => {
+      return formatIncompleteMessage(message, structuredPromptEnabled);
+    });
     const hasAssistant = round.messages.some((message) => {
       return message.role === "assistant";
     });
@@ -293,8 +314,9 @@ function buildWebChatIncompleteContext(
 export async function loadWebChatIncompleteContext(
   db: Db,
   threadId: string,
+  structuredPromptEnabled: boolean,
 ): Promise<string> {
   const selection = await selectIncompleteRoundFrontier(db, threadId);
   const rounds = await loadSelectedIncompleteRounds(db, threadId, selection);
-  return buildWebChatIncompleteContext(rounds);
+  return buildWebChatIncompleteContext(rounds, structuredPromptEnabled);
 }


### PR DESCRIPTION
## Summary

- build failed, cancelled, and timed-out user-message context from structuredPrompt when the StructuredPrompt switch is enabled
- apply the same projection for direct sends and promoted queued sends
- retain the legacy content and attachment fallback when the switch is disabled or a message has no structured document
- cover both direct and queued incomplete-round context with an API integration regression test

## User-visible impact

A later run now receives the same ordered template, file, thread-reference, and text semantics from an incomplete prior user message that the original run received.

## Verification

- API type check passes
- API lint passes with zero warnings
- API integration coverage is included; local execution requires the repository PostgreSQL environment and is left to PR CI

Split from #22636.
Refs #22314