### PR TITLE
fix(rust): keep child ownership through test timeouts

### DIFF
--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -1,15 +1,14 @@
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
-use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use guest_mock_codex::{read_session_file, session_artifacts};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::support::{BIN, require_session_file, run};
+use crate::support::{BIN, ChildWaitOutcome, require_session_file, run, wait_child_with_timeout};
 
 const APP_SERVER_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const APP_SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -18,7 +17,7 @@ struct AppServerProcess {
     child: Option<Child>,
     stdin: Option<ChildStdin>,
     stdout_rx: Receiver<Result<Option<Value>, String>>,
-    stdout_thread: Option<JoinHandle<()>>,
+    stdout_done_rx: Option<Receiver<()>>,
 }
 
 impl AppServerProcess {
@@ -85,18 +84,62 @@ impl AppServerProcess {
             .child
             .take()
             .ok_or_else(|| std::io::Error::other("app-server child already waited"))?;
-        let status = wait_child(child)?;
-        self.join_stdout_thread()?;
+        let stdout_deadline = Instant::now() + APP_SERVER_EXIT_TIMEOUT + APP_SERVER_EXIT_TIMEOUT;
+        let status = match wait_child_with_timeout(
+            child,
+            APP_SERVER_EXIT_TIMEOUT,
+            APP_SERVER_EXIT_TIMEOUT,
+        ) {
+            ChildWaitOutcome::Exited(status) | ChildWaitOutcome::TimedOut(status) => status,
+            ChildWaitOutcome::ReapTimedOut => {
+                self.detach_stdout_reader();
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "app-server child did not exit after SIGKILL",
+                ));
+            }
+            ChildWaitOutcome::KillFailed(error) => {
+                self.detach_stdout_reader();
+                return Err(std::io::Error::new(
+                    error.kind(),
+                    format!("failed to kill app-server child after timeout: {error}"),
+                ));
+            }
+            ChildWaitOutcome::ReapFailed(error) | ChildWaitOutcome::WaitFailed(error) => {
+                self.detach_stdout_reader();
+                return Err(std::io::Error::new(
+                    error.kind(),
+                    format!("wait for app-server child: {error}"),
+                ));
+            }
+        };
+        self.wait_for_stdout_reader_until(stdout_deadline)?;
         Ok(status.code().unwrap_or(-1))
     }
 
-    fn join_stdout_thread(&mut self) -> std::io::Result<()> {
-        if let Some(stdout_thread) = self.stdout_thread.take() {
-            stdout_thread
-                .join()
-                .map_err(|_| std::io::Error::other("app-server stdout reader panicked"))?;
+    fn wait_for_stdout_reader_until(&mut self, deadline: Instant) -> std::io::Result<()> {
+        if let Some(stdout_done_rx) = self.stdout_done_rx.take() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match stdout_done_rx.recv_timeout(remaining) {
+                Ok(()) => {}
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "app-server stdout reader did not finish before the output deadline",
+                    ));
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(std::io::Error::other(
+                        "app-server stdout reader exited without completion",
+                    ));
+                }
+            }
         }
         Ok(())
+    }
+
+    fn detach_stdout_reader(&mut self) {
+        self.stdout_done_rx.take();
     }
 }
 
@@ -114,47 +157,8 @@ impl Drop for AppServerProcess {
                 }
             }
         }
-        let _ = self.join_stdout_thread();
+        let _ = self.wait_for_stdout_reader_until(Instant::now() + APP_SERVER_EXIT_TIMEOUT);
     }
-}
-
-fn wait_child(mut child: Child) -> std::io::Result<ExitStatus> {
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-    let wait_thread = std::thread::spawn(move || {
-        let result = child.wait();
-        let _ = tx.send(result);
-    });
-
-    let status = match rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT) {
-        Ok(result) => result,
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            // SAFETY: this is test cleanup for the child process spawned by this helper.
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
-            }
-            match rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT) {
-                Ok(result) => result,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "app-server child did not exit after SIGKILL",
-                    ));
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
-                    "app-server child wait thread exited without status",
-                )),
-            }
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
-            "app-server child wait thread exited without status",
-        )),
-    };
-
-    wait_thread
-        .join()
-        .map_err(|_| std::io::Error::other("app-server child wait thread panicked"))?;
-    status
 }
 
 fn spawn_app_server(
@@ -198,14 +202,17 @@ fn spawn_app_server_with_env(
         )
     })?;
     let (stdout_tx, stdout_rx) = mpsc::channel();
-    let stdout_thread = std::thread::spawn(move || {
+    let (stdout_done_tx, stdout_done_rx) = mpsc::channel();
+    let _ = std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
+        let mut reached_eof = true;
         for line in reader.lines() {
             let line = match line {
                 Ok(line) => line,
                 Err(error) => {
                     let _ = stdout_tx.send(Err(format!("read app-server stdout line: {error}")));
-                    return;
+                    reached_eof = false;
+                    break;
                 }
             };
             if line.trim().is_empty() {
@@ -215,16 +222,20 @@ fn spawn_app_server_with_env(
                 .map(Some)
                 .map_err(|error| format!("parse app-server stdout JSON: {error}; line={line:?}"));
             if stdout_tx.send(value).is_err() {
-                return;
+                reached_eof = false;
+                break;
             }
         }
-        let _ = stdout_tx.send(Ok(None));
+        if reached_eof {
+            let _ = stdout_tx.send(Ok(None));
+        }
+        let _ = stdout_done_tx.send(());
     });
     Ok(AppServerProcess {
         child: Some(child),
         stdin: Some(stdin),
         stdout_rx,
-        stdout_thread: Some(stdout_thread),
+        stdout_done_rx: Some(stdout_done_rx),
     })
 }
 

--- a/crates/guest-mock-codex/tests/integration/support.rs
+++ b/crates/guest-mock-codex/tests/integration/support.rs
@@ -429,6 +429,8 @@ mod tests {
         })?;
         loop {
             let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+            // SAFETY: `pid` is the direct child still owned by the helper, and
+            // WNOWAIT observes its exit without releasing that identity.
             let result = unsafe {
                 libc::waitid(
                     libc::P_PID,
@@ -449,6 +451,8 @@ mod tests {
 
     fn assert_child_reaped(pid: u32) {
         let mut status = 0;
+        // SAFETY: the lifecycle helper has already returned this direct
+        // child's status; WNOHANG only verifies that no waitable child remains.
         let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
         assert_eq!(result, -1);
         assert_eq!(

--- a/crates/guest-mock-codex/tests/integration/support.rs
+++ b/crates/guest-mock-codex/tests/integration/support.rs
@@ -1,8 +1,8 @@
+use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
-use std::{io::Seek, io::Write};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
 
 use guest_mock_codex::find_session_file;
 use serde_json::Value;
@@ -10,6 +10,7 @@ use serde_json::Value;
 pub(crate) const BIN: &str = env!("CARGO_BIN_EXE_guest-mock-codex");
 const CLI_RUN_TIMEOUT: Duration = Duration::from_secs(10);
 const CLI_RUN_KILL_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 #[derive(Debug)]
 pub(crate) struct RunOutput {
@@ -93,70 +94,74 @@ fn run_with_env_and_stdin(
     })
 }
 
-fn output_with_timeout(mut cmd: Command, args: &[&str]) -> std::io::Result<Output> {
-    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let child = cmd.spawn()?;
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-    let wait_thread = std::thread::spawn(move || {
-        let result = child.wait_with_output();
-        let _ = tx.send(result);
-    });
+fn output_with_timeout(cmd: Command, args: &[&str]) -> std::io::Result<Output> {
+    output_with_timeout_before_kill(cmd, args, CLI_RUN_TIMEOUT, CLI_RUN_KILL_TIMEOUT, |_| {})
+}
 
-    match rx.recv_timeout(CLI_RUN_TIMEOUT) {
-        Ok(result) => {
-            wait_thread
-                .join()
-                .map_err(|_| std::io::Error::other("guest-mock-codex CLI wait thread panicked"))?;
-            result
+fn output_with_timeout_before_kill(
+    mut cmd: Command,
+    args: &[&str],
+    run_timeout: Duration,
+    kill_timeout: Duration,
+    before_kill: impl FnOnce(u32),
+) -> std::io::Result<Output> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest-mock-codex CLI stdout pipe missing"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest-mock-codex CLI stderr pipe missing"))?;
+    let stdout_reader = OutputReader::spawn(stdout);
+    let stderr_reader = OutputReader::spawn(stderr);
+    let output_deadline = Instant::now() + run_timeout + kill_timeout;
+
+    match wait_child_with_timeout_before_kill(child, run_timeout, kill_timeout, before_kill) {
+        ChildWaitOutcome::Exited(status) => {
+            collect_output(status, stdout_reader, stderr_reader, output_deadline)
         }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            // SAFETY: this is test cleanup for the child process spawned by this helper.
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
-            }
-            match rx.recv_timeout(CLI_RUN_KILL_TIMEOUT) {
-                Ok(Ok(output)) => {
-                    wait_thread.join().map_err(|_| {
-                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
-                    })?;
-                    Err(cli_run_timeout_error(args, Some(&output), None))
-                }
-                Ok(Err(err)) => {
-                    wait_thread.join().map_err(|_| {
-                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
-                    })?;
-                    Err(cli_run_timeout_error(args, None, Some(&err)))
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => Err(cli_run_timeout_error_after_kill(args)),
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    wait_thread.join().map_err(|_| {
-                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
-                    })?;
-                    Err(std::io::Error::other(
-                        "guest-mock-codex CLI wait thread exited without output",
-                    ))
-                }
-            }
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            wait_thread
-                .join()
-                .map_err(|_| std::io::Error::other("guest-mock-codex CLI wait thread panicked"))?;
-            Err(std::io::Error::other(
-                "guest-mock-codex CLI wait thread exited without output",
+        ChildWaitOutcome::TimedOut(status) => {
+            let output = collect_output(status, stdout_reader, stderr_reader, output_deadline)
+                .map_err(|error| cli_run_timeout_error(args, run_timeout, None, Some(&error)))?;
+            Err(cli_run_timeout_error(
+                args,
+                run_timeout,
+                Some(&output),
+                None,
             ))
         }
+        ChildWaitOutcome::ReapTimedOut => Err(cli_run_timeout_error_after_kill(
+            args,
+            run_timeout,
+            kill_timeout,
+        )),
+        ChildWaitOutcome::KillFailed(error) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "guest-mock-codex CLI timed out after {run_timeout:?} and failed to kill the \
+                 child: args={args:?}; error={error}"
+            ),
+        )),
+        ChildWaitOutcome::ReapFailed(error) => {
+            Err(cli_run_timeout_error(args, run_timeout, None, Some(&error)))
+        }
+        ChildWaitOutcome::WaitFailed(error) => Err(std::io::Error::other(format!(
+            "guest-mock-codex CLI child wait failed: args={args:?}; error={error}"
+        ))),
     }
 }
 
 fn cli_run_timeout_error(
     args: &[&str],
+    run_timeout: Duration,
     output: Option<&Output>,
-    wait_error: Option<&std::io::Error>,
+    cleanup_error: Option<&std::io::Error>,
 ) -> std::io::Error {
     let mut message =
-        format!("guest-mock-codex CLI timed out after {CLI_RUN_TIMEOUT:?}: args={args:?}");
+        format!("guest-mock-codex CLI timed out after {run_timeout:?}: args={args:?}");
     if let Some(output) = output {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -165,20 +170,146 @@ fn cli_run_timeout_error(
             output.status
         ));
     }
-    if let Some(err) = wait_error {
-        message.push_str(&format!("; wait_with_output after kill failed: {err}"));
+    if let Some(error) = cleanup_error {
+        message.push_str(&format!("; cleanup after timeout failed: {error}"));
     }
     std::io::Error::new(std::io::ErrorKind::TimedOut, message)
 }
 
-fn cli_run_timeout_error_after_kill(args: &[&str]) -> std::io::Error {
+fn cli_run_timeout_error_after_kill(
+    args: &[&str],
+    run_timeout: Duration,
+    kill_timeout: Duration,
+) -> std::io::Error {
     std::io::Error::new(
         std::io::ErrorKind::TimedOut,
         format!(
-            "guest-mock-codex CLI timed out after {CLI_RUN_TIMEOUT:?} and did not exit within \
-             {CLI_RUN_KILL_TIMEOUT:?} after SIGKILL: args={args:?}"
+            "guest-mock-codex CLI timed out after {run_timeout:?} and did not exit within \
+             {kill_timeout:?} after SIGKILL: args={args:?}"
         ),
     )
+}
+
+pub(crate) enum ChildWaitOutcome {
+    Exited(ExitStatus),
+    TimedOut(ExitStatus),
+    ReapTimedOut,
+    KillFailed(std::io::Error),
+    ReapFailed(std::io::Error),
+    WaitFailed(std::io::Error),
+}
+
+pub(crate) fn wait_child_with_timeout(
+    child: Child,
+    timeout: Duration,
+    kill_timeout: Duration,
+) -> ChildWaitOutcome {
+    wait_child_with_timeout_before_kill(child, timeout, kill_timeout, |_| {})
+}
+
+fn wait_child_with_timeout_before_kill(
+    mut child: Child,
+    timeout: Duration,
+    kill_timeout: Duration,
+    before_kill: impl FnOnce(u32),
+) -> ChildWaitOutcome {
+    // This function alone owns exit observation and signaling. The child only
+    // moves to another waiter after signaling authority has been consumed.
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return ChildWaitOutcome::Exited(status),
+            Ok(None) => {}
+            Err(error) => {
+                // A wait error can mean another actor reaped the child without
+                // caching its status here, so a later numeric-PID kill is unsafe.
+                spawn_child_reaper(child);
+                return ChildWaitOutcome::WaitFailed(error);
+            }
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
+    }
+
+    before_kill(child.id());
+    let kill_result = child.kill();
+    let reaper_rx = spawn_child_reaper(child);
+    if let Err(error) = kill_result {
+        return ChildWaitOutcome::KillFailed(error);
+    }
+
+    match reaper_rx.recv_timeout(kill_timeout) {
+        Ok(Ok(status)) => ChildWaitOutcome::TimedOut(status),
+        Ok(Err(error)) => ChildWaitOutcome::ReapFailed(error),
+        Err(mpsc::RecvTimeoutError::Timeout) => ChildWaitOutcome::ReapTimedOut,
+        Err(mpsc::RecvTimeoutError::Disconnected) => ChildWaitOutcome::ReapFailed(
+            std::io::Error::other("child reaper exited without status"),
+        ),
+    }
+}
+
+fn spawn_child_reaper(mut child: Child) -> Receiver<std::io::Result<ExitStatus>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+    rx
+}
+
+struct OutputReader {
+    rx: Receiver<std::io::Result<Vec<u8>>>,
+}
+
+impl OutputReader {
+    fn spawn(mut pipe: impl Read + Send + 'static) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let _ = std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            let result = pipe.read_to_end(&mut bytes).map(|_| bytes);
+            let _ = tx.send(result);
+        });
+        Self { rx }
+    }
+
+    fn finish(self, stream: &str, deadline: Instant) -> std::io::Result<Vec<u8>> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let result = match self.rx.recv_timeout(remaining) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("{stream} did not close before the child output deadline"),
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(std::io::Error::other(format!(
+                    "{stream} reader exited without output"
+                )));
+            }
+        };
+        result.map_err(|error| {
+            std::io::Error::new(error.kind(), format!("read child {stream}: {error}"))
+        })
+    }
+}
+
+fn collect_output(
+    status: ExitStatus,
+    stdout_reader: OutputReader,
+    stderr_reader: OutputReader,
+    deadline: Instant,
+) -> std::io::Result<Output> {
+    let stdout = stdout_reader.finish("stdout", deadline)?;
+    let stderr = stderr_reader.finish("stderr", deadline)?;
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 pub(crate) fn require_session_file(codex_home: &Path) -> std::io::Result<PathBuf> {
@@ -188,4 +319,141 @@ pub(crate) fn require_session_file(codex_home: &Path) -> std::io::Result<PathBuf
             format!("session file not found under {codex_home:?}"),
         )
     })
+}
+
+#[cfg(unix)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::ChildStdin;
+
+    #[test]
+    fn child_timeout_exit_stays_bound_to_the_original_child() {
+        let (child, stdin) = stdin_controlled_child(23);
+        let pid = child.id();
+
+        let outcome = wait_child_with_timeout_before_kill(
+            child,
+            Duration::ZERO,
+            Duration::from_secs(1),
+            move |observed_pid| {
+                assert_eq!(observed_pid, pid);
+                drop(stdin);
+                observe_child_exit_without_reaping(observed_pid).unwrap();
+            },
+        );
+
+        assert!(matches!(outcome, ChildWaitOutcome::TimedOut(status) if status.code() == Some(23)));
+        assert_child_reaped(pid);
+    }
+
+    #[test]
+    fn child_timeout_kills_and_reaps_a_hung_child() {
+        let child = Command::new("sh")
+            .args(["-c", "exec sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+
+        let outcome =
+            wait_child_with_timeout(child, Duration::from_millis(5), Duration::from_secs(1));
+
+        assert!(matches!(outcome, ChildWaitOutcome::TimedOut(status) if !status.success()));
+        assert_child_reaped(pid);
+    }
+
+    #[test]
+    fn output_with_timeout_drains_large_stdout_and_stderr() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "head -c 262144 /dev/zero & head -c 262144 /dev/zero >&2 & wait",
+        ]);
+
+        let output = output_with_timeout_before_kill(
+            command,
+            &["large-output"],
+            Duration::from_secs(2),
+            Duration::from_secs(1),
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(output.stdout, vec![0; 262_144]);
+        assert_eq!(output.stderr, vec![0; 262_144]);
+    }
+
+    #[test]
+    fn output_with_timeout_does_not_join_a_descendant_held_pipe() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 1 &"]);
+        let started = Instant::now();
+
+        let error = output_with_timeout_before_kill(
+            command,
+            &["descendant-held-pipe"],
+            Duration::from_millis(20),
+            Duration::from_millis(30),
+            |_| {},
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "output deadline should bound reader completion"
+        );
+    }
+
+    fn stdin_controlled_child(exit_code: i32) -> (Child, ChildStdin) {
+        let mut child = Command::new("sh")
+            .args(["-c", &format!("read _ || exit {exit_code}")])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        (child, stdin)
+    }
+
+    fn observe_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
+        let pid = libc::pid_t::try_from(pid).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "child PID does not fit in pid_t",
+            )
+        })?;
+        loop {
+            let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    pid as libc::id_t,
+                    info.as_mut_ptr(),
+                    libc::WEXITED | libc::WNOWAIT,
+                )
+            };
+            if result == 0 {
+                return Ok(());
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+
+    fn assert_child_reaped(pid: u32) {
+        let mut status = 0;
+        let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+        assert_eq!(result, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD)
+        );
+    }
 }

--- a/crates/guest-mock-codex/tests/integration/support.rs
+++ b/crates/guest-mock-codex/tests/integration/support.rs
@@ -395,13 +395,17 @@ mod tests {
         let error = output_with_timeout_before_kill(
             command,
             &["descendant-held-pipe"],
-            Duration::from_millis(20),
+            Duration::from_millis(100),
             Duration::from_millis(30),
             |_| {},
         )
         .unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert_eq!(
+            error.to_string(),
+            "stdout did not close before the child output deadline"
+        );
         assert!(
             started.elapsed() < Duration::from_millis(500),
             "output deadline should bound reader completion"

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -1,13 +1,15 @@
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
-use std::io::{ErrorKind, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
 const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch";
+const HELPER_KILL_TIMEOUT: Duration = Duration::from_secs(1);
+const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 fn run_helper(args: &[&str], stdin: &[u8]) -> std::process::Output {
     run_helper_with_current_dir(args, stdin, None)
@@ -75,34 +77,255 @@ fn run_helper_command(mut command: Command, stdin: &[u8]) -> std::process::Outpu
     wait_with_timeout(child, Duration::from_secs(5))
 }
 
-fn wait_with_timeout(child: std::process::Child, timeout: Duration) -> std::process::Output {
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
+fn wait_with_timeout(mut child: Child, timeout: Duration) -> Output {
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let stdout_reader = OutputReader::spawn(stdout);
+    let stderr_reader = OutputReader::spawn(stderr);
+    let output_deadline = Instant::now() + timeout + HELPER_KILL_TIMEOUT;
 
-    match rx.recv_timeout(timeout) {
-        Ok(output) => output.expect("wait guest-write-file"),
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            terminate_child(pid);
-            let _ = rx.recv_timeout(Duration::from_secs(1));
+    match wait_child_with_timeout(child, timeout, HELPER_KILL_TIMEOUT) {
+        ChildWaitOutcome::Exited(status) => {
+            collect_output(status, stdout_reader, stderr_reader, output_deadline)
+                .expect("collect guest-write-file output")
+        }
+        ChildWaitOutcome::TimedOut(status) => {
+            let cleanup_error =
+                collect_output(status, stdout_reader, stderr_reader, output_deadline).err();
+            if let Some(error) = cleanup_error {
+                panic!(
+                    "guest-write-file did not exit within {timeout:?}; output cleanup failed: \
+                     {error}"
+                );
+            }
             panic!("guest-write-file did not exit within {timeout:?}");
         }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            panic!("guest-write-file waiter thread exited without sending output");
+        ChildWaitOutcome::ReapTimedOut => {
+            panic!(
+                "guest-write-file did not exit within {timeout:?} or within \
+                 {HELPER_KILL_TIMEOUT:?} after SIGKILL"
+            );
+        }
+        ChildWaitOutcome::KillFailed(error) => {
+            panic!("guest-write-file did not exit within {timeout:?}; kill failed: {error}");
+        }
+        ChildWaitOutcome::ReapFailed(error) | ChildWaitOutcome::WaitFailed(error) => {
+            panic!("wait for guest-write-file failed: {error}");
+        }
+    }
+}
+
+enum ChildWaitOutcome {
+    Exited(ExitStatus),
+    TimedOut(ExitStatus),
+    ReapTimedOut,
+    KillFailed(std::io::Error),
+    ReapFailed(std::io::Error),
+    WaitFailed(std::io::Error),
+}
+
+fn wait_child_with_timeout(
+    child: Child,
+    timeout: Duration,
+    kill_timeout: Duration,
+) -> ChildWaitOutcome {
+    wait_child_with_timeout_before_kill(child, timeout, kill_timeout, |_| {})
+}
+
+fn wait_child_with_timeout_before_kill(
+    mut child: Child,
+    timeout: Duration,
+    kill_timeout: Duration,
+    before_kill: impl FnOnce(u32),
+) -> ChildWaitOutcome {
+    // This function alone owns exit observation and signaling. The child only
+    // moves to another waiter after signaling authority has been consumed.
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return ChildWaitOutcome::Exited(status),
+            Ok(None) => {}
+            Err(error) => {
+                // A wait error can mean another actor reaped the child without
+                // caching its status here, so a later numeric-PID kill is unsafe.
+                spawn_child_reaper(child);
+                return ChildWaitOutcome::WaitFailed(error);
+            }
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
+    }
+
+    before_kill(child.id());
+    let kill_result = child.kill();
+    let reaper_rx = spawn_child_reaper(child);
+    if let Err(error) = kill_result {
+        return ChildWaitOutcome::KillFailed(error);
+    }
+
+    match reaper_rx.recv_timeout(kill_timeout) {
+        Ok(Ok(status)) => ChildWaitOutcome::TimedOut(status),
+        Ok(Err(error)) => ChildWaitOutcome::ReapFailed(error),
+        Err(mpsc::RecvTimeoutError::Timeout) => ChildWaitOutcome::ReapTimedOut,
+        Err(mpsc::RecvTimeoutError::Disconnected) => ChildWaitOutcome::ReapFailed(
+            std::io::Error::other("child reaper exited without status"),
+        ),
+    }
+}
+
+fn spawn_child_reaper(mut child: Child) -> Receiver<std::io::Result<ExitStatus>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+    rx
+}
+
+struct OutputReader {
+    rx: Receiver<std::io::Result<Vec<u8>>>,
+}
+
+impl OutputReader {
+    fn spawn(mut pipe: impl Read + Send + 'static) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let _ = std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            let result = pipe.read_to_end(&mut bytes).map(|_| bytes);
+            let _ = tx.send(result);
+        });
+        Self { rx }
+    }
+
+    fn finish(self, stream: &str, deadline: Instant) -> std::io::Result<Vec<u8>> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let result = match self.rx.recv_timeout(remaining) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("{stream} did not close before the child output deadline"),
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(std::io::Error::other(format!(
+                    "{stream} reader exited without output"
+                )));
+            }
+        };
+        result.map_err(|error| {
+            std::io::Error::new(error.kind(), format!("read child {stream}: {error}"))
+        })
+    }
+}
+
+fn collect_output(
+    status: ExitStatus,
+    stdout_reader: OutputReader,
+    stderr_reader: OutputReader,
+    deadline: Instant,
+) -> std::io::Result<Output> {
+    let stdout = stdout_reader.finish("stdout", deadline)?;
+    let stderr = stderr_reader.finish("stderr", deadline)?;
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn child_timeout_exit_stays_bound_to_the_original_child() {
+    use std::process::ChildStdin;
+
+    fn stdin_controlled_child(exit_code: i32) -> (Child, ChildStdin) {
+        let mut child = Command::new("sh")
+            .args(["-c", &format!("read _ || exit {exit_code}")])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        (child, stdin)
+    }
+
+    let (child, stdin) = stdin_controlled_child(23);
+    let pid = child.id();
+    let outcome = wait_child_with_timeout_before_kill(
+        child,
+        Duration::ZERO,
+        Duration::from_secs(1),
+        move |observed_pid| {
+            assert_eq!(observed_pid, pid);
+            drop(stdin);
+            observe_child_exit_without_reaping(observed_pid).unwrap();
+        },
+    );
+
+    assert!(matches!(outcome, ChildWaitOutcome::TimedOut(status) if status.code() == Some(23)));
+    assert_child_reaped(pid);
+}
+
+#[cfg(unix)]
+#[test]
+fn child_timeout_kills_and_reaps_a_hung_child() {
+    let child = Command::new("sh")
+        .args(["-c", "exec sleep 30"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+
+    let outcome = wait_child_with_timeout(child, Duration::from_millis(5), Duration::from_secs(1));
+
+    assert!(matches!(outcome, ChildWaitOutcome::TimedOut(status) if !status.success()));
+    assert_child_reaped(pid);
+}
+
+#[cfg(unix)]
+fn observe_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
+    let pid = libc::pid_t::try_from(pid).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "child PID does not fit in pid_t",
+        )
+    })?;
+    loop {
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                info.as_mut_ptr(),
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
         }
     }
 }
 
 #[cfg(unix)]
-fn terminate_child(pid: u32) {
-    let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
-}
-
-#[cfg(not(unix))]
-fn terminate_child(_pid: u32) {
-    // Tests run on Unix in CI; keep a non-Unix fallback for compilation.
+fn assert_child_reaped(pid: u32) {
+    let mut status = 0;
+    let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    assert_eq!(result, -1);
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ECHILD)
+    );
 }
 
 #[test]

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -299,6 +299,8 @@ fn observe_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
     })?;
     loop {
         let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+        // SAFETY: `pid` is the direct child still owned by the helper, and
+        // WNOWAIT observes its exit without releasing that identity.
         let result = unsafe {
             libc::waitid(
                 libc::P_PID,
@@ -320,6 +322,8 @@ fn observe_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
 #[cfg(unix)]
 fn assert_child_reaped(pid: u32) {
     let mut status = 0;
+    // SAFETY: the lifecycle helper has already returned this direct child's
+    // status; WNOHANG only verifies that no waitable child remains.
     let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
     assert_eq!(result, -1);
     assert_eq!(


### PR DESCRIPTION
## Summary

- keep the original `Child` as the only lifecycle owner through timeout observation and termination in the `guest-mock-codex` and `guest-write-file` integration helpers
- move an already-signaled child to an explicit wait-only reaper, with separate outcomes for wait, kill, and post-kill failures
- drain stdout/stderr concurrently through bounded completion channels, including app-server stdout and descendant-held pipe handling
- add deterministic real-process coverage for exit-at-timeout ownership, hung-child cleanup, large dual-stream output, and inherited-pipe deadlines

## Scope

This changes test infrastructure only. It adds no dependency, shipped runtime behavior, API, protocol, persisted state, deployment requirement, or documentation surface.

The repository audit found no remaining affected Unix/Linux integration helper with a waiter that can reap before a cached PID is signaled. The existing `guest-mock-claude` match remains safe because it observes exit with `waitid(..., WNOWAIT)`.

## Validation

- `for i in {1..20}; do cargo test -p guest-mock-codex --test integration child_timeout_ --quiet >/dev/null || exit 1; cargo test -p guest-write-file --test integration child_timeout_ --quiet >/dev/null || exit 1; done`
- `cargo fmt --all -- --check`
- `cargo test -p guest-mock-codex -p guest-write-file --all-targets --all-features`
- `cargo clippy -p guest-mock-codex -p guest-write-file --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-mock-codex -p guest-write-file --all-features --no-deps`
- `git diff --check`
- repository pre-commit Rust formatting, workspace documentation, and workspace Clippy hooks

Closes #22675
