### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,14 +113,14 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.217"
+CLAUDE_CODE_VERSION="2.1.218"
 CODEX_CLI_VERSION="0.144.6"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
-AGENT_BROWSER_VERSION="0.32.3"
-PNPM_VERSION="11.15.1"
-CHROMIUM_VERSION="150.0.7871.124-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260716T075414Z"
+AGENT_BROWSER_VERSION="0.32.4"
+PNPM_VERSION="11.16.0"
+CHROMIUM_VERSION="150.0.7871.181-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260723T024428Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.217` to `2.1.218`.
- Update agent-browser from `0.32.3` to `0.32.4`.
- Update pnpm from `11.15.1` to `11.16.0`.
- Update Chromium from `150.0.7871.124-1~deb12u1` to `150.0.7871.181-1~deb12u1`.
- Move the Debian security snapshot from `20260716T075414Z` to `20260723T024428Z` so the updated Chromium packages remain reproducible on amd64 and arm64.

Go, Google Workspace CLI, xurl, Node.js 24 LTS, and PostgreSQL 18 remain at their current selected releases. Codex CLI remains at the intentionally restored `0.144.6` pin from #22639 rather than the known-problematic `0.145.0` release. Ubuntu remains unchanged.

## Verification

- Confirmed each updated tool release against its official release endpoint or npm registry.
- Confirmed Claude Code `2.1.218` manifests and binaries are available for linux-x64 and linux-arm64.
- Confirmed the selected Debian security snapshot publishes Chromium `150.0.7871.181-1~deb12u1` for amd64 and arm64.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
- Ran `git diff --check`.