### PR TITLE
refactor(artifacts): remove favorite controls

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -207,21 +207,6 @@ export const apiAgentsHandlers = [
     return respond(200, { artifacts: [], truncated: false, nextCursor: null });
   }),
 
-  // GET /api/zero/artifacts/favorites
-  mockApi(artifactsContract.listFavorites, ({ respond }) => {
-    return respond(200, { artifactUrls: [] });
-  }),
-
-  // POST /api/zero/artifacts/favorite
-  mockApi(artifactsContract.favorite, ({ respond }) => {
-    return respond(204);
-  }),
-
-  // POST /api/zero/artifacts/unfavorite
-  mockApi(artifactsContract.unfavorite, ({ respond }) => {
-    return respond(204);
-  }),
-
   // GET /api/zero/chat-threads/:id (thread detail)
   mockApi(chatThreadByIdContract.get, ({ respond }) => {
     return respond(200, {

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -20,7 +20,7 @@ import { chatIdb$ } from "../external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../external/idb-artifact-item-store.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
-import { onRef, onRejection } from "../utils.ts";
+import { onRef } from "../utils.ts";
 import {
   ensureAgentDraft$,
   loadAgentDraft$,
@@ -45,11 +45,6 @@ const ARTIFACT_FOCUS_TARGET_SELECTOR =
 const internalArtifactsSearch$ = state("");
 const internalArtifactsAgentId$ = state<string | null>(null);
 const internalArtifactsCategory$ = state<ArtifactCategory | null>(null);
-const internalArtifactsFavoritesOnly$ = state(false);
-const internalArtifactFavoriteOverrides$ = state<
-  Readonly<Record<string, boolean>>
->({});
-const internalArtifactFavoritesReload$ = state(0);
 const internalArtifactsReload$ = state(0);
 const internalArtifactsWindow$ = state(ARTIFACT_WINDOW_STEP);
 const internalArtifactsScrollViewport$ = state<HTMLElement | null>(null);
@@ -87,10 +82,6 @@ export const selectedArtifactsAgentId$ = computed((get) => {
 
 export const selectedArtifactsCategory$ = computed((get) => {
   return get(internalArtifactsCategory$);
-});
-
-export const artifactsFavoritesOnly$ = computed((get) => {
-  return get(internalArtifactsFavoritesOnly$);
 });
 
 // How many artifacts the grid currently makes available. Grown automatically
@@ -251,22 +242,10 @@ export const setSelectedArtifactsCategory$ = command(
   },
 );
 
-export const setArtifactsFavoritesOnly$ = command(
-  ({ set }, favoritesOnly: boolean) => {
-    set(internalArtifactsFavoritesOnly$, favoritesOnly);
-    set(internalArtifactsWindow$, ARTIFACT_WINDOW_STEP);
-  },
-);
-
 export const resetArtifactsFilters$ = command(({ set }) => {
   set(internalArtifactsSearch$, "");
   set(internalArtifactsAgentId$, null);
   set(internalArtifactsCategory$, null);
-  set(internalArtifactsFavoritesOnly$, false);
-  set(internalArtifactFavoriteOverrides$, {});
-  set(internalArtifactFavoritesReload$, (version) => {
-    return version + 1;
-  });
   set(internalArtifactsWindow$, ARTIFACT_WINDOW_STEP);
 });
 
@@ -399,64 +378,22 @@ export const cachedArtifacts$ = computed(
   },
 );
 
-export const remoteArtifactFavoriteUrls$ = computed(
-  async (get): Promise<ReadonlySet<string>> => {
-    get(internalArtifactFavoritesReload$);
-    const client = get(zeroClient$)(artifactsContract);
-    const result = await accept(client.listFavorites(), [200]);
-    return new Set(result.body.artifactUrls);
-  },
-);
-
-export type ArtifactPageItem = ArtifactItem & {
-  readonly isFavorited: boolean;
-};
-
-function applyArtifactFavoriteState(
-  item: ArtifactItem,
-  favoriteUrls: ReadonlySet<string> | null,
-  overrides: Readonly<Record<string, boolean>>,
-): ArtifactPageItem {
-  return {
-    ...item,
-    isFavorited: overrides[item.url] ?? favoriteUrls?.has(item.url) ?? false,
-  };
-}
-
-export function applyArtifactFavorites(
-  artifacts: readonly ArtifactItem[],
-  favoriteUrls: ReadonlySet<string> | null,
-  overrides: Readonly<Record<string, boolean>>,
-): ArtifactPageItem[] {
-  return artifacts.map((artifact) => {
-    return applyArtifactFavoriteState(artifact, favoriteUrls, overrides);
-  });
-}
-
-export const artifactFavoriteOverrides$ = computed((get) => {
-  return get(internalArtifactFavoriteOverrides$);
-});
-
 // Applies the search / agent / category filters in memory over the active set,
 // so switching filters is instant and never re-fetches or truncates.
 export function filterArtifacts(
-  artifacts: readonly ArtifactPageItem[],
+  artifacts: readonly ArtifactItem[],
   filters: {
     readonly search: string;
     readonly agentId: string | null;
     readonly category: ArtifactCategory | null;
-    readonly favoritesOnly: boolean;
   },
-): ArtifactPageItem[] {
+): ArtifactItem[] {
   const searchTokens = normalizedSearchTokens(filters.search);
   const filtered = artifacts.filter((item) => {
     if (filters.agentId && item.agentId !== filters.agentId) {
       return false;
     }
     if (!artifactMatchesCategory(item, filters.category)) {
-      return false;
-    }
-    if (filters.favoritesOnly && item.isFavorited !== true) {
       return false;
     }
     if (searchTokens.length === 0) {
@@ -469,41 +406,6 @@ export function filterArtifacts(
   });
   return filtered;
 }
-
-export const toggleArtifactFavorite$ = command(
-  async ({ get, set }, item: ArtifactPageItem, signal: AbortSignal) => {
-    const currentIsFavorited = item.isFavorited;
-    const nextIsFavorited = !currentIsFavorited;
-    set(internalArtifactFavoriteOverrides$, (overrides) => {
-      return { ...overrides, [item.url]: nextIsFavorited };
-    });
-
-    const client = get(zeroClient$)(artifactsContract);
-    const request = nextIsFavorited
-      ? accept(
-          client.favorite({
-            body: { artifactUrl: item.url },
-            fetchOptions: { signal },
-          }),
-          [204],
-        )
-      : accept(
-          client.unfavorite({
-            body: { artifactUrl: item.url },
-            fetchOptions: { signal },
-          }),
-          [204],
-        );
-    await onRejection(request, () => {
-      if (!signal.aborted) {
-        set(internalArtifactFavoriteOverrides$, (overrides) => {
-          return { ...overrides, [item.url]: currentIsFavorited };
-        });
-      }
-    });
-    signal.throwIfAborted();
-  },
-);
 
 export const navigateToArtifactThread$ = command(
   ({ set }, threadId: string) => {

--- a/turbo/apps/platform/src/signals/external/idb-artifact-item-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/idb-artifact-item-store.test.ts
@@ -295,17 +295,6 @@ describe("artifact item IndexedDB cache reads", () => {
     ).resolves.toStrictEqual(refreshed);
   });
 
-  it("does not persist artifact favorite state", async () => {
-    const { stores } = setupStores();
-    const favorited = { ...artifact(1), isFavorited: true };
-
-    await stores.writeStore.upsertItems([favorited]);
-
-    const cached = await stores.readStore.readRecent();
-    expect(cached).toStrictEqual([artifact(1)]);
-    expect(cached[0]).not.toHaveProperty("isFavorited");
-  });
-
   it("reads by agent, artifact kind, and their compound index", async () => {
     const { stores } = setupStores();
     const hostedFirst = artifact(1, {

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -394,12 +394,6 @@ function mockArtifacts(artifacts: readonly ArtifactItem[]): void {
   });
 }
 
-function mockArtifactFavorites(artifactUrls: readonly string[]): void {
-  context.mocks.api(artifactsContract.listFavorites, ({ respond }) => {
-    return respond(200, { artifactUrls: [...artifactUrls] });
-  });
-}
-
 function mockScrollViewport(
   element: HTMLElement,
   initial: {
@@ -440,13 +434,11 @@ function mockScrollViewport(
 function setupArtifactsPage({
   scope,
   enabled = true,
-  artifactFavoritesEnabled = false,
   htmlArtifactCommentEditingEnabled = false,
   imageEditingEnabled = false,
 }: {
   readonly scope: TestAuthScope;
   readonly enabled?: boolean;
-  readonly artifactFavoritesEnabled?: boolean;
   readonly htmlArtifactCommentEditingEnabled?: boolean;
   readonly imageEditingEnabled?: boolean;
 }): void {
@@ -463,7 +455,6 @@ function setupArtifactsPage({
     },
     featureSwitches: {
       [FeatureSwitchKey.Artifacts]: enabled,
-      [FeatureSwitchKey.ArtifactFavorites]: artifactFavoritesEnabled,
       [FeatureSwitchKey.HtmlArtifactCommentEditing]:
         htmlArtifactCommentEditingEnabled,
       [FeatureSwitchKey.ImageEditing]: imageEditingEnabled,
@@ -1243,131 +1234,19 @@ describe("artifacts page", () => {
     expect(listCalls).toBe(1);
   });
 
-  it("hides favorite controls when artifact favorites are disabled", async () => {
-    setupTeam();
-    const scope = testAuthScope("favorites-disabled");
-    mockArtifacts([createArtifact()]);
-
-    setupArtifactsPage({ scope });
-
-    await screen.findByText("launch-plan.html");
-    expect(
-      screen.queryByLabelText("Show favorite artifacts"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Add launch-plan.html to favorites"),
-    ).not.toBeInTheDocument();
-  });
-
   it("shows interaction feedback on artifact card actions", async () => {
     setupTeam();
     const scope = testAuthScope("card-action-feedback");
     mockArtifacts([createArtifact()]);
 
-    setupArtifactsPage({ scope, artifactFavoritesEnabled: true });
+    setupArtifactsPage({ scope });
 
     await screen.findByText("launch-plan.html");
-    expect(buttonByLabel("Add launch-plan.html to favorites")).toHaveClass(
-      "hover:bg-muted/60",
-      "active:bg-muted",
-    );
     expect(buttonByLabel("More actions for launch-plan.html")).toHaveClass(
       "hover:bg-muted/60",
       "active:bg-muted",
       "data-[state=open]:bg-muted",
     );
-  });
-
-  it("keeps artifacts visible when favorite state fails to load", async () => {
-    setupTeam();
-    const scope = testAuthScope("favorites-unavailable");
-    mockArtifacts([createArtifact()]);
-    context.mocks.api(artifactsContract.listFavorites, ({ respond }) => {
-      return respond(403, {
-        error: { code: "FORBIDDEN", message: "Could not load favorites" },
-      });
-    });
-
-    setupArtifactsPage({ scope, artifactFavoritesEnabled: true });
-
-    await screen.findByText("launch-plan.html");
-    expect(
-      screen.queryByLabelText("Show favorite artifacts"),
-    ).not.toBeInTheDocument();
-    expect(buttonByLabel("Add launch-plan.html to favorites")).toBeDisabled();
-  });
-
-  it("favorites artifacts optimistically and filters favorites locally", async () => {
-    setupTeam();
-    const scope = testAuthScope("favorites");
-    const launch = createArtifact({
-      artifactItemId: "favorite-launch:file-1",
-      runId: "favorite-launch",
-      filename: "launch-plan.html",
-      createdAt: "2026-01-03T00:00:00Z",
-      url: "https://artifacts.example.com/launch-plan.html",
-    });
-    const brief = createArtifact({
-      artifactItemId: "favorite-brief:file-1",
-      runId: "favorite-brief",
-      fileId: "favorite-brief-file",
-      filename: "favorite-brief.html",
-      createdAt: "2026-01-02T00:00:00Z",
-      url: "https://artifacts.example.com/favorite-brief.html",
-    });
-    const archive = createArtifact({
-      artifactItemId: "favorite-archive:file-1",
-      runId: "favorite-archive",
-      fileId: "favorite-archive-file",
-      filename: "archive.html",
-      createdAt: "2026-01-01T00:00:00Z",
-      url: "https://artifacts.example.com/archive.html",
-    });
-    mockArtifacts([launch, brief, archive]);
-    mockArtifactFavorites([brief.url]);
-
-    let favoriteBody: { readonly artifactUrl: string } | undefined;
-    context.mocks.api(artifactsContract.favorite, ({ body, respond }) => {
-      favoriteBody = body;
-      return respond(204);
-    });
-
-    let unfavoriteBody: { readonly artifactUrl: string } | undefined;
-    context.mocks.api(artifactsContract.unfavorite, ({ body, respond }) => {
-      unfavoriteBody = body;
-      return respond(204);
-    });
-
-    setupArtifactsPage({ scope, artifactFavoritesEnabled: true });
-
-    await screen.findByText("launch-plan.html");
-    await screen.findByText("favorite-brief.html");
-    await screen.findByText("archive.html");
-
-    const favoriteButton = buttonByLabel("Add launch-plan.html to favorites");
-    expect(
-      favoriteButton.closest('[data-testid="artifact-card-details"]'),
-    ).not.toBeNull();
-    click(favoriteButton);
-    await waitFor(() => {
-      expect(favoriteBody).toStrictEqual({ artifactUrl: launch.url });
-      expect(
-        buttonByLabel("Remove launch-plan.html from favorites"),
-      ).toBeInTheDocument();
-    });
-
-    click(buttonByLabel("Show favorite artifacts"));
-    await waitFor(() => {
-      expect(screen.getByText("launch-plan.html")).toBeInTheDocument();
-      expect(screen.getByText("favorite-brief.html")).toBeInTheDocument();
-      expect(screen.queryByText("archive.html")).not.toBeInTheDocument();
-    });
-
-    click(buttonByLabel("Remove favorite-brief.html from favorites"));
-    await waitFor(() => {
-      expect(unfavoriteBody).toStrictEqual({ artifactUrl: brief.url });
-      expect(screen.queryByText("favorite-brief.html")).not.toBeInTheDocument();
-    });
   });
 
   it("preserves a saved draft and references a hosted artifact by URL", async () => {
@@ -1541,7 +1420,6 @@ describe("artifacts page", () => {
       ).readStore.readRecent({ limit: 10_000 });
     });
     expect(cached).toStrictEqual([artifact]);
-    expect(cached[0]).not.toHaveProperty("isFavorited");
   });
 
   it("renders the cache immediately when returning while the remote refresh is pending", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -7,8 +7,6 @@ import type { ArtifactItem } from "@vm0/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
   IconAlertTriangle,
-  IconCarambola,
-  IconCarambolaFilled,
   IconCheck,
   IconChevronDown,
   IconDownload,
@@ -23,7 +21,6 @@ import {
   IconVideo,
   IconWorld,
 } from "@tabler/icons-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { r2ImageTransformUrl } from "@vm0/core";
 import {
   useGet,
@@ -49,11 +46,8 @@ import {
 import { agents$ } from "../../signals/agent.ts";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import {
-  applyArtifactFavorites,
-  artifactFavoriteOverrides$,
   artifactsGridElement$,
   artifactsGridWidth$,
-  artifactsFavoritesOnly$,
   artifactsSearch$,
   artifactsScrollMetrics$,
   artifactsScrollViewport$,
@@ -65,28 +59,23 @@ import {
   navigateToArtifactThread$,
   reloadArtifacts$,
   remoteArtifacts$,
-  remoteArtifactFavoriteUrls$,
   requestArtifactsKeyboardFocus$,
   selectedArtifactsAgentId$,
   selectedArtifactsCategory$,
   setArtifactCardRef$,
   setArtifactsGridRef$,
-  setArtifactsFavoritesOnly$,
   setArtifactsScrollViewportRef$,
   setArtifactsSearch$,
   setSelectedArtifactsAgentId$,
   setSelectedArtifactsCategory$,
   startArtifactChat$,
   syncArtifactsScrollMetrics$,
-  toggleArtifactFavorite$,
-  type ArtifactPageItem,
 } from "../../signals/artifacts-page/artifacts-signals.ts";
 import type { ArtifactCategory } from "../../signals/artifacts-page/artifact-category.ts";
 import {
   classifyChatAttachment,
   type BodyPreviewKind,
 } from "../../signals/chat-page/parse-body-blocks.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   lightboxUrl$,
@@ -421,69 +410,38 @@ function ArtifactsToolbar({
   search,
   selectedAgentId,
   selectedCategory,
-  favoritesOnly,
-  showFavoritesFilter,
   agents,
   onSearchChange,
   onAgentChange,
   onCategoryChange,
-  onFavoritesOnlyChange,
 }: {
   readonly search: string;
   readonly selectedAgentId: string | null;
   readonly selectedCategory: ArtifactCategory | null;
-  readonly favoritesOnly: boolean;
-  readonly showFavoritesFilter: boolean;
   readonly agents: readonly TeamComposeItem[];
   readonly onSearchChange: (value: string) => void;
   readonly onAgentChange: (value: string | null) => void;
   readonly onCategoryChange: (value: ArtifactCategory | null) => void;
-  readonly onFavoritesOnlyChange: (value: boolean) => void;
 }) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 flex-col gap-2 sm:flex-1 sm:flex-row sm:items-center">
-          <div className="relative min-w-0 flex-1 sm:max-w-sm">
-            <IconSearch
-              aria-hidden
-              size={15}
-              stroke={1.5}
-              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
-            />
-            <Input
-              aria-label="Search artifacts"
-              placeholder="Search artifacts..."
-              value={search}
-              onChange={(event) => {
-                onSearchChange(event.target.value);
-              }}
-              className="pl-9"
-            />
-          </div>
-          {showFavoritesFilter && (
-            <button
-              type="button"
-              aria-label="Show favorite artifacts"
-              aria-pressed={favoritesOnly}
-              onClick={() => {
-                onFavoritesOnlyChange(!favoritesOnly);
-              }}
-              className={cn(
-                "inline-flex h-9 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-border px-3 text-sm font-medium leading-none transition-colors",
-                favoritesOnly
-                  ? "bg-muted text-foreground"
-                  : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-              )}
-            >
-              {favoritesOnly ? (
-                <IconCarambolaFilled size={14} aria-hidden />
-              ) : (
-                <IconCarambola size={14} stroke={1.7} aria-hidden />
-              )}
-              Favorites
-            </button>
-          )}
+        <div className="relative min-w-0 flex-1 sm:max-w-sm">
+          <IconSearch
+            aria-hidden
+            size={15}
+            stroke={1.5}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+          />
+          <Input
+            aria-label="Search artifacts"
+            placeholder="Search artifacts..."
+            value={search}
+            onChange={(event) => {
+              onSearchChange(event.target.value);
+            }}
+            className="pl-9"
+          />
         </div>
         <ArtifactsAgentFilter
           agents={agents}
@@ -701,25 +659,17 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
 }
 
 interface ArtifactCardActionsProps {
-  readonly favorited: boolean;
-  readonly item: ArtifactPageItem;
+  readonly item: ArtifactItem;
   readonly previewUrl: string;
-  readonly favoriteActionEnabled: boolean;
-  readonly showFavoriteAction: boolean;
   readonly onOpenChat: (threadId: string) => void;
   readonly onStartChat: (item: ArtifactItem) => void;
-  readonly onToggleFavorite: (item: ArtifactPageItem) => void;
 }
 
 function ArtifactCardActions({
-  favorited,
   item,
   previewUrl,
-  favoriteActionEnabled,
-  showFavoriteAction,
   onOpenChat,
   onStartChat,
-  onToggleFavorite,
 }: ArtifactCardActionsProps) {
   return (
     <div
@@ -731,38 +681,6 @@ function ArtifactCardActions({
         event.stopPropagation();
       }}
     >
-      {showFavoriteAction && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={cn(
-            "h-8 w-8 rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground active:bg-muted",
-            favorited && "text-amber-500 hover:text-amber-500",
-          )}
-          aria-label={
-            favorited
-              ? `Remove ${item.filename} from favorites`
-              : `Add ${item.filename} to favorites`
-          }
-          aria-pressed={favorited}
-          disabled={!favoriteActionEnabled}
-          title={
-            favorited
-              ? `Remove ${item.filename} from favorites`
-              : `Add ${item.filename} to favorites`
-          }
-          onClick={() => {
-            onToggleFavorite(item);
-          }}
-        >
-          {favorited ? (
-            <IconCarambolaFilled size={16} aria-hidden />
-          ) : (
-            <IconCarambola size={16} stroke={1.5} aria-hidden />
-          )}
-        </Button>
-      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -841,25 +759,18 @@ function ArtifactCard({
   onOpenChat,
   onOpenPreview,
   onStartChat,
-  onToggleFavorite,
-  favoriteActionEnabled,
-  showFavoriteAction,
 }: {
   readonly cardRef: (element: HTMLElement | null) => void;
   readonly index: number;
-  readonly item: ArtifactPageItem;
+  readonly item: ArtifactItem;
   readonly onOpenChat: (threadId: string) => void;
   readonly onOpenPreview: (item: ArtifactItem) => void;
   readonly onStartChat: (item: ArtifactItem) => void;
-  readonly onToggleFavorite: (item: ArtifactPageItem) => void;
-  readonly favoriteActionEnabled: boolean;
-  readonly showFavoriteAction: boolean;
 }) {
   const kindLabel = formatArtifactKind(item.artifactKind);
   const contextLabel = artifactContextLabel({ item, kindLabel });
   const previewUrl = publicAttachmentUrl(item.url);
   const previewable = artifactLightboxKind(item) !== "file";
-  const favorited = item.isFavorited;
   return (
     <article
       ref={cardRef}
@@ -917,14 +828,10 @@ function ArtifactCard({
           </p>
         </div>
         <ArtifactCardActions
-          favorited={favorited}
-          favoriteActionEnabled={favoriteActionEnabled}
           item={item}
           previewUrl={previewUrl}
-          showFavoriteAction={showFavoriteAction}
           onOpenChat={onOpenChat}
           onStartChat={onStartChat}
-          onToggleFavorite={onToggleFavorite}
         />
       </div>
     </article>
@@ -1177,11 +1084,8 @@ function ArtifactsList({
   onOpenChat,
   onOpenPreview,
   onStartChat,
-  onToggleFavorite,
-  favoriteActionEnabled,
-  showFavoriteAction,
 }: {
-  readonly artifacts: readonly ArtifactPageItem[];
+  readonly artifacts: readonly ArtifactItem[];
   readonly loading: boolean;
   readonly error: boolean;
   readonly visibleCount: number;
@@ -1189,9 +1093,6 @@ function ArtifactsList({
   readonly onOpenChat: (threadId: string) => void;
   readonly onOpenPreview: (item: ArtifactItem) => void;
   readonly onStartChat: (item: ArtifactItem) => void;
-  readonly onToggleFavorite: (item: ArtifactPageItem) => void;
-  readonly favoriteActionEnabled: boolean;
-  readonly showFavoriteAction: boolean;
 }) {
   const scrollViewport = useGet(artifactsScrollViewport$);
   const scrollMetrics = useGet(artifactsScrollMetrics$);
@@ -1277,14 +1178,11 @@ function ArtifactsList({
             <ArtifactCard
               key={artifact.artifactItemId}
               cardRef={setArtifactCardRef}
-              favoriteActionEnabled={favoriteActionEnabled}
               index={index}
               item={artifact}
               onOpenChat={onOpenChat}
               onOpenPreview={onOpenPreview}
               onStartChat={onStartChat}
-              onToggleFavorite={onToggleFavorite}
-              showFavoriteAction={showFavoriteAction}
             />
           );
         })}
@@ -1300,13 +1198,9 @@ export function ArtifactsPage() {
   const search = useGet(artifactsSearch$);
   const selectedAgentId = useGet(selectedArtifactsAgentId$);
   const selectedCategory = useGet(selectedArtifactsCategory$);
-  const favoritesOnly = useGet(artifactsFavoritesOnly$);
-  const favoriteOverrides = useGet(artifactFavoriteOverrides$);
   const setSearch = useSet(setArtifactsSearch$);
   const setSelectedAgentId = useSet(setSelectedArtifactsAgentId$);
   const setSelectedCategory = useSet(setSelectedArtifactsCategory$);
-  const setFavoritesOnly = useSet(setArtifactsFavoritesOnly$);
-  const toggleFavorite = useSet(toggleArtifactFavorite$);
   const openChat = useSet(navigateToArtifactThread$);
   const startChat = useSet(startArtifactChat$);
   const pageSignal = useGet(pageSignal$);
@@ -1318,15 +1212,7 @@ export function ArtifactsPage() {
   const lightboxUrl = useGet(lightboxUrl$);
   const remoteLoadable = useLastLoadable(remoteArtifacts$);
   const cachedLoadable = useLastLoadable(cachedArtifacts$);
-  const favoriteUrlsLoadable = useLastLoadable(remoteArtifactFavoriteUrls$);
   const agents = useLastResolved(agents$) ?? [];
-  const features = useLastResolved(featureSwitch$);
-  const artifactFavoritesEnabled =
-    features?.[FeatureSwitchKey.ArtifactFavorites] ?? false;
-  const favoriteUrls =
-    favoriteUrlsLoadable.state === "hasData" ? favoriteUrlsLoadable.data : null;
-  const artifactFavoritesReady =
-    artifactFavoritesEnabled && favoriteUrls !== null;
   const remoteData =
     remoteLoadable.state === "hasData" ? remoteLoadable.data : null;
   const cachedData =
@@ -1335,16 +1221,11 @@ export function ArtifactsPage() {
   // authoritative set. Cached fallback is only used before remote data loads or
   // when the refresh errors.
   const sourceData = remoteData ?? cachedData;
-  const sourceArtifacts = applyArtifactFavorites(
-    sourceData?.artifacts ?? [],
-    favoriteUrls,
-    favoriteOverrides,
-  );
+  const sourceArtifacts = sourceData?.artifacts ?? [];
   const artifacts = filterArtifacts(sourceArtifacts, {
     search,
     agentId: selectedAgentId,
     category: selectedCategory,
-    favoritesOnly: artifactFavoritesReady && favoritesOnly,
   });
   // Drive first-paint loading / error off the source set (not the filtered
   // view, which is legitimately empty when a filter matches nothing).
@@ -1392,17 +1273,13 @@ export function ArtifactsPage() {
             search={search}
             selectedAgentId={selectedAgentId}
             selectedCategory={selectedCategory}
-            favoritesOnly={artifactFavoritesReady && favoritesOnly}
-            showFavoritesFilter={artifactFavoritesReady}
             agents={agents}
             onSearchChange={setSearch}
             onAgentChange={setSelectedAgentId}
             onCategoryChange={setSelectedCategory}
-            onFavoritesOnlyChange={setFavoritesOnly}
           />
           <ArtifactsList
             artifacts={artifacts}
-            favoriteActionEnabled={artifactFavoritesReady}
             loading={loading}
             error={error}
             visibleCount={visibleCount}
@@ -1412,10 +1289,6 @@ export function ArtifactsPage() {
             onStartChat={(item) => {
               detach(startChat(item, pageSignal), Reason.DomCallback);
             }}
-            onToggleFavorite={(item) => {
-              detach(toggleFavorite(item, pageSignal), Reason.DomCallback);
-            }}
-            showFavoriteAction={artifactFavoritesEnabled}
           />
         </div>
       </main>

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -153,8 +153,8 @@ describe("lab page", () => {
     });
 
     expectBefore(
-      featureSwitchRow(FeatureSwitchKey.ArtifactFavorites),
       featureSwitchRow(FeatureSwitchKey.Artifacts),
+      featureSwitchRow(FeatureSwitchKey.Banking),
     );
 
     expect(

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -72,7 +72,6 @@ export enum FeatureSwitchKey {
   PresentationGoogleSlidesUpload = "presentationGoogleSlidesUpload",
   PresentationElementDragging = "presentationElementDragging",
   Artifacts = "artifacts",
-  ArtifactFavorites = "artifactFavorites",
   HostedArtifactVersions = "hostedArtifactVersions",
   VideoArtifactPosters = "videoArtifactPosters",
   WebsiteTemplateV2 = "websiteTemplateV2",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -126,7 +126,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
@@ -160,7 +159,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -440,12 +440,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ArtifactFavorites]: {
-    maintainer: "bingjie@vm0.ai",
-    description: "Enable favoriting artifacts on the Artifacts page.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.HostedArtifactVersions]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the Favorites filter and per-card favorite action from the Artifacts page
- delete the frontend favorite state, optimistic updates, mocks, and feature switch
- keep the favorite API and database table temporarily so already-open browser clients remain compatible during rollout

## User impact

Artifact favorites are no longer visible or interactive in the web app. Artifact listing, search, category filtering, pagination, and IndexedDB caching are unchanged.

## Rollout

This is the frontend migration step. The favorite API and `user_artifact_favorites` table intentionally remain until this app version is deployed. API cleanup will follow in a separate PR, and the table will be dropped after the API rollout and rollback window.

## Verification

- `pnpm turbo run lint check-types --filter=@vm0/app --filter=@vm0/core --filter=@vm0/connectors`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests)
- `pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx src/views/lab-page/__tests__/lab-page.test.tsx src/signals/external/idb-artifact-item-store.test.ts` (42 tests)
- `pnpm knip --workspace @vm0/app --workspace @vm0/core --workspace @vm0/connectors`
