### PR TITLE
perf(api): collapse chat event cursors and narrow message ownership reads

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-event.service.ts
@@ -1,4 +1,5 @@
-import { and, asc, eq, sql, type SQL } from "drizzle-orm";
+import { and, asc, eq, gt, gte, or } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type {
   ChatThreadEvent,
   ChatThreadSnapshotProjection,
@@ -18,6 +19,11 @@ import {
 
 type ChatThreadEventDb = Pick<Db, "insert" | "select">;
 const CHAT_THREAD_EVENTS_PAGE_SIZE = 1000;
+const cursorChatThreadEvent = alias(
+  chatThreadEvents,
+  "cursor_chat_thread_event",
+);
+const pageChatThreadEvent = alias(chatThreadEvents, "page_chat_thread_event");
 
 export async function appendChatThreadEvent(
   db: ChatThreadEventDb,
@@ -106,7 +112,7 @@ export async function getChatThreadSnapshot(
   };
 }
 
-function toApiChatThreadEvent(row: {
+type ChatThreadEventRow = {
   readonly id: string;
   readonly kind: ChatThreadEventKind;
   readonly chatThreadId: string;
@@ -114,7 +120,9 @@ function toApiChatThreadEvent(row: {
   readonly title: string | null;
   readonly selectedModel: string | null;
   readonly createdAt: Date;
-}): ChatThreadEvent {
+};
+
+function toApiChatThreadEvent(row: ChatThreadEventRow): ChatThreadEvent {
   return {
     id: row.id,
     kind: row.kind,
@@ -142,64 +150,89 @@ export async function getChatThreadEventsSince(
     }
   | { readonly kind: "expired" }
 > {
-  let hasCursor = false;
-
+  let rows: readonly ChatThreadEventRow[];
   if (args.sinceEventId !== undefined) {
-    const [row] = await db
+    // Keep a valid cursor row when its page is empty while preserving the
+    // composite event index's timestamp lower bound.
+    const cursorRows = await db
+      .select({
+        event: {
+          id: pageChatThreadEvent.id,
+          kind: pageChatThreadEvent.kind,
+          chatThreadId: pageChatThreadEvent.chatThreadId,
+          agentComposeId: pageChatThreadEvent.agentComposeId,
+          title: pageChatThreadEvent.title,
+          selectedModel: pageChatThreadEvent.selectedModel,
+          createdAt: pageChatThreadEvent.createdAt,
+        },
+      })
+      .from(cursorChatThreadEvent)
+      .leftJoin(
+        pageChatThreadEvent,
+        and(
+          eq(pageChatThreadEvent.userId, args.userId),
+          eq(pageChatThreadEvent.orgId, args.orgId),
+          gte(pageChatThreadEvent.createdAt, cursorChatThreadEvent.createdAt),
+          or(
+            gt(pageChatThreadEvent.createdAt, cursorChatThreadEvent.createdAt),
+            and(
+              eq(
+                pageChatThreadEvent.createdAt,
+                cursorChatThreadEvent.createdAt,
+              ),
+              gt(pageChatThreadEvent.id, cursorChatThreadEvent.id),
+            ),
+          ),
+          args.includeCanonicalSlackThreads
+            ? undefined
+            : excludeCanonicalSlackChatThreads(
+                db,
+                pageChatThreadEvent.chatThreadId,
+              ),
+        ),
+      )
+      .where(
+        and(
+          eq(cursorChatThreadEvent.userId, args.userId),
+          eq(cursorChatThreadEvent.orgId, args.orgId),
+          eq(cursorChatThreadEvent.id, args.sinceEventId),
+        ),
+      )
+      .orderBy(asc(pageChatThreadEvent.createdAt), asc(pageChatThreadEvent.id))
+      .limit(CHAT_THREAD_EVENTS_PAGE_SIZE + 1);
+    if (cursorRows.length === 0) {
+      return { kind: "expired" };
+    }
+    rows = cursorRows.flatMap((row) => {
+      return row.event ? [row.event] : [];
+    });
+  } else {
+    rows = await db
       .select({
         id: chatThreadEvents.id,
+        kind: chatThreadEvents.kind,
+        chatThreadId: chatThreadEvents.chatThreadId,
+        agentComposeId: chatThreadEvents.agentComposeId,
+        title: chatThreadEvents.title,
+        selectedModel: chatThreadEvents.selectedModel,
+        createdAt: chatThreadEvents.createdAt,
       })
       .from(chatThreadEvents)
       .where(
         and(
           eq(chatThreadEvents.userId, args.userId),
           eq(chatThreadEvents.orgId, args.orgId),
-          eq(chatThreadEvents.id, args.sinceEventId),
+          args.includeCanonicalSlackThreads
+            ? undefined
+            : excludeCanonicalSlackChatThreads(
+                db,
+                chatThreadEvents.chatThreadId,
+              ),
         ),
       )
-      .limit(1);
-    if (!row) {
-      return { kind: "expired" };
-    }
-    hasCursor = true;
+      .orderBy(asc(chatThreadEvents.createdAt), asc(chatThreadEvents.id))
+      .limit(CHAT_THREAD_EVENTS_PAGE_SIZE + 1);
   }
-
-  const filters: SQL[] = [
-    eq(chatThreadEvents.userId, args.userId),
-    eq(chatThreadEvents.orgId, args.orgId),
-  ];
-  if (!args.includeCanonicalSlackThreads) {
-    filters.push(
-      excludeCanonicalSlackChatThreads(db, chatThreadEvents.chatThreadId),
-    );
-  }
-  if (hasCursor && args.sinceEventId !== undefined) {
-    filters.push(
-      sql`(${chatThreadEvents.createdAt}, ${chatThreadEvents.id}) > (
-        SELECT marker.created_at, marker.id
-        FROM ${chatThreadEvents} AS marker
-        WHERE marker.user_id = ${args.userId}
-          AND marker.org_id = ${args.orgId}
-          AND marker.id = ${args.sinceEventId}
-        LIMIT 1
-      )`,
-    );
-  }
-
-  const rows = await db
-    .select({
-      id: chatThreadEvents.id,
-      kind: chatThreadEvents.kind,
-      chatThreadId: chatThreadEvents.chatThreadId,
-      agentComposeId: chatThreadEvents.agentComposeId,
-      title: chatThreadEvents.title,
-      selectedModel: chatThreadEvents.selectedModel,
-      createdAt: chatThreadEvents.createdAt,
-    })
-    .from(chatThreadEvents)
-    .where(and(...filters))
-    .orderBy(asc(chatThreadEvents.createdAt), asc(chatThreadEvents.id))
-    .limit(CHAT_THREAD_EVENTS_PAGE_SIZE + 1);
 
   return {
     kind: "ok",

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1744,7 +1744,17 @@ export function zeroChatThreadMessagesPage(args: {
   } | null>
 > {
   return computed(async (get) => {
-    const owned = await get(ownedChatThread(args.threadId, args.userId));
+    const db = get(db$);
+    const [owned] = await db
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.threadId),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .limit(1);
     if (!owned) {
       return null;
     }
@@ -1753,7 +1763,6 @@ export function zeroChatThreadMessagesPage(args: {
       throw new Error("sinceId and beforeId are mutually exclusive");
     }
 
-    const db = get(db$);
     const threadFilter = eq(chatMessages.chatThreadId, args.threadId);
     const cursorSequence = chatMessageOrderSequenceSql();
     let rows: ChatMessageRow[];


### PR DESCRIPTION
## Summary

- collapse chat-thread event cursor validation and pagination into one parameterized Drizzle self-join
- preserve expired-cursor `410`, valid empty-page `200`, chronological ordering, page limits, and canonical Slack visibility filtering
- narrow the message-page ownership read to `chat_threads.id`, removing the full thread projection and `zero_agents` join from this endpoint
- add no schema, contract, feature-switch, or raw SQL; the event path removes its previous raw tuple comparison

## Impact

Production traces showed that about 92% of event requests paid for a separate cursor-presence query before pagination. The new query anchors pagination on the cursor row so that validation and page retrieval share one database round trip.

Message reads keep their existing round-trip structure in this focused change, but the ownership query now retrieves only the value the page needs. The more invasive ownership-plus-page consolidation remains out of scope.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/zero-chat-thread-event.service.ts apps/api/src/signals/services/zero-chat-thread.service.ts`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- generated the Drizzle cursor statement against a mock driver and verified it is one parameterized query
- verified the left-join null row maps to `kind: "ok"` with an empty page, while no cursor row maps to `kind: "expired"`

The existing route integration suite covers cursor expiry, a retained cursor with no later events, message pagination, empty owned threads, missing threads, and cross-user access. A local run of `chat-threads.bdd.test.ts` could not reach those assertions because this runtime has no PostgreSQL service or Docker; setup requests failed with `ECONNREFUSED`. The PR pipeline remains the authoritative route-test run.
