### PR TITLE
fix(chat): copy structured user messages

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -1,3 +1,7 @@
+import {
+  userMessageDocumentSchema,
+  type UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import { jsonParseOr, throwIfAbort } from "../utils.ts";
 
 const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
@@ -13,6 +17,7 @@ export interface ChatClipboardAttachment {
 export interface ChatClipboardPayload {
   text: string;
   attachments: ChatClipboardAttachment[];
+  structuredPrompt?: UserMessageDocument;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -48,9 +53,19 @@ function parseChatClipboardPayload(
   if (!parsed.attachments.every(isChatClipboardAttachment)) {
     return null;
   }
+  const structuredPrompt =
+    parsed.structuredPrompt === undefined
+      ? undefined
+      : userMessageDocumentSchema.safeParse(parsed.structuredPrompt);
+  if (structuredPrompt !== undefined && !structuredPrompt.success) {
+    return null;
+  }
   return {
     text: parsed.text,
     attachments: parsed.attachments,
+    ...(structuredPrompt?.success
+      ? { structuredPrompt: structuredPrompt.data }
+      : {}),
   };
 }
 
@@ -162,7 +177,7 @@ export async function writeChatMessageToClipboard(
 ): Promise<boolean> {
   const plainText = formatPlainText(payload);
   if (
-    payload.attachments.length === 0 ||
+    (payload.attachments.length === 0 && !payload.structuredPrompt) ||
     typeof ClipboardItem === "undefined" ||
     !navigator.clipboard?.write
   ) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -8,6 +8,7 @@ import {
   chatThreadRenameContract,
   chatThreadsContract,
   type PagedChatMessage,
+  type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroWorkflowsCollectionContract,
@@ -151,6 +152,7 @@ export function parseChatClipboardPayload(html: string): {
     contentType: string;
     size: number;
   }[];
+  structuredPrompt?: UserMessageDocument;
 } {
   const doc = new DOMParser().parseFromString(html, "text/html");
   const encoded = doc.querySelector<HTMLElement>("[data-vm0-chat-message]")
@@ -167,6 +169,7 @@ export function parseChatClipboardPayload(html: string): {
       contentType: string;
       size: number;
     }[];
+    structuredPrompt?: UserMessageDocument;
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
@@ -1227,6 +1228,95 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           size: 2048,
         },
       ],
+    });
+  });
+
+  it("copies the structured message snapshot instead of stale legacy fields", async () => {
+    const clipboard = context.mocks.browser.clipboardWrite();
+    const threadId = "structured-message-copy";
+    const referencedThreadId = "b0000000-0000-4000-a000-000000000799";
+    const style = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const firstAttachment = {
+      id: "structured-copy-first",
+      filename: "first.txt",
+      contentType: "text/plain",
+      size: 5,
+      url: "https://cdn.vm7.io/artifacts/test/copy/first.txt",
+    };
+    const secondAttachment = {
+      id: "structured-copy-second",
+      filename: "second.txt",
+      contentType: "text/plain",
+      size: 6,
+      url: "https://cdn.vm7.io/artifacts/test/copy/second.txt",
+    };
+    const structuredPrompt = {
+      version: 1 as const,
+      parts: [
+        {
+          type: "template" as const,
+          titleSnapshot: style.title,
+          template: {
+            type: "illustration" as const,
+            selection: {
+              illustrationStyleId: style.illustrationStyleId,
+            },
+          },
+        },
+        {
+          type: "file" as const,
+          fileId: secondAttachment.id,
+          filenameSnapshot: secondAttachment.filename,
+          contentType: secondAttachment.contentType,
+        },
+        { type: "text" as const, text: "Review " },
+        {
+          type: "chat_thread" as const,
+          threadId: referencedThreadId,
+          titleSnapshot: "Roadmap",
+        },
+        {
+          type: "file" as const,
+          fileId: firstAttachment.id,
+          filenameSnapshot: firstAttachment.filename,
+          contentType: firstAttachment.contentType,
+        },
+        { type: "text" as const, text: " now" },
+      ],
+    };
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          id: "msg-structured-copy",
+          role: "user",
+          content: "stale legacy content",
+          structuredPrompt,
+          attachFiles: [firstAttachment, secondAttachment],
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Review")).toBeInTheDocument();
+      expect(screen.getByText("Roadmap")).toBeInTheDocument();
+      expect(screen.queryByText("stale legacy content")).toBeNull();
+    });
+    click(screen.getByLabelText("Copy message"));
+
+    const item = await readSingleRichClipboardWrite(clipboard);
+    const html = await readClipboardItemText(item, "text/html");
+    expect(parseChatClipboardPayload(html)).toStrictEqual({
+      text: `Review [Roadmap](/chats/${referencedThreadId}) now`,
+      attachments: [secondAttachment, firstAttachment],
+      structuredPrompt,
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -93,7 +93,10 @@ import type {
   UserMessageDocument,
   UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { EditorDocumentSnapshot } from "../../signals/zero-page/user-message-document-codec.ts";
+import {
+  messageDocumentToPrompt,
+  type EditorDocumentSnapshot,
+} from "../../signals/zero-page/user-message-document-codec.ts";
 import type {
   ChatThreadWorkflowAutomation,
   ZeroWorkflowSchedule,
@@ -6054,6 +6057,24 @@ function clipboardAttachmentsFromMessage(
   });
 }
 
+function clipboardAttachmentsFromStructuredPrompt(
+  document: UserMessageDocument,
+  attachments: readonly ChatClipboardAttachment[],
+): ChatClipboardAttachment[] {
+  const attachmentById = new Map(
+    attachments.flatMap((attachment) => {
+      return attachment.id ? [[attachment.id, attachment] as const] : [];
+    }),
+  );
+  return document.parts.flatMap((part) => {
+    if (part.type !== "file") {
+      return [];
+    }
+    const attachment = attachmentById.get(part.fileId);
+    return attachment ? [attachment] : [];
+  });
+}
+
 function UserMessageAttachments({
   attachments,
   onImageClick,
@@ -6652,12 +6673,15 @@ function PagedUserMessage({
   // over from messages sent before #10243 split the flows. Use the structured
   // source when it's present and fall back to inline parsing otherwise.
   const { cleanContent, parsed } = parseInlineAttachments(content);
-  const copyText =
+  const legacyCopyText =
     message.attachFiles &&
     message.attachFiles.length > 0 &&
     cleanContent.trim() === ATTACH_ONLY_PLACEHOLDER
       ? ""
       : cleanContent;
+  const copyText = structuredPrompt
+    ? (messageDocumentToPrompt(structuredPrompt) ?? "")
+    : legacyCopyText;
   const bodyBlocks = message.blocks;
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
@@ -6668,8 +6692,20 @@ function PagedUserMessage({
   const copied = copiedId === message.id;
   const copyMessage = useSet(thread.copyMessage$);
   const allAttachments = resolveAttachments(message, parsed);
-  const clipboardAttachments = clipboardAttachmentsFromMessage(message, parsed);
-  const canCopy = copyText.trim().length > 0 || clipboardAttachments.length > 0;
+  const legacyClipboardAttachments = clipboardAttachmentsFromMessage(
+    message,
+    parsed,
+  );
+  const clipboardAttachments = structuredPrompt
+    ? clipboardAttachmentsFromStructuredPrompt(
+        structuredPrompt,
+        legacyClipboardAttachments,
+      )
+    : legacyClipboardAttachments;
+  const canCopy =
+    structuredPrompt !== undefined ||
+    copyText.trim().length > 0 ||
+    clipboardAttachments.length > 0;
 
   const handleCopy = () => {
     if (!canCopy) {
@@ -6678,7 +6714,11 @@ function PagedUserMessage({
     detach(
       copyMessage(
         message.id,
-        { text: copyText, attachments: clipboardAttachments },
+        {
+          text: copyText,
+          attachments: clipboardAttachments,
+          ...(structuredPrompt ? { structuredPrompt } : {}),
+        },
         pageSignal,
       ),
       Reason.DomCallback,


### PR DESCRIPTION
## Summary

- derive copied text from structuredPrompt instead of the legacy content field when the StructuredPrompt switch is enabled
- resolve and order copied attachment metadata from structured file parts
- include the validated structured document in the rich vm0 clipboard payload
- preserve the existing legacy copy path when the switch is disabled or no structured document exists

## User-visible impact

Copy now matches the structured message rendered in chat even when the legacy shadow fields are stale, including structured attachment order and thread references.

## Verification

- app production and test type checks pass
- app lint passes with zero warnings
- targeted chat workflow and copy tests: 20 passed

Split from #22636.
Refs #22314