### PR TITLE
fix(platform): highlight only standalone workflow tokens

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -937,9 +937,11 @@ function buildWorkflowDecorations(
       return;
     }
     for (const match of text.matchAll(pattern)) {
-      const start = pos + (match.index ?? 0);
+      const matchStart = pos + (match.index ?? 0);
+      const workflowStart = match[0].lastIndexOf("/");
+      const start = matchStart + workflowStart;
       decorations.push(
-        Decoration.inline(start, start + match[0].length, {
+        Decoration.inline(start, matchStart + match[0].length, {
           class: WORKFLOW_HIGHLIGHT_CLASS,
         }),
       );

--- a/turbo/apps/platform/src/signals/zero-page/workflow-composer-domain.ts
+++ b/turbo/apps/platform/src/signals/zero-page/workflow-composer-domain.ts
@@ -60,7 +60,7 @@ export function workflowTokenPattern(
   const escaped = workflowNames.map((name) => {
     return name.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
   });
-  return new RegExp(`/(?:${escaped.join("|")})(?=$|\\s)`, "g");
+  return new RegExp(`(?:^|\\s)/(?:${escaped.join("|")})(?=$|\\s)`, "g");
 }
 
 export function buildComposerSlashWorkflows({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -282,6 +282,36 @@ describe("chat composer models", () => {
     expect(highlightedWorkflow).toHaveClass("text-primary");
   });
 
+  it("does not highlight workflow names inside URLs", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+      return respond(200, [
+        workflowSummary({
+          name: "pr-review",
+          displayName: "PR Review",
+          description: "Review a pull request",
+          agentId: AGENT_ID,
+        }),
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("https://www.vm0.ai/en/use-cases/pr-review");
+
+    expect(editor).toHaveTextContent(
+      "https://www.vm0.ai/en/use-cases/pr-review",
+    );
+    expect(editor.querySelector("span.text-primary")).not.toBeInTheDocument();
+  });
+
   it("inserts a current-agent chat thread mention chip from @ suggestions", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");


### PR DESCRIPTION
## Summary

- require workflow slash tokens to be bounded by whitespace or the start/end of the composer text before applying the accent color
- keep the leading whitespace outside the inline decoration so only `/workflow` is highlighted
- add a page-level regression test covering a matching workflow name inside a URL path

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --maxWorkers=1 --silent=passed-only` (18 passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec knip --workspace @vm0/app --no-progress`
- Prettier 3.8.1 on all changed files

Fixes #22770
