### PR TITLE
feat(activity): show millisecond timestamps and run offsets

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -18,6 +18,7 @@ import {
   scrollToBottomActivityDetail$,
 } from "./activity-detail-scroll.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { formatActivityClockTime } from "./activity-time.ts";
 
 // ---------------------------------------------------------------------------
 // Filters — URL-derived
@@ -370,17 +371,7 @@ export const zeroActivityVisibleMessages$ = computed(async (get) => {
 // ---------------------------------------------------------------------------
 
 export function formatLogTime(createdAt: string): string {
-  const date = new Date(createdAt);
-  if (Number.isNaN(date.getTime())) {
-    return createdAt.trim().length > 0 ? createdAt : "—";
-  }
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-  const ampm = hours >= 12 ? "PM" : "AM";
-  const h12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-  return `${month}/${day} ${String(h12).padStart(2, "0")}:${String(minutes).padStart(2, "0")} ${ampm}`;
+  return formatActivityClockTime(createdAt);
 }
 
 export function formatDuration(

--- a/turbo/apps/platform/src/signals/activity-page/activity-time.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-time.ts
@@ -1,0 +1,61 @@
+function pad(value: number, length: number): string {
+  return String(value).padStart(length, "0");
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Format an activity timestamp without the calendar date. */
+export function formatActivityClockTime(timestamp: string): string {
+  const date = parseTimestamp(timestamp);
+  if (!date) {
+    return timestamp.trim().length > 0 ? timestamp : "—";
+  }
+
+  return `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(
+    date.getSeconds(),
+    2,
+  )}.${pad(date.getMilliseconds(), 3)}`;
+}
+
+function formatSignedElapsedTime(deltaMs: number): string {
+  const sign = deltaMs < 0 ? "-" : "+";
+  const absoluteMs = Math.abs(Math.round(deltaMs));
+  const hours = Math.floor(absoluteMs / 3_600_000);
+  const minutes = Math.floor(absoluteMs / 60_000) % 60;
+  const seconds = Math.floor(absoluteMs / 1000) % 60;
+  const milliseconds = absoluteMs % 1000;
+  const clock =
+    hours > 0
+      ? `${pad(hours, 2)}:${pad(minutes, 2)}:${pad(seconds, 2)}.${pad(milliseconds, 3)}`
+      : `${pad(minutes, 2)}:${pad(seconds, 2)}.${pad(milliseconds, 3)}`;
+
+  return `${sign}${clock}`;
+}
+
+/**
+ * Format an event timestamp and, when available, its offset from run start.
+ * The offset uses a signed race-timing style so events before the recorded
+ * start remain distinguishable too.
+ */
+export function formatActivityEventTime(
+  timestamp: string,
+  startedAt?: string | null,
+): string {
+  const formatted = formatActivityClockTime(timestamp);
+  const eventDate = parseTimestamp(timestamp);
+  const startDate = parseTimestamp(startedAt);
+  if (!eventDate || !startDate) {
+    return formatted;
+  }
+
+  return `${formatted} (${formatSignedElapsedTime(
+    eventDate.getTime() - startDate.getTime(),
+  )})`;
+}

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
@@ -435,6 +435,13 @@ describe("activity inspect page", () => {
     });
     expect(screen.getByText("Done")).toBeInTheDocument();
     expect(screen.getByText("5.0s")).toBeInTheDocument();
+    expect(screen.getByText(/^\d{2}:\d{2}:\d{2}\.000$/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/^\d{2}:\d{2}:\d{2}\.000 \(\+00:01\.000\)$/),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByText(/^\d{2}:\d{2}:\d{2}\.000 \(\+00:03\.000\)$/),
+    ).toHaveLength(2);
     expect(
       screen.getByText("Collected OAuth evidence from network logs."),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -183,6 +183,7 @@ function prepareInspectData(data: InspectLogData) {
       nullableStringValue(meta?.completedAt),
     ),
     time: createdAt ? formatLogTime(createdAt) : "—",
+    startedAt: nullableStringValue(meta?.startedAt),
     prompt: stringValue(meta?.prompt) ?? "",
     appendSystemPrompt: stringValue(meta?.appendSystemPrompt) ?? "",
   };
@@ -238,6 +239,7 @@ function StepsTab({
         messages={messages}
         stepSearch={stepSearch}
         isLoading={false}
+        startedAt={prepared.startedAt}
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
@@ -5,9 +5,9 @@ import {
   IconRobot,
   IconTerminal,
 } from "@tabler/icons-react";
-import { nowDate } from "../../../../lib/time.ts";
 import { Markdown } from "../../../components/markdown.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "@vm0/ui";
+import { formatActivityEventTime } from "../../../../signals/activity-page/activity-time.ts";
 
 type ModelUsage = Record<
   string,
@@ -19,31 +19,11 @@ type ModelUsage = Record<
 >;
 
 // Exported for reuse
-export function formatEventTime(isoString: string): string {
-  const date = new Date(isoString);
-  if (Number.isNaN(date.getTime())) {
-    return isoString.trim().length > 0 ? isoString : "—";
-  }
-  const now = nowDate();
-  const isToday = date.toDateString() === now.toDateString();
-
-  if (isToday) {
-    return date.toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    });
-  }
-
-  return date.toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
+export function formatEventTime(
+  isoString: string,
+  startedAt?: string | null,
+): string {
+  return formatActivityEventTime(isoString, startedAt);
 }
 
 // Exported for reuse

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -20,6 +20,7 @@ interface GroupedMessageCardProps {
   currentMatchIndex?: number;
   matchStartIndex?: number;
   showConnector?: boolean;
+  startedAt?: string | null;
 }
 
 // Layout constants
@@ -169,6 +170,7 @@ export function GroupedMessageCard({
   currentMatchIndex,
   matchStartIndex = 0,
   showConnector = false,
+  startedAt,
 }: GroupedMessageCardProps) {
   // System event
   if (message.type === "system") {
@@ -177,6 +179,7 @@ export function GroupedMessageCard({
         message={message}
         searchTerm={searchTerm}
         showConnector={showConnector}
+        startedAt={startedAt}
       />
     );
   }
@@ -184,7 +187,11 @@ export function GroupedMessageCard({
   // Result event
   if (message.type === "result") {
     return (
-      <ResultMessageCard message={message} showConnector={showConnector} />
+      <ResultMessageCard
+        message={message}
+        showConnector={showConnector}
+        startedAt={startedAt}
+      />
     );
   }
 
@@ -195,6 +202,7 @@ export function GroupedMessageCard({
         message={message}
         searchTerm={searchTerm}
         showConnector={showConnector}
+        startedAt={startedAt}
       />
     );
   }
@@ -207,6 +215,7 @@ export function GroupedMessageCard({
       currentMatchIndex={currentMatchIndex}
       matchStartIndex={matchStartIndex}
       showConnector={showConnector}
+      startedAt={startedAt}
     />
   );
 }
@@ -215,10 +224,12 @@ function TaskMessageCard({
   message,
   searchTerm,
   showConnector = false,
+  startedAt,
 }: {
   message: GroupedMessage;
   searchTerm?: string;
   showConnector?: boolean;
+  startedAt?: string | null;
 }) {
   const taskData = isTaskEventData(message.eventData)
     ? message.eventData
@@ -230,7 +241,7 @@ function TaskMessageCard({
   const taskStatus = stringValue(taskData?.task_status);
   const isFailed = isFailedTaskStatus(taskStatus);
   const isRunning = !taskStatus;
-  const timestamp = formatEventTime(message.createdAt);
+  const timestamp = formatEventTime(message.createdAt, startedAt);
   const children = message.childMessages ?? [];
   const hasChildren = children.length > 0;
 
@@ -320,6 +331,7 @@ function TaskMessageCard({
                 message={child}
                 searchTerm={searchTerm}
                 showConnector={i < children.length - 1}
+                startedAt={startedAt}
               />
             );
           })}
@@ -333,10 +345,12 @@ function SystemMessageCard({
   message,
   searchTerm,
   showConnector = false,
+  startedAt,
 }: {
   message: GroupedMessage;
   searchTerm?: string;
   showConnector?: boolean;
+  startedAt?: string | null;
 }) {
   const eventData = isRecord(message.eventData) ? message.eventData : {};
   const subtype =
@@ -349,11 +363,12 @@ function SystemMessageCard({
         message={message}
         searchTerm={searchTerm}
         showConnector={showConnector}
+        startedAt={startedAt}
       />
     );
   }
 
-  const timestamp = formatEventTime(message.createdAt);
+  const timestamp = formatEventTime(message.createdAt, startedAt);
   return (
     <div className={`${MESSAGE_SPACING} relative`}>
       {showConnector && (
@@ -384,12 +399,14 @@ function SystemMessageCard({
 function ResultMessageCard({
   message,
   showConnector = false,
+  startedAt,
 }: {
   message: GroupedMessage;
   showConnector?: boolean;
+  startedAt?: string | null;
 }) {
   const eventData = isRecord(message.eventData) ? message.eventData : {};
-  const timestamp = formatEventTime(message.createdAt);
+  const timestamp = formatEventTime(message.createdAt, startedAt);
   const isError = eventData.is_error === true || eventData.success === false;
   return (
     <div className="relative">
@@ -477,10 +494,12 @@ function TodoCard({
   message,
   searchTerm,
   showConnector = false,
+  startedAt,
 }: {
   message: GroupedMessage;
   searchTerm?: string;
   showConnector?: boolean;
+  startedAt?: string | null;
 }) {
   const todoItems = message.todoState ?? [];
   const operationErrors = getTodoOperationErrors(message);
@@ -508,7 +527,7 @@ function TodoCard({
       })),
   );
 
-  const timestamp = formatEventTime(message.createdAt);
+  const timestamp = formatEventTime(message.createdAt, startedAt);
   const todoKeyCounts = new Map<string, number>();
   return (
     <div className={`${MESSAGE_SPACING} relative`}>
@@ -817,12 +836,14 @@ function AssistantMessageCard({
   currentMatchIndex,
   matchStartIndex,
   showConnector = false,
+  startedAt,
 }: {
   message: GroupedMessage;
   searchTerm?: string;
   currentMatchIndex?: number;
   matchStartIndex?: number;
   showConnector?: boolean;
+  startedAt?: string | null;
 }) {
   const { thinkingBlocks, textBefore, textAfter, toolOperations } = message;
   const thinkingText = thinkingBlocks?.join("\n\n");
@@ -831,7 +852,7 @@ function AssistantMessageCard({
   const textBeforeMatches = countMatches(textBefore, searchTerm);
   const thinkingMatches = countMatches(thinkingText, searchTerm);
   const elements: React.ReactNode[] = [];
-  const timestamp = formatEventTime(message.createdAt);
+  const timestamp = formatEventTime(message.createdAt, startedAt);
 
   if (thinkingText) {
     const isLastElement = !textBefore && !hasTools && !textAfter;

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -441,6 +441,7 @@ function ActivityStepsContent({
         messages={messages}
         stepSearch={stepSearch}
         isLoading={visibleMessagesLoading}
+        startedAt={detail.startedAt}
       />
     </div>
   );
@@ -820,12 +821,14 @@ export function StepsList({
   messages,
   stepSearch,
   isLoading,
+  startedAt,
 }: {
   prompt: string;
   appendSystemPrompt: string;
   messages: GroupedMessage[];
   stepSearch: string;
   isLoading: boolean;
+  startedAt?: string | null;
 }) {
   const normalizedStepSearch = stepSearch.trim();
   const hasSystemPrompt = appendSystemPrompt.trim().length > 0;
@@ -867,6 +870,7 @@ export function StepsList({
               message={message}
               searchTerm={normalizedStepSearch}
               showConnector={index < messages.length - 1}
+              startedAt={startedAt}
             />
           );
         })


### PR DESCRIPTION
## Summary

- Show activity timestamps as local HH:MM:SS.mmm values without calendar dates.
- Append each event offset from the run start in signed race-timing format.
- Apply the formatting to live activity details, imported activity logs, and activity list/header timestamps.

## Verification

- Platform type-check passed.
- Activity page test suite passed: 5 files, 36 tests.
- Activity inspect regression test passed: 8 tests.
- Targeted oxlint and eslint checks passed.
- Local browser verification was blocked because the checkout lacks VITE_CLERK_PUBLISHABLE_KEY_PREVIEW; the page remained on the bootstrap skeleton.