### PR TITLE
fix(chat): show initial messages before history backfill

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2149,10 +2149,12 @@ function createSyncRemoteMessagesCommand({
     const accumulatedMessages: PagedChatMessage[] = [];
     let sinceId = persistentMessages.at(-1)?.message.id;
     const startedWithoutCursor = sinceId === undefined;
+    let initialPageOldestMessageId: string | undefined;
     let initialHasHistoryBefore: boolean | undefined;
 
     async function syncMessagesAfter(): Promise<void> {
       const requestedSinceId = sinceId;
+      const isInitialPage = requestedSinceId === undefined;
       const result = await set(
         dataSource.listMessagesAfter$,
         { threadId, sinceId: requestedSinceId },
@@ -2165,7 +2167,7 @@ function createSyncRemoteMessagesCommand({
         gotCount: result.messages.length,
       });
 
-      if (requestedSinceId === undefined) {
+      if (isInitialPage) {
         initialHasHistoryBefore = result.hasHistoryBefore;
       }
 
@@ -2173,9 +2175,14 @@ function createSyncRemoteMessagesCommand({
         return;
       }
 
-      accumulatedMessages.push(...result.messages);
       await set(writeIndexedDbChatMessages$, threadId, result.messages, signal);
       signal.throwIfAborted();
+      if (isInitialPage) {
+        initialPageOldestMessageId = result.messages[0]!.id;
+        set(mergePersistentMessages$, result.messages);
+      } else {
+        accumulatedMessages.push(...result.messages);
+      }
       sinceId = result.messages.at(-1)!.id;
 
       return syncMessagesAfter();
@@ -2185,7 +2192,9 @@ function createSyncRemoteMessagesCommand({
 
     if (!get(hasReachedOldestMessage$)) {
       const oldestMessageId =
-        persistentMessages[0]?.message.id ?? accumulatedMessages[0]?.id;
+        persistentMessages[0]?.message.id ??
+        initialPageOldestMessageId ??
+        accumulatedMessages[0]?.id;
       if (
         (startedWithoutCursor && initialHasHistoryBefore === false) ||
         oldestMessageId === undefined

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -44,9 +44,9 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 describe("chat lifecycle", () => {
-  it("publishes initial and older pages together after full history sync", async () => {
+  it("publishes the initial page before batching the remaining history", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000730";
-    const messages = Array.from({ length: 60 }, (_, index) => {
+    const messages = Array.from({ length: 70 }, (_, index) => {
       const itemNumber = index + 1;
       return {
         id: `00000000-0000-4000-8000-${String(itemNumber).padStart(12, "0")}`,
@@ -77,10 +77,16 @@ describe("chat lifecycle", () => {
       async ({ query, respond }) => {
         if (query.beforeId) {
           beforeIds.push(query.beforeId);
-          await beforePageGate.promise;
+          if (query.beforeId === messages[10]!.id) {
+            await beforePageGate.promise;
+            return respond(200, {
+              messages: messages.slice(0, 10),
+              hasHistoryBefore: false,
+            });
+          }
           return respond(200, {
-            messages: messages.slice(0, 10),
-            hasHistoryBefore: false,
+            messages: messages.slice(10, 20),
+            hasHistoryBefore: true,
           });
         }
         if (query.sinceId) {
@@ -91,7 +97,7 @@ describe("chat lifecycle", () => {
         initialPageRequested = true;
         await initialPageGate.promise;
         return respond(200, {
-          messages: messages.slice(10),
+          messages: messages.slice(20),
           hasHistoryBefore: true,
         });
       },
@@ -111,12 +117,13 @@ describe("chat lifecycle", () => {
 
       initialPageGate.resolve();
       await waitFor(() => {
-        expect(beforeIds).toStrictEqual([messages[10]!.id]);
+        expect(beforeIds).toStrictEqual([messages[20]!.id, messages[10]!.id]);
       });
+      expect(screen.getByText("Delayed history reply 70")).toBeInTheDocument();
       expect(
-        screen.queryByText("Delayed history reply 60"),
+        screen.queryByText("Delayed history reply 11"),
       ).not.toBeInTheDocument();
-      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
 
       beforePageGate.resolve();
     } finally {
@@ -149,7 +156,7 @@ describe("chat lifecycle", () => {
         latestMessageId,
       ]);
     });
-    expect(beforeIds).toStrictEqual([messages[10]!.id]);
+    expect(beforeIds).toStrictEqual([messages[20]!.id, messages[10]!.id]);
   });
 
   it("skips the forward sync when the created event watermark is already loaded", async () => {
@@ -220,7 +227,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("automatically loads older chat history before publishing messages", async () => {
+  it("automatically loads older chat history after publishing recent messages", async () => {
     const olderReply = "Earlier launch notes from last week.";
     const beforeHistoryGate = context.mocks.deferred<void>();
     let initialPageReturned = false;
@@ -261,8 +268,8 @@ describe("chat lifecycle", () => {
         expect(initialPageReturned).toBeTruthy();
       });
       expect(
-        screen.queryByText("Current launch risks are ready."),
-      ).not.toBeInTheDocument();
+        screen.getByText("Current launch risks are ready."),
+      ).toBeInTheDocument();
       expect(queryButtonByText("Load history")).toBeNull();
       expect(screen.queryByText(olderReply)).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

- publish the first remote message page after its IndexedDB write when a thread has no local messages
- keep later forward-sync and history-backfill pages batched until the full synchronization finishes
- extend the page-level chat integration test to verify the recent page renders while multiple older pages remain unpublished

## User impact

Opening an uncached chat thread now shows its recent messages as soon as the first page is durable, instead of keeping the skeleton visible until the entire history backfill completes. Cached-thread synchronization behavior is unchanged.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types` (12 tasks passed; the unrelated API task hit the local Node 2 GB heap limit)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-navigation.test.tsx` (30 tests passed)
