### PR TITLE
fix(runner): recover failed usage timer starts

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -135,15 +135,15 @@ class UsageEventBuffer:
                 atomic_source_key=atomic_source_key,
             )
             if accepted_count == 0:
-                return 0
-            if self._state.should_flush():
+                timer_to_start = self._schedule_timer_if_buffered_locked()
+            elif self._state.should_flush():
                 flush_now = True
             else:
                 timer_to_start = self._schedule_timer_locked()
             self._sync_buffered_counter_locked()
 
         if timer_to_start is not None:
-            timer_to_start.start()
+            self._start_timer(timer_to_start)
         if flush_now:
             self._flush_usage_events(trigger="threshold")
         return accepted_count
@@ -222,7 +222,7 @@ class UsageEventBuffer:
         if timer_to_cancel is not None:
             timer_to_cancel.cancel()
         if timer_to_start is not None:
-            timer_to_start.start()
+            self._start_timer(timer_to_start)
 
     def _flush_usage_events_owned(self, *, trigger: UsageFlushTrigger) -> int:
         flushed_batch_count = 0
@@ -253,7 +253,7 @@ class UsageEventBuffer:
                     self._sync_buffered_counter_locked()
 
             if timer_to_start is not None:
-                timer_to_start.start()
+                self._start_timer(timer_to_start)
             if pending_flush is None:
                 return flushed_batch_count
 
@@ -304,7 +304,7 @@ class UsageEventBuffer:
                     retain_result.dropped_batches,
                 )
             if timer_to_start is not None:
-                timer_to_start.start()
+                self._start_timer(timer_to_start)
             if admission_result.retained_batches:
                 return flushed_batch_count
 
@@ -320,8 +320,8 @@ class UsageEventBuffer:
         self._sync_buffered_counter_locked()
         return timer_to_start
 
-    @staticmethod
     def _finish_failed_flush_retention(
+        self,
         trigger: UsageFlushTrigger,
         pending_flush: _PendingFlush,
         retain_result: _RetainBatchesResult,
@@ -339,7 +339,7 @@ class UsageEventBuffer:
             retain_result.retained_batches,
         )
         if timer_to_start is not None:
-            timer_to_start.start()
+            self._start_timer(timer_to_start)
 
     def _enqueue_pending_flush(
         self,
@@ -431,7 +431,16 @@ class UsageEventBuffer:
                 completion.dropped_batches,
             )
         if timer_to_start is not None:
-            timer_to_start.start()
+            self._start_timer(timer_to_start)
+
+    def _start_timer(self, timer: _TimerHandle) -> None:
+        try:
+            timer.start()
+        except Exception:
+            with self._lock:
+                if self._timer is timer:
+                    self._timer = None
+            raise
 
     def _sync_buffered_counter_locked(self) -> None:
         set_buffered_usage_events(self._state.buffered_source_event_count())

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -53,6 +53,30 @@ class _FalseyFlushOwnerLock(_InstrumentedFlushOwnerLock):
         return super().acquire(blocking)
 
 
+class _FailingRecordingTimer(RecordingTimer):
+    def start(self) -> None:
+        raise RuntimeError("can't start new thread")
+
+
+class _BlockingFailingRecordingTimer(_FailingRecordingTimer):
+    def __init__(
+        self,
+        delay: float,
+        callback: Callable[[], None],
+        *,
+        start_entered: threading.Event,
+        release_start: threading.Event,
+    ) -> None:
+        super().__init__(delay, callback)
+        self._start_entered = start_entered
+        self._release_start = release_start
+
+    def start(self) -> None:
+        self._start_entered.set()
+        assert self._release_start.wait(timeout=1), "timer start was not released"
+        super().start()
+
+
 def test_usage_buffer_test_injections_accept_falsey_timer_factory_and_lock(tmp_path):
     enqueue = RecordingEnqueue()
     timer_factory = _FalseyTimerFactory()
@@ -710,6 +734,204 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
         reports=0,
         flush_request_id="priority-drained",
     )
+
+
+def test_failed_timer_start_allows_idempotent_replay_to_reschedule(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+    enqueue = RecordingEnqueue()
+    timers: list[RecordingTimer] = []
+
+    def timer_factory(delay: float, callback: Callable[[], None]) -> RecordingTimer:
+        timer = (
+            _FailingRecordingTimer(delay, callback)
+            if not timers
+            else RecordingTimer(delay, callback)
+        )
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(
+        timer_enabled=True,
+        timer_factory=timer_factory,
+        enqueue_webhook=enqueue,
+    )
+    usage.set_pending_path(str(pending_path))
+    source_event = event(source_key="source-1", quantity=10)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [source_event],
+            proxy_log_path,
+        )
+
+    assert len(timers) == 1
+    assert timers[0].started is False
+    assert_current_pending(pending_path, flows=0, buffered=1, reports=0)
+
+    assert (
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [source_event],
+            proxy_log_path,
+        )
+        == 0
+    )
+
+    assert len(timers) == 2
+    assert timers[1].started is True
+    enqueue.assert_not_called()
+
+    timers[1].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 10
+    assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+
+
+def test_failed_retained_retry_timer_allows_idempotent_replay_to_reschedule(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+    enqueue = RecordingEnqueue(return_value=False)
+    timers: list[RecordingTimer] = []
+
+    def timer_factory(delay: float, callback: Callable[[], None]) -> RecordingTimer:
+        timer = (
+            _FailingRecordingTimer(delay, callback)
+            if len(timers) == 1
+            else RecordingTimer(delay, callback)
+        )
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(
+        timer_enabled=True,
+        timer_factory=timer_factory,
+        enqueue_webhook=enqueue,
+    )
+    usage.set_pending_path(str(pending_path))
+    source_event = event(source_key="source-1", quantity=10)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [source_event],
+        proxy_log_path,
+    )
+
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        timers[0].callback()
+
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
+    assert timers[1].started is False
+    assert_current_pending(pending_path, flows=0, buffered=1, reports=0)
+
+    enqueue.return_value = True
+    enqueue.clear()
+    assert (
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [source_event],
+            proxy_log_path,
+        )
+        == 0
+    )
+
+    assert len(timers) == 3
+    assert timers[2].started is True
+
+    timers[2].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 10
+    assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+
+
+def test_failed_old_timer_start_does_not_clear_newer_timer(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+    enqueue = RecordingEnqueue()
+    start_entered = threading.Event()
+    release_start = threading.Event()
+    timers: list[RecordingTimer] = []
+
+    def timer_factory(delay: float, callback: Callable[[], None]) -> RecordingTimer:
+        timer = (
+            _BlockingFailingRecordingTimer(
+                delay,
+                callback,
+                start_entered=start_entered,
+                release_start=release_start,
+            )
+            if not timers
+            else RecordingTimer(delay, callback)
+        )
+        timers.append(timer)
+        return timer
+
+    usage.reset_usage_buffer_for_tests(
+        timer_enabled=True,
+        timer_factory=timer_factory,
+        enqueue_webhook=enqueue,
+    )
+    usage.set_pending_path(str(pending_path))
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+
+    def buffer_first_event() -> None:
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            proxy_log_path,
+        )
+
+    buffer_thread = ThreadUnderTest(target=buffer_first_event)
+    buffer_thread.start()
+    wait_for_event(start_entered, timeout=1, threads=[buffer_thread])
+
+    try:
+        assert usage.flush_usage_events(trigger="test") == 1
+        enqueue.clear()
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-2")],
+            proxy_log_path,
+        )
+        assert len(timers) == 2
+        assert timers[1].started is True
+    finally:
+        release_start.set()
+        buffer_thread.join(timeout=1)
+
+    assert buffer_thread.is_alive() is False
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        buffer_thread.raise_if_failed()
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-3")],
+        proxy_log_path,
+    )
+
+    assert len(timers) == 2
+
+    timers[1].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 2
+    assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
 
 
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):


### PR DESCRIPTION
## Summary

- clear a published usage-buffer timer handle when `start()` raises, without
  clearing a newer timer installed concurrently
- route every usage-buffer timer start through the same recovery path
- let an exact idempotent replay schedule a timer for already-buffered work
- cover initial scheduling failure, retained-retry failure, and stale cleanup
  racing with a newer timer

## Exclusions

- no database schema or persisted-state changes
- no API, runner protocol, or deployment compatibility changes
- no retry loop or timer cancellation during failed startup

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_usage_buffer_timer_shutdown.py -v` (20 passed)
- `python3 -m pytest tests/ -v` (4,181 passed)
- `git diff --check`

Closes #22687
