### PR TITLE
refactor(api): replace simple locking selects with drizzle builders

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
@@ -82,21 +82,6 @@ export function createEmailApi(context: TestContext) {
     postResendInboundWebhook,
     enqueueInboundErrorEmail,
 
-    /**
-     * Induce a pending email outbox row through public state only: an inbound
-     * email from a sender with no vm0 account makes the inbound webhook enqueue
-     * an inbound-error reply, and a rejecting Resend mock rolls back the inline
-     * drain so the row stays pending for the drain cron.
-     */
-    async triggerInboundErrorEmail(
-      opts: { readonly from?: string; readonly subject?: string } = {},
-    ): Promise<{ readonly from: string; readonly subject: string }> {
-      context.mocks.resend.send.mockRejectedValue(
-        new Error("inline drain down"),
-      );
-      return await enqueueInboundErrorEmail(opts);
-    },
-
     async suppressEmailAddress(address: string): Promise<void> {
       await postResendInboundWebhook(
         {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
@@ -56,8 +56,31 @@ export function createEmailApi(context: TestContext) {
     );
   }
 
+  async function enqueueInboundErrorEmail(
+    opts: { readonly from?: string; readonly subject?: string } = {},
+  ): Promise<{ readonly from: string; readonly subject: string }> {
+    const from =
+      opts.from ?? `bdd-sender-${randomUUID().slice(0, 12)}@example.test`;
+    const subject = opts.subject ?? `BDD drain ${randomUUID().slice(0, 8)}`;
+    context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
+    await postResendInboundWebhook(
+      {
+        type: "email.received",
+        data: {
+          email_id: `em_${randomUUID()}`,
+          to: ["bdd-org@mail.example.com"],
+          from,
+          subject,
+        },
+      },
+      [200],
+    );
+    return { from, subject };
+  }
+
   return {
     postResendInboundWebhook,
+    enqueueInboundErrorEmail,
 
     /**
      * Induce a pending email outbox row through public state only: an inbound
@@ -68,26 +91,10 @@ export function createEmailApi(context: TestContext) {
     async triggerInboundErrorEmail(
       opts: { readonly from?: string; readonly subject?: string } = {},
     ): Promise<{ readonly from: string; readonly subject: string }> {
-      const from =
-        opts.from ?? `bdd-sender-${randomUUID().slice(0, 12)}@example.test`;
-      const subject = opts.subject ?? `BDD drain ${randomUUID().slice(0, 8)}`;
-      context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
       context.mocks.resend.send.mockRejectedValue(
         new Error("inline drain down"),
       );
-      await postResendInboundWebhook(
-        {
-          type: "email.received",
-          data: {
-            email_id: `em_${randomUUID()}`,
-            to: ["bdd-org@mail.example.com"],
-            from,
-            subject,
-          },
-        },
-        [200],
-      );
-      return { from, subject };
+      return await enqueueInboundErrorEmail(opts);
     },
 
     async suppressEmailAddress(address: string): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -452,7 +452,7 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     expect(unauthorizedDrain.status).toBe(401);
   });
 
-  it("drains an inbound-error email once when its retry becomes eligible", async () => {
+  it("drains an inbound-error email once at its UTC retry boundary", async () => {
     const email = createEmailApi(context);
     const baseTime = now();
     mockNow(baseTime);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
-import { now } from "../../../lib/time";
+import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import {
   createBddApi,
   expectApiError,
@@ -451,9 +452,19 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     expect(unauthorizedDrain.status).toBe(401);
   });
 
-  it("drains a pending inbound-error email through Resend exactly once", async () => {
+  it("drains an inbound-error email once when its retry becomes eligible", async () => {
     const email = createEmailApi(context);
-    const { from, subject } = await email.triggerInboundErrorEmail();
+    const baseTime = now();
+    mockNow(baseTime);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+
+    context.mocks.resend.send.mockResolvedValue({
+      data: null,
+      error: { message: "inline drain down" },
+    });
+    const { from, subject } = await email.enqueueInboundErrorEmail();
     await flushWaitUntilForTest();
     expect(resendSendCallsTo(from)).toBe(1);
 
@@ -463,6 +474,14 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
 
+    const beforeRetry = await email.drainEmailOutboxCron(true);
+    if (beforeRetry.status !== 200) {
+      throw new Error("Expected drain email outbox cron to succeed");
+    }
+    expect(beforeRetry.body.success).toBeTruthy();
+    expect(resendSendCallsTo(from)).toBe(0);
+
+    mockNow(baseTime + 1000);
     const drain = await email.drainEmailOutboxCron(true);
     if (drain.status !== 200) {
       throw new Error("Expected drain email outbox cron to succeed");
@@ -482,6 +501,55 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     const second = await email.drainEmailOutboxCron(true);
     if (second.status !== 200) {
       throw new Error("Expected drain email outbox cron to succeed");
+    }
+    expect(resendSendCallsTo(from)).toBe(1);
+  });
+
+  it("skips an outbox row locked by the inline drain", async () => {
+    const email = createEmailApi(context);
+    const from = `bdd-locked-${randomUUID().slice(0, 12)}@example.test`;
+    const sendStarted = createDeferredPromise<void>(context.signal);
+    const releaseSend = createDeferredPromise<void>(context.signal);
+    onTestFinished(async () => {
+      if (!releaseSend.settled()) {
+        releaseSend.resolve(undefined);
+      }
+      await flushWaitUntilForTest();
+    });
+
+    context.mocks.resend.send.mockReset();
+    context.mocks.resend.send.mockImplementation(async (payload) => {
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        "to" in payload &&
+        payload.to === from
+      ) {
+        sendStarted.resolve(undefined);
+        await releaseSend.promise;
+      }
+      return { data: { id: "resend-bdd-locked" }, error: null };
+    });
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+
+    await email.enqueueInboundErrorEmail({ from });
+    await sendStarted.promise;
+    expect(resendSendCallsTo(from)).toBe(1);
+
+    const concurrentDrain = await email.drainEmailOutboxCron(true);
+    if (concurrentDrain.status !== 200) {
+      throw new Error("Expected concurrent email outbox drain to succeed");
+    }
+    expect(concurrentDrain.body.success).toBeTruthy();
+    expect(resendSendCallsTo(from)).toBe(1);
+
+    releaseSend.resolve(undefined);
+    await flushWaitUntilForTest();
+    expect(resendSendCallsTo(from)).toBe(1);
+
+    const afterRelease = await email.drainEmailOutboxCron(true);
+    if (afterRelease.status !== 200) {
+      throw new Error("Expected final email outbox drain to succeed");
     }
     expect(resendSendCallsTo(from)).toBe(1);
   });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -28,6 +28,7 @@ import {
   gt,
   inArray,
   lt,
+  lte,
   notInArray,
   or,
   sql,
@@ -58,6 +59,7 @@ import { logger } from "../../lib/log";
 import { executeRawRows } from "../../lib/db-raw-rows";
 import {
   nullableDriverValueDecoder,
+  pgBooleanDecoder,
   pgTextDecoder,
 } from "../../lib/db-structured-result";
 import { generateSandboxToken } from "../auth/tokens";
@@ -827,11 +829,6 @@ function claimTransitionErrorResponse(result: FailedClaimTransitionResult) {
   return notFound("Run not found");
 }
 
-const lockedRunnerJobRowSchema = z.object({
-  runId: z.string(),
-  isExpired: z.boolean(),
-});
-
 const claimTransitionSqlRowSchema = z.object({
   status: z.enum([
     "claimed",
@@ -858,22 +855,22 @@ async function lockClaimRun(
 }
 
 async function lockRunnerJob(
-  db: Pick<Db, "execute">,
+  db: Pick<Db, "select">,
   runId: string,
-): Promise<z.output<typeof lockedRunnerJobRowSchema> | undefined> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      SELECT
-        ${runnerJobQueue.runId} AS "runId",
-        ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
-      FROM ${runnerJobQueue}
-      WHERE ${eq(runnerJobQueue.runId, runId)}
-      FOR UPDATE
-    `,
-    lockedRunnerJobRowSchema,
-  );
-  return rows[0];
+): Promise<
+  { readonly runId: string; readonly isExpired: boolean } | undefined
+> {
+  const [row] = await db
+    .select({
+      runId: runnerJobQueue.runId,
+      isExpired: lte(runnerJobQueue.expiresAt, sql`now()`).mapWith(
+        pgBooleanDecoder,
+      ),
+    })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .for("update");
+  return row;
 }
 
 async function transitionClaimedJobToRunning(

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -787,6 +787,8 @@ async function drainNextOutboxItem(
           eq(emailOutbox.status, "pending"),
           or(
             isNull(emailOutbox.nextRetryAt),
+            // Keep the Date schema-bound so Drizzle encodes its UTC wall-clock
+            // value instead of letting node-postgres apply the process timezone.
             lte(emailOutbox.nextRetryAt, currentTime),
           ),
         ),

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -13,14 +13,13 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { users } from "@vm0/db/schema/user";
 import { command, computed, type Computed } from "ccstate";
-import { and, eq, lt, or, sql } from "drizzle-orm";
+import { and, asc, eq, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { convert, type FormatCallback } from "html-to-text";
 import { Resend } from "resend";
 import { delay } from "signal-timers";
 import { Webhook } from "svix";
 import { z } from "zod";
 
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -209,6 +208,21 @@ const outboxRowSchema = z.object({
   attempts: z.int(),
 });
 type OutboxRow = z.output<typeof outboxRowSchema>;
+
+function outboxRowSelection() {
+  return {
+    id: emailOutbox.id,
+    from_address: emailOutbox.fromAddress,
+    to_addresses: emailOutbox.toAddresses,
+    cc_addresses: emailOutbox.ccAddresses,
+    subject: emailOutbox.subject,
+    reply_to: emailOutbox.replyTo,
+    headers: emailOutbox.headers,
+    template: emailOutbox.template,
+    post_send_action: emailOutbox.postSendAction,
+    attempts: emailOutbox.attempts,
+  };
+}
 
 interface EnqueueEmailOptions {
   readonly from: string;
@@ -749,17 +763,12 @@ async function processOutboxItem(
 
 async function drainById(db: Db, itemId: string): Promise<boolean> {
   return await db.transaction(async (tx) => {
-    const rows = await executeRawRows(
-      tx,
-      sql`SELECT id, from_address, to_addresses, cc_addresses, subject,
-             reply_to, headers, template, post_send_action, attempts
-          FROM email_outbox
-          WHERE id = ${itemId}
-            AND status = 'pending'
-          FOR UPDATE SKIP LOCKED`,
-      outboxRowSchema,
-    );
-    const row = rows[0];
+    const [selectedRow] = await tx
+      .select(outboxRowSelection())
+      .from(emailOutbox)
+      .where(and(eq(emailOutbox.id, itemId), eq(emailOutbox.status, "pending")))
+      .for("update", { skipLocked: true });
+    const row = selectedRow ? outboxRowSchema.parse(selectedRow) : undefined;
     return row ? await processOutboxItem(tx, row) : false;
   });
 }
@@ -770,19 +779,22 @@ async function drainNextOutboxItem(
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
     const currentTime = new Date(currentTimeMs);
-    const rows = await executeRawRows(
-      tx,
-      sql`SELECT id, from_address, to_addresses, cc_addresses, subject,
-             reply_to, headers, template, post_send_action, attempts
-          FROM email_outbox
-          WHERE status = 'pending'
-            AND (next_retry_at IS NULL OR next_retry_at <= ${currentTime})
-          ORDER BY created_at ASC
-          LIMIT 1
-          FOR UPDATE SKIP LOCKED`,
-      outboxRowSchema,
-    );
-    const row = rows[0];
+    const [selectedRow] = await tx
+      .select(outboxRowSelection())
+      .from(emailOutbox)
+      .where(
+        and(
+          eq(emailOutbox.status, "pending"),
+          or(
+            isNull(emailOutbox.nextRetryAt),
+            lte(emailOutbox.nextRetryAt, currentTime),
+          ),
+        ),
+      )
+      .orderBy(asc(emailOutbox.createdAt))
+      .limit(1)
+      .for("update", { skipLocked: true });
+    const row = selectedRow ? outboxRowSchema.parse(selectedRow) : undefined;
     return row ? await processOutboxItem(tx, row, currentTimeMs) : false;
   });
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -101,6 +101,17 @@ const directQuery = `
   \`
 `;
 
+const runnerLockingQuery = `
+  sql\`
+    SELECT
+      \${runs.id} AS "runId",
+      \${runs.threadId} > 0 AS "isExpired"
+    FROM \${runs}
+    WHERE \${eq(runs.id, threadId)}
+    FOR UPDATE
+  \`
+`;
+
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
     {
@@ -161,6 +172,160 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           sql\`SELECT 1 FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
           rowSchema,
         );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT DISTINCT \${runs.id}
+            FROM \${runs}
+            WHERE \${eq(runs.id, threadId)}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            WITH locked AS (
+              SELECT \${runs.id}
+              FROM \${runs}
+              WHERE \${eq(runs.id, threadId)}
+              FOR UPDATE
+            )
+            SELECT * FROM locked
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            INNER JOIN \${runStates}
+              ON \${eq(runStates.id, runs.id)}
+            WHERE \${eq(runs.id, threadId)}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}, \${runStates}
+            WHERE \${eq(runs.id, threadId)}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            WHERE EXISTS (
+              SELECT 1
+              FROM \${callbacks}
+              WHERE \${eq(callbacks.runId, runs.id)}
+            )
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, threadId)} FOR SHARE\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, threadId)} FOR UPDATE NOWAIT\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT \${runs.id} FROM \${runs} WHERE \${eq(runs.id, threadId)} FOR UPDATE OF runs\`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            WHERE \${eq(runs.id, threadId)}
+            LIMIT \${1}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            WHERE \${eq(runs.id, threadId)}
+            LIMIT 2
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        const lockingQuery = ${runnerLockingQuery};
+        await executeRawRows(db, lockingQuery, rowSchema);
+      `,
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        async function executeRawRows(...args: unknown[]) { return args; }
+        await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const eq = (...values: unknown[]) => values;
+        await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
       `,
     },
     {
@@ -466,6 +631,53 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
     },
   ],
   invalid: [
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
+      `,
+      errors: [{ messageId: "lockingQueryBuilder" }],
+    },
+    {
+      code: `${schemaPreamble}
+        import { sql as query } from "drizzle-orm";
+        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
+        await decodeRows(
+          db,
+          query\`
+            SELECT id, from_address, to_addresses, attempts
+            FROM email_outbox
+            WHERE id = \${threadId}
+              AND status = 'pending'
+              AND 'FOR UPDATE ignored' = 'FOR UPDATE ignored'
+              /* SELECT FROM ignored */
+            FOR UPDATE SKIP LOCKED;
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "lockingQueryBuilder" }],
+    },
+    {
+      code: `${schemaPreamble}
+        import * as drizzle from "drizzle-orm";
+        import * as rawRows from "./lib/db-raw-rows";
+        await rawRows.executeRawRows(
+          db,
+          drizzle.sql\`
+            SELECT id, from_address, to_addresses, attempts
+            FROM email_outbox
+            WHERE status = 'pending'
+              AND (next_retry_at IS NULL OR next_retry_at <= \${threadId})
+            ORDER BY created_at ASC
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "lockingQueryBuilder" }],
+    },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -313,6 +313,22 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       `,
     },
     {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        const source = sql.identifier("runs");
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT id
+            FROM \${source}
+            WHERE \${eq(runs.id, threadId)}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         async function executeRawRows(...args: unknown[]) { return args; }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -72,6 +72,10 @@ interface SimpleSelectMatch {
   readonly sourceTableExpressionIndex: number;
 }
 
+interface SimpleLockingSelectMatch {
+  readonly sourceTableExpressionIndex: number | undefined;
+}
+
 const RESULT_FIELD_ARGUMENT = new Map<string, number>([
   ["returning", 0],
   ["select", 0],
@@ -98,6 +102,29 @@ const UNSUPPORTED_SCALAR_QUERY_KEYWORDS = new Set([
   ...UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS,
   "INTO",
   "OVER",
+]);
+
+const UNSUPPORTED_LOCKING_SELECT_KEYWORDS = new Set([
+  "DISTINCT",
+  "EXCEPT",
+  "FETCH",
+  "FULL",
+  "GROUP",
+  "HAVING",
+  "INNER",
+  "INTERSECT",
+  "INTO",
+  "JOIN",
+  "LEFT",
+  "NOWAIT",
+  "OFFSET",
+  "OUTER",
+  "QUALIFY",
+  "RIGHT",
+  "UNION",
+  "USING",
+  "WINDOW",
+  "WITH",
 ]);
 
 function quasiText(node: TSESTree.TemplateElement): string {
@@ -233,6 +260,209 @@ function isWord(token: SqlToken | undefined, value: string): boolean {
 
 function expressionIndex(token: SqlToken | undefined): number | undefined {
   return token?.kind === "expression" ? token.expressionIndex : undefined;
+}
+
+function onlyWhitespaceBetween(
+  source: string,
+  left: SqlToken,
+  right: SqlToken,
+): boolean {
+  return source.slice(left.end, right.start).trim() === "";
+}
+
+function simpleLockingSelectMatch(
+  syntaxSource: string,
+): SimpleLockingSelectMatch | undefined {
+  const tokens = topLevelTokens(syntaxSource);
+  if (tokens === undefined || !isWord(tokens[0], "SELECT")) {
+    return undefined;
+  }
+  if ((syntaxSource.match(/\bSELECT\b/gi) ?? []).length !== 1) {
+    return undefined;
+  }
+
+  let end = tokens.length;
+  const trailingToken = tokens[end - 1];
+  if (trailingToken?.kind === "punctuation" && trailingToken.value === ";") {
+    if (syntaxSource.slice(trailingToken.end).trim() !== "") {
+      return undefined;
+    }
+    end -= 1;
+  } else if (
+    trailingToken === undefined ||
+    syntaxSource.slice(trailingToken.end).trim() !== ""
+  ) {
+    return undefined;
+  }
+  if (
+    tokens.slice(0, end).some((token) => {
+      return token.kind === "punctuation" && token.value === ";";
+    })
+  ) {
+    return undefined;
+  }
+
+  let lockStart = end - 2;
+  let lockTokens = tokens.slice(lockStart, end);
+  if (
+    lockTokens.length !== 2 ||
+    !isWord(lockTokens[0], "FOR") ||
+    !isWord(lockTokens[1], "UPDATE")
+  ) {
+    lockStart = end - 4;
+    lockTokens = tokens.slice(lockStart, end);
+    if (
+      lockTokens.length !== 4 ||
+      !isWord(lockTokens[0], "FOR") ||
+      !isWord(lockTokens[1], "UPDATE") ||
+      !isWord(lockTokens[2], "SKIP") ||
+      !isWord(lockTokens[3], "LOCKED")
+    ) {
+      return undefined;
+    }
+  }
+  if (
+    lockStart <= 0 ||
+    lockTokens.some((token, index) => {
+      const next = lockTokens[index + 1];
+      return (
+        next !== undefined && !onlyWhitespaceBetween(syntaxSource, token, next)
+      );
+    })
+  ) {
+    return undefined;
+  }
+  const lockKeyword = lockTokens[0];
+  if (lockKeyword === undefined) {
+    return undefined;
+  }
+
+  const statementTokens = tokens.slice(0, lockStart);
+  if (
+    statementTokens.some((token) => {
+      return (
+        token.kind === "word" &&
+        UNSUPPORTED_LOCKING_SELECT_KEYWORDS.has(token.value)
+      );
+    })
+  ) {
+    return undefined;
+  }
+
+  const fromIndexes = statementTokens.flatMap((token, index) => {
+    return isWord(token, "FROM") ? [index] : [];
+  });
+  const whereIndexes = statementTokens.flatMap((token, index) => {
+    return isWord(token, "WHERE") ? [index] : [];
+  });
+  const orderIndexes = statementTokens.flatMap((token, index) => {
+    return isWord(token, "ORDER") ? [index] : [];
+  });
+  const limitIndexes = statementTokens.flatMap((token, index) => {
+    return isWord(token, "LIMIT") ? [index] : [];
+  });
+  if (
+    fromIndexes.length !== 1 ||
+    whereIndexes.length !== 1 ||
+    orderIndexes.length > 1 ||
+    limitIndexes.length > 1
+  ) {
+    return undefined;
+  }
+
+  const fromIndex = fromIndexes[0];
+  const whereIndex = whereIndexes[0];
+  const selectKeyword = statementTokens[0];
+  const fromKeyword =
+    fromIndex === undefined ? undefined : statementTokens[fromIndex];
+  const whereKeyword =
+    whereIndex === undefined ? undefined : statementTokens[whereIndex];
+  if (
+    fromIndex === undefined ||
+    whereIndex === undefined ||
+    fromIndex <= 0 ||
+    whereIndex !== fromIndex + 2 ||
+    selectKeyword === undefined ||
+    fromKeyword === undefined ||
+    whereKeyword === undefined ||
+    syntaxSource.slice(selectKeyword.end, fromKeyword.start).trim() === "" ||
+    syntaxSource.slice(fromKeyword.end, whereKeyword.start).trim() === ""
+  ) {
+    return undefined;
+  }
+
+  const sourceTable = statementTokens[fromIndex + 1];
+  if (
+    sourceTable === undefined ||
+    (sourceTable.kind !== "word" && sourceTable.kind !== "expression")
+  ) {
+    return undefined;
+  }
+
+  const orderIndex = orderIndexes[0];
+  const limitIndex = limitIndexes[0];
+  if (
+    (orderIndex !== undefined && orderIndex <= whereIndex) ||
+    (limitIndex !== undefined &&
+      (limitIndex <= whereIndex ||
+        (orderIndex !== undefined && limitIndex <= orderIndex)))
+  ) {
+    return undefined;
+  }
+
+  const whereEndIndex = orderIndex ?? limitIndex ?? statementTokens.length;
+  const whereEndToken =
+    whereEndIndex === statementTokens.length
+      ? lockKeyword
+      : statementTokens[whereEndIndex];
+  if (
+    whereEndToken === undefined ||
+    syntaxSource.slice(whereKeyword.end, whereEndToken.start).trim() === ""
+  ) {
+    return undefined;
+  }
+
+  if (orderIndex !== undefined) {
+    const orderKeyword = statementTokens[orderIndex];
+    const byKeyword = statementTokens[orderIndex + 1];
+    const orderEndIndex = limitIndex ?? statementTokens.length;
+    const orderEndToken =
+      orderEndIndex === statementTokens.length
+        ? lockKeyword
+        : statementTokens[orderEndIndex];
+    if (
+      orderKeyword === undefined ||
+      byKeyword === undefined ||
+      orderEndToken === undefined ||
+      !isWord(byKeyword, "BY") ||
+      !onlyWhitespaceBetween(syntaxSource, orderKeyword, byKeyword) ||
+      syntaxSource.slice(byKeyword.end, orderEndToken.start).trim() === ""
+    ) {
+      return undefined;
+    }
+  }
+
+  if (limitIndex !== undefined) {
+    const limitKeyword = statementTokens[limitIndex];
+    const limitValue = statementTokens[limitIndex + 1];
+    if (
+      limitKeyword === undefined ||
+      limitValue?.kind !== "number" ||
+      limitValue.value !== "1" ||
+      limitIndex + 2 !== statementTokens.length ||
+      !onlyWhitespaceBetween(syntaxSource, limitKeyword, limitValue) ||
+      !onlyWhitespaceBetween(syntaxSource, limitValue, lockKeyword)
+    ) {
+      return undefined;
+    }
+  }
+
+  return {
+    sourceTableExpressionIndex:
+      sourceTable.kind === "expression"
+        ? sourceTable.expressionIndex
+        : undefined,
+  };
 }
 
 function simpleSelectMatch(
@@ -443,7 +673,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete simple selects and scalar result queries",
+        "Prefer Drizzle query builders for complete simple selects, locking selects, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -451,6 +681,8 @@ export const preferDrizzleQueryBuilder = createRule({
     messages: {
       queryBuilder:
         "Use a Drizzle select builder for this complete schema-backed query.",
+      lockingQueryBuilder:
+        "Use a Drizzle select builder with .for(...) for this complete locking query.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -975,7 +1207,33 @@ export const preferDrizzleQueryBuilder = createRule({
         const source = query.quasi.quasis
           .map(quasiText)
           .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
-        const match = simpleSelectMatch(source, sqlCodeMask(source));
+        const syntaxSource = sqlCodeMask(source);
+        const lockingMatch = simpleLockingSelectMatch(syntaxSource);
+        if (lockingMatch !== undefined) {
+          const sourceTableExpressionIndex =
+            lockingMatch.sourceTableExpressionIndex;
+          if (sourceTableExpressionIndex !== undefined) {
+            const sourceTable =
+              query.quasi.expressions[sourceTableExpressionIndex];
+            if (sourceTable === undefined) {
+              return;
+            }
+            const sourceTableType = expressionType(sourceTable);
+            if (
+              !isDrizzleTableType(
+                checker,
+                sourceTableType.type,
+                sourceTableType.location,
+              )
+            ) {
+              return;
+            }
+          }
+          context.report({ node: query, messageId: "lockingQueryBuilder" });
+          return;
+        }
+
+        const match = simpleSelectMatch(source, syntaxSource);
         if (match === undefined) {
           return;
         }


### PR DESCRIPTION
## Summary

- replace the three simple `SELECT ... FOR UPDATE` raw-row queries with typed
  Drizzle builders while preserving database-clock evaluation, transaction
  ownership, row locks, and email Zod validation
- keep the FIFO retry cutoff schema-bound so Drizzle encodes the UTC wall-clock
  value instead of inheriting the old raw `Date` process-timezone dependency
- extend `api/prefer-drizzle-query-builder` with a conservative diagnostic for
  the proven single-table locking-select family
- cover retry eligibility and concurrent `SKIP LOCKED` behavior through the
  existing email and cron route boundary

Each converted lookup remains one database statement and one round trip. The
runner primary-key lookup and both email plans retain their previous lock and
index plan shapes. With a UTC process, the old and new FIFO predicates render
the same cutoff and return the same rows. With a non-UTC process, the new
schema-bound value intentionally fixes the old early-or-late retry behavior for
`timestamp without time zone` columns.

## Exclusions

- no schema, migration, persisted-data, API, or deployment-protocol changes
- no feature switch or compatibility shim
- complex materialized CTE, multi-relation, dynamic-source, and unsupported
  lock queries remain on the explicit SQL path

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/eslint-rules exec vitest run --maxWorkers=4 --silent=passed-only`
  (47 files, 744 tests)
- affected API integration suites for cron/email behavior and runner poison-row
  handling, including the complete run lifecycle against a freshly migrated
  local database
- rendered SQL/parameter comparison and representative
  `EXPLAIN (ANALYZE, BUFFERS)` checks for all three statements
- real-PostgreSQL validation under `TZ=Asia/Shanghai`: the old raw `Date`
  predicate selected a not-yet-eligible retry while the schema-bound builder did
  not; temporarily restoring the raw operand made the boundary test fail
- type-aware API ESLint timing comparison (no material matcher regression)
- `git diff --check`

Closes #22637

Parent context: #22439