### PR TITLE
fix(ci): preserve runner binary artifacts across reruns

### DIFF
--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -14,6 +14,16 @@ command -v yq >/dev/null || fail "yq is required"
 workflow_json=$(yq -o=json '.' "$WORKFLOW")
 
 jq -e '
+  [.jobs | to_entries[] | .value.steps[]? |
+    .with.name? // empty |
+    select(startswith("runner-binary-hits-") or startswith("runner-binary-compiled-"))
+  ] as $transport_names |
+  ($transport_names | length) == 5 and
+  all($transport_names[]; contains("${{ github.run_id }}")) and
+  all($transport_names[]; contains("${{ github.run_attempt }}") | not)
+' <<<"$workflow_json" >/dev/null || fail "runner binary transport identity must survive producer and consumer attempt mismatch"
+
+jq -e '
   .jobs.prepare["runs-on"] == "ubuntu-latest" and
   (.jobs.prepare | has("container") | not) and
   .jobs.prepare.permissions.actions == "read" and
@@ -27,7 +37,8 @@ jq -e '
   ) and
   any(.jobs.prepare.steps[];
     .uses == "actions/upload-artifact@v7" and
-    .with.name == "runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}" and
+    .with.name == "runner-binary-hits-${{ github.run_id }}" and
+    .with.overwrite == true and
     .if == "steps.binary-plan.outputs.hit-count != '\''0'\''" and
     .with["compression-level"] == 1 and
     (. | has("continue-on-error") | not)
@@ -51,7 +62,8 @@ jq -e '
   any(.jobs.compile.steps[]; .run == ".github/scripts/runner-binary-build/build.sh build") and
   any(.jobs.compile.steps[];
     .uses == "actions/upload-artifact@v7" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}" and
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}" and
+    .with.overwrite == true and
     (. | has("continue-on-error") | not)
   )
 ' <<<"$workflow_json" >/dev/null || fail "compile must be a required miss-only Rust/cache/build matrix"
@@ -74,11 +86,12 @@ jq -e '
   (.jobs.build.if | contains("needs.compile.result == '\''success'\''")) and
   any(.jobs.build.steps[];
     .name == "Download validated runner binary hit" and
-    (.if | contains("runner-binary-hit-targets"))
+    (.if | contains("runner-binary-hit-targets")) and
+    .with.name == "runner-binary-hits-${{ github.run_id }}"
   ) and
   any(.jobs.build.steps[];
     .name == "Download compiled runner binary" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}"
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}"
   ) and
   any(.jobs.build.steps[];
     .run == ".github/scripts/prepare-runner-image.sh" and
@@ -93,7 +106,7 @@ jq -e '
   .jobs.asset.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
   any(.jobs.asset.steps[];
     .name == "Download compiled runner binary" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}"
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}"
   ) and
   any(.jobs.asset.steps[];
     .name == "Validate fresh runner binary" and

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -248,7 +248,8 @@ jobs:
         if: steps.binary-plan.outputs.hit-count != '0'
         uses: actions/upload-artifact@v7
         with:
-          name: runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}
+          name: runner-binary-hits-${{ github.run_id }}
+          overwrite: true
           path: runner-binary-hits/
           if-no-files-found: error
           retention-days: 1
@@ -332,7 +333,8 @@ jobs:
       - name: Upload compiled runner binary
         uses: actions/upload-artifact@v7
         with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
+          overwrite: true
           path: runner-binary-fresh/
           if-no-files-found: error
           retention-days: 1
@@ -376,14 +378,14 @@ jobs:
         if: contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target)
         uses: actions/download-artifact@v8.0.1
         with:
-          name: runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}
+          name: runner-binary-hits-${{ github.run_id }}
           path: runner-binary-transport
 
       - name: Download compiled runner binary
         if: ${{ !contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target) }}
         uses: actions/download-artifact@v8.0.1
         with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
           path: runner-binary-transport/${{ matrix.target }}
 
       - name: Validate runner binary transport
@@ -503,7 +505,7 @@ jobs:
       - name: Download compiled runner binary
         uses: actions/download-artifact@v8.0.1
         with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
           path: runner-binary-fresh
 
       - name: Validate fresh runner binary


### PR DESCRIPTION
## Summary

- make transient runner binary artifact names stable across workflow attempts while retaining run and target isolation
- replace earlier-attempt producer artifacts during full reruns
- cover cache-hit and compiled-miss handoffs to both image builds and reusable asset publication

## Behavior

`Re-run failed jobs` can retain a successful `prepare` or `compile` producer while running its consumer under a later `github.run_attempt`. Consumers now select one run-scoped artifact identity instead of reconstructing the producer's attempt.

Full reruns use `overwrite: true` on transient producer uploads. Existing target and input-digest validation remains authoritative after download.

The SSH `Broken pipe` that exposed this workflow bug is intentionally not changed here.

## Validation

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- CI-equivalent ShellCheck selection
- `.github/scripts/check-workflow-shell-compatibility.sh`
- all 30 `.github/scripts/tests/*.sh` integration tests, sequentially
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `lefthook run pre-commit`
- `git diff --check`

Closes #22798
