### PR TITLE
refactor(api): replace atomic org credit upserts with builders

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2682,8 +2682,9 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect(broken.body).toStrictEqual({ error: "Internal server error" });
     expect((await billing.readBillingStatus(actor)).credits).toBe(60_000);
 
-    // Concurrent auto-recharge invoices grant the sentinel exactly once.
-    const autoRechargeInvoice = {
+    // Concurrent auto-recharge invoices accumulate distinct grants while a
+    // duplicate delivery still grants exactly once.
+    const autoRechargeInvoiceA = {
       id: `in_bdd_auto_${randomUUID().slice(0, 8)}`,
       customer: granted.customerId,
       metadata: {
@@ -2693,26 +2694,37 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       },
       parent: null,
     };
+    const autoRechargeInvoiceB = {
+      ...autoRechargeInvoiceA,
+      id: `in_bdd_auto_${randomUUID().slice(0, 8)}`,
+    };
     await Promise.all([
       api.postStripeEvent(
-        stripeEvent({ type: "invoice.paid", object: autoRechargeInvoice }),
+        stripeEvent({ type: "invoice.paid", object: autoRechargeInvoiceA }),
         [200],
       ),
       api.postStripeEvent(
-        stripeEvent({ type: "invoice.paid", object: autoRechargeInvoice }),
+        stripeEvent({ type: "invoice.paid", object: autoRechargeInvoiceA }),
+        [200],
+      ),
+      api.postStripeEvent(
+        stripeEvent({ type: "invoice.paid", object: autoRechargeInvoiceB }),
         [200],
       ),
     ]);
     const final = await billing.readBillingStatus(actor);
-    expect(final.credits).toBe(65_000);
-    const autoGrant = final.creditGrants.find((grant) => {
+    expect(final.credits).toBe(70_000);
+    const autoGrants = final.creditGrants.filter((grant) => {
       return grant.source === "auto_recharge";
     });
-    expect(autoGrant?.amount).toBe(5000);
-    expect(autoGrant?.remaining).toBe(5000);
-    expect(
-      new Date(autoGrant?.expiresAt ?? "1970-01-01").getUTCFullYear(),
-    ).toBeGreaterThanOrEqual(2999);
+    expect(autoGrants).toHaveLength(2);
+    for (const autoGrant of autoGrants) {
+      expect(autoGrant.amount).toBe(5000);
+      expect(autoGrant.remaining).toBe(5000);
+      expect(
+        new Date(autoGrant.expiresAt).getUTCFullYear(),
+      ).toBeGreaterThanOrEqual(2999);
+    }
   });
 
   it("grants, refreshes, and clamps trial credits from trial-period invoices", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2556,12 +2556,11 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     ]);
   });
 
-  it("replays, expires, and auto-recharges subscription invoice credits", async () => {
+  it("replays and expires subscription invoice credits", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
-    const orgId = orgOf(actor);
     const granted = await runs.grantProEntitlement(actor);
 
     const baseline = await billing.readBillingStatus(actor);
@@ -2681,6 +2680,17 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     );
     expect(broken.body).toStrictEqual({ error: "Internal server error" });
     expect((await billing.readBillingStatus(actor)).credits).toBe(60_000);
+  });
+
+  it("atomically accumulates distinct auto-recharge invoices", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsApi(context);
+    const billing = createBillingMediaApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const granted = await runs.grantProEntitlement(actor);
+
+    expect((await billing.readBillingStatus(actor)).credits).toBe(20_000);
 
     // Concurrent auto-recharge invoices accumulate distinct grants while a
     // duplicate delivery still grants exactly once.
@@ -2713,7 +2723,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       ),
     ]);
     const final = await billing.readBillingStatus(actor);
-    expect(final.credits).toBe(70_000);
+    expect(final.credits).toBe(30_000);
     const autoGrants = final.creditGrants.filter((grant) => {
       return grant.source === "auto_recharge";
     });

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -465,12 +465,23 @@ async function ensureStarterCreditGrant(
     return;
   }
 
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, tier, created_at, updated_at)
-        VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, 'free', now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, tier = 'free', updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: STARTER_GRANT_AMOUNT,
+      tier: "free",
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} + ${STARTER_GRANT_AMOUNT}`,
+        tier: "free",
+        updatedAt: sql`now()`,
+      },
+    });
 }
 
 async function slackInstallation(db: ReadonlyDb, teamId: string) {

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -490,12 +490,23 @@ async function ensureStarterCreditGrant(
     return;
   }
 
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, tier, created_at, updated_at)
-        VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, 'free', now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, tier = 'free', updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: STARTER_GRANT_AMOUNT,
+      tier: "free",
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} + ${STARTER_GRANT_AMOUNT}`,
+        tier: "free",
+        updatedAt: sql`now()`,
+      },
+    });
 }
 
 async function teamsInstallation(db: ReadonlyDb, tenantId: string) {

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1707,12 +1707,23 @@ async function ensureStarterCreditGrant(
     return;
   }
 
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, tier, created_at, updated_at)
-        VALUES (${orgId}, ${STARTER_GRANT_AMOUNT}, 'free', now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${STARTER_GRANT_AMOUNT}, tier = 'free', updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: STARTER_GRANT_AMOUNT,
+      tier: "free",
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} + ${STARTER_GRANT_AMOUNT}`,
+        tier: "free",
+        updatedAt: sql`now()`,
+      },
+    });
   signal.throwIfAborted();
 }
 

--- a/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
@@ -1,4 +1,5 @@
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { sql } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -23,12 +24,21 @@ async function grantOrgCredits(
   orgId: string,
   amount: number,
 ): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: amount,
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} + ${amount}`,
+        updatedAt: sql`now()`,
+      },
+    });
 }
 
 export async function grantOnboardingCredits(

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -1041,12 +1041,21 @@ async function grantOrgCredits(
   orgId: string,
   amount: number,
 ): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: amount,
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} + ${amount}`,
+        updatedAt: sql`now()`,
+      },
+    });
 }
 
 async function createExpiresRecord(

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -28,12 +28,21 @@ async function deductOrgCredits(
   orgId: string,
   amount: number,
 ): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${-amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits - ${amount}, updated_at = now()`,
-  );
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId,
+      credits: -amount,
+      createdAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: sql`${orgMetadata.credits} - ${amount}`,
+        updatedAt: sql`now()`,
+      },
+    });
 }
 
 async function getOrgCredits(tx: WriteTx, orgId: string): Promise<number> {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -86,6 +86,25 @@ const deletePreamble = `
   declare const cutoff: Date;
 `;
 
+const upsertPreamble = `
+  import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+  const orgMetadata = pgTable("org_metadata", {
+    orgId: text("org_id").primaryKey(),
+    credits: integer("credits").notNull(),
+    tier: text("tier").notNull(),
+    createdAt: timestamp("created_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+  });
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      orgMetadata: typeof orgMetadata;
+    }>;
+  declare const db: DrizzleDatabase;
+  declare const orgId: string;
+  declare const amount: number;
+`;
+
 const scalarQuery = `
   sql\`(
     SELECT "message"."id"
@@ -233,6 +252,181 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         await db.execute(sql\`
           DELETE FROM \${notATable}
           WHERE \${eq(cleanupRows.id, 1)}
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        const query = sql\`
+          INSERT INTO org_metadata (
+            org_id,
+            credits,
+            created_at,
+            updated_at
+          )
+          VALUES (\${orgId}, \${amount}, now(), now())
+          ON CONFLICT (org_id)
+          DO UPDATE SET
+            credits = org_metadata.credits + \${amount},
+            updated_at = now()
+        \`;
+        await db.execute(query);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        const fakeDb = {
+          async execute(query: unknown) {
+            return query;
+          },
+        };
+        await fakeDb.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        function sql(
+          strings: TemplateStringsArray,
+          ...values: readonly unknown[]
+        ) {
+          return { strings, values };
+        }
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          WITH incoming AS (SELECT \${orgId} AS org_id)
+          INSERT INTO org_metadata (org_id, credits)
+          SELECT org_id, \${amount} FROM incoming
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          SELECT \${orgId}, \${amount}
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO public.org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata AS target (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = target.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO "org_metadata" ("org_id", "credits")
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT ("org_id")
+          DO UPDATE SET "credits" = "org_metadata"."credits" + \${amount}
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount}), ('other', \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata DEFAULT VALUES
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT ON CONSTRAINT org_metadata_pkey
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id) DO NOTHING
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (lower(org_id))
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (\${orgMetadata.orgId})
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id) WHERE org_id IS NOT NULL
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+          WHERE org_metadata.credits >= 0
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
+          RETURNING org_id
+        \`);
+        await db.execute(sql\`
+          INSERT INTO org_metadata (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount};
+          SELECT 1
+        \`);
+      `,
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql } from "drizzle-orm";
+        const notATable = sql\`org_metadata\`;
+        await db.execute(sql\`
+          INSERT INTO \${notATable} (org_id, credits)
+          VALUES (\${orgId}, \${amount})
+          ON CONFLICT (org_id)
+          DO UPDATE SET credits = org_metadata.credits + \${amount}
         \`);
       `,
     },
@@ -827,6 +1021,46 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         void rowCount;
       `,
       errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${upsertPreamble}
+        import { sql as query } from "drizzle-orm";
+        await db.execute(query\`
+          INSERT INTO org_metadata (
+            org_id,
+            credits,
+            tier,
+            created_at,
+            updated_at
+          )
+          VALUES (\${orgId}, \${amount}, 'free', now(), now())
+          ON CONFLICT (org_id)
+          DO UPDATE SET
+            credits = org_metadata.credits + \${amount},
+            updated_at = now(),
+            tier = 'free';
+        \`);
+      `,
+      errors: [{ messageId: "upsertQueryBuilder" }],
+    },
+    {
+      code: `${upsertPreamble}
+        import * as drizzle from "drizzle-orm";
+        await db["execute"](drizzle.sql\`
+          INSERT INTO \${orgMetadata} (org_id, credits, created_at, updated_at)
+          VALUES (\${orgId}, \${amount}, now(), now())
+          ON CONFLICT (org_id)
+          DO UPDATE SET
+            credits = COALESCE((
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${orgId}
+                AND 'RETURNING ignored' = 'RETURNING ignored'
+            ), 0) + \${amount},
+            updated_at = now()
+        \`);
+      `,
+      errors: [{ messageId: "upsertQueryBuilder" }],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -86,6 +86,7 @@ interface SimpleUpsertMatch {
 
 interface CompleteSqlStatement {
   readonly end: number;
+  readonly hasTrailingSemicolon: boolean;
   readonly tokens: readonly SqlToken[];
 }
 
@@ -311,6 +312,7 @@ function completeSqlStatement(
   }
 
   let end = tokens.length;
+  let hasTrailingSemicolon = false;
   let statementEnd = syntaxSource.length;
   const trailingToken = tokens[end - 1];
   if (isPunctuation(trailingToken, ";")) {
@@ -320,6 +322,7 @@ function completeSqlStatement(
     ) {
       return undefined;
     }
+    hasTrailingSemicolon = true;
     statementEnd = trailingToken.start;
     end -= 1;
   }
@@ -336,7 +339,11 @@ function completeSqlStatement(
     return undefined;
   }
 
-  return { end: statementEnd, tokens: statementTokens };
+  return {
+    end: statementEnd,
+    hasTrailingSemicolon,
+    tokens: statementTokens,
+  };
 }
 
 function isSimpleIdentifierList(
@@ -397,8 +404,18 @@ function hasSimpleAssignments(
 
 function simpleDeleteMatch(
   syntaxSource: string,
-  tokens: readonly SqlToken[],
+  statement: CompleteSqlStatement,
 ): SimpleDeleteMatch | undefined {
+  const tokens = statement.tokens;
+  const trailingToken = tokens[tokens.length - 1];
+  if (
+    !statement.hasTrailingSemicolon &&
+    (trailingToken === undefined ||
+      syntaxSource.slice(trailingToken.end, statement.end).trim() !== "")
+  ) {
+    return undefined;
+  }
+
   const deleteKeyword = tokens[0];
   const fromKeyword = tokens[1];
   const targetTable = tokens[2];
@@ -1481,7 +1498,7 @@ export const preferDrizzleQueryBuilder = createRule({
       if (statement === undefined) {
         return;
       }
-      const deleteMatch = simpleDeleteMatch(syntaxSource, statement.tokens);
+      const deleteMatch = simpleDeleteMatch(syntaxSource, statement);
       const upsertMatch =
         deleteMatch === undefined
           ? simpleUpsertMatch(source, syntaxSource, statement)

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -80,6 +80,15 @@ interface SimpleDeleteMatch {
   readonly targetTableExpressionIndex: number | undefined;
 }
 
+interface SimpleUpsertMatch {
+  readonly targetTableExpressionIndex: number | undefined;
+}
+
+interface CompleteSqlStatement {
+  readonly end: number;
+  readonly tokens: readonly SqlToken[];
+}
+
 const RESULT_FIELD_ARGUMENT = new Map<string, number>([
   ["returning", 0],
   ["select", 0],
@@ -140,6 +149,8 @@ const UNSUPPORTED_DELETE_PREDICATE_KEYWORDS = new Set([
   "RETURNING",
   "USING",
 ]);
+
+const UNSUPPORTED_UPSERT_ASSIGNMENT_KEYWORDS = new Set(["RETURNING", "WHERE"]);
 
 function quasiText(node: TSESTree.TemplateElement): string {
   return node.value.cooked ?? node.value.raw;
@@ -284,35 +295,116 @@ function onlyWhitespaceBetween(
   return source.slice(left.end, right.start).trim() === "";
 }
 
-function simpleDeleteMatch(
+function isPunctuation(
+  token: SqlToken | undefined,
+  value: PunctuationToken["value"],
+): boolean {
+  return token?.kind === "punctuation" && token.value === value;
+}
+
+function completeSqlStatement(
   syntaxSource: string,
-): SimpleDeleteMatch | undefined {
+): CompleteSqlStatement | undefined {
   const tokens = topLevelTokens(syntaxSource);
-  if (tokens === undefined) {
+  if (tokens === undefined || tokens.length === 0) {
     return undefined;
   }
 
   let end = tokens.length;
+  let statementEnd = syntaxSource.length;
   const trailingToken = tokens[end - 1];
-  if (trailingToken?.kind === "punctuation" && trailingToken.value === ";") {
-    if (syntaxSource.slice(trailingToken.end).trim() !== "") {
+  if (isPunctuation(trailingToken, ";")) {
+    if (
+      trailingToken === undefined ||
+      syntaxSource.slice(trailingToken.end).trim() !== ""
+    ) {
       return undefined;
     }
+    statementEnd = trailingToken.start;
     end -= 1;
-  } else if (
-    trailingToken === undefined ||
-    syntaxSource.slice(trailingToken.end).trim() !== ""
+  }
+
+  const statementTokens = tokens.slice(0, end);
+  const firstToken = statementTokens[0];
+  if (
+    firstToken === undefined ||
+    syntaxSource.slice(0, firstToken.start).trim() !== "" ||
+    statementTokens.some((token) => {
+      return isPunctuation(token, ";");
+    })
   ) {
     return undefined;
   }
 
-  const statementTokens = tokens.slice(0, end);
-  const deleteKeyword = statementTokens[0];
-  const fromKeyword = statementTokens[1];
-  const targetTable = statementTokens[2];
-  const whereKeyword = statementTokens[3];
+  return { end: statementEnd, tokens: statementTokens };
+}
+
+function isSimpleIdentifierList(
+  syntaxSource: string,
+  open: SqlToken,
+  close: SqlToken,
+): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_$]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_$]*)*$/u.test(
+    syntaxSource.slice(open.end, close.start).trim(),
+  );
+}
+
+function hasSimpleAssignments(
+  source: string,
+  syntaxSource: string,
+  start: number,
+  end: number,
+): boolean {
+  const segments: Array<{ readonly start: number; readonly end: number }> = [];
+  let depth = 0;
+  let segmentStart = start;
+
+  for (let offset = start; offset < end; offset += 1) {
+    const character = syntaxSource[offset];
+    if (character === "(") {
+      depth += 1;
+    } else if (character === ")") {
+      depth -= 1;
+    } else if (character === "," && depth === 0) {
+      segments.push({ start: segmentStart, end: offset });
+      segmentStart = offset + 1;
+    }
+  }
+  segments.push({ start: segmentStart, end });
+
+  return segments.every((segment) => {
+    let assignmentOffset = -1;
+    let assignmentDepth = 0;
+    for (let offset = segment.start; offset < segment.end; offset += 1) {
+      const character = syntaxSource[offset];
+      if (character === "(") {
+        assignmentDepth += 1;
+      } else if (character === ")") {
+        assignmentDepth -= 1;
+      } else if (character === "=" && assignmentDepth === 0) {
+        assignmentOffset = offset;
+        break;
+      }
+    }
+    if (assignmentOffset === -1) {
+      return false;
+    }
+    const target = syntaxSource.slice(segment.start, assignmentOffset).trim();
+    const value = source.slice(assignmentOffset + 1, segment.end).trim();
+    return /^[A-Za-z_][A-Za-z0-9_$]*$/u.test(target) && value !== "";
+  });
+}
+
+function simpleDeleteMatch(
+  syntaxSource: string,
+  tokens: readonly SqlToken[],
+): SimpleDeleteMatch | undefined {
+  const deleteKeyword = tokens[0];
+  const fromKeyword = tokens[1];
+  const targetTable = tokens[2];
+  const whereKeyword = tokens[3];
   if (
-    statementTokens.length <= 4 ||
+    tokens.length <= 4 ||
     !isWord(deleteKeyword, "DELETE") ||
     !isWord(fromKeyword, "FROM") ||
     (targetTable?.kind !== "word" && targetTable?.kind !== "expression") ||
@@ -328,14 +420,107 @@ function simpleDeleteMatch(
   }
 
   if (
-    statementTokens.slice(4).some((token) => {
+    tokens.slice(4).some((token) => {
       return (
         (token.kind === "word" &&
           UNSUPPORTED_DELETE_PREDICATE_KEYWORDS.has(token.value)) ||
-        (token.kind === "punctuation" &&
-          (token.value === "," || token.value === ";"))
+        isPunctuation(token, ",")
       );
     })
+  ) {
+    return undefined;
+  }
+
+  return {
+    targetTableExpressionIndex:
+      targetTable.kind === "expression"
+        ? targetTable.expressionIndex
+        : undefined,
+  };
+}
+
+function simpleUpsertMatch(
+  source: string,
+  syntaxSource: string,
+  statement: CompleteSqlStatement,
+): SimpleUpsertMatch | undefined {
+  const tokens = statement.tokens;
+  const insertKeyword = tokens[0];
+  const intoKeyword = tokens[1];
+  const targetTable = tokens[2];
+  const insertColumnsOpen = tokens[3];
+  const insertColumnsClose = tokens[4];
+  const valuesKeyword = tokens[5];
+  const valuesOpen = tokens[6];
+  const valuesClose = tokens[7];
+  const onKeyword = tokens[8];
+  const conflictKeyword = tokens[9];
+  const conflictTargetOpen = tokens[10];
+  const conflictTargetClose = tokens[11];
+  const doKeyword = tokens[12];
+  const updateKeyword = tokens[13];
+  const setKeyword = tokens[14];
+
+  if (
+    tokens.length <= 15 ||
+    !isWord(insertKeyword, "INSERT") ||
+    !isWord(intoKeyword, "INTO") ||
+    (targetTable?.kind !== "word" && targetTable?.kind !== "expression") ||
+    !isPunctuation(insertColumnsOpen, "(") ||
+    !isPunctuation(insertColumnsClose, ")") ||
+    !isWord(valuesKeyword, "VALUES") ||
+    !isPunctuation(valuesOpen, "(") ||
+    !isPunctuation(valuesClose, ")") ||
+    !isWord(onKeyword, "ON") ||
+    !isWord(conflictKeyword, "CONFLICT") ||
+    !isPunctuation(conflictTargetOpen, "(") ||
+    !isPunctuation(conflictTargetClose, ")") ||
+    !isWord(doKeyword, "DO") ||
+    !isWord(updateKeyword, "UPDATE") ||
+    !isWord(setKeyword, "SET") ||
+    insertKeyword === undefined ||
+    intoKeyword === undefined ||
+    insertColumnsOpen === undefined ||
+    insertColumnsClose === undefined ||
+    valuesKeyword === undefined ||
+    valuesOpen === undefined ||
+    valuesClose === undefined ||
+    onKeyword === undefined ||
+    conflictKeyword === undefined ||
+    conflictTargetOpen === undefined ||
+    conflictTargetClose === undefined ||
+    doKeyword === undefined ||
+    updateKeyword === undefined ||
+    setKeyword === undefined ||
+    !onlyWhitespaceBetween(syntaxSource, insertKeyword, intoKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, intoKeyword, targetTable) ||
+    !onlyWhitespaceBetween(syntaxSource, targetTable, insertColumnsOpen) ||
+    !onlyWhitespaceBetween(syntaxSource, insertColumnsClose, valuesKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, valuesKeyword, valuesOpen) ||
+    !onlyWhitespaceBetween(syntaxSource, valuesClose, onKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, onKeyword, conflictKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, conflictKeyword, conflictTargetOpen) ||
+    !onlyWhitespaceBetween(syntaxSource, conflictTargetClose, doKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, doKeyword, updateKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, updateKeyword, setKeyword) ||
+    !isSimpleIdentifierList(
+      syntaxSource,
+      insertColumnsOpen,
+      insertColumnsClose,
+    ) ||
+    source.slice(valuesOpen.end, valuesClose.start).trim() === "" ||
+    !isSimpleIdentifierList(
+      syntaxSource,
+      conflictTargetOpen,
+      conflictTargetClose,
+    ) ||
+    tokens.slice(15).some((token) => {
+      return (
+        token.kind === "word" &&
+        UNSUPPORTED_UPSERT_ASSIGNMENT_KEYWORDS.has(token.value)
+      );
+    }) ||
+    !hasSimpleAssignments(source, syntaxSource, setKeyword.end, statement.end)
   ) {
     return undefined;
   }
@@ -751,7 +936,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete simple deletes, selects, locking selects, and scalar result queries",
+        "Prefer Drizzle query builders for complete simple deletes, upserts, selects, locking selects, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -763,6 +948,8 @@ export const preferDrizzleQueryBuilder = createRule({
         "Use a Drizzle select builder with .for(...) for this complete locking query.",
       deleteQueryBuilder:
         "Use a Drizzle delete builder for this complete single-target query.",
+      upsertQueryBuilder:
+        "Use a Drizzle insert builder with .onConflictDoUpdate(...) for this complete single-row upsert.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -1270,7 +1457,7 @@ export const preferDrizzleQueryBuilder = createRule({
       inspectSelectionContainer(fields, new Set<TSESTree.Node>());
     }
 
-    function inspectCompleteDelete(node: TSESTree.CallExpression): void {
+    function inspectCompleteWrite(node: TSESTree.CallExpression): void {
       if (
         node.callee.type !== AST_NODE_TYPES.MemberExpression ||
         memberName(node.callee) !== "execute" ||
@@ -1289,7 +1476,17 @@ export const preferDrizzleQueryBuilder = createRule({
       const source = query.quasi.quasis
         .map(quasiText)
         .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
-      const match = simpleDeleteMatch(sqlCodeMask(source));
+      const syntaxSource = sqlCodeMask(source);
+      const statement = completeSqlStatement(syntaxSource);
+      if (statement === undefined) {
+        return;
+      }
+      const deleteMatch = simpleDeleteMatch(syntaxSource, statement.tokens);
+      const upsertMatch =
+        deleteMatch === undefined
+          ? simpleUpsertMatch(source, syntaxSource, statement)
+          : undefined;
+      const match = deleteMatch ?? upsertMatch;
       if (
         match === undefined ||
         !isDrizzleSqlTag(checker, services, query.tag) ||
@@ -1316,12 +1513,18 @@ export const preferDrizzleQueryBuilder = createRule({
         }
       }
 
-      context.report({ node: query, messageId: "deleteQueryBuilder" });
+      context.report({
+        node: query,
+        messageId:
+          deleteMatch === undefined
+            ? "upsertQueryBuilder"
+            : "deleteQueryBuilder",
+      });
     }
 
     return {
       CallExpression(node: TSESTree.CallExpression): void {
-        inspectCompleteDelete(node);
+        inspectCompleteWrite(node);
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           RESULT_FIELD_ARGUMENT.has(memberName(node.callee) ?? "")


### PR DESCRIPTION
## Summary

- replace six complete raw `org_metadata` credit upserts with schema-backed Drizzle insert builders
- preserve PostgreSQL-side arithmetic, database timestamps, conflict targets, and starter-tier updates
- add concurrent Stripe coverage proving duplicate invoice idempotency and accumulation of distinct grants
- extend `api/prefer-drizzle-query-builder` to detect only unambiguous single-row `ON CONFLICT DO UPDATE` templates

## Scope

- no database schema or migration changes
- no shared credit helper or database function
- insert-select statements and advanced upsert forms remain intentionally outside the lint rule

## Validation

- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-query-builder.test.ts`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/usage-allowance.test.ts src/signals/routes/__tests__/test-slack-state.test.ts src/signals/routes/__tests__/test-teams-state.test.ts src/signals/routes/__tests__/test-telegram-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit formatting, Knip, and repository type checks
- PostgreSQL `EXPLAIN (ANALYZE, FORMAT JSON)` comparison for insert and conflict-update paths

Closes #22740

Parent context: #22439
