### PR TITLE
perf(ci): reuse trusted runner binaries across events

### DIFF
--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -517,6 +517,35 @@ validate_resolution_context() {
   esac
 }
 
+producer_is_main_reachable() {
+  local producer_head_sha=$1 comparison_json
+  if ! comparison_json=$(gh api \
+    "repos/${REPO}/compare/${producer_head_sha}...${DEFAULT_BRANCH}" 2>/dev/null); then
+    return 1
+  fi
+  jq -e \
+    --arg producer_head_sha "$producer_head_sha" '
+      (.base_commit | type == "object") and
+      .base_commit.sha == $producer_head_sha and
+      (.merge_base_commit | type == "object") and
+      .merge_base_commit.sha == $producer_head_sha and
+      (.ahead_by | type == "number" and floor == . and . >= 0) and
+      (.behind_by | type == "number" and floor == . and . >= 0) and
+      (
+        (
+          .status == "identical" and
+          .ahead_by == 0 and
+          .behind_by == 0
+        ) or
+        (
+          .status == "ahead" and
+          .ahead_by > 0 and
+          .behind_by == 0
+        )
+      )
+    ' <<<"$comparison_json" >/dev/null
+}
+
 collect_trusted_candidates() {
   local expected_target=$1 expected_digest=$2 output_dir=$3
   mkdir -p "$output_dir"
@@ -534,12 +563,14 @@ collect_trusted_candidates() {
     return 1
   fi
 
-  local potential_file sorted_potential trusted_file identities_file
+  local potential_file sorted_potential trusted_unsorted trusted_file identities_file
   potential_file="${output_dir}/potential-candidates.tsv"
   sorted_potential="${output_dir}/potential-candidates-sorted.tsv"
+  trusted_unsorted="${output_dir}/trusted-candidates-unsorted.tsv"
   trusted_file="${output_dir}/trusted-candidates.tsv"
   identities_file="${output_dir}/trusted-identities.tsv"
   : > "$potential_file"
+  : > "$trusted_unsorted"
   : > "$trusted_file"
   : > "$identities_file"
   while IFS= read -r artifact_encoded; do
@@ -556,37 +587,44 @@ collect_trusted_candidates() {
       [[ ! "$artifact_id" =~ ^[1-9][0-9]*$ ]] ||
       [[ ! "$artifact_size" =~ ^[1-9][0-9]*$ ]] ||
       [ "$artifact_size" -gt "$RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES" ] ||
+      [[ ! "$artifact_head_sha" =~ ^[0-9a-f]{40}$ ]] ||
       [ "$artifact_run_id" = "$CURRENT_RUN_ID" ]; then
       continue
     fi
 
-    local source="" rank=""
+    local discovery_rank="" discovery_source_rank=""
     if [ "$artifact_branch" = "$DEFAULT_BRANCH" ]; then
-      source="protected-main"
+      discovery_rank=0
       case "$CURRENT_EVENT" in
-        pull_request|push) rank=0 ;;
-        merge_group) rank=1 ;;
+        pull_request|push) discovery_source_rank=0 ;;
+        merge_group) discovery_source_rank=1 ;;
       esac
     elif [ -n "${CURRENT_PR_HEAD_REF:-}" ] && [ "$artifact_branch" = "$CURRENT_PR_HEAD_REF" ]; then
-      source="same-pr"
+      discovery_rank=0
       case "$CURRENT_EVENT" in
-        pull_request) rank=1 ;;
-        merge_group) rank=0 ;;
+        pull_request) discovery_source_rank=2 ;;
+        merge_group) discovery_source_rank=0 ;;
         push) continue ;;
       esac
     elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [[ "$artifact_branch" =~ (^|/)pr-${CURRENT_PR_NUMBER}- ]]; then
-      source="same-pr"
+      discovery_rank=0
       case "$CURRENT_EVENT" in
-        pull_request) rank=1 ;;
-        merge_group) rank=0 ;;
+        pull_request) discovery_source_rank=2 ;;
+        merge_group) discovery_source_rank=0 ;;
         push) continue ;;
       esac
+    else
+      discovery_rank=1
+      case "$CURRENT_EVENT" in
+        pull_request) discovery_source_rank=1 ;;
+        merge_group) discovery_source_rank=2 ;;
+        push) discovery_source_rank=1 ;;
+      esac
     fi
-    [ -n "$source" ] || continue
 
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$rank" "$artifact_created" "$artifact_id" "$artifact_run_id" "$source" \
-      "$artifact_head_sha" >> "$potential_file"
+      "$discovery_rank" "$discovery_source_rank" "$artifact_created" \
+      "$artifact_id" "$artifact_run_id" "$artifact_head_sha" >> "$potential_file"
   done < <(jq -r \
     --arg name "$artifact_name_value" '
       .[] | .artifacts[]? |
@@ -594,12 +632,13 @@ collect_trusted_candidates() {
       @base64
     ' <<<"$artifacts_json")
 
-  sort -t $'\t' -k1,1n -k2,2r "$potential_file" > "$sorted_potential"
+  # Inspect direct source hints before candidates that need an ancestry query.
+  sort -t $'\t' -k1,1n -k2,2n -k3,3r "$potential_file" > "$sorted_potential"
 
   local inspected=0 trusted_count=0 identity_count=0 limit_reached=false
   local potential_count
   potential_count=$(wc -l < "$sorted_potential" | tr -d ' ')
-  while IFS=$'\t' read -r rank artifact_created artifact_id artifact_run_id source artifact_head_sha; do
+  while IFS=$'\t' read -r _ _ artifact_created artifact_id artifact_run_id artifact_head_sha; do
     [ -n "$artifact_run_id" ] || continue
     if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ]; then
       break
@@ -619,29 +658,69 @@ collect_trusted_candidates() {
         .repository.full_name == $repo and
         .path == $workflow and
         .status == "completed" and
-        .conclusion == "success" and
         .head_sha == $artifact_head_sha and
         (.run_attempt | type == "number" and . > 0)
       ' <<<"$run_json" >/dev/null; then
       continue
     fi
 
-    local actual_source="" run_event run_branch
+    local actual_source="" run_event run_branch producer_pr_numbers
     run_event=$(jq -r '.event' <<<"$run_json")
     run_branch=$(jq -r '.head_branch' <<<"$run_json")
-    if [ "$run_event" = "push" ] && [ "$run_branch" = "$DEFAULT_BRANCH" ]; then
-      actual_source="protected-main"
-    elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [ "$run_event" = "pull_request" ] &&
-      jq -e --argjson pr "$CURRENT_PR_NUMBER" 'any(.pull_requests[]?; .number == $pr)' \
-        <<<"$run_json" >/dev/null; then
-      actual_source="same-pr"
-    elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [ "$run_event" = "merge_group" ] &&
-      [[ "$run_branch" =~ (^|/)pr-${CURRENT_PR_NUMBER}- ]]; then
-      actual_source="same-pr"
-    else
-      continue
+    case "$run_event" in
+      push)
+        producer_pr_numbers='[]'
+        if [ "$run_branch" = "$DEFAULT_BRANCH" ]; then
+          actual_source="protected-main"
+        fi
+        ;;
+      pull_request)
+        if ! producer_pr_numbers=$(jq -ce '
+          [.pull_requests[]?.number] |
+          select(
+            length > 0 and
+            all(.[]; type == "number" and floor == . and . > 0)
+          )
+        ' <<<"$run_json"); then
+          continue
+        fi
+        if [ -n "${CURRENT_PR_NUMBER:-}" ] &&
+          jq -e --argjson pr "$CURRENT_PR_NUMBER" 'index($pr) != null' \
+            <<<"$producer_pr_numbers" >/dev/null; then
+          actual_source="same-pr"
+        fi
+        ;;
+      merge_group)
+        if [[ ! "$run_branch" =~ (^|/)pr-([1-9][0-9]*)- ]]; then
+          continue
+        fi
+        producer_pr_numbers="[${BASH_REMATCH[2]}]"
+        if [ -n "${CURRENT_PR_NUMBER:-}" ] &&
+          [ "${BASH_REMATCH[2]}" = "$CURRENT_PR_NUMBER" ]; then
+          actual_source="same-pr"
+        fi
+        ;;
+      *) continue ;;
+    esac
+    if [ -z "$actual_source" ]; then
+      if producer_is_main_reachable "$artifact_head_sha"; then
+        actual_source="main-reachable"
+      else
+        continue
+      fi
     fi
-    [ "$actual_source" = "$source" ] || continue
+    local source_rank
+    case "${CURRENT_EVENT}:${actual_source}" in
+      pull_request:protected-main) source_rank=0 ;;
+      pull_request:main-reachable) source_rank=1 ;;
+      pull_request:same-pr) source_rank=2 ;;
+      merge_group:same-pr) source_rank=0 ;;
+      merge_group:protected-main) source_rank=1 ;;
+      merge_group:main-reachable) source_rank=2 ;;
+      push:protected-main) source_rank=0 ;;
+      push:main-reachable) source_rank=1 ;;
+      *) continue ;;
+    esac
 
     local candidate_dir manifest_path
     candidate_dir="${output_dir}/candidate-${artifact_id}"
@@ -666,24 +745,36 @@ collect_trusted_candidates() {
       continue
     fi
 
-    local run_attempt expected_pr_json
+    local run_attempt current_pr_json
     run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
-    if [ "$source" = "same-pr" ]; then
-      expected_pr_json="$CURRENT_PR_NUMBER"
-    else
-      expected_pr_json="null"
-    fi
+    current_pr_json="${CURRENT_PR_NUMBER:-null}"
     if ! jq -e \
       --argjson run_id "$artifact_run_id" \
       --argjson run_attempt "$run_attempt" \
       --arg event "$run_event" \
       --arg head_sha "$artifact_head_sha" \
-      --argjson pr_number "$expected_pr_json" '
+      --arg source "$actual_source" \
+      --argjson producer_pr_numbers "$producer_pr_numbers" \
+      --argjson current_pr_number "$current_pr_json" '
         .producer.runId == $run_id and
         .producer.runAttempt == $run_attempt and
         .producer.event == $event and
         .producer.headSha == $head_sha and
-        .producer.prNumber == $pr_number
+        (
+          if $event == "push" then
+            .producer.prNumber == null
+          else
+            .producer.prNumber as $producer_pr_number |
+            ($producer_pr_numbers | index($producer_pr_number)) != null
+          end
+        ) and
+        (
+          if $source == "same-pr" then
+            .producer.prNumber == $current_pr_number
+          else
+            true
+          end
+        )
       ' "$manifest_path" >/dev/null; then
       continue
     fi
@@ -696,13 +787,16 @@ collect_trusted_candidates() {
       identity_count=$((identity_count + 1))
     fi
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$rank" "$artifact_created" "$artifact_id" "$artifact_run_id" "$source" \
-      "$manifest_path" >> "$trusted_file"
+      "$source_rank" "$artifact_created" "$artifact_id" "$artifact_run_id" \
+      "$actual_source" "$manifest_path" >> "$trusted_unsorted"
     trusted_count=$((trusted_count + 1))
     if [ "$identity_count" -ge "$RUNNER_BINARY_MAX_TRUSTED_IDENTITIES" ]; then
       break
     fi
   done < "$sorted_potential"
+
+  # Select by the source proven from canonical run metadata, not the hint.
+  sort -t $'\t' -k1,1n -k2,2r "$trusted_unsorted" > "$trusted_file"
 
   if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ] &&
     [ "$potential_count" -gt "$inspected" ]; then
@@ -810,10 +904,6 @@ active_resolve() {
       exit 2
       ;;
   esac
-  if [ "$CURRENT_EVENT" = "push" ]; then
-    resolve_result "miss" "" "protected-main-full-build"
-    return 0
-  fi
   if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${R2_BUCKET_NAME:-}" ] ||
     [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
     resolve_result "miss" "" "missing-r2-config"

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -236,11 +236,25 @@ assert_contains "$forced" '"reason":"force-miss"'
 [ ! -s "${TMPDIR}/gh.log" ] || fail "force-miss plan must not query GitHub"
 
 : > "${TMPDIR}/gh.log"
-main=$(run_plan all-hit "${TMPDIR}/main" push)
-assert_contains "$main" 'hit-count=0'
-assert_contains "$main" 'miss-count=2'
-assert_contains "$main" '"reason":"protected-main-full-build"'
-[ ! -s "${TMPDIR}/gh.log" ] || fail "protected-main plan must not query GitHub"
+main_all_hit=$(run_plan all-hit "${TMPDIR}/main-all-hit" push)
+assert_contains "$main_all_hit" 'compile-matrix=[]'
+assert_contains "$main_all_hit" 'hit-count=2'
+assert_contains "$main_all_hit" 'miss-count=0'
+assert_contains "$main_all_hit" '"source":"protected-main"'
+
+main_mixed=$(run_plan mixed "${TMPDIR}/main-mixed" push)
+assert_contains "$main_mixed" 'hit-count=1'
+assert_contains "$main_mixed" 'miss-count=1'
+main_mixed_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$main_mixed")
+[ "$(jq -r '.[0].target' <<<"$main_mixed_matrix")" = "$x86_target" ] ||
+  fail "mixed main plan must compile x86 only"
+
+main_all_miss=$(run_plan all-miss "${TMPDIR}/main-all-miss" push)
+assert_contains "$main_all_miss" 'hit-count=0'
+assert_contains "$main_all_miss" 'miss-count=2'
+main_all_miss_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$main_all_miss")
+[ "$(jq 'length' <<<"$main_all_miss_matrix")" -eq 2 ] ||
+  fail "all-miss main plan must compile both targets"
 
 mkdir -p "${TMPDIR}/timeout-bin"
 cat > "${TMPDIR}/timeout-bin/timeout" <<'BASH'

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -351,8 +351,13 @@ assert_contains "$missing_config" "publish-reason=missing-r2-config"
 
 main_head=$(printf 'c%.0s' {1..40})
 pr_head=$(printf 'd%.0s' {1..40})
+reachable_head=$(printf '1%.0s' {1..40})
+unreachable_head=$(printf '2%.0s' {1..40})
 main_manifest="${TMPDIR}/main-manifest.json"
 pr_manifest="${TMPDIR}/pr-manifest.json"
+failed_main_manifest="${TMPDIR}/failed-main-manifest.json"
+reachable_manifest="${TMPDIR}/reachable-manifest.json"
+reachable_pr_mismatch_manifest="${TMPDIR}/reachable-pr-mismatch-manifest.json"
 jq --arg head "$main_head" '
   .producer.runId = 20 |
   .producer.event = "push" |
@@ -365,6 +370,14 @@ jq --arg head "$pr_head" '
   .producer.headSha = $head |
   .producer.prNumber = 123
 ' "${TMPDIR}/published/manifest.json" > "$pr_manifest"
+jq '.producer.runId = 22' "$main_manifest" > "$failed_main_manifest"
+jq --arg head "$reachable_head" '
+  .producer.runId = 24 |
+  .producer.event = "merge_group" |
+  .producer.headSha = $head |
+  .producer.prNumber = 456
+' "${TMPDIR}/published/manifest.json" > "$reachable_manifest"
+jq '.producer.prNumber = 999' "$reachable_manifest" > "$reachable_pr_mismatch_manifest"
 jq '.producer.runId = 999' "$main_manifest" > "${TMPDIR}/untrusted-manifest.json"
 
 conflict_sha=$(printf 'e%.0s' {1..64})
@@ -390,6 +403,15 @@ JSON
 cat > "${TMPDIR}/run-22.json" <<JSON
 {"id":22,"run_attempt":1,"event":"push","status":"completed","conclusion":"failure","head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
 JSON
+cat > "${TMPDIR}/run-23.json" <<JSON
+{"id":23,"run_attempt":1,"event":"push","status":"in_progress","conclusion":null,"head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
+JSON
+cat > "${TMPDIR}/run-24.json" <<JSON
+{"id":24,"run_attempt":1,"event":"merge_group","status":"completed","conclusion":"failure","head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"${reachable_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
+JSON
+cat > "${TMPDIR}/run-30.json" <<JSON
+{"id":30,"run_attempt":1,"event":"pull_request","status":"completed","conclusion":"success","head_branch":"other","head_sha":"${unreachable_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[{"number":999}]}
+JSON
 
 cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
@@ -402,6 +424,23 @@ if [ "$1" = "api" ]; then
     case "${GH_SCENARIO:-rank}" in
       failed)
         printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        ;;
+      failed-valid)
+        printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        ;;
+      in-progress)
+        printf '[{"artifacts":[{"id":123,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":23,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        ;;
+      reachable|reachable-identical|compare-fail|compare-malformed|compare-mismatch|compare-behind|compare-diverged|pr-mismatch)
+        printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD"
+        ;;
+      ranking-reachable)
+        printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]}]\n' \
+          "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD" \
+          "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD"
+        ;;
+      invalid-head)
+        printf '[{"artifacts":[{"id":126,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":26,"head_branch":"other","head_sha":"not-a-sha"}}]}]\n' "$EXPECTED_ARTIFACT_NAME"
         ;;
       untrusted)
         printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
@@ -431,10 +470,33 @@ if [ "$1" = "api" ]; then
       *)
         printf '[{"artifacts":[{"id":199,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T03:00:00Z","workflow_run":{"id":99,"head_branch":"feature","head_sha":"%s"}},{"id":130,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:30:00Z","workflow_run":{"id":30,"head_branch":"other","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]},{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
-          "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
+          "$EXPECTED_ARTIFACT_NAME" "$UNREACHABLE_HEAD" \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
           "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
+    esac
+    exit 0
+  fi
+  if [[ "$endpoint" == *'/compare/'* ]]; then
+    case "${GH_SCENARIO:-rank}" in
+      compare-fail) exit 8 ;;
+      compare-malformed) printf '{}\n' ;;
+      compare-mismatch)
+        printf '{"status":"ahead","ahead_by":1,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$UNREACHABLE_HEAD" "$UNREACHABLE_HEAD"
+        ;;
+      compare-behind)
+        printf '{"status":"behind","ahead_by":0,"behind_by":1,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$UNREACHABLE_HEAD"
+        ;;
+      compare-diverged|rank)
+        printf '{"status":"diverged","ahead_by":1,"behind_by":1,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$UNREACHABLE_HEAD" "$MAIN_HEAD"
+        ;;
+      reachable-identical)
+        printf '{"status":"identical","ahead_by":0,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$REACHABLE_HEAD"
+        ;;
+      reachable|ranking-reachable|pr-mismatch)
+        printf '{"status":"ahead","ahead_by":3,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$REACHABLE_HEAD"
+        ;;
+      *) exit 2 ;;
     esac
     exit 0
   fi
@@ -464,6 +526,12 @@ if [ "$1" = "run" ] && [ "$2" = "download" ]; then
     cp "${GH_FIXTURES}/main-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "21" ]; then
     cp "${GH_FIXTURES}/pr-manifest.json" "${output_dir}/manifest.json"
+  elif [ "$run_id" = "22" ] && [ "${GH_SCENARIO:-rank}" = "failed-valid" ]; then
+    cp "${GH_FIXTURES}/failed-main-manifest.json" "${output_dir}/manifest.json"
+  elif [ "$run_id" = "24" ] && [ "${GH_SCENARIO:-rank}" = "pr-mismatch" ]; then
+    cp "${GH_FIXTURES}/reachable-pr-mismatch-manifest.json" "${output_dir}/manifest.json"
+  elif [ "$run_id" = "24" ]; then
+    cp "${GH_FIXTURES}/reachable-manifest.json" "${output_dir}/manifest.json"
   else
     exit 1
   fi
@@ -488,6 +556,8 @@ run_shadow() {
   EXPECTED_ARTIFACT_NAME="$expected_artifact" \
   MAIN_HEAD="$main_head" \
   PR_HEAD="$pr_head" \
+  REACHABLE_HEAD="$reachable_head" \
+  UNREACHABLE_HEAD="$unreachable_head" \
   FRESH_METADATA_PATH="$fresh" \
   RUNNER_PATH="$runner" \
   EXPECTED_TARGET="$target" \
@@ -510,9 +580,8 @@ assert_contains "$pr_shadow" "shadow-source=protected-main"
 assert_contains "$pr_shadow" "shadow-producer-run-id=20"
 assert_output_keys "$shadow_output" \
   "shadow-outcome,shadow-producer-run-id,shadow-reason,shadow-source"
-if grep -qE 'actions/runs/(99|30)([^0-9]|$)' "${TMPDIR}/gh.log"; then
-  fail "shadow resolution queried current or unrelated producer runs"
-fi
+grep -qE 'actions/runs/99([^0-9]|$)' "${TMPDIR}/gh.log" &&
+  fail "shadow resolution queried the current run"
 
 if run_shadow unsupported rank "${TMPDIR}/shadow-invalid-context" \
   > "${TMPDIR}/shadow-invalid-context.out" \
@@ -527,6 +596,14 @@ assert_contains "$merge_shadow" "shadow-outcome=hit"
 assert_contains "$merge_shadow" "shadow-source=same-pr"
 assert_contains "$merge_shadow" "shadow-producer-run-id=21"
 
+pr_reachable_rank=$(run_shadow pull_request ranking-reachable "${TMPDIR}/shadow-pr-reachable-rank")
+assert_contains "$pr_reachable_rank" "shadow-source=main-reachable"
+assert_contains "$pr_reachable_rank" "shadow-producer-run-id=24"
+
+merge_reachable_rank=$(run_shadow merge_group ranking-reachable "${TMPDIR}/shadow-merge-reachable-rank")
+assert_contains "$merge_reachable_rank" "shadow-source=same-pr"
+assert_contains "$merge_reachable_rank" "shadow-producer-run-id=21"
+
 push_shadow=$(run_shadow push rank "${TMPDIR}/shadow-push")
 assert_contains "$push_shadow" "shadow-source=protected-main"
 
@@ -537,6 +614,10 @@ assert_contains "$api_failure" "shadow-reason=artifact-api-unavailable"
 failed_candidate=$(run_shadow pull_request failed "${TMPDIR}/shadow-failed")
 assert_contains "$failed_candidate" "shadow-outcome=miss"
 assert_contains "$failed_candidate" "shadow-reason=no-trusted-candidate"
+
+failed_valid_candidate=$(run_shadow pull_request failed-valid "${TMPDIR}/shadow-failed-valid")
+assert_contains "$failed_valid_candidate" "shadow-outcome=hit"
+assert_contains "$failed_valid_candidate" "shadow-source=protected-main"
 
 untrusted_candidate=$(run_shadow pull_request untrusted "${TMPDIR}/shadow-untrusted")
 assert_contains "$untrusted_candidate" "shadow-outcome=miss"
@@ -573,6 +654,8 @@ run_active() {
   EXPECTED_ARTIFACT_NAME="$expected_artifact" \
   MAIN_HEAD="$main_head" \
   PR_HEAD="$pr_head" \
+  REACHABLE_HEAD="$reachable_head" \
+  UNREACHABLE_HEAD="$unreachable_head" \
   AWS_LOG="${TMPDIR}/aws.log" \
   AWS_MODE="$aws_mode" \
   AWS_STORE="${TMPDIR}/store" \
@@ -610,10 +693,33 @@ EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
   "$CACHE" fresh-validate >/dev/null
 
 : > "${TMPDIR}/gh.log"
-main_miss=$(run_active push rank "${TMPDIR}/active-main")
-assert_contains "$main_miss" "resolve-outcome=miss"
-assert_contains "$main_miss" "resolve-reason=protected-main-full-build"
-[ ! -s "${TMPDIR}/gh.log" ] || fail "protected main must bypass candidate lookup"
+main_hit=$(run_active push rank "${TMPDIR}/active-main")
+assert_contains "$main_hit" "resolve-outcome=hit"
+assert_contains "$main_hit" "resolve-source=protected-main"
+assert_contains "$main_hit" "resolve-producer-run-id=20"
+
+reachable_hit=$(run_active push reachable "${TMPDIR}/active-reachable")
+assert_contains "$reachable_hit" "resolve-outcome=hit"
+assert_contains "$reachable_hit" "resolve-source=main-reachable"
+assert_contains "$reachable_hit" "resolve-producer-run-id=24"
+
+identical_hit=$(run_active push reachable-identical "${TMPDIR}/active-reachable-identical")
+assert_contains "$identical_hit" "resolve-outcome=hit"
+assert_contains "$identical_hit" "resolve-source=main-reachable"
+
+failed_valid_hit=$(run_active push failed-valid "${TMPDIR}/active-failed-valid")
+assert_contains "$failed_valid_hit" "resolve-outcome=hit"
+assert_contains "$failed_valid_hit" "resolve-source=protected-main"
+
+in_progress_miss=$(run_active push in-progress "${TMPDIR}/active-in-progress")
+assert_contains "$in_progress_miss" "resolve-outcome=miss"
+assert_contains "$in_progress_miss" "resolve-reason=no-trusted-candidate"
+
+for scenario in compare-fail compare-malformed compare-mismatch compare-behind compare-diverged pr-mismatch invalid-head; do
+  ancestry_miss=$(run_active push "$scenario" "${TMPDIR}/active-${scenario}")
+  assert_contains "$ancestry_miss" "resolve-outcome=miss"
+  assert_contains "$ancestry_miss" "resolve-reason=no-trusted-candidate"
+done
 
 : > "${TMPDIR}/gh.log"
 force_miss=$(RUNNER_BINARY_CACHE_FORCE_MISS=true \


### PR DESCRIPTION
## Summary

- let protected-main pushes use the normal runner-binary cache resolver
- trust historical Runner Image producers only when their exact SHA is proven
  reachable from the default branch
- use a completed canonical run plus the validated target manifest and R2
  bytes as publication proof, independent of unrelated host-job conclusions
- bind historical pull-request and merge-group manifests to the producer's own
  PR identity and preserve bounded source ranking and conflict detection
- cover main all-hit, mixed, and all-miss compile plans plus ancestry,
  failed-run publication, ranking, and fail-closed boundaries

## Compatibility and exclusions

- keeps the reusable manifest at schema version 1 and reuses existing R2
  objects without migration
- does not change database or product persistence, application APIs, queue
  payloads, runner protocols, or release assets
- does not change the binary-input digest; that work remains in #22685
- does not add concurrent producer coordination, guest caching, or host-image
  reuse

## Validation

- `bash -n .github/scripts/runner-binary-cache.sh .github/scripts/tests/runner-binary-cache-test.sh .github/scripts/tests/runner-binary-cache-plan-test.sh`
- `shellcheck --severity=warning .github/scripts/runner-binary-cache.sh .github/scripts/tests/runner-binary-cache-test.sh .github/scripts/tests/runner-binary-cache-plan-test.sh`
- `bash .github/scripts/tests/runner-binary-cache-test.sh`
- `bash .github/scripts/tests/runner-binary-cache-plan-test.sh`
- `bash .github/scripts/tests/runner-image-workflow-test.sh`
- `git diff --check`

Closes #22684

Parent delivery issue: #22672
