### PR TITLE
feat(billing): set additional concurrency price to $100 per month

### DIFF
--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -207,8 +207,8 @@ describe("queue drawer", () => {
     });
     expect(screen.queryByText(/Upgrade to/)).not.toBeInTheDocument();
     expect(screen.getByText("Additional concurrency")).toBeInTheDocument();
-    expect(screen.getByText("$10/month")).toBeInTheDocument();
-    expect(screen.getByText("Buy $10/month")).toBeInTheDocument();
+    expect(screen.getByText("$100/month")).toBeInTheDocument();
+    expect(screen.getByText("Buy $100/month")).toBeInTheDocument();
   });
 
   it("shows additional concurrency checkout for Custom admins without plan upgrade", async () => {
@@ -229,7 +229,7 @@ describe("queue drawer", () => {
       expect(screen.getByText("Custom")).toBeInTheDocument();
       expect(screen.getByText(/10 of 10 slots/)).toBeInTheDocument();
       expect(screen.getByText("Additional concurrency")).toBeInTheDocument();
-      expect(screen.getByText("Buy $10/month")).toBeInTheDocument();
+      expect(screen.getByText("Buy $100/month")).toBeInTheDocument();
     });
     expect(screen.queryByText(/Upgrade to/)).not.toBeInTheDocument();
   });
@@ -266,8 +266,8 @@ describe("queue drawer", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Additional concurrency")).toBeInTheDocument();
-      expect(screen.getByText("$10/month")).toBeInTheDocument();
-      expect(screen.getByText("Buy $10/month")).toBeInTheDocument();
+      expect(screen.getByText("$100/month")).toBeInTheDocument();
+      expect(screen.getByText("Buy $100/month")).toBeInTheDocument();
     });
 
     const increaseQuantityButton = queryAllByRoleFast("button").find((el) => {
@@ -278,10 +278,10 @@ describe("queue drawer", () => {
     }
     click(increaseQuantityButton);
     await waitFor(() => {
-      expect(screen.getByText("Buy $20/month")).toBeInTheDocument();
+      expect(screen.getByText("Buy $200/month")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Buy $20/month"));
+    click(screen.getByText("Buy $200/month"));
 
     await waitFor(() => {
       expect(checkoutQuantity).toBe(2);
@@ -318,7 +318,7 @@ describe("queue drawer", () => {
     expect(
       screen.queryByText("Additional concurrency"),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Buy $10/month")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buy $100/month")).not.toBeInTheDocument();
   });
 
   it("hides billing actions from non-admins", async () => {
@@ -373,6 +373,6 @@ describe("queue drawer", () => {
     expect(
       screen.queryByText("Additional concurrency"),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Buy $10/month")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buy $100/month")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -80,7 +80,7 @@ const UPGRADE_PATHS = {
   },
 } as const satisfies Record<string, UpgradePath>;
 
-const CONCURRENCY_SLOT_MONTHLY_PRICE_USD = 10;
+const CONCURRENCY_SLOT_MONTHLY_PRICE_USD = 100;
 
 function slotCountLabel(count: number): string {
   return `${count} slot${count === 1 ? "" : "s"}`;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -518,11 +518,11 @@ describe("organization billing settings", () => {
 
     await waitFor(() => {
       expect(
-        within(purchaseDialog).getByText("Buy $20/month"),
+        within(purchaseDialog).getByText("Buy $200/month"),
       ).toBeInTheDocument();
     });
 
-    click(buttonByText("Buy $20/month", purchaseDialog));
+    click(buttonByText("Buy $200/month", purchaseDialog));
 
     await waitFor(() => {
       expect(requestedQuantity).toBe(2);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -966,7 +966,7 @@ function cancellationNoticeText(tier: BillingTier, changeDate: string): string {
   )} plan has been cancelled and will end on ${formattedDate}.`;
 }
 
-const CONCURRENCY_SLOT_MONTHLY_PRICE_USD = 10;
+const CONCURRENCY_SLOT_MONTHLY_PRICE_USD = 100;
 
 function slotCountLabel(count: number): string {
   return `${count} slot${count === 1 ? "" : "s"}`;


### PR DESCRIPTION
## Summary

- update the displayed price for one additional concurrent slot from $10 to $100 per month
- keep quantity-based totals consistent across the Queue drawer and organization Billing page
- leave the Stripe product and `ZERO_PRICE_CONCURRENCY` configuration unchanged

## Verification

- `pnpm exec prettier --write <changed files>` (Prettier 3.8.1)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/queue-page/__tests__/queue-drawer.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx -t "shows team concurrency add-on and starts checkout for more slots"`

The initial combined two-file test run hit the existing 5-second timeout in an unrelated billing workflow test. That test passed when rerun in isolation.
