### PR TITLE
test(mitm-addon): reduce zlib expansion fixture

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -162,14 +162,15 @@ class TestStreamDecodeFeed:
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_zlib_high_ratio_output_stops_at_expansion_budget(self, headers, encoding):
-        plaintext = b"A" * (64 * 1024 * 1024)
+        plaintext_size = 8 * 1024 * 1024
+        compression_block = hashlib.shake_256(b"vm0-streaming-zlib-ratio-budget").digest(5 * 1024)
+        plaintext = (compression_block * (plaintext_size // len(compression_block) + 1))[
+            :plaintext_size
+        ]
         compressed = _compress_one_shot_body(encoding, plaintext)
         assert len(compressed) < STREAM_DECODE_CHUNK_LIMIT
-        expected_decoded_bytes = max(
-            STREAM_DECODE_EXPANSION_GRACE,
-            len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
-        )
-        assert expected_decoded_bytes < len(plaintext)
+        expected_decoded_bytes = len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO
+        assert STREAM_DECODE_EXPANSION_GRACE < expected_decoded_bytes < len(plaintext)
         chunks: list[bytes] = []
         session = create_stream_decode_session(
             headers(("Content-Encoding", encoding)), chunks.append


### PR DESCRIPTION
## Summary

- replace the 64 MiB all-`A` gzip/deflate expansion-budget fixture with an exactly 8 MiB
  deterministic repeated-block fixture
- use a 5 KiB SHAKE-256 block to leave balanced margin above the ratio-budget threshold and below
  the compressed-input limit
- assert explicitly that the ratio-derived budget exceeds the grace while preserving all existing
  output, chunking, terminal-error, and post-error assertions

## Resource verification

On Python 3.12.3 with zlib 1.3, isolated setup for both codec cases measured:

| Fixture | Elapsed | Peak RSS | gzip bytes | deflate bytes |
| --- | ---: | ---: | ---: | ---: |
| 64 MiB all-`A` | 0.231 s | 78,672 KiB | 65,251 | 65,239 |
| 8 MiB repeated 5 KiB block | 0.055 s | 29,192 KiB | 58,659 | 58,647 |

## Scope

This changes test data and assertions only. It does not change production decoder behavior,
limits, APIs, protocols, persisted state, dependencies, configuration, generated output, or
documentation.

## Validation

- `.venv/bin/python -m pytest 'tests/test_body_decoding.py::TestStreamDecodeFeed::test_zlib_high_ratio_output_stops_at_expansion_budget' -q` (2 passed)
- `.venv/bin/ruff format --check src tests`
- `.venv/bin/ruff check src tests`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/` (4,175 passed)
- `git diff --check`

Closes #22650
