### PR TITLE
fix: stop background chat sync from backfilling history

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
@@ -30,7 +30,6 @@ const resetSubscriberSignal$ = resetSignalScope();
 const USER_ID = "background-sync-user";
 const ORG_ID = "background-sync-org";
 const THREAD_ID = "b0000000-0000-4000-a000-000000000801";
-const OLD_MESSAGE_ID = "00000000-0000-4000-8000-000000000801";
 const FIRST_CACHED_MESSAGE_ID = "00000000-0000-4000-8000-000000000802";
 const LAST_CACHED_MESSAGE_ID = "00000000-0000-4000-8000-000000000803";
 const NEW_MESSAGE_ID = "00000000-0000-4000-8000-000000000804";
@@ -48,11 +47,6 @@ function assistantMessage(
   };
 }
 
-const oldMessage = assistantMessage(
-  OLD_MESSAGE_ID,
-  "Older remote message",
-  "2026-07-23T10:00:00.000Z",
-);
 const firstCachedMessage = assistantMessage(
   FIRST_CACHED_MESSAGE_ID,
   "First cached message",
@@ -106,7 +100,7 @@ describe("chat message background sync", () => {
     expect(context.mocks.ably.hasChannelSubscription()).toBeFalsy();
   });
 
-  it("fills missing messages before and after the cached thread bounds", async () => {
+  it("fills only messages after the cached thread end", async () => {
     mockSignedInUser();
     setMockFeatureSwitches({
       [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: true,
@@ -131,18 +125,12 @@ describe("chat message background sync", () => {
       if (query.sinceId === LAST_CACHED_MESSAGE_ID) {
         return respond(200, {
           messages: [newMessage],
-          hasHistoryBefore: false,
+          hasHistoryBefore: true,
         });
       }
       if (query.sinceId === NEW_MESSAGE_ID) {
         return respond(200, {
           messages: [],
-          hasHistoryBefore: false,
-        });
-      }
-      if (query.beforeId === FIRST_CACHED_MESSAGE_ID) {
-        return respond(200, {
-          messages: [oldMessage],
           hasHistoryBefore: false,
         });
       }
@@ -169,12 +157,6 @@ describe("chat message background sync", () => {
 
       await waitFor(async () => {
         await expect(
-          appDb.get(CHAT_MESSAGES_STORE, OLD_MESSAGE_ID),
-        ).resolves.toMatchObject({
-          id: OLD_MESSAGE_ID,
-          threadId: THREAD_ID,
-        });
-        await expect(
           appDb.get(CHAT_MESSAGES_STORE, NEW_MESSAGE_ID),
         ).resolves.toMatchObject({
           id: NEW_MESSAGE_ID,
@@ -185,7 +167,6 @@ describe("chat message background sync", () => {
       expect(requests).toStrictEqual([
         { sinceId: LAST_CACHED_MESSAGE_ID, beforeId: undefined },
         { sinceId: NEW_MESSAGE_ID, beforeId: undefined },
-        { sinceId: undefined, beforeId: FIRST_CACHED_MESSAGE_ID },
       ]);
     } finally {
       subscriber.abort(abortError("test done"));

--- a/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
@@ -9,10 +9,7 @@ import {
   loadIndexedDbChatMessageBounds$,
   writeIndexedDbChatMessages$,
 } from "./chat-message-indexed-db.ts";
-import {
-  listMessagesAfter$,
-  listMessagesBefore$,
-} from "./remote-chat-thread-data-source.ts";
+import { listMessagesAfter$ } from "./remote-chat-thread-data-source.ts";
 import { logger } from "../log.ts";
 
 const L = logger("ChatMessageBackgroundSync");
@@ -42,23 +39,14 @@ export const syncChatThreadMessagesToIndexedDb$ = command(
     signal.throwIfAborted();
 
     let sinceId = bounds.last?.id;
-    const startedWithoutCursor = sinceId === undefined;
-    let initialHasHistoryBefore: boolean | undefined;
-    let firstFetchedMessageId: string | undefined;
 
     async function syncMessagesAfter(): Promise<void> {
-      const requestedSinceId = sinceId;
       const result = await set(
         listMessagesAfter$,
-        { threadId, sinceId: requestedSinceId },
+        { threadId, sinceId },
         signal,
       );
       signal.throwIfAborted();
-
-      if (requestedSinceId === undefined) {
-        initialHasHistoryBefore = result.hasHistoryBefore;
-      }
-      firstFetchedMessageId ??= result.messages[0]?.id;
 
       if (result.messages.length === 0) {
         return;
@@ -71,44 +59,6 @@ export const syncChatThreadMessagesToIndexedDb$ = command(
     }
 
     await syncMessagesAfter();
-    signal.throwIfAborted();
-
-    const oldestMessageId = bounds.first?.id ?? firstFetchedMessageId;
-    if (
-      oldestMessageId === undefined ||
-      (startedWithoutCursor && initialHasHistoryBefore === false)
-    ) {
-      return;
-    }
-
-    let beforeId = oldestMessageId;
-    async function syncMessagesBefore(): Promise<void> {
-      const result = await set(
-        listMessagesBefore$,
-        { threadId, beforeId },
-        signal,
-      );
-      signal.throwIfAborted();
-
-      if (result.messages.length > 0) {
-        await set(
-          writeIndexedDbChatMessages$,
-          threadId,
-          result.messages,
-          signal,
-        );
-        signal.throwIfAborted();
-      }
-
-      if (!result.hasHistoryBefore) {
-        return;
-      }
-
-      beforeId = result.messages[0]!.id;
-      await syncMessagesBefore();
-    }
-
-    await syncMessagesBefore();
     signal.throwIfAborted();
     L.debug("synced chat messages to IndexedDB", { threadId });
   },


### PR DESCRIPTION
## Summary

- Limit realtime background chat message sync to forward pagination from the newest IndexedDB message via `sinceId`.
- Preserve the existing no-cursor latest-page load when a thread has no cached messages, while ignoring `hasHistoryBefore` and never issuing `beforeId` requests.
- Update integration coverage to prove background sync does not backfill older history even when the API reports that history exists.

## User impact

Non-focused thread notifications no longer trigger low-value backward history requests. Cached threads receive only messages newer than their current cursor, while opening a thread still uses the existing foreground history-sync path.

This is a focused follow-up to #22622.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped` (12 tasks passed)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (13 tasks passed)
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-message-background-sync.test.ts` (2 tests passed)
- Lefthook pre-commit checks: Prettier, Knip, and workspace type checks
