### PR TITLE
fix(platform): make composer connector permissions user-overridable

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -219,6 +219,9 @@ describe("user-overridable switches", () => {
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.ZeroWebSearch,
     );
+    expect(getUserOverridableFeatureSwitchKeys()).toContain(
+      FeatureSwitchKey.ComposerConnectorPermissions,
+    );
 
     expect(
       filterUserOverridableFeatureSwitchOverrides({
@@ -227,10 +230,12 @@ describe("user-overridable switches", () => {
         [FeatureSwitchKey.OrgPlanEntitlementReads]: true,
         [FeatureSwitchKey.PresentationElementDragging]: true,
         [FeatureSwitchKey.ZeroWebSearch]: true,
+        [FeatureSwitchKey.ComposerConnectorPermissions]: true,
         [FeatureSwitchKey.Dummy]: false,
       }),
     ).toStrictEqual({
       [FeatureSwitchKey.ZeroWebSearch]: true,
+      [FeatureSwitchKey.ComposerConnectorPermissions]: true,
       [FeatureSwitchKey.Dummy]: false,
     });
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -493,7 +493,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show the configure-permissions entry in the chat composer connector popover, opening the agent×connector firewall dialog inline.",
     enabled: false,
-    userOverridable: false,
+    userOverridable: true,
   },
 };
 


### PR DESCRIPTION
## Summary

- make composerConnectorPermissions user-overridable so it appears in Settings > Lab
- allow the existing feature-switch API to persist its per-user override
- cover both Lab discovery and override filtering in the core feature-switch test

## User-visible impact

The connector permission entry remains off by default. A user can now find composerConnectorPermissions in Lab and enable it for their own account.

## Verification

- npx -y prettier@3.8.1 --check on both changed files
- npx -y oxlint@1.57.0 on both changed files
- full local Vitest not run per vm0 PR policy; PR CI will run the test suite