### PR TITLE
fix(ci): use created release sha for production targets

### DIFF
--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -196,6 +196,53 @@ assert_failure "must be a full lowercase SHA-1" run_resolver "${tmp_dir}/invalid
 target_commit=$target_commit_before
 [ ! -s "${tmp_dir}/boundaries.log" ] || fail "invalid target must fail before external boundaries"
 
+release_target_script="${tmp_dir}/resolve-release-target.sh"
+ruby -e '
+  require "yaml"
+  workflow = YAML.safe_load(File.read(ARGV[0]), aliases: true)
+  release_job = workflow.fetch("jobs").fetch("release-please")
+  release_target_step = release_job.fetch("steps").find { |step| step["id"] == "release-target" }
+  raise "missing release target resolver step" unless release_target_step
+  puts release_target_step.fetch("run")
+' "${repo_root}/.github/workflows/release-please.yml" >"$release_target_script"
+
+release_target=cccccccccccccccccccccccccccccccccccccccc
+release_outputs=$(jq -nc \
+  --arg target "$release_target" \
+  '{
+    "turbo/apps/api--sha": $target,
+    "turbo/apps/platform--sha": $target,
+    "turbo/apps/api--body": "release notes",
+    releases_created: "true"
+  }')
+release_target_output="${tmp_dir}/release-target.output"
+RELEASE_OUTPUTS="$release_outputs" \
+  GITHUB_OUTPUT="$release_target_output" \
+  bash "$release_target_script"
+grep -qx "sha=${release_target}" "$release_target_output" || fail "release target resolver did not publish the unique release SHA"
+
+missing_release_target_output="${tmp_dir}/missing-release-target.output"
+assert_failure \
+  "release-please returned no release SHA" \
+  env \
+  RELEASE_OUTPUTS='{"releases_created":"true"}' \
+  GITHUB_OUTPUT="$missing_release_target_output" \
+  bash "$release_target_script"
+[ ! -s "$missing_release_target_output" ] || fail "missing release SHA must not publish an output"
+
+multiple_release_targets=$(jq -nc '{
+  "turbo/apps/api--sha": "cccccccccccccccccccccccccccccccccccccccc",
+  "turbo/apps/platform--sha": "dddddddddddddddddddddddddddddddddddddddd"
+}')
+multiple_release_target_output="${tmp_dir}/multiple-release-target.output"
+assert_failure \
+  "release-please returned multiple release SHAs" \
+  env \
+  RELEASE_OUTPUTS="$multiple_release_targets" \
+  GITHUB_OUTPUT="$multiple_release_target_output" \
+  bash "$release_target_script"
+[ ! -s "$multiple_release_target_output" ] || fail "ambiguous release SHAs must not publish an output"
+
 ruby -e '
   require "yaml"
   rollback_config = YAML.safe_load(File.read(ARGV[0]), aliases: true)
@@ -208,7 +255,19 @@ ruby -e '
   raise "App must wait for resolver" unless rollback.fetch("rollback-app").fetch("needs") == "resolve-target"
   raise "Runner must wait for resolver" unless rollback.fetch("rollback-runner").fetch("needs") == "resolve-target"
   raise "API must wait for resolver" unless rollback.fetch("rollback-api").fetch("needs") == "resolve-target"
-  raise "release must wait for production queue" unless release.fetch("release-please").fetch("needs") == "queue-production-deploy"
+  release_job = release.fetch("release-please")
+  raise "release must wait for production queue" unless release_job.fetch("needs") == "queue-production-deploy"
+  release_target_output = "$" + "{{ steps.release-target.outputs.sha }}"
+  raise "release job must expose the resolved release target" unless release_job.fetch("outputs").fetch("release_target") == release_target_output
+  raise "release workflow must not use the triggering workflow SHA as a release target" if File.read(ARGV[1]).include?("github.event.workflow_run.head_sha")
+
+  expected_target = "$" + "{{ needs.release-please.outputs.release_target }}"
+  host_worker_step = release.fetch("detect-host-worker-deploy-inputs").fetch("steps").find { |step| step["id"] == "detect" }
+  raise "Host Worker detection must use the resolved release target" unless host_worker_step.fetch("run").include?("HEAD_SHA=\"#{expected_target}\"")
+  schema_step = release.fetch("deploy-api-schema").fetch("steps").find { |step| step["name"] == "Publish Runtime API Schema" }
+  raise "Runtime API Schema must use the resolved release target" unless schema_step.fetch("env").fetch("RELEASE_SHA") == expected_target
+  dashboard_step = release.fetch("update-rollback-dashboard").fetch("steps").find { |step| step["name"] == "Update rollback dashboard issue" }
+  raise "rollback dashboard must use the resolved release target" unless dashboard_step.fetch("env").fetch("RELEASE_TARGET") == expected_target
 ' "${repo_root}/.github/workflows/rollback-production.yml" "${repo_root}/.github/workflows/release-please.yml"
 
 echo "resolve-production-rollback-target tests passed"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      release_target: ${{ steps.release-target.outputs.sha }}
       cli_release_created: ${{ steps.release.outputs['turbo/apps/cli--release_created'] }}
       api_release_created: ${{ steps.release.outputs['turbo/apps/api--release_created'] }}
       core_release_created: ${{ steps.release.outputs['turbo/packages/core--release_created'] }}
@@ -62,6 +63,41 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve release target
+        id: release-target
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          RELEASE_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+        run: |
+          set -euo pipefail
+
+          release_target=$(
+            jq -er '
+              [
+                to_entries[]
+                | select(.key == "sha" or (.key | endswith("--sha")))
+                | .value
+                | select(
+                    type == "string" and
+                    test("^[0-9a-f]{40}$")
+                  )
+              ]
+              | unique
+              | if length == 1 then
+                  .[0]
+                elif length == 0 then
+                  error("release-please returned no release SHA")
+                else
+                  error(
+                    "release-please returned multiple release SHAs: " +
+                    join(", ")
+                  )
+                end
+            ' <<<"$RELEASE_OUTPUTS"
+          )
+
+          echo "sha=$release_target" >> "$GITHUB_OUTPUT"
 
       # Create ci-gate check runs on release PR head commit.
       # GITHUB_TOKEN pushes don't trigger pull_request events, so the CI
@@ -933,10 +969,7 @@ jobs:
 
           git fetch --force --tags origin
 
-          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-          if [[ -z "$HEAD_SHA" ]]; then
-            HEAD_SHA="${{ github.sha }}"
-          fi
+          HEAD_SHA="${{ needs.release-please.outputs.release_target }}"
 
           if ! git cat-file -e "${HEAD_SHA}^{commit}"; then
             echo "::error::Release head commit $HEAD_SHA is not available"
@@ -1257,7 +1290,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SCHEMA_RELEASE_TAG: runtime-api-schema-prod
-          RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          RELEASE_SHA: ${{ needs.release-please.outputs.release_target }}
           API_VERSION: ${{ needs.release-please.outputs.api_version }}
         run: |
           set -euo pipefail
@@ -1585,7 +1618,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ vars.ROLLBACK_ISSUE_NUMBER }}
-          RELEASE_TARGET: ${{ github.event.workflow_run.head_sha }}
+          RELEASE_TARGET: ${{ needs.release-please.outputs.release_target }}
           ROLLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rollback-production.yml
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- derive the production release target from the SHAs returned by `release-please`, requiring one unique full commit SHA
- use that resolved target for Host Worker deploy-input detection, Runtime API Schema publication, and the production rollback dashboard
- execute the workflow's inline resolver in regression coverage, including missing and conflicting SHA failures

## User-visible impact

Production release metadata now stays aligned with the commit that actually owns the created GitHub Releases, even when a stale `workflow_run` event triggers publication. This prevents rollback dashboard updates from failing with `No release artifacts found` and avoids recording the triggering Turbo commit as the deployed release target.

## Context

The failing [release workflow run](https://github.com/vm0-ai/vm0/actions/runs/29996358642/job/89174749554) passed `ed29a8a` from `workflow_run.head_sha`, while all releases created by that run targeted `8cc288e`.

## Verification

- `npx -y prettier@3.8.1 --check .github/workflows/release-please.yml`
- Actionlint 1.7.12 with ShellCheck 0.11.0
- `npx -y shellcheck .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `git diff --check origin/main...HEAD`

TypeScript checks and Vitest were not run because this PR changes only GitHub Actions YAML and Bash workflow coverage.
