### PR TITLE
fix(runner): scope platform api auto-allow to configured port

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -292,9 +292,10 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
         except AuthorityValidationError:
             return
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        if upstream_admission.api_hostname_matches(
+        if upstream_admission.api_destination_matches(
             api_url,
             trusted_authority.host,
+            trusted_authority.port,
         ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
             classification = _classify_request_for_flow(
                 flow,

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -13,7 +13,6 @@ flow and must be popped by terminal, response/error, and final request paths so
 stale decisions cannot leak into later hook handling for the same flow.
 """
 
-import urllib.parse
 from dataclasses import dataclass, field
 from typing import Literal, Protocol, TypeAlias
 
@@ -351,9 +350,10 @@ def classify_request(
         port=trusted_authority.port,
     )
 
-    hostname = trusted_authority.host.lower()
-    if _api_hostname_matches(
-        api_url, hostname
+    if upstream_admission.api_destination_matches(
+        api_url,
+        trusted_authority.host,
+        trusted_authority.port,
     ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
         return ApiAllow(vm_info=vm_info)
 
@@ -544,16 +544,6 @@ def _store_trusted_authority_metadata(
         url=original_url,
         host=host,
         port=port,
-    )
-
-
-def _api_hostname_matches(api_url: str, hostname: str) -> bool:
-    if not api_url:
-        return False
-    parsed_api = urllib.parse.urlparse(api_url)
-    api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
-    return bool(
-        api_hostname and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
     )
 
 

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -134,9 +134,14 @@ def _requires_platform_connector_auth_bypass(
     *,
     kind: upstream_destination_binding.BindingKind,
     normalized_host: str,
+    port: int,
     api_url: str,
 ) -> bool:
-    return kind == "connector_auth" and api_hostname_matches(api_url, normalized_host)
+    return kind == "connector_auth" and api_destination_matches(
+        api_url,
+        normalized_host,
+        port,
+    )
 
 
 def _flow_requires_platform_connector_auth_bypass(
@@ -157,16 +162,17 @@ def _flow_requires_platform_connector_auth_bypass(
     return _requires_platform_connector_auth_bypass(
         kind=kind,
         normalized_host=normalized_host,
+        port=flow.request.port,
         api_url=api_url,
     )
 
 
-def api_hostname_matches(api_url: str, hostname: str) -> bool:
+def api_destination_matches(api_url: str, hostname: str, port: int) -> bool:
     api_destination = _api_destination(api_url)
     if api_destination is None:
         return False
-    api_hostname, _api_port = api_destination
-    return hostname == api_hostname or hostname.endswith(f".{api_hostname}")
+    api_hostname, api_port = api_destination
+    return port == api_port and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
 
 
 def _api_destination(api_url: str) -> tuple[str, int] | None:
@@ -193,13 +199,13 @@ def _server_connect_binding_kinds(
     hostname: str,
     port: int,
     compiled_firewalls: matching.CompiledFirewallSet | None,
-    is_api_host: bool,
+    is_api_destination: bool,
 ) -> frozenset[upstream_destination_binding.BindingKind]:
     kinds: set[upstream_destination_binding.BindingKind] = set()
-    if is_api_host:
+    if is_api_destination:
         kinds.add("api_allow")
     if (
-        not is_api_host
+        not is_api_destination
         and compiled_firewalls is not None
         and compiled_firewalls.matches_ordinary_credential_authority(
             hostname,
@@ -242,9 +248,9 @@ def _bind_privileged_upstream_destination(
     if address is None:
         return
     _original_host, port = address
-    is_api_host = api_hostname_matches(api_url, hostname)
+    is_api_destination = api_destination_matches(api_url, hostname, port)
     reusable_kind: upstream_destination_binding.BindingKind = (
-        "api_allow" if is_api_host else "connector_auth"
+        "api_allow" if is_api_destination else "connector_auth"
     )
     if upstream_destination_binding.reuse_server_binding_kind_if_matching(
         server,
@@ -259,7 +265,7 @@ def _bind_privileged_upstream_destination(
         hostname=hostname,
         port=port,
         compiled_firewalls=registry_state.compiled_firewalls.get(client_ip),
-        is_api_host=is_api_host,
+        is_api_destination=is_api_destination,
     )
     if not kinds:
         return
@@ -429,6 +435,7 @@ def _bind_flow_upstream_destination(
     if _requires_platform_connector_auth_bypass(
         kind=kind,
         normalized_host=normalized_host,
+        port=flow.request.port,
         api_url=api_url,
     ) and not _request_allows_platform_connector_auth(flow):
         return False

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -68,15 +68,167 @@ async def test_allowed_domain_passes_through(registry_file, real_flow, mitm_ctx)
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
-async def test_vm0_api_auto_allowed(registry_file, real_flow, mitm_ctx):
-    flow = real_flow(with_response=False, host="api.vm0.ai")
+@pytest.mark.parametrize(
+    ("api_url", "host", "scheme", "port"),
+    [
+        pytest.param(
+            "https://api.vm0.ai",
+            "api.vm0.ai",
+            "https",
+            443,
+            id="https-default-port",
+        ),
+        pytest.param(
+            "http://api.vm0.ai",
+            "api.vm0.ai",
+            "http",
+            80,
+            id="http-default-port",
+        ),
+        pytest.param(
+            "https://api.vm0.ai:8443",
+            "api.vm0.ai",
+            "https",
+            8443,
+            id="explicit-non-default-port",
+        ),
+        pytest.param(
+            "https://api.vm0.ai",
+            "preview.api.vm0.ai",
+            "https",
+            443,
+            id="subdomain",
+        ),
+    ],
+)
+async def test_vm0_api_auto_allowed(
+    registry_file,
+    real_flow,
+    mitm_ctx,
+    api_url,
+    host,
+    scheme,
+    port,
+):
+    flow = real_flow(
+        with_response=False,
+        host=host,
+        scheme=scheme,
+        port=port,
+    )
 
     with (
-        mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
+        mitm_ctx(registry_path=str(registry_file), api_url=api_url),
     ):
         await mitm_addon.request(flow)
 
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == host
+    assert binding.port == port
+    assert binding.kinds == frozenset(("api_allow",))
+
+
+async def test_vm0_api_wrong_port_uses_matching_firewall_deny_policy(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="alternate-api-port",
+            api_entry={
+                "base": "https://api.vm0.ai:8443",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "read", "rules": ["GET /restricted"]}],
+            },
+            network_policy={
+                "allow": [],
+                "deny": ["read"],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.vm0.ai",
+        port=8443,
+        path="/restricted",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["reason"] == "permission_denied"
+    assert body["permissions"] == ["read"]
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_vm0_api_wrong_port_uses_normal_connector_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="alternate-api-port",
+            api_entry={
+                "base": "https://api.vm0.ai:8443",
+                "auth": {
+                    "headers": {
+                        "Authorization": "Bearer ${{ secrets.API_TOKEN }}",
+                    }
+                },
+                "permissions": [{"name": "read", "rules": ["GET /restricted"]}],
+            },
+            network_policy={
+                "allow": ["read"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.vm0.ai",
+        port=8443,
+        path="/restricted",
+        request_headers=headers(("Host", "api.vm0.ai:8443")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved-api-token"}) as auth_fetch,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+        assert binding.host == "api.vm0.ai"
+        assert binding.port == 8443
+        assert binding.kinds == frozenset(("connector_auth",))
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.vm0.ai:8443"
+    assert flow.request.headers["Authorization"] == "Bearer resolved-api-token"
 
 
 async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -268,15 +268,55 @@ def test_server_connect_does_not_overwrite_clienthello_binding_after_address_cha
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx):
-    data = _data(client_ip="10.200.0.1", sni="api.vm0.ai")
+@pytest.mark.parametrize(
+    ("api_url", "port"),
+    [
+        pytest.param("https://api.vm0.ai", 443, id="implicit-default-port"),
+        pytest.param(
+            "https://api.vm0.ai:8443",
+            8443,
+            id="explicit-non-default-port",
+        ),
+    ],
+)
+def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx, api_url, port):
+    data = _data(
+        client_ip="10.200.0.1",
+        sni="api.vm0.ai",
+        address=("203.0.113.10", port),
+    )
 
-    with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+    with mitm_ctx(registry_path=str(registry_file), api_url=api_url):
         mitm_addon.server_connect(data)
 
-    assert data.server.address == ("api.vm0.ai", 443)
+    assert data.server.address == ("api.vm0.ai", port)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.port == port
     assert binding.kinds == frozenset(("api_allow",))
+
+
+def test_server_connect_treats_api_hostname_on_other_port_as_connector(
+    tmp_path,
+    mitm_ctx,
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        base="https://api.vm0.ai:8443",
+    )
+    data = _data(
+        sni="api.vm0.ai",
+        address=("203.0.113.10", 8443),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.server_connect(data)
+
+    assert data.server.address == ("api.vm0.ai", 8443)
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.port == 8443
+    assert binding.kinds == frozenset(("connector_auth",))
 
 
 def test_server_connect_does_not_prebind_platform_connector_auth(tmp_path, mitm_ctx):


### PR DESCRIPTION
## Summary

- treat the configured platform API as a hostname-and-effective-port destination across request classification and privileged upstream binding
- route same-host requests on other ports through normal firewall and connector-auth handling instead of granting `api_allow`
- cover HTTPS/HTTP defaults, explicit ports, subdomains, request handling, and server-connect prebinding

## Scope

- no schema, protocol, configuration, or documentation changes

## Validation

- `./.venv/bin/ruff check .`
- `./.venv/bin/ruff format --check .`
- `./.venv/bin/basedpyright -p .`
- `./.venv/bin/python -m pytest tests/ -v` (4189 passed)

Closes #22689
