### PR TITLE
perf(guest-agent): overlap artifact checkpoint pipelines

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
+ "futures-util",
  "guest-common",
  "guest-contracts",
  "hex",

--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -10,6 +10,7 @@ base64.workspace = true
 bytes.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 flate2.workspace = true
+futures-util.workspace = true
 process-control-ipc.workspace = true
 guest-contracts.workspace = true
 guest-common.workspace = true

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -1276,13 +1276,14 @@ mod tests {
 
     const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
 
-    async fn start_artifact_checkpoint_test_server()
-    -> (String, tokio::task::JoinHandle<Vec<String>>) {
+    async fn start_artifact_checkpoint_test_server(
+        artifact_count: usize,
+    ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let handle = tokio::spawn(async move {
-            let mut prepare_requests = Vec::with_capacity(ARTIFACT_CHECKPOINT_CONCURRENCY);
-            for _ in 0..ARTIFACT_CHECKPOINT_CONCURRENCY {
+            let mut prepare_requests = Vec::with_capacity(artifact_count);
+            for _ in 0..artifact_count {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let (path, payload) = read_test_json_request(&mut socket).await;
                 assert_eq!(path, "/api/webhooks/agent/storages/prepare");
@@ -1303,7 +1304,7 @@ mod tests {
                 )
                 .await;
             }
-            for _ in 0..ARTIFACT_CHECKPOINT_CONCURRENCY {
+            for _ in 0..artifact_count {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let (path, _) = read_test_json_request(&mut socket).await;
                 assert_eq!(path, "/api/webhooks/agent/storages/commit");
@@ -1598,10 +1599,6 @@ mod tests {
 
     #[tokio::test]
     async fn artifact_snapshot_pipelines_overlap_and_preserve_result_order() {
-        let (base_url, server) = start_artifact_checkpoint_test_server().await;
-        let http =
-            HttpClient::with_api_config(base_url, "test-token", "", "test-run-001", Duration::ZERO)
-                .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let workspace_mount = dir.path().join("workspace");
         let memory_mount = dir.path().join("memory");
@@ -1625,6 +1622,10 @@ mod tests {
                 missing_root_policy: None,
             },
         ];
+        let (base_url, server) = start_artifact_checkpoint_test_server(entries.len()).await;
+        let http =
+            HttpClient::with_api_config(base_url, "test-token", "", "test-run-001", Duration::ZERO)
+                .unwrap();
 
         let snapshots = tokio::time::timeout(
             REQUEST_OVERLAP_TIMEOUT,

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -21,6 +21,7 @@ use api_contracts::generated::types::{
 };
 use bytes::Bytes;
 use flate2::{Compression, write::GzEncoder};
+use futures_util::stream::{self, FuturesUnordered, StreamExt};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
@@ -30,6 +31,7 @@ use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::time::Duration;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const ARTIFACT_CHECKPOINT_CONCURRENCY: usize = 2;
 const SESSION_HISTORY_ZSTD_LEVEL: i32 = 3;
 const SESSION_HISTORY_COMPRESSION_MIN_BYTES: usize = SESSION_HISTORY_GZIP_MIN_BYTES as usize;
 
@@ -335,6 +337,124 @@ enum ArtifactSnapshotPlan<'a> {
     },
 }
 
+async fn build_artifact_snapshot_plan(
+    entry: &env::ArtifactEnv,
+) -> Result<ArtifactSnapshotPlan<'_>, artifact::WalkFilesError> {
+    log_info!(
+        LOG_TAG,
+        "Processing artifact '{}' at {}",
+        entry.name,
+        entry.mount_path
+    );
+    match artifact::walk_files_for_checkpoint(&entry.mount_path).await {
+        Ok(files) => Ok(ArtifactSnapshotPlan::Snapshot { entry, files }),
+        Err(error)
+            if error.is_missing_root()
+                && matches!(
+                    entry.missing_root_policy,
+                    Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+                ) =>
+        {
+            error.record_preserved_missing_root(&entry.name, &entry.mount_path);
+            Ok(ArtifactSnapshotPlan::PreserveParentVersion { entry })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn snapshot_artifact_plan(
+    http: &HttpClient,
+    run_id: &str,
+    plan: ArtifactSnapshotPlan<'_>,
+) -> Result<checkpoints::RequestArtifactSnapshot, AgentError> {
+    let (entry, files) = match plan {
+        ArtifactSnapshotPlan::Snapshot { entry, files } => (entry, files),
+        ArtifactSnapshotPlan::PreserveParentVersion { entry } => {
+            log_info!(
+                LOG_TAG,
+                "VAS artifact snapshot preserved parent version for missing root: {}@{}",
+                entry.name,
+                entry.version_id
+            );
+            return Ok(build_artifact_snapshot_entry(
+                &entry.name,
+                &entry.version_id,
+                &entry.mount_path,
+                entry.missing_root_policy,
+            ));
+        }
+    };
+    // Skip the VAS round-trips when the mount is byte-identical to what
+    // was originally mounted. `version_id` in VAS *is* the content hash
+    // (same SHA-256 the web producer emits), so an equality check on the
+    // locally-recomputed hash is sufficient — no extra metadata needed.
+    // See #10967 for the ~3.9s-per-checkpoint motivation.
+    let skip_check_start = std::time::Instant::now();
+    let content_hash_start = std::time::Instant::now();
+    let local_hash = content_hash::compute_content_hash(
+        &entry.storage_id,
+        files.iter().map(|f| (f.path.as_str(), f.hash.as_str())),
+    );
+    record_sandbox_op(
+        "artifact_content_hash_compute",
+        content_hash_start.elapsed(),
+        true,
+        None,
+    );
+    if local_hash == entry.version_id {
+        log_info!(
+            LOG_TAG,
+            "VAS artifact snapshot skipped (unchanged since mount): {}@{}",
+            entry.name,
+            entry.version_id
+        );
+        record_sandbox_op(
+            "artifact_snapshot_skipped",
+            skip_check_start.elapsed(),
+            true,
+            None,
+        );
+        return Ok(build_artifact_snapshot_entry(
+            &entry.name,
+            &entry.version_id,
+            &entry.mount_path,
+            entry.missing_root_policy,
+        ));
+    }
+
+    log_info!(
+        LOG_TAG,
+        "Creating VAS snapshot for artifact '{}'",
+        entry.name
+    );
+    let message = format!("Checkpoint from run {run_id}");
+    let snapshot = artifact::create_snapshot(
+        http,
+        artifact::CreateSnapshotRequest {
+            mount_path: &entry.mount_path,
+            files,
+            storage_name: &entry.name,
+            storage_type: "artifact",
+            run_id,
+            message: &message,
+            parent_version_id: &entry.version_id,
+        },
+    )
+    .await?;
+    log_info!(
+        LOG_TAG,
+        "VAS artifact snapshot created: {}@{}",
+        entry.name,
+        snapshot.version_id
+    );
+    Ok(build_artifact_snapshot_entry(
+        &entry.name,
+        &snapshot.version_id,
+        &entry.mount_path,
+        entry.missing_root_policy,
+    ))
+}
+
 struct CheckpointInputs<'a> {
     run_id: &'a str,
     framework: env::Framework,
@@ -537,124 +657,60 @@ async fn snapshot_artifact_entries(
         return Ok(None);
     }
 
-    let mut plans = Vec::with_capacity(entries.len());
-    for entry in entries {
-        log_info!(
-            LOG_TAG,
-            "Processing artifact '{}' at {}",
-            entry.name,
-            entry.mount_path
-        );
-        match artifact::walk_files_for_checkpoint(&entry.mount_path).await {
-            Ok(files) => {
-                plans.push(ArtifactSnapshotPlan::Snapshot { entry, files });
-            }
-            Err(error)
-                if error.is_missing_root()
-                    && matches!(
-                        entry.missing_root_policy,
-                        Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
-                    ) =>
-            {
-                error.record_preserved_missing_root(&entry.name, &entry.mount_path);
-                plans.push(ArtifactSnapshotPlan::PreserveParentVersion { entry });
-            }
-            Err(error) => return Err(error.into_agent_error()),
+    let mut indexed_plans = stream::iter(entries.iter().enumerate())
+        .map(|(index, entry)| async move { (index, build_artifact_snapshot_plan(entry).await) })
+        .buffer_unordered(ARTIFACT_CHECKPOINT_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+    indexed_plans.sort_unstable_by_key(|(index, _)| *index);
+    let plans = indexed_plans
+        .into_iter()
+        .map(|(_, result)| result.map_err(artifact::WalkFilesError::into_agent_error))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut pending = plans.into_iter().enumerate();
+    let snapshot =
+        |(index, plan)| async move { (index, snapshot_artifact_plan(http, run_id, plan).await) };
+    let mut in_flight = FuturesUnordered::new();
+    for _ in 0..ARTIFACT_CHECKPOINT_CONCURRENCY {
+        if let Some(plan) = pending.next() {
+            in_flight.push(snapshot(plan));
         }
     }
 
-    let mut results = Vec::with_capacity(plans.len());
-    for plan in plans {
-        let (entry, files) = match plan {
-            ArtifactSnapshotPlan::Snapshot { entry, files } => (entry, files),
-            ArtifactSnapshotPlan::PreserveParentVersion { entry } => {
-                log_info!(
-                    LOG_TAG,
-                    "VAS artifact snapshot preserved parent version for missing root: {}@{}",
-                    entry.name,
-                    entry.version_id
-                );
-                results.push(build_artifact_snapshot_entry(
-                    &entry.name,
-                    &entry.version_id,
-                    &entry.mount_path,
-                    entry.missing_root_policy,
-                ));
-                continue;
+    let mut indexed_results = Vec::with_capacity(entries.len());
+    let mut first_error: Option<(usize, AgentError)> = None;
+    while let Some((index, result)) = in_flight.next().await {
+        match result {
+            Ok(snapshot_result) => {
+                indexed_results.push((index, snapshot_result));
+                if first_error.is_none()
+                    && let Some(plan) = pending.next()
+                {
+                    in_flight.push(snapshot(plan));
+                }
             }
-        };
-        // Skip the VAS round-trips when the mount is byte-identical to what
-        // was originally mounted. `version_id` in VAS *is* the content hash
-        // (same SHA-256 the web producer emits), so an equality check on the
-        // locally-recomputed hash is sufficient — no extra metadata needed.
-        // See #10967 for the ~3.9s-per-checkpoint motivation.
-        let skip_check_start = std::time::Instant::now();
-        let content_hash_start = std::time::Instant::now();
-        let local_hash = content_hash::compute_content_hash(
-            &entry.storage_id,
-            files.iter().map(|f| (f.path.as_str(), f.hash.as_str())),
-        );
-        record_sandbox_op(
-            "artifact_content_hash_compute",
-            content_hash_start.elapsed(),
-            true,
-            None,
-        );
-        if local_hash == entry.version_id {
-            log_info!(
-                LOG_TAG,
-                "VAS artifact snapshot skipped (unchanged since mount): {}@{}",
-                entry.name,
-                entry.version_id
-            );
-            record_sandbox_op(
-                "artifact_snapshot_skipped",
-                skip_check_start.elapsed(),
-                true,
-                None,
-            );
-            results.push(build_artifact_snapshot_entry(
-                &entry.name,
-                &entry.version_id,
-                &entry.mount_path,
-                entry.missing_root_policy,
-            ));
-            continue;
+            Err(error) => {
+                if first_error
+                    .as_ref()
+                    .is_none_or(|(error_index, _)| index < *error_index)
+                {
+                    first_error = Some((index, error));
+                }
+            }
         }
-
-        log_info!(
-            LOG_TAG,
-            "Creating VAS snapshot for artifact '{}'",
-            entry.name
-        );
-        let message = format!("Checkpoint from run {run_id}");
-        let snapshot = artifact::create_snapshot(
-            http,
-            artifact::CreateSnapshotRequest {
-                mount_path: &entry.mount_path,
-                files,
-                storage_name: &entry.name,
-                storage_type: "artifact",
-                run_id,
-                message: &message,
-                parent_version_id: &entry.version_id,
-            },
-        )
-        .await?;
-        log_info!(
-            LOG_TAG,
-            "VAS artifact snapshot created: {}@{}",
-            entry.name,
-            snapshot.version_id
-        );
-        results.push(build_artifact_snapshot_entry(
-            &entry.name,
-            &snapshot.version_id,
-            &entry.mount_path,
-            entry.missing_root_policy,
-        ));
     }
-    Ok(Some(results))
+    if let Some((_, error)) = first_error {
+        return Err(error);
+    }
+
+    indexed_results.sort_unstable_by_key(|(index, _)| *index);
+    Ok(Some(
+        indexed_results
+            .into_iter()
+            .map(|(_, result)| result)
+            .collect(),
+    ))
 }
 
 /// Create a checkpoint after a successful run using the explicit runtime snapshot.
@@ -1215,6 +1271,107 @@ mod tests {
     use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
     use httpmock::prelude::*;
     use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+    async fn start_artifact_checkpoint_test_server()
+    -> (String, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            let mut prepare_requests = Vec::with_capacity(ARTIFACT_CHECKPOINT_CONCURRENCY);
+            for _ in 0..ARTIFACT_CHECKPOINT_CONCURRENCY {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let (path, payload) = read_test_json_request(&mut socket).await;
+                assert_eq!(path, "/api/webhooks/agent/storages/prepare");
+                let storage_name = payload["storageName"].as_str().unwrap().to_string();
+                prepare_requests.push((socket, storage_name));
+            }
+            let prepare_names = prepare_requests
+                .iter()
+                .map(|(_, storage_name)| storage_name.clone())
+                .collect();
+            for (mut socket, storage_name) in prepare_requests {
+                write_test_json_response(
+                    &mut socket,
+                    &json!({
+                        "versionId": format!("snapshot-{storage_name}"),
+                        "existing": true,
+                    }),
+                )
+                .await;
+            }
+            for _ in 0..ARTIFACT_CHECKPOINT_CONCURRENCY {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let (path, _) = read_test_json_request(&mut socket).await;
+                assert_eq!(path, "/api/webhooks/agent/storages/commit");
+                write_test_json_response(
+                    &mut socket,
+                    &json!({
+                        "success": true,
+                        "versionId": "ignored",
+                        "storageName": "ignored",
+                        "size": 0,
+                        "fileCount": 0,
+                    }),
+                )
+                .await;
+            }
+            prepare_names
+        });
+        (format!("http://{address}"), handle)
+    }
+
+    async fn read_test_json_request(socket: &mut TcpStream) -> (String, serde_json::Value) {
+        let mut request = Vec::new();
+        let header_end = loop {
+            if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break index;
+            }
+            let mut chunk = [0_u8; 1024];
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request headers");
+            request.extend_from_slice(&chunk[..read]);
+        };
+        let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+        let path = headers
+            .lines()
+            .next()
+            .unwrap()
+            .split_whitespace()
+            .nth(1)
+            .unwrap()
+            .to_string();
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .map(|(_, value)| value.trim().parse::<usize>().unwrap())
+            .unwrap_or_default();
+        let body_start = header_end + 4;
+        while request.len() < body_start + content_length {
+            let mut chunk = [0_u8; 1024];
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "connection closed before request body");
+            request.extend_from_slice(&chunk[..read]);
+        }
+        let payload =
+            serde_json::from_slice(&request[body_start..body_start + content_length]).unwrap();
+        (path, payload)
+    }
+
+    async fn write_test_json_response(socket: &mut TcpStream, body: &serde_json::Value) {
+        let body = serde_json::to_vec(body).unwrap();
+        let headers = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        );
+        socket.write_all(headers.as_bytes()).await.unwrap();
+        socket.write_all(&body).await.unwrap();
+        socket.shutdown().await.unwrap();
+    }
 
     struct CheckpointFilesGuard {
         guest_paths: crate::paths::GuestPaths,
@@ -1437,6 +1594,64 @@ mod tests {
         );
         prepare.assert_calls(0);
         commit.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn artifact_snapshot_pipelines_overlap_and_preserve_result_order() {
+        let (base_url, server) = start_artifact_checkpoint_test_server().await;
+        let http =
+            HttpClient::with_api_config(base_url, "test-token", "", "test-run-001", Duration::ZERO)
+                .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_mount = dir.path().join("workspace");
+        let memory_mount = dir.path().join("memory");
+        std::fs::create_dir(&workspace_mount).unwrap();
+        std::fs::create_dir(&memory_mount).unwrap();
+        std::fs::write(workspace_mount.join("workspace.txt"), "workspace").unwrap();
+        std::fs::write(memory_mount.join("memory.txt"), "memory").unwrap();
+        let entries = vec![
+            env::ArtifactEnv {
+                name: "workspace".to_string(),
+                mount_path: workspace_mount.to_string_lossy().into_owned(),
+                storage_id: "workspace-storage-id".to_string(),
+                version_id: "old-workspace-version".to_string(),
+                missing_root_policy: None,
+            },
+            env::ArtifactEnv {
+                name: "memory".to_string(),
+                mount_path: memory_mount.to_string_lossy().into_owned(),
+                storage_id: "memory-storage-id".to_string(),
+                version_id: "old-memory-version".to_string(),
+                missing_root_policy: None,
+            },
+        ];
+
+        let snapshots = tokio::time::timeout(
+            REQUEST_OVERLAP_TIMEOUT,
+            snapshot_artifact_entries(&http, "test-run", &entries),
+        )
+        .await
+        .expect("both artifact pipelines must reach prepare concurrently")
+        .unwrap()
+        .unwrap();
+        let mut prepare_names = server.await.unwrap();
+        prepare_names.sort_unstable();
+        assert_eq!(prepare_names, ["memory", "workspace"]);
+        assert_eq!(
+            serde_json::to_value(snapshots).unwrap(),
+            json!([
+                {
+                    "name": "workspace",
+                    "version": "snapshot-workspace",
+                    "mountPath": workspace_mount.to_string_lossy(),
+                },
+                {
+                    "name": "memory",
+                    "version": "snapshot-memory",
+                    "mountPath": memory_mount.to_string_lossy(),
+                },
+            ])
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- run artifact checkpoint preflight walks with bounded concurrency while preserving the no-storage-side-effect barrier
- overlap up to two artifact snapshot pipelines, stop admitting new work after a failure, and preserve input ordering
- add a deterministic HTTP-boundary test that requires workspace and memory snapshot requests to overlap

## Scope

- no API, schema, migration, configuration, or persisted-state changes
- unchanged artifacts and missing-root preservation retain their existing behavior and telemetry

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- repository pre-commit hooks, including workspace Rust formatting, documentation, and Clippy checks

Closes https://github.com/vm0-ai/vm0/issues/22671
