### PR TITLE
fix(chat): keep paused run groups expanded by default

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-run-lifecycle.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-run-lifecycle.ts
@@ -1,0 +1,12 @@
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+
+export function isCancelledAssistantMessage(
+  message: PagedChatMessage,
+): boolean {
+  return (
+    message.role === "assistant" &&
+    message.runId !== undefined &&
+    (message.runLifecycleEvent === "cancelled" ||
+      message.error?.trim().toLowerCase() === "run cancelled")
+  );
+}

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -75,6 +75,7 @@ import type {
   EnrichedChatMessage,
   GroupedChatMessageGroup,
 } from "./chat-message.ts";
+import { isCancelledAssistantMessage } from "./chat-run-lifecycle.ts";
 import { logger } from "../log.ts";
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
 import {
@@ -223,15 +224,6 @@ function isInterruptControlMessage(msg: PagedChatMessage): boolean {
     msg.role === "user" &&
     msg.runId === undefined &&
     msg.interruptsRunId !== undefined
-  );
-}
-
-function isCancelledAssistantMessage(msg: PagedChatMessage): boolean {
-  return (
-    msg.role === "assistant" &&
-    msg.runId !== undefined &&
-    (msg.runLifecycleEvent === "cancelled" ||
-      msg.error?.trim().toLowerCase() === "run cancelled")
   );
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -3,6 +3,7 @@ import type {
   EnrichedChatMessage,
   GroupedChatMessageGroup,
 } from "./chat-message.ts";
+import { isCancelledAssistantMessage } from "./chat-run-lifecycle.ts";
 import type { ChatMessageUsagePayload } from "@vm0/api-contracts/contracts/chat-threads";
 
 interface RunSegment {
@@ -31,6 +32,7 @@ export interface RunGroupFold {
   readonly hiddenRunCount: number;
   readonly hiddenGroups: GroupedChatMessageGroup[];
   readonly labelGroups: GroupedChatMessageGroup[];
+  readonly expanded: boolean;
 }
 
 export interface RunGroupFolding {
@@ -38,23 +40,25 @@ export interface RunGroupFolding {
   readonly foldsByNextGroupId: ReadonlyMap<string, readonly RunGroupFold[]>;
 }
 
-const internalRunGroupExpandedKeys$ = state<Set<string>>(new Set());
+const internalRunGroupExpansionOverrides$ = state<Map<string, boolean>>(
+  new Map(),
+);
 
-export const runGroupExpandedKeys$ = computed((get): Set<string> => {
-  return get(internalRunGroupExpandedKeys$);
-});
+export const runGroupExpansionOverrides$ = computed(
+  (get): ReadonlyMap<string, boolean> => {
+    return get(internalRunGroupExpansionOverrides$);
+  },
+);
 
-export const toggleRunGroupExpanded$ = command(({ set }, key: string) => {
-  set(internalRunGroupExpandedKeys$, (prev) => {
-    const next = new Set(prev);
-    if (next.has(key)) {
-      next.delete(key);
-    } else {
-      next.add(key);
-    }
-    return next;
-  });
-});
+export const toggleRunGroupExpanded$ = command(
+  ({ set }, key: string, expanded: boolean) => {
+    set(internalRunGroupExpansionOverrides$, (prev) => {
+      const next = new Map(prev);
+      next.set(key, !expanded);
+      return next;
+    });
+  },
+);
 
 function groupMessagesByRole(
   messages: readonly EnrichedChatMessage[],
@@ -478,6 +482,7 @@ export function previousRunGroupVisualWindowStartIndex(
 function buildFoldSection(
   runSegments: readonly GroupedRunSegment[],
   usageByRunId: ReadonlyMap<string, ChatMessageUsagePayload>,
+  expansionOverrides: ReadonlyMap<string, boolean> | undefined,
 ): {
   readonly fold: RunGroupFold;
   readonly expandedNextGroupId: string;
@@ -515,13 +520,19 @@ function buildFoldSection(
     return null;
   }
 
+  const key = `${latestSegment.runGroupId}:${firstHiddenRunId}:${latestSegment.runId}`;
+  const defaultExpanded = latestSegment.messages.some(
+    isCancelledAssistantMessage,
+  );
+
   return {
     fold: {
-      key: `${latestSegment.runGroupId}:${firstHiddenRunId}:${latestSegment.runId}`,
+      key,
       runGroupId: latestSegment.runGroupId,
       hiddenRunCount: hiddenSegments.length,
       hiddenGroups,
       labelGroups: expandedGroups,
+      expanded: expansionOverrides?.get(key) ?? defaultExpanded,
     },
     expandedNextGroupId,
     collapsedNextGroupId,
@@ -532,7 +543,7 @@ function buildFoldSection(
 
 export function buildRunGroupFolding(
   groups: readonly GroupedChatMessageGroup[],
-  expandedKeys?: ReadonlySet<string>,
+  expansionOverrides?: ReadonlyMap<string, boolean>,
 ): RunGroupFolding | null {
   const segments = messageSegmentsFromGroups(groups);
   const usageByRunId = usageByRunIdFromGroups(groups);
@@ -562,7 +573,11 @@ export function buildRunGroupFolding(
     const runSegments = segments
       .slice(index, endIndex)
       .filter(isGroupedRunSegment);
-    const foldSection = buildFoldSection(runSegments, usageByRunId);
+    const foldSection = buildFoldSection(
+      runSegments,
+      usageByRunId,
+      expansionOverrides,
+    );
     if (foldSection === null) {
       visibleGroups.push(
         ...runSegments.flatMap((item) => {
@@ -573,9 +588,7 @@ export function buildRunGroupFolding(
       continue;
     }
 
-    const expanded = expandedKeys?.has(foldSection.fold.key) ?? false;
-
-    if (expanded) {
+    if (foldSection.fold.expanded) {
       visibleGroups.push(...foldSection.expandedGroups);
       appendFoldBeforeGroup(
         foldsByNextGroupId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -960,6 +960,96 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
+  it("shows a paused latest workflow run group expanded by default", async () => {
+    const threadId = "thread-paused-workflow-run-group";
+    const runGroupId = "f0000001-0000-4000-a000-00000000074b";
+    const workflowPrompt = "/daily-workflow";
+    const workflowSnapshot = {
+      name: "daily-workflow",
+      displayName: "Daily workflow",
+      description: "Daily workflow summary",
+    };
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Paused workflow run group",
+      chatMessages: [
+        {
+          id: "msg-paused-workflow-user-1",
+          role: "user",
+          content: workflowPrompt,
+          runId: "f0000001-0000-4000-a000-00000000074c",
+          runGroupId,
+          triggerSource: "workflow-event",
+          workflowSnapshot,
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-paused-workflow-assistant-1",
+          role: "assistant",
+          content: "First workflow result",
+          runId: "f0000001-0000-4000-a000-00000000074c",
+          runGroupId,
+          triggerSource: "workflow-event",
+          workflowSnapshot,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+        {
+          id: "msg-paused-workflow-user-2",
+          role: "user",
+          content: workflowPrompt,
+          runId: "f0000001-0000-4000-a000-00000000074d",
+          runGroupId,
+          triggerSource: "workflow-event",
+          workflowSnapshot,
+          createdAt: "2026-06-09T10:02:00Z",
+        },
+        {
+          id: "msg-paused-workflow-assistant-2",
+          role: "assistant",
+          content: "Run cancelled",
+          error: "Run cancelled",
+          runId: "f0000001-0000-4000-a000-00000000074d",
+          runGroupId,
+          triggerSource: "workflow-event",
+          workflowSnapshot,
+          runLifecycleEvent: "cancelled",
+          createdAt: "2026-06-09T10:02:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("First workflow result")).toBeInTheDocument();
+      expect(
+        screen.getByText("Paused mid-thought — pick it back up whenever."),
+      ).toBeInTheDocument();
+      expect(buttonByLabel("Collapse grouped run history")).toHaveTextContent(
+        "1 run for Daily workflow summary",
+      );
+    });
+
+    fireEvent.click(buttonByLabel("Collapse grouped run history"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("First workflow result"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Paused mid-thought — pick it back up whenever."),
+      ).toBeInTheDocument();
+      expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
+        "1 run for Daily workflow summary",
+      );
+    });
+  });
+
   it("renders workflow automation user messages with the workflow title and brief", async () => {
     const threadId = "thread-workflow-user-message-marker";
     const workflowPrompt = "/daily-workflow";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -154,7 +154,7 @@ import {
 } from "../../signals/chat-page/completed-work-folding.ts";
 import {
   buildRunGroupFolding,
-  runGroupExpandedKeys$,
+  runGroupExpansionOverrides$,
   toggleRunGroupExpanded$,
   type RunGroupFold,
   type RunGroupFolding,
@@ -2670,11 +2670,11 @@ function ChatThreadRenderedMessageGroups({
     }) ?? [];
   const { activeGroups: renderedActiveGroups } =
     splitQueuedMessagesForThinkingIndicator(renderedGroups);
-  const runGroupExpandedKeys = useGet(runGroupExpandedKeys$);
+  const runGroupExpansionOverrides = useGet(runGroupExpansionOverrides$);
   const toggleRunGroupExpanded = useSet(toggleRunGroupExpanded$);
   const runGroupFolding = buildRunGroupFolding(
     renderedActiveGroups,
-    runGroupExpandedKeys,
+    runGroupExpansionOverrides,
   );
   const runGroupVisibleGroups =
     runGroupFolding?.visibleGroups ?? renderedActiveGroups;
@@ -2689,7 +2689,6 @@ function ChatThreadRenderedMessageGroups({
       thread={thread}
       groups={visibleGroups}
       runGroupFolding={runGroupFolding}
-      runGroupExpandedKeys={runGroupExpandedKeys}
       onToggleRunGroup={toggleRunGroupExpanded}
       completedWorkFolding={completedWorkFolding}
       completedWorkExpandedKeys={completedWorkExpandedKeys}
@@ -2778,7 +2777,6 @@ function ChatThreadMessageGroups({
   thread,
   groups,
   runGroupFolding,
-  runGroupExpandedKeys,
   onToggleRunGroup,
   completedWorkFolding,
   completedWorkExpandedKeys,
@@ -2787,8 +2785,7 @@ function ChatThreadMessageGroups({
   thread: ChatThreadSignals;
   groups: readonly GroupedChatMessageGroup[];
   runGroupFolding: RunGroupFolding | null;
-  runGroupExpandedKeys: ReadonlySet<string>;
-  onToggleRunGroup: (key: string) => void;
+  onToggleRunGroup: (key: string, expanded: boolean) => void;
   completedWorkFolding: CompletedWorkFolding | null;
   completedWorkExpandedKeys: ReadonlySet<string>;
   onToggleCompletedWork: (key: string) => void;
@@ -2797,7 +2794,6 @@ function ChatThreadMessageGroups({
     resolveRunGroupFoldPlacements({
       groups,
       runGroupFolding,
-      runGroupExpandedKeys,
       onToggleRunGroup,
     });
 
@@ -2858,13 +2854,11 @@ interface RunGroupFoldControl {
 function resolveRunGroupFoldPlacements({
   groups,
   runGroupFolding,
-  runGroupExpandedKeys,
   onToggleRunGroup,
 }: {
   groups: readonly GroupedChatMessageGroup[];
   runGroupFolding: RunGroupFolding | null;
-  runGroupExpandedKeys: ReadonlySet<string>;
-  onToggleRunGroup: (key: string) => void;
+  onToggleRunGroup: (key: string, expanded: boolean) => void;
 }): {
   embeddedRunGroupFolds: Map<string, RunGroupFoldControl[]>;
   externalRunGroupFolds: Map<string, RunGroupFoldControl[]>;
@@ -2885,9 +2879,9 @@ function resolveRunGroupFoldPlacements({
     for (const fold of folds) {
       const control: RunGroupFoldControl = {
         fold,
-        expanded: runGroupExpandedKeys.has(fold.key),
+        expanded: fold.expanded,
         onToggle: () => {
-          onToggleRunGroup(fold.key);
+          onToggleRunGroup(fold.key, fold.expanded);
         },
       };
       const embeddedGroupId = control.expanded


### PR DESCRIPTION
## Summary

- keep grouped run history expanded when the latest run was cancelled, so the context behind the paused result remains visible
- preserve manual collapse through explicit per-fold expansion overrides while leaving completed run groups collapsed by default
- share the semantic cancelled-run predicate, including the legacy `Run cancelled` fallback, across transcript projection and folding

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/chat-page/chat-run-lifecycle.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/signals/chat-page/run-group-folding.ts apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx src/signals/chat-page/__tests__/run-group-folding.test.ts` (31 tests passed)

Browser verification was not run because this checkout does not have the required `.env.local` files or 1Password CLI.
