### PR TITLE
fix(ci): run production rollback jobs in parallel

### DIFF
--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -207,8 +207,7 @@ ruby -e '
   raise "rollback resolver must wait for queue" unless rollback.fetch("resolve-target").fetch("needs") == "queue-production-deploy"
   raise "App must wait for resolver" unless rollback.fetch("rollback-app").fetch("needs") == "resolve-target"
   raise "Runner must wait for resolver" unless rollback.fetch("rollback-runner").fetch("needs") == "resolve-target"
-  api_needs = rollback.fetch("rollback-api").fetch("needs")
-  raise "API must wait for App and Runner" unless ["resolve-target", "rollback-app", "rollback-runner"].all? { |job| api_needs.include?(job) }
+  raise "API must wait for resolver" unless rollback.fetch("rollback-api").fetch("needs") == "resolve-target"
   raise "release must wait for production queue" unless release.fetch("release-please").fetch("needs") == "queue-production-deploy"
 ' "${repo_root}/.github/workflows/rollback-production.yml" "${repo_root}/.github/workflows/release-please.yml"
 

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -352,7 +352,7 @@ jobs:
 
   rollback-api:
     name: Roll back API
-    needs: [resolve-target, rollback-app, rollback-runner]
+    needs: resolve-target
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622


### PR DESCRIPTION
## Summary

- remove the App and Runner prerequisites from the API rollback job
- start App, Runner, and API rollback jobs in parallel after the shared target resolution succeeds
- retain the production deployment queue, compatibility confirmation, artifact verification, and environment gates

## User impact

Production rollback no longer waits for App and Runner to finish before promoting the target API deployment. A component-specific rollback failure also no longer prevents the other rollback jobs from starting.

## Verification

- `npx -y prettier@3.8.1 --check .github/workflows/rollback-production.yml`
- `actionlint v1.7.12 .github/workflows/rollback-production.yml`
- `git diff --check`

Full Vitest and a local development server were not run because this is a GitHub Actions dependency-only change, per repository guidance.
