### PR TITLE
test(platform): wait for sidebar rename dialog interactivity

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -912,6 +912,10 @@ describe("zero sidebar", () => {
     const titleInput = within(dialog).getByPlaceholderText("Chat title");
     expect(titleInput).toHaveValue("Release plan");
 
+    await waitFor(() => {
+      expect(dialog).toHaveStyle({ pointerEvents: "auto" });
+    });
+
     await fill(titleInput, "Launch plan");
     const renameForm = titleInput.closest("form");
     expect(renameForm).not.toBeNull();


### PR DESCRIPTION
## Summary

- Wait for the sidebar rename dialog's Radix layer to become pointer-interactive before typing.
- Preserve the full rename behavior assertion while removing the scheduling dependency between dropdown teardown and dialog setup.
- Fix the intermittent `pointer-events: none` failure observed in [Turbo run 29997693303](https://github.com/vm0-ai/vm0/actions/runs/29997693303/job/89176244893).

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t 'renames a chat thread from the sidebar menu' --reporter=dot` (7 consecutive targeted passes)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --reporter=dot` (44/44 tests passed)
- `pnpm -F @vm0/app check-types`
- Prettier, Oxlint, type-aware Oxlint, ESLint, and `git diff --check`
