### PR TITLE
fix(chat): preserve structured prompt templates

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -135,6 +135,7 @@ import { createMailDraftCardSignalsRegistry } from "./mail-draft.ts";
 import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 import {
   messageDocumentToDisplayText,
+  messageDocumentToPrompt,
   textToMessageDocument,
 } from "../zero-page/user-message-document-codec.ts";
 
@@ -3809,13 +3810,23 @@ function createRecallMessage(deps: RecallMessageDeps) {
         },
       });
       const features = get(featureSwitch$);
+      const structuredPrompt =
+        (features[FeatureSwitchKey.StructuredPrompt] ?? false)
+          ? (message.structuredPrompt ?? null)
+          : null;
+      const templatePart = structuredPrompt?.parts.find((part) => {
+        return part.type === "template";
+      });
       set(draft.seed$, {
-        content: message.content ?? "",
-        structuredPrompt:
-          (features[FeatureSwitchKey.StructuredPrompt] ?? false)
-            ? (message.structuredPrompt ?? null)
-            : null,
-        generationTemplate: message.generationTemplate,
+        content: structuredPrompt
+          ? (messageDocumentToPrompt(structuredPrompt) ?? "")
+          : (message.content ?? ""),
+        structuredPrompt,
+        generationTemplate: structuredPrompt
+          ? templatePart?.type === "template"
+            ? templatePart.template
+            : undefined
+          : message.generationTemplate,
         attachments: (message.attachFiles ?? []).map(createRestoredAttachment),
       });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1906,6 +1906,108 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("clears a recalled template after queueing the message again", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const generationTemplate = {
+      type: "illustration",
+      selection: {
+        illustrationStyleId: template.illustrationStyleId,
+      },
+    } satisfies GenerationTemplateRequest;
+    let queuedGenerationTemplate: GenerationTemplateRequest | undefined;
+    let queuedStructuredTemplate: GenerationTemplateRequest | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-template-active-user",
+          role: "user",
+          content: "Start an active illustration run",
+          runId: "run-template-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-template-active-assistant",
+          role: "assistant",
+          content: null,
+          runId: "run-template-active",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-template-queued-user",
+          role: "user",
+          content: "invalidate",
+          runId: undefined,
+          structuredPrompt: {
+            version: 1,
+            parts: [
+              {
+                type: "template",
+                titleSnapshot: template.title,
+                template: generationTemplate,
+              },
+              { type: "text", text: "Queue a recalled illustration" },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+      activeRunIds: ["run-template-active"],
+      onQueuedMessageAppend: (body) => {
+        queuedGenerationTemplate = body.generationTemplate;
+        const templatePart = body.structuredPrompt?.parts.find((part) => {
+          return part.type === "template";
+        });
+        queuedStructuredTemplate =
+          templatePart?.type === "template" ? templatePart.template : undefined;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.StructuredPrompt]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Queue a recalled illustration",
+      );
+    });
+
+    click(screen.getByLabelText("Remove queued message"));
+
+    const composer = await screen.findByRole("textbox", { name: "Message" });
+    await waitFor(() => {
+      expect(composer).toHaveTextContent("Queue a recalled illustration");
+      expect(
+        screen.getByLabelText(`Remove template ${template.title}`),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(composer);
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Queue a recalled illustration",
+      );
+      expect(queuedGenerationTemplate).toStrictEqual(generationTemplate);
+      expect(queuedStructuredTemplate).toStrictEqual(generationTemplate);
+      expect(screen.getByLabelText("Template")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+      expect(
+        screen.queryByLabelText(`Remove template ${template.title}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps newer template selections visible after a queued template is sent", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1319,4 +1319,130 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       structuredPrompt,
     });
   });
+
+  it("restores a copied structured template when pasting into the composer", async () => {
+    const clipboard = context.mocks.browser.clipboardWrite();
+    const threadId = "structured-template-copy-paste";
+    const style = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const generationTemplate = {
+      type: "illustration" as const,
+      selection: {
+        illustrationStyleId: style.illustrationStyleId,
+      },
+    };
+    const messageText = "Create a matching illustration";
+    const structuredPrompt = {
+      version: 1 as const,
+      parts: [
+        {
+          type: "template" as const,
+          titleSnapshot: style.title,
+          template: generationTemplate,
+        },
+        { type: "text" as const, text: messageText },
+      ],
+    };
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          id: "msg-structured-template-copy-paste",
+          role: "user",
+          content: "invalidate",
+          structuredPrompt,
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(messageText)).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Copy message"));
+
+    const item = await readSingleRichClipboardWrite(clipboard);
+    const html = await readClipboardItemText(item, "text/html");
+    const plainText = await readClipboardItemText(item, "text/plain");
+    const composer = await screen.findByRole("textbox", { name: "Message" });
+    fireEvent.paste(composer, {
+      clipboardData: {
+        getData: (type: string) => {
+          return type === "text/html"
+            ? html
+            : type === "text/plain"
+              ? plainText
+              : "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(composer).toHaveTextContent(messageText);
+      expect(
+        screen.getByLabelText(`Remove template ${style.title}`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not restore a copied structured template when the switch is off", async () => {
+    const threadId = "structured-template-paste-disabled";
+    const style = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const messageText = "Paste without restoring the template";
+    const payload = {
+      text: messageText,
+      attachments: [],
+      structuredPrompt: {
+        version: 1 as const,
+        parts: [
+          {
+            type: "template" as const,
+            titleSnapshot: style.title,
+            template: {
+              type: "illustration" as const,
+              selection: {
+                illustrationStyleId: style.illustrationStyleId,
+              },
+            },
+          },
+          { type: "text" as const, text: messageText },
+        ],
+      },
+    };
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: false },
+    });
+
+    const composer = await screen.findByRole("textbox", { name: "Message" });
+    fireEvent.paste(composer, {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return `<div data-vm0-chat-message="${encodeURIComponent(
+              JSON.stringify(payload),
+            )}"></div>`;
+          }
+          return type === "text/plain" ? messageText : "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(composer).toHaveTextContent(messageText);
+      expect(
+        screen.queryByLabelText(`Remove template ${style.title}`),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -141,6 +141,7 @@ import {
   type WebsiteTemplateItem,
   type WorkflowTemplateItem,
 } from "@vm0/core";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
@@ -164,6 +165,7 @@ import {
   codexFastModeEnabled$,
   composerUploadPopoverEnabled$,
   composerConnectorPermissionsEnabled$,
+  featureSwitch$,
 } from "../../signals/external/feature-switch.ts";
 import {
   zeroDesktopDownloadSupportStatus$,
@@ -6442,6 +6444,71 @@ function toPersistedAttachments(
     });
 }
 
+function restoreChatClipboardPayload({
+  event,
+  structuredPromptEnabled,
+  visualAttachmentUnsupported,
+  insertPromptMarkdown,
+  restoreAttachments,
+  onTemplateChange,
+  onDraftChange,
+}: {
+  event: ComposerPasteEvent;
+  structuredPromptEnabled: boolean;
+  visualAttachmentUnsupported: VisualAttachmentUnsupportedState | null;
+  insertPromptMarkdown: (value: string) => void;
+  restoreAttachments: (attachments: PersistedAttachment[]) => void;
+  onTemplateChange:
+    | ((value: GenerationTemplateRequest | undefined) => void)
+    | undefined;
+  onDraftChange: (() => void) | undefined;
+}): boolean {
+  if (!event.clipboardData) {
+    return false;
+  }
+  const payload = readChatMessageFromClipboard(event.clipboardData);
+  if (!payload) {
+    return false;
+  }
+  const structuredPrompt = structuredPromptEnabled
+    ? payload.structuredPrompt
+    : undefined;
+  const persistedAttachments = toPersistedAttachments(payload.attachments);
+  if (!structuredPrompt && persistedAttachments.length === 0) {
+    return false;
+  }
+  const allowedAttachments = visualAttachmentUnsupported
+    ? persistedAttachments.filter((attachment) => {
+        return !isVisualAttachment({
+          contentType: attachment.contentType,
+          filename: attachment.filename,
+        });
+      })
+    : persistedAttachments;
+  if (
+    visualAttachmentUnsupported &&
+    allowedAttachments.length < persistedAttachments.length
+  ) {
+    showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
+  }
+
+  event.preventDefault();
+  if (payload.text) {
+    insertPromptMarkdown(payload.text);
+  }
+  const templatePart = structuredPrompt?.parts.find((part) => {
+    return part.type === "template";
+  });
+  if (templatePart?.type === "template") {
+    onTemplateChange?.(templatePart.template);
+  }
+  if (allowedAttachments.length > 0) {
+    restoreAttachments(allowedAttachments);
+  }
+  onDraftChange?.();
+  return true;
+}
+
 type KeyboardSendAction = "none" | "send" | "queue";
 
 function ComposerInputSlot({
@@ -6734,6 +6801,9 @@ export function useZeroChatComposer({
   const showAddDialog = useGet(composerConnectors.showAddDialog$);
   const setShowAddDialog = useSet(composerConnectors.setShowAddDialog$);
   const openGoalDialog = useSet(openChatThreadGoalDialog$);
+  const featureSwitches = useGet(featureSwitch$);
+  const structuredPromptEnabled =
+    featureSwitches[FeatureSwitchKey.StructuredPrompt] ?? false;
 
   const resolved = useResolvedComposerSignals(
     draft,
@@ -6773,33 +6843,18 @@ export function useZeroChatComposer({
     if (!e.clipboardData) {
       return;
     }
-    const chatPayload = readChatMessageFromClipboard(e.clipboardData);
-    if (chatPayload && chatPayload.attachments.length > 0) {
-      const persistedAttachments = toPersistedAttachments(
-        chatPayload.attachments,
-      );
-      if (persistedAttachments.length > 0) {
-        const allowedAttachments = visualAttachmentUnsupported
-          ? persistedAttachments.filter((attachment) => {
-              return !isVisualAttachment({
-                contentType: attachment.contentType,
-                filename: attachment.filename,
-              });
-            })
-          : persistedAttachments;
-        if (allowedAttachments.length < persistedAttachments.length) {
-          showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported!);
-        }
-        e.preventDefault();
-        if (chatPayload.text) {
-          insertPromptMarkdown(chatPayload.text);
-        }
-        if (allowedAttachments.length > 0) {
-          restoreAttachments(allowedAttachments);
-        }
-        onDraftChange?.();
-        return;
-      }
+    if (
+      restoreChatClipboardPayload({
+        event: e,
+        structuredPromptEnabled,
+        visualAttachmentUnsupported,
+        insertPromptMarkdown,
+        restoreAttachments,
+        onTemplateChange: templatePicker?.onChange,
+        onDraftChange,
+      })
+    ) {
+      return;
     }
 
     const items = e.clipboardData?.items;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -126,7 +126,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationExport]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -339,6 +339,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable structured user prompt rendering, sends, and drafts while preserving the legacy content fallback.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- restore recalled queued-message content and template state from `structuredPrompt`
- restore copied historical-message templates on paste when the StructuredPrompt switch is enabled
- enable StructuredPrompt for staff organizations and cover enabled/disabled behavior with regression tests

## Testing

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- app/core type checks and lint
- app/core Knip checks
- Prettier check for changed files