### PR TITLE
fix(runner): reject invalid service environment names

### DIFF
--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -144,6 +144,10 @@ struct ServiceLogsArgs {
 // ---------------------------------------------------------------------------
 
 pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
+    if let ServiceCommand::Start(args) | ServiceCommand::Install(args) = &args.command {
+        validate_env_vars(&args.env)?;
+    }
+
     match args.command {
         ServiceCommand::Start(a) => start(a).await,
         ServiceCommand::Stop(a) => stop::run(a).await,
@@ -655,8 +659,6 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     let home = HomePaths::new()?;
     let _service_lock = acquire_service_lock(&unit, &home).await?;
 
-    validate_env_vars(&args.env)?;
-
     if is_unit_active(&unit).await? {
         return Err(RunnerError::Internal(format!(
             "unit {} is already running, stop it first with: runner service stop --name {}",
@@ -730,8 +732,6 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;
     let _service_lock = acquire_service_lock(&unit, &home).await?;
-
-    validate_env_vars(&args.env)?;
 
     let config_path = resolve_config_path(&args.config)?;
     let exe_path = validate_current_exe_path(
@@ -1082,18 +1082,62 @@ async fn logs(args: ServiceLogsArgs) -> RunnerResult<()> {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
-
-    use super::*;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, SystemTime};
 
+    use clap::Parser;
+
+    use super::*;
     use crate::paths::RootfsPaths;
 
     const TEST_ROOTFS_HASH: &str =
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const TEST_SNAPSHOT_HASH: &str =
         "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    fn parse_service_args(subcommand: &str, env: &str) -> ServiceArgs {
+        let cli = crate::Cli::try_parse_from([
+            "runner",
+            "service",
+            subcommand,
+            "--config",
+            "/does/not/exist/runner.yaml",
+            "--name",
+            "test",
+            "--env",
+            env,
+        ])
+        .unwrap();
+        let crate::Command::Service(args) = cli.command else {
+            panic!("expected service command");
+        };
+        args
+    }
+
+    #[tokio::test]
+    async fn service_run_commands_reject_invalid_env_names_before_setup() {
+        const SECRET: &str = "sentinel-service-env-secret";
+
+        for subcommand in ["start", "install"] {
+            for key in ["1INVALID", "API-KEY"] {
+                let assignment = format!("{key}={SECRET}");
+                let error = run_service(parse_service_args(subcommand, &assignment))
+                    .await
+                    .unwrap_err()
+                    .to_string();
+
+                assert!(
+                    error.contains(&format!("invalid --env key {key:?}")),
+                    "unexpected {subcommand} error: {error}"
+                );
+                assert!(
+                    !error.contains(SECRET),
+                    "{subcommand} error exposed the environment value: {error}"
+                );
+            }
+        }
+    }
 
     struct ServiceActivationFixture {
         _dir: tempfile::TempDir,

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -110,8 +110,8 @@ WantedBy=multi-user.target
 ///
 /// Bare newlines / carriage returns / NUL bytes anywhere in an assignment break the
 /// `Environment=` directive even with proper quote/backslash escaping
-/// (a literal newline terminates the directive line). Reject these at
-/// install time rather than letting `daemon-reload` fail obscurely later.
+/// (a literal newline terminates the directive line). Reject these before
+/// service setup rather than allowing systemd to fail obscurely later.
 pub(super) fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     for entry in vars {
         // Check directive-breaking bytes before parsing key/value syntax.

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -108,15 +108,13 @@ WantedBy=multi-user.target
 /// Validate that each env entry has a systemd-compatible key and contains no
 /// characters that would silently corrupt the generated systemd unit file.
 ///
-/// Bare newlines / carriage returns / NUL bytes inside a value break the
+/// Bare newlines / carriage returns / NUL bytes anywhere in an assignment break the
 /// `Environment=` directive even with proper quote/backslash escaping
 /// (a literal newline terminates the directive line). Reject these at
 /// install time rather than letting `daemon-reload` fail obscurely later.
 pub(super) fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     for entry in vars {
-        // Check dangerous chars first so the KEY=VALUE error below can
-        // safely interpolate `entry` without leaking newlines/NUL into
-        // log output.
+        // Check directive-breaking bytes before parsing key/value syntax.
         if entry.contains(['\n', '\r', '\0']) {
             return Err(RunnerError::Config(
                 "invalid --env value: newline or NUL characters are not allowed".to_string(),

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -105,7 +105,7 @@ WantedBy=multi-user.target
     )
 }
 
-/// Validate that each env entry is in `KEY=VALUE` format and contains no
+/// Validate that each env entry has a systemd-compatible key and contains no
 /// characters that would silently corrupt the generated systemd unit file.
 ///
 /// Bare newlines / carriage returns / NUL bytes inside a value break the
@@ -122,10 +122,20 @@ pub(super) fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
                 "invalid --env value: newline or NUL characters are not allowed".to_string(),
             ));
         }
-        let eq_pos = entry.find('=');
-        if eq_pos.is_none_or(|p| p == 0) {
+        let Some((key, _)) = entry.split_once('=') else {
+            return Err(RunnerError::Config(
+                "invalid --env value: expected KEY=VALUE format".to_string(),
+            ));
+        };
+        if key.is_empty() {
+            return Err(RunnerError::Config(
+                "invalid --env value: expected KEY=VALUE format".to_string(),
+            ));
+        }
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
+            let key = guest_contracts::env::sanitize_user_env_key_for_diagnostic(key);
             return Err(RunnerError::Config(format!(
-                "invalid --env value '{entry}': expected KEY=VALUE format"
+                "invalid --env key {key:?}: expected [_A-Za-z][_A-Za-z0-9]*"
             )));
         }
     }
@@ -675,10 +685,13 @@ mod tests {
 
     #[test]
     fn test_validate_env_vars_valid() {
+        for entry in ["KEY=VALUE", "_KEY=VALUE", "API_KEY_1=VALUE", "K=", "K=V=W"] {
+            assert!(
+                validate_env_vars(&[entry.to_string()]).is_ok(),
+                "expected valid environment assignment: {entry}"
+            );
+        }
         assert!(validate_env_vars(&[]).is_ok());
-        assert!(validate_env_vars(&["KEY=VALUE".to_string()]).is_ok());
-        assert!(validate_env_vars(&["K=".to_string()]).is_ok());
-        assert!(validate_env_vars(&["K=V=W".to_string()]).is_ok());
         // `"`, `\`, and `%` are valid at the validate layer — they get
         // escaped later in `escape_systemd_value`.
         assert!(validate_env_vars(&[r#"MSG=say "hi""#.to_string()]).is_ok());
@@ -692,9 +705,25 @@ mod tests {
 
     #[test]
     fn test_validate_env_vars_invalid() {
-        assert!(validate_env_vars(&["NOEQUALS".to_string()]).is_err());
+        const SECRET: &str = "sentinel-service-env-secret";
+
+        let malformed = validate_env_vars(&[SECRET.to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(malformed.contains("expected KEY=VALUE format"));
+        assert!(!malformed.contains(SECRET));
+
         assert!(validate_env_vars(&["=VALUE".to_string()]).is_err());
         assert!(validate_env_vars(&["".to_string()]).is_err());
+        for key in ["1INVALID", "API-KEY", "API KEY", "密钥"] {
+            let entry = format!("{key}={SECRET}");
+            let error = validate_env_vars(&[entry]).unwrap_err().to_string();
+            assert!(
+                error.contains(&format!("invalid --env key {key:?}")),
+                "unexpected error for key {key:?}: {error}"
+            );
+            assert!(!error.contains(SECRET), "error exposed value: {error}");
+        }
         // Bare newline / CR / NUL would silently corrupt the unit file.
         assert!(validate_env_vars(&["KEY=line1\nline2".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=foo\rbar".to_string()]).is_err());


### PR DESCRIPTION
## Summary

- validate `service start` and `service install` environment assignments once before service setup
- reject keys outside systemd's shell-identifier name contract using the existing guest-contracts predicate
- keep invalid diagnostics key-only and bounded so secret values are not exposed
- cover both service entry points plus valid, malformed, and invalid assignment cases

## Scope

This does not change environment value handling, generated unit syntax, persisted state, APIs, queue payloads, guest protocols, dependencies, or deployment compatibility.

## Validation

- `cargo test -p runner service_run_commands_reject_invalid_env_names_before_setup -- --nocapture`
- `cargo test -p runner test_validate_env_vars_ -- --nocapture`
- `cargo test -p runner`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `git diff --check`

Closes #22674
