### PR TITLE
test(runner): retain pool lock during cleanup assertions

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -34,6 +34,10 @@ DNS_ISOLATION_HOST_IF=""
 DNS_ISOLATION_LOCK_FD=""
 SPOOF_NS=""
 SPOOF_IP=""
+POOL_LOCK_GUARD_DIR=""
+POOL_LOCK_HOLDER_PID=""
+POOL_LOCK_RELEASE_FD=""
+POOL_LOCK_ERROR=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 
@@ -101,6 +105,22 @@ cleanup_spoof_address() {
   SPOOF_IP=""
 }
 
+cleanup_pool_lock_guard() {
+  if [ -n "$POOL_LOCK_RELEASE_FD" ]; then
+    exec {POOL_LOCK_RELEASE_FD}>&-
+    POOL_LOCK_RELEASE_FD=""
+  fi
+  if [ -n "$POOL_LOCK_HOLDER_PID" ]; then
+    kill "$POOL_LOCK_HOLDER_PID" 2>/dev/null || true
+    wait "$POOL_LOCK_HOLDER_PID" 2>/dev/null || true
+    POOL_LOCK_HOLDER_PID=""
+  fi
+  if [ -n "$POOL_LOCK_GUARD_DIR" ]; then
+    rm -rf "$POOL_LOCK_GUARD_DIR"
+    POOL_LOCK_GUARD_DIR=""
+  fi
+}
+
 rule_values() {
   local option=$1
   awk -v option="$option" '
@@ -155,6 +175,7 @@ cleanup() {
   echo "--- Cleanup ---"
   cleanup_spoof_address
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+  cleanup_pool_lock_guard
   cleanup_submit_pid "$SUBMIT_PID"
   if [ -n "$DNS_ISOLATION_NS" ]; then
     sudo ip netns delete "$DNS_ISOLATION_NS" 2>/dev/null || true
@@ -475,6 +496,9 @@ DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
 [ -n "$DNS_FILTER_COMMENT" ] || fail "DNS INPUT filter comment missing"
 DNS_FILTER_POOL=${DNS_FILTER_COMMENT#vm0-ns-}
 DNS_FILTER_POOL=${DNS_FILTER_POOL%-dns}
+[ "$RUNNER_POOL_PREFIX" = "vm0-ns-${DNS_FILTER_POOL}-" ] \
+  || fail "DNS filter and namespace pool identities differ"
+RUNNER_POOL_INDEX=$((16#$DNS_FILTER_POOL))
 DNS_FILTER_INTERFACE="vm0-ve-${DNS_FILTER_POOL}-+"
 
 assert_dns_input_filter_family() {
@@ -964,7 +988,118 @@ exec {DNS_ISOLATION_LOCK_FD}>&-
 DNS_ISOLATION_LOCK_FD=""
 echo "PASS: DNS resolution"
 
-# Stop transient service (kills sandbox, submit terminates naturally)
+# Retain the runner's existing pool flock across stop and cleanup assertions.
+# The owned Rust guard releases by final close, so pidfd_getfd can preserve the
+# same open file description without a handoff window.
+RUNNER_MAIN_PID=$(sudo systemctl show "$UNIT" \
+  --property=MainPID --value 2>/dev/null) \
+  || fail "failed to read runner MainPID before stop"
+case "$RUNNER_MAIN_PID" in
+  "" | 0 | *[!0-9]*)
+    fail "invalid runner MainPID before stop: ${RUNNER_MAIN_PID:-missing}"
+    ;;
+esac
+
+POOL_LOCK_GUARD_DIR=$(mktemp -d "/tmp/vm0-${SVC}-pool-lock.XXXXXX") \
+  || fail "failed to create pool-lock guard directory"
+POOL_LOCK_READY="$POOL_LOCK_GUARD_DIR/ready"
+POOL_LOCK_RELEASE_FIFO="$POOL_LOCK_GUARD_DIR/release"
+POOL_LOCK_ERROR="$POOL_LOCK_GUARD_DIR/error"
+mkfifo "$POOL_LOCK_RELEASE_FIFO" \
+  || fail "failed to create pool-lock release FIFO"
+exec {POOL_LOCK_RELEASE_FD}<>"$POOL_LOCK_RELEASE_FIFO" \
+  || fail "failed to open pool-lock release FIFO"
+
+sudo python3 - \
+  "$RUNNER_MAIN_PID" \
+  "$RUNNER_POOL_INDEX" \
+  "$POOL_LOCK_READY" \
+  "$POOL_LOCK_RELEASE_FIFO" \
+  {POOL_LOCK_RELEASE_FD}>&- >"$POOL_LOCK_ERROR" 2>&1 <<'PY' &
+import ctypes
+import errno
+import os
+import platform
+from pathlib import Path
+import signal
+import sys
+
+runner_pid = int(sys.argv[1])
+pool_index = int(sys.argv[2])
+ready_path = Path(sys.argv[3])
+release_fifo = Path(sys.argv[4])
+lock_name = f"vm0-netns-pool-{pool_index}.lock"
+
+
+def handle_timeout(_signum, _frame):
+    raise TimeoutError("timed out retaining the runner pool lock")
+
+
+signal.signal(signal.SIGALRM, handle_timeout)
+signal.alarm(360)
+
+machine = platform.machine()
+if machine not in {"aarch64", "x86_64"}:
+    raise RuntimeError(f"unsupported pidfd_getfd architecture: {machine}")
+
+matches = []
+for entry in Path(f"/proc/{runner_pid}/fd").iterdir():
+    try:
+        target = os.readlink(entry)
+    except FileNotFoundError:
+        continue
+    if Path(target).name == lock_name:
+        matches.append((int(entry.name), target))
+
+if len(matches) != 1:
+    raise RuntimeError(
+        f"expected one {lock_name} descriptor on pid {runner_pid}, "
+        f"found {len(matches)}"
+    )
+
+target_fd, target = matches[0]
+pidfd = os.pidfd_open(runner_pid)
+try:
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.syscall.restype = ctypes.c_long
+    duplicated_fd = libc.syscall(438, pidfd, target_fd, 0)
+    if duplicated_fd < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, errno.errorcode.get(error, os.strerror(error)))
+finally:
+    os.close(pidfd)
+
+try:
+    if Path(os.readlink(f"/proc/self/fd/{duplicated_fd}")).name != lock_name:
+        raise RuntimeError(
+            f"duplicated descriptor target changed from {target}"
+        )
+    release_fd = os.open(release_fifo, os.O_RDONLY)
+    try:
+        ready_path.touch()
+        while os.read(release_fd, 1):
+            pass
+    finally:
+        os.close(release_fd)
+finally:
+    os.close(duplicated_fd)
+
+signal.alarm(0)
+PY
+POOL_LOCK_HOLDER_PID=$!
+
+for _ in $(seq 1 200); do
+  [ -e "$POOL_LOCK_READY" ] && break
+  kill -0 "$POOL_LOCK_HOLDER_PID" 2>/dev/null \
+    || break
+  sleep 0.05
+done
+if [ ! -e "$POOL_LOCK_READY" ]; then
+  [ ! -s "$POOL_LOCK_ERROR" ] || cat "$POOL_LOCK_ERROR"
+  fail "failed to retain runner pool lock before stop"
+fi
+
+# Stop transient service (kills sandbox, submit terminates naturally).
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 if sudo iptables-save -t filter \
   | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
@@ -999,6 +1134,22 @@ LEAKED_HOST_VETHS=$(printf '%s\n' "$LINKS_AFTER_STOP" \
     ') || fail "failed to inspect network links after runner stop"
 [ -z "$LEAKED_HOST_VETHS" ] \
   || fail "host veth devices leaked after runner stop: $LEAKED_HOST_VETHS"
+
+exec {POOL_LOCK_RELEASE_FD}>&-
+POOL_LOCK_RELEASE_FD=""
+if wait "$POOL_LOCK_HOLDER_PID"; then
+  :
+else
+  POOL_LOCK_HOLDER_STATUS=$?
+  POOL_LOCK_HOLDER_PID=""
+  [ ! -s "$POOL_LOCK_ERROR" ] || cat "$POOL_LOCK_ERROR"
+  fail "pool-lock holder exited with status $POOL_LOCK_HOLDER_STATUS"
+fi
+POOL_LOCK_HOLDER_PID=""
+rm -rf "$POOL_LOCK_GUARD_DIR"
+POOL_LOCK_GUARD_DIR=""
+POOL_LOCK_ERROR=""
+
 cleanup_submit_pid "$SUBMIT_PID"
 SUBMIT_PID=""
 trap - EXIT

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1005,6 +1005,7 @@ POOL_LOCK_GUARD_DIR=$(mktemp -d "/tmp/vm0-${SVC}-pool-lock.XXXXXX") \
 POOL_LOCK_READY="$POOL_LOCK_GUARD_DIR/ready"
 POOL_LOCK_RELEASE_FIFO="$POOL_LOCK_GUARD_DIR/release"
 POOL_LOCK_ERROR="$POOL_LOCK_GUARD_DIR/error"
+POOL_LOCK_TARGET="$POOL_LOCK_GUARD_DIR/target"
 mkfifo "$POOL_LOCK_RELEASE_FIFO" \
   || fail "failed to create pool-lock release FIFO"
 exec {POOL_LOCK_RELEASE_FD}<>"$POOL_LOCK_RELEASE_FIFO" \
@@ -1015,6 +1016,7 @@ sudo python3 - \
   "$RUNNER_POOL_INDEX" \
   "$POOL_LOCK_READY" \
   "$POOL_LOCK_RELEASE_FIFO" \
+  "$POOL_LOCK_TARGET" \
   {POOL_LOCK_RELEASE_FD}>&- >"$POOL_LOCK_ERROR" 2>&1 <<'PY' &
 import ctypes
 import errno
@@ -1028,6 +1030,7 @@ runner_pid = int(sys.argv[1])
 pool_index = int(sys.argv[2])
 ready_path = Path(sys.argv[3])
 release_fifo = Path(sys.argv[4])
+target_path = Path(sys.argv[5])
 lock_name = f"vm0-netns-pool-{pool_index}.lock"
 
 
@@ -1076,6 +1079,7 @@ try:
         )
     release_fd = os.open(release_fifo, os.O_RDONLY)
     try:
+        target_path.write_text(target)
         ready_path.touch()
         while os.read(release_fd, 1):
             pass
@@ -1098,9 +1102,19 @@ if [ ! -e "$POOL_LOCK_READY" ]; then
   [ ! -s "$POOL_LOCK_ERROR" ] || cat "$POOL_LOCK_ERROR"
   fail "failed to retain runner pool lock before stop"
 fi
+POOL_LOCK_PATH=$(cat "$POOL_LOCK_TARGET") \
+  || fail "failed to read retained pool lock path"
+[ -n "$POOL_LOCK_PATH" ] || fail "retained pool lock path is empty"
 
 # Stop transient service (kills sandbox, submit terminates naturally).
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+if sudo flock -n "$POOL_LOCK_PATH" true; then
+  fail "pool lock released before cleanup assertions"
+else
+  POOL_LOCK_PROBE_STATUS=$?
+fi
+[ "$POOL_LOCK_PROBE_STATUS" -eq 1 ] \
+  || fail "failed to probe retained pool lock: status $POOL_LOCK_PROBE_STATUS"
 if sudo iptables-save -t filter \
   | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
   fail "IPv4 DNS INPUT filter leaked after runner stop"

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -2,11 +2,13 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::future::Future;
 use std::io::Write;
+use std::os::fd::AsRawFd;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use nix::errno::Errno;
 use nix::fcntl::{Flock, FlockArg};
 use tracing::{error, info, warn};
 
@@ -708,12 +710,33 @@ fn conntrack_command_missing(src: IgnoredCommandOutcome, dst: IgnoredCommandOutc
 // Pool index lock
 // ---------------------------------------------------------------------------
 
+/// Exclusive pool-index flock released when the final file descriptor closes.
+///
+/// Unlike [`Flock`], this guard does not issue an explicit `LOCK_UN` on drop.
+/// That lets a privileged integration test duplicate the open file description
+/// and retain ownership while it verifies shutdown cleanup.
+#[derive(Debug)]
+pub(super) struct PoolIndexLock {
+    _file: File,
+}
+
+impl PoolIndexLock {
+    pub(super) fn try_lock(file: File) -> std::result::Result<Self, (File, Errno)> {
+        // SAFETY: `file` owns a valid descriptor for the duration of the call.
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if result == 0 {
+            Ok(Self { _file: file })
+        } else {
+            Err((file, Errno::last()))
+        }
+    }
+}
+
 /// Try to acquire an exclusive flock on a pool index file (0..MAX_POOLS).
 ///
-/// Returns the first successfully locked `(index, Flock<File>)`. The lock is
-/// held for the lifetime of the returned `Flock` — when the process exits or
-/// the `Flock` is dropped, the OS releases the lock automatically.
-pub(super) fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
+/// Returns the first successfully locked `(index, PoolIndexLock)`. The lock is
+/// held until the final descriptor for its open file description closes.
+pub(super) fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, PoolIndexLock)> {
     for index in 0..MAX_POOLS {
         let path = locks.netns_pool(index);
         // Open for writing without O_CREAT first, fall back to create.
@@ -734,7 +757,7 @@ pub(super) fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)>
                 continue;
             }
         };
-        match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+        match PoolIndexLock::try_lock(file) {
             Ok(lock) => {
                 info!(index, "acquired pool index lock");
                 return Ok((index, lock));
@@ -1297,7 +1320,7 @@ async fn cleanup_namespaces_from_snapshot(
 pub(super) async fn reconcile_orphan_namespaces(
     locks: &LockPaths,
     own_index: u32,
-    _own_lock: &Flock<File>,
+    _own_lock: &PoolIndexLock,
 ) {
     let snapshot = ReconciliationSnapshot::capture().await;
     let candidate_indexes = snapshot.candidate_pool_indexes(own_index);

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashSet, VecDeque};
-use std::fs::File;
 #[cfg(test)]
 use std::future::Future;
 use std::sync::Arc;
@@ -7,9 +6,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::future::join_all;
-use nix::fcntl::Flock;
-#[cfg(test)]
-use nix::fcntl::FlockArg;
 use tokio::sync::watch;
 use tracing::{error, info, warn};
 
@@ -29,9 +25,9 @@ use super::completion::{
 #[cfg(test)]
 use super::host::ConntrackFlushOutcome;
 use super::host::{
-    NamespaceDeleteOutcome, NetnsLifecycleOps, acquire_pool_lock, create_single_namespace,
-    enable_host_ip_forwarding, get_default_interface, reconcile_orphan_namespaces,
-    setup_dns_input_filter,
+    NamespaceDeleteOutcome, NetnsLifecycleOps, PoolIndexLock, acquire_pool_lock,
+    create_single_namespace, enable_host_ip_forwarding, get_default_interface,
+    reconcile_orphan_namespaces, setup_dns_input_filter,
 };
 use super::naming::{MAX_NAMESPACES, format_hex_index, make_host_device_dnsmasq_pattern};
 use super::types::{
@@ -152,14 +148,14 @@ struct NetnsPoolState {
     #[cfg(test)]
     acquire_waiting_notify: Option<Arc<tokio::sync::Notify>>,
     /// Held for the lifetime of the pool to reserve the pool index.
-    _lock: Flock<File>,
+    _lock: PoolIndexLock,
 }
 
 impl NetnsPoolState {
     #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
         let file = tempfile::tempfile().expect("create test netns pool lock file");
-        let lock = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+        let lock = match PoolIndexLock::try_lock(file) {
             Ok(lock) => lock,
             Err((_, errno)) => panic!("lock test netns pool file: {errno}"),
         };


### PR DESCRIPTION
## Summary

- retain the runner's pool-index flock while post-stop cleanup assertions run
- use a close-only Rust lock guard so a privileged test helper can duplicate the same open file description without a handoff race
- derive the tested pool index from the runner's DNS/network identity and release the retained descriptor after all cleanup checks finish

## Scope

- keeps production pool selection and shutdown cleanup behavior unchanged
- does not change the existing runtime HTTPS checks or their timeouts

## Validation

- `bash -n .github/scripts/runner-behavior-exec.sh`
- `shellcheck .github/scripts/runner-behavior-exec.sh`
- embedded Python syntax compilation
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner`
- local-1 aarch64 target scenario: verified the duplicated pool lock remained contended after runner stop while IPv4/IPv6 DNS rules, raw source guards, namespaces, and host veths were absent; verified the lock became acquirable after the assertion guard released it

The complete behavior script was also attempted twice on local-1. Both attempts stopped before the changed cleanup path because the existing arm64 `HTTPS go` check exceeded its internal 30-second timeout during a cold `go run`; this PR does not alter that unrelated check.

Closes #22677
