### PR TITLE
revert(artifacts): roll back artifact cache loading changes

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
@@ -9,12 +9,10 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
-import { tapError } from "../utils.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import {
   reloadArtifacts$,
   resetArtifactsFilters$,
-  syncArtifacts$,
 } from "./artifacts-signals.ts";
 
 export const setupArtifactsPage$ = command(
@@ -34,6 +32,5 @@ export const setupArtifactsPage$ = command(
     await set(hideAppSkeleton$, signal);
 
     await set(onboardGuard$, signal);
-    await tapError(set(syncArtifacts$, signal));
   },
 );

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import type { IDBPDatabase } from "idb";
-import { delay } from "signal-timers";
 import {
   artifactItemSchema,
   artifactsContract,
@@ -21,7 +20,7 @@ import { chatIdb$ } from "../external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../external/idb-artifact-item-store.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
-import { onRef, resetSignal, settle } from "../utils.ts";
+import { onRef } from "../utils.ts";
 import {
   ensureAgentDraft$,
   loadAgentDraft$,
@@ -34,13 +33,12 @@ const ARTIFACTS_PAGE_SIZE = 2000;
 // Backstop against an unbounded fetch loop (e.g. a server that never returns a
 // null cursor). Sits far above any realistic per-org artifact count.
 const ARTIFACTS_MAX_PAGES = 100;
+// Read the whole locally-cached set back for the cache-first paint.
+const ARTIFACTS_CACHE_READ_LIMIT = ARTIFACTS_PAGE_SIZE * ARTIFACTS_MAX_PAGES;
+
 // Number of cards the grid makes available per automatic loading step. Row
 // virtualization keeps the mounted DOM bounded independently of this window.
 const ARTIFACT_WINDOW_STEP = 60;
-// The background merge still needs the complete cached snapshot, but first
-// paint only needs the first visible window.
-const ARTIFACTS_FULL_CACHE_READ_LIMIT =
-  ARTIFACTS_PAGE_SIZE * ARTIFACTS_MAX_PAGES;
 const ARTIFACT_FOCUS_TARGET_SELECTOR =
   'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
@@ -53,23 +51,6 @@ const internalArtifactsScrollViewport$ = state<HTMLElement | null>(null);
 const internalArtifactsGridElement$ = state<HTMLElement | null>(null);
 const internalArtifactsGridWidth$ = state(0);
 const internalArtifactsPendingFocusIndex$ = state<number | null>(null);
-const resetArtifactsSyncSignal$ = resetSignal();
-
-interface ArtifactsPageData {
-  readonly artifacts: readonly ArtifactItem[];
-}
-
-export interface RemoteArtifactsData extends ArtifactsPageData {
-  readonly mergeCachedArtifacts: boolean;
-}
-
-interface RemoteArtifactsProgress extends RemoteArtifactsData {
-  readonly reload: number;
-}
-
-const internalRemoteArtifactsProgress$ = state<RemoteArtifactsProgress | null>(
-  null,
-);
 
 interface ArtifactsScrollMetrics {
   readonly clientHeight: number;
@@ -80,6 +61,10 @@ const internalArtifactsScrollMetrics$ = state<ArtifactsScrollMetrics>({
   clientHeight: 0,
   scrollTop: 0,
 });
+
+interface ArtifactsPageData {
+  readonly artifacts: readonly ArtifactItem[];
+}
 
 function artifactItemCacheStores(dbPromise: Promise<IDBPDatabase>) {
   return createArtifactItemCacheStores(() => {
@@ -265,7 +250,6 @@ export const resetArtifactsFilters$ = command(({ set }) => {
 });
 
 export const reloadArtifacts$ = command(({ set }) => {
-  set(internalRemoteArtifactsProgress$, null);
   set(internalArtifactsReload$, (version) => {
     return version + 1;
   });
@@ -329,272 +313,67 @@ function mergeArtifactItems(
   });
 }
 
-interface InitialRemoteArtifactsPage extends RemoteArtifactsData {
-  readonly nextCursor: string | null;
-  readonly reload: number;
-  readonly syncUntil: string | undefined;
-  readonly updatedAfter: string | undefined;
-}
-
-interface FetchRemainingArtifactPagesInput {
-  readonly initialArtifacts: readonly ArtifactItem[];
-  readonly initialCursor: string | undefined;
-  readonly initialSyncUntil: string | undefined;
-  readonly mergeCachedArtifacts: boolean;
-  readonly reload: number;
-  readonly updatedAfter: string | undefined;
-}
-
-interface RemoteArtifactsSnapshot {
-  readonly artifacts: ArtifactItem[];
-  readonly syncUntil: string | undefined;
-}
-
-// The first remote page resolves independently so the view can render it while
-// later cursor pages continue loading.
-const initialRemoteArtifactsPage$ = computed(
-  async (get): Promise<InitialRemoteArtifactsPage> => {
-    const reload = get(internalArtifactsReload$);
+// Remote source: read the last-known cache immediately, request only rows that
+// changed since its synchronization timestamp, and merge those rows locally.
+// A server without incremental support omits `syncUntil`; in that case its
+// response is treated as the historical full snapshot for rolling-deploy
+// compatibility.
+export const remoteArtifacts$ = computed(
+  async (get): Promise<ArtifactsPageData> => {
+    get(internalArtifactsReload$);
     const dbPromise = get(chatIdb$);
     const client = get(zeroClient$)(artifactsContract);
     const stores = artifactItemCacheStores(dbPromise);
-    const [cachedHead, lastSyncedAt] = await Promise.all([
-      // This best-effort single-row read only preserves the rollout fallback
-      // for caches created before sync timestamps existed. The cache-first
-      // display uses the strict bounded read below.
-      stores.readStore.readRecentBestEffort({ limit: 1 }),
+    const [cachedArtifacts, lastSyncedAt] = await Promise.all([
+      stores.readStore.readRecent({ limit: ARTIFACTS_CACHE_READ_LIMIT }),
       stores.readStore.readLastSyncedAt(),
     ]);
-    const updatedAfter =
-      cachedHead.length === 0
-        ? undefined
-        : (lastSyncedAt ?? cachedHead[0]?.createdAt);
-    const result = await accept(
-      client.list({
-        query: {
-          limit: ARTIFACTS_PAGE_SIZE,
-          updatedAfter,
-        },
-      }),
-      [200],
-    );
-    const syncUntil = result.body.syncUntil;
-    return {
-      artifacts: mergeArtifactItems(
-        [],
-        result.body.artifacts.map((item) => {
-          return artifactItemSchema.parse(item);
-        }),
-      ),
-      mergeCachedArtifacts: Boolean(updatedAfter && syncUntil),
-      nextCursor: result.body.nextCursor,
-      reload,
-      syncUntil,
-      updatedAfter,
-    };
-  },
-);
-
-// Remote source: publish the first page immediately, then adopt each cumulative
-// page produced by syncArtifacts$.
-export const remoteArtifacts$ = computed(
-  async (get): Promise<RemoteArtifactsData> => {
-    const progress = get(internalRemoteArtifactsProgress$);
-    const initial = await get(initialRemoteArtifactsPage$);
-    const current = progress?.reload === initial.reload ? progress : initial;
-    return {
-      artifacts: current.artifacts,
-      mergeCachedArtifacts: current.mergeCachedArtifacts,
-    };
-  },
-);
-
-const fetchRemainingArtifactPages$ = command(
-  async (
-    { get, set },
-    input: FetchRemainingArtifactPagesInput,
-    signal: AbortSignal,
-  ): Promise<RemoteArtifactsSnapshot | null> => {
-    const client = get(zeroClient$)(artifactsContract);
-    let artifacts = [...input.initialArtifacts];
-    let cursor = input.initialCursor;
-    let syncUntil = input.initialSyncUntil;
-    set(internalRemoteArtifactsProgress$, {
-      artifacts,
-      mergeCachedArtifacts: input.mergeCachedArtifacts,
-      reload: input.reload,
-    });
-
-    for (let page = 1; cursor && page < ARTIFACTS_MAX_PAGES; page += 1) {
+    const updatedAfter = lastSyncedAt ?? cachedArtifacts[0]?.createdAt;
+    const remoteArtifacts: ArtifactItem[] = [];
+    let cursor: string | undefined;
+    let syncUntil: string | undefined;
+    for (let page = 0; page < ARTIFACTS_MAX_PAGES; page += 1) {
       const result = await accept(
         client.list({
           query: {
             limit: ARTIFACTS_PAGE_SIZE,
             cursor,
-            updatedAfter: input.updatedAfter,
+            updatedAfter,
           },
-          fetchOptions: { signal },
         }),
         [200],
       );
-      signal.throwIfAborted();
       syncUntil ??= result.body.syncUntil;
-      artifacts = mergeArtifactItems(
-        artifacts,
-        result.body.artifacts.map((item) => {
+      remoteArtifacts.push(
+        ...result.body.artifacts.map((item) => {
           return artifactItemSchema.parse(item);
         }),
       );
-      if (get(internalArtifactsReload$) !== input.reload) {
-        return null;
+      if (!result.body.nextCursor) {
+        break;
       }
-      set(internalRemoteArtifactsProgress$, {
-        artifacts,
-        mergeCachedArtifacts: input.mergeCachedArtifacts,
-        reload: input.reload,
-      });
-      cursor = result.body.nextCursor ?? undefined;
+      cursor = result.body.nextCursor;
     }
 
-    return { artifacts, syncUntil };
-  },
-);
-
-// Continue the remote cursor walk after first-page paint. Cache persistence is
-// deliberately last so it never gates data already published to the view.
-export const syncArtifacts$ = command(
-  async ({ get, set }, parentSignal: AbortSignal) => {
-    const signal = set(resetArtifactsSyncSignal$, parentSignal);
-    const initial = await get(initialRemoteArtifactsPage$);
-    signal.throwIfAborted();
-    if (get(internalArtifactsReload$) !== initial.reload) {
-      return;
-    }
-
-    const incrementalSnapshot = await set(
-      fetchRemainingArtifactPages$,
-      {
-        initialArtifacts: initial.artifacts,
-        initialCursor: initial.nextCursor ?? undefined,
-        initialSyncUntil: initial.syncUntil,
-        mergeCachedArtifacts: initial.mergeCachedArtifacts,
-        reload: initial.reload,
-        updatedAfter: initial.updatedAfter,
-      },
-      signal,
-    );
-    if (!incrementalSnapshot) {
-      return;
-    }
-    let { artifacts, syncUntil } = incrementalSnapshot;
-
-    signal.throwIfAborted();
-    if (get(internalArtifactsReload$) !== initial.reload) {
-      return;
-    }
-
-    const stores = artifactItemCacheStores(get(chatIdb$));
-    if (initial.mergeCachedArtifacts) {
-      const cachedArtifactsResult = await settle(
-        stores.readStore.readRecent(
-          { limit: ARTIFACTS_FULL_CACHE_READ_LIMIT },
-          signal,
-        ),
-        signal,
-      );
-      if (get(internalArtifactsReload$) !== initial.reload) {
-        return;
-      }
-      if (cachedArtifactsResult.ok) {
-        artifacts = mergeArtifactItems(cachedArtifactsResult.value, artifacts);
-      } else {
-        // An incremental response is incomplete without the full local
-        // snapshot. If IndexedDB cannot provide it within its strict deadline,
-        // recover with an authoritative server snapshot instead of silently
-        // leaving the view capped at its 60-item first-paint window.
-        const result = await accept(
-          get(zeroClient$)(artifactsContract).list({
-            query: { limit: ARTIFACTS_PAGE_SIZE },
-            fetchOptions: { signal },
-          }),
-          [200],
-        );
-        signal.throwIfAborted();
-        if (get(internalArtifactsReload$) !== initial.reload) {
-          return;
-        }
-        const fullSnapshot = await set(
-          fetchRemainingArtifactPages$,
-          {
-            initialArtifacts: mergeArtifactItems(
-              [],
-              result.body.artifacts.map((item) => {
-                return artifactItemSchema.parse(item);
-              }),
-            ),
-            initialCursor: result.body.nextCursor ?? undefined,
-            initialSyncUntil: result.body.syncUntil,
-            mergeCachedArtifacts: false,
-            reload: initial.reload,
-            updatedAfter: undefined,
-          },
-          signal,
-        );
-        if (!fullSnapshot) {
-          return;
-        }
-        ({ artifacts, syncUntil } = fullSnapshot);
-      }
-    }
-    set(internalRemoteArtifactsProgress$, {
-      artifacts,
-      mergeCachedArtifacts: false,
-      reload: initial.reload,
-    });
-
-    // Yield a browser task after publishing the complete snapshot so React can
-    // paint it before a large clear-and-replace transaction starts.
-    await delay(0, { signal });
-    signal.throwIfAborted();
-    if (get(internalArtifactsReload$) !== initial.reload) {
-      return;
-    }
-    const cacheUpdated = await stores.writeStore.replaceItems(
-      artifacts,
-      signal,
-    );
-    signal.throwIfAborted();
-    if (get(internalArtifactsReload$) !== initial.reload) {
-      return;
-    }
+    const mergeBase = updatedAfter && syncUntil ? cachedArtifacts : [];
+    const artifacts = mergeArtifactItems(mergeBase, remoteArtifacts);
+    const cacheUpdated = await stores.writeStore.replaceItems(artifacts);
     if (cacheUpdated && syncUntil) {
-      await stores.writeStore.setLastSyncedAt(syncUntil, signal);
+      await stores.writeStore.setLastSyncedAt(syncUntil);
     }
+    return { artifacts };
   },
 );
 
-export function mergeArtifactSources(
-  cachedArtifacts: readonly ArtifactItem[],
-  remote: RemoteArtifactsData | null,
-): readonly ArtifactItem[] {
-  if (!remote) {
-    return cachedArtifacts;
-  }
-  return remote.mergeCachedArtifacts
-    ? mergeArtifactItems(cachedArtifacts, remote.artifacts)
-    : remote.artifacts;
-}
-
-// Cache-first paint reads only the first visible window. Unlike the background
-// full-snapshot read, failures remain distinguishable from a genuinely empty
-// cache through the loadable state.
+// Cache-first paint: the last-known artifact set from IndexedDB. Never throws
+// (reads degrade to an empty list), so it is always a safe fallback.
 export const cachedArtifacts$ = computed(
   async (get): Promise<ArtifactsPageData> => {
     get(internalArtifactsReload$);
     const dbPromise = get(chatIdb$);
     const artifacts = await artifactItemCacheStores(
       dbPromise,
-    ).readStore.readRecent({ limit: ARTIFACT_WINDOW_STEP });
+    ).readStore.readRecent({ limit: ARTIFACTS_CACHE_READ_LIMIT });
     return { artifacts };
   },
 );

--- a/turbo/apps/platform/src/signals/external/idb-artifact-item-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/idb-artifact-item-store.test.ts
@@ -33,7 +33,6 @@ interface FakeStore {
 }
 
 interface FakeTransaction {
-  abort(): void;
   readonly store: FakeStore;
   readonly done: Promise<void>;
 }
@@ -133,15 +132,9 @@ class MemoryArtifactDb {
 
   get db(): IDBPDatabase {
     return {
-      transaction: (storeName: string) => {
+      transaction: () => {
         return {
-          abort: () => {
-            return undefined;
-          },
-          store:
-            storeName === ARTIFACT_SYNC_STORE
-              ? this.syncStateStore()
-              : this.store(),
+          store: this.store(),
           done: Promise.resolve(),
         } satisfies FakeTransaction;
       },
@@ -157,29 +150,6 @@ class MemoryArtifactDb {
         return Promise.resolve();
       },
     } as unknown as IDBPDatabase;
-  }
-
-  private syncStateStore(): FakeStore {
-    return {
-      put: (value) => {
-        this.syncState = value;
-        return Promise.resolve();
-      },
-      delete: () => {
-        this.syncState = undefined;
-        return Promise.resolve();
-      },
-      clear: () => {
-        this.syncState = undefined;
-        return Promise.resolve();
-      },
-      get: () => {
-        return Promise.resolve(this.syncState);
-      },
-      index: () => {
-        throw new Error("Sync state store has no indexes");
-      },
-    };
   }
 
   private store(): FakeStore {
@@ -299,20 +269,6 @@ describe("artifact item IndexedDB cache reads", () => {
       second,
       first,
     ]);
-  });
-
-  it("stops after the requested recent-item window", async () => {
-    const { stores } = setupStores();
-    const items = Array.from({ length: 61 }, (_, index) => {
-      return artifact(index + 1);
-    });
-
-    await stores.writeStore.upsertItems(items);
-
-    const recent = await stores.readStore.readRecent({ limit: 60 });
-    expect(recent).toHaveLength(60);
-    expect(recent[0]).toStrictEqual(items[60]);
-    expect(recent[59]).toStrictEqual(items[1]);
   });
 
   it("upserts idempotently and replaces stale metadata", async () => {
@@ -442,29 +398,15 @@ describe("artifact item IndexedDB cache writes and failures", () => {
     await expect(stores.readStore.readRecent()).resolves.toStrictEqual([fresh]);
   });
 
-  it("distinguishes strict cache reads from best-effort misses", async () => {
+  it("falls back to cache miss values when IndexedDB reads fail", async () => {
     const stores = createArtifactItemCacheStores(() => {
       return Promise.reject(new Error("open failed"));
     });
 
-    await expect(stores.readStore.readRecent()).rejects.toThrow("open failed");
-    await expect(
-      stores.readStore.readRecentBestEffort(),
-    ).resolves.toStrictEqual([]);
+    await expect(stores.readStore.readRecent()).resolves.toStrictEqual([]);
     await expect(
       stores.readStore.readByRunFile("run-1", "file-1"),
     ).resolves.toBe(null);
-  });
-
-  it("rejects strict cache reads when IndexedDB misses the deadline", async () => {
-    const pendingDb = Promise.withResolvers<IDBPDatabase>();
-    const stores = createArtifactItemCacheStores(() => {
-      return pendingDb.promise;
-    });
-
-    await expect(stores.readStore.readRecent()).rejects.toThrow(
-      "IndexedDB operation timed out: artifacts:readRecent",
-    );
   });
 
   it("ignores best-effort write failures", async () => {

--- a/turbo/apps/platform/src/signals/external/idb-artifact-item-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-artifact-item-store.ts
@@ -21,12 +21,7 @@ import {
   ARTIFACT_ITEMS_STORE,
   ARTIFACT_SYNC_STORE,
 } from "./chat-idb-schema.ts";
-import {
-  chatIdbReadOr,
-  chatIdbWriteBestEffort,
-  withChatIdbTimeout,
-} from "./chat-idb-safe.ts";
-import { withCleanup } from "../utils.ts";
+import { chatIdbReadOr, chatIdbWriteBestEffort } from "./chat-idb-safe.ts";
 
 const L = logger("ChatIdbCache");
 const DEFAULT_ARTIFACT_ITEM_LIMIT = 50;
@@ -66,10 +61,6 @@ interface ArtifactItemCacheFilter {
 
 interface ArtifactItemReadStore {
   readRecent(
-    filter?: ArtifactItemCacheFilter,
-    signal?: AbortSignal,
-  ): Promise<ArtifactItem[]>;
-  readRecentBestEffort(
     filter?: ArtifactItemCacheFilter,
     signal?: AbortSignal,
   ): Promise<ArtifactItem[]>;
@@ -113,31 +104,6 @@ interface IndexedReadPlan {
 interface ValidatedStoredArtifactItem {
   readonly item: ArtifactItem;
   readonly searchText: string;
-}
-
-async function runAbortableTransaction(
-  transaction: {
-    readonly done: Promise<unknown>;
-    abort(): void;
-  },
-  operation: () => Promise<void>,
-  signal?: AbortSignal,
-): Promise<void> {
-  const abortTransaction = () => {
-    transaction.abort();
-  };
-  signal?.addEventListener("abort", abortTransaction, { once: true });
-  await withCleanup(
-    (async () => {
-      signal?.throwIfAborted();
-      await operation();
-      signal?.throwIfAborted();
-      await transaction.done;
-    })(),
-    () => {
-      signal?.removeEventListener("abort", abortTransaction);
-    },
-  );
 }
 
 function storedArtifactItem(item: ArtifactItem): StoredArtifactItem {
@@ -202,64 +168,42 @@ function matchesFilter(
   });
 }
 
-async function readRecentItems(
-  storeName: string,
-  getDb: GetDb,
-  filter?: ArtifactItemCacheFilter,
-  signal?: AbortSignal,
-): Promise<ArtifactItem[]> {
-  const effectiveFilter = filter ?? {};
-  const limit = effectiveFilter.limit ?? DEFAULT_ARTIFACT_ITEM_LIMIT;
-  if (limit <= 0) {
-    return [];
-  }
-
-  const db = await getDb();
-  signal?.throwIfAborted();
-  const tx = db.transaction(storeName, "readonly");
-  const plan = indexedReadPlan(effectiveFilter);
-  const index = tx.store.index(plan.indexName);
-  const queryTokens = normalizedSearchTokens(effectiveFilter.query);
-  const items: ArtifactItem[] = [];
-  let cursor = await index.openCursor(plan.range, "prev");
-  while (cursor && items.length < limit) {
-    signal?.throwIfAborted();
-    const stored = validateStoredArtifactItem(cursor.value);
-    if (matchesFilter(stored, effectiveFilter, queryTokens)) {
-      items.push(stored.item);
-    }
-    if (items.length >= limit) {
-      break;
-    }
-    cursor = await cursor.continue();
-  }
-  L.debug("artifacts:readRecent:done", {
-    count: items.length,
-    filter: effectiveFilter,
-  });
-  return items;
-}
-
 function createReadStore(
   storeName: string,
   getDb: GetDb,
 ): ArtifactItemReadStore {
   return {
     async readRecent(filter, signal) {
-      return await withChatIdbTimeout(
-        "artifacts:readRecent",
-        async () => {
-          return await readRecentItems(storeName, getDb, filter, signal);
-        },
-        signal,
-      );
-    },
-
-    async readRecentBestEffort(filter, signal) {
       return await chatIdbReadOr(
         "artifacts:readRecent",
         async () => {
-          return await readRecentItems(storeName, getDb, filter, signal);
+          const effectiveFilter = filter ?? {};
+          const limit = effectiveFilter.limit ?? DEFAULT_ARTIFACT_ITEM_LIMIT;
+          if (limit <= 0) {
+            return [];
+          }
+
+          const db = await getDb();
+          signal?.throwIfAborted();
+          const tx = db.transaction(storeName, "readonly");
+          const plan = indexedReadPlan(effectiveFilter);
+          const index = tx.store.index(plan.indexName);
+          const queryTokens = normalizedSearchTokens(effectiveFilter.query);
+          const items: ArtifactItem[] = [];
+          let cursor = await index.openCursor(plan.range, "prev");
+          while (cursor && items.length < limit) {
+            signal?.throwIfAborted();
+            const stored = validateStoredArtifactItem(cursor.value);
+            if (matchesFilter(stored, effectiveFilter, queryTokens)) {
+              items.push(stored.item);
+            }
+            cursor = await cursor.continue();
+          }
+          L.debug("artifacts:readRecent:done", {
+            count: items.length,
+            filter: effectiveFilter,
+          });
+          return items;
         },
         [],
         signal,
@@ -335,17 +279,12 @@ function createWriteStore(
           const db = await getDb();
           signal?.throwIfAborted();
           const tx = db.transaction(storeName, "readwrite");
-          await runAbortableTransaction(
-            tx,
-            async () => {
-              await tx.store.clear();
-              for (const item of items) {
-                signal?.throwIfAborted();
-                await tx.store.put(storedArtifactItem(item));
-              }
-            },
-            signal,
-          );
+          await tx.store.clear();
+          for (const item of items) {
+            signal?.throwIfAborted();
+            await tx.store.put(storedArtifactItem(item));
+          }
+          await tx.done;
           L.debug("artifacts:replaceItems:done", { count: items.length });
         },
         signal,
@@ -358,17 +297,10 @@ function createWriteStore(
         async () => {
           const db = await getDb();
           signal?.throwIfAborted();
-          const tx = db.transaction(ARTIFACT_SYNC_STORE, "readwrite");
-          await runAbortableTransaction(
-            tx,
-            async () => {
-              await tx.store.put({
-                id: ARTIFACT_SYNC_STATE_ID,
-                lastSyncedAt,
-              });
-            },
-            signal,
-          );
+          await db.put(ARTIFACT_SYNC_STORE, {
+            id: ARTIFACT_SYNC_STATE_ID,
+            lastSyncedAt,
+          });
         },
         signal,
       );

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1,9 +1,7 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   artifactsContract,
-  chatThreadArtifactsContract,
   type ArtifactItem,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroAgentDraftContract } from "@vm0/api-contracts/contracts/zero-agents";
@@ -33,36 +31,18 @@ const artifactIdbMock = vi.hoisted(() => {
     readonly value: Record<string, unknown>;
   }
 
-  let artifactReplacementGate: {
-    readonly completed: PromiseWithResolvers<void>;
-    readonly started: PromiseWithResolvers<void>;
-    readonly released: PromiseWithResolvers<void>;
-  } | null = null;
-  let artifactReadGate: {
-    readonly afterItems: number;
-    readonly started: PromiseWithResolvers<void>;
-    readonly released: PromiseWithResolvers<void>;
-  } | null = null;
-
   class MemoryCursor {
     private position = 0;
 
-    constructor(
-      private readonly values: readonly Record<string, unknown>[],
-      private readonly readGate: typeof artifactReadGate,
-    ) {}
+    constructor(private readonly values: readonly Record<string, unknown>[]) {}
 
     get value(): unknown {
       return this.values[this.position];
     }
 
-    async continue(): Promise<MemoryCursor | null> {
-      if (this.readGate && this.position === this.readGate.afterItems - 1) {
-        this.readGate.started.resolve();
-        await this.readGate.released.promise;
-      }
+    continue(): Promise<MemoryCursor | null> {
       this.position += 1;
-      return this.position < this.values.length ? this : null;
+      return Promise.resolve(this.position < this.values.length ? this : null);
     }
   }
 
@@ -152,15 +132,9 @@ const artifactIdbMock = vi.hoisted(() => {
   }
 
   class MemoryObjectStore {
-    constructor(
-      private readonly store: StoredObjectStore,
-      private readonly transactionAborted: () => boolean = () => {
-        return false;
-      },
-    ) {}
+    constructor(private readonly store: StoredObjectStore) {}
 
     put(value: Record<string, unknown>): Promise<void> {
-      this.throwIfTransactionAborted();
       const key = value[this.store.keyPath];
       if (typeof key === "string") {
         this.store.rows.set(key, value);
@@ -169,29 +143,17 @@ const artifactIdbMock = vi.hoisted(() => {
     }
 
     delete(key: IDBValidKey): Promise<void> {
-      this.throwIfTransactionAborted();
       if (typeof key === "string") {
         this.store.rows.delete(key);
       }
       return Promise.resolve();
     }
 
-    async clear(): Promise<void> {
-      const gate = artifactReplacementGate;
-      if (this.store.keyPath === "artifactItemId" && gate) {
-        artifactReplacementGate = null;
-        gate.started.resolve();
-        try {
-          await gate.released.promise;
-          this.throwIfTransactionAborted();
-        } finally {
-          gate.completed.resolve();
-        }
-      }
-      this.throwIfTransactionAborted();
+    clear(): Promise<void> {
       for (const key of this.store.rows.keys()) {
         this.store.rows.delete(key);
       }
+      return Promise.resolve();
     }
 
     get(key: IDBValidKey): Promise<unknown> {
@@ -237,7 +199,6 @@ const artifactIdbMock = vi.hoisted(() => {
               rows.map((row) => {
                 return row.value;
               }),
-              this.store.keyPath === "artifactItemId" ? artifactReadGate : null,
             ),
           );
         },
@@ -252,12 +213,6 @@ const artifactIdbMock = vi.hoisted(() => {
         const key = artifactIndexKey(indexName, item);
         return key === null ? [] : [{ key, value: item }];
       });
-    }
-
-    private throwIfTransactionAborted(): void {
-      if (this.transactionAborted()) {
-        throw new DOMException("Transaction aborted", "AbortError");
-      }
     }
   }
 
@@ -282,23 +237,15 @@ const artifactIdbMock = vi.hoisted(() => {
     }
 
     transaction(storeName: string): {
-      abort: () => void;
       readonly store: MemoryObjectStore;
       readonly done: Promise<void>;
       objectStore: () => MemoryObjectStore;
     } {
-      const stored = this.ensureStoredObjectStore(
+      const store = this.ensureStore(
         storeName,
         storeName === "artifact_items" ? "artifactItemId" : "id",
       );
-      let aborted = false;
-      const store = new MemoryObjectStore(stored, () => {
-        return aborted;
-      });
       return {
-        abort: () => {
-          aborted = true;
-        },
         store,
         done: Promise.resolve(),
         objectStore: () => {
@@ -330,72 +277,22 @@ const artifactIdbMock = vi.hoisted(() => {
     }
 
     private ensureStore(storeName: string, keyPath: string): MemoryObjectStore {
-      return new MemoryObjectStore(
-        this.ensureStoredObjectStore(storeName, keyPath),
-      );
-    }
-
-    private ensureStoredObjectStore(
-      storeName: string,
-      keyPath: string,
-    ): StoredObjectStore {
       const existing = this.stores.get(storeName);
       if (existing !== undefined) {
-        return existing;
+        return new MemoryObjectStore(existing);
       }
       const store = {
         keyPath,
         rows: new Map<string, Record<string, unknown>>(),
       };
       this.stores.set(storeName, store);
-      return store;
+      return new MemoryObjectStore(store);
     }
   }
 
   const dbs = new Map<string, MemoryDb>();
 
   return {
-    blockArtifactCursorContinuation(afterItems = 1): {
-      readonly started: Promise<void>;
-      release(): void;
-    } {
-      const started = Promise.withResolvers<void>();
-      const released = Promise.withResolvers<void>();
-      const gate = { afterItems, started, released };
-      artifactReadGate = gate;
-      return {
-        started: started.promise,
-        release: () => {
-          if (artifactReadGate === gate) {
-            artifactReadGate = null;
-          }
-          released.resolve();
-        },
-      };
-    },
-
-    blockArtifactReplacement(): {
-      readonly completed: Promise<void>;
-      readonly started: Promise<void>;
-      release(): void;
-    } {
-      const completed = Promise.withResolvers<void>();
-      const started = Promise.withResolvers<void>();
-      const released = Promise.withResolvers<void>();
-      const gate = { completed, started, released };
-      artifactReplacementGate = gate;
-      return {
-        completed: completed.promise,
-        started: started.promise,
-        release: () => {
-          if (artifactReplacementGate === gate) {
-            artifactReplacementGate = null;
-          }
-          released.resolve();
-        },
-      };
-    },
-
     async openDB(
       name: string,
       _version?: number,
@@ -450,23 +347,6 @@ function createAgent(id: string, displayName: string | null): TeamComposeItem {
     avatarUrl: null,
     visibility: "public",
     headVersionId: "version_1",
-    updatedAt: "2026-01-01T00:00:00Z",
-  };
-}
-
-function googleDriveConnector(): ConnectorResponse {
-  return {
-    id: "11111111-1111-4111-8111-111111111111",
-    type: "google-drive",
-    authMethod: "oauth",
-    externalId: "google-drive-external-id",
-    externalUsername: "drive-user",
-    externalEmail: "drive-user@example.com",
-    oauthScopes: ["drive.file"],
-    connectionStatus: "connected",
-    reconnectReason: null,
-    tokenExpiresAt: null,
-    createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
   };
 }
@@ -604,14 +484,10 @@ async function withChatIdb<T>(
 async function seedCachedArtifacts(
   scope: TestAuthScope,
   artifacts: readonly ArtifactItem[],
-  lastSyncedAt?: string,
 ): Promise<void> {
   await withChatIdb(scope, async (db) => {
     const stores = createArtifactItemCacheStores(resolvedChatIdb(db));
     await stores.writeStore.replaceItems(artifacts);
-    if (lastSyncedAt) {
-      await stores.writeStore.setLastSyncedAt(lastSyncedAt);
-    }
     const seeded = await stores.readStore.readRecent({ limit: 10_000 });
     if (seeded.length !== artifacts.length) {
       throw new Error("Expected artifact cache seed to be readable");
@@ -627,16 +503,6 @@ async function cachedArtifactIds(scope: TestAuthScope): Promise<string[]> {
     return artifacts.map((artifact) => {
       return artifact.artifactItemId;
     });
-  });
-}
-
-async function cachedArtifactsLastSyncedAt(
-  scope: TestAuthScope,
-): Promise<string | null> {
-  return await withChatIdb(scope, async (db) => {
-    return await createArtifactItemCacheStores(
-      resolvedChatIdb(db),
-    ).readStore.readLastSyncedAt();
   });
 }
 
@@ -1530,111 +1396,6 @@ describe("artifacts page", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("shows an error when an incremental response needs a timed-out cache", async () => {
-    setupTeam();
-    const scope = testAuthScope("incremental-cache-timeout");
-    const lastSyncedAt = "2026-01-02T00:00:00.000Z";
-    await seedCachedArtifacts(
-      scope,
-      [
-        createArtifact({
-          artifactItemId: "cached-timeout-run:file-1",
-          runId: "cached-timeout-run",
-          filename: "cached-timeout.html",
-          createdAt: lastSyncedAt,
-        }),
-      ],
-      lastSyncedAt,
-    );
-    const blockedRead = artifactIdbMock.blockArtifactCursorContinuation();
-    let requestedUpdatedAfter: string | undefined;
-    context.mocks.api(artifactsContract.list, ({ query, respond }) => {
-      requestedUpdatedAfter = query.updatedAfter;
-      return respond(200, {
-        artifacts: [],
-        truncated: false,
-        nextCursor: null,
-        syncUntil: "2026-01-03T00:00:00.000Z",
-      });
-    });
-
-    setupArtifactsPage({ scope });
-
-    await blockedRead.started;
-    try {
-      await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
-        "Could not load artifacts",
-      );
-      expect(screen.queryByText("No artifacts found")).not.toBeInTheDocument();
-      expect(requestedUpdatedAfter).toBe(lastSyncedAt);
-    } finally {
-      blockedRead.release();
-    }
-  });
-
-  it("refetches a full snapshot when the background cache merge times out", async () => {
-    setupTeam();
-    const scope = testAuthScope("incremental-full-cache-timeout");
-    const lastSyncedAt = "2026-01-03T00:00:00.000Z";
-    const cachedArtifacts = Array.from({ length: 61 }, (_, index) => {
-      const sequence = String(index).padStart(2, "0");
-      const createdAt = new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString();
-      return createArtifact({
-        artifactItemId: `cached-${sequence}:file-1`,
-        runId: `cached-${sequence}`,
-        filename: `cached-${sequence}.html`,
-        createdAt,
-        updatedAt: createdAt,
-      });
-    });
-    const changedArtifact = createArtifact({
-      artifactItemId: "changed:file-1",
-      runId: "changed",
-      filename: "changed.html",
-      createdAt: "2026-01-04T00:00:00.000Z",
-      updatedAt: "2026-01-04T00:00:00.000Z",
-    });
-    await seedCachedArtifacts(scope, cachedArtifacts, lastSyncedAt);
-    // The first-paint read stops at 60 without continuing. Only the background
-    // full-cache read reaches this gate while requesting the 61st item.
-    const blockedRead = artifactIdbMock.blockArtifactCursorContinuation(60);
-    let fullSnapshotRequests = 0;
-    context.mocks.api(artifactsContract.list, ({ query, respond }) => {
-      if (query.updatedAfter) {
-        return respond(200, {
-          artifacts: [changedArtifact],
-          truncated: false,
-          nextCursor: null,
-          syncUntil: "2026-01-05T00:00:00.000Z",
-        });
-      }
-      fullSnapshotRequests += 1;
-      return respond(200, {
-        artifacts: [changedArtifact, ...cachedArtifacts],
-        truncated: false,
-        nextCursor: null,
-        syncUntil: "2026-01-05T00:00:00.000Z",
-      });
-    });
-
-    setupArtifactsPage({ scope });
-
-    await blockedRead.started;
-    try {
-      await fill(
-        screen.getByPlaceholderText("Search artifacts..."),
-        "cached-00.html",
-      );
-      await expect(
-        screen.findByText("cached-00.html"),
-      ).resolves.toBeInTheDocument();
-      expect(fullSnapshotRequests).toBe(1);
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    } finally {
-      blockedRead.release();
-    }
-  });
-
   it("writes remote artifacts to the IndexedDB cache", async () => {
     setupTeam();
     const scope = testAuthScope("remote-cache-fill");
@@ -1659,111 +1420,6 @@ describe("artifacts page", () => {
       ).readStore.readRecent({ limit: 10_000 });
     });
     expect(cached).toStrictEqual([artifact]);
-  });
-
-  it("renders remote artifacts before replacing the IndexedDB cache", async () => {
-    setupTeam();
-    const scope = testAuthScope("remote-cache-background-write");
-    const artifact = createArtifact({
-      artifactItemId: "background-write-run:file-1",
-      runId: "background-write-run",
-      filename: "background-write.html",
-    });
-    const replacement = artifactIdbMock.blockArtifactReplacement();
-    mockArtifacts([artifact]);
-
-    setupArtifactsPage({ scope });
-
-    await replacement.started;
-    try {
-      expect(screen.getByText("background-write.html")).toBeInTheDocument();
-    } finally {
-      replacement.release();
-    }
-    await waitFor(async () => {
-      await expect(cachedArtifactIds(scope)).resolves.toStrictEqual([
-        artifact.artifactItemId,
-      ]);
-    });
-  });
-
-  it("cancels an obsolete cache replacement when metadata refreshes", async () => {
-    setupTeam();
-    context.mocks.data.connectors([googleDriveConnector()]);
-    const scope = testAuthScope("obsolete-cache-replacement");
-    const obsoleteArtifact = createArtifact({
-      artifactItemId: "obsolete-sync:file-1",
-      runId: "obsolete-sync",
-      filename: "obsolete-sync.html",
-    });
-    const currentArtifact = createArtifact({
-      artifactItemId: "current-sync:file-1",
-      runId: "current-sync",
-      filename: "current-sync.html",
-    });
-    const obsoleteSyncUntil = "2026-01-02T00:00:00.000Z";
-    const currentSyncUntil = "2026-01-03T00:00:00.000Z";
-    let serveCurrentArtifacts = false;
-    let listCalls = 0;
-    context.mocks.api(artifactsContract.list, ({ respond }) => {
-      listCalls += 1;
-      return respond(200, {
-        artifacts: [serveCurrentArtifacts ? currentArtifact : obsoleteArtifact],
-        truncated: false,
-        nextCursor: null,
-        syncUntil: serveCurrentArtifacts ? currentSyncUntil : obsoleteSyncUntil,
-      });
-    });
-    context.mocks.api(
-      chatThreadArtifactsContract.syncGoogleDrive,
-      ({ respond }) => {
-        serveCurrentArtifacts = true;
-        return respond(200, {
-          id: "drive-current-sync",
-          name: currentArtifact.filename,
-          webViewLink: "https://drive.test/current-sync",
-        });
-      },
-    );
-    const replacement = artifactIdbMock.blockArtifactReplacement();
-
-    setupArtifactsPage({ scope });
-
-    await replacement.started;
-    try {
-      expect(screen.getByText("obsolete-sync.html")).toBeInTheDocument();
-      click(buttonByLabel("Preview obsolete-sync.html"));
-      await expect(
-        screen.findByRole("dialog", { name: "obsolete-sync.html preview" }),
-      ).resolves.toBeInTheDocument();
-      click(buttonByLabel("Download options"));
-      await waitFor(() => {
-        expect(menuItemByText("Upload to Google Drive")).toBeInTheDocument();
-      });
-      click(menuItemByText("Upload to Google Drive"));
-      await expect(
-        screen.findByText("current-sync.html"),
-      ).resolves.toBeInTheDocument();
-      await expect(cachedArtifactIds(scope)).resolves.toStrictEqual([
-        currentArtifact.artifactItemId,
-      ]);
-      await expect(cachedArtifactsLastSyncedAt(scope)).resolves.toBe(
-        currentSyncUntil,
-      );
-    } finally {
-      replacement.release();
-    }
-
-    await replacement.completed;
-    await waitFor(async () => {
-      await expect(cachedArtifactIds(scope)).resolves.toStrictEqual([
-        currentArtifact.artifactItemId,
-      ]);
-      await expect(cachedArtifactsLastSyncedAt(scope)).resolves.toBe(
-        currentSyncUntil,
-      );
-    });
-    expect(listCalls).toBeGreaterThanOrEqual(2);
   });
 
   it("renders the cache immediately when returning while the remote refresh is pending", async () => {
@@ -2006,33 +1662,6 @@ describe("artifacts page", () => {
     // instead of stopping at the first (capped) response.
     await screen.findByText("page-one.html");
     await screen.findByText("page-two.html");
-  });
-
-  it("renders the first remote page while the next cursor is pending", async () => {
-    setupTeam();
-    const scope = testAuthScope("paged-progressive");
-    context.mocks.api(artifactsContract.list, ({ query, respond, never }) => {
-      if (query.cursor) {
-        return never();
-      }
-      return respond(200, {
-        artifacts: [
-          createArtifact({
-            artifactItemId: "progressive-page-one:file-1",
-            runId: "progressive-page-one",
-            filename: "progressive-page-one.html",
-          }),
-        ],
-        truncated: false,
-        nextCursor: "cursor-page-2",
-      });
-    });
-
-    setupArtifactsPage({ scope });
-
-    await expect(
-      screen.findByText("progressive-page-one.html"),
-    ).resolves.toBeInTheDocument();
   });
 
   it("virtualizes a large set and loads more near the scroll boundary", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -27,7 +27,6 @@ import {
   useLastLoadable,
   useLastResolved,
   useSet,
-  type LoadableState,
 } from "ccstate-react";
 import {
   Button,
@@ -57,7 +56,6 @@ import {
   filterArtifacts,
   getArtifactFocusTarget,
   growArtifactsWindow$,
-  mergeArtifactSources,
   navigateToArtifactThread$,
   reloadArtifacts$,
   remoteArtifacts$,
@@ -71,7 +69,6 @@ import {
   setSelectedArtifactsAgentId$,
   setSelectedArtifactsCategory$,
   startArtifactChat$,
-  syncArtifacts$,
   syncArtifactsScrollMetrics$,
 } from "../../signals/artifacts-page/artifacts-signals.ts";
 import type { ArtifactCategory } from "../../signals/artifacts-page/artifact-category.ts";
@@ -88,7 +85,7 @@ import {
   openVideoLightbox$,
   type AttachmentArtifactMetadata,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
-import { detach, Reason, tapError } from "../../signals/utils.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { AttachmentLightbox } from "../zero-page/zero-attachment-chips.tsx";
 import {
   FilePreviewIcon,
@@ -116,37 +113,6 @@ const ARTIFACT_CARD_IMAGE_HEIGHT = 400;
 const ARTIFACT_CARD_PREVIEW_ASPECT_RATIO = 16 / 10;
 const ARTIFACT_CARD_DETAILS_HEIGHT_PX = 64;
 const ARTIFACT_CARD_BORDER_WIDTH_PX = 1;
-
-function getArtifactsPageLoadState({
-  cacheState,
-  hasSourceArtifacts,
-  mergeCachedArtifacts,
-  remoteState,
-}: {
-  cacheState: LoadableState;
-  hasSourceArtifacts: boolean;
-  mergeCachedArtifacts: boolean;
-  remoteState: LoadableState;
-}): {
-  error: boolean;
-  loading: boolean;
-} {
-  const remotePending = remoteState === "loading";
-  const remoteStillNeedsCache =
-    remotePending || remoteState === "hasError" || mergeCachedArtifacts;
-  const noSourceArtifacts = !hasSourceArtifacts;
-
-  return {
-    error:
-      noSourceArtifacts &&
-      (remoteState === "hasError" ||
-        (cacheState === "hasError" && remoteStillNeedsCache)),
-    loading:
-      noSourceArtifacts &&
-      (remotePending || (cacheState === "loading" && remoteStillNeedsCache)),
-  };
-}
-
 const ARTIFACT_CATEGORY_OPTIONS: readonly {
   readonly ariaLabel: string;
   readonly label: string;
@@ -271,18 +237,13 @@ function artifactLightboxMetadata(
 
 function useOpenArtifactPreview(): (item: ArtifactItem) => void {
   const reloadArtifacts = useSet(reloadArtifacts$);
-  const syncArtifacts = useSet(syncArtifacts$);
-  const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openImageLightbox$);
   const openDocumentLightbox = useSet(openDocumentLightbox$);
   const openVideoLightbox = useSet(openVideoLightbox$);
   const openAudioLightbox = useSet(openAudioLightbox$);
 
   return (item: ArtifactItem) => {
-    const artifact = artifactLightboxMetadata(item, () => {
-      reloadArtifacts();
-      detach(tapError(syncArtifacts(pageSignal)), Reason.DomCallback);
-    });
+    const artifact = artifactLightboxMetadata(item, reloadArtifacts);
     const base = {
       artifact,
       editAvailable: false,
@@ -1256,13 +1217,11 @@ export function ArtifactsPage() {
     remoteLoadable.state === "hasData" ? remoteLoadable.data : null;
   const cachedData =
     cachedLoadable.state === "hasData" ? cachedLoadable.data : null;
-  // Keep the bounded cache visible while incremental pages arrive. A full
-  // remote snapshot replaces it; an incremental response merges into it until
-  // the background sync has rebuilt the complete local snapshot.
-  const sourceArtifacts = mergeArtifactSources(
-    cachedData?.artifacts ?? [],
-    remoteData,
-  );
+  // Cache-first paint, then let the successful remote bulk response become the
+  // authoritative set. Cached fallback is only used before remote data loads or
+  // when the refresh errors.
+  const sourceData = remoteData ?? cachedData;
+  const sourceArtifacts = sourceData?.artifacts ?? [];
   const artifacts = filterArtifacts(sourceArtifacts, {
     search,
     agentId: selectedAgentId,
@@ -1270,12 +1229,11 @@ export function ArtifactsPage() {
   });
   // Drive first-paint loading / error off the source set (not the filtered
   // view, which is legitimately empty when a filter matches nothing).
-  const { error, loading } = getArtifactsPageLoadState({
-    cacheState: cachedLoadable.state,
-    hasSourceArtifacts: sourceArtifacts.length > 0,
-    mergeCachedArtifacts: remoteData?.mergeCachedArtifacts === true,
-    remoteState: remoteLoadable.state,
-  });
+  const nothingCached = sourceArtifacts.length === 0;
+  const loading =
+    nothingCached &&
+    (remoteLoadable.state === "loading" || cachedLoadable.state === "loading");
+  const error = nothingCached && remoteLoadable.state === "hasError";
   const handleScroll = (event: ReactUIEvent<HTMLElement>) => {
     const viewport = event.currentTarget;
     syncScrollMetrics(viewport);


### PR DESCRIPTION
## Summary

- revert the Artifact cache and progressive-loading changes introduced by PR #22646
- restore the previous Artifact cache read, remote pagination, and cache replacement behavior
- keep the rollback scoped to the exact six files changed by the original merge

## Reason

Repeated navigation to the Artifact page can still expose a loading state, so the intended cache-first experience is not reliable enough to keep this rollout.

## Verification

- `git diff --check origin/main...HEAD`
- confirmed the six affected files were unchanged on `main` after merge commit `53c7133`
- confirmed this commit is the exact inverse of PR #22646 for those files
- local tests were not run because this fresh clone has no installed dependencies; PR CI is the verification source

Reverts #22646.