### PR TITLE
fix(runner): classify dns readiness network boundary

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -153,6 +153,31 @@ rule_packet_count() {
   '
 }
 
+link_fields() {
+  local expected_ifname=$1
+  jq -er --arg expected_ifname "$expected_ifname" '
+    if type == "array"
+      and length == 1
+      and .[0].ifname == $expected_ifname
+    then
+      [
+        .[0].ifindex,
+        .[0].link_index,
+        .[0].stats64.rx.packets,
+        .[0].stats64.rx.bytes,
+        .[0].stats64.rx.errors,
+        .[0].stats64.rx.dropped,
+        .[0].stats64.tx.packets,
+        .[0].stats64.tx.bytes,
+        .[0].stats64.tx.errors,
+        .[0].stats64.tx.dropped
+      ] | @tsv
+    else
+      error("expected exactly one link named \($expected_ifname)")
+    end
+  '
+}
+
 send_udp_dns_query() {
   local namespace=$1 source_ip=$2
   sudo ip netns exec "$namespace" python3 - "$source_ip" <<'PY'
@@ -443,7 +468,78 @@ ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
   | head -n 1 || true)
 ATTACKER_GUARD_BEFORE=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
 [ -n "$ATTACKER_GUARD_BEFORE" ] || fail "source guard counter missing"
+
+ATTACKER_NS_LINK_BEFORE=$(sudo ip -n "$ATTACKER_NS" -j -s \
+  link show dev veth0)
+ATTACKER_ROOT_LINK_BEFORE=$(sudo ip -j -s link show dev "$ATTACKER_IF")
+IFS=$'\t' read -r \
+  ATTACKER_NS_IFINDEX_BEFORE ATTACKER_NS_LINK_INDEX_BEFORE \
+  ATTACKER_NS_RX_PACKETS_BEFORE ATTACKER_NS_RX_BYTES_BEFORE \
+  ATTACKER_NS_RX_ERRORS_BEFORE ATTACKER_NS_RX_DROPPED_BEFORE \
+  ATTACKER_NS_TX_PACKETS_BEFORE ATTACKER_NS_TX_BYTES_BEFORE \
+  ATTACKER_NS_TX_ERRORS_BEFORE ATTACKER_NS_TX_DROPPED_BEFORE \
+  <<< "$(printf '%s\n' "$ATTACKER_NS_LINK_BEFORE" | link_fields veth0)"
+IFS=$'\t' read -r \
+  ATTACKER_ROOT_IFINDEX_BEFORE ATTACKER_ROOT_LINK_INDEX_BEFORE \
+  ATTACKER_ROOT_RX_PACKETS_BEFORE ATTACKER_ROOT_RX_BYTES_BEFORE \
+  ATTACKER_ROOT_RX_ERRORS_BEFORE ATTACKER_ROOT_RX_DROPPED_BEFORE \
+  ATTACKER_ROOT_TX_PACKETS_BEFORE ATTACKER_ROOT_TX_BYTES_BEFORE \
+  ATTACKER_ROOT_TX_ERRORS_BEFORE ATTACKER_ROOT_TX_DROPPED_BEFORE \
+  <<< "$(printf '%s\n' "$ATTACKER_ROOT_LINK_BEFORE" \
+    | link_fields "$ATTACKER_IF")"
+[ "$ATTACKER_NS_IFINDEX_BEFORE" -eq "$ATTACKER_ROOT_LINK_INDEX_BEFORE" ] \
+  && [ "$ATTACKER_NS_LINK_INDEX_BEFORE" -eq "$ATTACKER_ROOT_IFINDEX_BEFORE" ] \
+  || fail "attacker veth peers do not have reciprocal identities"
+
 send_udp_dns_query "$ATTACKER_NS" "$ATTACKER_PEER"
+
+ATTACKER_NS_LINK_AFTER=$(sudo ip -n "$ATTACKER_NS" -j -s \
+  link show dev veth0)
+ATTACKER_ROOT_LINK_AFTER=$(sudo ip -j -s link show dev "$ATTACKER_IF")
+IFS=$'\t' read -r \
+  ATTACKER_NS_IFINDEX_AFTER ATTACKER_NS_LINK_INDEX_AFTER \
+  ATTACKER_NS_RX_PACKETS_AFTER ATTACKER_NS_RX_BYTES_AFTER \
+  ATTACKER_NS_RX_ERRORS_AFTER ATTACKER_NS_RX_DROPPED_AFTER \
+  ATTACKER_NS_TX_PACKETS_AFTER ATTACKER_NS_TX_BYTES_AFTER \
+  ATTACKER_NS_TX_ERRORS_AFTER ATTACKER_NS_TX_DROPPED_AFTER \
+  <<< "$(printf '%s\n' "$ATTACKER_NS_LINK_AFTER" | link_fields veth0)"
+IFS=$'\t' read -r \
+  ATTACKER_ROOT_IFINDEX_AFTER ATTACKER_ROOT_LINK_INDEX_AFTER \
+  ATTACKER_ROOT_RX_PACKETS_AFTER ATTACKER_ROOT_RX_BYTES_AFTER \
+  ATTACKER_ROOT_RX_ERRORS_AFTER ATTACKER_ROOT_RX_DROPPED_AFTER \
+  ATTACKER_ROOT_TX_PACKETS_AFTER ATTACKER_ROOT_TX_BYTES_AFTER \
+  ATTACKER_ROOT_TX_ERRORS_AFTER ATTACKER_ROOT_TX_DROPPED_AFTER \
+  <<< "$(printf '%s\n' "$ATTACKER_ROOT_LINK_AFTER" \
+    | link_fields "$ATTACKER_IF")"
+[ "$ATTACKER_NS_IFINDEX_AFTER" -eq "$ATTACKER_NS_IFINDEX_BEFORE" ] \
+  && [ "$ATTACKER_NS_LINK_INDEX_AFTER" -eq "$ATTACKER_NS_LINK_INDEX_BEFORE" ] \
+  && [ "$ATTACKER_ROOT_IFINDEX_AFTER" -eq "$ATTACKER_ROOT_IFINDEX_BEFORE" ] \
+  && [ "$ATTACKER_ROOT_LINK_INDEX_AFTER" -eq "$ATTACKER_ROOT_LINK_INDEX_BEFORE" ] \
+  || fail "attacker veth identity changed during the control query"
+[ "$ATTACKER_NS_IFINDEX_AFTER" -eq "$ATTACKER_ROOT_LINK_INDEX_AFTER" ] \
+  && [ "$ATTACKER_NS_LINK_INDEX_AFTER" -eq "$ATTACKER_ROOT_IFINDEX_AFTER" ] \
+  || fail "attacker veth peers lost reciprocal identities"
+
+ATTACKER_NS_TX_PACKET_DELTA=$((ATTACKER_NS_TX_PACKETS_AFTER -
+  ATTACKER_NS_TX_PACKETS_BEFORE))
+ATTACKER_NS_TX_BYTE_DELTA=$((ATTACKER_NS_TX_BYTES_AFTER -
+  ATTACKER_NS_TX_BYTES_BEFORE))
+ATTACKER_ROOT_RX_PACKET_DELTA=$((ATTACKER_ROOT_RX_PACKETS_AFTER -
+  ATTACKER_ROOT_RX_PACKETS_BEFORE))
+ATTACKER_ROOT_RX_BYTE_DELTA=$((ATTACKER_ROOT_RX_BYTES_AFTER -
+  ATTACKER_ROOT_RX_BYTES_BEFORE))
+[ "$ATTACKER_NS_TX_PACKET_DELTA" -gt 0 ] \
+  && [ "$ATTACKER_NS_TX_PACKET_DELTA" -eq "$ATTACKER_ROOT_RX_PACKET_DELTA" ] \
+  || fail "control query did not produce matching namespace TX and root RX packets"
+[ "$ATTACKER_NS_TX_BYTE_DELTA" -gt 0 ] \
+  && [ "$ATTACKER_NS_TX_BYTE_DELTA" -eq "$ATTACKER_ROOT_RX_BYTE_DELTA" ] \
+  || fail "control query did not produce matching namespace TX and root RX bytes"
+[ "$ATTACKER_NS_TX_ERRORS_AFTER" -eq "$ATTACKER_NS_TX_ERRORS_BEFORE" ] \
+  && [ "$ATTACKER_NS_TX_DROPPED_AFTER" -eq "$ATTACKER_NS_TX_DROPPED_BEFORE" ] \
+  && [ "$ATTACKER_ROOT_RX_ERRORS_AFTER" -eq "$ATTACKER_ROOT_RX_ERRORS_BEFORE" ] \
+  && [ "$ATTACKER_ROOT_RX_DROPPED_AFTER" -eq "$ATTACKER_ROOT_RX_DROPPED_BEFORE" ] \
+  || fail "control query incremented veth error or drop counters"
+
 ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
   | grep -F -- "$ATTACKER_NS" \
   | grep -F -- "-A PREROUTING" \

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -5,6 +5,7 @@ mod invariant;
 mod leak_cleaner;
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -24,6 +25,10 @@ use crate::factory::create_transaction::{
     rollback_create_transaction,
 };
 use crate::factory::leak_cleaner::LeakCleaner;
+use crate::guest_dns_network_evidence::{
+    GuestDnsNetworkEvidenceBaseline, GuestDnsNetworkEvidenceTarget,
+    capture_guest_dns_network_evidence_baseline,
+};
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
@@ -218,61 +223,64 @@ impl FirecrackerFactory {
         };
         let mut tx = SandboxCreateTransaction::new_with_leak_tx(id.clone(), leak_tx.clone());
 
-        let create_result: sandbox::Result<SandboxCreateResources> =
-            async {
-                // Prepare the stable sandbox workspace before acquiring a
-                // connected COW pair. This keeps all await points before
-                // checkout and makes the final pair transfer cancellation-safe.
-                let target_workspace = self.factory_paths.workspace(&id);
-                clean_stale_workspace_dir(&id, &target_workspace)?;
-                tx.track_workspace(target_workspace.clone())?;
-                std::fs::create_dir_all(&target_workspace).map_err(|error| {
-                    SandboxError::Initialization {
-                        phase: SandboxInitializationPhase::SandboxAllocation,
-                        message: format!("create target workspace: {error}"),
-                    }
-                })?;
-                let sandbox_paths = SandboxPaths::new(target_workspace);
-
-                if let Some(workspace_drive) = config.workspace_drive.as_ref() {
-                    let stage_started = Instant::now();
-                    let prepare_result = prepare_workspace_drive_image(
-                        &sandbox_paths.workspace_image(),
-                        workspace_drive,
-                        Some(&mut timing),
-                    )
-                    .await;
-                    timing.record_stage_result(
-                        SandboxCreateStage::WorkspaceDrivePrepare,
-                        stage_started,
-                        prepare_result,
-                    )?;
+        let create_result: sandbox::Result<(
+            SandboxCreateResources,
+            Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
+        )> = async {
+            // Prepare the stable sandbox workspace before acquiring a
+            // connected COW pair. This keeps all await points before
+            // checkout and makes the final pair transfer cancellation-safe.
+            let target_workspace = self.factory_paths.workspace(&id);
+            clean_stale_workspace_dir(&id, &target_workspace)?;
+            tx.track_workspace(target_workspace.clone())?;
+            std::fs::create_dir_all(&target_workspace).map_err(|error| {
+                SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::SandboxAllocation,
+                    message: format!("create target workspace: {error}"),
                 }
+            })?;
+            let sandbox_paths = SandboxPaths::new(target_workspace);
 
-                // Clean stale sock dir and create vsock directory.
+            if let Some(workspace_drive) = config.workspace_drive.as_ref() {
                 let stage_started = Instant::now();
-                let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
-                let sock_result = match clean_stale_sock_dir(&id, sock_paths.dir()) {
-                    Ok(()) => {
-                        tx.track_sock_dir(sock_paths.dir().to_owned());
-                        prepare_runtime_socket_dir(&sock_paths).map_err(|e| {
-                            SandboxError::Initialization {
-                                phase: SandboxInitializationPhase::SandboxAllocation,
-                                message: format!("prepare sock dir: {e}"),
-                            }
-                        })
-                    }
-                    Err(e) => Err(e),
-                };
+                let prepare_result = prepare_workspace_drive_image(
+                    &sandbox_paths.workspace_image(),
+                    workspace_drive,
+                    Some(&mut timing),
+                )
+                .await;
                 timing.record_stage_result(
-                    SandboxCreateStage::SockDirPrepare,
+                    SandboxCreateStage::WorkspaceDrivePrepare,
                     stage_started,
-                    sock_result,
+                    prepare_result,
                 )?;
+            }
 
-                // Acquire a network namespace from the pool.
-                let stage_started = Instant::now();
-                let network = timing.record_stage_result(
+            // Clean stale sock dir and create vsock directory.
+            let stage_started = Instant::now();
+            let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
+            let sock_result = match clean_stale_sock_dir(&id, sock_paths.dir()) {
+                Ok(()) => {
+                    tx.track_sock_dir(sock_paths.dir().to_owned());
+                    prepare_runtime_socket_dir(&sock_paths).map_err(|e| {
+                        SandboxError::Initialization {
+                            phase: SandboxInitializationPhase::SandboxAllocation,
+                            message: format!("prepare sock dir: {e}"),
+                        }
+                    })
+                }
+                Err(e) => Err(e),
+            };
+            timing.record_stage_result(
+                SandboxCreateStage::SockDirPrepare,
+                stage_started,
+                sock_result,
+            )?;
+
+            // Acquire a network namespace from the pool.
+            let stage_started = Instant::now();
+            let mut network =
+                timing.record_stage_result(
                     SandboxCreateStage::NetnsAcquire,
                     stage_started,
                     resources.netns_pool.acquire().await.map_err(|e| {
@@ -282,12 +290,24 @@ impl FirecrackerFactory {
                         }
                     }),
                 )?;
-                tx.track_network(network);
+            let network_evidence_target = self.config.dns_port.map(|_| {
+                (
+                    GuestDnsNetworkEvidenceTarget::new(
+                        network.info().name(),
+                        network.info().host_device(),
+                    ),
+                    network.take_dns_network_baseline(),
+                )
+            });
+            tx.track_network(network);
 
-                // Acquire a complete file + connected-device pair only after
-                // all asynchronous sandbox preparation has finished.
+            // Acquire a complete file + connected-device pair only after
+            // the network attachment is known. A newly created namespace
+            // captures its baseline concurrently with this acquisition;
+            // reused namespaces carry a quiescent snapshot from teardown.
+            let acquire_cow_slot = async {
                 let stage_started = Instant::now();
-                let slot = timing.record_stage_result(
+                timing.record_stage_result(
                     SandboxCreateStage::CowPoolAcquire,
                     stage_started,
                     resources.cow_pool.acquire().await.map_err(|error| {
@@ -296,53 +316,68 @@ impl FirecrackerFactory {
                             message: format!("acquire prepared COW slot: {error}"),
                         }
                     }),
-                )?;
+                )
+            };
+            let (slot_result, guest_dns_network_baseline) = match network_evidence_target {
+                Some((target, None)) => {
+                    let (slot_result, baseline) = tokio::join!(
+                        acquire_cow_slot,
+                        capture_guest_dns_network_evidence_baseline(target),
+                    );
+                    (slot_result, Some(baseline))
+                }
+                Some((_, Some(baseline))) => (acquire_cow_slot.await, Some(baseline)),
+                None => (acquire_cow_slot.await, None),
+            };
+            let slot = slot_result?;
 
-                // Checkout is entirely synchronous. Once it succeeds there are
-                // no await points before the transaction owns the device and
-                // commits all resources.
-                let stage_started = Instant::now();
-                let prepared_device = match slot.checkout_to(sandbox_paths.workspace()) {
-                    Ok(device) => timing.record_stage_result(
+            // Checkout is entirely synchronous. Once it succeeds there are
+            // no await points before the transaction owns the device and
+            // commits all resources.
+            let stage_started = Instant::now();
+            let prepared_device = match slot.checkout_to(sandbox_paths.workspace()) {
+                Ok(device) => timing.record_stage_result(
+                    SandboxCreateStage::WorkspaceDirRename,
+                    stage_started,
+                    Ok::<_, SandboxError>(device),
+                )?,
+                Err(error) => {
+                    let message = error.to_string();
+                    let checkout_result: sandbox::Result<(
+                        SandboxCreateResources,
+                        Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
+                    )> = timing.record_stage_result(
                         SandboxCreateStage::WorkspaceDirRename,
                         stage_started,
-                        Ok::<_, SandboxError>(device),
-                    )?,
-                    Err(error) => {
-                        let message = error.to_string();
-                        let checkout_result: sandbox::Result<SandboxCreateResources> = timing
-                            .record_stage_result(
-                                SandboxCreateStage::WorkspaceDirRename,
-                                stage_started,
-                                Err(SandboxError::Initialization {
-                                    phase: SandboxInitializationPhase::SandboxAllocation,
-                                    message: format!("checkout prepared COW slot: {message}"),
-                                }),
-                            );
-                        tx.preserve_workspace_on_leak_cleanup();
-                        let cleanup_outcome =
-                            crate::cow_pool::destroy_prepared_slot_async(error.into_slot()).await;
-                        if cleanup_outcome.backing_files_safe_to_delete() {
-                            tx.allow_workspace_delete_on_leak_cleanup();
-                        }
-                        return checkout_result;
-                    }
-                };
-                let cow_device =
-                    prepared_device
-                        .into_real()
-                        .map_err(|error| SandboxError::Initialization {
+                        Err(SandboxError::Initialization {
                             phase: SandboxInitializationPhase::SandboxAllocation,
-                            message: format!("use prepared COW device: {error}"),
-                        })?;
-                tx.track_cow_device(cow_device);
+                            message: format!("checkout prepared COW slot: {message}"),
+                        }),
+                    );
+                    tx.preserve_workspace_on_leak_cleanup();
+                    let cleanup_outcome =
+                        crate::cow_pool::destroy_prepared_slot_async(error.into_slot()).await;
+                    if cleanup_outcome.backing_files_safe_to_delete() {
+                        tx.allow_workspace_delete_on_leak_cleanup();
+                    }
+                    return checkout_result;
+                }
+            };
+            let cow_device =
+                prepared_device
+                    .into_real()
+                    .map_err(|error| SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("use prepared COW device: {error}"),
+                    })?;
+            tx.track_cow_device(cow_device);
 
-                tx.commit()
-            }
-            .await;
+            Ok((tx.commit()?, guest_dns_network_baseline))
+        }
+        .await;
 
-        let resources = match create_result {
-            Ok(resources) => resources,
+        let (resources, guest_dns_network_baseline) = match create_result {
+            Ok(result) => result,
             Err(e) => {
                 rollback_create_transaction(tx, rollback_cleanup, &self.cleanup_group).await;
                 return Err(e);
@@ -367,6 +402,7 @@ impl FirecrackerFactory {
             cow_device,
             device_rate_limits,
             leak_tx,
+            guest_dns_network_baseline,
         });
         Ok(Box::new(sandbox))
     }
@@ -509,19 +545,27 @@ async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool
     // After kill_process_group + child.wait(), the kernel may still be
     // releasing file descriptors (particularly the NBD device fd).
     // Retry a few times to let it finish.
-    let cow_cleanup_outcome = match sandbox.cow_device.take() {
-        Some(cow_device) => {
-            // If shutdown aborts this task while the COW finalizer is running,
-            // Drop-based leak cleanup must not delete the backing workspace.
-            sandbox.preserve_workspace_on_leak_cleanup();
-            let outcome = destroy_cow_device_with_retries(&sandbox_id, cow_device).await;
-            if outcome.backing_files_safe_to_delete() {
-                sandbox.allow_workspace_delete_on_leak_cleanup();
-            }
-            outcome
-        }
+    let cow_device = sandbox.cow_device.take();
+    if cow_device.is_some() {
+        // If shutdown aborts this task while the COW finalizer is running,
+        // Drop-based leak cleanup must not delete the backing workspace.
+        sandbox.preserve_workspace_on_leak_cleanup();
+    }
+    let network_evidence_target = sandbox.dns_network_evidence_target_for_reuse();
+    let cow_cleanup_outcome = match cow_device {
+        Some(cow_device) => destroy_cow_device_with_retries(&sandbox_id, cow_device).await,
         None => CowCleanupOutcome::BackingFilesSafeToDelete,
     };
+    if cow_cleanup_outcome.backing_files_safe_to_delete() {
+        sandbox.allow_workspace_delete_on_leak_cleanup();
+    }
+    let dns_network_baseline = match network_evidence_target {
+        Some(target) => Some(capture_guest_dns_network_evidence_baseline(target).await),
+        None => None,
+    };
+    sandbox
+        .network
+        .set_dns_network_baseline(dns_network_baseline);
 
     // Return the network namespace to the pool.
     let outcome = netns_pool.release(sandbox.network.lease_mut()).await;

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -7,9 +7,11 @@ use vsock_host::{ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutpu
 
 use crate::command::{CommandError, exec_with_timeout};
 use crate::duration::duration_ms;
-use crate::network::{
-    make_pool_dns_filter_comment, parse_netns_name, probe_namespace_dns_diagnostic,
+use crate::guest_dns_network_evidence::{
+    GuestDnsNetworkEvidenceBaseline, GuestDnsNetworkEvidenceTarget,
+    capture_guest_dns_network_evidence_report,
 };
+use crate::network::probe_namespace_dns_diagnostic;
 
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(2);
 const HOST_COMMAND_TIMEOUT: Duration = Duration::from_millis(1_500);
@@ -39,6 +41,8 @@ pub(crate) struct GuestDnsFailureDiagnosticContext<'a> {
     pub(crate) peer_ip: &'a str,
     pub(crate) dns_port: u16,
     pub(crate) attachment_generation: u64,
+    pub(crate) readiness_attempts: u16,
+    pub(crate) network_evidence_baseline: Option<&'a GuestDnsNetworkEvidenceBaseline>,
     pub(crate) startup_mode: &'static str,
 }
 
@@ -58,6 +62,7 @@ pub(crate) async fn capture_guest_dns_failure_diagnostics(
             peer_ip = context.peer_ip,
             dns_port = context.dns_port,
             attachment_generation = context.attachment_generation,
+            readiness_attempts = context.readiness_attempts,
             startup_mode = context.startup_mode,
             timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
             "guest DNS failure diagnostic snapshot timed out"
@@ -69,32 +74,8 @@ pub(crate) async fn capture_guest_dns_failure_diagnostics(
 async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
     let namespace = context.namespace;
     let peer_ip = context.peer_ip;
-    let listener_port = format!(":{}", context.dns_port);
-    let pool_filter_comment =
-        parse_netns_name(namespace).map(|parsed| make_pool_dns_filter_comment(parsed.pool_index));
-
-    let namespace_links_args = [
-        "netns",
-        "exec",
-        namespace,
-        "ip",
-        "-details",
-        "-statistics",
-        "link",
-        "show",
-    ];
-    let namespace_nat_args = [
-        "netns",
-        "exec",
-        namespace,
-        "iptables-save",
-        "-c",
-        "-t",
-        "nat",
-    ];
-    let raw_rules_args = ["-c", "-t", "raw"];
-    let nat_rules_args = ["-c", "-t", "nat"];
-    let filter_rules_args = ["-c", "-t", "filter"];
+    let network_evidence_target =
+        GuestDnsNetworkEvidenceTarget::new(namespace, context.host_device);
     let conntrack_source_args = ["-L", "-s", peer_ip];
     let conntrack_destination_args = ["-L", "-d", peer_ip];
     let namespace_conntrack_args = [
@@ -108,35 +89,19 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
         "--dport",
         "53",
     ];
-    let listener_args = ["-H", "-luntpm", "sport", "=", listener_port.as_str()];
-
     let (
         guest_state,
-        namespace_links,
-        namespace_nat,
-        host_raw_rules,
-        host_nat_rules,
-        host_filter_rules_ipv4,
-        host_filter_rules_ipv6,
+        attachment_network_evidence,
         conntrack_source,
         conntrack_destination,
         namespace_dns_conntrack,
-        dnsmasq_listener,
     ) = tokio::join!(
         capture_guest_state(guest),
-        exec_with_timeout("ip", &namespace_links_args, HOST_COMMAND_TIMEOUT),
-        exec_with_timeout("ip", &namespace_nat_args, HOST_COMMAND_TIMEOUT),
-        exec_with_timeout("iptables-save", &raw_rules_args, HOST_COMMAND_TIMEOUT),
-        exec_with_timeout("iptables-save", &nat_rules_args, HOST_COMMAND_TIMEOUT),
-        capture_pool_filter_rules(
-            "iptables-save",
-            &filter_rules_args,
-            pool_filter_comment.as_deref(),
-        ),
-        capture_pool_filter_rules(
-            "ip6tables-save",
-            &filter_rules_args,
-            pool_filter_comment.as_deref(),
+        capture_guest_dns_network_evidence_report(
+            network_evidence_target,
+            context.network_evidence_baseline,
+            context.readiness_attempts,
+            HOST_COMMAND_TIMEOUT,
         ),
         exec_with_timeout("conntrack", &conntrack_source_args, HOST_COMMAND_TIMEOUT),
         exec_with_timeout(
@@ -145,24 +110,14 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
             HOST_COMMAND_TIMEOUT,
         ),
         exec_with_timeout("ip", &namespace_conntrack_args, HOST_COMMAND_TIMEOUT),
-        exec_with_timeout("ss", &listener_args, HOST_COMMAND_TIMEOUT),
     );
 
     log_component(context, "guest_state", guest_state);
-    log_component(context, "namespace_links", command_output(namespace_links));
-    log_component(context, "namespace_nat", command_output(namespace_nat));
     log_component(
         context,
-        "host_raw_rules",
-        filtered_command_output(host_raw_rules, namespace),
+        "attachment_network_evidence",
+        attachment_network_evidence,
     );
-    log_component(
-        context,
-        "host_nat_rules",
-        filtered_command_output(host_nat_rules, namespace),
-    );
-    log_component(context, "host_filter_rules_ipv4", host_filter_rules_ipv4);
-    log_component(context, "host_filter_rules_ipv6", host_filter_rules_ipv6);
     log_component(
         context,
         "conntrack_source",
@@ -178,21 +133,6 @@ async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticC
         "namespace_dns_conntrack",
         command_output(namespace_dns_conntrack),
     );
-    log_component(
-        context,
-        "dnsmasq_listener",
-        command_output(dnsmasq_listener),
-    );
-}
-
-async fn capture_pool_filter_rules(program: &str, args: &[&str], comment: Option<&str>) -> String {
-    let Some(comment) = comment else {
-        return "identity_error=invalid_namespace".to_string();
-    };
-    filtered_command_output(
-        exec_with_timeout(program, args, HOST_COMMAND_TIMEOUT).await,
-        comment,
-    )
 }
 
 async fn run_host_namespace_control_probe(context: GuestDnsFailureDiagnosticContext<'_>) {
@@ -270,36 +210,6 @@ fn command_output(result: Result<String, CommandError>) -> String {
     }
 }
 
-fn filtered_command_output(result: Result<String, CommandError>, needle: &str) -> String {
-    match result {
-        Ok(output) => {
-            let filtered = output
-                .lines()
-                .filter(|line| line_has_exact_comment(line, needle))
-                .collect::<Vec<_>>()
-                .join("\n");
-            if filtered.is_empty() {
-                "[no matching output]".to_string()
-            } else {
-                bounded_output(filtered)
-            }
-        }
-        Err(error) => bounded_output(format!("command_error={error}")),
-    }
-}
-
-fn line_has_exact_comment(line: &str, expected: &str) -> bool {
-    let mut tokens = line.split_whitespace();
-    while let Some(token) = tokens.next() {
-        if token == "--comment" {
-            return tokens
-                .next()
-                .is_some_and(|comment| comment.trim_matches('"') == expected);
-        }
-    }
-    false
-}
-
 fn bounded_output(output: String) -> String {
     if output.len() <= LOG_OUTPUT_LIMIT_BYTES {
         return output;
@@ -324,6 +234,7 @@ fn log_component(
         peer_ip = context.peer_ip,
         dns_port = context.dns_port,
         attachment_generation = context.attachment_generation,
+        readiness_attempts = context.readiness_attempts,
         startup_mode = context.startup_mode,
         component,
         output,
@@ -345,47 +256,5 @@ mod tests {
         assert!(bounded.starts_with(&"a".repeat(LOG_OUTPUT_LIMIT_BYTES - 1)));
         assert!(bounded.ends_with("\n[output truncated]"));
         assert!(!bounded.contains('界'));
-    }
-
-    #[test]
-    fn filtered_command_output_keeps_only_namespace_rules() {
-        let namespace = "vm0-ns-0c-20";
-        let output = [
-            "-A PREROUTING -m comment --comment vm0-ns-0c-1f -j DROP",
-            "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP",
-            "-A PREROUTING -m comment --comment vm0-ns-0c-200 -j DROP",
-            "-A PREROUTING -m comment --comment vm0-ns-0c-21 -j DROP",
-        ]
-        .join("\n");
-
-        let filtered = filtered_command_output(Ok(output), namespace);
-
-        assert_eq!(
-            filtered,
-            "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP"
-        );
-    }
-
-    #[test]
-    fn filtered_command_output_keeps_only_exact_pool_dns_rules() {
-        let comment = "vm0-ns-0c-dns";
-        let output = [
-            "-A INPUT -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns",
-            "-A INPUT ! -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns -j REJECT",
-            "-A INPUT -i vm0-ve-0b-+ -p udp --dport 5353 -m comment --comment vm0-ns-0b-dns",
-            "-A INPUT -i vm0-ve-0c-+ -p udp --dport 5353 -m comment --comment vm0-ns-0c-dns-old",
-        ]
-        .join("\n");
-
-        let filtered = filtered_command_output(Ok(output), comment);
-
-        assert_eq!(filtered.lines().count(), 2);
-        assert!(
-            filtered
-                .lines()
-                .all(|line| line_has_exact_comment(line, comment))
-        );
-        assert!(filtered.contains("-j REJECT"));
-        assert!(filtered.lines().any(|line| !line.contains("-j")));
     }
 }

--- a/crates/sandbox-fc/src/guest_dns_network_evidence.rs
+++ b/crates/sandbox-fc/src/guest_dns_network_evidence.rs
@@ -1,0 +1,830 @@
+//! Attachment-local network evidence for terminal guest DNS readiness failures.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::command::{CommandError, exec_with_timeout};
+
+const BASELINE_COMMAND_TIMEOUT: Duration = Duration::from_millis(250);
+const PEER_DEVICE: &str = "veth0";
+const EXPECTED_NAMESPACE_MASQUERADE_RULE: &str =
+    "-A POSTROUTING -s 192.168.241.0/29 -o veth0 -j MASQUERADE";
+const EXPECTED_READINESS_PACKET_BYTES: u64 = 67;
+const FAILURE_DETAIL_LIMIT_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct GuestDnsNetworkEvidenceTarget {
+    namespace: String,
+    host_device: String,
+}
+
+impl GuestDnsNetworkEvidenceTarget {
+    pub(crate) fn new(namespace: &str, host_device: &str) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            host_device: host_device.to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GuestDnsNetworkEvidenceBaseline {
+    target: GuestDnsNetworkEvidenceTarget,
+    capture: NetworkCapture,
+}
+
+pub(crate) async fn capture_guest_dns_network_evidence_baseline(
+    target: GuestDnsNetworkEvidenceTarget,
+) -> Arc<GuestDnsNetworkEvidenceBaseline> {
+    let capture = capture_network_evidence(&target, BASELINE_COMMAND_TIMEOUT).await;
+    Arc::new(GuestDnsNetworkEvidenceBaseline { target, capture })
+}
+
+pub(crate) async fn capture_guest_dns_network_evidence_report(
+    target: GuestDnsNetworkEvidenceTarget,
+    baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
+    readiness_attempts: u16,
+    command_timeout: Duration,
+) -> String {
+    let terminal = capture_network_evidence(&target, command_timeout).await;
+    render_report(&target, baseline, &terminal, readiness_attempts)
+}
+
+async fn capture_network_evidence(
+    target: &GuestDnsNetworkEvidenceTarget,
+    command_timeout: Duration,
+) -> NetworkCapture {
+    let namespace_link_args = [
+        "-n",
+        target.namespace.as_str(),
+        "-j",
+        "-s",
+        "link",
+        "show",
+        "dev",
+        PEER_DEVICE,
+    ];
+    let root_link_args = [
+        "-j",
+        "-s",
+        "link",
+        "show",
+        "dev",
+        target.host_device.as_str(),
+    ];
+    let namespace_nat_args = [
+        "netns",
+        "exec",
+        target.namespace.as_str(),
+        "iptables-save",
+        "-c",
+        "-t",
+        "nat",
+    ];
+
+    let (namespace_link, root_link, namespace_nat) = tokio::join!(
+        exec_with_timeout("ip", &namespace_link_args, command_timeout),
+        exec_with_timeout("ip", &root_link_args, command_timeout),
+        exec_with_timeout("ip", &namespace_nat_args, command_timeout),
+    );
+
+    NetworkCapture {
+        namespace_link: link_capture(namespace_link, PEER_DEVICE),
+        root_link: link_capture(root_link, &target.host_device),
+        namespace_masquerade: masquerade_capture(namespace_nat),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct NetworkCapture {
+    namespace_link: CaptureValue<LinkSnapshot>,
+    root_link: CaptureValue<LinkSnapshot>,
+    namespace_masquerade: CaptureValue<PacketCounters>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", content = "value", rename_all = "snake_case")]
+enum CaptureValue<T> {
+    Captured(T),
+    Unavailable(CaptureFailure),
+}
+
+#[derive(Debug, Serialize)]
+struct CaptureFailure {
+    kind: CaptureFailureKind,
+    detail: String,
+}
+
+impl CaptureFailure {
+    fn command(error: CommandError) -> Self {
+        Self {
+            kind: CaptureFailureKind::Command,
+            detail: bounded_detail(error.to_string()),
+        }
+    }
+
+    fn parse(detail: String) -> Self {
+        Self {
+            kind: CaptureFailureKind::Parse,
+            detail: bounded_detail(detail),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CaptureFailureKind {
+    Command,
+    Parse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct LinkSnapshot {
+    ifindex: u32,
+    link_index: u32,
+    ifname: String,
+    stats64: LinkStats,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct LinkStats {
+    rx: PacketCounters,
+    tx: PacketCounters,
+}
+
+impl LinkStats {
+    fn checked_delta(self, before: Self) -> Option<Self> {
+        Some(Self {
+            rx: self.rx.checked_delta(before.rx)?,
+            tx: self.tx.checked_delta(before.tx)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct PacketCounters {
+    packets: u64,
+    bytes: u64,
+    errors: u64,
+    dropped: u64,
+}
+
+impl PacketCounters {
+    fn checked_delta(self, before: Self) -> Option<Self> {
+        Some(Self {
+            packets: self.packets.checked_sub(before.packets)?,
+            bytes: self.bytes.checked_sub(before.bytes)?,
+            errors: self.errors.checked_sub(before.errors)?,
+            dropped: self.dropped.checked_sub(before.dropped)?,
+        })
+    }
+}
+
+fn link_capture(
+    result: Result<String, CommandError>,
+    expected_ifname: &str,
+) -> CaptureValue<LinkSnapshot> {
+    match result {
+        Ok(output) => match parse_link_snapshot(&output, expected_ifname) {
+            Ok(link) => CaptureValue::Captured(link),
+            Err(error) => CaptureValue::Unavailable(CaptureFailure::parse(error)),
+        },
+        Err(error) => CaptureValue::Unavailable(CaptureFailure::command(error)),
+    }
+}
+
+fn masquerade_capture(result: Result<String, CommandError>) -> CaptureValue<PacketCounters> {
+    match result {
+        Ok(output) => match parse_namespace_masquerade(&output) {
+            Ok(counters) => CaptureValue::Captured(counters),
+            Err(error) => CaptureValue::Unavailable(CaptureFailure::parse(error)),
+        },
+        Err(error) => CaptureValue::Unavailable(CaptureFailure::command(error)),
+    }
+}
+
+fn parse_link_snapshot(output: &str, expected_ifname: &str) -> Result<LinkSnapshot, String> {
+    let links = serde_json::from_str::<Vec<LinkSnapshot>>(output)
+        .map_err(|error| format!("invalid link JSON: {error}"))?;
+    let [link] = <[LinkSnapshot; 1]>::try_from(links).map_err(|links| {
+        format!(
+            "expected one link object for {expected_ifname}, found {}",
+            links.len()
+        )
+    })?;
+    if link.ifname != expected_ifname {
+        return Err(format!(
+            "expected interface {expected_ifname}, found {}",
+            link.ifname
+        ));
+    }
+    Ok(link)
+}
+
+fn parse_namespace_masquerade(output: &str) -> Result<PacketCounters, String> {
+    let mut counters = output.lines().filter_map(|line| {
+        let (counter_token, rule) = line.trim().split_once(' ')?;
+        (rule.trim() == EXPECTED_NAMESPACE_MASQUERADE_RULE).then_some(counter_token)
+    });
+    let counter_token = counters
+        .next()
+        .ok_or_else(|| "exact namespace MASQUERADE rule not found".to_string())?;
+    if counters.next().is_some() {
+        return Err("duplicate exact namespace MASQUERADE rule".to_string());
+    }
+    parse_iptables_counters(counter_token)
+}
+
+fn parse_iptables_counters(token: &str) -> Result<PacketCounters, String> {
+    let values = token
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .ok_or_else(|| format!("invalid iptables counter token: {token}"))?;
+    let (packets, bytes) = values
+        .split_once(':')
+        .ok_or_else(|| format!("invalid iptables counter token: {token}"))?;
+    Ok(PacketCounters {
+        packets: packets
+            .parse()
+            .map_err(|_| format!("invalid iptables packet counter: {packets}"))?,
+        bytes: bytes
+            .parse()
+            .map_err(|_| format!("invalid iptables byte counter: {bytes}"))?,
+        errors: 0,
+        dropped: 0,
+    })
+}
+
+fn bounded_detail(detail: String) -> String {
+    if detail.len() <= FAILURE_DETAIL_LIMIT_BYTES {
+        return detail;
+    }
+    let mut end = FAILURE_DETAIL_LIMIT_BYTES;
+    while !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{} [truncated]", &detail[..end])
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceClassification {
+    ReadinessCorrelatedRootVethRx,
+    Inconclusive,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceReason {
+    ExactCorrelation,
+    ZeroAttempts,
+    BaselineUnavailable,
+    TerminalUnavailable,
+    IdentityMismatch,
+    CounterReset,
+    MasqueradePacketMismatch,
+    MasqueradeByteMismatch,
+    NamespaceTxPacketMismatch,
+    RootRxPacketMismatch,
+    VethByteMismatch,
+    VethErrorOrDrop,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceBoundary {
+    RootVethRx,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+struct EvidenceDeltas {
+    namespace_link: LinkStats,
+    root_link: LinkStats,
+    namespace_masquerade: PacketCounters,
+}
+
+#[derive(Debug)]
+struct EvidenceCorrelation {
+    classification: EvidenceClassification,
+    reason: EvidenceReason,
+    farthest_observed_boundary: Option<EvidenceBoundary>,
+    deltas: Option<EvidenceDeltas>,
+}
+
+impl EvidenceCorrelation {
+    fn inconclusive(reason: EvidenceReason, deltas: Option<EvidenceDeltas>) -> Self {
+        Self {
+            classification: EvidenceClassification::Inconclusive,
+            reason,
+            farthest_observed_boundary: None,
+            deltas,
+        }
+    }
+
+    fn root_veth_rx(deltas: EvidenceDeltas) -> Self {
+        Self {
+            classification: EvidenceClassification::ReadinessCorrelatedRootVethRx,
+            reason: EvidenceReason::ExactCorrelation,
+            farthest_observed_boundary: Some(EvidenceBoundary::RootVethRx),
+            deltas: Some(deltas),
+        }
+    }
+}
+
+fn correlate(
+    target: &GuestDnsNetworkEvidenceTarget,
+    baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
+    terminal: &NetworkCapture,
+    readiness_attempts: u16,
+) -> EvidenceCorrelation {
+    if readiness_attempts == 0 {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::ZeroAttempts, None);
+    }
+    let Some(baseline) = baseline else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::BaselineUnavailable, None);
+    };
+    if baseline.target != *target {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::IdentityMismatch, None);
+    }
+
+    let CaptureValue::Captured(baseline_namespace_link) = &baseline.capture.namespace_link else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::BaselineUnavailable, None);
+    };
+    let CaptureValue::Captured(baseline_root_link) = &baseline.capture.root_link else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::BaselineUnavailable, None);
+    };
+    let CaptureValue::Captured(baseline_masquerade) = &baseline.capture.namespace_masquerade else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::BaselineUnavailable, None);
+    };
+    let CaptureValue::Captured(terminal_namespace_link) = &terminal.namespace_link else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::TerminalUnavailable, None);
+    };
+    let CaptureValue::Captured(terminal_root_link) = &terminal.root_link else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::TerminalUnavailable, None);
+    };
+    let CaptureValue::Captured(terminal_masquerade) = &terminal.namespace_masquerade else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::TerminalUnavailable, None);
+    };
+
+    if !reciprocal_identity(baseline_namespace_link, baseline_root_link)
+        || !reciprocal_identity(terminal_namespace_link, terminal_root_link)
+        || !same_identity(baseline_namespace_link, terminal_namespace_link)
+        || !same_identity(baseline_root_link, terminal_root_link)
+    {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::IdentityMismatch, None);
+    }
+
+    let Some(namespace_link_delta) = terminal_namespace_link
+        .stats64
+        .checked_delta(baseline_namespace_link.stats64)
+    else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::CounterReset, None);
+    };
+    let Some(root_link_delta) = terminal_root_link
+        .stats64
+        .checked_delta(baseline_root_link.stats64)
+    else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::CounterReset, None);
+    };
+    let Some(namespace_masquerade_delta) = terminal_masquerade.checked_delta(*baseline_masquerade)
+    else {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::CounterReset, None);
+    };
+    let deltas = EvidenceDeltas {
+        namespace_link: namespace_link_delta,
+        root_link: root_link_delta,
+        namespace_masquerade: namespace_masquerade_delta,
+    };
+    let expected_packets = u64::from(readiness_attempts);
+
+    if deltas.namespace_masquerade.packets != expected_packets {
+        return EvidenceCorrelation::inconclusive(
+            EvidenceReason::MasqueradePacketMismatch,
+            Some(deltas),
+        );
+    }
+    if deltas.namespace_masquerade.bytes != expected_packets * EXPECTED_READINESS_PACKET_BYTES {
+        return EvidenceCorrelation::inconclusive(
+            EvidenceReason::MasqueradeByteMismatch,
+            Some(deltas),
+        );
+    }
+    if deltas.namespace_link.tx.packets != expected_packets {
+        return EvidenceCorrelation::inconclusive(
+            EvidenceReason::NamespaceTxPacketMismatch,
+            Some(deltas),
+        );
+    }
+    if deltas.root_link.rx.packets != expected_packets {
+        return EvidenceCorrelation::inconclusive(
+            EvidenceReason::RootRxPacketMismatch,
+            Some(deltas),
+        );
+    }
+    if deltas.namespace_link.tx.bytes == 0
+        || deltas.namespace_link.tx.bytes != deltas.root_link.rx.bytes
+    {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::VethByteMismatch, Some(deltas));
+    }
+    if deltas.namespace_link.tx.errors != 0
+        || deltas.namespace_link.tx.dropped != 0
+        || deltas.root_link.rx.errors != 0
+        || deltas.root_link.rx.dropped != 0
+    {
+        return EvidenceCorrelation::inconclusive(EvidenceReason::VethErrorOrDrop, Some(deltas));
+    }
+
+    EvidenceCorrelation::root_veth_rx(deltas)
+}
+
+fn reciprocal_identity(namespace_link: &LinkSnapshot, root_link: &LinkSnapshot) -> bool {
+    namespace_link.ifindex == root_link.link_index && namespace_link.link_index == root_link.ifindex
+}
+
+fn same_identity(baseline: &LinkSnapshot, terminal: &LinkSnapshot) -> bool {
+    baseline.ifname == terminal.ifname
+        && baseline.ifindex == terminal.ifindex
+        && baseline.link_index == terminal.link_index
+}
+
+#[derive(Serialize)]
+struct EvidenceReport<'a> {
+    target: &'a GuestDnsNetworkEvidenceTarget,
+    readiness_attempts: u16,
+    classification: EvidenceClassification,
+    reason: EvidenceReason,
+    farthest_observed_boundary: Option<EvidenceBoundary>,
+    baseline: Option<&'a NetworkCapture>,
+    terminal: &'a NetworkCapture,
+    deltas: Option<&'a EvidenceDeltas>,
+}
+
+fn render_report(
+    target: &GuestDnsNetworkEvidenceTarget,
+    baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
+    terminal: &NetworkCapture,
+    readiness_attempts: u16,
+) -> String {
+    let correlation = correlate(target, baseline, terminal, readiness_attempts);
+    let report = EvidenceReport {
+        target,
+        readiness_attempts,
+        classification: correlation.classification,
+        reason: correlation.reason,
+        farthest_observed_boundary: correlation.farthest_observed_boundary,
+        baseline: baseline.map(|baseline| &baseline.capture),
+        terminal,
+        deltas: correlation.deltas.as_ref(),
+    };
+    match serde_json::to_string(&report) {
+        Ok(output) => output,
+        Err(error) => format!("serialization_error={error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LINK_JSON: &str = r#"[{
+        "ifindex": 1471341,
+        "link_index": 3,
+        "ifname": "vm0-ve-06-41",
+        "stats64": {
+            "rx": {"bytes": 891, "packets": 12, "errors": 0, "dropped": 0},
+            "tx": {"bytes": 907, "packets": 12, "errors": 0, "dropped": 0}
+        }
+    }]"#;
+
+    fn counters(packets: u64, bytes: u64) -> PacketCounters {
+        PacketCounters {
+            packets,
+            bytes,
+            errors: 0,
+            dropped: 0,
+        }
+    }
+
+    fn link(
+        ifname: &str,
+        ifindex: u32,
+        link_index: u32,
+        rx: PacketCounters,
+        tx: PacketCounters,
+    ) -> LinkSnapshot {
+        LinkSnapshot {
+            ifindex,
+            link_index,
+            ifname: ifname.to_string(),
+            stats64: LinkStats { rx, tx },
+        }
+    }
+
+    fn exact_capture() -> NetworkCapture {
+        NetworkCapture {
+            namespace_link: CaptureValue::Captured(link(
+                PEER_DEVICE,
+                3,
+                100,
+                counters(20, 2_000),
+                counters(10, 810),
+            )),
+            root_link: CaptureValue::Captured(link(
+                "vm0-ve-00-01",
+                100,
+                3,
+                counters(10, 810),
+                counters(20, 2_000),
+            )),
+            namespace_masquerade: CaptureValue::Captured(counters(7, 469)),
+        }
+    }
+
+    fn terminal_exact_capture() -> NetworkCapture {
+        NetworkCapture {
+            namespace_link: CaptureValue::Captured(link(
+                PEER_DEVICE,
+                3,
+                100,
+                counters(20, 2_000),
+                counters(13, 1_053),
+            )),
+            root_link: CaptureValue::Captured(link(
+                "vm0-ve-00-01",
+                100,
+                3,
+                counters(13, 1_053),
+                counters(20, 2_000),
+            )),
+            namespace_masquerade: CaptureValue::Captured(counters(10, 670)),
+        }
+    }
+
+    fn target() -> GuestDnsNetworkEvidenceTarget {
+        GuestDnsNetworkEvidenceTarget::new("vm0-ns-00-01", "vm0-ve-00-01")
+    }
+
+    fn baseline(capture: NetworkCapture) -> GuestDnsNetworkEvidenceBaseline {
+        GuestDnsNetworkEvidenceBaseline {
+            target: target(),
+            capture,
+        }
+    }
+
+    fn unavailable<T>() -> CaptureValue<T> {
+        CaptureValue::Unavailable(CaptureFailure::parse("unavailable".to_string()))
+    }
+
+    #[test]
+    fn parses_verified_link_json_shape() {
+        let link = parse_link_snapshot(LINK_JSON, "vm0-ve-06-41").unwrap();
+
+        assert_eq!(link.ifindex, 1_471_341);
+        assert_eq!(link.link_index, 3);
+        assert_eq!(link.stats64.rx, counters(12, 891));
+        assert_eq!(link.stats64.tx, counters(12, 907));
+    }
+
+    #[test]
+    fn rejects_missing_multiple_and_wrong_link_objects() {
+        assert!(parse_link_snapshot("[]", "veth0").is_err());
+        assert!(parse_link_snapshot("[{}, {}]", "veth0").is_err());
+        assert!(parse_link_snapshot(LINK_JSON, "veth0").is_err());
+        assert!(parse_link_snapshot("not-json", "veth0").is_err());
+    }
+
+    #[test]
+    fn parses_only_the_exact_namespace_masquerade_rule() {
+        let output = [
+            "# Generated by iptables-save",
+            "*nat",
+            ":POSTROUTING ACCEPT [1:67]",
+            "[3:201] -A POSTROUTING -s 192.168.241.0/29 -o veth0 -j MASQUERADE",
+            "COMMIT",
+        ]
+        .join("\n");
+
+        assert_eq!(
+            parse_namespace_masquerade(&output).unwrap(),
+            counters(3, 201)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_duplicate_and_malformed_masquerade_counters() {
+        assert!(parse_namespace_masquerade("*nat\nCOMMIT").is_err());
+        let exact = "[3:201] -A POSTROUTING -s 192.168.241.0/29 -o veth0 -j MASQUERADE";
+        assert!(parse_namespace_masquerade(&format!("{exact}\n{exact}")).is_err());
+        assert!(
+            parse_namespace_masquerade(
+                "[three:201] -A POSTROUTING -s 192.168.241.0/29 -o veth0 -j MASQUERADE"
+            )
+            .is_err()
+        );
+        assert!(
+            parse_namespace_masquerade(
+                "[3:201] -A POSTROUTING -s 192.168.241.1/29 -o veth0 -j MASQUERADE"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn exact_attempt_and_veth_progress_reaches_root_rx() {
+        let baseline = baseline(exact_capture());
+        let terminal = terminal_exact_capture();
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+
+        assert_eq!(
+            correlation.classification,
+            EvidenceClassification::ReadinessCorrelatedRootVethRx
+        );
+        assert_eq!(correlation.reason, EvidenceReason::ExactCorrelation);
+        assert_eq!(
+            correlation.farthest_observed_boundary,
+            Some(EvidenceBoundary::RootVethRx)
+        );
+        let deltas = correlation.deltas.unwrap();
+        assert_eq!(deltas.namespace_masquerade, counters(3, 201));
+        assert_eq!(deltas.namespace_link.tx, counters(3, 243));
+        assert_eq!(deltas.root_link.rx, counters(3, 243));
+    }
+
+    #[test]
+    fn partial_noisy_and_inconsistent_progress_is_inconclusive() {
+        let cases = [
+            (
+                EvidenceReason::MasqueradePacketMismatch,
+                counters(9, 603),
+                counters(13, 1_053),
+                counters(13, 1_053),
+            ),
+            (
+                EvidenceReason::MasqueradeByteMismatch,
+                counters(10, 669),
+                counters(13, 1_053),
+                counters(13, 1_053),
+            ),
+            (
+                EvidenceReason::NamespaceTxPacketMismatch,
+                counters(10, 670),
+                counters(12, 972),
+                counters(13, 1_053),
+            ),
+            (
+                EvidenceReason::RootRxPacketMismatch,
+                counters(10, 670),
+                counters(13, 1_053),
+                counters(12, 972),
+            ),
+            (
+                EvidenceReason::VethByteMismatch,
+                counters(10, 670),
+                counters(13, 1_052),
+                counters(13, 1_053),
+            ),
+        ];
+
+        for (reason, masquerade, namespace_tx, root_rx) in cases {
+            let baseline = baseline(exact_capture());
+            let mut terminal = terminal_exact_capture();
+            terminal.namespace_masquerade = CaptureValue::Captured(masquerade);
+            if let CaptureValue::Captured(namespace_link) = &mut terminal.namespace_link {
+                namespace_link.stats64.tx = namespace_tx;
+            }
+            if let CaptureValue::Captured(root_link) = &mut terminal.root_link {
+                root_link.stats64.rx = root_rx;
+            }
+
+            let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+
+            assert_eq!(
+                correlation.classification,
+                EvidenceClassification::Inconclusive
+            );
+            assert_eq!(correlation.reason, reason);
+            assert!(correlation.deltas.is_some());
+        }
+    }
+
+    #[test]
+    fn error_or_drop_progress_is_inconclusive() {
+        let baseline = baseline(exact_capture());
+        let mut terminal = terminal_exact_capture();
+        if let CaptureValue::Captured(namespace_link) = &mut terminal.namespace_link {
+            namespace_link.stats64.tx.dropped = 1;
+        }
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+
+        assert_eq!(correlation.reason, EvidenceReason::VethErrorOrDrop);
+        assert_eq!(
+            correlation.classification,
+            EvidenceClassification::Inconclusive
+        );
+    }
+
+    #[test]
+    fn identity_change_is_inconclusive() {
+        let baseline = baseline(exact_capture());
+        let mut terminal = terminal_exact_capture();
+        if let CaptureValue::Captured(root_link) = &mut terminal.root_link {
+            root_link.ifindex += 1;
+        }
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+
+        assert_eq!(correlation.reason, EvidenceReason::IdentityMismatch);
+        assert!(correlation.deltas.is_none());
+    }
+
+    #[test]
+    fn counter_reset_is_inconclusive() {
+        let baseline = baseline(exact_capture());
+        let mut terminal = terminal_exact_capture();
+        if let CaptureValue::Captured(namespace_link) = &mut terminal.namespace_link {
+            namespace_link.stats64.rx.bytes = 1_999;
+        }
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+
+        assert_eq!(correlation.reason, EvidenceReason::CounterReset);
+        assert!(correlation.deltas.is_none());
+    }
+
+    #[test]
+    fn every_packet_counter_field_rejects_reset() {
+        let before = PacketCounters {
+            packets: 10,
+            bytes: 10,
+            errors: 10,
+            dropped: 10,
+        };
+        for after in [
+            PacketCounters {
+                packets: 9,
+                ..before
+            },
+            PacketCounters { bytes: 9, ..before },
+            PacketCounters {
+                errors: 9,
+                ..before
+            },
+            PacketCounters {
+                dropped: 9,
+                ..before
+            },
+        ] {
+            assert!(after.checked_delta(before).is_none());
+        }
+    }
+
+    #[test]
+    fn unavailable_baseline_or_terminal_is_inconclusive() {
+        let mut baseline_capture = exact_capture();
+        baseline_capture.namespace_masquerade = unavailable();
+        let unavailable_baseline = baseline(baseline_capture);
+        let terminal = terminal_exact_capture();
+        assert_eq!(
+            correlate(&target(), Some(&unavailable_baseline), &terminal, 3).reason,
+            EvidenceReason::BaselineUnavailable
+        );
+
+        let baseline = baseline(exact_capture());
+        let mut terminal = terminal_exact_capture();
+        terminal.root_link = unavailable();
+        assert_eq!(
+            correlate(&target(), Some(&baseline), &terminal, 3).reason,
+            EvidenceReason::TerminalUnavailable
+        );
+    }
+
+    #[test]
+    fn zero_attempts_is_inconclusive() {
+        let baseline = baseline(exact_capture());
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal_exact_capture(), 0);
+
+        assert_eq!(correlation.reason, EvidenceReason::ZeroAttempts);
+        assert_eq!(
+            correlation.classification,
+            EvidenceClassification::Inconclusive
+        );
+    }
+
+    #[test]
+    fn report_is_bounded_and_contains_attempt_correlation() {
+        let baseline = baseline(exact_capture());
+        let report = render_report(&target(), Some(&baseline), &terminal_exact_capture(), 3);
+        let value: serde_json::Value = serde_json::from_str(&report).unwrap();
+
+        assert!(report.len() < 4 * 1024);
+        assert_eq!(value["readiness_attempts"], 3);
+        assert_eq!(value["classification"], "readiness_correlated_root_veth_rx");
+        assert_eq!(value["farthest_observed_boundary"], "root_veth_rx");
+        assert_eq!(value["deltas"]["namespace_masquerade"]["packets"], 3);
+    }
+}

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -34,6 +34,7 @@ mod duration;
 mod exec_operation_result;
 mod factory;
 mod guest_dns_failure_diagnostics;
+mod guest_dns_network_evidence;
 mod guest_dns_readiness;
 mod guest_operations;
 mod leaked_resources;

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -5,9 +5,9 @@ mod readiness;
 
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
+pub(crate) use pool::NetnsPoolHandle;
 pub use pool::{
     NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
-pub(crate) use pool::{NetnsPoolHandle, make_pool_dns_filter_comment};
 pub(crate) use readiness::probe_namespace_dns_diagnostic;
 pub use readiness::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -45,7 +45,6 @@ mod naming;
 mod state;
 mod types;
 
-pub(crate) use naming::make_pool_dns_filter_comment;
 pub use naming::{ParsedNetnsName, parse_netns_name};
 pub use state::NetnsPool;
 pub(crate) use state::NetnsPoolHandle;

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
 use sandbox::SandboxError;
 use tracing::warn;
+
+use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceBaseline;
 
 /// Cloneable metadata for a network namespace.
 ///
@@ -17,6 +21,8 @@ pub struct NetnsInfo {
     pub(super) peer_ip: String,
     /// Process-local count of successful checkouts for this namespace.
     pub(super) attachment_generation: u64,
+    /// Last quiescent DNS evidence snapshot retained only in this process.
+    dns_network_baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
 }
 
 impl NetnsInfo {
@@ -26,6 +32,7 @@ impl NetnsInfo {
             host_device,
             peer_ip,
             attachment_generation: 0,
+            dns_network_baseline: None,
         }
     }
 
@@ -111,8 +118,21 @@ impl NetnsLease {
         self.reuse_eligible = true;
     }
 
-    pub(super) fn reuse_eligible(&self) -> bool {
+    pub(crate) fn reuse_eligible(&self) -> bool {
         self.reuse_eligible
+    }
+
+    pub(crate) fn set_dns_network_baseline(
+        &mut self,
+        baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
+    ) {
+        self.info.dns_network_baseline = baseline;
+    }
+
+    pub(crate) fn take_dns_network_baseline(
+        &mut self,
+    ) -> Option<Arc<GuestDnsNetworkEvidenceBaseline>> {
+        self.info.dns_network_baseline.take()
     }
 
     pub(super) fn into_info(mut self) -> NetnsInfo {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -41,6 +41,8 @@ use crate::factory::InvariantConfig;
 use crate::guest_dns_failure_diagnostics::{
     GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_diagnostics,
 };
+use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceBaseline;
+use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceTarget;
 use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::leaked_resources::LeakedResources;
@@ -457,6 +459,8 @@ pub struct FirecrackerSandbox {
     pub(crate) cow_device: Option<PooledNbdCowDevice>,
     /// Firecracker-local device rate limiters for this sandbox lifecycle.
     device_rate_limits: Option<FirecrackerDeviceRateLimits>,
+    /// Attachment-local counters captured before Firecracker starts.
+    guest_dns_network_baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
     /// Per-sandbox runtime task handles.
     runtime: SandboxRuntimeHandles,
     /// Process-group leader PID for the spawned Firecracker wrapper.
@@ -510,6 +514,7 @@ pub(crate) struct FirecrackerSandboxInit {
     pub(crate) cow_device: PooledNbdCowDevice,
     pub(crate) device_rate_limits: Option<FirecrackerDeviceRateLimits>,
     pub(crate) leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
+    pub(crate) guest_dns_network_baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
 }
 
 pub(crate) struct SandboxNetwork {
@@ -539,6 +544,19 @@ impl SandboxNetwork {
 
     fn attachment_generation(&self) -> u64 {
         self.info.attachment_generation()
+    }
+
+    fn reuse_eligible(&self) -> bool {
+        self.lease.as_ref().is_some_and(NetnsLease::reuse_eligible)
+    }
+
+    pub(crate) fn set_dns_network_baseline(
+        &mut self,
+        baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
+    ) {
+        if let Some(lease) = self.lease.as_mut() {
+            lease.set_dns_network_baseline(baseline);
+        }
     }
 
     fn mark_non_reusable(&mut self) -> sandbox::Result<()> {
@@ -581,6 +599,7 @@ impl FirecrackerSandbox {
             cow_device,
             device_rate_limits,
             leak_tx,
+            guest_dns_network_baseline,
         } = init;
         let id = config.id.to_string();
         Self {
@@ -592,6 +611,7 @@ impl FirecrackerSandbox {
             network: SandboxNetwork::from_lease(network),
             cow_device: Some(cow_device),
             device_rate_limits,
+            guest_dns_network_baseline,
             runtime: SandboxRuntimeHandles::default(),
             process_group_pid: None,
             state: Arc::new(AtomicU8::new(SandboxState::Created as u8)),
@@ -620,6 +640,14 @@ impl FirecrackerSandbox {
 
     pub(crate) fn allow_workspace_delete_on_leak_cleanup(&mut self) {
         self.delete_workspace_on_leak_cleanup = true;
+    }
+
+    pub(crate) fn dns_network_evidence_target_for_reuse(
+        &self,
+    ) -> Option<GuestDnsNetworkEvidenceTarget> {
+        (self.factory_config.dns_port.is_some() && self.network.reuse_eligible()).then(|| {
+            GuestDnsNetworkEvidenceTarget::new(self.network.name(), self.network.host_device())
+        })
     }
 
     fn current_state(&self) -> SandboxState {
@@ -1280,6 +1308,8 @@ impl FirecrackerSandbox {
                             peer_ip: self.network.peer_ip(),
                             dns_port,
                             attachment_generation: self.network.attachment_generation(),
+                            readiness_attempts: error.attempts,
+                            network_evidence_baseline: self.guest_dns_network_baseline.as_deref(),
                             startup_mode: if self.factory_config.snapshot.is_some() {
                                 "snapshot_restore"
                             } else {

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -100,6 +100,7 @@ fn test_sandbox_with_state(state: SandboxState) -> FirecrackerSandbox {
         },
         cow_device: None,
         device_rate_limits: None,
+        guest_dns_network_baseline: None,
         runtime: SandboxRuntimeHandles::default(),
         process_group_pid: None,
         state: Arc::new(AtomicU8::new(state as u8)),


### PR DESCRIPTION
## Summary

- add generation-local typed evidence for namespace POSTROUTING to root-veth RX progress
- capture DNS attachment baselines in memory and correlate bounded terminal deltas conservatively
- remove obsolete host-global and downstream terminal diagnostics
- extend the privileged behavior path with reciprocal veth identity and directional counter checks

The diagnostic remains runner-local and introduces no API, schema, persisted-state, status, rootfs, guest-protocol, firewall, or readiness-policy change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo test -p sandbox-fc --all-features`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- local-1 metal smoke/performance runs with the isolated `issue-22648-perf` runner

The local-1 timing samples were dominated by variable `nbd_cow_create_ms` long tails in both the changed and main binaries; the cached-baseline path avoids evidence subprocesses on reused sandbox creation. The issue records the corrected local-1 validation scope.

Closes #22648
