### PR TITLE
ci: reduce dev runner concurrency factor

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2040,7 +2040,7 @@ jobs:
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \
-              --concurrency-factor 2.0 \
+              --concurrency-factor 1.5 \
               --api-url ${RUNNER_API_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 


### PR DESCRIPTION
## Summary

- reduce the development runner concurrency factor from `2.0` to `1.5`
- lower per-runner CPU and memory admission budgets during Turbo runner CI

## Scope

- changes only the runner configuration generated by the Turbo workflow
- does not add host-local overrides or change runner runtime code

## Validation

- `git diff --check`
- `./actionlint`

Relates to #22764
