### PR TITLE
fix(runner): preserve session history cancellation

### DIFF
--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -21,6 +21,9 @@ pub enum RunnerError {
     #[error("config error: {0}")]
     Config(String),
 
+    #[error("cancelled")]
+    Cancelled,
+
     #[error("internal error: {0}")]
     Internal(String),
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -347,9 +347,7 @@ async fn materialize_session_history_sidecar(
     let bytes = tokio::select! {
         biased;
         _ = cancel.cancelled() => {
-            return Err(RunnerError::Internal(
-                "session history sidecar materialization cancelled".into(),
-            ));
+            return Err(RunnerError::Cancelled);
         }
         result = read_session_history_sidecar_bytes(sidecar) => result?,
     };
@@ -1625,17 +1623,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         })
     })
     .await;
-    let PreparedAgentProcess {
-        mut handle,
-        agent_started_at: t,
-        deferred_background_fill,
-        session_restore_diagnostics,
-        mut pre_run_restored_session_identity,
-        env_diagnostics,
-        env_pairs,
-    } = match prepared_agent {
-        Some(result) => result?,
-        None => {
+    let prepared_agent = match prepared_agent {
+        Some(Ok(prepared_agent)) => prepared_agent,
+        Some(Err(RunnerError::Cancelled)) | None => {
             info!(
                 run_id = %context.run_id,
                 "cancel received before guest process started"
@@ -1652,7 +1642,17 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             );
             return Ok(result);
         }
+        Some(Err(error)) => return Err(error),
     };
+    let PreparedAgentProcess {
+        mut handle,
+        agent_started_at: t,
+        deferred_background_fill,
+        session_restore_diagnostics,
+        mut pre_run_restored_session_identity,
+        env_diagnostics,
+        env_pairs,
+    } = prepared_agent;
 
     // Claude Code process has a PID now — record end-to-end startup latency.
     record_api_latency("api_to_spawn", context, telemetry);

--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -1118,7 +1118,7 @@ fn check_cancelled(cancel: &CancellationToken) -> RunnerResult<()> {
 }
 
 fn cpu_cancelled_error() -> RunnerError {
-    RunnerError::Internal(CPU_CANCELLED.into())
+    RunnerError::Cancelled
 }
 
 #[cfg(test)]
@@ -1375,7 +1375,7 @@ mod tests {
 
         cancel.cancel();
         let error = wait_for(task).await.unwrap().unwrap_err();
-        assert!(error.to_string().contains("cancelled"));
+        assert!(matches!(error, RunnerError::Cancelled));
         wait_for(gate.wait_completed()).await;
     }
 
@@ -1427,7 +1427,7 @@ mod tests {
         wait_for(gate.wait_submitted()).await;
         cancel.cancel();
         let error = wait_for(second).await.unwrap().unwrap_err();
-        assert!(error.to_string().contains("cancelled"));
+        assert!(matches!(error, RunnerError::Cancelled));
         assert_eq!(gate.entry_count(), 1);
 
         gate.release_one();
@@ -1455,7 +1455,7 @@ mod tests {
 
         cancel.cancel();
         let error = wait_for(task).await.unwrap().unwrap_err();
-        assert!(error.to_string().contains("cancelled"));
+        assert!(matches!(error, RunnerError::Cancelled));
         wait_for(reader_gate.wait_completed()).await;
     }
 

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -640,9 +640,7 @@ impl SessionHistoryDownloadTaskResult {
         Self {
             elapsed: started_at.elapsed(),
             timings: SessionHistoryDownloadTimings::for_metadata(metadata),
-            result: Err(RunnerError::Internal(
-                "session history download cancelled".into(),
-            )),
+            result: Err(RunnerError::Cancelled),
         }
     }
 }
@@ -916,7 +914,7 @@ async fn download_body(
 }
 
 fn session_history_download_cancelled_error() -> RunnerError {
-    RunnerError::Internal("session history download cancelled".into())
+    RunnerError::Cancelled
 }
 
 async fn download_body_once(
@@ -2793,7 +2791,7 @@ mod tests {
 
         match result {
             SessionHistoryMaterialization::Failed { error, timings, .. } => {
-                assert!(error.to_string().contains("cancelled"));
+                assert!(matches!(error, RunnerError::Cancelled));
                 assert_no_phase(timings.request_status());
                 assert_no_phase(timings.body_read());
                 assert_no_phase(timings.validation());
@@ -2905,7 +2903,7 @@ mod tests {
         let result = materializer.finish(&CancellationToken::new()).await;
         match result {
             SessionHistoryMaterialization::Failed { error, timings, .. } => {
-                assert!(error.to_string().contains("cancelled"));
+                assert!(matches!(error, RunnerError::Cancelled));
                 assert_no_phase(timings.request_status());
                 assert_no_phase(timings.body_read());
                 assert_no_phase(timings.validation());
@@ -2947,7 +2945,7 @@ mod tests {
         let result = materializer.finish(&cancel).await;
         match result {
             SessionHistoryMaterialization::Failed { error, timings, .. } => {
-                assert!(error.to_string().contains("cancelled"));
+                assert!(matches!(error, RunnerError::Cancelled));
                 assert_no_phase(timings.request_status());
                 assert_no_phase(timings.body_read());
                 assert_no_phase(timings.validation());
@@ -2995,7 +2993,7 @@ mod tests {
         let result = materializer.finish(&cancel).await;
         match result {
             SessionHistoryMaterialization::Failed { error, .. } => {
-                assert!(error.to_string().contains("cancelled"));
+                assert!(matches!(error, RunnerError::Cancelled));
             }
             _ => panic!("expected cancelled download"),
         }
@@ -3033,7 +3031,7 @@ mod tests {
         let result = materializer.finish(&cancel).await;
         match result {
             SessionHistoryMaterialization::Failed { error, .. } => {
-                assert!(error.to_string().contains("cancelled"));
+                assert!(matches!(error, RunnerError::Cancelled));
             }
             _ => panic!("expected cancelled download"),
         }

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -3493,6 +3493,98 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_reports_cancelled_while_session_history_download_is_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_received_tx, request_received_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 1024];
+        let request_bytes = stream.read(&mut request).await.unwrap();
+        assert!(request_bytes > 0);
+        request_received_tx.send(()).unwrap();
+        let mut byte = [0u8; 1];
+        let closed = stream.read(&mut byte).await.unwrap();
+        assert_eq!(closed, 0);
+    });
+    let history = br#"{"type":"init"}"#;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-cancel-pending-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: format!("http://{address}/history.blob?token=secret"),
+                encoding: None,
+                raw_size: history.len() as u64,
+                encoded_size: history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+    // Production materializers receive a child of the run token. Keep the
+    // tokens independent here so the inner cancellation result deterministically
+    // reaches the result-first pre-spawn branch instead of racing the outer
+    // cancellation branch.
+    let materializer_cancel = tokio_util::sync::CancellationToken::new();
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        &config.session_history_cpu,
+        ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
+        materializer_cancel.clone(),
+        Some(&config.session_history_probe),
+    );
+    let run_task = tokio::spawn(async move {
+        let mut telemetry = test_telemetry(&config, &ctx);
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+                .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                    materializer,
+                    fallback: None,
+                }),
+        )
+        .await
+    });
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_received_rx)
+        .await
+        .expect("session history request should start")
+        .unwrap();
+    materializer_cancel.cancel();
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .expect("cancelled run should finish")
+        .unwrap()
+        .unwrap();
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
+        .await
+        .expect("session history server should observe disconnect")
+        .unwrap();
+
+    let failure = result.failure.expect("cancelled run should fail");
+    assert_eq!(failure.exit_code, EXIT_SIGKILL);
+    assert_eq!(failure.error, "cancelled by user");
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+}
+
+#[tokio::test]
 async fn run_in_sandbox_starts_no_guest_work_when_already_cancelled() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1517,6 +1517,96 @@ async fn run_in_sandbox_restores_session_history_from_workspace_sidecar() {
     assert_successful_action_once(&ops, "session_history_workspace_cache_restore");
     assert_successful_action_once(&ops, "session_restore");
     assert_no_action(&ops, "session_history_download");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_reports_cancelled_while_workspace_sidecar_read_is_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let history = b"x";
+    let sidecar_path = dir.path().join("pending-session-history.blob");
+    nix::unistd::mkfifo(
+        &sidecar_path,
+        nix::sys::stat::Mode::from_bits_truncate(0o600),
+    )
+    .unwrap();
+    let writer_path = sidecar_path.clone();
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-sidecar-cancel-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: "https://example.test/history.blob?token=secret".into(),
+                encoding: None,
+                raw_size: history.len() as u64,
+                encoded_size: history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let run_cancel = cancel.clone();
+    let run_task = tokio::spawn(async move {
+        let mut telemetry = test_telemetry(&config, &ctx);
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(run_cancel, None).with_session_history_restore_plan(
+                SessionHistoryRestorePlan::LocalSidecar {
+                    sidecar: WorkspaceSessionHistorySidecar {
+                        path: sidecar_path,
+                        representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+                        encoded_size: history.len() as u64,
+                    },
+                    fallback: None,
+                },
+            ),
+        )
+        .await
+    });
+
+    let writer = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        loop {
+            match fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&writer_path)
+            {
+                Ok(writer) => break writer,
+                Err(error) if error.raw_os_error() == Some(libc::ENXIO) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => panic!("open sidecar FIFO writer: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("run should open the sidecar reader");
+    cancel.cancel();
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .expect("cancelled run should finish")
+        .unwrap()
+        .unwrap();
+    drop(writer);
+
+    let failure = result.failure.expect("cancelled run should fail");
+    assert_eq!(failure.exit_code, EXIT_SIGKILL);
+    assert_eq!(failure.error, "cancelled by user");
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve session-history cancellation with a typed runner error instead of encoding it as an internal failure
- translate that cancellation at the pre-spawn lifecycle boundary into the existing cancelled execution result
- cover cancellation during pending hash-backed downloads and local workspace-sidecar reads without starting or waiting for a guest process

## Scope

- keeps the result-first pre-spawn selection and process-handle ownership unchanged
- leaves genuine download, validation, decompression, hashing, I/O, and materialization errors unchanged
- does not change protocols, persisted state, configuration, dependencies, or unrelated runner cancellation paths

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_reports_cancelled_while_session_history_download_is_pending`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_reports_cancelled_while_workspace_sidecar_read_is_pending`
- both focused cancellation regressions passed 20 consecutive additional runs
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- repository pre-commit hooks for the staged Rust files

Closes #22653
