### PR TITLE
feat: roll out chat message background sync

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message-background-sync.test.ts
@@ -3,7 +3,6 @@ import {
   chatThreadMessagesContract,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -11,7 +10,6 @@ import {
   mockOrganization,
   mockUser,
 } from "../../../__tests__/mock-auth.ts";
-import { setMockFeatureSwitches } from "../../../mocks/handlers/api-feature-switches.helpers.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { CHAT_MESSAGES_STORE } from "../../external/chat-idb-schema.ts";
 import { chatIdb$ } from "../../external/chat-idb-store.ts";
@@ -89,22 +87,8 @@ describe("chat message background sync", () => {
     clearMockedAuth();
   });
 
-  it("does not subscribe when the feature switch is disabled", async () => {
-    mockSignedInUser();
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: false,
-    });
-
-    await context.store.set(setupChatMessageBackgroundSync$, context.signal);
-
-    expect(context.mocks.ably.hasChannelSubscription()).toBeFalsy();
-  });
-
   it("fills only messages after the cached thread end", async () => {
     mockSignedInUser();
-    setMockFeatureSwitches({
-      [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: true,
-    });
     const appDb = await context.store.get(chatIdb$);
     await context.store.set(
       writeIndexedDbChatMessages$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message-background-sync.ts
@@ -1,9 +1,4 @@
 import { command } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  featureSwitch$,
-  reloadFeatureSwitch$,
-} from "../external/feature-switch.ts";
 import { setAblyMessageLoop$ } from "../realtime.ts";
 import {
   loadIndexedDbChatMessageBounds$,
@@ -88,15 +83,7 @@ export const subscribeChatMessageBackgroundSync$ = command(
 );
 
 export const setupChatMessageBackgroundSync$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    await set(reloadFeatureSwitch$, signal);
-    signal.throwIfAborted();
-    if (
-      !get(featureSwitch$)[FeatureSwitchKey.ChatThreadMessageBackgroundSync]
-    ) {
-      return;
-    }
-
+  async ({ set }, signal: AbortSignal): Promise<void> => {
     await set(subscribeChatMessageBackgroundSync$, signal);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -133,6 +133,7 @@ describe("chat lifecycle", () => {
     });
 
     const forwardRequestCount = sinceIds.length;
+    const latestMessageId = messages.at(-1)!.id;
     await waitFor(() => {
       expect(
         context.mocks.ably.hasSubscription(
@@ -142,7 +143,10 @@ describe("chat lifecycle", () => {
     });
     context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`, {});
     await waitFor(() => {
-      expect(sinceIds).toHaveLength(forwardRequestCount + 1);
+      expect(sinceIds.slice(forwardRequestCount)).toStrictEqual([
+        latestMessageId,
+        latestMessageId,
+      ]);
     });
     expect(beforeIds).toStrictEqual([messages[10]!.id]);
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
@@ -278,9 +278,6 @@ describe("chat message persistence", () => {
       detachedSetupPage({
         context,
         path: `/chats/${threadId}`,
-        featureSwitches: {
-          [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: false,
-        },
         user: { id: userId, fullName: "IndexedDB Event User" },
         org: {
           activeOrg: { id: orgId, name: "IndexedDB Event Org" },

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -63,7 +63,6 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   DesktopX64Download = "desktopX64Download",
   AgentUnreadIndicators = "agentUnreadIndicators",
-  ChatThreadMessageBackgroundSync = "chatThreadMessageBackgroundSync",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ComposerChatThreadSuggestions = "composerChatThreadSuggestions",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -368,13 +368,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatThreadMessageBackgroundSync]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Prefetch chat thread messages into IndexedDB when message-created realtime events arrive outside the focused thread.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Start authenticated chat message background sync for every organization without loading or checking a feature switch.
- Remove `ChatThreadMessageBackgroundSync` from the shared feature-switch key enum and registry.
- Remove the disabled-switch test path while retaining the integration coverage for realtime subscription and IndexedDB synchronization.

## User impact

Chat messages created outside the focused thread are now prefetched into IndexedDB for all authenticated users, completing the rollout beyond staff organizations.

## Verification

- `prettier 3.8.1 --write` on all four changed files
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-message-background-sync.test.ts` (1 test)
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
- `knip --workspace @vm0/app --workspace @vm0/core --workspace @vm0/connectors`

Full local Vitest and a local dev server were not run, per repository PR verification guidance.
