### PR TITLE
fix(chat): admit structured-only messages into prior-run context

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -31,7 +31,9 @@ import {
   inArray,
   isNotNull,
   isNull,
+  or,
   sql,
+  type SQL,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
@@ -720,6 +722,18 @@ function formatAttachFileIds(
     .join("\n");
 }
 
+function priorMessageContentCondition(structuredPromptEnabled: boolean): SQL {
+  return structuredPromptEnabled
+    ? (or(
+        isNotNull(chatMessages.content),
+        and(
+          eq(chatMessages.role, "user"),
+          isNotNull(chatMessages.structuredPrompt),
+        ),
+      ) as SQL)
+    : isNotNull(chatMessages.content);
+}
+
 function formatPriorRunMessage(
   message: WebChatPriorRunMessage,
   structuredPromptEnabled: boolean,
@@ -859,6 +873,7 @@ async function getLatestRunsByThreadId(
   db: Db,
   threadId: string,
   limit: number,
+  structuredPromptEnabled: boolean,
 ): Promise<WebChatPriorRun[]> {
   const runRows = await db
     .select({
@@ -900,7 +915,7 @@ async function getLatestRunsByThreadId(
     .where(
       and(
         eq(chatMessages.chatThreadId, threadId),
-        isNotNull(chatMessages.content),
+        priorMessageContentCondition(structuredPromptEnabled),
         inArray(chatMessages.runId, runIds),
         inArray(chatMessages.role, ["user", "assistant"]),
         visibleChatMessageCondition(db),
@@ -910,9 +925,13 @@ async function getLatestRunsByThreadId(
 
   const messagesByRunId = new Map<string, WebChatPriorRunMessage[]>();
   for (const row of messageRows) {
+    const hasStructuredContent =
+      structuredPromptEnabled &&
+      row.role === "user" &&
+      row.structuredPrompt !== null;
     if (
       row.runId === null ||
-      row.content === null ||
+      (row.content === null && !hasStructuredContent) ||
       (row.role !== "user" && row.role !== "assistant")
     ) {
       continue;
@@ -920,7 +939,7 @@ async function getLatestRunsByThreadId(
     const existing = messagesByRunId.get(row.runId) ?? [];
     existing.push({
       role: row.role,
-      content: row.content,
+      content: row.content ?? "",
       structuredPrompt: row.structuredPrompt,
       attachFiles: row.attachFiles,
       generationTemplate: row.generationTemplate,
@@ -1507,7 +1526,12 @@ async function prepareRecentChatContext(
     return "";
   }
   return buildWebChatPriorRunsContext(
-    await getLatestRunsByThreadId(db, threadId, RECENT_CHAT_RUN_LIMIT),
+    await getLatestRunsByThreadId(
+      db,
+      threadId,
+      RECENT_CHAT_RUN_LIMIT,
+      structuredPromptEnabled,
+    ),
     structuredPromptEnabled,
   );
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -27,7 +27,9 @@ import {
   isNotNull,
   lte,
   max,
+  or,
   sql,
+  type SQL,
 } from "drizzle-orm";
 import { z } from "zod";
 
@@ -1438,6 +1440,18 @@ function formatAttachFileIds(
     .join("\n");
 }
 
+function priorMessageContentCondition(structuredPromptEnabled: boolean): SQL {
+  return structuredPromptEnabled
+    ? (or(
+        isNotNull(chatMessages.content),
+        and(
+          eq(chatMessages.role, "user"),
+          isNotNull(chatMessages.structuredPrompt),
+        ),
+      ) as SQL)
+    : isNotNull(chatMessages.content);
+}
+
 function truncatePrior(value: string): string {
   if (value.length <= PRIOR_MESSAGE_CHAR_CAP) {
     return value;
@@ -1509,6 +1523,7 @@ async function getLatestRunsByThreadId(
   threadId: string,
   triggerSource: "web" | "slack",
   limit: number,
+  structuredPromptEnabled: boolean,
 ): Promise<PriorRun[]> {
   const runRows = await db
     .select({
@@ -1551,7 +1566,7 @@ async function getLatestRunsByThreadId(
     .where(
       and(
         eq(chatMessages.chatThreadId, threadId),
-        isNotNull(chatMessages.content),
+        priorMessageContentCondition(structuredPromptEnabled),
         inArray(chatMessages.runId, runIds),
         inArray(chatMessages.role, ["user", "assistant"]),
         visibleChatMessageCondition(db),
@@ -1561,9 +1576,13 @@ async function getLatestRunsByThreadId(
 
   const messagesByRunId = new Map<string, PriorRunMessage[]>();
   for (const row of messageRows) {
+    const hasStructuredContent =
+      structuredPromptEnabled &&
+      row.role === "user" &&
+      row.structuredPrompt !== null;
     if (
       row.runId === null ||
-      row.content === null ||
+      (row.content === null && !hasStructuredContent) ||
       (row.role !== "user" && row.role !== "assistant")
     ) {
       continue;
@@ -1571,7 +1590,7 @@ async function getLatestRunsByThreadId(
     const existing = messagesByRunId.get(row.runId) ?? [];
     existing.push({
       role: row.role,
-      content: row.content,
+      content: row.content ?? "",
       structuredPrompt: row.structuredPrompt,
       attachFiles: row.attachFiles,
       generationTemplate: row.generationTemplate,
@@ -1735,6 +1754,7 @@ async function buildQueuedPriorContext(args: {
       args.threadId,
       args.triggerSource,
       RECENT_CHAT_RUN_LIMIT,
+      args.structuredPromptEnabled,
     ),
     args.triggerSource,
     args.structuredPromptEnabled,


### PR DESCRIPTION
## Summary

- allow user messages with `structured_prompt` and null `content` into recent prior-run context when `StructuredPrompt` is enabled
- apply the same eligibility rule to direct Web sends and callback-driven queued sends
- keep assistant-message selection and all disabled-switch behavior on the existing non-null `content` path

## Why

Prior-run formatting already prefers `structuredPrompt`, but both database queries filtered on `content IS NOT NULL` first. Once compatibility `content` shadows stop being written, valid structured user messages would be discarded before projection. This PR removes that hidden selection dependency without changing the legacy path.

## Verification

- API type-check passed against latest `main`
- API oxlint, type-aware oxlint, and ESLint passed
- diff is limited to the two prior-run query paths; no schema or migration changes

A structured-only persisted row is not currently constructible through the public API because structured sends still write the compatibility `content` shadow, so the new null-content state cannot be exercised by a compliant route test yet.

Refs #22314
