### PR TITLE
refactor(api): use builders for artifact history and visibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -435,7 +435,7 @@ describe("GET /api/zero/artifacts", () => {
     },
   );
 
-  it("isolates artifacts and favorites by organization and hides shadowed uploads", async () => {
+  it("lists chat-thread artifacts for the active organization and hides uploads shadowed by hosted artifacts", async () => {
     const userId = `user_${randomUUID()}`;
     const actor = bdd.user({ userId, orgId: `org_${randomUUID()}` });
     const otherOrgActor = bdd.user({
@@ -527,15 +527,6 @@ describe("GET /api/zero/artifacts", () => {
         return artifact.fileId === otherOrgArtifact.fileId;
       }),
     ).toBeFalsy();
-    const favorite = await chat.requestFavoriteArtifact(
-      actor,
-      otherOrgArtifact.url,
-      [404],
-    );
-    if (favorite.status !== 404) {
-      throw new Error("Expected other-organization favorite request to 404");
-    }
-    expect(favorite.body.error.code).toBe("NOT_FOUND");
     expect(response.truncated).toBeFalsy();
   }, 120_000);
 
@@ -968,7 +959,22 @@ describe("POST /api/zero/artifacts/favorite", () => {
   }, 120_000);
 
   it("rejects favorite requests for artifacts outside the caller visibility set", async () => {
-    const owner = await artifactActor("Artifacts API favorites visibility");
+    const userId = `user_${randomUUID()}`;
+    const owner = await artifactActor(
+      "Artifacts API favorites visibility",
+      bdd.user({ userId, orgId: `org_${randomUUID()}` }),
+    );
+    const otherOrg = await artifactActor(
+      "Artifacts API other-org favorite",
+      bdd.user({ userId, orgId: `org_${randomUUID()}` }),
+    );
+    const otherOrgArtifact = await createRunUploadedFile({
+      owner: otherOrg,
+      prompt: "create an artifact outside the favorite visibility scope",
+      filename: `other-org-${randomUUID().slice(0, 8)}.txt`,
+      contentType: "text/plain",
+    });
+
     const missing = await chat.requestFavoriteArtifact(
       owner.actor,
       `https://artifacts.example.com/${randomUUID()}.html`,
@@ -979,5 +985,15 @@ describe("POST /api/zero/artifacts/favorite", () => {
       throw new Error("Expected missing artifact favorite request to 404");
     }
     expect(missing.body.error.code).toBe("NOT_FOUND");
+
+    const otherOrganization = await chat.requestFavoriteArtifact(
+      owner.actor,
+      otherOrgArtifact.url,
+      [404],
+    );
+    if (otherOrganization.status !== 404) {
+      throw new Error("Expected other-organization favorite request to 404");
+    }
+    expect(otherOrganization.body.error.code).toBe("NOT_FOUND");
   }, 120_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -435,7 +435,7 @@ describe("GET /api/zero/artifacts", () => {
     },
   );
 
-  it("lists chat-thread artifacts for the active organization and hides uploads shadowed by hosted artifacts", async () => {
+  it("isolates artifacts and favorites by organization and hides shadowed uploads", async () => {
     const userId = `user_${randomUUID()}`;
     const actor = bdd.user({ userId, orgId: `org_${randomUUID()}` });
     const otherOrgActor = bdd.user({
@@ -527,6 +527,15 @@ describe("GET /api/zero/artifacts", () => {
         return artifact.fileId === otherOrgArtifact.fileId;
       }),
     ).toBeFalsy();
+    const favorite = await chat.requestFavoriteArtifact(
+      actor,
+      otherOrgArtifact.url,
+      [404],
+    );
+    if (favorite.status !== 404) {
+      throw new Error("Expected other-organization favorite request to 404");
+    }
+    expect(favorite.body.error.code).toBe("NOT_FOUND");
     expect(response.truncated).toBeFalsy();
   }, 120_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -809,8 +809,8 @@ describe("GET /api/zero/artifacts", () => {
       expect(pages).toBeLessThanOrEqual(10);
     } while (cursor);
 
-    // Every raw artifact row surfaced exactly once across pages with no cursor
-    // drift, repeated rows, or skips.
+    // Every visible artifact row surfaced exactly once across pages with no
+    // cursor drift, repeated rows, or skips.
     expect(collected).toHaveLength(created.length);
     expect(new Set(collected)).toStrictEqual(new Set(created));
   }, 120_000);

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -83,6 +83,7 @@ import {
 import {
   nullableDriverValueDecoder,
   pgBooleanDecoder,
+  pgInt8ToSafeIntegerDecoder,
   pgIntegerDecoder,
   pgTextDecoder,
   zodEnumDriverValueDecoder,
@@ -195,7 +196,10 @@ const artifactListSqlRowSchema = z.object({
 });
 type ArtifactListSqlRow = z.output<typeof artifactListSqlRowSchema>;
 
-const artifactVisibilityRowSchema = z.object({ visible: z.boolean() });
+type ArtifactListRow = Omit<ArtifactListSqlRow, "url"> & {
+  readonly url: string | null;
+};
+
 const artifactSyncUntilRowSchema = z.object({ sync_until: z.string() });
 
 type ChatSearchMessageRow = {
@@ -1222,7 +1226,24 @@ function artifactVisibilityConditions(
   ];
 }
 
-function toArtifactItem(row: ArtifactListSqlRow): ArtifactItem {
+function artifactChatThreadId(db: Pick<Db, "select">): SQL {
+  const earliestThread = db
+    .select({ threadId: chatMessages.chatThreadId })
+    .from(chatMessages)
+    .where(eq(chatMessages.runId, runUploadedFiles.runId))
+    .orderBy(asc(chatMessages.seqId))
+    .limit(1);
+
+  return sql`COALESCE(${zeroRuns.chatThreadId}, (${earliestThread}))`;
+}
+
+function toArtifactItem(row: ArtifactListRow): ArtifactItem {
+  if (row.url === null) {
+    throw new Error(
+      "artifact list invariant violated: URL is null despite isNotNull filter",
+    );
+  }
+
   const filename = row.filename ?? row.external_id;
   const artifactKind = parseHostedArtifactKindFromMetadata(row.metadata);
   const canonical =
@@ -1501,69 +1522,57 @@ async function listArtifactHistory(args: {
   readonly syncUntil: string;
   readonly signal: AbortSignal;
 }): Promise<ZeroArtifactsResult> {
-  // The full path returns raw visible rows. IndexedDB owns stable-ID merging
-  // and hosted-run shadowing, so this query avoids a history-wide URL sort.
-  const keysetClause = args.cursor
-    ? sql`AND (${runUploadedFiles.createdAt}, ${runUploadedFiles.id}) < (${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
-    : sql.empty();
+  // The full path returns visible rows. IndexedDB owns stable-ID merging and
+  // hosted-run shadowing, so this query avoids a history-wide URL sort.
+  const keysetCondition = args.cursor
+    ? sql`(${runUploadedFiles.createdAt}, ${runUploadedFiles.id}) < (${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
+    : undefined;
   const conditions = artifactVisibilityConditions(args.db, args.query);
-  const rows = await executeRawRows(
-    args.db,
-    sql`
-      SELECT
-        ${runUploadedFiles.id} AS row_id,
-        ${runUploadedFiles.assetVersion} AS asset_version,
-        ${runUploadedFiles.runId} AS run_id,
-        ${runUploadedFiles.externalId} AS external_id,
-        ${runUploadedFiles.filename} AS filename,
-        ${runUploadedFiles.contentType} AS content_type,
-        ${runUploadedFiles.sizeBytes} AS size_bytes,
-        ${runUploadedFiles.url} AS url,
-        ${runUploadedFiles.previewImageUrl} AS preview_image_url,
-        ${runUploadedFiles.metadata} AS metadata,
-        ${runUploadedFiles.classification} AS classification,
-        ${runUploadedFiles.accessLevel} AS access_level,
-        ${runUploadedFiles.materializationStatus} AS materialization_status,
-        ${runUploadedFiles.materializationError} AS materialization_error,
-        ${runUploadedFiles.provenance} AS provenance,
-        ${runUploadedFiles.createdAt} AS created_at,
-        ${runUploadedFiles.updatedAt} AS updated_at,
-        ${chatThreads.id} AS thread_id,
-        ${chatThreads.title} AS thread_title,
-        ${zeroAgents.id} AS agent_id,
-        COALESCE(${zeroAgents.displayName}, ${agentComposes.name}) AS agent_name,
-        ${zeroAgents.avatarUrl} AS agent_avatar_url,
-        to_char(
-          ${runUploadedFiles.createdAt},
-          'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
-        ) AS cursor_created_at
-      FROM ${runUploadedFiles}
-      INNER JOIN ${agentRuns}
-        ON ${eq(agentRuns.id, runUploadedFiles.runId)}
-      INNER JOIN ${zeroRuns}
-        ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
-      INNER JOIN ${chatThreads}
-        ON ${chatThreads.id} = COALESCE(
-          ${zeroRuns.chatThreadId},
-          (
-            SELECT ${chatMessages.chatThreadId}
-            FROM ${chatMessages}
-            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${asc(chatMessages.seqId)}
-            LIMIT 1
-          )
-        )
-      INNER JOIN ${agentComposes}
-        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
-      INNER JOIN ${zeroAgents}
-        ON ${eq(zeroAgents.id, agentComposes.id)}
-      WHERE ${sql.join(conditions, sql` AND `)}
-      ${keysetClause}
-    ORDER BY ${desc(runUploadedFiles.createdAt)}, ${desc(runUploadedFiles.id)}
-      LIMIT ${args.limit + 1}
-    `,
-    artifactListSqlRowSchema,
-  );
+  const rows: ArtifactListRow[] = await args.db
+    .select({
+      row_id: runUploadedFiles.id,
+      asset_version: runUploadedFiles.assetVersion,
+      run_id: agentRuns.id,
+      external_id: runUploadedFiles.externalId,
+      filename: runUploadedFiles.filename,
+      content_type: runUploadedFiles.contentType,
+      size_bytes: sql`${runUploadedFiles.sizeBytes}`
+        .mapWith(nullableDriverValueDecoder(pgInt8ToSafeIntegerDecoder))
+        .as("size_bytes"),
+      url: runUploadedFiles.url,
+      preview_image_url: runUploadedFiles.previewImageUrl,
+      metadata: runUploadedFiles.metadata,
+      classification: runUploadedFiles.classification,
+      access_level: runUploadedFiles.accessLevel,
+      materialization_status: runUploadedFiles.materializationStatus,
+      materialization_error: runUploadedFiles.materializationError,
+      provenance: runUploadedFiles.provenance,
+      created_at: runUploadedFiles.createdAt,
+      updated_at: runUploadedFiles.updatedAt,
+      thread_id: chatThreads.id,
+      thread_title: chatThreads.title,
+      agent_id: zeroAgents.id,
+      agent_name:
+        sql`COALESCE(${zeroAgents.displayName}, ${agentComposes.name})`
+          .mapWith(nullableTextDecoder)
+          .as("agent_name"),
+      agent_avatar_url: zeroAgents.avatarUrl,
+      cursor_created_at: sql`to_char(
+        ${runUploadedFiles.createdAt},
+        'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      )`
+        .mapWith(pgTextDecoder)
+        .as("cursor_created_at"),
+    })
+    .from(runUploadedFiles)
+    .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
+    .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
+    .innerJoin(chatThreads, eq(chatThreads.id, artifactChatThreadId(args.db)))
+    .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
+    .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
+    .where(and(...conditions, keysetCondition))
+    .orderBy(desc(runUploadedFiles.createdAt), desc(runUploadedFiles.id))
+    .limit(args.limit + 1);
   args.signal.throwIfAborted();
 
   const hasMore = rows.length > args.limit;
@@ -1658,43 +1667,23 @@ export const artifactFavoriteUrls$ = command(
 );
 
 async function artifactUrlIsVisible(
-  db: Pick<Db, "execute" | "select">,
+  db: Pick<Db, "select">,
   args: ArtifactFavoriteArgs,
 ): Promise<boolean> {
   const conditions = [
     ...artifactVisibilityConditions(db, args),
     eq(runUploadedFiles.url, args.artifactUrl),
   ];
-  const rows = await executeRawRows(
-    db,
-    sql`
-      SELECT EXISTS (
-      SELECT 1
-      FROM ${runUploadedFiles}
-      INNER JOIN ${agentRuns}
-        ON ${eq(agentRuns.id, runUploadedFiles.runId)}
-      INNER JOIN ${zeroRuns}
-        ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
-      INNER JOIN ${chatThreads}
-        ON ${chatThreads.id} = COALESCE(
-          ${zeroRuns.chatThreadId},
-          (
-            SELECT ${chatMessages.chatThreadId}
-            FROM ${chatMessages}
-            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${asc(chatMessages.seqId)}
-            LIMIT 1
-          )
-        )
-      INNER JOIN ${agentComposes}
-        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
-      WHERE ${sql.join(conditions, sql` AND `)}
-      LIMIT 1
-      ) AS visible
-    `,
-    artifactVisibilityRowSchema,
-  );
-  return rows[0]?.visible === true;
+  const rows = await db
+    .select({ id: runUploadedFiles.id })
+    .from(runUploadedFiles)
+    .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
+    .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
+    .innerJoin(chatThreads, eq(chatThreads.id, artifactChatThreadId(db)))
+    .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
+    .where(and(...conditions))
+    .limit(1);
+  return rows.length > 0;
 }
 
 export const favoriteArtifact$ = command(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -43,6 +43,9 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import {
+  CANONICAL_ASSET_ACCESS_LEVELS,
+  CANONICAL_ASSET_CLASSIFICATIONS,
+  CANONICAL_ASSET_MATERIALIZATION_STATUSES,
   CANONICAL_ASSET_VERSION,
   chatMessageAssetRefs,
   runUploadedFiles,
@@ -86,6 +89,7 @@ import {
   pgInt8ToSafeIntegerDecoder,
   pgIntegerDecoder,
   pgTextDecoder,
+  zodDriverValueDecoder,
   zodEnumDriverValueDecoder,
 } from "../../lib/db-structured-result";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
@@ -158,6 +162,22 @@ type ChatMessageRow = {
   readonly workflowAutomationUserTimezone: string | null;
 };
 
+const canonicalAssetClassificationSchema = z.enum(
+  CANONICAL_ASSET_CLASSIFICATIONS,
+);
+const canonicalAssetAccessLevelSchema = z.enum(CANONICAL_ASSET_ACCESS_LEVELS);
+const canonicalAssetMaterializationStatusSchema = z.enum(
+  CANONICAL_ASSET_MATERIALIZATION_STATUSES,
+);
+const canonicalAssetMaterializationErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  retryable: z.boolean(),
+});
+const canonicalAssetProvenanceSchema = z.object({
+  provider: z.string(),
+});
+
 const artifactListSqlRowSchema = z.object({
   row_id: z.string(),
   asset_version: z.number().nullable(),
@@ -169,21 +189,11 @@ const artifactListSqlRowSchema = z.object({
   url: z.string(),
   preview_image_url: z.string().nullable(),
   metadata: z.unknown(),
-  classification: z.enum(["input", "published-output"]).nullable(),
-  access_level: z.enum(["private", "published"]).nullable(),
-  materialization_status: z.enum(["pending", "ready", "failed"]).nullable(),
-  materialization_error: z
-    .object({
-      code: z.string(),
-      message: z.string(),
-      retryable: z.boolean(),
-    })
-    .nullable(),
-  provenance: z
-    .object({
-      provider: z.string(),
-    })
-    .nullable(),
+  classification: canonicalAssetClassificationSchema.nullable(),
+  access_level: canonicalAssetAccessLevelSchema.nullable(),
+  materialization_status: canonicalAssetMaterializationStatusSchema.nullable(),
+  materialization_error: canonicalAssetMaterializationErrorSchema.nullable(),
+  provenance: canonicalAssetProvenanceSchema.nullable(),
   created_at: pgTimestampWithoutTimezoneToDateSchema,
   updated_at: pgTimestampWithoutTimezoneToDateSchema,
   cursor_created_at: z.string(),
@@ -199,6 +209,24 @@ type ArtifactListSqlRow = z.output<typeof artifactListSqlRowSchema>;
 type ArtifactListRow = Omit<ArtifactListSqlRow, "url"> & {
   readonly url: string | null;
 };
+
+const nullableCanonicalAssetClassificationDecoder = nullableDriverValueDecoder(
+  zodEnumDriverValueDecoder(canonicalAssetClassificationSchema),
+);
+const nullableCanonicalAssetAccessLevelDecoder = nullableDriverValueDecoder(
+  zodEnumDriverValueDecoder(canonicalAssetAccessLevelSchema),
+);
+const nullableCanonicalAssetMaterializationStatusDecoder =
+  nullableDriverValueDecoder(
+    zodEnumDriverValueDecoder(canonicalAssetMaterializationStatusSchema),
+  );
+const nullableCanonicalAssetMaterializationErrorDecoder =
+  nullableDriverValueDecoder(
+    zodDriverValueDecoder(canonicalAssetMaterializationErrorSchema),
+  );
+const nullableCanonicalAssetProvenanceDecoder = nullableDriverValueDecoder(
+  zodDriverValueDecoder(canonicalAssetProvenanceSchema),
+);
 
 const artifactSyncUntilRowSchema = z.object({ sync_until: z.string() });
 
@@ -1542,11 +1570,21 @@ async function listArtifactHistory(args: {
       url: runUploadedFiles.url,
       preview_image_url: runUploadedFiles.previewImageUrl,
       metadata: runUploadedFiles.metadata,
-      classification: runUploadedFiles.classification,
-      access_level: runUploadedFiles.accessLevel,
-      materialization_status: runUploadedFiles.materializationStatus,
-      materialization_error: runUploadedFiles.materializationError,
-      provenance: runUploadedFiles.provenance,
+      classification: sql`${runUploadedFiles.classification}`
+        .mapWith(nullableCanonicalAssetClassificationDecoder)
+        .as("classification"),
+      access_level: sql`${runUploadedFiles.accessLevel}`
+        .mapWith(nullableCanonicalAssetAccessLevelDecoder)
+        .as("access_level"),
+      materialization_status: sql`${runUploadedFiles.materializationStatus}`
+        .mapWith(nullableCanonicalAssetMaterializationStatusDecoder)
+        .as("materialization_status"),
+      materialization_error: sql`${runUploadedFiles.materializationError}`
+        .mapWith(nullableCanonicalAssetMaterializationErrorDecoder)
+        .as("materialization_error"),
+      provenance: sql`${runUploadedFiles.provenance}`
+        .mapWith(nullableCanonicalAssetProvenanceDecoder)
+        .as("provenance"),
       created_at: runUploadedFiles.createdAt,
       updated_at: runUploadedFiles.updatedAt,
       thread_id: chatThreads.id,

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -50,6 +50,7 @@ const schemaPreamble = `
   declare const rowSchema: never;
   declare const threadId: number;
   declare const excludedRunId: number;
+  declare const pageLimit: number;
 `;
 
 const structuredSelectionPreamble = `
@@ -132,6 +133,47 @@ const directQuery = `
         OR \${eq(runs.id, excludedRunId)}
       )
     LIMIT 1
+  \`
+`;
+
+const joinedHistoryQuery = `
+  sql\`
+    SELECT
+      \${runs.id} AS "rowId",
+      \${runs.threadId} AS "threadId",
+      COALESCE(\${runStates.status}, 'unknown') AS "status"
+    FROM \${runs}
+    INNER JOIN \${runStates}
+      ON \${eq(runStates.id, runs.id)}
+    LEFT JOIN \${callbacks}
+      ON \${callbacks.runId} = COALESCE(
+        \${runs.id},
+        (
+          SELECT \${callbacks.runId}
+          FROM \${callbacks}
+          WHERE \${eq(callbacks.runId, runs.id)}
+          ORDER BY \${callbacks.id}
+          LIMIT 1
+        )
+      )
+    WHERE \${eq(runs.threadId, threadId)}
+      AND \${eq(runs.id, excludedRunId)}
+    ORDER BY \${desc(runs.id)}, \${desc(runs.threadId)}
+    LIMIT \${pageLimit}
+  \`
+`;
+
+const joinedExistsQuery = `
+  sql\`
+    SELECT EXISTS (
+      SELECT 1
+      FROM \${runs}
+      INNER JOIN \${runStates}
+        ON \${eq(runStates.id, runs.id)}
+      WHERE \${eq(runs.threadId, threadId)}
+        AND \${eq(runs.id, excludedRunId)}
+      LIMIT 1
+    ) AS visible
   \`
 `;
 
@@ -485,6 +527,97 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         import { eq, sql } from "drizzle-orm";
         await executeRawRows(
           db,
+          sql\`
+            SELECT (
+              \${eq(runs.id, threadId)}
+              OR \${eq(runs.id, excludedRunId)}
+            ) AS allowed
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`SELECT clock_timestamp() AS database_time\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH visible_runs AS MATERIALIZED (
+              SELECT \${runs.id}
+              FROM \${runs}
+              WHERE \${eq(runs.threadId, threadId)}
+            )
+            SELECT id FROM visible_runs
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT EXISTS (
+              SELECT count(*)
+              FROM \${runs}
+              INNER JOIN \${runStates}
+                ON \${eq(runStates.id, runs.id)}
+              WHERE \${eq(runs.threadId, threadId)}
+              LIMIT 1
+            ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        const source = sql.identifier("runs");
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}, \${runs.threadId}
+            FROM \${source}
+            INNER JOIN \${runStates}
+              ON \${eq(runStates.id, runs.id)}
+            WHERE \${eq(runs.threadId, threadId)}
+            ORDER BY \${runs.id}
+            LIMIT \${pageLimit}
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}, \${runs.threadId}
+            FROM \${runs}
+            INNER JOIN \${runStates}
+              ON \${eq(runStates.id, runs.id)}
+            WHERE \${eq(runs.threadId, threadId)}
+            ORDER BY \${pageLimit}
+            LIMIT \${pageLimit}
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}, \${runs.threadId}
+            FROM \${runs}
+            INNER JOIN \${runStates}
+              ON \${eq(runStates.id, runs.id)}
+            WHERE \${eq(runs.threadId, threadId)}
+            ORDER BY \${runs.id}
+            LIMIT \${String(pageLimit)}
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
           sql\`SELECT 1 FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
           rowSchema,
         );
@@ -676,16 +809,6 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         await executeRawRows(
           db,
           sql\`SELECT \${runs.id} FROM runs WHERE \${eq(runs.id, 1)} LIMIT 1\`,
-          rowSchema,
-        );
-      `,
-    },
-    {
-      code: `${rawRowsImport}${schemaPreamble}
-        import { eq, sql } from "drizzle-orm";
-        await executeRawRows(
-          db,
-          sql\`SELECT \${runs.id} FROM \${runs} LEFT JOIN \${runStates} ON \${eq(runStates.id, runs.id)} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
           rowSchema,
         );
       `,
@@ -1061,6 +1184,38 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         \`);
       `,
       errors: [{ messageId: "upsertQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { desc, eq, sql } from "drizzle-orm";
+        await executeRawRows(db, ${joinedHistoryQuery}, rowSchema);
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(db, ${joinedExistsQuery}, rowSchema);
+      `,
+      errors: [{ messageId: "existsQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${runs}
+            LEFT JOIN \${runStates}
+              ON \${eq(runStates.id, runs.id)}
+            WHERE \${eq(runs.id, threadId)}
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -1207,7 +1207,7 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           sql\`
             SELECT \${runs.id}
             FROM \${runs}
-            LEFT JOIN \${runStates}
+            LEFT OUTER JOIN \${runStates}
               ON \${eq(runStates.id, runs.id)}
             WHERE \${eq(runs.id, threadId)}
             LIMIT 1

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -17,6 +17,7 @@ import {
   isVariableDeclarationList,
   NodeFlags,
   SyntaxKind,
+  TypeFlags,
   type Node,
   type Type,
   type VariableDeclaration,
@@ -72,6 +73,14 @@ interface SimpleSelectMatch {
   readonly sourceTableExpressionIndex: number;
 }
 
+interface PaginatedJoinedSelectMatch {
+  readonly clauseExpressionIndexes: readonly number[];
+  readonly joinTableExpressionIndexes: readonly number[];
+  readonly limitExpressionIndex: number | undefined;
+  readonly selectedExpressionIndexes: readonly number[];
+  readonly sourceTableExpressionIndex: number;
+}
+
 interface SimpleLockingSelectMatch {
   readonly sourceTableExpressionIndex: number | undefined;
 }
@@ -116,6 +125,27 @@ const UNSUPPORTED_SCALAR_QUERY_KEYWORDS = new Set([
   ...UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS,
   "INTO",
   "OVER",
+]);
+
+const UNSUPPORTED_PAGINATED_JOINED_SELECT_KEYWORDS = new Set([
+  "CROSS",
+  "DISTINCT",
+  "EXCEPT",
+  "FETCH",
+  "FOR",
+  "FULL",
+  "GROUP",
+  "HAVING",
+  "INTERSECT",
+  "INTO",
+  "LATERAL",
+  "OFFSET",
+  "QUALIFY",
+  "RIGHT",
+  "UNION",
+  "USING",
+  "WINDOW",
+  "WITH",
 ]);
 
 const UNSUPPORTED_LOCKING_SELECT_KEYWORDS = new Set([
@@ -861,6 +891,304 @@ function simpleSelectMatch(
   };
 }
 
+function isPaginatedJoinedSelectClauseBoundary(
+  token: SqlToken | undefined,
+): boolean {
+  return (
+    isWord(token, "INNER") ||
+    isWord(token, "LEFT") ||
+    isWord(token, "WHERE") ||
+    isWord(token, "ORDER") ||
+    isWord(token, "LIMIT")
+  );
+}
+
+function expressionIndexesBetween(
+  tokens: readonly SqlToken[],
+  start: number,
+  end: number,
+): number[] {
+  return tokens.slice(start, end).flatMap((token) => {
+    return token.kind === "expression" ? [token.expressionIndex] : [];
+  });
+}
+
+/**
+ * Recognizes only the recurring schema-backed join shape that Drizzle can own:
+ * joins, a predicate, optional ordering, and a bounded result. Unsupported
+ * statement features fail closed instead of being approximated.
+ */
+function paginatedJoinedSelectMatch(
+  syntaxSource: string,
+  selectionKind: "literal-one" | "schema-expression",
+): PaginatedJoinedSelectMatch | undefined {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined) {
+    return undefined;
+  }
+  const tokens = statement.tokens;
+  if (
+    !isWord(tokens[0], "SELECT") ||
+    tokens.some((token) => {
+      return (
+        token.kind === "word" &&
+        UNSUPPORTED_PAGINATED_JOINED_SELECT_KEYWORDS.has(token.value)
+      );
+    })
+  ) {
+    return undefined;
+  }
+
+  const fromIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "FROM") ? [index] : [];
+  });
+  const fromIndex = fromIndexes.length === 1 ? fromIndexes[0] : undefined;
+  const selectKeyword = tokens[0];
+  const fromKeyword = fromIndex === undefined ? undefined : tokens[fromIndex];
+  if (
+    fromIndex === undefined ||
+    fromIndex <= 1 ||
+    selectKeyword === undefined ||
+    fromKeyword === undefined ||
+    syntaxSource.slice(selectKeyword.end, fromKeyword.start).trim() === ""
+  ) {
+    return undefined;
+  }
+
+  const selectedExpressionIndexes = expressionIndexesBetween(
+    tokens,
+    1,
+    fromIndex,
+  );
+  if (selectionKind === "literal-one") {
+    const selectedToken = tokens[1];
+    if (
+      fromIndex !== 2 ||
+      selectedToken?.kind !== "number" ||
+      selectedToken.value !== "1" ||
+      !onlyWhitespaceBetween(syntaxSource, selectKeyword, selectedToken) ||
+      !onlyWhitespaceBetween(syntaxSource, selectedToken, fromKeyword)
+    ) {
+      return undefined;
+    }
+  } else if (selectedExpressionIndexes.length === 0) {
+    return undefined;
+  }
+
+  let cursor = fromIndex + 1;
+  const sourceTableExpressionIndex = expressionIndex(tokens[cursor]);
+  const sourceTable = tokens[cursor];
+  if (
+    sourceTableExpressionIndex === undefined ||
+    sourceTable === undefined ||
+    !onlyWhitespaceBetween(syntaxSource, fromKeyword, sourceTable)
+  ) {
+    return undefined;
+  }
+  cursor += 1;
+
+  const joinTableExpressionIndexes: number[] = [];
+  const clauseExpressionIndexes: number[] = [];
+  while (isWord(tokens[cursor], "INNER") || isWord(tokens[cursor], "LEFT")) {
+    const joinKind = tokens[cursor];
+    cursor += 1;
+    let joinPrefixEnd = joinKind;
+    if (isWord(joinKind, "LEFT") && isWord(tokens[cursor], "OUTER")) {
+      const outerKeyword = tokens[cursor];
+      if (
+        outerKeyword === undefined ||
+        !onlyWhitespaceBetween(syntaxSource, joinKind, outerKeyword)
+      ) {
+        return undefined;
+      }
+      joinPrefixEnd = outerKeyword;
+      cursor += 1;
+    }
+    const joinKeyword = tokens[cursor];
+    if (
+      joinKind === undefined ||
+      joinPrefixEnd === undefined ||
+      joinKeyword === undefined ||
+      !isWord(joinKeyword, "JOIN") ||
+      !onlyWhitespaceBetween(syntaxSource, joinPrefixEnd, joinKeyword)
+    ) {
+      return undefined;
+    }
+    cursor += 1;
+
+    const joinTable = tokens[cursor];
+    const joinTableExpressionIndex = expressionIndex(joinTable);
+    if (
+      joinTable === undefined ||
+      joinTableExpressionIndex === undefined ||
+      !onlyWhitespaceBetween(syntaxSource, joinKeyword, joinTable)
+    ) {
+      return undefined;
+    }
+    joinTableExpressionIndexes.push(joinTableExpressionIndex);
+    cursor += 1;
+
+    const onKeyword = tokens[cursor];
+    if (
+      onKeyword === undefined ||
+      !isWord(onKeyword, "ON") ||
+      !onlyWhitespaceBetween(syntaxSource, joinTable, onKeyword)
+    ) {
+      return undefined;
+    }
+    cursor += 1;
+    const conditionStart = cursor;
+    while (
+      cursor < tokens.length &&
+      !isPaginatedJoinedSelectClauseBoundary(tokens[cursor])
+    ) {
+      cursor += 1;
+    }
+    const conditionEnd =
+      cursor === tokens.length ? statement.end : tokens[cursor]?.start;
+    const conditionExpressionIndexes = expressionIndexesBetween(
+      tokens,
+      conditionStart,
+      cursor,
+    );
+    if (
+      conditionEnd === undefined ||
+      syntaxSource.slice(onKeyword.end, conditionEnd).trim() === "" ||
+      conditionExpressionIndexes.length === 0
+    ) {
+      return undefined;
+    }
+    clauseExpressionIndexes.push(...conditionExpressionIndexes);
+  }
+  if (joinTableExpressionIndexes.length === 0) {
+    return undefined;
+  }
+
+  const whereKeyword = tokens[cursor];
+  if (whereKeyword === undefined || !isWord(whereKeyword, "WHERE")) {
+    return undefined;
+  }
+  cursor += 1;
+  const whereStart = cursor;
+  while (
+    cursor < tokens.length &&
+    !isWord(tokens[cursor], "ORDER") &&
+    !isWord(tokens[cursor], "LIMIT")
+  ) {
+    cursor += 1;
+  }
+  const whereEnd =
+    cursor === tokens.length ? statement.end : tokens[cursor]?.start;
+  const whereExpressionIndexes = expressionIndexesBetween(
+    tokens,
+    whereStart,
+    cursor,
+  );
+  if (
+    whereEnd === undefined ||
+    syntaxSource.slice(whereKeyword.end, whereEnd).trim() === "" ||
+    whereExpressionIndexes.length === 0
+  ) {
+    return undefined;
+  }
+  clauseExpressionIndexes.push(...whereExpressionIndexes);
+
+  if (isWord(tokens[cursor], "ORDER")) {
+    const orderKeyword = tokens[cursor];
+    const byKeyword = tokens[cursor + 1];
+    if (
+      orderKeyword === undefined ||
+      byKeyword === undefined ||
+      !isWord(byKeyword, "BY") ||
+      !onlyWhitespaceBetween(syntaxSource, orderKeyword, byKeyword)
+    ) {
+      return undefined;
+    }
+    cursor += 2;
+    const orderStart = cursor;
+    while (cursor < tokens.length && !isWord(tokens[cursor], "LIMIT")) {
+      cursor += 1;
+    }
+    const orderEnd =
+      cursor === tokens.length ? statement.end : tokens[cursor]?.start;
+    const orderExpressionIndexes = expressionIndexesBetween(
+      tokens,
+      orderStart,
+      cursor,
+    );
+    if (
+      orderEnd === undefined ||
+      syntaxSource.slice(byKeyword.end, orderEnd).trim() === "" ||
+      orderExpressionIndexes.length === 0
+    ) {
+      return undefined;
+    }
+    clauseExpressionIndexes.push(...orderExpressionIndexes);
+  }
+
+  const limitKeyword = tokens[cursor];
+  const limitValue = tokens[cursor + 1];
+  if (
+    limitKeyword === undefined ||
+    limitValue === undefined ||
+    !isWord(limitKeyword, "LIMIT") ||
+    (limitValue.kind !== "number" && limitValue.kind !== "expression") ||
+    cursor + 2 !== tokens.length ||
+    !onlyWhitespaceBetween(syntaxSource, limitKeyword, limitValue) ||
+    syntaxSource.slice(limitValue.end, statement.end).trim() !== ""
+  ) {
+    return undefined;
+  }
+
+  return {
+    clauseExpressionIndexes,
+    joinTableExpressionIndexes,
+    limitExpressionIndex:
+      limitValue.kind === "expression" ? limitValue.expressionIndex : undefined,
+    selectedExpressionIndexes,
+    sourceTableExpressionIndex,
+  };
+}
+
+function completePaginatedExistsSelectMatch(
+  syntaxSource: string,
+): PaginatedJoinedSelectMatch | undefined {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined) {
+    return undefined;
+  }
+  const tokens = statement.tokens;
+  const selectKeyword = tokens[0];
+  const existsKeyword = tokens[1];
+  const open = tokens[2];
+  const close = tokens[3];
+  if (
+    tokens.length !== 6 ||
+    selectKeyword === undefined ||
+    existsKeyword === undefined ||
+    open === undefined ||
+    close === undefined ||
+    !isWord(selectKeyword, "SELECT") ||
+    !isWord(existsKeyword, "EXISTS") ||
+    !isPunctuation(open, "(") ||
+    !isPunctuation(close, ")") ||
+    !isWord(tokens[4], "AS") ||
+    tokens[5]?.kind !== "word" ||
+    !onlyWhitespaceBetween(syntaxSource, selectKeyword, existsKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, existsKeyword, open) ||
+    syntaxSource.slice(close.end, tokens[4]?.start).trim() !== "" ||
+    syntaxSource.slice(tokens[4]?.end, tokens[5]?.start).trim() !== "" ||
+    syntaxSource.slice(tokens[5]?.end, statement.end).trim() !== ""
+  ) {
+    return undefined;
+  }
+
+  const innerSyntaxSource = syntaxSource.slice(open.end, close.start);
+  // The validated outer statement has no interpolations before its inner
+  // SELECT, so the inner expression indexes already address the full template.
+  return paginatedJoinedSelectMatch(innerSyntaxSource, "literal-one");
+}
+
 function parenthesizedScalarSelect(
   source: string,
   syntaxSource: string,
@@ -953,7 +1281,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete simple deletes, upserts, selects, locking selects, and scalar result queries",
+        "Prefer Drizzle query builders for complete schema-backed deletes, upserts, selects, existence checks, locking selects, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -961,6 +1289,8 @@ export const preferDrizzleQueryBuilder = createRule({
     messages: {
       queryBuilder:
         "Use a Drizzle select builder for this complete schema-backed query.",
+      existsQueryBuilder:
+        "Use a Drizzle select builder and row existence check for this complete schema-backed EXISTS query.",
       lockingQueryBuilder:
         "Use a Drizzle select builder with .for(...) for this complete locking query.",
       deleteQueryBuilder:
@@ -1068,6 +1398,59 @@ export const preferDrizzleQueryBuilder = createRule({
         location: tsNode,
         type: checker.getTypeAtLocation(tsNode),
       };
+    }
+
+    function isNumberLikeType(type: Type): boolean {
+      if (type.isUnion()) {
+        return type.types.every(isNumberLikeType);
+      }
+      return (type.flags & (TypeFlags.Number | TypeFlags.NumberLiteral)) !== 0;
+    }
+
+    function isDrizzleWrapperExpression(
+      node: TSESTree.Expression | undefined,
+    ): boolean {
+      return (
+        node !== undefined &&
+        isDrizzleWrapperType(checker, expressionType(node).type)
+      );
+    }
+
+    function isDrizzleTableExpression(
+      node: TSESTree.Expression | undefined,
+    ): boolean {
+      if (node === undefined) {
+        return false;
+      }
+      const value = expressionType(node);
+      return isDrizzleTableType(checker, value.type, value.location);
+    }
+
+    function isSchemaBackedPaginatedJoin(
+      query: TSESTree.TaggedTemplateExpression,
+      match: PaginatedJoinedSelectMatch,
+    ): boolean {
+      const expressions = query.quasi.expressions;
+      const limitExpression =
+        match.limitExpressionIndex === undefined
+          ? undefined
+          : expressions[match.limitExpressionIndex];
+      return (
+        isDrizzleTableExpression(
+          expressions[match.sourceTableExpressionIndex],
+        ) &&
+        match.joinTableExpressionIndexes.every((index) => {
+          return isDrizzleTableExpression(expressions[index]);
+        }) &&
+        match.selectedExpressionIndexes.every((index) => {
+          return isDrizzleWrapperExpression(expressions[index]);
+        }) &&
+        match.clauseExpressionIndexes.every((index) => {
+          return isDrizzleWrapperExpression(expressions[index]);
+        }) &&
+        (limitExpression === undefined ||
+          isNumberLikeType(expressionType(limitExpression).type))
+      );
     }
 
     function symbolAt(node: TSESTree.Node) {
@@ -1595,55 +1978,68 @@ export const preferDrizzleQueryBuilder = createRule({
           return;
         }
 
-        const match = simpleSelectMatch(source, syntaxSource);
-        if (match === undefined) {
-          return;
-        }
-
-        const selectedColumn =
-          query.quasi.expressions[match.selectedColumnExpressionIndex];
-        const sourceTable =
-          query.quasi.expressions[match.sourceTableExpressionIndex];
-        if (selectedColumn === undefined || sourceTable === undefined) {
-          return;
-        }
-        const selectedColumnType = expressionType(selectedColumn);
-        const sourceTableType = expressionType(sourceTable);
+        const simpleMatch = simpleSelectMatch(source, syntaxSource);
+        const joinedMatch =
+          simpleMatch === undefined
+            ? paginatedJoinedSelectMatch(syntaxSource, "schema-expression")
+            : undefined;
+        const existsMatch =
+          simpleMatch === undefined && joinedMatch === undefined
+            ? completePaginatedExistsSelectMatch(syntaxSource)
+            : undefined;
         if (
-          !isDrizzleColumnType(
-            checker,
-            selectedColumnType.type,
-            selectedColumnType.location,
-          ) ||
-          !isDrizzleTableType(
-            checker,
-            sourceTableType.type,
-            sourceTableType.location,
-          ) ||
-          !match.joinTableExpressionIndexes.every((index) => {
-            const expression = query.quasi.expressions[index];
-            if (expression === undefined) {
-              return false;
-            }
-            const expressionValue = expressionType(expression);
-            return isDrizzleTableType(
-              checker,
-              expressionValue.type,
-              expressionValue.location,
-            );
-          }) ||
-          !match.joinConditionExpressionIndexes.every((index) => {
-            const expression = query.quasi.expressions[index];
-            return (
-              expression !== undefined &&
-              isDrizzleWrapperType(checker, expressionType(expression).type)
-            );
-          })
+          simpleMatch === undefined &&
+          joinedMatch === undefined &&
+          existsMatch === undefined
         ) {
           return;
         }
 
-        context.report({ node: query, messageId: "queryBuilder" });
+        if (simpleMatch !== undefined) {
+          const selectedColumn =
+            query.quasi.expressions[simpleMatch.selectedColumnExpressionIndex];
+          const sourceTable =
+            query.quasi.expressions[simpleMatch.sourceTableExpressionIndex];
+          if (selectedColumn === undefined || sourceTable === undefined) {
+            return;
+          }
+          const selectedColumnType = expressionType(selectedColumn);
+          const sourceTableType = expressionType(sourceTable);
+          if (
+            !isDrizzleColumnType(
+              checker,
+              selectedColumnType.type,
+              selectedColumnType.location,
+            ) ||
+            !isDrizzleTableType(
+              checker,
+              sourceTableType.type,
+              sourceTableType.location,
+            ) ||
+            !simpleMatch.joinTableExpressionIndexes.every((index) => {
+              return isDrizzleTableExpression(query.quasi.expressions[index]);
+            }) ||
+            !simpleMatch.joinConditionExpressionIndexes.every((index) => {
+              return isDrizzleWrapperExpression(query.quasi.expressions[index]);
+            })
+          ) {
+            return;
+          }
+        } else {
+          const structuredMatch = joinedMatch ?? existsMatch;
+          if (
+            structuredMatch === undefined ||
+            !isSchemaBackedPaginatedJoin(query, structuredMatch)
+          ) {
+            return;
+          }
+        }
+
+        context.report({
+          node: query,
+          messageId:
+            existsMatch === undefined ? "queryBuilder" : "existsQueryBuilder",
+        });
       },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
         const source = node.quasi.quasis


### PR DESCRIPTION
## Summary

- replace the complete raw artifact-history statement with a typed Drizzle
  select while preserving visibility joins, tuple pagination, ordering, and
  response mapping
- preserve runtime decoding with the safe-integer bigint decoder and an honest
  nullable URL boundary before constructing an artifact response
- replace the raw favorite visibility `SELECT EXISTS` with a one-row Drizzle
  select inside the existing transaction
- cover same-user, different-organization favorite rejection through the API
- extend the type-aware query-builder lint for the recurring schema-backed
  paginated JOIN shape and its exact `SELECT EXISTS (SELECT 1 ... LIMIT 1)`
  wrapper

## Deliberate exclusions

This PR retains three complete SQL statements whose current semantics do not
have equivalent supported builder forms:

- the temporary combined snapshot access check, which must remain one statement
- the no-`FROM` PostgreSQL clock read
- incremental artifact synchronization with explicit `MATERIALIZED` CTEs

The lint intentionally fails closed for unsupported statement features,
non-schema tables, non-Drizzle clause expressions, non-numeric bound limits,
and existence subqueries whose selected expression could change empty-result
semantics.

There is no schema, migration, persisted-data, API, cursor, statement-count,
feature-switch, frontend, or runner change.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/zero-chat-thread.service.ts apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts`
- `pnpm exec prettier --check packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/artifacts.bdd.test.ts --maxWorkers=1 --silent=passed-only` (15 passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test` (47 files, 768 tests)
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/eslint-rules`
- pre-commit full Turbo type checks (13 workspaces passed)
- compared rendered SQL and `EXPLAIN (ANALYZE, BUFFERS)` for favorite
  visibility, initial history, and tuple-cursor history; access nodes, costs,
  indexes, subplans, and shared buffers remained equivalent

Closes #22769

Parent context: #22439
