### PR TITLE
fix: stop usage settlement from refreshing billing status

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
@@ -296,6 +296,7 @@ describe("zero web-search route", () => {
         return HttpResponse.json(providerResponse());
       }),
     );
+    context.mocks.ably.publish.mockClear();
 
     const response = await accept(
       client()(zeroWebSearchContract).search({
@@ -330,6 +331,10 @@ describe("zero web-search route", () => {
     expect(usage.body.runs).toHaveLength(1);
     expect(usage.body.runs[0]?.runId).toBe(run.runId);
     expect(usage.body.runs[0]?.creditsCharged).toBe(5);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      "billing:changed",
+      null,
+    );
   });
 
   it("rejects invalid filters before calling Perplexity", async () => {

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -18,7 +18,6 @@ import {
 } from "./zero-credit-low-balance-alert.service";
 import { triggerAutoRecharge$ } from "./zero-credit-recharge.service";
 import { applyUsageAllowanceToUsageEventsInLockedTransaction } from "./usage-allowance.service";
-import { publishBillingChangedForOrg } from "./zero-billing-realtime.service";
 
 const L = logger("CreditUsage");
 
@@ -131,7 +130,6 @@ async function deductFromExpiresRecords(
 
 interface ProcessOrgUsageEventsResult {
   readonly billableCredits: number;
-  readonly allowanceCreditsApplied: number;
   readonly runIds: readonly string[];
   readonly lowBalanceAlert: CreditLowBalanceAlertArgs | null;
 }
@@ -279,7 +277,6 @@ async function processOrgUsageEventsInTransaction(
   if (pendingRecords.length === 0) {
     return {
       billableCredits: 0,
-      allowanceCreditsApplied: 0,
       runIds: [],
       lowBalanceAlert: null,
     };
@@ -312,11 +309,9 @@ async function processOrgUsageEventsInTransaction(
       }),
     });
   let billableCredits = 0;
-  let allowanceCreditsApplied = 0;
   const settlementOutcomes = pricedEvents.map((event) => {
     const allowanceUnits = allowanceByUsageEvent.get(event.record.id) ?? 0;
     const creditsCharged = event.grossCredits - allowanceUnits;
-    allowanceCreditsApplied += allowanceUnits;
     billableCredits += creditsCharged;
     return {
       usageEventId: event.record.id,
@@ -348,7 +343,7 @@ async function processOrgUsageEventsInTransaction(
     }
   }
   signal.throwIfAborted();
-  return { billableCredits, allowanceCreditsApplied, runIds, lowBalanceAlert };
+  return { billableCredits, runIds, lowBalanceAlert };
 }
 
 /**
@@ -377,14 +372,10 @@ export const processOrgUsageEvents$ = command(
   async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
     const writeDb = set(writeDb$);
 
-    const {
-      billableCredits,
-      allowanceCreditsApplied,
-      runIds,
-      lowBalanceAlert,
-    } = await writeDb.transaction((tx) => {
-      return processOrgUsageEventsInTransaction(tx, orgId, signal);
-    });
+    const { billableCredits, runIds, lowBalanceAlert } =
+      await writeDb.transaction((tx) => {
+        return processOrgUsageEventsInTransaction(tx, orgId, signal);
+      });
     signal.throwIfAborted();
 
     if (billableCredits > 0) {
@@ -393,11 +384,6 @@ export const processOrgUsageEvents$ = command(
       // its own errors (clearPendingFlag in catch); the await here is
       // bounded by the route handler's outer waitUntil envelope.
       await set(triggerAutoRecharge$, orgId, signal);
-      signal.throwIfAborted();
-    }
-
-    if (billableCredits > 0 || allowanceCreditsApplied > 0) {
-      await publishBillingChangedForOrg(writeDb, orgId);
       signal.throwIfAborted();
     }
 


### PR DESCRIPTION
## Summary

- stop publishing `billing:changed` after credit or usage allowance settlement
- keep Stripe webhook billing invalidations unchanged
- add regression coverage for managed usage settlement

## Impact

Prevents each usage charge from making every open admin tab refetch `/api/zero/billing/status`.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-web-search.test.ts` (29 passed)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- Prettier, Oxlint, and ESLint on the changed files
