### PR TITLE
fix: show full step text and drop leading icon in onboarding workflow cards

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1335,7 +1335,7 @@ details[open] > summary > span:first-child {
   --workflow-action-left: 142px;
   --workflow-action-one-width: 339px;
   --workflow-action-two-width: 341px;
-  --workflow-action-height: 79px;
+  --workflow-action-height: 98px;
   --workflow-action-one-center-x: calc(
     var(--workflow-action-left) + calc(var(--workflow-action-one-width) / 2)
   );
@@ -1676,64 +1676,6 @@ details[open] > summary > span:first-child {
   width: var(--workflow-action-two-width);
 }
 
-.owf-diagram-action-icon {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  overflow: hidden;
-  border-radius: 999px;
-  background: #f3f5f8;
-}
-
-.owf-diagram-action-icon-filed {
-  background: #1f2329;
-}
-
-.owf-diagram-action-icon-filed span {
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: #ffffff;
-}
-
-.owf-diagram-action-icon-complete {
-  background: #31a653;
-}
-
-.owf-diagram-action-icon-complete span {
-  position: relative;
-  width: 13px;
-  height: 10px;
-}
-
-.owf-diagram-action-icon-complete span::before,
-.owf-diagram-action-icon-complete span::after {
-  position: absolute;
-  background: #ffffff;
-  content: "";
-}
-
-.owf-diagram-action-icon-complete span::before {
-  top: 1px;
-  left: 1px;
-  width: 4px;
-  height: 4px;
-  border-radius: 999px;
-}
-
-.owf-diagram-action-icon-complete span::after {
-  right: 1px;
-  bottom: 1px;
-  width: 7px;
-  height: 7px;
-  border: 1.6px solid #ffffff;
-  border-radius: 999px;
-  background: transparent;
-}
-
 .owf-diagram-action-copy {
   display: flex;
   min-width: 0;
@@ -1755,11 +1697,12 @@ details[open] > summary > span:first-child {
 }
 
 .owf-diagram-action-copy span {
-  display: block;
+  display: -webkit-box;
   overflow: hidden;
   color: var(--workflow-diagram-action-muted);
   font-size: 14px;
   line-height: 20px;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -260,25 +260,14 @@ function WorkflowDiagramNode({
 function WorkflowDiagramAction({
   title,
   description,
-  variant,
   className,
 }: {
   readonly title: string;
   readonly description: string;
-  readonly variant: "filed" | "complete";
   readonly className: string;
 }) {
   return (
     <div className={`owf-diagram-action ${className}`}>
-      <span
-        className={`owf-diagram-action-icon ${
-          variant === "complete"
-            ? "owf-diagram-action-icon-complete"
-            : "owf-diagram-action-icon-filed"
-        }`}
-      >
-        <span />
-      </span>
       <span className="owf-diagram-action-copy">
         <strong>{title}</strong>
         <span>{description}</span>
@@ -375,7 +364,6 @@ export function WorkflowPreviewDiagram({
             firstStep?.description ??
             "Zero prepares the next step from your tools."
           }
-          variant="filed"
           className="owf-diagram-action-one"
         />
         <WorkflowDiagramAction
@@ -384,7 +372,6 @@ export function WorkflowPreviewDiagram({
             lastStep?.description ??
             "Zero completes the workflow and returns the result."
           }
-          variant="complete"
           className="owf-diagram-action-two"
         />
       </div>


### PR DESCRIPTION
## Problem

In the onboarding workflow-preview diagram, each step card's description was clipped to a single line with an ellipsis, so the copy explaining what the workflow does was cut off (e.g. *"Zero finds the biggest risers and fal…"*, *"Zero posts the adoption changes to…"*). Each card also showed a decorative leading status icon (black dot / green check) that added visual noise without conveying meaning in a static preview.

Reported with annotations on the PostHog "Surface the biggest weekly shifts in feature usage" onboarding scenario: *文字缩略了* (text is truncated) and *去掉这个* (remove this icon).

## Changes

- **Remove the leading status icon** from `WorkflowDiagramAction`, along with its now-unused `variant` prop and the associated `.owf-diagram-action-icon*` CSS. This also widens the copy column.
- **Show the full description** — the description now wraps to up to two lines (`-webkit-line-clamp: 2`) instead of a single-line ellipsis.
- **Grow the card height** `--workflow-action-height` 79px → 98px so a two-line description fits. All connector dots and the vertical beam derive their positions from this variable, so the diagram choreography stays aligned automatically; card two's new bottom (450px) still sits inside the 470px canvas.

## User-visible impact

Onboarding workflow-preview cards read cleanly: no leading icon, and each step's full title and description are visible (wrapping to a second line when needed) instead of being truncated.

## Verification

- `pnpm -F @vm0/app check-types` — passes
- `pnpm -F @vm0/app lint` — passes
- `pnpm prettier --check` on the two changed files — clean
- Rendered the card markup with the new CSS in a headless browser to confirm the icon is gone and the longest description wraps to two lines fully within the 98px card (no clipping).

Files touched:
- `turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx`
- `turbo/apps/platform/src/views/css/index.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)