### PR TITLE
feat(mail): add rich draft rendering and selection feedback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1713,6 +1713,7 @@ describe("CHAT-02: Zero Mail link delivery", () => {
               id: "gmail-agent-reply-message",
               threadId: "gmail-agent-reply-thread",
               payload: {
+                partId: "",
                 mimeType: "text/plain",
                 filename: "",
                 headers: [

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1826,6 +1826,10 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(appendSystemPrompt).toContain("zero web upload-file -h");
     expect(appendSystemPrompt).toContain("zero mail link <gmail-draft-id>");
     expect(appendSystemPrompt).toContain(
+      "GET /gmail/v1/users/me/settings/sendAs",
+    );
+    expect(appendSystemPrompt).toContain("append that signature exactly once");
+    expect(appendSystemPrompt).toContain(
       "return the link from the command to the user",
     );
     expect(appendSystemPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -35,13 +35,18 @@ const GMAIL_DRAFT_ID = "r-test-draft";
 const GMAIL_THREAD_ID = "gmail-thread-id";
 const GMAIL_MESSAGE_ID = "gmail-draft-message-id";
 const GMAIL_SENT_MESSAGE_ID = "gmail-sent-message-id";
+const GMAIL_IMAGE_ATTACHMENT_ID = "attachment-image";
+const GMAIL_IMAGE_BYTES = Buffer.from("mail draft image");
+const GMAIL_HTML_BODY =
+  '<div>Mail body <strong>before</strong></div><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a>';
 
 function encodedBody(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
 }
 
-function gmailPayload() {
+function gmailPayload(imageAttachmentId: string = GMAIL_IMAGE_ATTACHMENT_ID) {
   return {
+    partId: "",
     mimeType: "multipart/mixed",
     filename: "",
     headers: [
@@ -53,16 +58,56 @@ function gmailPayload() {
     body: { size: 0 },
     parts: [
       {
-        mimeType: "text/plain",
+        partId: "0",
+        mimeType: "multipart/alternative",
         filename: "",
         headers: [],
-        body: { size: 9, data: encodedBody("Mail body") },
+        body: { size: 0 },
+        parts: [
+          {
+            partId: "0.0",
+            mimeType: "text/plain",
+            filename: "",
+            headers: [],
+            body: { size: 9, data: encodedBody("Mail body") },
+          },
+          {
+            partId: "0.1",
+            mimeType: "text/html",
+            filename: "",
+            headers: [],
+            body: {
+              size: 180,
+              data: encodedBody(GMAIL_HTML_BODY),
+            },
+          },
+        ],
       },
       {
+        partId: "1",
         mimeType: "application/pdf",
         filename: "report.pdf",
         headers: [],
         body: { attachmentId: "attachment-1", size: 248_192 },
+      },
+      {
+        partId: "2",
+        mimeType: "image/png",
+        filename: "email-test-illustration.png",
+        headers: [
+          {
+            name: "Content-ID",
+            value: "<email-test-illustration>",
+          },
+          {
+            name: "Content-Disposition",
+            value: 'inline; filename="email-test-illustration.png"',
+          },
+        ],
+        body: {
+          attachmentId: imageAttachmentId,
+          size: GMAIL_IMAGE_BYTES.byteLength,
+        },
       },
     ],
   };
@@ -82,6 +127,8 @@ function mockGmailDraftApi(): GmailDraftTestState {
     deleteCount: 0,
     sentBody: null,
   };
+  let draftReadCount = 0;
+  let currentImageAttachmentId = GMAIL_IMAGE_ATTACHMENT_ID;
   server.use(
     http.get(`${GMAIL_API_BASE}/drafts/:draftId`, ({ params, request }) => {
       expect(params.draftId).toBe(GMAIL_DRAFT_ID);
@@ -92,12 +139,14 @@ function mockGmailDraftApi(): GmailDraftTestState {
       if (!state.exists) {
         return new HttpResponse(null, { status: 404 });
       }
+      draftReadCount += 1;
+      currentImageAttachmentId = `${GMAIL_IMAGE_ATTACHMENT_ID}-${draftReadCount}`;
       return HttpResponse.json({
         id: GMAIL_DRAFT_ID,
         message: {
           id: GMAIL_MESSAGE_ID,
           threadId: GMAIL_THREAD_ID,
-          payload: gmailPayload(),
+          payload: gmailPayload(currentImageAttachmentId),
         },
       });
     }),
@@ -119,6 +168,20 @@ function mockGmailDraftApi(): GmailDraftTestState {
         payload: gmailPayload(),
       });
     }),
+    http.get(
+      `${GMAIL_API_BASE}/messages/:messageId/attachments/:attachmentId`,
+      ({ params, request }) => {
+        expect(params.messageId).toBe(GMAIL_MESSAGE_ID);
+        expect(params.attachmentId).toBe(currentImageAttachmentId);
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer gmail-mail-card-token",
+        );
+        return HttpResponse.json({
+          size: GMAIL_IMAGE_BYTES.byteLength,
+          data: GMAIL_IMAGE_BYTES.toString("base64url"),
+        });
+      },
+    ),
     http.delete(`${GMAIL_API_BASE}/drafts/:draftId`, ({ params }) => {
       expect(params.draftId).toBe(GMAIL_DRAFT_ID);
       state.exists = false;
@@ -224,15 +287,41 @@ describe("POST /api/zero/mail/drafts/link", () => {
       cc: ["copy@example.com"],
       subject: "Attachment review",
       body: "Mail body",
+      bodyHtml: GMAIL_HTML_BODY,
+      inlineImages: [
+        {
+          contentId: "email-test-illustration",
+          partId: "2",
+          alt: "Cheerful envelope illustration",
+        },
+      ],
       status: "draft",
       attachments: [
         {
           filename: "report.pdf",
           contentType: "application/pdf",
           size: 248_192,
+          partId: "1",
         },
       ],
     });
+
+    const attachment = await accept(
+      client().getAttachment({
+        headers: authHeaders(),
+        params: {
+          mailDraftId: linked.body.mailDraftId,
+          partId: "2",
+        },
+      }),
+      [200],
+    );
+    expect(attachment.body).toBeInstanceOf(Blob);
+    expect(
+      Buffer.from(await attachment.body.arrayBuffer()).equals(
+        GMAIL_IMAGE_BYTES,
+      ),
+    ).toBeTruthy();
 
     const sent = await accept(
       client().sendDraft({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -44,7 +44,9 @@ function encodedBody(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
 }
 
-function gmailPayload(imageAttachmentId: string = GMAIL_IMAGE_ATTACHMENT_ID) {
+function gmailPayload(
+  imageAttachmentId: string | null = GMAIL_IMAGE_ATTACHMENT_ID,
+) {
   return {
     partId: "",
     mimeType: "multipart/mixed",
@@ -104,10 +106,16 @@ function gmailPayload(imageAttachmentId: string = GMAIL_IMAGE_ATTACHMENT_ID) {
             value: 'inline; filename="email-test-illustration.png"',
           },
         ],
-        body: {
-          attachmentId: imageAttachmentId,
-          size: GMAIL_IMAGE_BYTES.byteLength,
-        },
+        body:
+          imageAttachmentId === null
+            ? {
+                size: GMAIL_IMAGE_BYTES.byteLength,
+                data: GMAIL_IMAGE_BYTES.toString("base64url"),
+              }
+            : {
+                attachmentId: imageAttachmentId,
+                size: GMAIL_IMAGE_BYTES.byteLength,
+              },
       },
     ],
   };
@@ -120,7 +128,9 @@ interface GmailDraftTestState {
   sentBody: unknown;
 }
 
-function mockGmailDraftApi(): GmailDraftTestState {
+function mockGmailDraftApi(options?: {
+  readonly inlineImageData?: boolean;
+}): GmailDraftTestState {
   const state: GmailDraftTestState = {
     exists: true,
     sendCount: 0,
@@ -146,7 +156,9 @@ function mockGmailDraftApi(): GmailDraftTestState {
         message: {
           id: GMAIL_MESSAGE_ID,
           threadId: GMAIL_THREAD_ID,
-          payload: gmailPayload(currentImageAttachmentId),
+          payload: gmailPayload(
+            options?.inlineImageData ? null : currentImageAttachmentId,
+          ),
         },
       });
     }),
@@ -322,6 +334,9 @@ describe("POST /api/zero/mail/drafts/link", () => {
         GMAIL_IMAGE_BYTES,
       ),
     ).toBeTruthy();
+    expect(attachment.headers.get("content-disposition")).toBe(
+      "attachment; filename*=UTF-8''email-test-illustration.png",
+    );
 
     const sent = await accept(
       client().sendDraft({
@@ -350,6 +365,29 @@ describe("POST /api/zero/mail/drafts/link", () => {
       fixture.thread.id,
     );
     expect(page.messages).toHaveLength(0);
+  });
+
+  it("serves an inline image stored directly in the Gmail MIME body", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    mockGmailDraftApi({ inlineImageData: true });
+
+    const linked = await linkDraft(fixture);
+    const attachment = await accept(
+      client().getAttachment({
+        headers: authHeaders(),
+        params: {
+          mailDraftId: linked.body.mailDraftId,
+          partId: "2",
+        },
+      }),
+      [200],
+    );
+
+    expect(
+      Buffer.from(await attachment.body.arrayBuffer()).equals(
+        GMAIL_IMAGE_BYTES,
+      ),
+    ).toBeTruthy();
   });
 
   it("rejects a missing Gmail draft and cross-chat relinking", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -37,6 +37,7 @@ const GMAIL_MESSAGE_ID = "gmail-draft-message-id";
 const GMAIL_SENT_MESSAGE_ID = "gmail-sent-message-id";
 const GMAIL_IMAGE_ATTACHMENT_ID = "attachment-image";
 const GMAIL_IMAGE_BYTES = Buffer.from("mail draft image");
+const GMAIL_PDF_BYTES = Buffer.from("mail draft pdf");
 const GMAIL_HTML_BODY =
   '<div>Mail body <strong>before</strong></div><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a>';
 
@@ -46,6 +47,7 @@ function encodedBody(value: string): string {
 
 function gmailPayload(
   imageAttachmentId: string | null = GMAIL_IMAGE_ATTACHMENT_ID,
+  pdfAttachmentId: string | null = "attachment-1",
 ) {
   return {
     partId: "",
@@ -90,7 +92,13 @@ function gmailPayload(
         mimeType: "application/pdf",
         filename: "report.pdf",
         headers: [],
-        body: { attachmentId: "attachment-1", size: 248_192 },
+        body:
+          pdfAttachmentId === null
+            ? {
+                size: GMAIL_PDF_BYTES.byteLength,
+                data: GMAIL_PDF_BYTES.toString("base64url"),
+              }
+            : { attachmentId: pdfAttachmentId, size: 248_192 },
       },
       {
         partId: "2",
@@ -130,6 +138,7 @@ interface GmailDraftTestState {
 
 function mockGmailDraftApi(options?: {
   readonly inlineImageData?: boolean;
+  readonly regularAttachmentData?: boolean;
 }): GmailDraftTestState {
   const state: GmailDraftTestState = {
     exists: true,
@@ -158,6 +167,7 @@ function mockGmailDraftApi(options?: {
           threadId: GMAIL_THREAD_ID,
           payload: gmailPayload(
             options?.inlineImageData ? null : currentImageAttachmentId,
+            options?.regularAttachmentData ? null : "attachment-1",
           ),
         },
       });
@@ -387,6 +397,40 @@ describe("POST /api/zero/mail/drafts/link", () => {
       Buffer.from(await attachment.body.arrayBuffer()).equals(
         GMAIL_IMAGE_BYTES,
       ),
+    ).toBeTruthy();
+  });
+
+  it("serves a regular attachment stored directly in the Gmail MIME body", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    mockGmailDraftApi({ regularAttachmentData: true });
+
+    const linked = await linkDraft(fixture);
+    const loaded = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(loaded.body.mailDraft.attachments).toContainEqual({
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      size: GMAIL_PDF_BYTES.byteLength,
+      partId: "1",
+    });
+
+    const attachment = await accept(
+      client().getAttachment({
+        headers: authHeaders(),
+        params: {
+          mailDraftId: linked.body.mailDraftId,
+          partId: "1",
+        },
+      }),
+      [200],
+    );
+    expect(
+      Buffer.from(await attachment.body.arrayBuffer()).equals(GMAIL_PDF_BYTES),
     ).toBeTruthy();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -131,6 +131,8 @@ function gmailPayload(
 
 interface GmailDraftTestState {
   exists: boolean;
+  unauthorized: boolean;
+  draftReadCount: number;
   sendCount: number;
   deleteCount: number;
   sentBody: unknown;
@@ -142,11 +144,12 @@ function mockGmailDraftApi(options?: {
 }): GmailDraftTestState {
   const state: GmailDraftTestState = {
     exists: true,
+    unauthorized: false,
+    draftReadCount: 0,
     sendCount: 0,
     deleteCount: 0,
     sentBody: null,
   };
-  let draftReadCount = 0;
   let currentImageAttachmentId = GMAIL_IMAGE_ATTACHMENT_ID;
   server.use(
     http.get(`${GMAIL_API_BASE}/drafts/:draftId`, ({ params, request }) => {
@@ -155,11 +158,17 @@ function mockGmailDraftApi(options?: {
         "Bearer gmail-mail-card-token",
       );
       expect(new URL(request.url).searchParams.get("format")).toBe("full");
+      state.draftReadCount += 1;
+      if (state.unauthorized) {
+        return HttpResponse.json(
+          { error: { message: "Invalid Credentials" } },
+          { status: 401 },
+        );
+      }
       if (!state.exists) {
         return new HttpResponse(null, { status: 404 });
       }
-      draftReadCount += 1;
-      currentImageAttachmentId = `${GMAIL_IMAGE_ATTACHMENT_ID}-${draftReadCount}`;
+      currentImageAttachmentId = `${GMAIL_IMAGE_ATTACHMENT_ID}-${state.draftReadCount}`;
       return HttpResponse.json({
         id: GMAIL_DRAFT_ID,
         message: {
@@ -432,6 +441,71 @@ describe("POST /api/zero/mail/drafts/link", () => {
     expect(
       Buffer.from(await attachment.body.arrayBuffer()).equals(GMAIL_PDF_BYTES),
     ).toBeTruthy();
+  });
+
+  it("returns cached mail details and requires reconnect after Gmail rejects access", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const gmail = mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+    gmail.unauthorized = true;
+
+    const unavailable = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(unavailable.body.mailDraft).toMatchObject({
+      accessStatus: "reconnect",
+      detailAvailable: false,
+      status: "draft",
+      subject: "Attachment review",
+    });
+
+    const gmailReadsAfterUnauthorized = gmail.draftReadCount;
+    const cached = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(cached.body.mailDraft.accessStatus).toBe("reconnect");
+    expect(gmail.draftReadCount).toBe(gmailReadsAfterUnauthorized);
+  });
+
+  it("restores a draft after its Gmail connector is reconnected", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const gmail = mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+
+    await connectors.deleteConnectorByType(fixture.actor, "gmail");
+    const start = await connectors.startOauth(fixture.actor, "gmail", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Gmail OAuth state");
+    }
+    await connectors.completeOauthCallback("gmail", {
+      code: "zero-mail-reconnect-code",
+      state,
+    });
+
+    const restored = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(restored.body.mailDraft).toMatchObject({
+      accessStatus: "ready",
+      detailAvailable: true,
+      from: "sender@example.com",
+      status: "draft",
+      subject: "Attachment review",
+    });
+    expect(gmail.draftReadCount).toBe(2);
   });
 
   it("rejects a missing Gmail draft and cross-chat relinking", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-mail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-mail.ts
@@ -155,7 +155,7 @@ const getAttachmentInner$ = command(
         headers.set("X-Content-Type-Options", "nosniff");
         headers.set(
           "Content-Disposition",
-          `inline; filename*=UTF-8''${encodeURIComponent(result.filename)}`,
+          `attachment; filename*=UTF-8''${encodeURIComponent(result.filename)}`,
         );
         const body = new Uint8Array(result.content.byteLength);
         body.set(result.content);

--- a/turbo/apps/api/src/signals/routes/zero-mail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-mail.ts
@@ -12,6 +12,7 @@ import type { RouteEntry } from "../route-entry";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import {
   deleteZeroMailDraft$,
+  getZeroMailDraftAttachment$,
   getZeroMailDraft$,
   linkZeroMailDraft$,
   sendZeroMailDraft$,
@@ -123,6 +124,47 @@ const getDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
+const getAttachmentParams$ = pathParamsOf(zeroMailContract.getAttachment);
+const getAttachmentInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (!(await set(zeroMailEnabled$))) {
+      return zeroMailDisabled;
+    }
+    const result = await set(
+      getZeroMailDraftAttachment$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        ...get(getAttachmentParams$),
+      },
+      signal,
+    );
+    switch (result.kind) {
+      case "not_found": {
+        return notFound(result.message);
+      }
+      case "conflict": {
+        return conflict(result.message);
+      }
+      case "ok": {
+        const headers = new Headers();
+        headers.set("Content-Type", result.contentType);
+        headers.set("Content-Length", String(result.content.byteLength));
+        headers.set("Cache-Control", "private, max-age=300");
+        headers.set("X-Content-Type-Options", "nosniff");
+        headers.set(
+          "Content-Disposition",
+          `inline; filename*=UTF-8''${encodeURIComponent(result.filename)}`,
+        );
+        const body = new Uint8Array(result.content.byteLength);
+        body.set(result.content);
+        return new Response(body, { status: 200, headers });
+      }
+    }
+  },
+);
+
 const deleteDraftParams$ = pathParamsOf(zeroMailContract.deleteDraft);
 const deleteDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
@@ -185,6 +227,10 @@ export const zeroMailRoutes: readonly RouteEntry[] = [
   {
     route: zeroMailContract.getDraft,
     handler: authRoute(mailDraftHumanAuth, getDraftInner$),
+  },
+  {
+    route: zeroMailContract.getAttachment,
+    handler: authRoute(mailDraftHumanAuth, getAttachmentInner$),
   },
   {
     route: zeroMailContract.deleteDraft,

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -723,7 +723,10 @@ function findAttachmentPart(
   part: GmailMessagePart,
   partId: string,
 ): GmailMessagePart | null {
-  if (part.partId === partId && part.body.attachmentId) {
+  if (
+    part.partId === partId &&
+    (part.body.data !== undefined || part.body.attachmentId)
+  ) {
     return part;
   }
   for (const child of part.parts ?? []) {
@@ -1179,7 +1182,6 @@ async function gmailAttachmentSource(args: {
   readonly partId: string;
   readonly signal: AbortSignal;
 }): Promise<{
-  readonly attachmentId: string;
   readonly messageId: string;
   readonly part: GmailMessagePart;
 } | null> {
@@ -1198,9 +1200,10 @@ async function gmailAttachmentSource(args: {
     const part = message
       ? findAttachmentPart(message.payload, args.partId)
       : null;
-    return message && part?.body.attachmentId
+    return message &&
+      part &&
+      (part.body.data !== undefined || part.body.attachmentId)
       ? {
-          attachmentId: part.body.attachmentId,
           messageId: message.id,
           part,
         }
@@ -1214,13 +1217,35 @@ async function gmailAttachmentSource(args: {
   const part = draft
     ? findAttachmentPart(draft.message.payload, args.partId)
     : null;
-  return draft && part?.body.attachmentId
+  return draft &&
+    part &&
+    (part.body.data !== undefined || part.body.attachmentId)
     ? {
-        attachmentId: part.body.attachmentId,
         messageId: draft.message.id,
         part,
       }
     : null;
+}
+
+async function gmailAttachmentContent(args: {
+  readonly accessToken: string;
+  readonly messageId: string;
+  readonly part: GmailMessagePart;
+  readonly signal: AbortSignal;
+}): Promise<Uint8Array | null> {
+  if (args.part.body.data !== undefined) {
+    return new Uint8Array(Buffer.from(args.part.body.data, "base64url"));
+  }
+  const attachmentId = args.part.body.attachmentId;
+  if (!attachmentId) {
+    return null;
+  }
+  return await gmailGetAttachment({
+    accessToken: args.accessToken,
+    gmailMessageId: args.messageId,
+    attachmentId,
+    signal: args.signal,
+  });
 }
 
 export const linkZeroMailDraft$ = command(
@@ -1395,10 +1420,10 @@ export const getZeroMailDraftAttachment$ = command(
         message: "Mail draft attachment not found",
       };
     }
-    const content = await gmailGetAttachment({
+    const content = await gmailAttachmentContent({
       accessToken: access.accessToken,
-      gmailMessageId: source.messageId,
-      attachmentId: source.attachmentId,
+      messageId: source.messageId,
+      part: source.part,
       signal,
     });
     if (!content) {

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -670,7 +670,9 @@ function attachmentMetadata(
         filename: decodeHeader(part.filename || "attachment"),
         contentType: part.mimeType,
         size: part.body.size,
-        ...(part.body.attachmentId ? { partId: part.partId } : {}),
+        ...(part.body.data !== undefined || part.body.attachmentId
+          ? { partId: part.partId }
+          : {}),
       },
     ];
   }

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -25,7 +25,7 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
-import { tapError } from "../utils";
+import { settle } from "../utils";
 import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
@@ -148,6 +148,11 @@ type ZeroMailDraftAttachmentResult =
   | MailDraftAttachmentResult
   | MailDraftErrorResult;
 
+const reconnectMailError = Object.freeze({
+  kind: "conflict" as const,
+  message: "Reconnect Gmail before continuing",
+});
+
 interface MailDraftRow {
   readonly id: string;
   readonly agentId: string;
@@ -223,6 +228,13 @@ interface GmailSentValue {
   readonly messageId: string;
   readonly threadId: string;
   readonly details: MailDetails | null;
+}
+
+class GmailAuthorizationError extends Error {
+  constructor() {
+    super("Gmail authorization is no longer valid");
+    this.name = "GmailAuthorizationError";
+  }
 }
 
 interface MailAccess {
@@ -752,6 +764,9 @@ async function gmailGetDraftResource(args: {
       headers: { Authorization: `Bearer ${args.accessToken}` },
     },
   );
+  if (response.status === 401) {
+    throw new GmailAuthorizationError();
+  }
   if (response.status === 404) {
     return null;
   }
@@ -796,6 +811,9 @@ async function gmailSendLinkedDraft(args: {
     },
     body: JSON.stringify({ id: args.gmailDraftId }),
   });
+  if (response.status === 401) {
+    throw new GmailAuthorizationError();
+  }
   if (response.status === 404) {
     return null;
   }
@@ -818,6 +836,9 @@ async function gmailGetMessageResource(args: {
       headers: { Authorization: `Bearer ${args.accessToken}` },
     },
   );
+  if (response.status === 401) {
+    throw new GmailAuthorizationError();
+  }
   if (response.status === 404) {
     return null;
   }
@@ -862,6 +883,9 @@ async function gmailGetAttachment(args: {
       headers: { Authorization: `Bearer ${args.accessToken}` },
     },
   );
+  if (response.status === 401) {
+    throw new GmailAuthorizationError();
+  }
   if (response.status === 404) {
     return null;
   }
@@ -887,6 +911,9 @@ async function gmailDeleteDraft(args: {
       headers: { Authorization: `Bearer ${args.accessToken}` },
     },
   );
+  if (response.status === 401) {
+    throw new GmailAuthorizationError();
+  }
   if (response.status !== 204 && response.status !== 404) {
     throw new Error(`Gmail rejected draft deletion (HTTP ${response.status})`);
   }
@@ -915,6 +942,7 @@ function responseDraft(args: {
   readonly row: MailDraftRow;
   readonly details: MailDetails | null;
   readonly detailAvailable: boolean;
+  readonly accessStatus?: "ready" | "reconnect";
 }): ZeroMailDraft {
   const details = responseDetails(args.row, args.details);
   return zeroMailDraftSchema.parse({
@@ -929,6 +957,7 @@ function responseDraft(args: {
     body: details.body,
     bodyHtml: details.bodyHtml,
     inlineImages: details.inlineImages,
+    accessStatus: args.accessStatus ?? "ready",
     replyTo: details.replyTo,
     inReplyTo: details.inReplyTo,
     references: details.references,
@@ -945,6 +974,54 @@ function responseDraft(args: {
   });
 }
 
+async function markGmailNeedsReconnect(args: {
+  readonly db: Db;
+  readonly connectorId: string;
+}): Promise<void> {
+  await args.db
+    .update(connectors)
+    .set({
+      needsReconnect: true,
+      updatedAt: sql`clock_timestamp()`,
+    })
+    .where(eq(connectors.id, args.connectorId));
+}
+
+async function runGmailOperation<T>(args: {
+  readonly db: Db;
+  readonly connectorId: string;
+  readonly operation: () => Promise<T>;
+  readonly signal: AbortSignal;
+}): Promise<
+  | { readonly kind: "ok"; readonly value: T }
+  | { readonly kind: "reconnect" }
+  | { readonly kind: "error"; readonly error: unknown }
+> {
+  const result = await settle(args.operation(), args.signal);
+  args.signal.throwIfAborted();
+  if (result.ok) {
+    return { kind: "ok", value: result.value };
+  }
+  if (!(result.error instanceof GmailAuthorizationError)) {
+    return { kind: "error", error: result.error };
+  }
+  await markGmailNeedsReconnect(args);
+  args.signal.throwIfAborted();
+  return { kind: "reconnect" };
+}
+
+function reconnectDraftResult(row: MailDraftRow): MailDraftResult {
+  return okResult(
+    row.id,
+    responseDraft({
+      row,
+      details: null,
+      detailAvailable: false,
+      accessStatus: "reconnect",
+    }),
+  );
+}
+
 async function connectionForRow(args: {
   readonly db: ReadonlyDb;
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -959,9 +1036,16 @@ async function connectionForRow(args: {
     userId: args.userId,
     agentId: args.row.agentId,
   });
+  const linked = connections.find((connection) => {
+    return connection.connectorId === args.row.connectorId;
+  });
+  if (linked || args.row.connectorId !== null) {
+    return linked ?? null;
+  }
+  const senderAddress = args.row.senderAddress.toLowerCase();
   return (
     connections.find((connection) => {
-      return connection.connectorId === args.row.connectorId;
+      return connection.externalEmail.toLowerCase() === senderAddress;
     }) ?? null
   );
 }
@@ -1108,31 +1192,44 @@ async function getMailDraft(args: {
   }
   const access = await accessForRow(args);
   if (args.row.status === "sent") {
+    const sentGmailMessageId = args.row.sentGmailMessageId;
     const stored = okResult(
       args.row.id,
       responseDraft({ row: args.row, details: null, detailAvailable: false }),
     );
-    if (access.kind !== "ok" || !args.row.sentGmailMessageId) {
-      return stored;
+    if (access.kind !== "ok" || !sentGmailMessageId) {
+      return access.kind === "ok" ? stored : reconnectDraftResult(args.row);
     }
-    const sent = await tapError(
-      gmailGetMessage({
-        accessToken: access.accessToken,
-        gmailMessageId: args.row.sentGmailMessageId,
-        fallbackSender: {
-          address: access.connection.externalEmail,
-          name: access.connection.externalUsername,
-        },
-        signal: args.signal,
-      }),
-      (error) => {
-        L.warn("Failed to enrich sent Gmail draft card", {
-          mailDraftId: args.row.id,
-          gmailMessageId: args.row.sentGmailMessageId,
-          error,
+    let sent: GmailSentValue | null = null;
+    const sentResult = await runGmailOperation({
+      db: args.writeDb,
+      connectorId: access.connection.connectorId,
+      operation: async () => {
+        return await gmailGetMessage({
+          accessToken: access.accessToken,
+          gmailMessageId: sentGmailMessageId,
+          fallbackSender: {
+            address: access.connection.externalEmail,
+            name: access.connection.externalUsername,
+          },
+          signal: args.signal,
         });
       },
-    );
+      signal: args.signal,
+    });
+    args.signal.throwIfAborted();
+    if (sentResult.kind === "reconnect") {
+      return reconnectDraftResult(args.row);
+    }
+    if (sentResult.kind === "error") {
+      L.warn("Failed to enrich sent Gmail draft card", {
+        mailDraftId: args.row.id,
+        gmailMessageId: sentGmailMessageId,
+        error: sentResult.error,
+      });
+    } else {
+      sent = sentResult.value;
+    }
     return sent
       ? okResult(
           args.row.id,
@@ -1145,17 +1242,32 @@ async function getMailDraft(args: {
       : stored;
   }
   if (access.kind !== "ok") {
-    return access;
+    return reconnectDraftResult(args.row);
   }
-  const gmail = await gmailGetDraft({
-    accessToken: access.accessToken,
-    gmailDraftId: args.row.gmailDraftId,
-    fallbackSender: {
-      address: access.connection.externalEmail,
-      name: access.connection.externalUsername,
+  const gmailResult = await runGmailOperation({
+    db: args.writeDb,
+    connectorId: access.connection.connectorId,
+    operation: async () => {
+      return await gmailGetDraft({
+        accessToken: access.accessToken,
+        gmailDraftId: args.row.gmailDraftId,
+        fallbackSender: {
+          address: access.connection.externalEmail,
+          name: access.connection.externalUsername,
+        },
+        signal: args.signal,
+      });
     },
     signal: args.signal,
   });
+  args.signal.throwIfAborted();
+  if (gmailResult.kind === "reconnect") {
+    return reconnectDraftResult(args.row);
+  }
+  if (gmailResult.kind === "error") {
+    throw gmailResult.error;
+  }
+  const gmail = gmailResult.value;
   if (!gmail) {
     const deleted = await markDeleted({ db: args.writeDb, row: args.row });
     return okResult(
@@ -1250,6 +1362,70 @@ async function gmailAttachmentContent(args: {
   });
 }
 
+async function sendGmailDraftWithAccess(args: {
+  readonly access: MailAccess;
+  readonly db: Db;
+  readonly row: MailDraftRow;
+  readonly signal: AbortSignal;
+}): Promise<
+  | {
+      readonly kind: "ok";
+      readonly current: GmailDraftValue;
+      readonly sent: { readonly messageId: string; readonly threadId: string };
+    }
+  | { readonly kind: "missing" }
+  | { readonly kind: "reconnect" }
+> {
+  const currentResult = await runGmailOperation({
+    db: args.db,
+    connectorId: args.access.connection.connectorId,
+    operation: async () => {
+      return await gmailGetDraft({
+        accessToken: args.access.accessToken,
+        gmailDraftId: args.row.gmailDraftId,
+        fallbackSender: {
+          address: args.access.connection.externalEmail,
+          name: args.access.connection.externalUsername,
+        },
+        signal: args.signal,
+      });
+    },
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  if (currentResult.kind === "reconnect") {
+    return currentResult;
+  }
+  if (currentResult.kind === "error") {
+    throw currentResult.error;
+  }
+  if (!currentResult.value) {
+    return { kind: "missing" };
+  }
+  const sentResult = await runGmailOperation({
+    db: args.db,
+    connectorId: args.access.connection.connectorId,
+    operation: async () => {
+      return await gmailSendLinkedDraft({
+        accessToken: args.access.accessToken,
+        gmailDraftId: args.row.gmailDraftId,
+        signal: args.signal,
+      });
+    },
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  if (sentResult.kind === "reconnect") {
+    return sentResult;
+  }
+  if (sentResult.kind === "error") {
+    throw sentResult.error;
+  }
+  return sentResult.value
+    ? { kind: "ok", current: currentResult.value, sent: sentResult.value }
+    : { kind: "missing" };
+}
+
 export const linkZeroMailDraft$ = command(
   async (
     { get, set },
@@ -1317,15 +1493,30 @@ export const linkZeroMailDraft$ = command(
     if (access.kind !== "ok") {
       return { kind: "conflict", message: access.message };
     }
-    const gmail = await gmailGetDraft({
-      accessToken: access.accessToken,
-      gmailDraftId: args.gmailDraftId,
-      fallbackSender: {
-        address: connection.externalEmail,
-        name: connection.externalUsername,
+    const gmailResult = await runGmailOperation({
+      db: set(writeDb$),
+      connectorId: connection.connectorId,
+      operation: async () => {
+        return await gmailGetDraft({
+          accessToken: access.accessToken,
+          gmailDraftId: args.gmailDraftId,
+          fallbackSender: {
+            address: connection.externalEmail,
+            name: connection.externalUsername,
+          },
+          signal,
+        });
       },
       signal,
     });
+    signal.throwIfAborted();
+    if (gmailResult.kind === "reconnect") {
+      return reconnectMailError;
+    }
+    if (gmailResult.kind === "error") {
+      throw gmailResult.error;
+    }
+    const gmail = gmailResult.value;
     if (!gmail) {
       return { kind: "not_found", message: "Gmail draft not found" };
     }
@@ -1410,24 +1601,54 @@ export const getZeroMailDraftAttachment$ = command(
     if (access.kind !== "ok") {
       return access;
     }
-    const source = await gmailAttachmentSource({
-      accessToken: access.accessToken,
-      row,
-      partId: args.partId,
+    const sourceResult = await runGmailOperation({
+      db: set(writeDb$),
+      connectorId: access.connection.connectorId,
+      operation: async () => {
+        return await gmailAttachmentSource({
+          accessToken: access.accessToken,
+          row,
+          partId: args.partId,
+          signal,
+        });
+      },
       signal,
     });
+    signal.throwIfAborted();
+    if (sourceResult.kind === "reconnect") {
+      return reconnectMailError;
+    }
+    if (sourceResult.kind === "error") {
+      throw sourceResult.error;
+    }
+    const source = sourceResult.value;
     if (!source) {
       return {
         kind: "not_found",
         message: "Mail draft attachment not found",
       };
     }
-    const content = await gmailAttachmentContent({
-      accessToken: access.accessToken,
-      messageId: source.messageId,
-      part: source.part,
+    const contentResult = await runGmailOperation({
+      db: set(writeDb$),
+      connectorId: access.connection.connectorId,
+      operation: async () => {
+        return await gmailAttachmentContent({
+          accessToken: access.accessToken,
+          messageId: source.messageId,
+          part: source.part,
+          signal,
+        });
+      },
       signal,
     });
+    signal.throwIfAborted();
+    if (contentResult.kind === "reconnect") {
+      return reconnectMailError;
+    }
+    if (contentResult.kind === "error") {
+      throw contentResult.error;
+    }
+    const content = contentResult.value;
     if (!content) {
       return {
         kind: "not_found",
@@ -1479,12 +1700,25 @@ export const deleteZeroMailDraft$ = command(
     if (access.kind !== "ok") {
       return access;
     }
-    await gmailDeleteDraft({
-      accessToken: access.accessToken,
-      gmailDraftId: row.gmailDraftId,
+    const deletion = await runGmailOperation({
+      db: set(writeDb$),
+      connectorId: access.connection.connectorId,
+      operation: async () => {
+        await gmailDeleteDraft({
+          accessToken: access.accessToken,
+          gmailDraftId: row.gmailDraftId,
+          signal,
+        });
+      },
       signal,
     });
     signal.throwIfAborted();
+    if (deletion.kind === "reconnect") {
+      return reconnectMailError;
+    }
+    if (deletion.kind === "error") {
+      throw deletion.error;
+    }
     const deletedDraft = responseDraft({
       row: { ...row, status: "deleted" },
       details: null,
@@ -1530,29 +1764,17 @@ export const sendZeroMailDraft$ = command(
     if (access.kind !== "ok") {
       return access;
     }
-    const current = await gmailGetDraft({
-      accessToken: access.accessToken,
-      gmailDraftId: row.gmailDraftId,
-      fallbackSender: {
-        address: access.connection.externalEmail,
-        name: access.connection.externalUsername,
-      },
+    const gmail = await sendGmailDraftWithAccess({
+      access,
+      db: set(writeDb$),
+      row,
       signal,
     });
-    if (!current) {
-      const deleted = await markDeleted({ db: set(writeDb$), row });
-      signal.throwIfAborted();
-      return okResult(
-        row.id,
-        responseDraft({ row: deleted, details: null, detailAvailable: false }),
-      );
+    signal.throwIfAborted();
+    if (gmail.kind === "reconnect") {
+      return reconnectMailError;
     }
-    const sent = await gmailSendLinkedDraft({
-      accessToken: access.accessToken,
-      gmailDraftId: row.gmailDraftId,
-      signal,
-    });
-    if (!sent) {
+    if (gmail.kind === "missing") {
       const deleted = await markDeleted({ db: set(writeDb$), row });
       signal.throwIfAborted();
       return okResult(
@@ -1565,12 +1787,12 @@ export const sendZeroMailDraft$ = command(
       .update(mailDrafts)
       .set({
         status: "sent",
-        gmailThreadId: sent.threadId,
-        gmailMessageId: current.messageId,
-        sentGmailMessageId: sent.messageId,
-        senderName: current.details.fromName ?? null,
-        senderAddress: current.details.from,
-        subject: current.details.subject,
+        gmailThreadId: gmail.sent.threadId,
+        gmailMessageId: gmail.current.messageId,
+        sentGmailMessageId: gmail.sent.messageId,
+        senderName: gmail.current.details.fromName ?? null,
+        senderAddress: gmail.current.details.from,
+        subject: gmail.current.details.subject,
         sentAt,
         updatedAt: sentAt,
       })
@@ -1579,12 +1801,12 @@ export const sendZeroMailDraft$ = command(
     const sentRow: MailDraftRow = {
       ...row,
       status: "sent",
-      gmailThreadId: sent.threadId,
-      gmailMessageId: current.messageId,
-      sentGmailMessageId: sent.messageId,
-      senderName: current.details.fromName ?? null,
-      senderAddress: current.details.from,
-      subject: current.details.subject,
+      gmailThreadId: gmail.sent.threadId,
+      gmailMessageId: gmail.current.messageId,
+      sentGmailMessageId: gmail.sent.messageId,
+      senderName: gmail.current.details.fromName ?? null,
+      senderAddress: gmail.current.details.from,
+      subject: gmail.current.details.subject,
       sentAt,
       updatedAt: sentAt,
     };
@@ -1592,7 +1814,7 @@ export const sendZeroMailDraft$ = command(
       row.id,
       responseDraft({
         row: sentRow,
-        details: current.details,
+        details: gmail.current.details,
         detailAvailable: true,
       }),
     );

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -9,6 +9,7 @@ import {
   type ZeroMailAttachment,
   type ZeroMailDraft,
   type ZeroMailDraftStatus,
+  type ZeroMailInlineImage,
 } from "@vm0/api-contracts/contracts/zero-mail";
 import { connectorAuthMethodHasRequiredScopes } from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -46,6 +47,7 @@ const GMAIL_ACCESS_TOKEN_ENV = "GMAIL_TOKEN";
 const oauthScopesSchema = z.array(z.string());
 
 interface GmailMessagePart {
+  readonly partId: string;
   readonly mimeType: string;
   readonly filename: string;
   readonly headers: readonly {
@@ -62,6 +64,7 @@ interface GmailMessagePart {
 
 const gmailMessagePartSchema: z.ZodType<GmailMessagePart> = z.lazy(() => {
   return z.object({
+    partId: z.string(),
     mimeType: z.string(),
     filename: z.string().default(""),
     headers: z
@@ -96,6 +99,11 @@ const gmailSentResourceSchema = z.object({
   threadId: z.string(),
 });
 
+const gmailAttachmentResourceSchema = z.object({
+  size: z.number().int().nonnegative(),
+  data: z.string(),
+});
+
 interface MailConnection extends ConnectorCredentialConnection {
   readonly connectorRef: "gmail";
   readonly externalEmail: string;
@@ -116,6 +124,13 @@ interface MailDraftLinkResult {
   readonly mailDraftUrl: string;
 }
 
+interface MailDraftAttachmentResult {
+  readonly kind: "ok";
+  readonly content: Uint8Array;
+  readonly contentType: string;
+  readonly filename: string;
+}
+
 interface MailDraftErrorResult {
   readonly kind: "not_found" | "conflict";
   readonly message: string;
@@ -127,6 +142,10 @@ export type ZeroMailDraftMutationResult =
 
 export type ZeroMailDraftLinkMutationResult =
   | MailDraftLinkResult
+  | MailDraftErrorResult;
+
+type ZeroMailDraftAttachmentResult =
+  | MailDraftAttachmentResult
   | MailDraftErrorResult;
 
 interface MailDraftRow {
@@ -185,6 +204,8 @@ interface MailDetails {
   readonly bcc: readonly string[];
   readonly subject: string;
   readonly body: string;
+  readonly bodyHtml?: string;
+  readonly inlineImages?: readonly ZeroMailInlineImage[];
   readonly replyTo?: string;
   readonly inReplyTo?: string;
   readonly references: readonly string[];
@@ -550,20 +571,111 @@ function findBodyPart(
   return null;
 }
 
+const htmlAttributesSchema = z.record(z.string(), z.string());
+
+function normalizedContentId(value: string): string {
+  return value
+    .trim()
+    .replace(/^cid:/iu, "")
+    .replace(/^<|>$/gu, "")
+    .toLowerCase();
+}
+
+function inlineImagePartsByContentId(
+  part: GmailMessagePart,
+): ReadonlyMap<string, GmailMessagePart> {
+  const parts = new Map<string, GmailMessagePart>();
+  const contentId = headerValue(part, "content-id");
+  if (
+    contentId &&
+    part.partId &&
+    part.mimeType.toLowerCase().startsWith("image/")
+  ) {
+    parts.set(normalizedContentId(contentId), part);
+  }
+  for (const child of part.parts ?? []) {
+    for (const [childContentId, childPart] of inlineImagePartsByContentId(
+      child,
+    )) {
+      parts.set(childContentId, childPart);
+    }
+  }
+  return parts;
+}
+
+interface RichMailBody {
+  readonly html: string;
+  readonly inlineImages: readonly ZeroMailInlineImage[];
+  readonly inlinePartIds: ReadonlySet<string>;
+}
+
+function richMailBody(
+  payload: GmailMessagePart,
+  htmlBody: string | null,
+): RichMailBody | null {
+  if (!htmlBody) {
+    return null;
+  }
+  const mimeParts = inlineImagePartsByContentId(payload);
+  const inlineImages: ZeroMailInlineImage[] = [];
+  convert(htmlBody, {
+    wordwrap: false,
+    formatters: {
+      inlineImage(element) {
+        const attributes = htmlAttributesSchema.safeParse(element.attribs);
+        if (!attributes.success) {
+          return;
+        }
+        const source = attributes.data.src;
+        if (!source?.toLowerCase().startsWith("cid:")) {
+          return;
+        }
+        const mimePart = mimeParts.get(normalizedContentId(source));
+        if (!mimePart) {
+          return;
+        }
+        inlineImages.push({
+          contentId: normalizedContentId(source),
+          partId: mimePart.partId,
+          alt:
+            attributes.data.alt?.trim() ||
+            decodeHeader(mimePart.filename) ||
+            "Inline email image",
+        });
+      },
+    },
+    selectors: [{ selector: "img", format: "inlineImage" }],
+  });
+  return {
+    html: htmlBody,
+    inlineImages,
+    inlinePartIds: new Set(
+      inlineImages.map((image) => {
+        return image.partId;
+      }),
+    ),
+  };
+}
+
 function attachmentMetadata(
   part: GmailMessagePart,
+  inlinePartIds: ReadonlySet<string>,
 ): readonly ZeroMailAttachment[] {
+  if (inlinePartIds.has(part.partId)) {
+    return [];
+  }
   if (part.filename || part.body.attachmentId) {
     return [
       {
         filename: decodeHeader(part.filename || "attachment"),
         contentType: part.mimeType,
         size: part.body.size,
+        ...(part.body.attachmentId ? { partId: part.partId } : {}),
       },
     ];
   }
   return (part.parts ?? []).flatMap((child) => {
-    return attachmentMetadata(child);
+    return attachmentMetadata(child, inlinePartIds);
   });
 }
 
@@ -573,8 +685,8 @@ function mailDetailsFromPayload(
 ): MailDetails {
   const from = parseFromHeader(headerValue(payload, "from"), fallbackSender);
   const plainBody = findBodyPart(payload, "text/plain");
-  const htmlBody =
-    plainBody === null ? findBodyPart(payload, "text/html") : null;
+  const htmlBody = findBodyPart(payload, "text/html");
+  const richBody = richMailBody(payload, htmlBody);
   return {
     from: from.address,
     ...(from.name ? { fromName: from.name } : {}),
@@ -585,6 +697,12 @@ function mailDetailsFromPayload(
     body:
       plainBody ??
       (htmlBody ? convert(htmlBody, { wordwrap: false }).trim() : ""),
+    ...(richBody
+      ? {
+          bodyHtml: richBody.html,
+          inlineImages: richBody.inlineImages,
+        }
+      : {}),
     ...(headerValue(payload, "reply-to")
       ? { replyTo: decodeHeader(headerValue(payload, "reply-to")!) }
       : {}),
@@ -594,19 +712,34 @@ function mailDetailsFromPayload(
     references: (headerValue(payload, "references") ?? "")
       .split(/\s+/u)
       .filter(Boolean),
-    attachments: attachmentMetadata(payload),
+    attachments: attachmentMetadata(
+      payload,
+      richBody?.inlinePartIds ?? new Set(),
+    ),
   };
 }
 
-async function gmailGetDraft(args: {
+function findAttachmentPart(
+  part: GmailMessagePart,
+  partId: string,
+): GmailMessagePart | null {
+  if (part.partId === partId && part.body.attachmentId) {
+    return part;
+  }
+  for (const child of part.parts ?? []) {
+    const found = findAttachmentPart(child, partId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+async function gmailGetDraftResource(args: {
   readonly accessToken: string;
   readonly gmailDraftId: string;
-  readonly fallbackSender: {
-    readonly address: string;
-    readonly name: string | null;
-  };
   readonly signal: AbortSignal;
-}): Promise<GmailDraftValue | null> {
+}): Promise<z.infer<typeof gmailDraftResourceSchema> | null> {
   const response = await fetch(
     `${GMAIL_API_BASE}/drafts/${encodeURIComponent(args.gmailDraftId)}?format=full`,
     {
@@ -620,7 +753,22 @@ async function gmailGetDraft(args: {
   if (!response.ok) {
     throw new Error(`Failed to read Gmail draft (HTTP ${response.status})`);
   }
-  const draft = gmailDraftResourceSchema.parse(await response.json());
+  return gmailDraftResourceSchema.parse(await response.json());
+}
+
+async function gmailGetDraft(args: {
+  readonly accessToken: string;
+  readonly gmailDraftId: string;
+  readonly fallbackSender: {
+    readonly address: string;
+    readonly name: string | null;
+  };
+  readonly signal: AbortSignal;
+}): Promise<GmailDraftValue | null> {
+  const draft = await gmailGetDraftResource(args);
+  if (!draft) {
+    return null;
+  }
   return {
     draftId: draft.id,
     messageId: draft.message.id,
@@ -653,15 +801,11 @@ async function gmailSendLinkedDraft(args: {
   return { messageId: message.id, threadId: message.threadId };
 }
 
-async function gmailGetMessage(args: {
+async function gmailGetMessageResource(args: {
   readonly accessToken: string;
   readonly gmailMessageId: string;
-  readonly fallbackSender: {
-    readonly address: string;
-    readonly name: string | null;
-  };
   readonly signal: AbortSignal;
-}): Promise<GmailSentValue | null> {
+}): Promise<z.infer<typeof gmailMessageResourceSchema> | null> {
   const response = await fetch(
     `${GMAIL_API_BASE}/messages/${encodeURIComponent(args.gmailMessageId)}?format=full`,
     {
@@ -677,12 +821,52 @@ async function gmailGetMessage(args: {
       `Failed to read sent Gmail message (HTTP ${response.status})`,
     );
   }
-  const message = gmailMessageResourceSchema.parse(await response.json());
+  return gmailMessageResourceSchema.parse(await response.json());
+}
+
+async function gmailGetMessage(args: {
+  readonly accessToken: string;
+  readonly gmailMessageId: string;
+  readonly fallbackSender: {
+    readonly address: string;
+    readonly name: string | null;
+  };
+  readonly signal: AbortSignal;
+}): Promise<GmailSentValue | null> {
+  const message = await gmailGetMessageResource(args);
+  if (!message) {
+    return null;
+  }
   return {
     messageId: message.id,
     threadId: message.threadId,
     details: mailDetailsFromPayload(message.payload, args.fallbackSender),
   };
+}
+
+async function gmailGetAttachment(args: {
+  readonly accessToken: string;
+  readonly gmailMessageId: string;
+  readonly attachmentId: string;
+  readonly signal: AbortSignal;
+}): Promise<Uint8Array | null> {
+  const response = await fetch(
+    `${GMAIL_API_BASE}/messages/${encodeURIComponent(args.gmailMessageId)}/attachments/${encodeURIComponent(args.attachmentId)}`,
+    {
+      signal: args.signal,
+      headers: { Authorization: `Bearer ${args.accessToken}` },
+    },
+  );
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read Gmail attachment (HTTP ${response.status})`,
+    );
+  }
+  const attachment = gmailAttachmentResourceSchema.parse(await response.json());
+  return new Uint8Array(Buffer.from(attachment.data, "base64url"));
 }
 
 async function gmailDeleteDraft(args: {
@@ -738,6 +922,8 @@ function responseDraft(args: {
     bcc: details.bcc,
     subject: details.subject,
     body: details.body,
+    bodyHtml: details.bodyHtml,
+    inlineImages: details.inlineImages,
     replyTo: details.replyTo,
     inReplyTo: details.inReplyTo,
     references: details.references,
@@ -987,6 +1173,56 @@ async function getMailDraft(args: {
   );
 }
 
+async function gmailAttachmentSource(args: {
+  readonly accessToken: string;
+  readonly row: MailDraftRow;
+  readonly partId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly attachmentId: string;
+  readonly messageId: string;
+  readonly part: GmailMessagePart;
+} | null> {
+  if (args.row.status === "deleted") {
+    return null;
+  }
+  if (args.row.status === "sent") {
+    if (!args.row.sentGmailMessageId) {
+      return null;
+    }
+    const message = await gmailGetMessageResource({
+      accessToken: args.accessToken,
+      gmailMessageId: args.row.sentGmailMessageId,
+      signal: args.signal,
+    });
+    const part = message
+      ? findAttachmentPart(message.payload, args.partId)
+      : null;
+    return message && part?.body.attachmentId
+      ? {
+          attachmentId: part.body.attachmentId,
+          messageId: message.id,
+          part,
+        }
+      : null;
+  }
+  const draft = await gmailGetDraftResource({
+    accessToken: args.accessToken,
+    gmailDraftId: args.row.gmailDraftId,
+    signal: args.signal,
+  });
+  const part = draft
+    ? findAttachmentPart(draft.message.payload, args.partId)
+    : null;
+  return draft && part?.body.attachmentId
+    ? {
+        attachmentId: part.body.attachmentId,
+        messageId: draft.message.id,
+        part,
+      }
+    : null;
+}
+
 export const linkZeroMailDraft$ = command(
   async (
     { get, set },
@@ -1113,6 +1349,70 @@ export const getZeroMailDraft$ = command(
       row,
       signal,
     });
+  },
+);
+
+export const getZeroMailDraftAttachment$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly mailDraftId: string;
+      readonly partId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ZeroMailDraftAttachmentResult> => {
+    const db = get(db$);
+    const row = await loadOwnedMailDraft({ db, ...args });
+    signal.throwIfAborted();
+    if (!row) {
+      return { kind: "not_found", message: "Mail draft not found" };
+    }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+    const access = await accessForRow({
+      db,
+      writeDb: set(writeDb$),
+      snapshot,
+      orgId: args.orgId,
+      userId: args.userId,
+      row,
+      signal,
+    });
+    if (access.kind !== "ok") {
+      return access;
+    }
+    const source = await gmailAttachmentSource({
+      accessToken: access.accessToken,
+      row,
+      partId: args.partId,
+      signal,
+    });
+    if (!source) {
+      return {
+        kind: "not_found",
+        message: "Mail draft attachment not found",
+      };
+    }
+    const content = await gmailGetAttachment({
+      accessToken: access.accessToken,
+      gmailMessageId: source.messageId,
+      attachmentId: source.attachmentId,
+      signal,
+    });
+    if (!content) {
+      return {
+        kind: "not_found",
+        message: "Mail draft attachment not found",
+      };
+    }
+    return {
+      kind: "ok",
+      content,
+      contentType: source.part.mimeType,
+      filename: decodeHeader(source.part.filename || "attachment"),
+    };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -275,7 +275,7 @@ function buildIntegrationToolsPrompt(
         crossIntegrationMessage,
         ...(zeroMailEnabled
           ? [
-              "- Email from web chat: use the Gmail skill and `GMAIL_TOKEN` to create the draft directly in Gmail. For attachments, upload a valid RFC822 multipart message through Gmail's draft media-upload endpoint. Never call `messages.send` or `drafts.send`. After Gmail returns the draft ID, run `zero mail link <gmail-draft-id>` and return the link from the command to the user.",
+              "- Email from web chat: use the Gmail skill and `GMAIL_TOKEN` to create the draft directly in Gmail. Before composing, list `GET /gmail/v1/users/me/settings/sendAs`; select the entry matching the message's From address, or the `isDefault` entry when no From address is specified. If it has a non-empty HTML `signature`, append that signature exactly once to the draft's HTML body and include a readable text equivalent in the plain-text body. For attachments, upload a valid RFC822 multipart message through Gmail's draft media-upload endpoint. Never call `messages.send` or `drafts.send`. After Gmail returns the draft ID, run `zero mail link <gmail-draft-id>` and return the link from the command to the user.",
             ]
           : []),
         ...localFileContextLines,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -136,7 +136,11 @@ import type {
   ThinkingIndicatorMode,
 } from "./chat-thread-signals.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
-import { createMailDraftCardSignalsRegistry } from "./mail-draft.ts";
+import {
+  createMailDraftCardSignalsRegistry,
+  parseMailDraftUrl,
+} from "./mail-draft.ts";
+import { currentMailDraftId$ } from "../zero-page/mail-draft-sidebar.ts";
 import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 import {
   messageDocumentToDisplayText,
@@ -2462,7 +2466,7 @@ function createPagedMessages(
   dataSource: ChatThreadRemote,
   initialOptimisticEntries: readonly OptimisticChatMessageEntry[],
 ) {
-  const mailDraftCardSignals = createMailDraftCardSignalsRegistry();
+  const mailDraftCardSignals = createMailDraftCardSignalsRegistry(threadId);
   const artifactCardSignals = createArtifactCardSignalsRegistry();
   const connectorCardSignals = createConnectorCardSignalsRegistry();
   const customConnectorCardSignals = createCustomConnectorCardSignalsRegistry();
@@ -2545,7 +2549,14 @@ function createPagedMessages(
 
   const mailDraftCardSignalsById$ = computed((get) => {
     get(rawMessages$);
-    return mailDraftCardSignals.entries();
+    const selectedMailDraftId = get(currentMailDraftId$);
+    const selectedMailDraftDescriptor = selectedMailDraftId
+      ? parseMailDraftUrl(`/mail/drafts/${selectedMailDraftId}`)
+      : null;
+    if (selectedMailDraftDescriptor) {
+      mailDraftCardSignals.register(selectedMailDraftDescriptor);
+    }
+    return new Map(mailDraftCardSignals.entries());
   });
 
   const mergePersistentMessages$ = createMergePersistentMessages(

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -139,6 +139,8 @@ import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-comp
 import {
   createMailDraftCardSignalsRegistry,
   parseMailDraftUrl,
+  type MailDraftCardSignalsRegistry,
+  type MailDraftSignals,
 } from "./mail-draft.ts";
 import { currentMailDraftId$ } from "../zero-page/mail-draft-sidebar.ts";
 import { searchParams$ } from "../route.ts";
@@ -2462,6 +2464,29 @@ function createInitializeIndexedDbMessages({
   });
 }
 
+function createMailDraftCardSignalsById(
+  threadId: string,
+  rawMessages$: Computed<ChatMessageProjectionEntry[]>,
+  mailDraftCardSignals: MailDraftCardSignalsRegistry,
+): Computed<ReadonlyMap<string, MailDraftSignals>> {
+  return computed((get) => {
+    get(rawMessages$);
+    const selectedMailDraftId = get(currentMailDraftId$);
+    const restoredDraftOwnerThreadId =
+      get(searchParams$).get("sidebar") || threadId;
+    const selectedMailDraftDescriptor = selectedMailDraftId
+      ? parseMailDraftUrl(`/mail/drafts/${selectedMailDraftId}`)
+      : null;
+    if (
+      selectedMailDraftDescriptor &&
+      restoredDraftOwnerThreadId === threadId
+    ) {
+      mailDraftCardSignals.register(selectedMailDraftDescriptor);
+    }
+    return new Map(mailDraftCardSignals.entries());
+  });
+}
+
 function createPagedMessages(
   threadId: string,
   dataSource: ChatThreadRemote,
@@ -2548,22 +2573,11 @@ function createPagedMessages(
 
   const renderedMessages = createRenderedChatGroups(semanticMessages$);
 
-  const mailDraftCardSignalsById$ = computed((get) => {
-    get(rawMessages$);
-    const selectedMailDraftId = get(currentMailDraftId$);
-    const restoredDraftOwnerThreadId =
-      get(searchParams$).get("sidebar") || threadId;
-    const selectedMailDraftDescriptor = selectedMailDraftId
-      ? parseMailDraftUrl(`/mail/drafts/${selectedMailDraftId}`)
-      : null;
-    if (
-      selectedMailDraftDescriptor &&
-      restoredDraftOwnerThreadId === threadId
-    ) {
-      mailDraftCardSignals.register(selectedMailDraftDescriptor);
-    }
-    return new Map(mailDraftCardSignals.entries());
-  });
+  const mailDraftCardSignalsById$ = createMailDraftCardSignalsById(
+    threadId,
+    rawMessages$,
+    mailDraftCardSignals,
+  );
 
   const mergePersistentMessages$ = createMergePersistentMessages(
     threadId,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2487,6 +2487,30 @@ function createMailDraftCardSignalsById(
   });
 }
 
+function createHistoryBackfillProgress(
+  hasReachedOldestMessage$: Computed<boolean>,
+  persistentMessages$: PersistentChatMessages$,
+): Computed<Promise<number | null>> {
+  // Approximate backfill progress from the loaded seqId range. The thread's
+  // true max seqId is not exposed to the client, so the newest loaded message
+  // stands in for it. The reached-oldest computed hides progress once the
+  // first persistent seqId is 1. Null hides the progress bar.
+  return computed((get): Promise<number | null> => {
+    if (get(hasReachedOldestMessage$)) {
+      return Promise.resolve(null);
+    }
+    const messages = get(persistentMessages$);
+    const first = messages[0];
+    const last = messages.at(-1);
+    if (first === undefined || last === undefined) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(
+      (last.message.seqId - first.message.seqId) / last.message.seqId,
+    );
+  });
+}
+
 function createPagedMessages(
   threadId: string,
   dataSource: ChatThreadRemote,
@@ -2537,24 +2561,10 @@ function createPagedMessages(
     optimisticMessages$,
     resolveBodyBlocks,
   });
-  // Approximate backfill progress from the loaded seqId range. The thread's
-  // true max seqId is not exposed to the client, so the newest loaded message
-  // stands in for it. The reached-oldest computed hides progress once the
-  // first persistent seqId is 1. Null hides the progress bar.
-  const historyBackfillProgress$ = computed((get): Promise<number | null> => {
-    if (get(hasReachedOldestMessage$)) {
-      return Promise.resolve(null);
-    }
-    const messages = get(persistentChatMessages$);
-    const first = messages[0];
-    const last = messages.at(-1);
-    if (first === undefined || last === undefined) {
-      return Promise.resolve(null);
-    }
-    return Promise.resolve(
-      (last.message.seqId - first.message.seqId) / last.message.seqId,
-    );
-  });
+  const historyBackfillProgress$ = createHistoryBackfillProgress(
+    hasReachedOldestMessage$,
+    persistentChatMessages$,
+  );
   const semanticMessages$ = computed((get): SemanticChatMessage[] => {
     return semanticTranscriptMessagesFromRaw(get(rawMessages$));
   });

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -141,6 +141,7 @@ import {
   parseMailDraftUrl,
 } from "./mail-draft.ts";
 import { currentMailDraftId$ } from "../zero-page/mail-draft-sidebar.ts";
+import { searchParams$ } from "../route.ts";
 import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 import {
   messageDocumentToDisplayText,
@@ -2550,10 +2551,15 @@ function createPagedMessages(
   const mailDraftCardSignalsById$ = computed((get) => {
     get(rawMessages$);
     const selectedMailDraftId = get(currentMailDraftId$);
+    const restoredDraftOwnerThreadId =
+      get(searchParams$).get("sidebar") || threadId;
     const selectedMailDraftDescriptor = selectedMailDraftId
       ? parseMailDraftUrl(`/mail/drafts/${selectedMailDraftId}`)
       : null;
-    if (selectedMailDraftDescriptor) {
+    if (
+      selectedMailDraftDescriptor &&
+      restoredDraftOwnerThreadId === threadId
+    ) {
       mailDraftCardSignals.register(selectedMailDraftDescriptor);
     }
     return new Map(mailDraftCardSignals.entries());

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -15,6 +15,7 @@ import {
   getOrCreateCardSignals,
   registeredCardSignals,
 } from "./card-signal-map.ts";
+import { onRef } from "../utils.ts";
 
 export interface MailDraftDescriptor {
   readonly mailDraftId: string;
@@ -28,6 +29,10 @@ export interface MailDraftSignals extends MailDraftDescriptor {
   readonly sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>;
   readonly attachmentUrls$: Computed<
     Promise<ReadonlyMap<string, string | null>>
+  >;
+  readonly setAttachmentScopeRef$: Command<
+    (() => void) | undefined,
+    [HTMLDivElement | null]
   >;
   readonly reloadSidebar$: Command<void, []>;
   readonly delete$: Command<Promise<void>, [AbortSignal]>;
@@ -125,8 +130,9 @@ export function parseMailDraftUrl(value: string): MailDraftDescriptor | null {
 function createAttachmentUrls(
   descriptor: MailDraftDescriptor,
   sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>,
-): MailDraftSignals["attachmentUrls$"] {
+): Pick<MailDraftSignals, "attachmentUrls$" | "setAttachmentScopeRef$"> {
   const attachmentObjectUrls = new Map<string, string>();
+  const attachmentScopeActive$ = state(false);
   let cleanupSignal: AbortSignal | null = null;
   let loadVersion = 0;
   const revokeAttachmentObjectUrls = () => {
@@ -135,68 +141,94 @@ function createAttachmentUrls(
     }
     attachmentObjectUrls.clear();
   };
-  return computed(async (get): Promise<ReadonlyMap<string, string | null>> => {
-    const currentLoadVersion = ++loadVersion;
-    const draftPromise = get(sidebarDraft$);
-    const signal = get(pageSignal$);
-    const client = get(zeroClient$)(zeroMailContract);
-    signal.throwIfAborted();
-    if (cleanupSignal !== signal) {
-      cleanupSignal?.removeEventListener("abort", revokeAttachmentObjectUrls);
-      cleanupSignal = signal;
-      signal.addEventListener("abort", revokeAttachmentObjectUrls, {
-        once: true,
-      });
-    }
-    const draft = await draftPromise;
-    signal.throwIfAborted();
-    if (currentLoadVersion !== loadVersion) {
-      return new Map();
-    }
-    const partIds = Array.from(
-      new Set([
-        ...(draft?.inlineImages ?? []).map((image) => {
-          return image.partId;
-        }),
-        ...(draft?.version === 3 ? draft.attachments : []).flatMap(
-          (attachment) => {
-            return attachment.partId ? [attachment.partId] : [];
-          },
-        ),
-      ]),
-    );
-    const responses = await Promise.all(
-      partIds.map(async (partId) => {
-        const response = await accept(
-          client.getAttachment({
-            params: {
-              mailDraftId: descriptor.mailDraftId,
-              partId,
-            },
-            fetchOptions: { signal },
-          }),
-          [200, 404],
-        );
-        return { partId, response };
-      }),
-    );
-    signal.throwIfAborted();
-    if (currentLoadVersion !== loadVersion) {
-      return new Map();
-    }
+  const releaseAttachmentObjectUrls = () => {
+    loadVersion += 1;
     revokeAttachmentObjectUrls();
-    const imageUrls = new Map<string, string | null>();
-    for (const { partId, response } of responses) {
-      if (response.status === 404) {
-        imageUrls.set(partId, null);
-        continue;
+  };
+  const attachmentUrls$ = computed(
+    async (get): Promise<ReadonlyMap<string, string | null>> => {
+      if (!get(attachmentScopeActive$)) {
+        return new Map();
       }
-      const url = URL.createObjectURL(response.body);
-      attachmentObjectUrls.set(partId, url);
-      imageUrls.set(partId, url);
-    }
-    return imageUrls;
-  });
+      const currentLoadVersion = ++loadVersion;
+      const draftPromise = get(sidebarDraft$);
+      const signal = get(pageSignal$);
+      const client = get(zeroClient$)(zeroMailContract);
+      signal.throwIfAborted();
+      if (cleanupSignal !== signal) {
+        cleanupSignal?.removeEventListener(
+          "abort",
+          releaseAttachmentObjectUrls,
+        );
+        cleanupSignal = signal;
+        signal.addEventListener("abort", releaseAttachmentObjectUrls, {
+          once: true,
+        });
+      }
+      const draft = await draftPromise;
+      signal.throwIfAborted();
+      if (currentLoadVersion !== loadVersion) {
+        return new Map();
+      }
+      const partIds = Array.from(
+        new Set([
+          ...(draft?.inlineImages ?? []).map((image) => {
+            return image.partId;
+          }),
+          ...(draft?.version === 3 ? draft.attachments : []).flatMap(
+            (attachment) => {
+              return attachment.partId ? [attachment.partId] : [];
+            },
+          ),
+        ]),
+      );
+      const responses = await Promise.all(
+        partIds.map(async (partId) => {
+          const response = await accept(
+            client.getAttachment({
+              params: {
+                mailDraftId: descriptor.mailDraftId,
+                partId,
+              },
+              fetchOptions: { signal },
+            }),
+            [200, 404],
+          );
+          return { partId, response };
+        }),
+      );
+      signal.throwIfAborted();
+      if (currentLoadVersion !== loadVersion) {
+        return new Map();
+      }
+      revokeAttachmentObjectUrls();
+      const imageUrls = new Map<string, string | null>();
+      for (const { partId, response } of responses) {
+        if (response.status === 404) {
+          imageUrls.set(partId, null);
+          continue;
+        }
+        const url = URL.createObjectURL(response.body);
+        attachmentObjectUrls.set(partId, url);
+        imageUrls.set(partId, url);
+      }
+      return imageUrls;
+    },
+  );
+  const setAttachmentScopeRef$ = onRef(
+    command(({ set }, _element: HTMLDivElement, signal: AbortSignal) => {
+      set(attachmentScopeActive$, true);
+      signal.addEventListener(
+        "abort",
+        () => {
+          releaseAttachmentObjectUrls();
+          set(attachmentScopeActive$, false);
+        },
+        { once: true },
+      );
+    }),
+  );
+  return { attachmentUrls$, setAttachmentScopeRef$ };
 }
 
 function createMailDraftSignals(
@@ -237,7 +269,7 @@ function createMailDraftSignals(
     );
     return response.status === 200 ? response.body.mailDraft : null;
   });
-  const attachmentUrls$ = createAttachmentUrls(descriptor, sidebarDraft$);
+  const attachmentUrls = createAttachmentUrls(descriptor, sidebarDraft$);
   const reloadSidebar$ = command(({ set }) => {
     set(sidebarDraftOverride$, undefined);
     set(sidebarReloadVersion$, (version) => {
@@ -275,7 +307,7 @@ function createMailDraftSignals(
     threadId,
     draft$,
     sidebarDraft$,
-    attachmentUrls$,
+    ...attachmentUrls,
     reloadSidebar$,
     delete$,
     send$,

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -33,7 +33,7 @@ export interface MailDraftSignals extends MailDraftDescriptor {
   readonly threadId: string;
   readonly draft$: Computed<Promise<ZeroMailDraft | null>>;
   readonly sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>;
-  attachmentImageUrl(partId: string): Computed<Promise<string | null>>;
+  attachmentUrl(partId: string): Computed<Promise<string | null>>;
   readonly reloadSidebar$: Command<void, []>;
   readonly delete$: Command<Promise<void>, [AbortSignal]>;
   readonly send$: Command<Promise<void>, [AbortSignal]>;
@@ -127,19 +127,14 @@ export function parseMailDraftUrl(value: string): MailDraftDescriptor | null {
   };
 }
 
-function createAttachmentImageUrl(
+function createAttachmentUrl(
   descriptor: MailDraftDescriptor,
   sidebarReloadVersion$: State<number>,
-): MailDraftSignals["attachmentImageUrl"] {
-  const attachmentImageUrls = new Map<
-    string,
-    Computed<Promise<string | null>>
-  >();
+): MailDraftSignals["attachmentUrl"] {
+  const attachmentUrls = new Map<string, Computed<Promise<string | null>>>();
   const attachmentObjectUrls = new Map<string, string>();
-  const attachmentImageUrl = (
-    partId: string,
-  ): Computed<Promise<string | null>> => {
-    const registered = attachmentImageUrls.get(partId);
+  const attachmentUrl = (partId: string): Computed<Promise<string | null>> => {
+    const registered = attachmentUrls.get(partId);
     if (registered) {
       return registered;
     }
@@ -178,10 +173,10 @@ function createAttachmentImageUrl(
       );
       return url;
     });
-    attachmentImageUrls.set(partId, imageUrl$);
+    attachmentUrls.set(partId, imageUrl$);
     return imageUrl$;
   };
-  return attachmentImageUrl;
+  return attachmentUrl;
 }
 
 function createMailDraftSignals(
@@ -222,10 +217,7 @@ function createMailDraftSignals(
     );
     return response.status === 200 ? response.body.mailDraft : null;
   });
-  const attachmentImageUrl = createAttachmentImageUrl(
-    descriptor,
-    sidebarReloadVersion$,
-  );
+  const attachmentUrl = createAttachmentUrl(descriptor, sidebarReloadVersion$);
   const reloadSidebar$ = command(({ set }) => {
     set(sidebarDraftOverride$, undefined);
     set(sidebarReloadVersion$, (version) => {
@@ -263,7 +255,7 @@ function createMailDraftSignals(
     threadId,
     draft$,
     sidebarDraft$,
-    attachmentImageUrl,
+    attachmentUrl,
     reloadSidebar$,
     delete$,
     send$,

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -1,4 +1,11 @@
-import { command, computed, state, type Command, type Computed } from "ccstate";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
 import {
   zeroMailContract,
   type ZeroMailDraft,
@@ -23,7 +30,11 @@ export interface MailDraftDescriptor {
 }
 
 export interface MailDraftSignals extends MailDraftDescriptor {
+  readonly threadId: string;
   readonly draft$: Computed<Promise<ZeroMailDraft | null>>;
+  readonly sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>;
+  attachmentImageUrl(partId: string): Computed<Promise<string | null>>;
+  readonly reloadSidebar$: Command<void, []>;
   readonly delete$: Command<Promise<void>, [AbortSignal]>;
   readonly send$: Command<Promise<void>, [AbortSignal]>;
 }
@@ -116,12 +127,76 @@ export function parseMailDraftUrl(value: string): MailDraftDescriptor | null {
   };
 }
 
+function createAttachmentImageUrl(
+  descriptor: MailDraftDescriptor,
+  sidebarReloadVersion$: State<number>,
+): MailDraftSignals["attachmentImageUrl"] {
+  const attachmentImageUrls = new Map<
+    string,
+    Computed<Promise<string | null>>
+  >();
+  const attachmentObjectUrls = new Map<string, string>();
+  const attachmentImageUrl = (
+    partId: string,
+  ): Computed<Promise<string | null>> => {
+    const registered = attachmentImageUrls.get(partId);
+    if (registered) {
+      return registered;
+    }
+    const imageUrl$ = computed(async (get): Promise<string | null> => {
+      get(sidebarReloadVersion$);
+      const signal = get(pageSignal$);
+      const response = await accept(
+        get(zeroClient$)(zeroMailContract).getAttachment({
+          params: {
+            mailDraftId: descriptor.mailDraftId,
+            partId,
+          },
+          fetchOptions: { signal },
+        }),
+        [200, 404],
+      );
+      const previousUrl = attachmentObjectUrls.get(partId);
+      if (previousUrl) {
+        URL.revokeObjectURL(previousUrl);
+        attachmentObjectUrls.delete(partId);
+      }
+      if (response.status === 404) {
+        return null;
+      }
+      const url = URL.createObjectURL(response.body);
+      attachmentObjectUrls.set(partId, url);
+      signal.addEventListener(
+        "abort",
+        () => {
+          if (attachmentObjectUrls.get(partId) === url) {
+            URL.revokeObjectURL(url);
+            attachmentObjectUrls.delete(partId);
+          }
+        },
+        { once: true },
+      );
+      return url;
+    });
+    attachmentImageUrls.set(partId, imageUrl$);
+    return imageUrl$;
+  };
+  return attachmentImageUrl;
+}
+
 function createMailDraftSignals(
+  threadId: string,
   descriptor: MailDraftDescriptor,
 ): MailDraftSignals {
-  const reloadVersion$ = state(0);
+  const draftOverride$ = state<ZeroMailDraft | null | undefined>(undefined);
+  const sidebarDraftOverride$ = state<ZeroMailDraft | null | undefined>(
+    undefined,
+  );
   const draft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
-    get(reloadVersion$);
+    const override = get(draftOverride$);
+    if (override !== undefined) {
+      return override;
+    }
     const response = await accept(
       get(zeroClient$)(zeroMailContract).getDraft({
         params: { mailDraftId: descriptor.mailDraftId },
@@ -131,8 +206,29 @@ function createMailDraftSignals(
     );
     return response.status === 200 ? response.body.mailDraft : null;
   });
-  const reload$ = command(({ set }) => {
-    set(reloadVersion$, (version) => {
+  const sidebarReloadVersion$ = state(0);
+  const sidebarDraft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
+    get(sidebarReloadVersion$);
+    const override = get(sidebarDraftOverride$);
+    if (override !== undefined) {
+      return override;
+    }
+    const response = await accept(
+      get(zeroClient$)(zeroMailContract).getDraft({
+        params: { mailDraftId: descriptor.mailDraftId },
+        fetchOptions: { signal: get(pageSignal$) },
+      }),
+      [200, 404],
+    );
+    return response.status === 200 ? response.body.mailDraft : null;
+  });
+  const attachmentImageUrl = createAttachmentImageUrl(
+    descriptor,
+    sidebarReloadVersion$,
+  );
+  const reloadSidebar$ = command(({ set }) => {
+    set(sidebarDraftOverride$, undefined);
+    set(sidebarReloadVersion$, (version) => {
       return version + 1;
     });
   });
@@ -146,11 +242,12 @@ function createMailDraftSignals(
         [204],
       );
       signal.throwIfAborted();
-      set(reload$);
+      set(draftOverride$, null);
+      set(sidebarDraftOverride$, null);
     },
   );
   const send$ = command(async ({ get, set }, signal: AbortSignal) => {
-    await accept(
+    const response = await accept(
       get(zeroClient$)(zeroMailContract).sendDraft({
         params: { mailDraftId: descriptor.mailDraftId },
         fetchOptions: { signal },
@@ -158,12 +255,24 @@ function createMailDraftSignals(
       [200],
     );
     signal.throwIfAborted();
-    set(reload$);
+    set(draftOverride$, response.body.mailDraft);
+    set(sidebarDraftOverride$, response.body.mailDraft);
   });
-  return { ...descriptor, draft$, delete$, send$ };
+  return {
+    ...descriptor,
+    threadId,
+    draft$,
+    sidebarDraft$,
+    attachmentImageUrl,
+    reloadSidebar$,
+    delete$,
+    send$,
+  };
 }
 
-export function createMailDraftCardSignalsRegistry(): MailDraftCardSignalsRegistry {
+export function createMailDraftCardSignalsRegistry(
+  threadId: string,
+): MailDraftCardSignalsRegistry {
   const signalsByResourceKey = new Map<string, MailDraftSignals>();
   return {
     register(descriptor) {
@@ -171,7 +280,7 @@ export function createMailDraftCardSignalsRegistry(): MailDraftCardSignalsRegist
         signalsByResourceKey,
         descriptor.mailDraftId,
         () => {
-          return createMailDraftSignals(descriptor);
+          return createMailDraftSignals(threadId, descriptor);
         },
       );
     },

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -16,6 +16,7 @@ import {
   registeredCardSignals,
 } from "./card-signal-map.ts";
 import { onRef } from "../utils.ts";
+import { connectorChangedVersion$ } from "../connector-reload.ts";
 
 export interface MailDraftDescriptor {
   readonly mailDraftId: string;
@@ -240,6 +241,7 @@ function createMailDraftSignals(
     undefined,
   );
   const draft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
+    get(connectorChangedVersion$);
     const override = get(draftOverride$);
     if (override !== undefined) {
       return override;
@@ -255,6 +257,7 @@ function createMailDraftSignals(
   });
   const sidebarReloadVersion$ = state(0);
   const sidebarDraft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
+    get(connectorChangedVersion$);
     get(sidebarReloadVersion$);
     const override = get(sidebarDraftOverride$);
     if (override !== undefined) {

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -1,11 +1,4 @@
-import {
-  command,
-  computed,
-  state,
-  type Command,
-  type Computed,
-  type State,
-} from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 import {
   zeroMailContract,
   type ZeroMailDraft,
@@ -33,7 +26,9 @@ export interface MailDraftSignals extends MailDraftDescriptor {
   readonly threadId: string;
   readonly draft$: Computed<Promise<ZeroMailDraft | null>>;
   readonly sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>;
-  attachmentUrl(partId: string): Computed<Promise<string | null>>;
+  readonly attachmentUrls$: Computed<
+    Promise<ReadonlyMap<string, string | null>>
+  >;
   readonly reloadSidebar$: Command<void, []>;
   readonly delete$: Command<Promise<void>, [AbortSignal]>;
   readonly send$: Command<Promise<void>, [AbortSignal]>;
@@ -127,56 +122,81 @@ export function parseMailDraftUrl(value: string): MailDraftDescriptor | null {
   };
 }
 
-function createAttachmentUrl(
+function createAttachmentUrls(
   descriptor: MailDraftDescriptor,
-  sidebarReloadVersion$: State<number>,
-): MailDraftSignals["attachmentUrl"] {
-  const attachmentUrls = new Map<string, Computed<Promise<string | null>>>();
+  sidebarDraft$: Computed<Promise<ZeroMailDraft | null>>,
+): MailDraftSignals["attachmentUrls$"] {
   const attachmentObjectUrls = new Map<string, string>();
-  const attachmentUrl = (partId: string): Computed<Promise<string | null>> => {
-    const registered = attachmentUrls.get(partId);
-    if (registered) {
-      return registered;
+  let cleanupSignal: AbortSignal | null = null;
+  let loadVersion = 0;
+  const revokeAttachmentObjectUrls = () => {
+    for (const url of attachmentObjectUrls.values()) {
+      URL.revokeObjectURL(url);
     }
-    const imageUrl$ = computed(async (get): Promise<string | null> => {
-      get(sidebarReloadVersion$);
-      const signal = get(pageSignal$);
-      const response = await accept(
-        get(zeroClient$)(zeroMailContract).getAttachment({
-          params: {
-            mailDraftId: descriptor.mailDraftId,
-            partId,
-          },
-          fetchOptions: { signal },
+    attachmentObjectUrls.clear();
+  };
+  return computed(async (get): Promise<ReadonlyMap<string, string | null>> => {
+    const currentLoadVersion = ++loadVersion;
+    const draftPromise = get(sidebarDraft$);
+    const signal = get(pageSignal$);
+    const client = get(zeroClient$)(zeroMailContract);
+    signal.throwIfAborted();
+    if (cleanupSignal !== signal) {
+      cleanupSignal?.removeEventListener("abort", revokeAttachmentObjectUrls);
+      cleanupSignal = signal;
+      signal.addEventListener("abort", revokeAttachmentObjectUrls, {
+        once: true,
+      });
+    }
+    const draft = await draftPromise;
+    signal.throwIfAborted();
+    if (currentLoadVersion !== loadVersion) {
+      return new Map();
+    }
+    const partIds = Array.from(
+      new Set([
+        ...(draft?.inlineImages ?? []).map((image) => {
+          return image.partId;
         }),
-        [200, 404],
-      );
-      const previousUrl = attachmentObjectUrls.get(partId);
-      if (previousUrl) {
-        URL.revokeObjectURL(previousUrl);
-        attachmentObjectUrls.delete(partId);
-      }
+        ...(draft?.version === 3 ? draft.attachments : []).flatMap(
+          (attachment) => {
+            return attachment.partId ? [attachment.partId] : [];
+          },
+        ),
+      ]),
+    );
+    const responses = await Promise.all(
+      partIds.map(async (partId) => {
+        const response = await accept(
+          client.getAttachment({
+            params: {
+              mailDraftId: descriptor.mailDraftId,
+              partId,
+            },
+            fetchOptions: { signal },
+          }),
+          [200, 404],
+        );
+        return { partId, response };
+      }),
+    );
+    signal.throwIfAborted();
+    if (currentLoadVersion !== loadVersion) {
+      return new Map();
+    }
+    revokeAttachmentObjectUrls();
+    const imageUrls = new Map<string, string | null>();
+    for (const { partId, response } of responses) {
       if (response.status === 404) {
-        return null;
+        imageUrls.set(partId, null);
+        continue;
       }
       const url = URL.createObjectURL(response.body);
       attachmentObjectUrls.set(partId, url);
-      signal.addEventListener(
-        "abort",
-        () => {
-          if (attachmentObjectUrls.get(partId) === url) {
-            URL.revokeObjectURL(url);
-            attachmentObjectUrls.delete(partId);
-          }
-        },
-        { once: true },
-      );
-      return url;
-    });
-    attachmentUrls.set(partId, imageUrl$);
-    return imageUrl$;
-  };
-  return attachmentUrl;
+      imageUrls.set(partId, url);
+    }
+    return imageUrls;
+  });
 }
 
 function createMailDraftSignals(
@@ -217,7 +237,7 @@ function createMailDraftSignals(
     );
     return response.status === 200 ? response.body.mailDraft : null;
   });
-  const attachmentUrl = createAttachmentUrl(descriptor, sidebarReloadVersion$);
+  const attachmentUrls$ = createAttachmentUrls(descriptor, sidebarDraft$);
   const reloadSidebar$ = command(({ set }) => {
     set(sidebarDraftOverride$, undefined);
     set(sidebarReloadVersion$, (version) => {
@@ -255,7 +275,7 @@ function createMailDraftSignals(
     threadId,
     draft$,
     sidebarDraft$,
-    attachmentUrl,
+    attachmentUrls$,
     reloadSidebar$,
     delete$,
     send$,

--- a/turbo/apps/platform/src/signals/connector-reload.ts
+++ b/turbo/apps/platform/src/signals/connector-reload.ts
@@ -1,13 +1,27 @@
-import { command } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { reloadConnectors$ } from "./external/connectors.ts";
 import { setAblyLoop$ } from "./realtime.ts";
 import { reloadAgentConnectorAuthorizations$ } from "./zero-page/agent-connector-authorizations.ts";
 
+const internalConnectorChangedVersion$ = state(0);
+
+export const connectorChangedVersion$ = computed((get) => {
+  return get(internalConnectorChangedVersion$);
+});
+
 export const subscribeConnectorChanged$ = command(
   async ({ set }, signal: AbortSignal) => {
+    let initialRun = true;
     const onChanged$ = command(({ set }) => {
       set(reloadConnectors$);
       set(reloadAgentConnectorAuthorizations$);
+      if (initialRun) {
+        initialRun = false;
+      } else {
+        set(internalConnectorChangedVersion$, (version) => {
+          return version + 1;
+        });
+      }
       return false;
     });
     await set(

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -12,9 +12,10 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { writeToClipboard } from "./clipboard.ts";
 import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
 
-// Assistant message bubbles carry this class in the chat thread. Text selected
-// inside one of them is what we offer feedback on.
-const ASSISTANT_BUBBLE_SELECTOR = ".zero-chat-bubble-assistant";
+// Assistant messages and other agent-produced content, such as linked email
+// drafts, opt into the shared Copy / Provide feedback interaction.
+const FEEDBACK_SOURCE_SELECTOR =
+  ".zero-chat-bubble-assistant, [data-feedback-source]";
 const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
 
 // Each chat thread renders inside a container tagged with its thread id. We
@@ -73,35 +74,35 @@ export interface FeedbackSignals {
   >;
 }
 
-function closestAssistantBubble(node: Node | null): Element | null {
+function closestFeedbackSource(node: Node | null): Element | null {
   if (!node) {
     return null;
   }
   const element = node instanceof Element ? node : node.parentElement;
-  return element?.closest(ASSISTANT_BUBBLE_SELECTOR) ?? null;
+  return element?.closest(FEEDBACK_SOURCE_SELECTOR) ?? null;
 }
 
-function resolveSelectionBubble(range: Range): Element | null {
-  const commonBubble = closestAssistantBubble(range.commonAncestorContainer);
-  if (commonBubble) {
-    return commonBubble;
+function resolveSelectionSource(range: Range): Element | null {
+  const commonSource = closestFeedbackSource(range.commonAncestorContainer);
+  if (commonSource) {
+    return commonSource;
   }
 
   // Multi-line selections can report an outer message group as the range's
   // common ancestor even when both endpoints are inside assistant bubbles.
-  const startBubble = closestAssistantBubble(range.startContainer);
-  const endBubble = closestAssistantBubble(range.endContainer);
-  if (!startBubble || !endBubble) {
+  const startSource = closestFeedbackSource(range.startContainer);
+  const endSource = closestFeedbackSource(range.endContainer);
+  if (!startSource || !endSource) {
     return null;
   }
-  if (startBubble === endBubble) {
-    return startBubble;
+  if (startSource === endSource) {
+    return startSource;
   }
 
-  const startGroup = startBubble.closest(ASSISTANT_GROUP_SELECTOR);
-  const endGroup = endBubble.closest(ASSISTANT_GROUP_SELECTOR);
+  const startGroup = startSource.closest(ASSISTANT_GROUP_SELECTOR);
+  const endGroup = endSource.closest(ASSISTANT_GROUP_SELECTOR);
   if (startGroup !== null && startGroup === endGroup) {
-    return startBubble;
+    return startSource;
   }
 
   return null;
@@ -109,8 +110,8 @@ function resolveSelectionBubble(range: Range): Element | null {
 
 // The id of the thread that owns the selected passage, or null when it sits
 // outside any thread container.
-function resolveSelectionThreadId(bubble: Element): string | null {
-  const container = bubble.closest(THREAD_CONTAINER_SELECTOR);
+function resolveSelectionThreadId(source: Element): string | null {
+  const container = source.closest(THREAD_CONTAINER_SELECTOR);
   if (!(container instanceof HTMLElement)) {
     return null;
   }
@@ -173,11 +174,11 @@ const setFeedbackHighlight$ = command(
   },
 );
 
-// Read the live document selection when it sits inside an assistant message.
-function readAssistantSelection(): {
+// Read the live document selection when it sits inside supported content.
+function readFeedbackSourceSelection(): {
   text: string;
   range: Range;
-  bubble: Element;
+  source: Element;
 } | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
@@ -188,11 +189,11 @@ function readAssistantSelection(): {
     return null;
   }
   const range = selection.getRangeAt(0);
-  const bubble = resolveSelectionBubble(range);
-  if (!bubble) {
+  const source = resolveSelectionSource(range);
+  if (!source) {
     return null;
   }
-  return { text, range, bubble };
+  return { text, range, source };
 }
 
 function hasVisibleArea(rect: DOMRectReadOnly): boolean {
@@ -240,14 +241,14 @@ function rectFromRange(range: Range): FeedbackSelectionRect {
 }
 
 function readFeedbackSelection(): FeedbackSelection | null {
-  const found = readAssistantSelection();
+  const found = readFeedbackSourceSelection();
   if (!found) {
     return null;
   }
   const rect = rectFromRange(found.range);
   return {
     text: found.text,
-    threadId: resolveSelectionThreadId(found.bubble),
+    threadId: resolveSelectionThreadId(found.source),
     range: found.range.cloneRange(),
     rect,
   };
@@ -512,7 +513,7 @@ function createDocumentSelectionListeners({
         mouseSelectionInProgress =
           event.button === 0 &&
           event.target instanceof Node &&
-          closestAssistantBubble(event.target) !== null;
+          closestFeedbackSource(event.target) !== null;
       },
       { capture: true, signal },
     );

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -33,6 +33,8 @@ export interface FeedbackSelectionRect {
 export interface FeedbackSource {
   readonly type: "mail";
   readonly id: string;
+  readonly status: "draft" | "sent";
+  readonly sentId?: string;
 }
 
 export interface FeedbackSelection {
@@ -131,10 +133,12 @@ function resolveFeedbackSource(source: Element): FeedbackSource | undefined {
   }
   const type = source.dataset.feedbackSourceType;
   const id = source.dataset.feedbackSourceId;
-  if (type !== "mail" || !id) {
+  const status = source.dataset.feedbackSourceStatus;
+  const sentId = source.dataset.feedbackSourceSentId;
+  if (type !== "mail" || !id || (status !== "draft" && status !== "sent")) {
     return undefined;
   }
-  return { type, id };
+  return { type, id, status, ...(sentId ? { sentId } : {}) };
 }
 
 // ---------------------------------------------------------------------------
@@ -278,19 +282,27 @@ function readFeedbackSelection(): FeedbackSelection | null {
 // Compose every noted fragment into a single follow-up turn, each passage
 // quoted above the note that belongs to it.
 export function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
-  const firstMailDraftId = items[0]?.source?.id;
-  const commonMailDraftId =
-    firstMailDraftId !== undefined &&
+  const firstMailSource = items[0]?.source;
+  const commonMailSource =
+    firstMailSource !== undefined &&
     items.every((item) => {
       return (
-        item.source?.type === "mail" && item.source.id === firstMailDraftId
+        item.source?.type === "mail" &&
+        item.source.id === firstMailSource.id &&
+        item.source.status === firstMailSource.status &&
+        item.source.sentId === firstMailSource.sentId
       );
     })
-      ? firstMailDraftId
+      ? firstMailSource
       : null;
   const hasSourceContext = items.some((item) => {
     return item.source !== undefined;
   });
+  const mailSourceLabel = (source: FeedbackSource) => {
+    return source.status === "draft"
+      ? `an email draft (mail draft ID: ${source.id})`
+      : `a sent email (mail ID: ${source.id}${source.sentId ? `, sent ID: ${source.sentId}` : ""})`;
+  };
   const blocks = items.map((item) => {
     const quoted = item.quote
       .split("\n")
@@ -299,15 +311,15 @@ export function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
       })
       .join("\n");
     const source =
-      commonMailDraftId === null && item.source?.type === "mail"
-        ? `Source: email draft (mail draft ID: ${item.source.id})\n\n`
+      commonMailSource === null && item.source?.type === "mail"
+        ? `Source: ${mailSourceLabel(item.source)}\n\n`
         : "";
     return `${source}${quoted}\n\n${item.note.trim()}`;
   });
-  const intro = commonMailDraftId
+  const intro = commonMailSource
     ? items.length === 1
-      ? `Feedback on this part of an email draft (mail draft ID: ${commonMailDraftId}):`
-      : `Feedback on ${items.length} parts of an email draft (mail draft ID: ${commonMailDraftId}):`
+      ? `Feedback on this part of ${mailSourceLabel(commonMailSource)}:`
+      : `Feedback on ${items.length} parts of ${mailSourceLabel(commonMailSource)}:`
     : hasSourceContext
       ? `Feedback on ${items.length} selected ${items.length === 1 ? "passage" : "passages"}:`
       : items.length === 1

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -30,6 +30,11 @@ export interface FeedbackSelectionRect {
   readonly height: number;
 }
 
+export interface FeedbackSource {
+  readonly type: "mail";
+  readonly id: string;
+}
+
 export interface FeedbackSelection {
   readonly text: string;
   readonly rect: FeedbackSelectionRect;
@@ -39,6 +44,7 @@ export interface FeedbackSelection {
   // A snapshot of the selected range. Kept so the passage can stay highlighted
   // once the comment is drafted and the native selection clears.
   readonly range: Range | null;
+  readonly source?: FeedbackSource;
 }
 
 // A quoted passage together with the note the user is writing about it. Every
@@ -48,6 +54,7 @@ export interface FeedbackItem {
   readonly id: number;
   readonly quote: string;
   readonly note: string;
+  readonly source?: FeedbackSource;
 }
 
 export interface FeedbackEditorAdapter {
@@ -116,6 +123,18 @@ function resolveSelectionThreadId(source: Element): string | null {
     return null;
   }
   return container.dataset.chatThreadContainerId ?? null;
+}
+
+function resolveFeedbackSource(source: Element): FeedbackSource | undefined {
+  if (!(source instanceof HTMLElement)) {
+    return undefined;
+  }
+  const type = source.dataset.feedbackSourceType;
+  const id = source.dataset.feedbackSourceId;
+  if (type !== "mail" || !id) {
+    return undefined;
+  }
+  return { type, id };
 }
 
 // ---------------------------------------------------------------------------
@@ -246,17 +265,32 @@ function readFeedbackSelection(): FeedbackSelection | null {
     return null;
   }
   const rect = rectFromRange(found.range);
+  const source = resolveFeedbackSource(found.source);
   return {
     text: found.text,
     threadId: resolveSelectionThreadId(found.source),
     range: found.range.cloneRange(),
     rect,
+    ...(source ? { source } : {}),
   };
 }
 
 // Compose every noted fragment into a single follow-up turn, each passage
 // quoted above the note that belongs to it.
 export function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
+  const firstMailDraftId = items[0]?.source?.id;
+  const commonMailDraftId =
+    firstMailDraftId !== undefined &&
+    items.every((item) => {
+      return (
+        item.source?.type === "mail" && item.source.id === firstMailDraftId
+      );
+    })
+      ? firstMailDraftId
+      : null;
+  const hasSourceContext = items.some((item) => {
+    return item.source !== undefined;
+  });
   const blocks = items.map((item) => {
     const quoted = item.quote
       .split("\n")
@@ -264,12 +298,21 @@ export function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
         return `> ${line}`;
       })
       .join("\n");
-    return `${quoted}\n\n${item.note.trim()}`;
+    const source =
+      commonMailDraftId === null && item.source?.type === "mail"
+        ? `Source: email draft (mail draft ID: ${item.source.id})\n\n`
+        : "";
+    return `${source}${quoted}\n\n${item.note.trim()}`;
   });
-  const intro =
-    items.length === 1
-      ? "Feedback on this part of your reply:"
-      : `Feedback on ${items.length} parts of your reply:`;
+  const intro = commonMailDraftId
+    ? items.length === 1
+      ? `Feedback on this part of an email draft (mail draft ID: ${commonMailDraftId}):`
+      : `Feedback on ${items.length} parts of an email draft (mail draft ID: ${commonMailDraftId}):`
+    : hasSourceContext
+      ? `Feedback on ${items.length} selected ${items.length === 1 ? "passage" : "passages"}:`
+      : items.length === 1
+        ? "Feedback on this part of your reply:"
+        : `Feedback on ${items.length} parts of your reply:`;
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 
@@ -378,7 +421,12 @@ function createFeedbackItemSignals({
       return;
     }
     const id = get(nextIdState$);
-    const item = { id, quote: selection.text, note: "" };
+    const item = {
+      id,
+      quote: selection.text,
+      note: "",
+      ...(selection.source ? { source: selection.source } : {}),
+    };
     const items = [...get(itemsState$), item];
     set(nextIdState$, id + 1);
     set(itemsState$, items);

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -270,6 +270,8 @@ interface FeedbackItemNodeAttributes {
   readonly fill: boolean;
   readonly sourceType: "mail" | null;
   readonly sourceId: string | null;
+  readonly sourceStatus: "draft" | "sent" | null;
+  readonly sourceSentId: string | null;
 }
 
 function feedbackItemNodeAttributes(
@@ -281,6 +283,8 @@ function feedbackItemNodeAttributes(
   const fill: unknown = node.attrs.fill;
   const sourceType: unknown = node.attrs.sourceType;
   const sourceId: unknown = node.attrs.sourceId;
+  const sourceStatus: unknown = node.attrs.sourceStatus;
+  const sourceSentId: unknown = node.attrs.sourceSentId;
   if (
     typeof feedbackId !== "number" ||
     typeof quote !== "string" ||
@@ -288,7 +292,13 @@ function feedbackItemNodeAttributes(
     typeof fill !== "boolean" ||
     (sourceType !== null && sourceType !== "mail") ||
     (sourceId !== null && typeof sourceId !== "string") ||
-    (sourceType === null) !== (sourceId === null)
+    (sourceStatus !== null &&
+      sourceStatus !== "draft" &&
+      sourceStatus !== "sent") ||
+    (sourceSentId !== null && typeof sourceSentId !== "string") ||
+    (sourceType === null) !== (sourceId === null) ||
+    (sourceType === null) !== (sourceStatus === null) ||
+    (sourceType === null && sourceSentId !== null)
   ) {
     throw new Error("Feedback item node attributes are invalid");
   }
@@ -299,6 +309,8 @@ function feedbackItemNodeAttributes(
     fill,
     sourceType,
     sourceId,
+    sourceStatus,
+    sourceSentId,
   };
 }
 
@@ -625,6 +637,8 @@ function feedbackItemNode(editor: Editor, item: FeedbackItem): ProseMirrorNode {
       fill: false,
       sourceType: item.source?.type ?? null,
       sourceId: item.source?.id ?? null,
+      sourceStatus: item.source?.status ?? null,
+      sourceSentId: item.source?.sentId ?? null,
     },
     content: feedbackNoteContent(item.note),
   });
@@ -720,11 +734,17 @@ function feedbackItemsFromWorkflowComposer(
       id: attributes.feedbackId,
       quote: attributes.quote,
       note: feedbackNoteFromNode(node),
-      ...(attributes.sourceType === "mail" && attributes.sourceId !== null
+      ...(attributes.sourceType === "mail" &&
+      attributes.sourceId !== null &&
+      attributes.sourceStatus !== null
         ? {
             source: {
               type: attributes.sourceType,
               id: attributes.sourceId,
+              status: attributes.sourceStatus,
+              ...(attributes.sourceSentId !== null
+                ? { sentId: attributes.sourceSentId }
+                : {}),
             },
           }
         : {}),
@@ -919,11 +939,17 @@ function workflowComposerDocToString(editor: Editor): string {
         id: attributes.feedbackId,
         quote: attributes.quote,
         note: feedbackNoteFromNode(node),
-        ...(attributes.sourceType === "mail" && attributes.sourceId !== null
+        ...(attributes.sourceType === "mail" &&
+        attributes.sourceId !== null &&
+        attributes.sourceStatus !== null
           ? {
               source: {
                 type: attributes.sourceType,
                 id: attributes.sourceId,
+                status: attributes.sourceStatus,
+                ...(attributes.sourceSentId !== null
+                  ? { sentId: attributes.sourceSentId }
+                  : {}),
               },
             }
           : {}),
@@ -1143,6 +1169,8 @@ function createFeedbackItemNode(
         fill: { default: false },
         sourceType: { default: null },
         sourceId: { default: null },
+        sourceStatus: { default: null },
+        sourceSentId: { default: null },
       };
     },
     parseHTML() {

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -268,6 +268,8 @@ interface FeedbackItemNodeAttributes {
   readonly quote: string;
   readonly showDivider: boolean;
   readonly fill: boolean;
+  readonly sourceType: "mail" | null;
+  readonly sourceId: string | null;
 }
 
 function feedbackItemNodeAttributes(
@@ -277,15 +279,27 @@ function feedbackItemNodeAttributes(
   const quote: unknown = node.attrs.quote;
   const showDivider: unknown = node.attrs.showDivider;
   const fill: unknown = node.attrs.fill;
+  const sourceType: unknown = node.attrs.sourceType;
+  const sourceId: unknown = node.attrs.sourceId;
   if (
     typeof feedbackId !== "number" ||
     typeof quote !== "string" ||
     typeof showDivider !== "boolean" ||
-    typeof fill !== "boolean"
+    typeof fill !== "boolean" ||
+    (sourceType !== null && sourceType !== "mail") ||
+    (sourceId !== null && typeof sourceId !== "string") ||
+    (sourceType === null) !== (sourceId === null)
   ) {
     throw new Error("Feedback item node attributes are invalid");
   }
-  return { feedbackId, quote, showDivider, fill };
+  return {
+    feedbackId,
+    quote,
+    showDivider,
+    fill,
+    sourceType,
+    sourceId,
+  };
 }
 
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
@@ -609,6 +623,8 @@ function feedbackItemNode(editor: Editor, item: FeedbackItem): ProseMirrorNode {
       quote: item.quote,
       showDivider: false,
       fill: false,
+      sourceType: item.source?.type ?? null,
+      sourceId: item.source?.id ?? null,
     },
     content: feedbackNoteContent(item.note),
   });
@@ -704,6 +720,14 @@ function feedbackItemsFromWorkflowComposer(
       id: attributes.feedbackId,
       quote: attributes.quote,
       note: feedbackNoteFromNode(node),
+      ...(attributes.sourceType === "mail" && attributes.sourceId !== null
+        ? {
+            source: {
+              type: attributes.sourceType,
+              id: attributes.sourceId,
+            },
+          }
+        : {}),
     });
   }
   return items;
@@ -895,6 +919,14 @@ function workflowComposerDocToString(editor: Editor): string {
         id: attributes.feedbackId,
         quote: attributes.quote,
         note: feedbackNoteFromNode(node),
+        ...(attributes.sourceType === "mail" && attributes.sourceId !== null
+          ? {
+              source: {
+                type: attributes.sourceType,
+                id: attributes.sourceId,
+              },
+            }
+          : {}),
       });
       continue;
     }
@@ -1109,6 +1141,8 @@ function createFeedbackItemNode(
         quote: { default: "" },
         showDivider: { default: false },
         fill: { default: false },
+        sourceType: { default: null },
+        sourceId: { default: null },
       };
     },
     parseHTML() {

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -29,6 +29,7 @@ export type AttachmentLightboxState =
       filename?: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     }
@@ -38,6 +39,7 @@ export type AttachmentLightboxState =
       filename: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     }
@@ -47,6 +49,7 @@ export type AttachmentLightboxState =
       filename: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     };
@@ -105,6 +108,7 @@ export const openImageLightbox$ = command(
           filename?: string;
           artifact?: AttachmentArtifactMetadata;
           editAvailable?: boolean;
+          shareAvailable?: boolean;
           showSizeInSubtitle?: boolean;
           splitViewAvailable?: boolean;
         },
@@ -136,6 +140,7 @@ export const navigateImageLightbox$ = command(
       filename?: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     },
@@ -153,6 +158,7 @@ export const openDocumentLightbox$ = command(
       filename: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     },
@@ -174,6 +180,7 @@ export const openVideoLightbox$ = command(
       filename: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     },
@@ -195,6 +202,7 @@ export const openAudioLightbox$ = command(
       filename: string;
       artifact?: AttachmentArtifactMetadata;
       editAvailable?: boolean;
+      shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
       splitViewAvailable?: boolean;
     },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -317,61 +317,82 @@ describe("chat inline feedback", () => {
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
   });
 
-  it("includes email draft context when submitting mail feedback", async () => {
-    const user = userEvent.setup({ delay: null });
-    const assistantReply = "Mail body after";
-    const mailDraftId = "c0000000-0000-4000-a000-000000000012";
-    const sentPrompts: string[] = [];
+  it.each([
+    {
+      status: "draft" as const,
+      sourceDescription: "an email draft",
+      idLabel: "mail draft ID",
+      sentId: null,
+    },
+    {
+      status: "sent" as const,
+      sourceDescription: "a sent email",
+      idLabel: "mail ID",
+      sentId: "gmail-sent-message-id",
+    },
+  ])(
+    "includes $status email context when submitting mail feedback",
+    async ({ status, sourceDescription, idLabel, sentId }) => {
+      const user = userEvent.setup({ delay: null });
+      const assistantReply = "Mail body after";
+      const mailDraftId = "c0000000-0000-4000-a000-000000000012";
+      const sentPrompts: string[] = [];
 
-    mockChatLifecycle(context, {
-      threadId: FEEDBACK_THREAD_ID,
-      threadTitle: "Mail feedback",
-      chatMessages: [
-        {
-          id: "msg-mail-feedback-assistant",
-          role: "assistant",
-          content: assistantReply,
-          runId: "run-mail-feedback",
-          createdAt: "2026-07-24T02:00:00Z",
+      mockChatLifecycle(context, {
+        threadId: FEEDBACK_THREAD_ID,
+        threadTitle: "Mail feedback",
+        chatMessages: [
+          {
+            id: "msg-mail-feedback-assistant",
+            role: "assistant",
+            content: assistantReply,
+            runId: "run-mail-feedback",
+            createdAt: "2026-07-24T02:00:00Z",
+          },
+        ],
+        onRunCreate: (body) => {
+          if (body.prompt !== undefined) {
+            sentPrompts.push(body.prompt);
+          }
         },
-      ],
-      onRunCreate: (body) => {
-        if (body.prompt !== undefined) {
-          sentPrompts.push(body.prompt);
-        }
-      },
-    });
+      });
 
-    detachedSetupPage({
-      context,
-      path: `/chats/${FEEDBACK_THREAD_ID}`,
-    });
+      detachedSetupPage({
+        context,
+        path: `/chats/${FEEDBACK_THREAD_ID}`,
+      });
 
-    const assistantReplyElement = await screen.findByText(assistantReply);
-    const feedbackSource = assistantReplyElement.closest(
-      ".zero-chat-bubble-assistant",
-    );
-    if (!(feedbackSource instanceof HTMLElement)) {
-      throw new Error("Feedback source not found");
-    }
-    feedbackSource.dataset.feedbackSourceType = "mail";
-    feedbackSource.dataset.feedbackSourceId = mailDraftId;
+      const assistantReplyElement = await screen.findByText(assistantReply);
+      const feedbackSource = assistantReplyElement.closest(
+        ".zero-chat-bubble-assistant",
+      );
+      if (!(feedbackSource instanceof HTMLElement)) {
+        throw new Error("Feedback source not found");
+      }
+      feedbackSource.dataset.feedbackSourceType = "mail";
+      feedbackSource.dataset.feedbackSourceId = mailDraftId;
+      feedbackSource.dataset.feedbackSourceStatus = status;
+      if (sentId) {
+        feedbackSource.dataset.feedbackSourceSentId = sentId;
+      }
 
-    selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Provide feedback"));
-    const feedbackNote = await findFeedbackNote();
-    pastePlainText(feedbackNote, "Rewrite this paragraph.");
-    await user.click(screen.getByLabelText("Send"));
+      selectTextForInlineFeedback(assistantReplyElement);
+      await user.click(await screen.findByText("Provide feedback"));
+      const feedbackNote = await findFeedbackNote();
+      pastePlainText(feedbackNote, "Rewrite this paragraph.");
+      await user.click(screen.getByLabelText("Send"));
 
-    await waitFor(() => {
-      expect(sentPrompts).toHaveLength(1);
-    });
-    expect(sentPrompts[0]).toContain(
-      `Feedback on this part of an email draft (mail draft ID: ${mailDraftId}):`,
-    );
-    expect(sentPrompts[0]).toContain("> Mail body after");
-    expect(sentPrompts[0]).toContain("Rewrite this paragraph.");
-  });
+      await waitFor(() => {
+        expect(sentPrompts).toHaveLength(1);
+      });
+      const sentIdSuffix = sentId ? `, sent ID: ${sentId}` : "";
+      expect(sentPrompts[0]).toContain(
+        `Feedback on this part of ${sourceDescription} (${idLabel}: ${mailDraftId}${sentIdSuffix}):`,
+      );
+      expect(sentPrompts[0]).toContain("> Mail body after");
+      expect(sentPrompts[0]).toContain("Rewrite this paragraph.");
+    },
+  );
 
   it("uses slash workflow suggestions inside an inline feedback note", async () => {
     const user = userEvent.setup({ delay: null });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -265,6 +265,9 @@ describe("chat inline feedback", () => {
       composerEditor,
       "Mention the dates before the risk summary.",
     );
+    // The composer restores its own selection in a deferred task after paste;
+    // selecting the assistant reply before that settles races the toolbar's
+    // deferred selection capture against the composer's selection restore.
     await waitForDeferredSelectionCapture();
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -317,6 +317,62 @@ describe("chat inline feedback", () => {
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
   });
 
+  it("includes email draft context when submitting mail feedback", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "Mail body after";
+    const mailDraftId = "c0000000-0000-4000-a000-000000000012";
+    const sentPrompts: string[] = [];
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Mail feedback",
+      chatMessages: [
+        {
+          id: "msg-mail-feedback-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-mail-feedback",
+          createdAt: "2026-07-24T02:00:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        if (body.prompt !== undefined) {
+          sentPrompts.push(body.prompt);
+        }
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    const feedbackSource = assistantReplyElement.closest(
+      ".zero-chat-bubble-assistant",
+    );
+    if (!(feedbackSource instanceof HTMLElement)) {
+      throw new Error("Feedback source not found");
+    }
+    feedbackSource.dataset.feedbackSourceType = "mail";
+    feedbackSource.dataset.feedbackSourceId = mailDraftId;
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await user.click(await screen.findByText("Provide feedback"));
+    const feedbackNote = await findFeedbackNote();
+    pastePlainText(feedbackNote, "Rewrite this paragraph.");
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(sentPrompts).toHaveLength(1);
+    });
+    expect(sentPrompts[0]).toContain(
+      `Feedback on this part of an email draft (mail draft ID: ${mailDraftId}):`,
+    );
+    expect(sentPrompts[0]).toContain("> Mail body after");
+    expect(sentPrompts[0]).toContain("Rewrite this paragraph.");
+  });
+
   it("uses slash workflow suggestions inside an inline feedback note", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The launch plan needs a concrete owner.";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -811,21 +811,21 @@ describe("chat message action cards", () => {
       ({ params, query, respond }) => {
         if (
           params.threadId !== rightThreadId ||
-          query.beforeId ||
-          query.sinceId
+          query.beforeSeqId ||
+          query.sinceSeqId
         ) {
           return respond(200, {
             messages: [],
-            ...(query.beforeId ? { hasHistoryBefore: false } : {}),
+            ...(query.beforeSeqId ? { hasHistoryBefore: false } : {}),
           });
         }
         return respond(200, {
           messages: [
             {
               id: "c0000000-0000-4000-a000-000000000034",
+              seqId: 1,
               role: "assistant",
               content: `https://app.vm0.ai/mail/drafts/${mailDraftId}`,
-              runId: "d0000000-0000-4000-a000-000000000035",
               createdAt,
             },
           ],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -271,6 +271,7 @@ describe("chat message action cards", () => {
     let sent = false;
     const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
     const imageBytes = new TextEncoder().encode("mail draft image");
+    const pdfBytes = new TextEncoder().encode("mail draft pdf");
     const mailDraftHtml =
       '<div>Mail body <strong>before</strong></div><p><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><br>After image</p><hr><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a>';
 
@@ -331,6 +332,7 @@ describe("chat message action cards", () => {
               filename: "report.pdf",
               contentType: "application/pdf",
               size: 248_192,
+              partId: "1",
             },
           ],
           createdAt,
@@ -378,6 +380,7 @@ describe("chat message action cards", () => {
               filename: "report.pdf",
               contentType: "application/pdf",
               size: 248_192,
+              partId: "1",
             },
           ],
           createdAt,
@@ -390,6 +393,12 @@ describe("chat message action cards", () => {
       "*/api/zero/mail/drafts/:mailDraftId/attachments/:partId",
       ({ params }) => {
         expect(params.mailDraftId).toBe(mailDraftId);
+        if (params.partId === "1") {
+          return new HttpResponse(pdfBytes, {
+            status: 200,
+            headers: { "Content-Type": "application/pdf" },
+          });
+        }
         expect(params.partId).toBe("2");
         return new HttpResponse(imageBytes, {
           status: 200,
@@ -460,16 +469,25 @@ describe("chat message action cards", () => {
     await user.click(cards[0]!);
 
     let sidebar = await screen.findByTestId("mail-draft-sidebar");
+    expect(
+      within(sidebar).getByRole("heading", { name: "Hello" }),
+    ).toBeInTheDocument();
+    expect(within(sidebar).queryByText("Message")).toBeNull();
     expect(within(sidebar).getByText("sender@example.com")).toBeInTheDocument();
     expect(
       within(sidebar).getByText(
-        "recipient@example.com, teammate@example.com, reviewer@example.com",
+        /to recipient@example\.com, teammate@example\.com, reviewer@example\.com/u,
       ),
     ).toBeInTheDocument();
-    expect(within(sidebar).getByText("copy@example.com")).toBeInTheDocument();
-    expect(within(sidebar).getByText("hidden@example.com")).toBeInTheDocument();
-    const messageLabel = within(sidebar).getByText("Message");
-    const messageSection = messageLabel.parentElement;
+    expect(
+      within(sidebar).getByText(/cc copy@example\.com/u),
+    ).toBeInTheDocument();
+    expect(
+      within(sidebar).getByText(/bcc hidden@example\.com/u),
+    ).toBeInTheDocument();
+    const messageSection = sidebar.querySelector<HTMLElement>(
+      "[data-feedback-source]",
+    );
     if (!messageSection) {
       throw new Error("Expected mail message section");
     }
@@ -488,7 +506,28 @@ describe("chat message action cards", () => {
     );
     expect(reviewLink).toHaveAttribute("href", "https://example.com/review");
     expect(within(sidebar).getByText("report.pdf")).toBeInTheDocument();
-    expect(within(sidebar).getByText("242 KB")).toBeInTheDocument();
+    let pdfPreview: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      pdfPreview = sidebar.querySelector(
+        '[aria-label="Open pdf preview for report.pdf"]',
+      );
+      expect(pdfPreview).toBeInstanceOf(HTMLButtonElement);
+    });
+    if (!pdfPreview) {
+      throw new Error("Expected PDF attachment preview");
+    }
+    await user.click(pdfPreview);
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    expect(within(lightbox).getByTitle("report.pdf preview")).toHaveAttribute(
+      "src",
+      expect.stringMatching(/^blob:.+#navpanes=0$/u),
+    );
+    expect(within(lightbox).queryByLabelText("Share")).toBeNull();
+    expect(within(lightbox).queryByLabelText("Open in split view")).toBeNull();
+    await user.click(within(lightbox).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("attachment-lightbox")).toBeNull();
+    });
     const inlineImage = await within(messageSection).findByRole("img", {
       name: "Cheerful envelope illustration",
     });
@@ -514,18 +553,16 @@ describe("chat message action cards", () => {
       within(sidebar).queryByText("<reference-message@example.com>"),
     ).toBeNull();
     expect(within(sidebar).queryByRole("textbox")).not.toBeInTheDocument();
-    expect(
-      messageSection.querySelector("[data-feedback-source]"),
-    ).toHaveAttribute("data-feedback-source-type", "mail");
-    expect(
-      messageSection.querySelector("[data-feedback-source]"),
-    ).toHaveAttribute("data-feedback-source-id", mailDraftId);
-    expect(
-      messageSection.querySelector("[data-feedback-source]"),
-    ).toHaveAttribute("data-feedback-source-status", "draft");
-    expect(
-      messageSection.querySelector("[data-feedback-source]"),
-    ).not.toHaveAttribute("data-feedback-source-sent-id");
+    expect(messageSection).toHaveAttribute("data-feedback-source-type", "mail");
+    expect(messageSection).toHaveAttribute(
+      "data-feedback-source-id",
+      mailDraftId,
+    );
+    expect(messageSection).toHaveAttribute(
+      "data-feedback-source-status",
+      "draft",
+    );
+    expect(messageSection).not.toHaveAttribute("data-feedback-source-sent-id");
 
     selectMailText(boldText);
     await user.click(await waitForSelectionToolbarButton("Copy"));
@@ -545,21 +582,27 @@ describe("chat message action cards", () => {
 
     await waitFor(() => {
       expect(sent).toBeTruthy();
-      expect(screen.getAllByText("Sent")).toHaveLength(2);
+      expect(screen.getByText("Email sent")).toBeInTheDocument();
     });
-    sidebar = await screen.findByTestId("mail-draft-sidebar");
+    await waitFor(() => {
+      sidebar = screen.getByTestId("mail-draft-sidebar");
+      expect(within(sidebar).getByText("Sent")).toBeInTheDocument();
+    });
     expect(queryButtonByText("Send", sidebar)).toBeNull();
-    const sentMessageSection =
-      within(sidebar).getByText("Message").parentElement;
+    const sentMessageSection = sidebar.querySelector<HTMLElement>(
+      "[data-feedback-source]",
+    );
     if (!sentMessageSection) {
       throw new Error("Expected sent mail message section");
     }
-    expect(
-      sentMessageSection.querySelector("[data-feedback-source]"),
-    ).toHaveAttribute("data-feedback-source-status", "sent");
-    expect(
-      sentMessageSection.querySelector("[data-feedback-source]"),
-    ).toHaveAttribute("data-feedback-source-sent-id", "gmail-sent-message-id");
+    expect(sentMessageSection).toHaveAttribute(
+      "data-feedback-source-status",
+      "sent",
+    );
+    expect(sentMessageSection).toHaveAttribute(
+      "data-feedback-source-sent-id",
+      "gmail-sent-message-id",
+    );
     expect(draftRequests).toBe(2);
   });
 
@@ -662,9 +705,11 @@ describe("chat message action cards", () => {
     });
 
     const sidebar = await screen.findByTestId("mail-draft-sidebar");
-    expect(within(sidebar).getAllByText("Restored draft")).toHaveLength(2);
+    expect(within(sidebar).getByText("Restored draft")).toBeInTheDocument();
     expect(
-      within(sidebar).getByText("recipient@example.com, teammate@example.com"),
+      within(sidebar).getByText(
+        /to recipient@example\.com, teammate@example\.com/u,
+      ),
     ).toBeInTheDocument();
     const sendButton = await waitForButtonByText("Send", sidebar);
     expect(sendButton).toBeInTheDocument();
@@ -747,7 +792,7 @@ describe("chat message action cards", () => {
     );
     let sidebar = await screen.findByTestId("mail-draft-sidebar");
     await waitFor(() => {
-      expect(within(sidebar).getAllByText("First draft")).toHaveLength(2);
+      expect(within(sidebar).getByText("First draft")).toBeInTheDocument();
     });
 
     await user.click(
@@ -755,7 +800,7 @@ describe("chat message action cards", () => {
     );
     await waitFor(() => {
       sidebar = screen.getByTestId("mail-draft-sidebar");
-      expect(within(sidebar).getAllByText("Second draft")).toHaveLength(2);
+      expect(within(sidebar).getByText("Second draft")).toBeInTheDocument();
     });
 
     await user.click(within(sidebar).getByLabelText("Close email details"));
@@ -769,9 +814,9 @@ describe("chat message action cards", () => {
     );
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     await waitFor(() => {
-      expect(within(sidebar).getAllByText("Updated second draft")).toHaveLength(
-        2,
-      );
+      expect(
+        within(sidebar).getByText("Updated second draft"),
+      ).toBeInTheDocument();
     });
     expect(
       screen.getByLabelText("Open draft email: Second draft"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1,4 +1,5 @@
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import { chatThreadMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroConnectorManualGrantContract,
   zeroConnectorNoAuthGrantContract,
@@ -714,6 +715,104 @@ describe("chat message action cards", () => {
     const sendButton = await waitForButtonByText("Send", sidebar);
     expect(sendButton).toBeInTheDocument();
     expect(draftRequests).toBe(1);
+  });
+
+  it("keeps mail feedback scoped to the chat that owns the draft in split view", async () => {
+    const user = userEvent.setup({ delay: null });
+    const leftThreadId = "c0000000-0000-4000-a000-000000000031";
+    const rightThreadId = "c0000000-0000-4000-a000-000000000032";
+    const mailDraftId = "c0000000-0000-4000-a000-000000000033";
+    const createdAt = "2026-07-14T10:00:00.000Z";
+
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "gmail",
+        label: "Gmail",
+      }),
+    ]);
+    context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+      return respond(200, {
+        mailDraftId,
+        mailDraftUrl: `https://app.vm0.ai/mail/drafts/${mailDraftId}`,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: ["recipient@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Right chat draft",
+          body: "Feedback belongs to the right chat.",
+          status: "draft",
+          detailAvailable: true,
+          gmailDraftId: "r-right-chat-draft",
+          gmailThreadId: "gmail-right-chat-thread",
+          gmailMessageId: "gmail-right-chat-message",
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: leftThreadId,
+      threadTitle: "Left chat",
+      chatMessages: [],
+    });
+    context.mocks.api(
+      chatThreadMessagesContract.list,
+      ({ params, query, respond }) => {
+        if (
+          params.threadId !== rightThreadId ||
+          query.beforeId ||
+          query.sinceId
+        ) {
+          return respond(200, {
+            messages: [],
+            ...(query.beforeId ? { hasHistoryBefore: false } : {}),
+          });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "c0000000-0000-4000-a000-000000000034",
+              role: "assistant",
+              content: `https://app.vm0.ai/mail/drafts/${mailDraftId}`,
+              runId: "d0000000-0000-4000-a000-000000000035",
+              createdAt,
+            },
+          ],
+          hasHistoryBefore: false,
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${leftThreadId}?sidebar=${rightThreadId}&mail-draft=${mailDraftId}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
+    });
+
+    const sidebar = await screen.findByTestId("mail-draft-sidebar");
+    expect(sidebar).toHaveAttribute(
+      "data-chat-thread-container-id",
+      rightThreadId,
+    );
+
+    selectMailText(
+      within(sidebar).getByText("Feedback belongs to the right chat."),
+    );
+    await user.click(await waitForSelectionToolbarButton("Provide feedback"));
+    const chatThreads = await screen.findAllByLabelText("Chat thread");
+    await waitFor(() => {
+      expect(
+        chatThreads[0]?.querySelector("[data-feedback-item]"),
+      ).not.toBeInTheDocument();
+      expect(
+        chatThreads[1]?.querySelector("[data-feedback-item]"),
+      ).toHaveTextContent("Feedback belongs to the right chat.");
+    });
   });
 
   it("switches drafts and reloads a draft when it is reopened", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -460,11 +460,6 @@ describe("chat message action cards", () => {
     await user.click(cards[0]!);
 
     let sidebar = await screen.findByTestId("mail-draft-sidebar");
-    expect(
-      within(sidebar).getByText(
-        "You can ask your agent to continue editing this draft.",
-      ),
-    ).toBeInTheDocument();
     expect(within(sidebar).getByText("sender@example.com")).toBeInTheDocument();
     expect(
       within(sidebar).getByText(
@@ -548,11 +543,6 @@ describe("chat message action cards", () => {
     });
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Send", sidebar)).toBeNull();
-    expect(
-      screen.queryByText(
-        "You can ask your agent to continue editing this draft.",
-      ),
-    ).toBeNull();
     expect(draftRequests).toBe(2);
   });
 
@@ -656,11 +646,6 @@ describe("chat message action cards", () => {
 
     const sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(within(sidebar).getAllByText("Restored draft")).toHaveLength(2);
-    expect(
-      within(sidebar).getByText(
-        "You can ask your agent to continue editing this draft.",
-      ),
-    ).toBeInTheDocument();
     expect(
       within(sidebar).getByText("recipient@example.com, teammate@example.com"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -19,6 +19,7 @@ import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -205,6 +206,29 @@ async function waitForButtonByText(
   return button;
 }
 
+async function waitForSelectionToolbarButton(
+  text: string,
+): Promise<HTMLElement> {
+  let button: HTMLElement | undefined;
+  await waitFor(() => {
+    button = queryAllByRoleFast("button").find((candidate) => {
+      const label = candidate.textContent?.replace(/\s+/g, " ").trim();
+      return (
+        label === text ||
+        label === `${text} C` ||
+        label === `${text} F` ||
+        label === `${text}C` ||
+        label === `${text}F`
+      );
+    });
+    expect(button).toBeEnabled();
+  });
+  if (!button) {
+    throw new Error(`${text} selection toolbar button not found`);
+  }
+  return button;
+}
+
 async function confirmPermissionAction(
   user: ReturnType<typeof userEvent.setup>,
   card: HTMLElement,
@@ -212,9 +236,30 @@ async function confirmPermissionAction(
   await user.click(await waitForButtonByText("Confirm", card));
 }
 
+function selectMailText(element: HTMLElement): void {
+  element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return new DOMRect(24, 32, 180, 20);
+    },
+  });
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Selection API is not available");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.dispatchEvent(new Event("selectionchange"));
+  element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
 describe("chat message action cards", () => {
   it("opens a shared mail draft without reloading and refreshes after sending", async () => {
     const user = userEvent.setup({ delay: null });
+    const clipboard = context.mocks.browser.clipboardWriteText();
     const threadId = "c0000000-0000-4000-a000-000000000010";
     const messageId = "c0000000-0000-4000-a000-000000000011";
     const secondMessageId = "c0000000-0000-4000-a000-000000000013";
@@ -225,6 +270,9 @@ describe("chat message action cards", () => {
     let draftRequests = 0;
     let sent = false;
     const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const imageBytes = new TextEncoder().encode("mail draft image");
+    const mailDraftHtml =
+      '<div>Mail body <strong>before</strong></div><p><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><br>After image</p><hr><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a>';
 
     mockConnectorCatalogStatus([
       publicConnectorStatusItem({
@@ -247,11 +295,23 @@ describe("chat message action cards", () => {
           version: 3,
           provider: "gmail",
           from: "sender@example.com",
-          to: ["recipient@example.com"],
+          to: [
+            "recipient@example.com",
+            "teammate@example.com",
+            "reviewer@example.com",
+          ],
           cc: ["copy@example.com"],
           bcc: ["hidden@example.com"],
           subject: "Hello",
           body: "Mail body",
+          bodyHtml: mailDraftHtml,
+          inlineImages: [
+            {
+              contentId: "email-test-illustration",
+              partId: "2",
+              alt: "Cheerful envelope illustration",
+            },
+          ],
           replyTo: "reply-only@example.com",
           inReplyTo: "<thread-message@example.com>",
           status: sent ? "sent" : "draft",
@@ -287,11 +347,23 @@ describe("chat message action cards", () => {
           version: 3,
           provider: "gmail",
           from: "sender@example.com",
-          to: ["recipient@example.com"],
+          to: [
+            "recipient@example.com",
+            "teammate@example.com",
+            "reviewer@example.com",
+          ],
           cc: ["copy@example.com"],
           bcc: ["hidden@example.com"],
           subject: "Hello",
           body: "Mail body",
+          bodyHtml: mailDraftHtml,
+          inlineImages: [
+            {
+              contentId: "email-test-illustration",
+              partId: "2",
+              alt: "Cheerful envelope illustration",
+            },
+          ],
           replyTo: "reply-only@example.com",
           inReplyTo: "<thread-message@example.com>",
           status: "sent",
@@ -314,6 +386,17 @@ describe("chat message action cards", () => {
         },
       });
     });
+    context.mocks.http.get(
+      "*/api/zero/mail/drafts/:mailDraftId/attachments/:partId",
+      ({ params }) => {
+        expect(params.mailDraftId).toBe(mailDraftId);
+        expect(params.partId).toBe("2");
+        return new HttpResponse(imageBytes, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        });
+      },
+    );
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Mail card",
@@ -358,7 +441,7 @@ describe("chat message action cards", () => {
     });
     for (const card of cards) {
       expect(
-        within(card).getByText("To: recipient@example.com"),
+        within(card).getByText("To: recipient@example.com +2"),
       ).toBeInTheDocument();
       expect(within(card).queryByText("sender@example.com")).toBeNull();
       const icon = card.querySelector<HTMLImageElement>(
@@ -377,12 +460,56 @@ describe("chat message action cards", () => {
     await user.click(cards[0]!);
 
     let sidebar = await screen.findByTestId("mail-draft-sidebar");
+    expect(
+      within(sidebar).getByText(
+        "You can ask your agent to continue editing this draft.",
+      ),
+    ).toBeInTheDocument();
     expect(within(sidebar).getByText("sender@example.com")).toBeInTheDocument();
+    expect(
+      within(sidebar).getByText(
+        "recipient@example.com, teammate@example.com, reviewer@example.com",
+      ),
+    ).toBeInTheDocument();
     expect(within(sidebar).getByText("copy@example.com")).toBeInTheDocument();
     expect(within(sidebar).getByText("hidden@example.com")).toBeInTheDocument();
-    expect(within(sidebar).getByText("Mail body")).toBeInTheDocument();
+    const messageLabel = within(sidebar).getByText("Message");
+    const messageSection = messageLabel.parentElement;
+    if (!messageSection) {
+      throw new Error("Expected mail message section");
+    }
+    const boldText = within(messageSection).getByText("before");
+    expect(boldText.tagName).toBe("STRONG");
+    expect(
+      within(messageSection).getByText("Mail body after"),
+    ).toBeInTheDocument();
+    expect(within(messageSection).getByRole("listitem")).toHaveTextContent(
+      "Mail body after",
+    );
+    const reviewLink = queryAllByRoleFast("link", messageSection).find(
+      (link) => {
+        return link.textContent === "Review";
+      },
+    );
+    expect(reviewLink).toHaveAttribute("href", "https://example.com/review");
     expect(within(sidebar).getByText("report.pdf")).toBeInTheDocument();
     expect(within(sidebar).getByText("242 KB")).toBeInTheDocument();
+    const inlineImage = await within(messageSection).findByRole("img", {
+      name: "Cheerful envelope illustration",
+    });
+    expect(inlineImage).toHaveAttribute(
+      "src",
+      expect.stringMatching(/^blob:/u),
+    );
+    const attachmentsLabel = within(sidebar).getByText("Attachments");
+    const attachmentsSection = attachmentsLabel.parentElement;
+    if (!attachmentsSection) {
+      throw new Error("Expected mail attachments section");
+    }
+    expect(within(attachmentsSection).queryByRole("img")).toBeNull();
+    expect(
+      within(sidebar).queryByText("email-test-illustration.png"),
+    ).toBeNull();
     expect(within(sidebar).queryByText(/application\/pdf/u)).toBeNull();
     expect(within(sidebar).queryByText("reply-only@example.com")).toBeNull();
     expect(
@@ -392,7 +519,21 @@ describe("chat message action cards", () => {
       within(sidebar).queryByText("<reference-message@example.com>"),
     ).toBeNull();
     expect(within(sidebar).queryByRole("textbox")).not.toBeInTheDocument();
-    expect(draftRequests).toBe(1);
+
+    selectMailText(boldText);
+    await user.click(await waitForSelectionToolbarButton("Copy"));
+    await waitFor(() => {
+      expect(clipboard.writes).toStrictEqual(["before"]);
+    });
+
+    selectMailText(within(messageSection).getByRole("listitem"));
+    await user.click(await waitForSelectionToolbarButton("Provide feedback"));
+    await waitFor(() => {
+      const feedbackItem = document.querySelector("[data-feedback-item]");
+      expect(feedbackItem).toHaveTextContent("Mail body after");
+    });
+
+    expect(draftRequests).toBe(2);
     await user.click(await waitForButtonByText("Send", sidebar));
 
     await waitFor(() => {
@@ -401,6 +542,11 @@ describe("chat message action cards", () => {
     });
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Send", sidebar)).toBeNull();
+    expect(
+      screen.queryByText(
+        "You can ask your agent to continue editing this draft.",
+      ),
+    ).toBeNull();
     expect(draftRequests).toBe(2);
   });
 
@@ -456,6 +602,178 @@ describe("chat message action cards", () => {
       return link.textContent === "Untrusted connector";
     });
     expect(untrustedLink).toHaveAttribute("href", untrustedUrl);
+  });
+
+  it("restores the mail draft sidebar from the URL before its card is loaded", async () => {
+    const threadId = "c0000000-0000-4000-a000-000000000021";
+    const mailDraftId = "c0000000-0000-4000-a000-000000000022";
+    const createdAt = "2026-07-14T10:00:00.000Z";
+    let draftRequests = 0;
+
+    context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+      draftRequests += 1;
+      return respond(200, {
+        mailDraftId,
+        mailDraftUrl: `https://app.vm0.ai/mail/drafts/${mailDraftId}`,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: ["recipient@example.com", "teammate@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Restored draft",
+          body: "Mail body",
+          status: "draft",
+          detailAvailable: true,
+          gmailDraftId: "r-restored-draft",
+          gmailThreadId: "gmail-thread-id",
+          gmailMessageId: "gmail-message-id",
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Restored mail draft",
+      chatMessages: [],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}?mail-draft=${mailDraftId}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
+    });
+
+    const sidebar = await screen.findByTestId("mail-draft-sidebar");
+    expect(within(sidebar).getAllByText("Restored draft")).toHaveLength(2);
+    expect(
+      within(sidebar).getByText(
+        "You can ask your agent to continue editing this draft.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(sidebar).getByText("recipient@example.com, teammate@example.com"),
+    ).toBeInTheDocument();
+    const sendButton = await waitForButtonByText("Send", sidebar);
+    expect(sendButton).toBeInTheDocument();
+    expect(draftRequests).toBe(1);
+  });
+
+  it("switches drafts and reloads a draft when it is reopened", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "c0000000-0000-4000-a000-000000000023";
+    const firstMailDraftId = "c0000000-0000-4000-a000-000000000024";
+    const secondMailDraftId = "c0000000-0000-4000-a000-000000000025";
+    const runId = "d0000000-0000-4000-a000-000000000028";
+    const createdAt = "2026-07-14T10:00:00.000Z";
+    let firstDraftRequests = 0;
+    let secondDraftRequests = 0;
+    let secondSubject = "Second draft";
+
+    context.mocks.api(zeroMailContract.getDraft, ({ params, respond }) => {
+      const isSecondDraft = params.mailDraftId === secondMailDraftId;
+      if (isSecondDraft) {
+        secondDraftRequests += 1;
+      } else {
+        firstDraftRequests += 1;
+      }
+      const subject = isSecondDraft ? secondSubject : "First draft";
+      return respond(200, {
+        mailDraftId: params.mailDraftId,
+        mailDraftUrl: `https://app.vm0.ai/mail/drafts/${params.mailDraftId}`,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: ["recipient@example.com"],
+          cc: [],
+          bcc: [],
+          subject,
+          body: `${subject} body`,
+          status: "draft",
+          detailAvailable: true,
+          gmailDraftId: `gmail-${params.mailDraftId}`,
+          gmailThreadId: `thread-${params.mailDraftId}`,
+          gmailMessageId: `message-${params.mailDraftId}`,
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Switch mail drafts",
+      chatMessages: [
+        {
+          id: "c0000000-0000-4000-a000-000000000026",
+          role: "assistant",
+          content: `https://app.vm0.ai/mail/drafts/${firstMailDraftId}`,
+          runId,
+          createdAt,
+        },
+        {
+          id: "c0000000-0000-4000-a000-000000000027",
+          role: "assistant",
+          content: `https://app.vm0.ai/mail/drafts/${secondMailDraftId}`,
+          runId,
+          createdAt: "2026-07-14T10:00:01.000Z",
+        },
+      ],
+      activeRunIds: [runId],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
+    });
+
+    await user.click(
+      await screen.findByLabelText("Open draft email: First draft"),
+    );
+    let sidebar = await screen.findByTestId("mail-draft-sidebar");
+    await waitFor(() => {
+      expect(within(sidebar).getAllByText("First draft")).toHaveLength(2);
+    });
+
+    await user.click(
+      await screen.findByLabelText("Open draft email: Second draft"),
+    );
+    await waitFor(() => {
+      sidebar = screen.getByTestId("mail-draft-sidebar");
+      expect(within(sidebar).getAllByText("Second draft")).toHaveLength(2);
+    });
+
+    await user.click(within(sidebar).getByLabelText("Close email details"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("mail-draft-sidebar")).toBeNull();
+    });
+
+    secondSubject = "Updated second draft";
+    await user.click(
+      await screen.findByLabelText("Open draft email: Second draft"),
+    );
+    sidebar = await screen.findByTestId("mail-draft-sidebar");
+    await waitFor(() => {
+      expect(within(sidebar).getAllByText("Updated second draft")).toHaveLength(
+        2,
+      );
+    });
+    expect(
+      screen.getByLabelText("Open draft email: Second draft"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Open draft email: Updated second draft"),
+    ).toBeNull();
+
+    expect(firstDraftRequests).toBe(2);
+    expect(secondDraftRequests).toBe(3);
   });
 
   it("connects a single OAuth connector directly and resumes the chat", async () => {
@@ -735,7 +1053,7 @@ describe("chat message action cards", () => {
     expect(draftRequests).toBe(1);
     await user.click(card);
     const sidebar = await screen.findByTestId("mail-draft-sidebar");
-    expect(draftRequests).toBe(1);
+    expect(draftRequests).toBe(2);
     expect(within(sidebar).queryByText("Cc")).toBeNull();
     expect(within(sidebar).queryByText("Bcc")).toBeNull();
     await user.click(await waitForButtonByText("Delete", sidebar));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1264,6 +1264,176 @@ describe("chat message action cards", () => {
     });
   });
 
+  it("shows a Gmail reconnect action when mail access is no longer authorized", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "c0000000-0000-4000-a000-00000000001b";
+    const mailDraftId = "c0000000-0000-4000-a000-00000000001c";
+    const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const createdAt = "2026-07-14T10:00:00.000Z";
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    const openAuthWindow = context.mocks.browser.open(authWindow);
+    let reconnectRequired = true;
+    let catalogRequests = 0;
+    let oauthStartRequests = 0;
+
+    context.mocks.data.connectors([
+      connectedConnector({
+        type: "gmail",
+        authMethod: "oauth",
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      }),
+    ]);
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      catalogRequests += 1;
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            connectorRef: "gmail",
+            label: "Gmail",
+            connected: true,
+            connectionStatus: reconnectRequired
+              ? "reconnect-required"
+              : "connected",
+            connection: {
+              authMethod: "oauth",
+              externalUsername: null,
+              externalEmail: "sender@example.com",
+              reconnectReason: reconnectRequired
+                ? "authorization_expired_or_revoked"
+                : null,
+            },
+            authMethods: [
+              {
+                id: "oauth",
+                label: "OAuth",
+                description: null,
+                grantKind: "auth-code",
+                manualFields: [],
+                startOptions: [],
+              },
+            ],
+            singleAuthCodeAuthMethodId: "oauth",
+          }),
+        ],
+      });
+    });
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        oauthStartRequests += 1;
+        expect(params.type).toBe("gmail");
+        return respond(200, {
+          authorizationUrl: "https://accounts.google.test/oauth",
+        });
+      },
+    );
+    context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+      return respond(200, {
+        mailDraftId,
+        mailDraftUrl,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: [],
+          cc: [],
+          bcc: [],
+          subject: "Reconnect required",
+          body: "",
+          accessStatus: reconnectRequired ? "reconnect" : "ready",
+          status: "draft",
+          detailAvailable: !reconnectRequired,
+          gmailDraftId: "r-reconnect",
+          gmailThreadId: "gmail-thread-id",
+          gmailMessageId: "gmail-message-id",
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Reconnect Gmail",
+      chatMessages: [
+        {
+          id: "c0000000-0000-4000-a000-00000000001d",
+          role: "assistant",
+          content: mailDraftUrl,
+          createdAt,
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}?mail-draft=${mailDraftId}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
+    });
+
+    const card = await screen.findByLabelText(
+      "Reconnect Gmail to access email: Reconnect required",
+    );
+    expect(within(card).getByText("Need reconnect")).toBeInTheDocument();
+    expect(card).toBeEnabled();
+
+    const message = await screen.findByText(
+      "You no longer have permission to access this email. Reconnect Gmail to continue.",
+    );
+    const sidebar = message.closest("aside");
+    if (!sidebar) {
+      throw new Error("Expected Gmail reconnect sidebar");
+    }
+    const reconnect = buttonByText("Reconnect Gmail", sidebar);
+    await waitFor(() => {
+      expect(hasSubscription("connector:changed")).toBeTruthy();
+      expect(catalogRequests).toBeGreaterThanOrEqual(2);
+    });
+
+    await user.click(reconnect);
+    await waitFor(() => {
+      expect(oauthStartRequests).toBe(1);
+      expect(openAuthWindow.calls).toHaveLength(1);
+      expect(authWindow.location.href).toBe(
+        "https://accounts.google.test/oauth",
+      );
+      expect(within(card).getByText("Reconnecting…")).toBeInTheDocument();
+    });
+
+    reconnectRequired = false;
+    context.mocks.data.connectors([
+      connectedConnector({
+        type: "gmail",
+        authMethod: "oauth",
+        updatedAt: "2026-01-01T00:00:01Z",
+      }),
+    ]);
+    triggerAblyEvent("connector:changed");
+
+    const refreshedCard = await screen.findByLabelText(
+      "Open draft email: Reconnect required",
+    );
+    expect(within(refreshedCard).getByText("Draft")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "You no longer have permission to access this email. Reconnect Gmail to continue.",
+        ),
+      ).toBeNull();
+      expect(
+        within(screen.getByTestId("mail-draft-sidebar")).getByRole("heading", {
+          name: "Reconnect required",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("renders a deleted email card without an interactive sidebar trigger", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000014";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -520,6 +520,12 @@ describe("chat message action cards", () => {
     expect(
       messageSection.querySelector("[data-feedback-source]"),
     ).toHaveAttribute("data-feedback-source-id", mailDraftId);
+    expect(
+      messageSection.querySelector("[data-feedback-source]"),
+    ).toHaveAttribute("data-feedback-source-status", "draft");
+    expect(
+      messageSection.querySelector("[data-feedback-source]"),
+    ).not.toHaveAttribute("data-feedback-source-sent-id");
 
     selectMailText(boldText);
     await user.click(await waitForSelectionToolbarButton("Copy"));
@@ -543,6 +549,17 @@ describe("chat message action cards", () => {
     });
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Send", sidebar)).toBeNull();
+    const sentMessageSection =
+      within(sidebar).getByText("Message").parentElement;
+    if (!sentMessageSection) {
+      throw new Error("Expected sent mail message section");
+    }
+    expect(
+      sentMessageSection.querySelector("[data-feedback-source]"),
+    ).toHaveAttribute("data-feedback-source-status", "sent");
+    expect(
+      sentMessageSection.querySelector("[data-feedback-source]"),
+    ).toHaveAttribute("data-feedback-source-sent-id", "gmail-sent-message-id");
     expect(draftRequests).toBe(2);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -287,7 +287,7 @@ describe("chat message action cards", () => {
     const imageBytes = new TextEncoder().encode("mail draft image");
     const pdfBytes = new TextEncoder().encode("mail draft pdf");
     const mailDraftHtml =
-      '<div>Mail body <strong>before</strong></div><p><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><br>After image</p><hr><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a>';
+      '<div>Mail body <strong>before</strong></div><p><img src="cid:email-test-illustration" alt="Cheerful envelope illustration"><br>After image</p><hr><ul><li>Mail body after</li></ul><a href="https://example.com/review">Review</a><div><img src="https://images.example.test/signature.png" alt="Sender signature logo" width="96" height="32"><img src="data:image/png;base64,dW5zYWZl" alt="Unsafe signature image"></div>';
 
     mockConnectorCatalogStatus([
       publicConnectorStatusItem({
@@ -549,6 +549,22 @@ describe("chat message action cards", () => {
       "src",
       expect.stringMatching(/^blob:/u),
     );
+    const signatureImage = within(messageSection).getByRole("img", {
+      name: "Sender signature logo",
+    });
+    expect(signatureImage).toHaveAttribute(
+      "src",
+      "https://images.example.test/signature.png",
+    );
+    expect(signatureImage).toHaveAttribute("width", "96");
+    expect(signatureImage).toHaveAttribute("height", "32");
+    expect(signatureImage).toHaveAttribute("loading", "lazy");
+    expect(signatureImage).toHaveAttribute("referrerpolicy", "no-referrer");
+    expect(
+      within(messageSection).queryByRole("img", {
+        name: "Unsafe signature image",
+      }),
+    ).toBeNull();
     const attachmentsLabel = within(sidebar).getByText("Attachments");
     const attachmentsSection = attachmentsLabel.parentElement;
     if (!attachmentsSection) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -21,7 +21,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   detachedSetupPage,
@@ -261,6 +261,19 @@ describe("chat message action cards", () => {
   it("opens a shared mail draft without reloading and refreshes after sending", async () => {
     const user = userEvent.setup({ delay: null });
     const clipboard = context.mocks.browser.clipboardWriteText();
+    const nativeCreateObjectUrl = URL.createObjectURL.bind(URL);
+    const nativeRevokeObjectUrl = URL.revokeObjectURL.bind(URL);
+    const createdAttachmentUrls: string[] = [];
+    const revokedAttachmentUrls: string[] = [];
+    vi.spyOn(URL, "createObjectURL").mockImplementation((object) => {
+      const url = nativeCreateObjectUrl(object);
+      createdAttachmentUrls.push(url);
+      return url;
+    });
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation((url) => {
+      revokedAttachmentUrls.push(url);
+      nativeRevokeObjectUrl(url);
+    });
     const threadId = "c0000000-0000-4000-a000-000000000010";
     const messageId = "c0000000-0000-4000-a000-000000000011";
     const secondMessageId = "c0000000-0000-4000-a000-000000000013";
@@ -605,6 +618,23 @@ describe("chat message action cards", () => {
       "gmail-sent-message-id",
     );
     expect(draftRequests).toBe(2);
+
+    let liveAttachmentUrls: string[] = [];
+    await waitFor(() => {
+      liveAttachmentUrls = createdAttachmentUrls.filter((url) => {
+        return !revokedAttachmentUrls.includes(url);
+      });
+      expect(liveAttachmentUrls.length).toBeGreaterThan(0);
+    });
+    await user.click(within(sidebar).getByLabelText("Close email details"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("mail-draft-sidebar")).toBeNull();
+      expect(
+        liveAttachmentUrls.every((url) => {
+          return revokedAttachmentUrls.includes(url);
+        }),
+      ).toBeTruthy();
+    });
   });
 
   it("renders canonical connector actions on alternate production origins", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1276,7 +1276,10 @@ describe("chat message action cards", () => {
       configurable: true,
     });
     const openAuthWindow = context.mocks.browser.open(authWindow);
+    const refreshStarted = Promise.withResolvers<void>();
+    const completeRefresh = Promise.withResolvers<void>();
     let reconnectRequired = true;
+    let pauseReadyRefresh = false;
     let catalogRequests = 0;
     let oauthStartRequests = 0;
 
@@ -1332,7 +1335,11 @@ describe("chat message action cards", () => {
         });
       },
     );
-    context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+    context.mocks.api(zeroMailContract.getDraft, async ({ respond }) => {
+      if (pauseReadyRefresh && !reconnectRequired) {
+        refreshStarted.resolve();
+        await completeRefresh.promise;
+      }
       return respond(200, {
         mailDraftId,
         mailDraftUrl,
@@ -1407,6 +1414,7 @@ describe("chat message action cards", () => {
     });
 
     reconnectRequired = false;
+    pauseReadyRefresh = true;
     context.mocks.data.connectors([
       connectedConnector({
         type: "gmail",
@@ -1415,6 +1423,13 @@ describe("chat message action cards", () => {
       }),
     ]);
     triggerAblyEvent("connector:changed");
+
+    await refreshStarted.promise;
+    const cardRemainedVisible = card.isConnected;
+    const sidebarRemainedVisible = message.isConnected;
+    completeRefresh.resolve();
+    expect(cardRemainedVisible).toBeTruthy();
+    expect(sidebarRemainedVisible).toBeTruthy();
 
     const refreshedCard = await screen.findByLabelText(
       "Open draft email: Reconnect required",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -519,6 +519,12 @@ describe("chat message action cards", () => {
       within(sidebar).queryByText("<reference-message@example.com>"),
     ).toBeNull();
     expect(within(sidebar).queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      messageSection.querySelector("[data-feedback-source]"),
+    ).toHaveAttribute("data-feedback-source-type", "mail");
+    expect(
+      messageSection.querySelector("[data-feedback-source]"),
+    ).toHaveAttribute("data-feedback-source-id", mailDraftId);
 
     selectMailText(boldText);
     await user.click(await waitForSelectionToolbarButton("Copy"));

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-mail";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { cn } from "@vm0/ui";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
 
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
@@ -111,7 +111,7 @@ function MailDraftCardContent({
 }
 
 function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
-  const draftLoadable = useLoadable(signals.draft$);
+  const draftLoadable = useLastLoadable(signals.draft$);
   const selectedMailDraftId = useGet(currentMailDraftId$);
   const openSidebar = useSet(openMailDraftSidebar$);
   const reloadSidebar = useSet(signals.reloadSidebar$);

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -50,6 +50,7 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const catalogByRefLoadable = useLastLoadable(connectorCatalogStatusByRef$);
   const selectedMailDraftId = useGet(currentMailDraftId$);
   const openSidebar = useSet(openMailDraftSidebar$);
+  const reloadSidebar = useSet(signals.reloadSidebar$);
   const gmailIcon =
     catalogByRefLoadable.state === "hasData"
       ? catalogByRefLoadable.data.get("gmail")?.icon
@@ -65,7 +66,12 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const draft = draftLoadable.data;
   const deleted = draft.status === "deleted";
   const selected = selectedMailDraftId === signals.mailDraftId;
-  const recipients = draft.to.join(", ") || "(No recipient)";
+  const firstRecipient = draft.to[0];
+  const recipients = firstRecipient
+    ? draft.to.length === 1
+      ? firstRecipient
+      : `${firstRecipient} +${draft.to.length - 1}`
+    : "(No recipient)";
   const content = (
     <>
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-background">
@@ -120,6 +126,7 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
       data-mail-draft-card
       data-mail-draft-status={draft.status}
       onClick={() => {
+        reloadSidebar();
         openSidebar(signals.mailDraftId);
       }}
       className={cn(

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -1,17 +1,21 @@
 import { IconChevronRight, IconLoader2 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import type { ZeroMailDraftStatus } from "@vm0/api-contracts/contracts/zero-mail";
+import type {
+  ZeroMailDraft,
+  ZeroMailDraftStatus,
+} from "@vm0/api-contracts/contracts/zero-mail";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { cn } from "@vm0/ui";
-import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
 import {
   currentMailDraftId$,
   openMailDraftSidebar$,
 } from "../../signals/zero-page/mail-draft-sidebar.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { useGmailReconnect } from "./use-gmail-reconnect.ts";
 
 interface MailDraftCardProps {
   readonly signals: MailDraftSignals;
@@ -45,16 +49,74 @@ function MailDraftCardSkeleton() {
   );
 }
 
+function mailDraftRecipients(draft: ZeroMailDraft): string {
+  const firstRecipient = draft.to[0];
+  if (!firstRecipient) {
+    return "(No recipient)";
+  }
+  return draft.to.length === 1
+    ? firstRecipient
+    : `${firstRecipient} +${draft.to.length - 1}`;
+}
+
+function MailDraftCardContent({
+  draft,
+  gmailIcon,
+  reconnecting,
+}: {
+  readonly draft: ZeroMailDraft;
+  readonly gmailIcon: PublicConnectorCatalogIcon | undefined;
+  readonly reconnecting: boolean;
+}) {
+  const deleted = draft.status === "deleted";
+  const reconnect = draft.accessStatus === "reconnect";
+  return (
+    <>
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-background">
+        <ConnectorIcon icon={gmailIcon} size={23} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium leading-5 text-foreground">
+          {draft.subject || "(No subject)"}
+        </span>
+        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+          To: {mailDraftRecipients(draft)}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-1.5 self-center">
+        <span
+          className={cn(
+            "rounded-full px-2 py-1 text-[11px] font-medium",
+            draft.status === "sent" &&
+              "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+            draft.status === "draft" &&
+              !reconnect &&
+              "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+            reconnect && "bg-destructive/10 text-destructive dark:text-red-300",
+            deleted && "bg-muted text-muted-foreground",
+          )}
+        >
+          {reconnecting
+            ? "Reconnecting…"
+            : reconnect
+              ? "Need reconnect"
+              : statusLabel(draft.status)}
+        </span>
+        {!deleted ? (
+          <IconChevronRight size={16} className="text-muted-foreground" />
+        ) : null}
+      </span>
+    </>
+  );
+}
+
 function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const draftLoadable = useLoadable(signals.draft$);
-  const catalogByRefLoadable = useLastLoadable(connectorCatalogStatusByRef$);
   const selectedMailDraftId = useGet(currentMailDraftId$);
   const openSidebar = useSet(openMailDraftSidebar$);
   const reloadSidebar = useSet(signals.reloadSidebar$);
-  const gmailIcon =
-    catalogByRefLoadable.state === "hasData"
-      ? catalogByRefLoadable.data.get("gmail")?.icon
-      : undefined;
+  const { connectorIcon, reconnect, reconnectDisabled, reconnecting } =
+    useGmailReconnect();
 
   if (draftLoadable.state === "loading") {
     return <MailDraftCardSkeleton />;
@@ -65,44 +127,14 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
 
   const draft = draftLoadable.data;
   const deleted = draft.status === "deleted";
+  const needsReconnect = draft.accessStatus === "reconnect";
   const selected = selectedMailDraftId === signals.mailDraftId;
-  const firstRecipient = draft.to[0];
-  const recipients = firstRecipient
-    ? draft.to.length === 1
-      ? firstRecipient
-      : `${firstRecipient} +${draft.to.length - 1}`
-    : "(No recipient)";
   const content = (
-    <>
-      <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-background">
-        <ConnectorIcon icon={gmailIcon} size={23} />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-medium leading-5 text-foreground">
-          {draft.subject || "(No subject)"}
-        </span>
-        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-          To: {recipients}
-        </span>
-      </span>
-      <span className="flex shrink-0 items-center gap-1.5 self-center">
-        <span
-          className={cn(
-            "rounded-full px-2 py-1 text-[11px] font-medium",
-            draft.status === "sent" &&
-              "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-            draft.status === "draft" &&
-              "bg-amber-500/10 text-amber-700 dark:text-amber-300",
-            deleted && "bg-muted text-muted-foreground",
-          )}
-        >
-          {statusLabel(draft.status)}
-        </span>
-        {!deleted ? (
-          <IconChevronRight size={16} className="text-muted-foreground" />
-        ) : null}
-      </span>
-    </>
+    <MailDraftCardContent
+      draft={draft}
+      gmailIcon={connectorIcon}
+      reconnecting={needsReconnect && reconnecting}
+    />
   );
 
   if (deleted) {
@@ -116,6 +148,22 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
       >
         {content}
       </div>
+    );
+  }
+
+  if (needsReconnect) {
+    return (
+      <button
+        type="button"
+        disabled={reconnectDisabled}
+        onClick={reconnect}
+        aria-label={`Reconnect Gmail to access email: ${draft.subject || "No subject"}`}
+        data-mail-draft-card
+        data-mail-draft-status={draft.status}
+        className="flex min-h-[76px] w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait disabled:opacity-70"
+      >
+        {content}
+      </button>
     );
   }
 

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -1,7 +1,10 @@
 import {
+  IconCircleCheck,
   IconExternalLink,
   IconLoader2,
   IconPaperclip,
+  IconPencil,
+  IconPlayerPlay,
   IconSend,
   IconTrash,
   IconX,
@@ -12,14 +15,25 @@ import type {
   ZeroMailInlineImage,
 } from "@vm0/api-contracts/contracts/zero-mail";
 import { Button } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { CSSProperties, ReactNode } from "react";
 
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
+import { classifyChatAttachment } from "../../signals/chat-page/parse-body-blocks.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  openImageLightbox$,
+  openVideoLightbox$,
+} from "../../signals/zero-page/zero-attachment-chips.ts";
 import { closeMailDraftSidebar$ } from "../../signals/zero-page/mail-draft-sidebar.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  FileAttachmentChip,
+  PreviewableAudioAttachmentChip,
+  PreviewableFileAttachmentChip,
+} from "./zero-attachment-chips.tsx";
 
 interface MailDraftSidebarProps {
   readonly signals: MailDraftSignals;
@@ -45,29 +59,24 @@ function MailDraftSidebarSkeleton({ close }: { readonly close: () => void }) {
       aria-label="Loading email details"
       className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0"
     >
-      <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
-        <div className="min-w-0 flex-1 space-y-1.5 animate-pulse">
-          <div className="h-4 w-40 rounded bg-muted/60" />
-          <div className="h-3 w-20 rounded bg-muted/50" />
-          <div className="h-3 w-64 max-w-full rounded bg-muted/50" />
+      <div className="min-h-0 flex-1 overflow-hidden px-5 py-5 animate-pulse">
+        <div className="border-b border-border/60 pb-5">
+          <div className="flex items-start gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <div className="h-6 w-52 max-w-full rounded bg-muted/60" />
+              <div className="relative top-0.5 h-5 w-12 shrink-0 rounded-full bg-muted/50" />
+            </div>
+            <SidebarCloseButton close={close} />
+          </div>
+          <div className="mt-4 flex items-center gap-3">
+            <div className="size-9 shrink-0 rounded-full bg-muted/60" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="h-4 w-44 max-w-full rounded bg-muted/60" />
+              <div className="h-3 w-64 max-w-full rounded bg-muted/50" />
+            </div>
+          </div>
         </div>
-        <SidebarCloseButton close={close} />
-      </div>
-      <div className="min-h-0 flex-1 space-y-5 overflow-hidden px-4 py-4 animate-pulse">
-        <div className="space-y-1.5">
-          <div className="h-3 w-10 rounded bg-muted/50" />
-          <div className="h-4 w-48 max-w-full rounded bg-muted/60" />
-        </div>
-        <div className="space-y-1.5">
-          <div className="h-3 w-6 rounded bg-muted/50" />
-          <div className="h-4 w-64 max-w-full rounded bg-muted/60" />
-        </div>
-        <div className="space-y-1.5">
-          <div className="h-3 w-14 rounded bg-muted/50" />
-          <div className="h-4 w-52 max-w-full rounded bg-muted/60" />
-        </div>
-        <div className="space-y-1.5">
-          <div className="h-3 w-12 rounded bg-muted/50" />
+        <div className="space-y-2 py-5">
           <div className="h-4 w-full rounded bg-muted/60" />
           <div className="h-4 w-5/6 rounded bg-muted/60" />
           <div className="h-4 w-2/3 rounded bg-muted/60" />
@@ -104,35 +113,80 @@ function UnavailableMailDraftSidebar({
   );
 }
 
-function DetailField({
-  label,
-  value,
+function MailMessageHeader({
+  close,
+  draft,
 }: {
-  readonly label: string;
-  readonly value: string;
+  readonly close: () => void;
+  readonly draft: ZeroMailDraft;
 }) {
+  const active = draft.status === "draft";
+  const senderName = draft.fromName?.trim() || null;
+  const senderInitial = (senderName ?? draft.from).slice(0, 1).toUpperCase();
   return (
-    <div className="grid gap-1.5">
-      <div className="text-xs font-medium text-muted-foreground">{label}</div>
-      <div className="break-words text-sm text-foreground">{value}</div>
-    </div>
+    <header className="border-b border-border/60 pb-5">
+      <div className="flex items-start gap-3">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <h1 className="break-words text-xl font-semibold leading-7 tracking-[-0.015em] text-foreground">
+            {draft.subject || "(No subject)"}
+          </h1>
+          <span
+            className={
+              active
+                ? "relative top-0.5 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                : "relative top-0.5 inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-400"
+            }
+          >
+            {active ? (
+              <IconPencil size={11} stroke={2} />
+            ) : (
+              <IconCircleCheck size={11} stroke={2} />
+            )}
+            {active ? "Draft" : "Sent"}
+          </span>
+        </div>
+        <SidebarCloseButton close={close} />
+      </div>
+      <div className="mt-4 flex min-w-0 items-center gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground/[0.07] text-sm font-semibold text-foreground/75">
+          {senderInitial}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+            {senderName ? (
+              <span className="truncate text-sm font-semibold text-foreground">
+                {senderName}
+              </span>
+            ) : null}
+            <span
+              className={
+                senderName
+                  ? "truncate text-xs text-muted-foreground"
+                  : "truncate text-sm font-semibold text-foreground"
+              }
+            >
+              {draft.from}
+            </span>
+          </div>
+          <div className="mt-0.5 min-w-0 break-words text-xs leading-5 text-muted-foreground">
+            <span>to {draft.to.join(", ") || "—"}</span>
+            {draft.cc.length > 0 ? (
+              <>
+                <span aria-hidden="true"> · </span>
+                <span>cc {draft.cc.join(", ")}</span>
+              </>
+            ) : null}
+            {draft.bcc.length > 0 ? (
+              <>
+                <span aria-hidden="true"> · </span>
+                <span>bcc {draft.bcc.join(", ")}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </header>
   );
-}
-
-function formatAttachmentSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-  const units = ["KB", "MB", "GB"] as const;
-  let value = bytes / 1024;
-  for (let i = 0; i < units.length; i++) {
-    const unit = units[i]!;
-    if (value < 1024 || i === units.length - 1) {
-      return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
-    }
-    value = value / 1024;
-  }
-  return `${bytes} B`;
 }
 
 function AttachmentSummary({
@@ -141,19 +195,143 @@ function AttachmentSummary({
   readonly attachment: ZeroMailAttachment;
 }) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 py-2.5">
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
-        <IconPaperclip size={15} />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm text-foreground">
-          {attachment.filename}
-        </span>
-        <span className="block truncate text-xs text-muted-foreground">
-          {formatAttachmentSize(attachment.size)}
-        </span>
+    <div className="inline-flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border border-foreground/15 bg-background/80 px-1.5">
+      <IconPaperclip size={14} className="shrink-0 text-muted-foreground" />
+      <span className="min-w-0 truncate text-xs font-medium">
+        {attachment.filename}
       </span>
     </div>
+  );
+}
+
+function MailAttachmentPreview({
+  attachment,
+  partId,
+  signals,
+}: {
+  readonly attachment: ZeroMailAttachment;
+  readonly partId: string;
+  readonly signals: MailDraftSignals;
+}) {
+  const attachmentLoadable = useLoadable(signals.attachmentUrl(partId));
+  if (
+    attachmentLoadable.state !== "hasData" ||
+    attachmentLoadable.data === null
+  ) {
+    return <AttachmentSummary attachment={attachment} />;
+  }
+  const url = attachmentLoadable.data;
+  const kind = classifyChatAttachment({
+    filename: attachment.filename,
+    contentType: attachment.contentType,
+    url,
+  });
+  let preview: ReactNode;
+  if (kind === "image" || kind === "video") {
+    preview = (
+      <MailMediaAttachmentPreview
+        filename={attachment.filename}
+        kind={kind}
+        url={url}
+      />
+    );
+  } else if (
+    kind === "markdown" ||
+    kind === "text" ||
+    kind === "json" ||
+    kind === "csv" ||
+    kind === "pdf" ||
+    kind === "html"
+  ) {
+    preview = (
+      <PreviewableFileAttachmentChip
+        filename={attachment.filename}
+        kind={kind}
+        shareAvailable={false}
+        splitViewAvailable={false}
+        url={url}
+      />
+    );
+  } else if (kind === "audio") {
+    preview = (
+      <PreviewableAudioAttachmentChip
+        contentType={attachment.contentType}
+        filename={attachment.filename}
+        shareAvailable={false}
+        splitViewAvailable={false}
+        url={url}
+      />
+    );
+  } else {
+    preview = (
+      <FileAttachmentChip
+        contentType={attachment.contentType}
+        filename={attachment.filename}
+        url={url}
+      />
+    );
+  }
+  return preview;
+}
+
+function MailMediaAttachmentPreview({
+  filename,
+  kind,
+  url,
+}: {
+  readonly filename: string;
+  readonly kind: "image" | "video";
+  readonly url: string;
+}) {
+  const openImageLightbox = useSet(openImageLightbox$);
+  const openVideoLightbox = useSet(openVideoLightbox$);
+  const onPreview = () => {
+    if (kind === "image") {
+      openImageLightbox({
+        url,
+        filename,
+        shareAvailable: false,
+        splitViewAvailable: false,
+      });
+      return;
+    }
+    openVideoLightbox({
+      url,
+      filename,
+      shareAvailable: false,
+      splitViewAvailable: false,
+    });
+  };
+  return (
+    <button
+      type="button"
+      onClick={onPreview}
+      aria-label={`Preview ${filename}`}
+      title={filename}
+      className="group relative aspect-[10/9] w-[50px] max-w-full cursor-pointer overflow-hidden rounded-lg border border-foreground/10 bg-muted/30 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30"
+    >
+      {kind === "image" ? (
+        <img
+          src={url}
+          alt={filename}
+          className="block h-full w-full object-contain"
+        />
+      ) : (
+        <>
+          <video
+            src={`${url}#t=0.001`}
+            preload="metadata"
+            muted
+            playsInline
+            aria-hidden="true"
+            className="h-full w-full object-contain"
+          />
+          <span className="absolute inset-0 flex items-center justify-center bg-black/10 text-white transition-colors group-hover:bg-black/30">
+            <IconPlayerPlay size={16} stroke={1.8} />
+          </span>
+        </>
+      )}
+    </button>
   );
 }
 
@@ -164,7 +342,7 @@ function MailDraftInlineImage({
   readonly image: ZeroMailInlineImage;
   readonly signals: MailDraftSignals;
 }) {
-  const imageLoadable = useLoadable(signals.attachmentImageUrl(image.partId));
+  const imageLoadable = useLoadable(signals.attachmentUrl(image.partId));
   if (imageLoadable.state === "loading") {
     return (
       <span
@@ -647,42 +825,39 @@ function MailDraftMessage({
 }
 
 function MailDraftDetails({
+  close,
   draft,
   signals,
 }: {
+  readonly close: () => void;
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
   const attachments = draft.version === 3 ? draft.attachments : [];
   return (
-    <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4">
-      <DetailField
-        label="From"
-        value={
-          draft.fromName ? `${draft.fromName} <${draft.from}>` : draft.from
-        }
-      />
-      <DetailField label="To" value={draft.to.join(", ") || "—"} />
-      {draft.cc.length > 0 ? (
-        <DetailField label="Cc" value={draft.cc.join(", ")} />
-      ) : null}
-      {draft.bcc.length > 0 ? (
-        <DetailField label="Bcc" value={draft.bcc.join(", ")} />
-      ) : null}
-      <DetailField label="Subject" value={draft.subject || "(No subject)"} />
-      <div className="grid gap-1.5">
-        <div className="text-xs font-medium text-muted-foreground">Message</div>
+    <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+      <MailMessageHeader close={close} draft={draft} />
+      <div className="py-5">
         <MailDraftMessage draft={draft} signals={signals} />
       </div>
       {attachments.length > 0 ? (
-        <div className="grid gap-2">
-          <div className="text-xs font-medium text-muted-foreground">
+        <div className="grid gap-2.5 border-t border-border/60 pt-4">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Attachments
           </div>
-          <div className="grid gap-2">
+          <div className="flex flex-wrap gap-3">
             {attachments.map((attachment) => {
               const key = `${attachment.filename}-${attachment.contentType}-${attachment.size}`;
-              return <AttachmentSummary key={key} attachment={attachment} />;
+              return attachment.partId ? (
+                <MailAttachmentPreview
+                  key={key}
+                  attachment={attachment}
+                  partId={attachment.partId}
+                  signals={signals}
+                />
+              ) : (
+                <AttachmentSummary key={key} attachment={attachment} />
+              );
             })}
           </div>
         </div>
@@ -717,6 +892,13 @@ function MailDraftDetail({
     };
     detach(deleteAndClose(), Reason.DomCallback);
   };
+  const onSend = () => {
+    const sendAndNotify = async () => {
+      await send(pageSignal);
+      toast.success("Email sent");
+    };
+    detach(sendAndNotify(), Reason.DomCallback);
+  };
 
   return (
     <aside
@@ -725,18 +907,7 @@ function MailDraftDetail({
       data-testid="mail-draft-sidebar"
       className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0 animate-in fade-in slide-in-from-right-2 duration-[180ms] ease"
     >
-      <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
-            {draft.subject || "(No subject)"}
-          </div>
-          <div className="truncate text-xs text-muted-foreground">
-            {active ? "Gmail draft" : "Sent email"}
-          </div>
-        </div>
-        <SidebarCloseButton close={close} />
-      </div>
-      <MailDraftDetails draft={draft} signals={signals} />
+      <MailDraftDetails close={close} draft={draft} signals={signals} />
       <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-border/60 px-4 py-3">
         {active ? (
           <Button
@@ -767,14 +938,7 @@ function MailDraftDetail({
             </Button>
           ) : null}
           {active ? (
-            <Button
-              type="button"
-              size="sm"
-              disabled={pending}
-              onClick={() => {
-                detach(send(pageSignal), Reason.DomCallback);
-              }}
-            >
+            <Button type="button" size="sm" disabled={pending} onClick={onSend}>
               {sendLoadable.state === "loading" ? (
                 <IconLoader2 size={15} className="animate-spin" />
               ) : (

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -6,10 +6,15 @@ import {
   IconTrash,
   IconX,
 } from "@tabler/icons-react";
-import type { ZeroMailDraft } from "@vm0/api-contracts/contracts/zero-mail";
+import type {
+  ZeroMailAttachment,
+  ZeroMailDraft,
+  ZeroMailInlineImage,
+} from "@vm0/api-contracts/contracts/zero-mail";
 import { Button } from "@vm0/ui";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import type { CSSProperties, ReactNode } from "react";
 
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -30,6 +35,49 @@ function SidebarCloseButton({ close }: { readonly close: () => void }) {
     >
       <IconX size={16} />
     </button>
+  );
+}
+
+function MailDraftSidebarSkeleton({ close }: { readonly close: () => void }) {
+  return (
+    <aside
+      aria-busy="true"
+      aria-label="Loading email details"
+      className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0"
+    >
+      <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
+        <div className="min-w-0 flex-1 space-y-1.5 animate-pulse">
+          <div className="h-4 w-40 rounded bg-muted/60" />
+          <div className="h-3 w-20 rounded bg-muted/50" />
+          <div className="h-3 w-64 max-w-full rounded bg-muted/50" />
+        </div>
+        <SidebarCloseButton close={close} />
+      </div>
+      <div className="min-h-0 flex-1 space-y-5 overflow-hidden px-4 py-4 animate-pulse">
+        <div className="space-y-1.5">
+          <div className="h-3 w-10 rounded bg-muted/50" />
+          <div className="h-4 w-48 max-w-full rounded bg-muted/60" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-6 rounded bg-muted/50" />
+          <div className="h-4 w-64 max-w-full rounded bg-muted/60" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-14 rounded bg-muted/50" />
+          <div className="h-4 w-52 max-w-full rounded bg-muted/60" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-12 rounded bg-muted/50" />
+          <div className="h-4 w-full rounded bg-muted/60" />
+          <div className="h-4 w-5/6 rounded bg-muted/60" />
+          <div className="h-4 w-2/3 rounded bg-muted/60" />
+        </div>
+      </div>
+      <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-border/60 px-4 py-3 animate-pulse">
+        <div className="h-8 w-20 rounded-md bg-muted/50" />
+        <div className="h-8 w-24 rounded-md bg-muted/50" />
+      </footer>
+    </aside>
   );
 }
 
@@ -87,7 +135,516 @@ function formatAttachmentSize(bytes: number): string {
   return `${bytes} B`;
 }
 
-function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
+function AttachmentSummary({
+  attachment,
+}: {
+  readonly attachment: ZeroMailAttachment;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 py-2.5">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
+        <IconPaperclip size={15} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-foreground">
+          {attachment.filename}
+        </span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {formatAttachmentSize(attachment.size)}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function MailDraftInlineImage({
+  image,
+  signals,
+}: {
+  readonly image: ZeroMailInlineImage;
+  readonly signals: MailDraftSignals;
+}) {
+  const imageLoadable = useLoadable(signals.attachmentImageUrl(image.partId));
+  if (imageLoadable.state === "loading") {
+    return (
+      <span
+        aria-label={`Loading ${image.alt}`}
+        className="my-2 inline-block aspect-video w-full rounded-lg bg-muted/50 align-middle animate-pulse"
+      />
+    );
+  }
+  if (imageLoadable.state === "hasError" || imageLoadable.data === null) {
+    return (
+      <span className="text-sm text-muted-foreground">
+        [Image unavailable: {image.alt}]
+      </span>
+    );
+  }
+  return (
+    <img
+      src={imageLoadable.data}
+      alt={image.alt}
+      className="max-h-80 max-w-full rounded-lg object-contain"
+    />
+  );
+}
+
+const BLOCKED_MAIL_HTML_ELEMENTS = [
+  "audio",
+  "button",
+  "canvas",
+  "embed",
+  "form",
+  "head",
+  "iframe",
+  "input",
+  "link",
+  "math",
+  "meta",
+  "object",
+  "option",
+  "script",
+  "select",
+  "source",
+  "style",
+  "svg",
+  "textarea",
+  "title",
+  "video",
+] as const;
+
+function blockedMailHtmlElement(value: string): boolean {
+  return BLOCKED_MAIL_HTML_ELEMENTS.some((candidate) => {
+    return candidate === value;
+  });
+}
+
+const ALLOWED_MAIL_HTML_ELEMENTS = [
+  "a",
+  "abbr",
+  "b",
+  "blockquote",
+  "br",
+  "center",
+  "code",
+  "del",
+  "div",
+  "em",
+  "font",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "i",
+  "ins",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "s",
+  "small",
+  "span",
+  "strike",
+  "strong",
+  "sub",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+  "u",
+  "ul",
+] as const;
+
+type AllowedMailHtmlElement = (typeof ALLOWED_MAIL_HTML_ELEMENTS)[number];
+
+function allowedMailHtmlElement(value: string): AllowedMailHtmlElement | null {
+  return (
+    ALLOWED_MAIL_HTML_ELEMENTS.find((candidate) => {
+      return candidate === value;
+    }) ?? null
+  );
+}
+
+function normalizedContentId(value: string): string {
+  return value
+    .trim()
+    .replace(/^cid:/iu, "")
+    .replace(/^<|>$/gu, "")
+    .toLowerCase();
+}
+
+function safeMailHref(value: string | null): string | undefined {
+  if (!value || !URL.canParse(value)) {
+    return undefined;
+  }
+  const protocol = new URL(value).protocol;
+  return ["http:", "https:", "mailto:", "tel:"].includes(protocol)
+    ? value
+    : undefined;
+}
+
+function supportedFontSize(value: string): string | undefined {
+  const keywordSizes = new Set([
+    "xx-small",
+    "x-small",
+    "small",
+    "medium",
+    "large",
+    "x-large",
+    "xx-large",
+    "smaller",
+    "larger",
+  ]);
+  if (keywordSizes.has(value)) {
+    return value;
+  }
+  const match = value.match(/^(\d+(?:\.\d+)?)(px|pt|em|rem|%)$/u);
+  if (!match?.[1] || !match[2]) {
+    return undefined;
+  }
+  const size = Number.parseFloat(match[1]);
+  const limits: Readonly<Record<string, number>> = {
+    px: 72,
+    pt: 54,
+    em: 4,
+    rem: 4,
+    "%": 400,
+  };
+  return size > 0 && size <= (limits[match[2]] ?? 0) ? value : undefined;
+}
+
+const MAIL_FONT_WEIGHTS: Readonly<Record<string, CSSProperties["fontWeight"]>> =
+  {
+    normal: "normal",
+    bold: "bold",
+    bolder: "bolder",
+    lighter: "lighter",
+  };
+const MAIL_FONT_STYLES: Readonly<Record<string, CSSProperties["fontStyle"]>> = {
+  normal: "normal",
+  italic: "italic",
+  oblique: "oblique",
+};
+const MAIL_TEXT_ALIGNMENTS: Readonly<
+  Record<string, CSSProperties["textAlign"]>
+> = {
+  left: "left",
+  right: "right",
+  center: "center",
+  justify: "justify",
+};
+const MAIL_TEXT_DIRECTIONS: Readonly<
+  Record<string, CSSProperties["direction"]>
+> = {
+  ltr: "ltr",
+  rtl: "rtl",
+};
+const MAIL_LEGACY_FONT_SIZES: Readonly<Record<string, string>> = {
+  "1": "0.625rem",
+  "2": "0.8125rem",
+  "3": "1rem",
+  "4": "1.125rem",
+  "5": "1.5rem",
+  "6": "2rem",
+  "7": "3rem",
+};
+
+function mailTypographyStyle(source: CSSStyleDeclaration): CSSProperties {
+  const style: CSSProperties = {};
+  const fontWeight = MAIL_FONT_WEIGHTS[source.fontWeight];
+  if (fontWeight) {
+    style.fontWeight = fontWeight;
+  } else if (/^[1-9]00$/u.test(source.fontWeight)) {
+    style.fontWeight = Number.parseInt(source.fontWeight, 10);
+  }
+  const fontStyle = MAIL_FONT_STYLES[source.fontStyle];
+  if (fontStyle) {
+    style.fontStyle = fontStyle;
+  }
+  if (
+    /^(?:none|underline|line-through|underline line-through|line-through underline)$/u.test(
+      source.textDecorationLine,
+    )
+  ) {
+    style.textDecorationLine = source.textDecorationLine;
+  }
+  const fontSize = supportedFontSize(source.fontSize);
+  if (fontSize) {
+    style.fontSize = fontSize;
+  }
+  return style;
+}
+
+function mailColorStyle(element: HTMLElement): CSSProperties {
+  const style: CSSProperties = {};
+  const source = element.style;
+  if (source.color && source.color.length <= 100) {
+    style.color = source.color;
+  }
+  if (source.backgroundColor && source.backgroundColor.length <= 100) {
+    style.backgroundColor = source.backgroundColor;
+  }
+  const legacyColor = element.getAttribute("color");
+  if (!style.color && legacyColor && legacyColor.length <= 100) {
+    style.color = legacyColor;
+  }
+  return style;
+}
+
+function mailLayoutStyle(element: HTMLElement): CSSProperties {
+  const source = element.style;
+  const textAlign = MAIL_TEXT_ALIGNMENTS[source.textAlign];
+  const direction = MAIL_TEXT_DIRECTIONS[source.direction];
+  return {
+    ...(textAlign ? { textAlign } : {}),
+    ...(direction ? { direction } : {}),
+    ...(element.tagName.toLowerCase() === "center"
+      ? { textAlign: "center" }
+      : {}),
+  };
+}
+
+function mailLegacyFontStyle(element: HTMLElement): CSSProperties {
+  const legacySize = element.getAttribute("size");
+  const fontSize = legacySize ? MAIL_LEGACY_FONT_SIZES[legacySize] : undefined;
+  return fontSize ? { fontSize } : {};
+}
+
+function mailRichTextStyle(element: HTMLElement): CSSProperties | undefined {
+  const style: CSSProperties = {
+    ...mailLegacyFontStyle(element),
+    ...mailTypographyStyle(element.style),
+    ...mailColorStyle(element),
+    ...mailLayoutStyle(element),
+  };
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+interface MailHtmlElementProps {
+  readonly className?: string;
+  readonly colSpan?: number;
+  readonly href?: string;
+  readonly rel?: string;
+  readonly rowSpan?: number;
+  readonly start?: number;
+  readonly style?: CSSProperties;
+  readonly target?: string;
+  readonly title?: string;
+}
+
+function positiveIntegerAttribute(
+  element: Element,
+  name: string,
+): number | undefined {
+  const parsed = Number.parseInt(element.getAttribute(name) ?? "", 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function isElementNode(node: ChildNode): node is Element {
+  return node.nodeType === 1;
+}
+
+function renderInlineMailImage(args: {
+  readonly element: Element;
+  readonly key: string;
+  readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
+  readonly signals: MailDraftSignals;
+}): ReactNode {
+  const source = args.element.getAttribute("src");
+  const image = source?.toLowerCase().startsWith("cid:")
+    ? args.inlineImages.get(normalizedContentId(source))
+    : undefined;
+  return image ? (
+    <MailDraftInlineImage key={args.key} image={image} signals={args.signals} />
+  ) : null;
+}
+
+function mailHtmlElementProps(args: {
+  readonly element: Element;
+  readonly tag: AllowedMailHtmlElement;
+  readonly href?: string;
+}): MailHtmlElementProps {
+  const title = args.element.getAttribute("title") ?? undefined;
+  return {
+    ...(args.element instanceof HTMLElement
+      ? { style: mailRichTextStyle(args.element) }
+      : {}),
+    ...(args.href
+      ? {
+          href: args.href,
+          target: "_blank",
+          rel: "noreferrer",
+        }
+      : {}),
+    ...(title ? { title } : {}),
+    ...(args.tag === "td" || args.tag === "th"
+      ? {
+          colSpan: positiveIntegerAttribute(args.element, "colspan"),
+          rowSpan: positiveIntegerAttribute(args.element, "rowspan"),
+        }
+      : {}),
+    ...(args.tag === "ol"
+      ? { start: positiveIntegerAttribute(args.element, "start") }
+      : {}),
+    ...(!args.href && args.tag === "a" ? { className: "contents" } : {}),
+  };
+}
+
+function renderAllowedMailElement(args: {
+  readonly tag: AllowedMailHtmlElement;
+  readonly key: string;
+  readonly href?: string;
+  readonly props: MailHtmlElementProps;
+  readonly children: readonly ReactNode[];
+}): ReactNode {
+  if (args.tag === "br") {
+    return <br key={args.key} {...args.props} />;
+  }
+  if (args.tag === "hr") {
+    return <hr key={args.key} {...args.props} />;
+  }
+  if (args.tag === "a" && !args.href) {
+    return (
+      <span key={args.key} {...args.props}>
+        {args.children}
+      </span>
+    );
+  }
+  const MailElement =
+    args.tag === "font"
+      ? "span"
+      : args.tag === "center"
+        ? "div"
+        : args.tag === "strike"
+          ? "s"
+          : args.tag;
+  return (
+    <MailElement key={args.key} {...args.props}>
+      {args.children}
+    </MailElement>
+  );
+}
+
+function renderMailHtmlNode(args: {
+  readonly node: ChildNode;
+  readonly key: string;
+  readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
+  readonly signals: MailDraftSignals;
+}): ReactNode {
+  if (args.node.nodeType === 3) {
+    return args.node.textContent;
+  }
+  if (!isElementNode(args.node)) {
+    return null;
+  }
+  const element = args.node;
+  const tag = element.tagName.toLowerCase();
+  if (blockedMailHtmlElement(tag)) {
+    return null;
+  }
+  if (tag === "img") {
+    return renderInlineMailImage({
+      element,
+      key: args.key,
+      inlineImages: args.inlineImages,
+      signals: args.signals,
+    });
+  }
+  const children = Array.from(element.childNodes).map((child, index) => {
+    return renderMailHtmlNode({
+      node: child,
+      key: `${args.key}-${index}`,
+      inlineImages: args.inlineImages,
+      signals: args.signals,
+    });
+  });
+  const allowedTag = allowedMailHtmlElement(tag);
+  if (!allowedTag) {
+    return children;
+  }
+
+  const href =
+    allowedTag === "a" ? safeMailHref(element.getAttribute("href")) : undefined;
+  return renderAllowedMailElement({
+    tag: allowedTag,
+    key: args.key,
+    href,
+    props: mailHtmlElementProps({
+      element,
+      tag: allowedTag,
+      href,
+    }),
+    children,
+  });
+}
+
+function MailDraftRichMessage({
+  draft,
+  signals,
+}: {
+  readonly draft: ZeroMailDraft;
+  readonly signals: MailDraftSignals;
+}) {
+  if (!draft.bodyHtml || typeof DOMParser === "undefined") {
+    return null;
+  }
+  const document = new DOMParser().parseFromString(draft.bodyHtml, "text/html");
+  const inlineImages = new Map(
+    (draft.inlineImages ?? []).map((image) => {
+      return [normalizedContentId(image.contentId), image] as const;
+    }),
+  );
+  return (
+    <div
+      data-feedback-source
+      className="break-words text-sm leading-6 text-foreground [&_a]:text-primary [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:font-semibold [&_hr]:my-3 [&_li]:ml-5 [&_ol]:list-decimal [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_table]:my-2 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_ul]:list-disc"
+    >
+      {Array.from(document.body.childNodes).map((node, index) => {
+        return renderMailHtmlNode({
+          node,
+          key: `mail-html-${index}`,
+          inlineImages,
+          signals,
+        });
+      })}
+    </div>
+  );
+}
+
+function MailDraftMessage({
+  draft,
+  signals,
+}: {
+  readonly draft: ZeroMailDraft;
+  readonly signals: MailDraftSignals;
+}) {
+  if (draft.bodyHtml && typeof DOMParser !== "undefined") {
+    return <MailDraftRichMessage draft={draft} signals={signals} />;
+  }
+  return (
+    <div
+      data-feedback-source
+      className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground"
+    >
+      {draft.body || "(No message)"}
+    </div>
+  );
+}
+
+function MailDraftDetails({
+  draft,
+  signals,
+}: {
+  readonly draft: ZeroMailDraft;
+  readonly signals: MailDraftSignals;
+}) {
   const attachments = draft.version === 3 ? draft.attachments : [];
   return (
     <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4">
@@ -107,9 +664,7 @@ function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
       <DetailField label="Subject" value={draft.subject || "(No subject)"} />
       <div className="grid gap-1.5">
         <div className="text-xs font-medium text-muted-foreground">Message</div>
-        <div className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground">
-          {draft.body || "(No message)"}
-        </div>
+        <MailDraftMessage draft={draft} signals={signals} />
       </div>
       {attachments.length > 0 ? (
         <div className="grid gap-2">
@@ -118,24 +673,8 @@ function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
           </div>
           <div className="grid gap-2">
             {attachments.map((attachment) => {
-              return (
-                <div
-                  key={`${attachment.filename}-${attachment.contentType}-${attachment.size}`}
-                  className="flex items-center gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 py-2.5"
-                >
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
-                    <IconPaperclip size={15} />
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-foreground">
-                      {attachment.filename}
-                    </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {formatAttachmentSize(attachment.size)}
-                    </span>
-                  </span>
-                </div>
-              );
+              const key = `${attachment.filename}-${attachment.contentType}-${attachment.size}`;
+              return <AttachmentSummary key={key} attachment={attachment} />;
             })}
           </div>
         </div>
@@ -174,6 +713,7 @@ function MailDraftDetail({
   return (
     <aside
       aria-label="Email details"
+      data-chat-thread-container-id={signals.threadId}
       data-testid="mail-draft-sidebar"
       className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0 animate-in fade-in slide-in-from-right-2 duration-[180ms] ease"
     >
@@ -185,10 +725,15 @@ function MailDraftDetail({
           <div className="truncate text-xs text-muted-foreground">
             {active ? "Gmail draft" : "Sent email"}
           </div>
+          {active ? (
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              You can ask your agent to continue editing this draft.
+            </div>
+          ) : null}
         </div>
         <SidebarCloseButton close={close} />
       </div>
-      <MailDraftDetails draft={draft} />
+      <MailDraftDetails draft={draft} signals={signals} />
       <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-border/60 px-4 py-3">
         {active ? (
           <Button
@@ -242,17 +787,10 @@ function MailDraftDetail({
 }
 
 export function MailDraftSidebar({ signals }: MailDraftSidebarProps) {
-  const draftLoadable = useLoadable(signals.draft$);
+  const draftLoadable = useLoadable(signals.sidebarDraft$);
   const close = useSet(closeMailDraftSidebar$);
   if (draftLoadable.state === "loading") {
-    return (
-      <aside
-        aria-label="Email details"
-        className="flex h-full w-full items-center justify-center border-l border-border/60 bg-background xl:border-l-0"
-      >
-        <IconLoader2 className="animate-spin text-muted-foreground" size={18} />
-      </aside>
-    );
+    return <MailDraftSidebarSkeleton close={close} />;
   }
   if (draftLoadable.state === "hasError" || draftLoadable.data === null) {
     return (

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -604,6 +604,8 @@ function MailDraftRichMessage({
   return (
     <div
       data-feedback-source
+      data-feedback-source-type="mail"
+      data-feedback-source-id={signals.mailDraftId}
       className="break-words text-sm leading-6 text-foreground [&_a]:text-primary [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:font-semibold [&_hr]:my-3 [&_li]:ml-5 [&_ol]:list-decimal [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_table]:my-2 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_ul]:list-disc"
     >
       {Array.from(document.body.childNodes).map((node, index) => {
@@ -631,6 +633,8 @@ function MailDraftMessage({
   return (
     <div
       data-feedback-source
+      data-feedback-source-type="mail"
+      data-feedback-source-id={signals.mailDraftId}
       className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground"
     >
       {draft.body || "(No message)"}

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -847,6 +847,7 @@ function MailDraftDetails({
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
+  const setAttachmentScopeRef = useSet(signals.setAttachmentScopeRef$);
   const attachmentUrlsLoadable = useLoadable(signals.attachmentUrls$);
   const attachmentUrls =
     attachmentUrlsLoadable.state === "hasData"
@@ -855,7 +856,10 @@ function MailDraftDetails({
   const attachmentUrlsLoading = attachmentUrlsLoadable.state === "loading";
   const attachments = draft.version === 3 ? draft.attachments : [];
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+    <div
+      ref={setAttachmentScopeRef}
+      className="min-h-0 flex-1 overflow-y-auto px-5 py-5"
+    >
       <MailMessageHeader close={close} draft={draft} />
       <div className="py-5">
         <MailDraftMessage

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -459,6 +459,13 @@ function safeMailHref(value: string | null): string | undefined {
     : undefined;
 }
 
+function safeMailImageSrc(value: string | null): string | undefined {
+  if (!value || !URL.canParse(value)) {
+    return undefined;
+  }
+  return new URL(value).protocol === "https:" ? value : undefined;
+}
+
 function supportedFontSize(value: string): string | undefined {
   const keywordSizes = new Set([
     "xx-small",
@@ -620,7 +627,7 @@ function isElementNode(node: ChildNode): node is Element {
   return node.nodeType === 1;
 }
 
-function renderInlineMailImage(args: {
+function renderMailImage(args: {
   readonly element: Element;
   readonly key: string;
   readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
@@ -631,12 +638,32 @@ function renderInlineMailImage(args: {
   const image = source?.toLowerCase().startsWith("cid:")
     ? args.inlineImages.get(normalizedContentId(source))
     : undefined;
-  const imageUrl = args.inlineImageUrlsLoading
-    ? undefined
-    : (args.inlineImageUrls?.get(image?.partId ?? "") ?? null);
-  return image ? (
-    <MailDraftInlineImage key={args.key} image={image} imageUrl={imageUrl} />
-  ) : null;
+  if (image) {
+    const imageUrl = args.inlineImageUrlsLoading
+      ? undefined
+      : (args.inlineImageUrls?.get(image.partId) ?? null);
+    return (
+      <MailDraftInlineImage key={args.key} image={image} imageUrl={imageUrl} />
+    );
+  }
+  const remoteSource = safeMailImageSrc(source);
+  if (!remoteSource) {
+    return null;
+  }
+  return (
+    <img
+      key={args.key}
+      src={remoteSource}
+      alt={args.element.getAttribute("alt") ?? ""}
+      title={args.element.getAttribute("title") ?? undefined}
+      width={positiveIntegerAttribute(args.element, "width")}
+      height={positiveIntegerAttribute(args.element, "height")}
+      loading="lazy"
+      decoding="async"
+      referrerPolicy="no-referrer"
+      className="my-2 inline-block max-h-80 max-w-full object-contain align-middle"
+    />
+  );
 }
 
 function mailHtmlElementProps(args: {
@@ -724,7 +751,7 @@ function renderMailHtmlNode(args: {
     return null;
   }
   if (tag === "img") {
-    return renderInlineMailImage({
+    return renderMailImage({
       element,
       key: args.key,
       inlineImages: args.inlineImages,

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -206,21 +206,14 @@ function AttachmentSummary({
 
 function MailAttachmentPreview({
   attachment,
-  partId,
-  signals,
+  url,
 }: {
   readonly attachment: ZeroMailAttachment;
-  readonly partId: string;
-  readonly signals: MailDraftSignals;
+  readonly url: string | null | undefined;
 }) {
-  const attachmentLoadable = useLoadable(signals.attachmentUrl(partId));
-  if (
-    attachmentLoadable.state !== "hasData" ||
-    attachmentLoadable.data === null
-  ) {
+  if (!url) {
     return <AttachmentSummary attachment={attachment} />;
   }
-  const url = attachmentLoadable.data;
   const kind = classifyChatAttachment({
     filename: attachment.filename,
     contentType: attachment.contentType,
@@ -240,8 +233,7 @@ function MailAttachmentPreview({
     kind === "text" ||
     kind === "json" ||
     kind === "csv" ||
-    kind === "pdf" ||
-    kind === "html"
+    kind === "pdf"
   ) {
     preview = (
       <PreviewableFileAttachmentChip
@@ -337,13 +329,12 @@ function MailMediaAttachmentPreview({
 
 function MailDraftInlineImage({
   image,
-  signals,
+  imageUrl,
 }: {
   readonly image: ZeroMailInlineImage;
-  readonly signals: MailDraftSignals;
+  readonly imageUrl: string | null | undefined;
 }) {
-  const imageLoadable = useLoadable(signals.attachmentUrl(image.partId));
-  if (imageLoadable.state === "loading") {
+  if (imageUrl === undefined) {
     return (
       <span
         aria-label={`Loading ${image.alt}`}
@@ -351,7 +342,7 @@ function MailDraftInlineImage({
       />
     );
   }
-  if (imageLoadable.state === "hasError" || imageLoadable.data === null) {
+  if (imageUrl === null) {
     return (
       <span className="text-sm text-muted-foreground">
         [Image unavailable: {image.alt}]
@@ -360,7 +351,7 @@ function MailDraftInlineImage({
   }
   return (
     <img
-      src={imageLoadable.data}
+      src={imageUrl}
       alt={image.alt}
       className="max-h-80 max-w-full rounded-lg object-contain"
     />
@@ -633,14 +624,18 @@ function renderInlineMailImage(args: {
   readonly element: Element;
   readonly key: string;
   readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
-  readonly signals: MailDraftSignals;
+  readonly inlineImageUrls: ReadonlyMap<string, string | null> | null;
+  readonly inlineImageUrlsLoading: boolean;
 }): ReactNode {
   const source = args.element.getAttribute("src");
   const image = source?.toLowerCase().startsWith("cid:")
     ? args.inlineImages.get(normalizedContentId(source))
     : undefined;
+  const imageUrl = args.inlineImageUrlsLoading
+    ? undefined
+    : (args.inlineImageUrls?.get(image?.partId ?? "") ?? null);
   return image ? (
-    <MailDraftInlineImage key={args.key} image={image} signals={args.signals} />
+    <MailDraftInlineImage key={args.key} image={image} imageUrl={imageUrl} />
   ) : null;
 }
 
@@ -714,7 +709,8 @@ function renderMailHtmlNode(args: {
   readonly node: ChildNode;
   readonly key: string;
   readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
-  readonly signals: MailDraftSignals;
+  readonly inlineImageUrls: ReadonlyMap<string, string | null> | null;
+  readonly inlineImageUrlsLoading: boolean;
 }): ReactNode {
   if (args.node.nodeType === 3) {
     return args.node.textContent;
@@ -732,7 +728,8 @@ function renderMailHtmlNode(args: {
       element,
       key: args.key,
       inlineImages: args.inlineImages,
-      signals: args.signals,
+      inlineImageUrls: args.inlineImageUrls,
+      inlineImageUrlsLoading: args.inlineImageUrlsLoading,
     });
   }
   const children = Array.from(element.childNodes).map((child, index) => {
@@ -740,7 +737,8 @@ function renderMailHtmlNode(args: {
       node: child,
       key: `${args.key}-${index}`,
       inlineImages: args.inlineImages,
-      signals: args.signals,
+      inlineImageUrls: args.inlineImageUrls,
+      inlineImageUrlsLoading: args.inlineImageUrlsLoading,
     });
   });
   const allowedTag = allowedMailHtmlElement(tag);
@@ -764,9 +762,13 @@ function renderMailHtmlNode(args: {
 }
 
 function MailDraftRichMessage({
+  attachmentUrls,
+  attachmentUrlsLoading,
   draft,
   signals,
 }: {
+  readonly attachmentUrls: ReadonlyMap<string, string | null> | null;
+  readonly attachmentUrlsLoading: boolean;
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
@@ -793,7 +795,8 @@ function MailDraftRichMessage({
           node,
           key: `mail-html-${index}`,
           inlineImages,
-          signals,
+          inlineImageUrls: attachmentUrls,
+          inlineImageUrlsLoading: attachmentUrlsLoading,
         });
       })}
     </div>
@@ -801,14 +804,25 @@ function MailDraftRichMessage({
 }
 
 function MailDraftMessage({
+  attachmentUrls,
+  attachmentUrlsLoading,
   draft,
   signals,
 }: {
+  readonly attachmentUrls: ReadonlyMap<string, string | null> | null;
+  readonly attachmentUrlsLoading: boolean;
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
   if (draft.bodyHtml && typeof DOMParser !== "undefined") {
-    return <MailDraftRichMessage draft={draft} signals={signals} />;
+    return (
+      <MailDraftRichMessage
+        attachmentUrls={attachmentUrls}
+        attachmentUrlsLoading={attachmentUrlsLoading}
+        draft={draft}
+        signals={signals}
+      />
+    );
   }
   return (
     <div
@@ -833,12 +847,23 @@ function MailDraftDetails({
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
+  const attachmentUrlsLoadable = useLoadable(signals.attachmentUrls$);
+  const attachmentUrls =
+    attachmentUrlsLoadable.state === "hasData"
+      ? attachmentUrlsLoadable.data
+      : null;
+  const attachmentUrlsLoading = attachmentUrlsLoadable.state === "loading";
   const attachments = draft.version === 3 ? draft.attachments : [];
   return (
     <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
       <MailMessageHeader close={close} draft={draft} />
       <div className="py-5">
-        <MailDraftMessage draft={draft} signals={signals} />
+        <MailDraftMessage
+          attachmentUrls={attachmentUrls}
+          attachmentUrlsLoading={attachmentUrlsLoading}
+          draft={draft}
+          signals={signals}
+        />
       </div>
       {attachments.length > 0 ? (
         <div className="grid gap-2.5 border-t border-border/60 pt-4">
@@ -852,8 +877,11 @@ function MailDraftDetails({
                 <MailAttachmentPreview
                   key={key}
                   attachment={attachment}
-                  partId={attachment.partId}
-                  signals={signals}
+                  url={
+                    attachmentUrlsLoading
+                      ? undefined
+                      : (attachmentUrls?.get(attachment.partId) ?? null)
+                  }
                 />
               ) : (
                 <AttachmentSummary key={key} attachment={attachment} />

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -34,6 +34,7 @@ import {
   PreviewableAudioAttachmentChip,
   PreviewableFileAttachmentChip,
 } from "./zero-attachment-chips.tsx";
+import { useGmailReconnect } from "./use-gmail-reconnect.ts";
 
 interface MailDraftSidebarProps {
   readonly signals: MailDraftSignals;
@@ -91,9 +92,11 @@ function MailDraftSidebarSkeleton({ close }: { readonly close: () => void }) {
 }
 
 function UnavailableMailDraftSidebar({
+  action,
   close,
   message,
 }: {
+  readonly action?: ReactNode;
   readonly close: () => void;
   readonly message: string;
 }) {
@@ -106,10 +109,28 @@ function UnavailableMailDraftSidebar({
         <span className="min-w-0 flex-1 text-sm font-medium">Email</span>
         <SidebarCloseButton close={close} />
       </div>
-      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-        {message}
+      <div className="flex flex-1 items-center justify-center px-6 text-center">
+        <div className="grid max-w-sm justify-items-center gap-4">
+          <p className="text-sm text-muted-foreground">{message}</p>
+          {action}
+        </div>
       </div>
     </aside>
+  );
+}
+
+function GmailReconnectButton() {
+  const { reconnect, reconnectDisabled, reconnecting } = useGmailReconnect();
+  return (
+    <Button
+      type="button"
+      size="sm"
+      disabled={reconnectDisabled}
+      onClick={reconnect}
+    >
+      {reconnecting ? <IconLoader2 size={15} className="animate-spin" /> : null}
+      {reconnecting ? "Reconnecting…" : "Reconnect Gmail"}
+    </Button>
   );
 }
 
@@ -1023,6 +1044,15 @@ export function MailDraftSidebar({ signals }: MailDraftSidebarProps) {
       <UnavailableMailDraftSidebar
         close={close}
         message="This email is no longer available."
+      />
+    );
+  }
+  if (draftLoadable.data.accessStatus === "reconnect") {
+    return (
+      <UnavailableMailDraftSidebar
+        close={close}
+        message="You no longer have permission to access this email. Reconnect Gmail to continue."
+        action={<GmailReconnectButton />}
       />
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -729,11 +729,6 @@ function MailDraftDetail({
           <div className="truncate text-xs text-muted-foreground">
             {active ? "Gmail draft" : "Sent email"}
           </div>
-          {active ? (
-            <div className="mt-0.5 text-xs text-muted-foreground">
-              You can ask your agent to continue editing this draft.
-            </div>
-          ) : null}
         </div>
         <SidebarCloseButton close={close} />
       </div>

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -606,6 +606,8 @@ function MailDraftRichMessage({
       data-feedback-source
       data-feedback-source-type="mail"
       data-feedback-source-id={signals.mailDraftId}
+      data-feedback-source-status={draft.status === "draft" ? "draft" : "sent"}
+      data-feedback-source-sent-id={draft.sentGmailMessageId}
       className="break-words text-sm leading-6 text-foreground [&_a]:text-primary [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:font-semibold [&_hr]:my-3 [&_li]:ml-5 [&_ol]:list-decimal [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_table]:my-2 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_ul]:list-disc"
     >
       {Array.from(document.body.childNodes).map((node, index) => {
@@ -635,6 +637,8 @@ function MailDraftMessage({
       data-feedback-source
       data-feedback-source-type="mail"
       data-feedback-source-id={signals.mailDraftId}
+      data-feedback-source-status={draft.status === "draft" ? "draft" : "sent"}
+      data-feedback-source-sent-id={draft.sentGmailMessageId}
       className="whitespace-pre-wrap break-words text-sm leading-6 text-foreground"
     >
       {draft.body || "(No message)"}

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-mail";
 import { Button } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { CSSProperties, ReactNode } from "react";
 
@@ -1034,7 +1034,7 @@ function MailDraftDetail({
 }
 
 export function MailDraftSidebar({ signals }: MailDraftSidebarProps) {
-  const draftLoadable = useLoadable(signals.sidebarDraft$);
+  const draftLoadable = useLastLoadable(signals.sidebarDraft$);
   const close = useSet(closeMailDraftSidebar$);
   if (draftLoadable.state === "loading") {
     return <MailDraftSidebarSkeleton close={close} />;

--- a/turbo/apps/platform/src/views/zero-page/use-gmail-reconnect.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-gmail-reconnect.ts
@@ -1,0 +1,47 @@
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  connectConnectorOAuthAuthCode$,
+  connectFlowConnectorRef$,
+  getOnlyAvailableStatusBrowserAuthMethodDetail,
+} from "../../signals/zero-page/settings/connectors.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function useGmailReconnect() {
+  const catalogByRef = useLastResolved(connectorCatalogStatusByRef$);
+  const connectFlowConnectorRef = useGet(connectFlowConnectorRef$);
+  const connect = useSet(connectConnectorOAuthAuthCode$);
+  const signal = useGet(pageSignal$);
+  const connector = catalogByRef?.get("gmail");
+  const authMethod = connector
+    ? getOnlyAvailableStatusBrowserAuthMethodDetail(connector)
+    : null;
+  const reconnecting = connectFlowConnectorRef === "gmail";
+
+  return {
+    connectorIcon: connector?.icon,
+    reconnecting,
+    reconnectDisabled:
+      !connector || !authMethod || connectFlowConnectorRef !== null,
+    reconnect() {
+      if (!connector || !authMethod || connectFlowConnectorRef !== null) {
+        return;
+      }
+      detach(
+        connect(
+          "gmail",
+          authMethod,
+          {
+            authorizeVisibleAgents: true,
+            connectorLabel: connector.label,
+            connectorIcon: connector.icon,
+          },
+          signal,
+        ),
+        Reason.DomCallback,
+      );
+    },
+  };
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1084,6 +1084,7 @@ function ArtifactPreviewDialogActions({
     preview.kind === "html" &&
     artifact?.artifactKind === "hosted-site" &&
     Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]);
+  const showShare = preview.shareAvailable !== false;
   const showSplitView = preview.splitViewAvailable !== false;
   const resetDialogImageZoom = (targetFullscreen: boolean) => {
     resetArtifactDialogImageZoom({
@@ -1109,7 +1110,13 @@ function ArtifactPreviewDialogActions({
   };
   return (
     <div className="flex shrink-0 items-center gap-1">
-      <ArtifactShareButton ariaLabel="Share" iconSize={18} url={preview.url} />
+      {showShare && (
+        <ArtifactShareButton
+          ariaLabel="Share"
+          iconSize={18}
+          url={preview.url}
+        />
+      )}
       <ArtifactDownloadMenu
         ariaLabel="Download options"
         artifactKind={artifact?.artifactKind}
@@ -1318,12 +1325,16 @@ export function FileAttachmentChip({
 
 export function PreviewableFileAttachmentChip({
   filename,
-  url,
   kind,
+  shareAvailable,
+  splitViewAvailable,
+  url,
 }: {
   filename: string;
-  url: string;
   kind: "markdown" | "text" | "json" | "csv" | "pdf" | "html";
+  shareAvailable?: boolean;
+  splitViewAvailable?: boolean;
+  url: string;
 }) {
   const openDocumentLightbox = useSet(openDocumentLightbox$);
 
@@ -1331,7 +1342,13 @@ export function PreviewableFileAttachmentChip({
     <button
       type="button"
       onClick={() => {
-        openDocumentLightbox({ kind, url, filename });
+        openDocumentLightbox({
+          kind,
+          url,
+          filename,
+          ...(shareAvailable === undefined ? {} : { shareAvailable }),
+          ...(splitViewAvailable === undefined ? {} : { splitViewAvailable }),
+        });
       }}
       title={filename}
       aria-label={`Open ${kind} preview for ${filename}`}
@@ -1349,10 +1366,14 @@ export function PreviewableFileAttachmentChip({
 export function PreviewableAudioAttachmentChip({
   contentType,
   filename,
+  shareAvailable,
+  splitViewAvailable,
   url,
 }: {
   contentType?: string;
   filename: string;
+  shareAvailable?: boolean;
+  splitViewAvailable?: boolean;
   url: string;
 }) {
   const openAudioLightbox = useSet(openAudioLightbox$);
@@ -1361,7 +1382,12 @@ export function PreviewableAudioAttachmentChip({
     <button
       type="button"
       onClick={() => {
-        openAudioLightbox({ url, filename });
+        openAudioLightbox({
+          url,
+          filename,
+          ...(shareAvailable === undefined ? {} : { shareAvailable }),
+          ...(splitViewAvailable === undefined ? {} : { splitViewAvailable }),
+        });
       }}
       title={filename}
       aria-label={`Open audio preview for ${filename}`}

--- a/turbo/packages/api-contracts/src/contracts/zero-mail.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mail.ts
@@ -33,6 +33,7 @@ const zeroMailDraftBaseSchema = z.object({
   body: z.string(),
   bodyHtml: z.string().optional(),
   inlineImages: z.array(zeroMailInlineImageSchema).optional(),
+  accessStatus: z.enum(["ready", "reconnect"]).optional(),
   replyTo: z.string().optional(),
   inReplyTo: z.string().optional(),
   references: z.array(z.string()),

--- a/turbo/packages/api-contracts/src/contracts/zero-mail.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mail.ts
@@ -13,6 +13,13 @@ export const zeroMailAttachmentSchema = z.object({
   filename: z.string(),
   contentType: z.string(),
   size: z.number().int().nonnegative(),
+  partId: z.string().optional(),
+});
+
+export const zeroMailInlineImageSchema = z.object({
+  contentId: z.string().min(1),
+  partId: z.string().min(1),
+  alt: z.string(),
 });
 
 const zeroMailDraftBaseSchema = z.object({
@@ -24,6 +31,8 @@ const zeroMailDraftBaseSchema = z.object({
   bcc: z.array(z.email()),
   subject: z.string(),
   body: z.string(),
+  bodyHtml: z.string().optional(),
+  inlineImages: z.array(zeroMailInlineImageSchema).optional(),
   replyTo: z.string().optional(),
   inReplyTo: z.string().optional(),
   references: z.array(z.string()),
@@ -58,6 +67,11 @@ const zeroMailDraftPathParamsSchema = z.object({
   mailDraftId: z.string().uuid(),
 });
 
+const zeroMailDraftAttachmentPathParamsSchema =
+  zeroMailDraftPathParamsSchema.extend({
+    partId: z.string().min(1),
+  });
+
 export const zeroMailContract = c.router({
   linkDraft: {
     method: "POST",
@@ -90,6 +104,23 @@ export const zeroMailContract = c.router({
       409: apiErrorSchema,
     },
     summary: "Get an email draft by ID",
+  },
+  getAttachment: {
+    method: "GET",
+    path: "/api/zero/mail/drafts/:mailDraftId/attachments/:partId",
+    headers: authHeadersSchema,
+    pathParams: zeroMailDraftAttachmentPathParamsSchema,
+    responses: {
+      200: c.otherResponse({
+        contentType: "application/octet-stream",
+        body: c.type<Blob>(),
+      }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Get a Gmail draft attachment",
   },
   deleteDraft: {
     method: "DELETE",
@@ -127,5 +158,6 @@ export const zeroMailContract = c.router({
 export type ZeroMailProvider = z.infer<typeof zeroMailProviderSchema>;
 export type ZeroMailDraftStatus = z.infer<typeof zeroMailDraftStatusSchema>;
 export type ZeroMailAttachment = z.infer<typeof zeroMailAttachmentSchema>;
+export type ZeroMailInlineImage = z.infer<typeof zeroMailInlineImageSchema>;
 export type ZeroMailDraft = z.infer<typeof zeroMailDraftSchema>;
 export type ZeroMailContract = typeof zeroMailContract;


### PR DESCRIPTION
## Summary

- render Gmail draft HTML with a safe element and style allowlist
- load CID inline images through an authenticated attachment endpoint and exclude them from the attachment list
- support Copy and Provide feedback for text selected inside email bodies
- restore and refresh the mail draft sidebar independently from chat message cards

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-mail.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx --silent=passed-only`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/api-contracts --workspace api --workspace @vm0/app`