### PR TITLE
fix: restore thinking status for canonical slack threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -12,6 +12,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import {
@@ -1508,13 +1509,32 @@ describe("INT-01: Slack app deep webhook flows", () => {
     context.mocks.slack.chat.postMessage.mockRejectedValueOnce(
       new DOMException("Slack delivery aborted", "AbortError"),
     );
+    const terminalStatusClearStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseTerminalStatusClear = createDeferredPromise<void>(
+      context.signal,
+    );
+    const overlappingThinkingStatusSet = createDeferredPromise<void>(
+      context.signal,
+    );
+    context.mocks.slack.assistant.threads.setStatus
+      .mockImplementationOnce(async () => {
+        terminalStatusClearStarted.resolve(undefined);
+        await releaseTerminalStatusClear.promise;
+        return { ok: true };
+      })
+      .mockImplementationOnce(() => {
+        overlappingThinkingStatusSet.resolve(undefined);
+        return Promise.resolve({ ok: true });
+      });
     await completeSlackTriggeredRun({
       runId: run2Id,
       sandboxToken: claim2.sandboxToken,
       cliAgentType: claim2.cliAgentType,
       assistantText: "Canonical Slack answer two",
     });
-    await flushWaitUntilForTest();
+    await terminalStatusClearStarted.promise;
     await expect
       .poll(async () => {
         const callbacks = await callbackStore.set(
@@ -1550,23 +1570,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
       lastError: "Slack delivery aborted",
     });
     expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledOnce();
-    expect(
-      context.mocks.slack.assistant.threads.setStatus.mock.calls.map(
-        ([input]) => {
-          if (!isRecord(input)) {
-            throw new Error("Expected Slack thread status request");
-          }
-          return readStringField(input, "status");
-        },
-      ),
-    ).toStrictEqual(["is thinking...", "is thinking...", ""]);
-    expect(
-      context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenLastCalledWith({
-      channel_id: channelId,
-      thread_ts: threadTs,
-      status: "",
-    });
     const cancelledEventId = `EvBDD${randomUUID().replace(/-/g, "")}`;
     const cancelledBody = JSON.stringify({
       type: "event_callback",
@@ -1584,10 +1587,22 @@ describe("INT-01: Slack app deep webhook flows", () => {
       integrations.signedSlackIngressHeaders(cancelledBody),
       [200],
     );
+    await overlappingThinkingStatusSet.promise;
+    expect(
+      context.mocks.slack.assistant.threads.setStatus.mock.calls.map(
+        ([input]) => {
+          if (!isRecord(input)) {
+            throw new Error("Expected Slack thread status request");
+          }
+          return readStringField(input, "status");
+        },
+      ),
+    ).toStrictEqual(["is thinking...", "is thinking...", "", "is thinking..."]);
+    releaseTerminalStatusClear.resolve(undefined);
     await flushWaitUntilForTest();
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledTimes(4);
+    ).toHaveBeenCalledTimes(5);
     expect(
       context.mocks.slack.assistant.threads.setStatus,
     ).toHaveBeenLastCalledWith({
@@ -1605,7 +1620,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     await flushWaitUntilForTest();
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledTimes(5);
+    ).toHaveBeenCalledTimes(6);
     expect(
       context.mocks.slack.assistant.threads.setStatus,
     ).toHaveBeenLastCalledWith({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1264,7 +1264,14 @@ describe("INT-01: Slack app deep webhook flows", () => {
     );
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledOnce();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      status: "is thinking...",
+    });
     const run1Id = await pollSlackRun(runnerGroup);
     const claim1 = await runs.claimRunnerJob(run1Id);
 
@@ -1543,6 +1550,69 @@ describe("INT-01: Slack app deep webhook flows", () => {
       lastError: "Slack delivery aborted",
     });
     expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledOnce();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus.mock.calls.map(
+        ([input]) => {
+          if (!isRecord(input)) {
+            throw new Error("Expected Slack thread status request");
+          }
+          return readStringField(input, "status");
+        },
+      ),
+    ).toStrictEqual(["is thinking...", "is thinking...", ""]);
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenLastCalledWith({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      status: "",
+    });
+    const cancelledEventId = `EvBDD${randomUUID().replace(/-/g, "")}`;
+    const cancelledBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: cancelledEventId,
+      event: {
+        ...event,
+        text: "cancel this canonical Slack run",
+        ts: "2900.000300",
+        thread_ts: threadTs,
+      },
+    });
+    await integrations.requestSlackEvent(
+      cancelledBody,
+      integrations.signedSlackIngressHeaders(cancelledBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledTimes(4);
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenLastCalledWith({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      status: "is thinking...",
+    });
+    const cancelledRunId = await pollSlackRun(runnerGroup);
+    await runs.requestCancelRun(actor, cancelledRunId, [200]);
+    await expect
+      .poll(async () => {
+        return (await runs.readRun(actor, cancelledRunId)).status;
+      })
+      .toBe("cancelled");
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledTimes(5);
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenLastCalledWith({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      status: "",
+    });
     await updateFeatureSwitchesForUser(context, featureSwitchActor, {
       [FeatureSwitchKey.CanonicalSlackWebVisibility]: true,
     });

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -22,9 +22,14 @@ import {
   createSlackClient,
   createSlackUserInfoResolver,
   getMessagePermalink,
+  setThreadStatus,
 } from "../external/slack-message-client";
-import { settle } from "../utils";
+import { settle, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import {
+  canonicalSlackThreadStatusTargetForIngress,
+  clearCanonicalSlackThreadStatusIfIdle,
+} from "./canonical-slack-thread-status.service";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -234,6 +239,42 @@ async function markIngressFailed(
 interface PersistedCanonicalSlackIngress {
   readonly userId: string;
   readonly chatThreadId: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+}
+
+function persistedCanonicalSlackIngress(
+  ingress: NonNullable<Awaited<ReturnType<typeof loadClaimedIngress>>>,
+  chatThreadId: string,
+): PersistedCanonicalSlackIngress {
+  return {
+    userId: ingress.userId,
+    chatThreadId,
+    channelId: ingress.channelId,
+    threadTs: ingress.threadTs,
+  };
+}
+
+async function setCanonicalSlackThinkingStatus(args: {
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly ingressId: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+}): Promise<void> {
+  await tapError(
+    setThreadStatus(
+      args.client,
+      args.channelId,
+      args.threadTs,
+      "is thinking...",
+    ),
+    (error) => {
+      L.warn("Failed to set canonical Slack thinking status", {
+        ingressId: args.ingressId,
+        error,
+      });
+    },
+  );
 }
 
 async function persistClaimedCanonicalSlackIngress(
@@ -261,6 +302,13 @@ async function persistClaimedCanonicalSlackIngress(
   );
   signal.throwIfAborted();
   const client = createSlackClient(botToken);
+  await setCanonicalSlackThinkingStatus({
+    client,
+    ingressId,
+    channelId: ingress.channelId,
+    threadTs: ingress.threadTs,
+  });
+  signal.throwIfAborted();
   const userInfoResolver = createSlackUserInfoResolver(client);
   const messageContent = stripBotMention(event.text, ingress.botUserId);
   const [enriched, context, permalinkResult] = await Promise.all([
@@ -357,7 +405,7 @@ async function persistClaimedCanonicalSlackIngress(
     signal.throwIfAborted();
   });
   signal.throwIfAborted();
-  return { userId: ingress.userId, chatThreadId };
+  return persistedCanonicalSlackIngress(ingress, chatThreadId);
 }
 
 export const processCanonicalSlackIngress$ = command(
@@ -397,6 +445,24 @@ export const processCanonicalSlackIngress$ = command(
           signal,
         );
         signal.throwIfAborted();
+        await tapError(
+          clearCanonicalSlackThreadStatusIfIdle(
+            db,
+            {
+              chatThreadId: ingress.chatThreadId,
+              channelId: ingress.channelId,
+              threadTs: ingress.threadTs,
+            },
+            signal,
+          ),
+          (error) => {
+            L.warn("Failed to reconcile canonical Slack thread status", {
+              ingressId: args.ingressId,
+              error,
+            });
+          },
+        );
+        signal.throwIfAborted();
         return true;
       })(),
       signal,
@@ -407,6 +473,25 @@ export const processCanonicalSlackIngress$ = command(
     }
 
     await markIngressFailed(db, args.ingressId, result.error);
+    signal.throwIfAborted();
+    await tapError(
+      (async () => {
+        const target = await canonicalSlackThreadStatusTargetForIngress(
+          db,
+          args.ingressId,
+        );
+        signal.throwIfAborted();
+        if (target) {
+          await clearCanonicalSlackThreadStatusIfIdle(db, target, signal);
+        }
+      })(),
+      (error) => {
+        L.warn("Failed to clear canonical Slack status after ingress failure", {
+          ingressId: args.ingressId,
+          error,
+        });
+      },
+    );
     signal.throwIfAborted();
     L.error("Failed to process canonical Slack ingress", {
       ingressId: args.ingressId,

--- a/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
@@ -1,0 +1,236 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
+import { slackChatIngress } from "@vm0/db/schema/slack-chat-ingress";
+import { slackChatThreadRoutes } from "@vm0/db/schema/slack-chat-thread-route";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import {
+  createSlackClient,
+  setThreadStatus,
+} from "../external/slack-message-client";
+import { decryptPersistentSecretValue } from "./crypto.utils";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+
+const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+const ACTIVE_INGRESS_STATUSES = ["pending", "processing"] as const;
+
+export interface CanonicalSlackThreadStatusTarget {
+  readonly chatThreadId: string;
+  readonly channelId: string;
+  readonly threadTs: string;
+}
+
+interface CanonicalSlackThreadStatusBinding {
+  readonly encryptedBotToken: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly workspaceId: string;
+}
+
+async function loadCanonicalSlackThreadStatusBinding(
+  db: Db,
+  target: CanonicalSlackThreadStatusTarget,
+): Promise<CanonicalSlackThreadStatusBinding | undefined> {
+  const [binding] = await db
+    .select({
+      encryptedBotToken: slackOrgInstallations.encryptedBotToken,
+      orgId: slackOrgInstallations.orgId,
+      userId: slackChatThreadRoutes.userId,
+      workspaceId: slackOrgConnections.slackWorkspaceId,
+    })
+    .from(slackChatThreadRoutes)
+    .innerJoin(
+      slackOrgConnections,
+      eq(slackOrgConnections.id, slackChatThreadRoutes.connectionId),
+    )
+    .innerJoin(
+      slackOrgInstallations,
+      eq(
+        slackOrgInstallations.slackWorkspaceId,
+        slackOrgConnections.slackWorkspaceId,
+      ),
+    )
+    .where(
+      and(
+        eq(slackChatThreadRoutes.chatThreadId, target.chatThreadId),
+        eq(slackChatThreadRoutes.channelId, target.channelId),
+        eq(slackChatThreadRoutes.threadTs, target.threadTs),
+        eq(slackChatThreadRoutes.backend, "canonical"),
+        eq(slackOrgConnections.vm0UserId, slackChatThreadRoutes.userId),
+      ),
+    )
+    .limit(1);
+  if (!binding?.orgId) {
+    return undefined;
+  }
+  return { ...binding, orgId: binding.orgId };
+}
+
+async function canonicalSlackThreadHasOutstandingWork(
+  db: Db,
+  target: CanonicalSlackThreadStatusTarget,
+  workspaceId: string,
+): Promise<boolean> {
+  const routes = await db
+    .select({
+      id: slackChatThreadRoutes.id,
+      chatThreadId: slackChatThreadRoutes.chatThreadId,
+    })
+    .from(slackChatThreadRoutes)
+    .innerJoin(
+      slackOrgConnections,
+      eq(slackOrgConnections.id, slackChatThreadRoutes.connectionId),
+    )
+    .where(
+      and(
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+        eq(slackChatThreadRoutes.channelId, target.channelId),
+        eq(slackChatThreadRoutes.threadTs, target.threadTs),
+        eq(slackChatThreadRoutes.backend, "canonical"),
+        isNotNull(slackChatThreadRoutes.chatThreadId),
+      ),
+    );
+  const routeIds = routes.map((route) => {
+    return route.id;
+  });
+  const chatThreadIds = routes.flatMap((route) => {
+    return route.chatThreadId ? [route.chatThreadId] : [];
+  });
+  if (routeIds.length === 0 || chatThreadIds.length === 0) {
+    return false;
+  }
+
+  const [activeIngress, activeRuns, queuedSlackMessages] = await Promise.all([
+    db
+      .select({ id: slackChatIngress.id })
+      .from(slackChatIngress)
+      .where(
+        and(
+          inArray(slackChatIngress.routeId, routeIds),
+          inArray(slackChatIngress.status, ACTIVE_INGRESS_STATUSES),
+        ),
+      )
+      .limit(1),
+    db
+      .select({
+        chatThreadId: zeroRuns.chatThreadId,
+        triggerSource: zeroRuns.triggerSource,
+      })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(
+        and(
+          inArray(zeroRuns.chatThreadId, chatThreadIds),
+          inArray(agentRuns.status, ACTIVE_RUN_STATUSES),
+        ),
+      ),
+    db
+      .select({ chatThreadId: chatMessageQueue.chatThreadId })
+      .from(chatMessageQueue)
+      .where(
+        and(
+          inArray(chatMessageQueue.chatThreadId, chatThreadIds),
+          eq(chatMessageQueue.itemType, "slack_user_message"),
+        ),
+      ),
+  ]);
+  if (activeIngress.length > 0) {
+    return true;
+  }
+  if (
+    activeRuns.some((run) => {
+      return run.triggerSource === "slack";
+    })
+  ) {
+    return true;
+  }
+
+  const activeChatThreadIds = new Set(
+    activeRuns.flatMap((run) => {
+      return run.chatThreadId ? [run.chatThreadId] : [];
+    }),
+  );
+  return queuedSlackMessages.some((message) => {
+    return activeChatThreadIds.has(message.chatThreadId);
+  });
+}
+
+export async function canonicalSlackThreadStatusTargetForIngress(
+  db: Db,
+  ingressId: string,
+): Promise<CanonicalSlackThreadStatusTarget | undefined> {
+  const [target] = await db
+    .select({
+      chatThreadId: slackChatThreadRoutes.chatThreadId,
+      channelId: slackChatThreadRoutes.channelId,
+      threadTs: slackChatThreadRoutes.threadTs,
+    })
+    .from(slackChatIngress)
+    .innerJoin(
+      slackChatThreadRoutes,
+      eq(slackChatThreadRoutes.id, slackChatIngress.routeId),
+    )
+    .where(
+      and(
+        eq(slackChatIngress.id, ingressId),
+        eq(slackChatThreadRoutes.backend, "canonical"),
+        isNotNull(slackChatThreadRoutes.chatThreadId),
+      ),
+    )
+    .limit(1);
+  if (!target?.chatThreadId) {
+    return undefined;
+  }
+  return {
+    chatThreadId: target.chatThreadId,
+    channelId: target.channelId,
+    threadTs: target.threadTs,
+  };
+}
+
+export async function clearCanonicalSlackThreadStatusIfIdle(
+  db: Db,
+  target: CanonicalSlackThreadStatusTarget,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const binding = await loadCanonicalSlackThreadStatusBinding(db, target);
+  signal.throwIfAborted();
+  if (!binding) {
+    return false;
+  }
+  if (
+    await canonicalSlackThreadHasOutstandingWork(
+      db,
+      target,
+      binding.workspaceId,
+    )
+  ) {
+    signal.throwIfAborted();
+    return false;
+  }
+  signal.throwIfAborted();
+
+  const featureContext = await loadUserFeatureSwitchContext(
+    db,
+    binding.orgId,
+    binding.userId,
+  );
+  signal.throwIfAborted();
+  const botToken = await decryptPersistentSecretValue(
+    binding.encryptedBotToken,
+    featureContext,
+  );
+  signal.throwIfAborted();
+  await setThreadStatus(
+    createSlackClient(botToken),
+    target.channelId,
+    target.threadTs,
+    "",
+  );
+  signal.throwIfAborted();
+  return true;
+}

--- a/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
@@ -225,12 +225,31 @@ export async function clearCanonicalSlackThreadStatusIfIdle(
     featureContext,
   );
   signal.throwIfAborted();
-  await setThreadStatus(
-    createSlackClient(botToken),
-    target.channelId,
-    target.threadTs,
-    "",
-  );
-  signal.throwIfAborted();
-  return true;
+  const client = createSlackClient(botToken);
+  let appliedStatus = "";
+  while (true) {
+    await setThreadStatus(
+      client,
+      target.channelId,
+      target.threadTs,
+      appliedStatus,
+    );
+    signal.throwIfAborted();
+
+    // Work can start while a Slack status request is in flight. Reconcile
+    // until the persisted lifecycle agrees with the last status we applied;
+    // later lifecycle transitions schedule their own reconciliation.
+    const desiredStatus = (await canonicalSlackThreadHasOutstandingWork(
+      db,
+      target,
+      binding.workspaceId,
+    ))
+      ? "is thinking..."
+      : "";
+    signal.throwIfAborted();
+    if (desiredStatus === appliedStatus) {
+      return appliedStatus === "";
+    }
+    appliedStatus = desiredStatus;
+  }
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -55,6 +55,10 @@ import {
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import { dispatchSlackChatDeliveryOnce } from "./internal-slack-chat-run-callback.service";
+import {
+  clearCanonicalSlackThreadStatusIfIdle,
+  type CanonicalSlackThreadStatusTarget,
+} from "./canonical-slack-thread-status.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
 import {
   insertAssistantEventMessages,
@@ -402,6 +406,10 @@ interface ChatCallbackDependencies {
     callbackId: string,
     signal: AbortSignal,
   ) => Promise<void>;
+  readonly clearSlackThreadStatusIfIdle: (
+    target: CanonicalSlackThreadStatusTarget,
+    signal: AbortSignal,
+  ) => Promise<boolean>;
   readonly createQueuedRun?: CreateQueuedRun;
   readonly drainThreadQueue?: (
     chatThreadId: string,
@@ -2540,6 +2548,65 @@ async function maybeDrainThreadQueueForTerminalCallback(args: {
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
+async function clearSlackThreadStatusAfterTerminalCallback(args: {
+  readonly chatThreadId: string;
+  readonly slackDelivery: SlackDeliveryTarget | undefined;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  if (!args.slackDelivery) {
+    return;
+  }
+  await tapError(
+    args.dependencies.clearSlackThreadStatusIfIdle(
+      {
+        chatThreadId: args.chatThreadId,
+        channelId: args.slackDelivery.channelId,
+        threadTs: args.slackDelivery.threadTs,
+      },
+      args.signal,
+    ),
+    (error) => {
+      log.warn("Failed to clear canonical Slack thread status", {
+        chatThreadId: args.chatThreadId,
+        error,
+      });
+    },
+  );
+  args.signal.throwIfAborted();
+}
+
+async function handleTerminalChatCallbackPreparationFailure(args: {
+  readonly runId: string;
+  readonly error: unknown;
+  readonly chatThreadId: string;
+  readonly slackDelivery: SlackDeliveryTarget | undefined;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly timing: ChatCallbackPreCreateTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<never> {
+  const fallbackDrain = await maybeDrainThreadQueueForTerminalCallback({
+    enabled: true,
+    chatThreadId: args.chatThreadId,
+    dependencies: args.dependencies,
+    timing: args.timing,
+    signal: args.signal,
+  });
+  if (!fallbackDrain.ok) {
+    log.error("Failed to drain thread queue after terminal callback error", {
+      runId: args.runId,
+      error: fallbackDrain.error,
+    });
+  }
+  await clearSlackThreadStatusAfterTerminalCallback({
+    chatThreadId: args.chatThreadId,
+    slackDelivery: args.slackDelivery,
+    dependencies: args.dependencies,
+    signal: args.signal,
+  });
+  throw args.error;
+}
+
 async function processTerminalChatCallback(args: {
   readonly db: Db;
   readonly callback: InternalRunCallbackEnvelope;
@@ -2569,6 +2636,12 @@ async function processTerminalChatCallback(args: {
     },
   );
   if (!loaded) {
+    await clearSlackThreadStatusAfterTerminalCallback({
+      chatThreadId: args.payload.threadId,
+      slackDelivery: args.payload.slackDelivery,
+      dependencies: args.dependencies,
+      signal: args.signal,
+    });
     return;
   }
   const { run, chatThread } = loaded;
@@ -2607,20 +2680,15 @@ async function processTerminalChatCallback(args: {
   );
 
   if (!prepared.ok) {
-    const fallbackDrain = await maybeDrainThreadQueueForTerminalCallback({
-      enabled: true,
+    return await handleTerminalChatCallbackPreparationFailure({
+      runId,
+      error: prepared.error,
       chatThreadId: chatThread.chatThreadId,
+      slackDelivery: args.payload.slackDelivery,
       dependencies: args.dependencies,
       timing,
       signal: args.signal,
     });
-    if (!fallbackDrain.ok) {
-      log.error("Failed to drain thread queue after terminal callback error", {
-        runId,
-        error: fallbackDrain.error,
-      });
-    }
-    throw prepared.error;
   }
   const work = prepared.value;
 
@@ -2648,6 +2716,12 @@ async function processTerminalChatCallback(args: {
     timing,
     signal: args.signal,
   });
+  await clearSlackThreadStatusAfterTerminalCallback({
+    chatThreadId: chatThread.chatThreadId,
+    slackDelivery: args.payload.slackDelivery,
+    dependencies: args.dependencies,
+    signal: args.signal,
+  });
 
   if (work.deferredSideEffects) {
     await runTerminalChatCallbackSideEffects({
@@ -2671,6 +2745,7 @@ function withoutQueuedRunDependency(
     formatRunError: dependencies.formatRunError,
     getResolvedAttachFiles: dependencies.getResolvedAttachFiles,
     dispatchSlackDelivery: dependencies.dispatchSlackDelivery,
+    clearSlackThreadStatusIfIdle: dependencies.clearSlackThreadStatusIfIdle,
     drainThreadQueue: dependencies.drainThreadQueue,
   };
 }
@@ -2810,6 +2885,9 @@ export async function handleChatInternalCallbackWithoutCcstate(
       dispatchSlackDelivery: (callbackId, inputSignal) => {
         return dispatchSlackChatDeliveryOnce(db, callbackId, inputSignal);
       },
+      clearSlackThreadStatusIfIdle: (target, inputSignal) => {
+        return clearCanonicalSlackThreadStatusIfIdle(db, target, inputSignal);
+      },
     },
   });
 }
@@ -2847,6 +2925,9 @@ const buildChatCallbackDependencies$ = command(
       },
       dispatchSlackDelivery: (callbackId, inputSignal) => {
         return dispatchSlackChatDeliveryOnce(db, callbackId, inputSignal);
+      },
+      clearSlackThreadStatusIfIdle: (target, inputSignal) => {
+        return clearCanonicalSlackThreadStatusIfIdle(db, target, inputSignal);
       },
       drainThreadQueue: input.drainThreadQueue,
     };


### PR DESCRIPTION
## Summary

- restore Slack Assistant `is thinking...` status when canonical Slack ingress begins processing
- keep the shared physical Slack thread active while canonical ingress, Slack-triggered runs, or Slack work blocked in the mixed thread queue remains
- reconcile and clear the status after terminal success, failure, cancellation, ingress/dispatch failure, and final Slack delivery failure
- extend the canonical Slack BDD flow to cover retry deduplication, mixed Web/Slack queueing, failed final delivery, and cancellation

## User impact

Canonical Slack threads once again show in-progress feedback while work is pending or running, without clearing early when another Slack message is still waiting.

## Verification

- `npx -p pnpm@10.33.4 pnpm -F api lint`
- `node --max-old-space-size=4096 ../../node_modules/typescript/bin/tsc --noEmit` from `turbo/apps/api`
- targeted `integrations.bdd.test.ts` canonical ingress scenario (`1 passed`, `29 skipped`)
- `git diff --check`

Closes #22663
