### PR TITLE
refactor(api): replace complete raw deletes with drizzle builders

### DIFF
--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -1,5 +1,9 @@
 import { vi } from "vitest";
 
+export function stubTestTimezone(timezone: "Asia/Shanghai" | "UTC"): void {
+  vi.stubEnv("TZ", timezone);
+}
+
 if (!process.env.DATABASE_URL) {
   vi.stubEnv(
     "DATABASE_URL",

--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -1,6 +1,8 @@
 import { vi } from "vitest";
 
-export function stubTestTimezone(timezone: "Asia/Shanghai" | "UTC"): void {
+export function stubTestTimezone(
+  timezone: "America/New_York" | "Asia/Shanghai" | "UTC",
+): void {
   vi.stubEnv("TZ", timezone);
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
@@ -31,7 +31,8 @@ const CRON_SECRET = "test-delete-cleanups-secret";
 const CONNECTOR_EXPIRED_COUNT = 10_001;
 const TELEGRAM_EXPIRED_COUNT = 10_001;
 const CUTOFF_MS = Date.parse("1950-01-31T00:00:00.000Z");
-const TELEGRAM_NOW_MS = Date.parse("1950-03-02T00:00:00.000Z");
+const TELEGRAM_CUTOFF_MS = Date.parse("1950-04-20T00:00:00.000Z");
+const TELEGRAM_NOW_MS = Date.parse("1950-05-20T00:00:00.000Z");
 
 function connectorState(marker: string, kind: string): string {
   return `${marker}:${kind}`;
@@ -83,7 +84,7 @@ async function seedTelegramFixture(expiredCount: number): Promise<string> {
   await requestFixture({
     action: "seed-telegram",
     marker,
-    cutoff: new Date(CUTOFF_MS).toISOString(),
+    cutoff: new Date(TELEGRAM_CUTOFF_MS).toISOString(),
     expiredCount,
   });
   return marker;
@@ -150,10 +151,10 @@ describe("complete delete cleanup crons", () => {
 
     const empty = await cleanupConnectorOauthStates();
     expect(empty.body.deleted).toBe(0);
-  });
+  }, 15_000);
 
-  it("runs full and short telegram batches without crossing the UTC cutoff outside UTC", async () => {
-    stubTestTimezone("Asia/Shanghai");
+  it("runs full and short telegram batches across a non-UTC daylight-saving boundary", async () => {
+    stubTestTimezone("America/New_York");
     mockNow(TELEGRAM_NOW_MS);
     const marker = await seedTelegramFixture(TELEGRAM_EXPIRED_COUNT);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-delete-cleanups.test.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  cronConnectorOauthStateCleanupContract,
+  cronTelegramCleanupContract,
+} from "@vm0/api-contracts/contracts/cron";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vitest";
+
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { stubTestTimezone } from "../../../__tests__/env-stub";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import {
+  type TestCronDeleteCleanupsStateActionBody,
+  type TestCronDeleteCleanupsStateResponse,
+  testCronDeleteCleanupsStateContract,
+  testCronDeleteCleanupsStateResponseSchema,
+  testCronDeleteCleanupsStateRoutes,
+} from "../test-cron-delete-cleanups-state";
+
+const context = testContext();
+const CRON_SECRET = "test-delete-cleanups-secret";
+const CONNECTOR_EXPIRED_COUNT = 10_001;
+const TELEGRAM_EXPIRED_COUNT = 10_001;
+const CUTOFF_MS = Date.parse("1950-01-31T00:00:00.000Z");
+const TELEGRAM_NOW_MS = Date.parse("1950-03-02T00:00:00.000Z");
+
+function connectorState(marker: string, kind: string): string {
+  return `${marker}:${kind}`;
+}
+
+async function requestFixture(
+  body: TestCronDeleteCleanupsStateActionBody,
+): Promise<TestCronDeleteCleanupsStateResponse> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: testCronDeleteCleanupsStateRoutes,
+  });
+  const response = await app.request(
+    testCronDeleteCleanupsStateContract.action.path,
+    {
+      method: testCronDeleteCleanupsStateContract.action.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  expect(response.status).toBe(200);
+  return testCronDeleteCleanupsStateResponseSchema.parse(await response.json());
+}
+
+function registerFixtureCleanup(
+  action: "delete-connector" | "delete-telegram",
+  marker: string,
+): void {
+  onTestFinished(async () => {
+    await requestFixture({ action, marker });
+  });
+}
+
+async function seedConnectorFixture(expiredCount: number): Promise<string> {
+  const marker = `connector-cleanup-${randomUUID()}`;
+  registerFixtureCleanup("delete-connector", marker);
+  await requestFixture({
+    action: "seed-connector",
+    marker,
+    cutoff: new Date(CUTOFF_MS).toISOString(),
+    expiredCount,
+  });
+  return marker;
+}
+
+async function seedTelegramFixture(expiredCount: number): Promise<string> {
+  const marker = `telegram-cleanup-${randomUUID()}`;
+  registerFixtureCleanup("delete-telegram", marker);
+  await requestFixture({
+    action: "seed-telegram",
+    marker,
+    cutoff: new Date(CUTOFF_MS).toISOString(),
+    expiredCount,
+  });
+  return marker;
+}
+
+function cronHeaders() {
+  return { authorization: `Bearer ${CRON_SECRET}` };
+}
+
+async function cleanupConnectorOauthStates() {
+  return await accept(
+    setupApp({ context })(cronConnectorOauthStateCleanupContract).cleanup({
+      headers: cronHeaders(),
+    }),
+    [200],
+  );
+}
+
+async function cleanupTelegramMessages() {
+  return await accept(
+    setupApp({ context })(cronTelegramCleanupContract).cleanup({
+      headers: cronHeaders(),
+    }),
+    [200],
+  );
+}
+
+describe("complete delete cleanup crons", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+  });
+
+  afterEach(() => {
+    clearMockNow();
+    stubTestTimezone("UTC");
+  });
+
+  it("caps connector cleanup at ten batches and preserves the UTC cutoff outside UTC", async () => {
+    stubTestTimezone("Asia/Shanghai");
+    mockNow(CUTOFF_MS);
+    const marker = await seedConnectorFixture(CONNECTOR_EXPIRED_COUNT);
+
+    const first = await cleanupConnectorOauthStates();
+    expect(first.body.deleted).toBe(10_000);
+    await expect(
+      requestFixture({ action: "read-connector", marker }),
+    ).resolves.toStrictEqual({
+      ok: true,
+      remaining: [
+        connectorState(marker, "equal"),
+        connectorState(marker, "expired-10000"),
+        connectorState(marker, "future"),
+      ],
+    });
+
+    const second = await cleanupConnectorOauthStates();
+    expect(second.body.deleted).toBe(2);
+    await expect(
+      requestFixture({ action: "read-connector", marker }),
+    ).resolves.toStrictEqual({
+      ok: true,
+      remaining: [connectorState(marker, "future")],
+    });
+
+    const empty = await cleanupConnectorOauthStates();
+    expect(empty.body.deleted).toBe(0);
+  });
+
+  it("runs full and short telegram batches without crossing the UTC cutoff outside UTC", async () => {
+    stubTestTimezone("Asia/Shanghai");
+    mockNow(TELEGRAM_NOW_MS);
+    const marker = await seedTelegramFixture(TELEGRAM_EXPIRED_COUNT);
+
+    const cleanup = await cleanupTelegramMessages();
+    expect(cleanup.body.deleted).toBe(TELEGRAM_EXPIRED_COUNT);
+    await expect(
+      requestFixture({ action: "read-telegram", marker }),
+    ).resolves.toStrictEqual({
+      ok: true,
+      remaining: ["equal", "future"],
+    });
+
+    const empty = await cleanupTelegramMessages();
+    expect(empty.body.deleted).toBe(0);
+  });
+
+  it("preserves the strict telegram cutoff in UTC", async () => {
+    stubTestTimezone("UTC");
+    mockNow(TELEGRAM_NOW_MS);
+    const marker = await seedTelegramFixture(1);
+
+    const cleanup = await cleanupTelegramMessages();
+    expect(cleanup.body.deleted).toBe(1);
+    await expect(
+      requestFixture({ action: "read-telegram", marker }),
+    ).resolves.toStrictEqual({
+      ok: true,
+      remaining: ["equal", "future"],
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -4,13 +4,16 @@ import { gzipSync, zstdCompressSync } from "node:zlib";
 import AdmZip from "adm-zip";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { cronAggregateModelStatsContract } from "@vm0/api-contracts/contracts/cron";
 import { zeroAgentInstructionsContract } from "@vm0/api-contracts/contracts/zero-agents";
 
+import { createAppWithRoutes } from "../../../app-factory-core";
 import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { accept, setupApp } from "../../../__tests__/test-helpers";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { modelStatsRoutes } from "../model-stats";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
@@ -435,6 +438,46 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 
     const fallback = await api.readModelRankings("unsupported");
     expect(fallback.body.period).toBe("week");
+
+    // A failed rebuild must roll back the window DELETE. 1,024 maximum safe
+    // integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
+    mockNow(mainObservedAt);
+    const overflowEvents = Array.from({ length: 1025 }, () => {
+      return {
+        idempotencyKey: randomUUID(),
+        model,
+        category: "tokens.input" as const,
+        quantity: Number.MAX_SAFE_INTEGER,
+      };
+    });
+    for (let offset = 0; offset < overflowEvents.length; offset += 100) {
+      await webhooks.requestAgentModelUsageObservation(
+        {
+          runId: created.runId,
+          events: overflowEvents.slice(offset, offset + 100),
+        },
+        sandboxHeaders,
+        [200],
+      );
+    }
+
+    mockNow(aggregateAt);
+    const aggregateApp = createAppWithRoutes({
+      signal: context.signal,
+      routes: modelStatsRoutes,
+    });
+    const failedAggregate = await aggregateApp.request(
+      `${cronAggregateModelStatsContract.aggregate.path}?hours=24`,
+      {
+        headers: { authorization: "Bearer test-cron-secret" },
+      },
+    );
+    expect(failedAggregate.status).toBe(500);
+    await expect(failedAggregate.json()).resolves.toStrictEqual({
+      error: "Internal server error",
+    });
+    const afterFailedRebuild = await api.readModelRankings("today");
+    expect(afterFailedRebuild.body).toStrictEqual(reprocessed.body);
 
     // Retention: 33 days later the cron deletes every observation at or
     // before our day; the re-aggregation then empties the window's stats, so

--- a/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
@@ -1,0 +1,308 @@
+import { initContract } from "@vm0/api-contracts/contracts/trpc-contract";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { command } from "ccstate";
+import { asc, eq, like } from "drizzle-orm";
+import { z } from "zod";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { type Db, writeDb$ } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const FIXTURE_INSERT_BATCH_SIZE = 500;
+const MAX_EXPIRED_COUNT = 10_001;
+
+const markerSchema = z.string().min(1);
+const actionBodySchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("seed-connector"),
+    marker: markerSchema,
+    cutoff: z.iso.datetime(),
+    expiredCount: z.number().int().min(0).max(MAX_EXPIRED_COUNT),
+  }),
+  z.object({
+    action: z.literal("read-connector"),
+    marker: markerSchema,
+  }),
+  z.object({
+    action: z.literal("delete-connector"),
+    marker: markerSchema,
+  }),
+  z.object({
+    action: z.literal("seed-telegram"),
+    marker: markerSchema,
+    cutoff: z.iso.datetime(),
+    expiredCount: z.number().int().min(0).max(MAX_EXPIRED_COUNT),
+  }),
+  z.object({
+    action: z.literal("read-telegram"),
+    marker: markerSchema,
+  }),
+  z.object({
+    action: z.literal("delete-telegram"),
+    marker: markerSchema,
+  }),
+]);
+
+export const testCronDeleteCleanupsStateResponseSchema = z.object({
+  ok: z.literal(true),
+  remaining: z.array(z.string()),
+});
+
+const c = initContract();
+export const testCronDeleteCleanupsStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/cron-delete-cleanups-state/action",
+    body: actionBodySchema,
+    responses: {
+      200: testCronDeleteCleanupsStateResponseSchema,
+      400: z.object({
+        error: z.object({
+          code: z.string(),
+          message: z.string(),
+        }),
+      }),
+      404: z.string(),
+    },
+  },
+});
+
+export type TestCronDeleteCleanupsStateActionBody = z.infer<
+  typeof actionBodySchema
+>;
+export type TestCronDeleteCleanupsStateResponse = z.infer<
+  typeof testCronDeleteCleanupsStateResponseSchema
+>;
+
+const actionBody$ = bodyResultOf(testCronDeleteCleanupsStateContract.action);
+
+function connectorState(marker: string, kind: string): string {
+  return `${marker}:${kind}`;
+}
+
+function telegramMessageId(kind: string, index?: number): string {
+  return index === undefined ? kind : `${kind}-${index}`;
+}
+
+async function seedConnectorStates(
+  db: Db,
+  body: Extract<
+    TestCronDeleteCleanupsStateActionBody,
+    { readonly action: "seed-connector" }
+  >,
+  signal: AbortSignal,
+): Promise<void> {
+  const cutoff = new Date(body.cutoff);
+  const expiredStart = cutoff.getTime() - 2 * 24 * 60 * 60_000;
+  const expiredStates = Array.from(
+    { length: body.expiredCount },
+    (_, index) => {
+      return {
+        state: connectorState(body.marker, `expired-${index}`),
+        type: "github",
+        authMethod: "oauth",
+        userId: body.marker,
+        orgId: body.marker,
+        redirectUri: "https://example.test/oauth/callback",
+        expiresAt: new Date(expiredStart + index),
+      };
+    },
+  );
+  for (
+    let offset = 0;
+    offset < expiredStates.length;
+    offset += FIXTURE_INSERT_BATCH_SIZE
+  ) {
+    await db
+      .insert(connectorOauthStates)
+      .values(expiredStates.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE));
+    signal.throwIfAborted();
+  }
+  await db.insert(connectorOauthStates).values([
+    {
+      state: connectorState(body.marker, "equal"),
+      type: "github",
+      authMethod: "oauth",
+      userId: body.marker,
+      orgId: body.marker,
+      redirectUri: "https://example.test/oauth/callback",
+      expiresAt: cutoff,
+    },
+    {
+      state: connectorState(body.marker, "future"),
+      type: "github",
+      authMethod: "oauth",
+      userId: body.marker,
+      orgId: body.marker,
+      redirectUri: "https://example.test/oauth/callback",
+      expiresAt: new Date(cutoff.getTime() + 60 * 60_000),
+    },
+  ]);
+  signal.throwIfAborted();
+}
+
+async function readConnectorStates(
+  db: Db,
+  marker: string,
+  signal: AbortSignal,
+): Promise<string[]> {
+  const rows = await db
+    .select({ state: connectorOauthStates.state })
+    .from(connectorOauthStates)
+    .where(like(connectorOauthStates.state, `${marker}:%`))
+    .orderBy(asc(connectorOauthStates.state));
+  signal.throwIfAborted();
+  return rows.map((row) => {
+    return row.state;
+  });
+}
+
+async function deleteConnectorStates(
+  db: Db,
+  marker: string,
+  signal: AbortSignal,
+): Promise<void> {
+  await db
+    .delete(connectorOauthStates)
+    .where(like(connectorOauthStates.state, `${marker}:%`));
+  signal.throwIfAborted();
+}
+
+async function seedTelegramMessages(
+  db: Db,
+  body: Extract<
+    TestCronDeleteCleanupsStateActionBody,
+    { readonly action: "seed-telegram" }
+  >,
+  signal: AbortSignal,
+): Promise<void> {
+  const cutoff = new Date(body.cutoff);
+  const expiredMessages = Array.from(
+    { length: body.expiredCount },
+    (_, index) => {
+      return {
+        officialOrgId: body.marker,
+        chatId: body.marker,
+        messageId: telegramMessageId("expired", index),
+        fromUserId: body.marker,
+        createdAt: new Date(cutoff.getTime() - 1),
+      };
+    },
+  );
+  for (
+    let offset = 0;
+    offset < expiredMessages.length;
+    offset += FIXTURE_INSERT_BATCH_SIZE
+  ) {
+    await db
+      .insert(telegramMessages)
+      .values(
+        expiredMessages.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE),
+      );
+    signal.throwIfAborted();
+  }
+  await db.insert(telegramMessages).values([
+    {
+      officialOrgId: body.marker,
+      chatId: body.marker,
+      messageId: telegramMessageId("equal"),
+      fromUserId: body.marker,
+      createdAt: cutoff,
+    },
+    {
+      officialOrgId: body.marker,
+      chatId: body.marker,
+      messageId: telegramMessageId("future"),
+      fromUserId: body.marker,
+      createdAt: new Date(cutoff.getTime() + 60 * 60_000),
+    },
+  ]);
+  signal.throwIfAborted();
+}
+
+async function readTelegramMessages(
+  db: Db,
+  marker: string,
+  signal: AbortSignal,
+): Promise<string[]> {
+  const rows = await db
+    .select({ messageId: telegramMessages.messageId })
+    .from(telegramMessages)
+    .where(eq(telegramMessages.officialOrgId, marker))
+    .orderBy(asc(telegramMessages.messageId));
+  signal.throwIfAborted();
+  return rows.map((row) => {
+    return row.messageId;
+  });
+}
+
+async function deleteTelegramMessages(
+  db: Db,
+  marker: string,
+  signal: AbortSignal,
+): Promise<void> {
+  await db
+    .delete(telegramMessages)
+    .where(eq(telegramMessages.officialOrgId, marker));
+  signal.throwIfAborted();
+}
+
+function actionOk(remaining: string[] = []) {
+  return {
+    status: 200 as const,
+    body: { ok: true as const, remaining },
+  };
+}
+
+const mutateTestCronDeleteCleanupsState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(actionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const db = set(writeDb$);
+    const body = bodyResult.data;
+    switch (body.action) {
+      case "seed-connector": {
+        await seedConnectorStates(db, body, signal);
+        return actionOk();
+      }
+      case "read-connector": {
+        return actionOk(await readConnectorStates(db, body.marker, signal));
+      }
+      case "delete-connector": {
+        await deleteConnectorStates(db, body.marker, signal);
+        return actionOk();
+      }
+      case "seed-telegram": {
+        await seedTelegramMessages(db, body, signal);
+        return actionOk();
+      }
+      case "read-telegram": {
+        return actionOk(await readTelegramMessages(db, body.marker, signal));
+      }
+      case "delete-telegram": {
+        await deleteTelegramMessages(db, body.marker, signal);
+        return actionOk();
+      }
+    }
+  },
+);
+
+export const testCronDeleteCleanupsStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testCronDeleteCleanupsStateContract.action,
+    handler: mutateTestCronDeleteCleanupsState$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
@@ -14,7 +14,7 @@ import {
   testEndpointNotFoundResponse,
 } from "./test-oauth-provider-helpers";
 
-const FIXTURE_INSERT_BATCH_SIZE = 500;
+const FIXTURE_INSERT_BATCH_SIZE = 5000;
 const MAX_EXPIRED_COUNT = 10_001;
 
 const markerSchema = z.string().min(1);

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -5,7 +5,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { exportJobs } from "@vm0/db/schema/export-job";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, eq, inArray, isNotNull, lt, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, lt, lte, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -425,10 +425,9 @@ async function cleanupExpiredRunnerJobs(
   db: Db,
   signal: AbortSignal,
 ): Promise<number> {
-  const { rowCount } = await db.execute(sql`
-    DELETE FROM ${runnerJobQueue}
-    WHERE ${runnerJobQueue.expiresAt} <= now()
-  `);
+  const { rowCount } = await db
+    .delete(runnerJobQueue)
+    .where(lte(runnerJobQueue.expiresAt, sql`now()`));
   signal.throwIfAborted();
 
   const deletedCount = rowCount ?? 0;
@@ -444,10 +443,9 @@ async function cleanupExpiredCustomConnectorAuthRefs(
   db: Db,
   signal: AbortSignal,
 ): Promise<number> {
-  const { rowCount } = await db.execute(sql`
-    DELETE FROM ${agentRunCustomConnectorAuthRefs}
-    WHERE ${agentRunCustomConnectorAuthRefs.expiresAt} <= now()
-  `);
+  const { rowCount } = await db
+    .delete(agentRunCustomConnectorAuthRefs)
+    .where(lte(agentRunCustomConnectorAuthRefs.expiresAt, sql`now()`));
   signal.throwIfAborted();
 
   const deletedCount = rowCount ?? 0;

--- a/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
-import { sql } from "drizzle-orm";
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { asc, inArray, lte } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
@@ -14,16 +15,15 @@ export const cleanupConnectorOauthStates$ = command(
     let totalDeleted = 0;
 
     for (let batch = 0; batch < MAX_BATCHES; batch += 1) {
-      const { rowCount } = await db.execute(sql`
-        DELETE FROM connector_oauth_states
-        WHERE id IN (
-          SELECT id
-          FROM connector_oauth_states
-          WHERE expires_at <= ${cutoff}
-          ORDER BY expires_at
-          LIMIT ${DELETE_BATCH_SIZE}
-        )
-      `);
+      const expiredStates = db
+        .select({ id: connectorOauthStates.id })
+        .from(connectorOauthStates)
+        .where(lte(connectorOauthStates.expiresAt, cutoff))
+        .orderBy(asc(connectorOauthStates.expiresAt))
+        .limit(DELETE_BATCH_SIZE);
+      const { rowCount } = await db
+        .delete(connectorOauthStates)
+        .where(inArray(connectorOauthStates.id, expiredStates));
       signal.throwIfAborted();
 
       const batchDeleted = rowCount ?? 0;

--- a/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
@@ -14,7 +14,9 @@ export const cleanupTelegramMessages$ = command(
   async ({ set }, signal: AbortSignal): Promise<number> => {
     const db = set(writeDb$);
     const cutoffDate = nowDate();
-    cutoffDate.setDate(cutoffDate.getDate() - TELEGRAM_MESSAGE_RETENTION_DAYS);
+    cutoffDate.setUTCDate(
+      cutoffDate.getUTCDate() - TELEGRAM_MESSAGE_RETENTION_DAYS,
+    );
 
     let totalDeleted = 0;
     let batchDeleted: number;

--- a/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
@@ -1,11 +1,14 @@
 import { command } from "ccstate";
-import { sql } from "drizzle-orm";
+import { telegramMessages } from "@vm0/db/schema/telegram-message";
+import { inArray, lt, sql } from "drizzle-orm";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 
 const TELEGRAM_MESSAGE_RETENTION_DAYS = 30;
 const TELEGRAM_MESSAGE_DELETE_BATCH_SIZE = 10_000;
+const telegramMessageCtid = sql`ctid`.mapWith(pgTextDecoder);
 
 export const cleanupTelegramMessages$ = command(
   async ({ set }, signal: AbortSignal): Promise<number> => {
@@ -17,14 +20,14 @@ export const cleanupTelegramMessages$ = command(
     let batchDeleted: number;
 
     do {
-      const { rowCount } = await db.execute(sql`
-        DELETE FROM telegram_messages
-        WHERE ctid IN (
-          SELECT ctid FROM telegram_messages
-          WHERE created_at < ${cutoffDate}
-          LIMIT ${TELEGRAM_MESSAGE_DELETE_BATCH_SIZE}
-        )
-      `);
+      const expiredMessages = db
+        .select({ ctid: telegramMessageCtid })
+        .from(telegramMessages)
+        .where(lt(telegramMessages.createdAt, cutoffDate))
+        .limit(TELEGRAM_MESSAGE_DELETE_BATCH_SIZE);
+      const { rowCount } = await db
+        .delete(telegramMessages)
+        .where(inArray(telegramMessageCtid, expiredMessages));
       signal.throwIfAborted();
 
       batchDeleted = rowCount ?? 0;

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { eq, gte, inArray, lt, sql, sum } from "drizzle-orm";
+import { and, eq, gte, inArray, lt, sql, sum } from "drizzle-orm";
 import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -164,12 +164,15 @@ async function replaceModelStats(
   const windowEndParam = utcTimestampParam(windowEnd);
 
   const insertedCount = await db.transaction(async (tx) => {
-    await tx.execute(sql`
-      DELETE FROM ${modelStat}
-      WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
-        AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
-        AND ${inArray(modelStat.model, modelStatsModelIds)}
-    `);
+    await tx
+      .delete(modelStat)
+      .where(
+        and(
+          gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`),
+          lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
+          inArray(modelStat.model, modelStatsModelIds),
+        ),
+      );
 
     const { rowCount } = await tx.execute(sql`
       WITH usage_rows AS (

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -71,6 +71,21 @@ const structuredSelectionPreamble = `
   declare const db: DrizzleDatabase;
 `;
 
+const deletePreamble = `
+  import { integer, pgTable, timestamp } from "drizzle-orm/pg-core";
+
+  const cleanupRows = pgTable("cleanup_rows", {
+    id: integer("id").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+  });
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      cleanupRows: typeof cleanupRows;
+    }>;
+  declare const db: DrizzleDatabase;
+  declare const cutoff: Date;
+`;
+
 const scalarQuery = `
   sql\`(
     SELECT "message"."id"
@@ -114,6 +129,113 @@ const runnerLockingQuery = `
 
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        const query = sql\`
+          DELETE FROM cleanup_rows
+          WHERE expires_at <= \${cutoff}
+        \`;
+        await db.execute(query);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        const fakeDb = {
+          async execute(query: unknown) {
+            return query;
+          },
+        };
+        await fakeDb.execute(sql\`
+          DELETE FROM cleanup_rows
+          WHERE expires_at <= \${cutoff}
+        \`);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        function sql(
+          strings: TemplateStringsArray,
+          ...values: readonly unknown[]
+        ) {
+          return { strings, values };
+        }
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+          WHERE expires_at <= \${cutoff}
+        \`);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          WITH expired AS (
+            SELECT id FROM cleanup_rows WHERE expires_at <= \${cutoff}
+          )
+          DELETE FROM cleanup_rows
+          WHERE id IN (SELECT id FROM expired)
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+          USING other_rows
+          WHERE cleanup_rows.id = other_rows.id
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+          WHERE expires_at <= \${cutoff}
+          RETURNING id
+        \`);
+        await db.execute(sql\`
+          DELETE FROM ONLY cleanup_rows
+          WHERE expires_at <= \${cutoff}
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows *
+          WHERE expires_at <= \${cutoff}
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+          WHERE CURRENT OF cleanup_cursor
+        \`);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows AS target
+          WHERE target.expires_at <= \${cutoff}
+        \`);
+        await db.execute(sql\`
+          DELETE FROM public.cleanup_rows
+          WHERE expires_at <= \${cutoff}
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows, other_rows
+          WHERE cleanup_rows.id = other_rows.id
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+        \`);
+        await db.execute(sql\`
+          DELETE FROM cleanup_rows
+          WHERE expires_at <= \${cutoff};
+          SELECT 1
+        \`);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const notATable = sql\`cleanup_rows\`;
+        await db.execute(sql\`
+          DELETE FROM \${notATable}
+          WHERE \${eq(cleanupRows.id, 1)}
+        \`);
+      `,
+    },
     {
       code: `
         import { sql } from "drizzle-orm";
@@ -647,6 +769,65 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
     },
   ],
   invalid: [
+    {
+      code: `${deletePreamble}
+        import { lte, sql } from "drizzle-orm";
+        const { rowCount } = await db.execute(sql\`
+          DELETE FROM \${cleanupRows}
+          WHERE \${lte(cleanupRows.expiresAt, cutoff)}
+        \`);
+        void rowCount;
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { gte, inArray, lt, sql } from "drizzle-orm";
+        declare const windowStart: Date;
+        declare const windowEnd: Date;
+        await db.execute(sql\`
+          DELETE FROM \${cleanupRows}
+          WHERE \${gte(cleanupRows.expiresAt, windowStart)}
+            AND \${lt(cleanupRows.expiresAt, windowEnd)}
+            AND \${inArray(cleanupRows.id, [1, 2])}
+        \`);
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql as query } from "drizzle-orm";
+        await db.execute(query\`
+          DELETE FROM cleanup_rows
+          WHERE id IN (
+            SELECT id
+            FROM cleanup_rows
+            WHERE expires_at <= \${cutoff}
+              AND 'RETURNING ignored' = 'RETURNING ignored'
+              /* USING and DELETE FROM ignored */
+            ORDER BY expires_at
+            LIMIT \${1000}
+          );
+        \`);
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import * as drizzle from "drizzle-orm";
+        const { rowCount } = await db["execute"](drizzle.sql\`
+          DELETE FROM cleanup_rows
+          WHERE ctid IN (
+            SELECT ctid
+            FROM cleanup_rows
+            WHERE expires_at < \${cutoff}
+            LIMIT \${10_000}
+          )
+        \`);
+        void rowCount;
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -76,6 +76,10 @@ interface SimpleLockingSelectMatch {
   readonly sourceTableExpressionIndex: number | undefined;
 }
 
+interface SimpleDeleteMatch {
+  readonly targetTableExpressionIndex: number | undefined;
+}
+
 const RESULT_FIELD_ARGUMENT = new Map<string, number>([
   ["returning", 0],
   ["select", 0],
@@ -125,6 +129,16 @@ const UNSUPPORTED_LOCKING_SELECT_KEYWORDS = new Set([
   "USING",
   "WINDOW",
   "WITH",
+]);
+
+const UNSUPPORTED_DELETE_PREDICATE_KEYWORDS = new Set([
+  "CURRENT",
+  "FETCH",
+  "LIMIT",
+  "OFFSET",
+  "ORDER",
+  "RETURNING",
+  "USING",
 ]);
 
 function quasiText(node: TSESTree.TemplateElement): string {
@@ -268,6 +282,70 @@ function onlyWhitespaceBetween(
   right: SqlToken,
 ): boolean {
   return source.slice(left.end, right.start).trim() === "";
+}
+
+function simpleDeleteMatch(
+  syntaxSource: string,
+): SimpleDeleteMatch | undefined {
+  const tokens = topLevelTokens(syntaxSource);
+  if (tokens === undefined) {
+    return undefined;
+  }
+
+  let end = tokens.length;
+  const trailingToken = tokens[end - 1];
+  if (trailingToken?.kind === "punctuation" && trailingToken.value === ";") {
+    if (syntaxSource.slice(trailingToken.end).trim() !== "") {
+      return undefined;
+    }
+    end -= 1;
+  } else if (
+    trailingToken === undefined ||
+    syntaxSource.slice(trailingToken.end).trim() !== ""
+  ) {
+    return undefined;
+  }
+
+  const statementTokens = tokens.slice(0, end);
+  const deleteKeyword = statementTokens[0];
+  const fromKeyword = statementTokens[1];
+  const targetTable = statementTokens[2];
+  const whereKeyword = statementTokens[3];
+  if (
+    statementTokens.length <= 4 ||
+    !isWord(deleteKeyword, "DELETE") ||
+    !isWord(fromKeyword, "FROM") ||
+    (targetTable?.kind !== "word" && targetTable?.kind !== "expression") ||
+    !isWord(whereKeyword, "WHERE") ||
+    deleteKeyword === undefined ||
+    fromKeyword === undefined ||
+    whereKeyword === undefined ||
+    !onlyWhitespaceBetween(syntaxSource, deleteKeyword, fromKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, fromKeyword, targetTable) ||
+    !onlyWhitespaceBetween(syntaxSource, targetTable, whereKeyword)
+  ) {
+    return undefined;
+  }
+
+  if (
+    statementTokens.slice(4).some((token) => {
+      return (
+        (token.kind === "word" &&
+          UNSUPPORTED_DELETE_PREDICATE_KEYWORDS.has(token.value)) ||
+        (token.kind === "punctuation" &&
+          (token.value === "," || token.value === ";"))
+      );
+    })
+  ) {
+    return undefined;
+  }
+
+  return {
+    targetTableExpressionIndex:
+      targetTable.kind === "expression"
+        ? targetTable.expressionIndex
+        : undefined,
+  };
 }
 
 function simpleLockingSelectMatch(
@@ -673,7 +751,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete simple selects, locking selects, and scalar result queries",
+        "Prefer Drizzle query builders for complete simple deletes, selects, locking selects, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -683,6 +761,8 @@ export const preferDrizzleQueryBuilder = createRule({
         "Use a Drizzle select builder for this complete schema-backed query.",
       lockingQueryBuilder:
         "Use a Drizzle select builder with .for(...) for this complete locking query.",
+      deleteQueryBuilder:
+        "Use a Drizzle delete builder for this complete single-target query.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -763,6 +843,18 @@ export const preferDrizzleQueryBuilder = createRule({
             isRawRowsModule(importSource(declaration))
           );
         }) === true
+      );
+    }
+
+    function isDrizzleExecuteMember(node: TSESTree.MemberExpression): boolean {
+      if (memberName(node) !== "execute") {
+        return false;
+      }
+      const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
+      return (
+        checker
+          .getSymbolAtLocation(tsProperty)
+          ?.declarations?.some(isDrizzleDeclaration) === true
       );
     }
 
@@ -1178,8 +1270,58 @@ export const preferDrizzleQueryBuilder = createRule({
       inspectSelectionContainer(fields, new Set<TSESTree.Node>());
     }
 
+    function inspectCompleteDelete(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "execute" ||
+        node.arguments.length !== 1
+      ) {
+        return;
+      }
+      const query = node.arguments[0];
+      if (
+        query === undefined ||
+        query.type !== AST_NODE_TYPES.TaggedTemplateExpression
+      ) {
+        return;
+      }
+
+      const source = query.quasi.quasis
+        .map(quasiText)
+        .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
+      const match = simpleDeleteMatch(sqlCodeMask(source));
+      if (
+        match === undefined ||
+        !isDrizzleSqlTag(checker, services, query.tag) ||
+        !isDrizzleExecuteMember(node.callee)
+      ) {
+        return;
+      }
+
+      const targetTableExpressionIndex = match.targetTableExpressionIndex;
+      if (targetTableExpressionIndex !== undefined) {
+        const targetTable = query.quasi.expressions[targetTableExpressionIndex];
+        if (targetTable === undefined) {
+          return;
+        }
+        const targetTableType = expressionType(targetTable);
+        if (
+          !isDrizzleTableType(
+            checker,
+            targetTableType.type,
+            targetTableType.location,
+          )
+        ) {
+          return;
+        }
+      }
+
+      context.report({ node: query, messageId: "deleteQueryBuilder" });
+    }
+
     return {
       CallExpression(node: TSESTree.CallExpression): void {
+        inspectCompleteDelete(node);
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           RESULT_FIELD_ARGUMENT.has(memberName(node.callee) ?? "")


### PR DESCRIPTION
## Summary

- replace all five complete top-level raw `DELETE` statements with Drizzle delete/select builders while preserving database-clock predicates, the model-stat transaction, batch limits, ordering, loop termination, and `rowCount`
- keep PostgreSQL `ctid` as the only irreducible mapped SQL leaf and make connector/Telegram timestamp cutoffs UTC-stable through schema-column encoding and UTC retention arithmetic
- extend `api/prefer-drizzle-query-builder` with a conservative type-aware diagnostic for direct complete single-target deletes
- add real-database route coverage for exact batch boundaries, UTC/non-UTC and daylight-saving cutoffs, empty batches, and model-stat transaction rollback

## Compatibility and exclusions

- each delete remains one PostgreSQL statement and one round trip per batch
- no schema, migration, persisted-data rewrite, production API contract, feature switch, compatibility shim, or deployment coordination is required
- CTE-led deletes, `USING`, `RETURNING`, inheritance/`ONLY`, aliases, qualified or multiple targets, multi-statement SQL, and indirect query flow remain outside the lint boundary
- the dedicated fixture route is test-only and is not mounted by production route composition

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-query-builder.test.ts` — 72 tests passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts src/signals/routes/__tests__/cron-delete-cleanups.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts --maxWorkers=1` — 38 tests passed
- `pnpm -F api lint`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm check-types` — 13 workspaces passed
- `pnpm knip`
- `git diff --check`
- rendered-SQL comparison confirmed unchanged tables, predicates, casts, parameter ordering, limits, and statement counts; the intentional Date parameter change is UTC-stable in UTC, Asia/Shanghai, and across an America/New_York daylight-saving boundary
- representative real PostgreSQL `EXPLAIN (ANALYZE, BUFFERS)` runs retained the connector expiry-index plan and Telegram `ctid` batch plan with no material execution-time regression
- `TIMING=100 pnpm -F api exec eslint . --max-warnings 0` — `api/prefer-drizzle-query-builder` 69.646 ms versus 69.991 ms baseline

Closes #22699

Parent context: #22439
