### PR TITLE
test(vsock-guest): isolate connection tests from host cgroups

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -22,7 +22,7 @@ use crate::handlers::{
     MessageOutcome, decode_write_file_message, decode_write_files_message, handle_basic_message,
 };
 use crate::log::log;
-use crate::process_containment::verify_exec_process_containment_empty;
+use crate::process_containment::{ProcessContainmentMode, verify_exec_process_containment_empty};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
 
@@ -198,6 +198,7 @@ fn handle_quiesce_operations(
     seq: u32,
     payload: &[u8],
     operation_state: &OperationState,
+    process_containment_mode: ProcessContainmentMode,
     writer: &GuestWriter,
 ) -> io::Result<()> {
     if !validate_empty_control_payload(
@@ -212,14 +213,16 @@ fn handle_quiesce_operations(
     match operation_state.enter_quiescing() {
         // Quiescing atomically fences new guest operations. Once pending is
         // zero, this is the final race-free boundary before the VM is parked.
-        QuiesceResult::Quiesced => match verify_exec_process_containment_empty() {
-            Ok(()) => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),
-            Err(error) => send_error_response(
-                seq,
-                &format!("guest process containment is not empty: {error}"),
-                writer,
-            ),
-        },
+        QuiesceResult::Quiesced => {
+            match verify_exec_process_containment_empty(process_containment_mode) {
+                Ok(()) => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),
+                Err(error) => send_error_response(
+                    seq,
+                    &format!("guest process containment is not empty: {error}"),
+                    writer,
+                ),
+            }
+        }
         QuiesceResult::Busy { pending } => send_error_response(
             seq,
             &format!("guest operations still pending: {pending}"),
@@ -254,10 +257,15 @@ struct ConnectionDispatcher {
     exec_operation_registry: ExecOperationRegistry,
     exec_control_registry: ExecControlRegistry,
     operation_state: OperationState,
+    process_containment_mode: ProcessContainmentMode,
 }
 
 impl ConnectionDispatcher {
-    fn new(writer: GuestWriter, connection_cancel: Arc<AtomicBool>) -> io::Result<Self> {
+    fn new(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+        process_containment_mode: ProcessContainmentMode,
+    ) -> io::Result<Self> {
         let file_write_worker =
             FileWriteWorker::start(writer.clone(), Arc::clone(&connection_cancel))?;
         Ok(Self {
@@ -267,6 +275,7 @@ impl ConnectionDispatcher {
             exec_operation_registry: ExecOperationRegistry::default(),
             exec_control_registry: ExecControlRegistry::default(),
             operation_state: OperationState::default(),
+            process_containment_mode,
         })
     }
 
@@ -299,7 +308,11 @@ impl ConnectionDispatcher {
                 return Ok(());
             }
         };
-        let mut request = match ExecOperationWorkerRequest::from_decoded(msg.seq, decoded) {
+        let mut request = match ExecOperationWorkerRequest::from_decoded(
+            msg.seq,
+            decoded,
+            self.process_containment_mode,
+        ) {
             Ok(request) => request,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -456,7 +469,13 @@ impl ConnectionDispatcher {
     }
 
     fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
-        handle_quiesce_operations(msg.seq, msg.payload, &self.operation_state, &self.writer)
+        handle_quiesce_operations(
+            msg.seq,
+            msg.payload,
+            &self.operation_state,
+            self.process_containment_mode,
+            &self.writer,
+        )
     }
 
     fn handle_resume_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
@@ -538,13 +557,32 @@ pub fn connect_unix(path: &str) -> io::Result<UnixStream> {
 /// Handle connection - the main event loop
 /// Uses separate reader/writer to avoid deadlock between main loop and background threads
 pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
-    match handle_connection_with_outcome(stream) {
+    handle_connection_with_mode(stream, ProcessContainmentMode::BuildConfigured)
+}
+
+/// Handles a host-side test connection without accessing the guest cgroup hierarchy.
+///
+/// This remains available without `test-support` so this crate's integration
+/// tests can select deterministic containment in their normal library build.
+#[doc(hidden)]
+pub fn handle_connection_with_test_process_containment(stream: UnixStream) -> io::Result<()> {
+    handle_connection_with_mode(stream, ProcessContainmentMode::TestNoop)
+}
+
+fn handle_connection_with_mode(
+    stream: UnixStream,
+    process_containment_mode: ProcessContainmentMode,
+) -> io::Result<()> {
+    match handle_connection_with_outcome(stream, process_containment_mode) {
         Ok(_) => Ok(()),
         Err(failure) => Err(failure.error),
     }
 }
 
-fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, ConnectionFailure> {
+fn handle_connection_with_outcome(
+    stream: UnixStream,
+    process_containment_mode: ProcessContainmentMode,
+) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
     let mut reader = stream.try_clone().map_err(unstable_connection_failure)?;
@@ -566,8 +604,9 @@ fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, C
     log("INFO", "Sent ready signal");
 
     let mut session = ConnectionSession::new();
-    let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone())
-        .map_err(|error| session.failure(error))?;
+    let dispatcher =
+        ConnectionDispatcher::new(writer, connection_cancel.clone(), process_containment_mode)
+            .map_err(|error| session.failure(error))?;
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
         // Read from stream (reader is separate, no lock needed)
@@ -675,13 +714,20 @@ fn retry_or_fail(failure: ReconnectFailure, attempts: u32) -> io::Result<()> {
     Ok(())
 }
 
-/// Run the vsock guest agent with the given options.
+/// Run the vsock guest agent over vsock, or over a host-side Unix test socket.
 /// Includes reconnection logic for snapshot restore scenarios where
 /// the connection is lost when VM is paused and resumed.
 pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
     log("INFO", "Starting vsock guest...");
 
     let mut attempts = 0u32;
+    // The Unix transport exists for host-side integration tests and does not
+    // own the guest cgroup hierarchy. Deployed guests connect over vsock.
+    let process_containment_mode = if unix_socket.is_some() {
+        ProcessContainmentMode::TestNoop
+    } else {
+        ProcessContainmentMode::BuildConfigured
+    };
 
     loop {
         let result = if let Some(path) = unix_socket {
@@ -690,7 +736,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream)
+                    handle_connection_with_outcome(stream, process_containment_mode)
                 })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
@@ -698,7 +744,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream)
+                    handle_connection_with_outcome(stream, process_containment_mode)
                 })
         };
 

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -21,6 +21,7 @@ use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child};
 use crate::process_containment::{
     ExecProcessContainment, ProcessContainmentCleanupMode, ProcessContainmentError,
+    ProcessContainmentMode,
 };
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
@@ -170,12 +171,14 @@ pub(crate) struct ExecOperationWorkerRequest {
     control: ExecControlPolicy,
     exec_control_guard: Option<ExecControlGuard>,
     exec_control_bootstrap_endpoint: Option<String>,
+    process_containment_mode: ProcessContainmentMode,
 }
 
 impl ExecOperationWorkerRequest {
     pub(crate) fn from_decoded(
         seq: u32,
         decoded: vsock_proto::DecodedExecStart<'_>,
+        process_containment_mode: ProcessContainmentMode,
     ) -> io::Result<Self> {
         let lifecycle = match decoded.lifecycle {
             ExecLifecyclePolicy::OneShot => ExecOperationLifecycle::OneShot,
@@ -229,6 +232,7 @@ impl ExecOperationWorkerRequest {
             control: decoded.control,
             exec_control_guard: None,
             exec_control_bootstrap_endpoint: None,
+            process_containment_mode,
         })
     }
 
@@ -878,15 +882,16 @@ fn run_exec_operation_worker<S>(
     } else {
         env_refs.as_slice()
     };
-    let process_containment = match ExecProcessContainment::create(request.seq) {
-        Ok(process_containment) => process_containment,
-        Err(error) => {
-            completion.start_failed(&format!(
-                "Failed to initialize exec process containment: {error}"
-            ));
-            return;
-        }
-    };
+    let process_containment =
+        match ExecProcessContainment::create(request.seq, request.process_containment_mode) {
+            Ok(process_containment) => process_containment,
+            Err(error) => {
+                completion.start_failed(&format!(
+                    "Failed to initialize exec process containment: {error}"
+                ));
+                return;
+            }
+        };
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
         effective_env,
@@ -1638,6 +1643,7 @@ mod tests {
             control: ExecControlPolicy::Disabled,
             exec_control_guard: None,
             exec_control_bootstrap_endpoint: None,
+            process_containment_mode: ProcessContainmentMode::BuildConfigured,
         }
     }
 

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -26,7 +26,10 @@ mod user;
 mod wait;
 mod writer;
 
-pub use connection::{connect_unix, connect_vsock, handle_connection, run};
+pub use connection::{
+    connect_unix, connect_vsock, handle_connection,
+    handle_connection_with_test_process_containment, run,
+};
 pub use log::log;
 
 #[cfg(any(debug_assertions, feature = "test-support"))]

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -33,6 +33,12 @@ pub(crate) enum ProcessContainmentCleanupMode {
     Forced,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum ProcessContainmentMode {
+    BuildConfigured,
+    TestNoop,
+}
+
 enum ContainmentBackend {
     Cgroup(CgroupGuard),
     TestNoop,
@@ -72,11 +78,11 @@ impl ProcessContainmentError {
 }
 
 impl ExecProcessContainment {
-    pub(crate) fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
-        // Host-side debug integration tests have no guest cgroup hierarchy.
-        // A real guest, including a debug build, gets the hierarchy from
-        // guest-init before vsock-guest starts and therefore uses cgroups.
-        if use_test_noop_backend() {
+    pub(crate) fn create(
+        sequence: u32,
+        mode: ProcessContainmentMode,
+    ) -> Result<Self, ProcessContainmentError> {
+        if use_test_noop_backend(mode) {
             return Ok(Self {
                 backend: ContainmentBackend::TestNoop,
             });
@@ -113,19 +119,20 @@ impl ExecProcessContainment {
     }
 }
 
-pub(crate) fn verify_exec_process_containment_empty() -> Result<(), ProcessContainmentError> {
-    if use_test_noop_backend() {
+pub(crate) fn verify_exec_process_containment_empty(
+    mode: ProcessContainmentMode,
+) -> Result<(), ProcessContainmentError> {
+    if use_test_noop_backend(mode) {
         return Ok(());
     }
     verify_exec_process_containment_empty_in(Path::new(EXEC_CGROUP_BASE_PATH))
 }
 
-fn use_test_noop_backend() -> bool {
-    // Library unit tests do not own the guest cgroup hierarchy. Controlled
-    // containment tests exercise real behavior through caller-provided paths.
-    cfg!(test)
-        || cfg!(feature = "test-support")
-        || (cfg!(debug_assertions) && !Path::new(EXEC_CGROUP_BASE_PATH).is_dir())
+fn use_test_noop_backend(mode: ProcessContainmentMode) -> bool {
+    // Host-side connection tests pass TestNoop explicitly, while library unit
+    // tests and downstream test-support builds select it at compile time.
+    // Controlled containment tests exercise real behavior through paths they own.
+    matches!(mode, ProcessContainmentMode::TestNoop) || cfg!(test) || cfg!(feature = "test-support")
 }
 
 fn verify_exec_process_containment_empty_in(

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -7,11 +7,11 @@ use std::time::{Duration, Instant};
 
 use vsock_guest::run;
 use vsock_proto::{
-    self, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    self, MSG_OPERATIONS_QUIESCED, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
 };
 
 use super::support::{
-    read_and_discard_message, read_message, send_resume_operations, unique_socket_path,
+    read_and_discard_message, read_message, send_quiesce_operations, unique_socket_path,
 };
 
 const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
@@ -63,10 +63,10 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
         .set_read_timeout(Some(Duration::from_secs(5)))
         .unwrap();
     read_and_discard_message(&mut real_work_stream);
-    send_resume_operations(&mut real_work_stream, 9);
-    let resumed = read_message(&mut real_work_stream);
-    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
-    assert_eq!(resumed.seq, 9);
+    send_quiesce_operations(&mut real_work_stream, 9);
+    let quiesced = read_message(&mut real_work_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+    assert_eq!(quiesced.seq, 9);
     drop(real_work_stream);
 
     let mut shutdown_stream =

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -2,7 +2,7 @@ use std::os::unix::net::UnixStream;
 use std::thread;
 use std::time::Duration;
 
-use vsock_guest::handle_connection;
+use vsock_guest::handle_connection_with_test_process_containment;
 
 use super::protocol::read_and_discard_message;
 
@@ -10,7 +10,8 @@ pub(crate) type GuestConnectionHandle = thread::JoinHandle<std::io::Result<()>>;
 
 pub(crate) fn start_guest_connection() -> (GuestConnectionHandle, UnixStream) {
     let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
-    let handle = thread::spawn(move || handle_connection(guest_stream));
+    let handle =
+        thread::spawn(move || handle_connection_with_test_process_containment(guest_stream));
     read_and_discard_message(&mut host_stream);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))


### PR DESCRIPTION
## Summary

- carry an explicit process-containment mode from each connection through exec workers and quiesce verification
- make the direct connection harness and `run(Some(unix_socket))` select the existing no-op test backend without consulting host cgroup state
- remove the debug cgroup-path existence fallback so ordinary debug and release guest entry points remain fail-closed
- exercise the Unix reconnect path with quiesce so its containment selection is covered

## Scope

This is limited to `vsock-guest` connection/test containment selection. It adds no generic containment provider, process-global override, environment switch, protocol change, persisted state, migration, payload change, or deployment compatibility requirement.

Ordinary `handle_connection()` and `run(None)` remain build-configured runtime entry points. Library unit tests and downstream builds with `test-support` retain their existing no-op behavior.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection exec_basic::exec_operation_large_env_payload_succeeds -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --test connection quiesce::quiesced_connection_rejects_write_file_without_creating_file -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --test connection reconnect::run_resets_reconnect_attempts_after_real_host_work -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --no-default-features`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --test production_identity --no-run`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- pre-commit workspace Rust formatting, Clippy, documentation, file-size, and commit-message hooks

The existing CI production-configuration step remains responsible for executing the ignored production identity case with its root-owned sandbox account fixture.

Closes #22678
