### PR TITLE
docs(rust): expose private path guarantees in guest-agent

### DIFF
--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -15,7 +15,8 @@
 pub use api_contracts::generated::constants::runners::paths::{
     CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR,
 };
-use std::io;
+#[doc(inline)]
+pub use guest_contracts::runtime_paths::{ensure_parent_dir, write_private};
 use std::path::{Path, PathBuf};
 
 /// Immutable run-scoped guest paths derived from one runtime directory.
@@ -192,14 +193,6 @@ fn resolve_run_dir_from_captured_env(
 
 fn path_to_string(path: PathBuf) -> String {
     path.to_string_lossy().into_owned()
-}
-
-pub fn ensure_parent_dir(path: impl AsRef<Path>) -> io::Result<()> {
-    guest_contracts::runtime_paths::ensure_parent_dir(path)
-}
-
-pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
-    guest_contracts::runtime_paths::write_private(path, bytes)
 }
 
 #[cfg(test)]

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -645,6 +645,11 @@ pub fn ensure_dir(path: impl AsRef<Path>) -> io::Result<()> {
 ///
 /// This applies [`ensure_dir`] to the path's parent and returns
 /// [`io::ErrorKind::InvalidInput`] when the path has no parent.
+///
+/// On Unix, missing directory components are created with `0700` permissions,
+/// an existing final parent directory is tightened to `0700`, and `..` or
+/// symlinked components are rejected. On non-Unix targets, this creates the
+/// parent path without claiming equivalent permission or symlink guarantees.
 pub fn ensure_parent_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref();
     let parent = path.parent().ok_or_else(|| {
@@ -815,9 +820,15 @@ pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
 
 /// Write bytes to a runtime-private file.
 ///
-/// On Unix, missing parent directories are created with private permissions,
-/// symlinked parent components are rejected, and private permissions are
-/// enforced on the final parent directory.
+/// This creates or truncates the file through [`create_private`], then writes
+/// all provided bytes.
+///
+/// On Unix, missing parent directories are created with `0700` permissions, an
+/// existing final parent directory is tightened to `0700`, and `..` or
+/// symlinked parent components are rejected. The final path must be a regular
+/// file rather than a symlink, and its permissions are tightened to `0600`. On
+/// non-Unix targets, parent directories are created and the file is created or
+/// truncated without claiming equivalent permission or symlink guarantees.
 pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
     let mut file = create_private(path)?;
     std::io::Write::write_all(&mut file, bytes.as_ref())


### PR DESCRIPTION
## Summary

- document the complete parent-directory and private-write contract in `guest_contracts::runtime_paths`
- inline re-export the canonical helpers from `guest_agent::paths` so the facade renders the same documentation
- distinguish Unix permission and symlink guarantees from the weaker non-Unix behavior

## Compatibility

The existing `guest_agent::paths::{ensure_parent_dir, write_private}` names and callable signatures remain available and resolve to the same canonical functions the wrappers previously invoked.

This PR does not change runtime behavior, callers, schemas, migrations, persisted data, wire formats, or deployment sequencing.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 cargo test --manifest-path crates/Cargo.toml -p guest-agent -p guest-contracts --all-targets --all-features -- --test-threads=1`
- `git diff --check`
- inspected the generated canonical and `guest_agent::paths` function pages for summaries, platform guarantees, source ownership, and helper links
- pre-commit Rust formatting, workspace rustdoc, and workspace Clippy hooks

Closes #22673
