### PR TITLE
fix(db): preserve legacy session continuation migration

### DIFF
--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -28,6 +28,7 @@
  */
 
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import { readFileSync } from "node:fs";
@@ -1259,6 +1260,9 @@ const sessionStorageBackfillFixture = {
   legacySessionId: "70000000-0000-4000-8000-000000000002",
   emptySessionId: "70000000-0000-4000-8000-000000000003",
   canonicalSessionId: "70000000-0000-4000-8000-000000000004",
+  provenanceSessionId: "70000000-0000-4000-8000-000000000005",
+  missingLatestSessionId: "70000000-0000-4000-8000-000000000006",
+  missingImplicitLatestSessionId: "70000000-0000-4000-8000-000000000007",
   storageIds: {
     head: "71000000-0000-4000-8000-000000000001",
     latest: "71000000-0000-4000-8000-000000000002",
@@ -1413,6 +1417,66 @@ async function seedSessionStorageBackfillFixture(
       JSON.stringify(canonicalMounts),
     ],
   );
+
+  const historicalSessions = [
+    {
+      id: fixture.provenanceSessionId,
+      artifacts: [
+        {
+          name: "head",
+          mountPath: "/home/oai/share/provenance",
+          generatedBy: "apiAutoMemory",
+        },
+      ],
+      updatedAt: "2020-01-04 00:00:00",
+    },
+    {
+      id: fixture.missingLatestSessionId,
+      artifacts: [
+        {
+          name: "recreated",
+          version: "latest",
+          mountPath: "/home/oai/share/recreated-latest",
+          generatedBy: "apiAutoMemory",
+        },
+      ],
+      updatedAt: "2020-01-05 00:00:00",
+    },
+    {
+      id: fixture.missingImplicitLatestSessionId,
+      artifacts: [
+        {
+          name: "recreated",
+          mountPath: "/home/oai/share/recreated-implicit",
+        },
+      ],
+      updatedAt: "2020-01-06 00:00:00",
+    },
+  ] as const;
+
+  for (const session of historicalSessions) {
+    await client.query(
+      `
+        INSERT INTO "agent_sessions" (
+          "id",
+          "user_id",
+          "org_id",
+          "agent_compose_id",
+          "artifacts",
+          "updated_at"
+        )
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+      `,
+      [
+        session.id,
+        fixture.userId,
+        fixture.orgId,
+        fixture.composeId,
+        JSON.stringify(session.artifacts),
+        session.updatedAt,
+      ],
+    );
+  }
 }
 
 async function seedSessionStorageBackfillRejections(
@@ -1428,6 +1492,11 @@ async function seedSessionStorageBackfillRejections(
           mountPath: "/home/oai/share/malformed",
           unexpected: true,
         },
+        {
+          name: "latest",
+          mountPath: "/home/oai/share/malformed-generated-by",
+          generatedBy: "unknown",
+        },
       ],
       storageMounts: null,
     },
@@ -1441,7 +1510,13 @@ async function seedSessionStorageBackfillRejections(
     },
     {
       id: "72000000-0000-4000-8000-000000000003",
-      artifacts: [{ name: "missing", mountPath: "/home/oai/share/missing" }],
+      artifacts: [
+        {
+          name: "missing",
+          version: "deadbeef",
+          mountPath: "/home/oai/share/missing",
+        },
+      ],
       storageMounts: null,
     },
     {
@@ -1527,6 +1602,17 @@ async function seedSessionStorageBackfillRejections(
         },
       ],
     },
+    {
+      id: "72000000-0000-4000-8000-000000000010",
+      artifacts: [
+        {
+          name: "rollback-latest",
+          version: "latest",
+          mountPath: "/home/oai/share/rollback-latest",
+        },
+      ],
+      storageMounts: null,
+    },
   ];
 
   for (const row of rows) {
@@ -1591,7 +1677,10 @@ async function validateSessionStorageBackfill(): Promise<void> {
         WHERE "id" IN (
           '${sessionStorageBackfillFixture.legacySessionId}',
           '${sessionStorageBackfillFixture.emptySessionId}',
-          '${sessionStorageBackfillFixture.canonicalSessionId}'
+          '${sessionStorageBackfillFixture.canonicalSessionId}',
+          '${sessionStorageBackfillFixture.provenanceSessionId}',
+          '${sessionStorageBackfillFixture.missingLatestSessionId}',
+          '${sessionStorageBackfillFixture.missingImplicitLatestSessionId}'
         )
         ORDER BY "id"
       `);
@@ -1681,6 +1770,125 @@ async function validateSessionStorageBackfill(): Promise<void> {
       ]);
       assert.equal(canonical.updated_at, "2020-01-03 00:00:00");
 
+      const provenance = rowsById.get(fixture.provenanceSessionId);
+      assert.ok(provenance);
+      assert.deepEqual(provenance.storage_mounts, [
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          name: "head",
+          storageId: fixture.storageIds.head,
+          mountPath: "/home/oai/share/provenance",
+          writeback: true,
+        },
+      ]);
+      assert.deepEqual(provenance.artifacts, [
+        {
+          name: "head",
+          mountPath: "/home/oai/share/provenance",
+          generatedBy: "apiAutoMemory",
+        },
+      ]);
+      assert.equal(provenance.updated_at, "2020-01-04 00:00:00");
+
+      const recreatedStorage = await client.query<{
+        archive_size: number;
+        created_by: string;
+        file_count: number;
+        head_version_id: string;
+        id: string;
+        message: string;
+        name: string;
+        s3_key: string;
+        s3_prefix: string;
+        size: number;
+        type: string;
+      }>(`
+        SELECT
+          storage."id",
+          storage."name",
+          storage."type",
+          storage."s3_prefix",
+          storage."head_version_id",
+          version."s3_key",
+          version."size"::integer,
+          version."archive_size"::integer,
+          version."file_count",
+          version."message",
+          version."created_by"
+        FROM "storages" AS storage
+        INNER JOIN "storage_versions" AS version
+          ON version."id" = storage."head_version_id"
+        WHERE storage."org_id" = '${fixture.orgId}'
+          AND storage."user_id" = '${fixture.userId}'
+          AND storage."name" = 'recreated'
+      `);
+      assert.equal(recreatedStorage.rows.length, 1);
+      const recreatedStorageRow = recreatedStorage.rows[0];
+      assert.ok(recreatedStorageRow);
+      const recreatedStorageId = recreatedStorageRow.id;
+      const expectedEmptyVersionId = createHash("sha256")
+        .update(`storage:${recreatedStorageId}\n`)
+        .digest("hex");
+      assert.deepEqual(recreatedStorageRow, {
+        id: recreatedStorageId,
+        name: "recreated",
+        type: "artifact",
+        s3_prefix: `${fixture.orgId}/${recreatedStorageId}`,
+        head_version_id: expectedEmptyVersionId,
+        s3_key: `${fixture.orgId}/${recreatedStorageId}/${expectedEmptyVersionId}`,
+        size: 0,
+        archive_size: 0,
+        file_count: 0,
+        message: "Initial empty artifact",
+        created_by: fixture.userId,
+      });
+
+      const recreatedLatest = rowsById.get(fixture.missingLatestSessionId);
+      assert.ok(recreatedLatest);
+      assert.deepEqual(recreatedLatest.storage_mounts, [
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          name: "recreated",
+          storageId: recreatedStorageId,
+          version: "latest",
+          mountPath: "/home/oai/share/recreated-latest",
+          writeback: true,
+        },
+      ]);
+      assert.deepEqual(recreatedLatest.artifacts, [
+        {
+          name: "recreated",
+          version: "latest",
+          mountPath: "/home/oai/share/recreated-latest",
+          generatedBy: "apiAutoMemory",
+        },
+      ]);
+      assert.equal(recreatedLatest.updated_at, "2020-01-05 00:00:00");
+
+      const recreatedImplicit = rowsById.get(
+        fixture.missingImplicitLatestSessionId,
+      );
+      assert.ok(recreatedImplicit);
+      assert.deepEqual(recreatedImplicit.storage_mounts, [
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          name: "recreated",
+          storageId: recreatedStorageId,
+          mountPath: "/home/oai/share/recreated-implicit",
+          writeback: true,
+        },
+      ]);
+      assert.deepEqual(recreatedImplicit.artifacts, [
+        {
+          name: "recreated",
+          mountPath: "/home/oai/share/recreated-implicit",
+        },
+      ]);
+      assert.equal(recreatedImplicit.updated_at, "2020-01-06 00:00:00");
+
       const unmigrated = await client.query<{ count: number }>(`
         SELECT count(*)::integer AS "count"
         FROM "agent_sessions"
@@ -1708,6 +1916,12 @@ async function validateSessionStorageBackfill(): Promise<void> {
       await seedSessionStorageBackfillFixture(client);
       await seedSessionStorageBackfillRejections(client);
 
+      const beforeRejection = await client.query<{ count: number }>(`
+        SELECT count(*)::integer AS "count"
+        FROM "agent_sessions"
+        WHERE "storage_mounts" IS NULL
+      `);
+
       let rejection: unknown;
       try {
         await applyMigrationsUpToInTransaction(
@@ -1730,7 +1944,16 @@ async function validateSessionStorageBackfill(): Promise<void> {
         FROM "agent_sessions"
         WHERE "storage_mounts" IS NULL
       `);
-      assert.equal(unchanged.rows[0]?.count, 6);
+      assert.equal(unchanged.rows[0]?.count, beforeRejection.rows[0]?.count);
+
+      const rolledBackStorage = await client.query<{ count: number }>(`
+        SELECT count(*)::integer AS "count"
+        FROM "storages"
+        WHERE "org_id" = '${sessionStorageBackfillFixture.orgId}'
+          AND "user_id" = '${sessionStorageBackfillFixture.userId}'
+          AND "name" = 'rollback-latest'
+      `);
+      assert.equal(rolledBackStorage.rows[0]?.count, 0);
 
       const migrationRecord = await client.query<{ count: number }>(`
         SELECT count(*)::integer AS "count"

--- a/turbo/packages/db/src/migrations/0654_backfill_session_continuation_storage_mounts.sql
+++ b/turbo/packages/db/src/migrations/0654_backfill_session_continuation_storage_mounts.sql
@@ -3,11 +3,118 @@
 -- checkpoint resume is a separate legacy path. Keep artifact version
 -- declarations unchanged: omitted and "latest" versions must continue to
 -- resolve HEAD at run time instead of freezing the HEAD visible here.
+-- Historical apiAutoMemory declarations may retain generatedBy provenance,
+-- which is not part of mount behavior. Legacy continuation also initializes an
+-- empty artifact Storage when a dynamic declaration has lost its Storage row;
+-- materialize the same canonical identity before validating the backfill.
 LOCK TABLE "agent_sessions" IN SHARE ROW EXCLUSIVE MODE;
 --> statement-breakpoint
-LOCK TABLE "storages" IN SHARE MODE;
+LOCK TABLE "storages" IN SHARE ROW EXCLUSIVE MODE;
 --> statement-breakpoint
-LOCK TABLE "storage_versions" IN SHARE MODE;
+LOCK TABLE "storage_versions" IN SHARE ROW EXCLUSIVE MODE;
+--> statement-breakpoint
+
+CREATE TEMP TABLE vm0_session_missing_latest_storage_plan ON COMMIT DROP AS
+WITH missing_storage_identities AS (
+  SELECT DISTINCT
+    session."org_id",
+    session."user_id",
+    artifact.value ->> 'name' AS name
+  FROM "agent_sessions" AS session
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE
+      WHEN jsonb_typeof(session."artifacts") = 'array'
+        THEN session."artifacts"
+      ELSE '[]'::jsonb
+    END
+  ) AS artifact(value)
+  LEFT JOIN "storages" AS storage
+    ON storage."org_id" = session."org_id"
+    AND storage."user_id" = session."user_id"
+    AND storage."name" = artifact.value ->> 'name'
+  WHERE session."storage_mounts" IS NULL
+    AND jsonb_typeof(artifact.value) = 'object'
+    AND jsonb_typeof(artifact.value -> 'name') = 'string'
+    AND jsonb_typeof(artifact.value -> 'mountPath') = 'string'
+    AND (
+      NOT (artifact.value ? 'version')
+      OR (
+        jsonb_typeof(artifact.value -> 'version') = 'string'
+        AND artifact.value ->> 'version' = 'latest'
+      )
+    )
+    AND storage."id" IS NULL
+),
+new_storage_identities AS (
+  SELECT
+    gen_random_uuid() AS storage_id,
+    missing."org_id",
+    missing."user_id",
+    missing.name
+  FROM missing_storage_identities AS missing
+)
+SELECT
+  identity.storage_id,
+  identity."org_id",
+  identity."user_id",
+  identity.name,
+  identity."org_id" || '/' || identity.storage_id::text AS s3_prefix,
+  encode(
+    digest(
+      'storage:' || identity.storage_id::text || E'\n',
+      'sha256'
+    ),
+    'hex'
+  ) AS version_id
+FROM new_storage_identities AS identity;
+--> statement-breakpoint
+
+INSERT INTO "storages" (
+  "id",
+  "user_id",
+  "name",
+  "type",
+  "org_id",
+  "s3_prefix"
+)
+SELECT
+  plan.storage_id,
+  plan."user_id",
+  plan.name,
+  'artifact',
+  plan."org_id",
+  plan.s3_prefix
+FROM pg_temp.vm0_session_missing_latest_storage_plan AS plan;
+--> statement-breakpoint
+
+INSERT INTO "storage_versions" (
+  "id",
+  "storage_id",
+  "s3_key",
+  "size",
+  "archive_size",
+  "file_count",
+  "message",
+  "created_by"
+)
+SELECT
+  plan.version_id,
+  plan.storage_id,
+  plan.s3_prefix || '/' || plan.version_id,
+  0,
+  0,
+  0,
+  'Initial empty artifact',
+  plan."user_id"
+FROM pg_temp.vm0_session_missing_latest_storage_plan AS plan;
+--> statement-breakpoint
+
+UPDATE "storages" AS storage
+SET
+  "head_version_id" = plan.version_id,
+  "updated_at" = now()
+FROM pg_temp.vm0_session_missing_latest_storage_plan AS plan
+WHERE storage."id" = plan.storage_id;
 --> statement-breakpoint
 
 DO $$
@@ -50,8 +157,21 @@ BEGIN
               NOT IN ('fail', 'preserveParentVersion')
           )
         )
+        OR (
+          artifact.value ? 'generatedBy'
+          AND (
+            jsonb_typeof(artifact.value -> 'generatedBy') IS DISTINCT FROM 'string'
+            OR artifact.value ->> 'generatedBy' <> 'apiAutoMemory'
+          )
+        )
         OR artifact.value
-          - ARRAY['name', 'version', 'mountPath', 'missingRootPolicy']::text[]
+          - ARRAY[
+            'name',
+            'version',
+            'mountPath',
+            'missingRootPolicy',
+            'generatedBy'
+          ]::text[]
           <> '{}'::jsonb
     );
 
@@ -381,7 +501,27 @@ BEGIN
   FROM "agent_sessions" AS session
   WHERE session."storage_mounts" IS NOT NULL
     AND session."artifacts" <> '[]'::jsonb
-    AND session."artifacts" IS DISTINCT FROM COALESCE(
+    AND COALESCE(
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN jsonb_typeof(artifact.value -> 'generatedBy') = 'string'
+              AND artifact.value ->> 'generatedBy' = 'apiAutoMemory'
+              THEN artifact.value - 'generatedBy'
+            ELSE artifact.value
+          END
+          ORDER BY artifact.ordinality
+        )
+        FROM jsonb_array_elements(
+          CASE
+            WHEN jsonb_typeof(session."artifacts") = 'array'
+              THEN session."artifacts"
+            ELSE '[]'::jsonb
+          END
+        ) WITH ORDINALITY AS artifact(value, ordinality)
+      ),
+      '[]'::jsonb
+    ) IS DISTINCT FROM COALESCE(
       (
         SELECT jsonb_agg(
           jsonb_strip_nulls(
@@ -512,7 +652,27 @@ BEGIN
   INTO lossy_sessions
   FROM "agent_sessions" AS session
   WHERE session."artifacts" <> '[]'::jsonb
-    AND session."artifacts" IS DISTINCT FROM COALESCE(
+    AND COALESCE(
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN jsonb_typeof(artifact.value -> 'generatedBy') = 'string'
+              AND artifact.value ->> 'generatedBy' = 'apiAutoMemory'
+              THEN artifact.value - 'generatedBy'
+            ELSE artifact.value
+          END
+          ORDER BY artifact.ordinality
+        )
+        FROM jsonb_array_elements(
+          CASE
+            WHEN jsonb_typeof(session."artifacts") = 'array'
+              THEN session."artifacts"
+            ELSE '[]'::jsonb
+          END
+        ) WITH ORDINALITY AS artifact(value, ordinality)
+      ),
+      '[]'::jsonb
+    ) IS DISTINCT FROM COALESCE(
       (
         SELECT jsonb_agg(
           jsonb_strip_nulls(


### PR DESCRIPTION
## Summary

- accept the exact historical `generatedBy: "apiAutoMemory"` provenance marker in migration 0654 without mutating legacy `artifacts`
- atomically recreate one empty artifact Storage and initial HEAD for each missing dynamic `latest`/implicit-latest identity before canonicalizing session mounts
- retain fail-closed guards for pinned versions, unknown provenance, malformed declarations, identity conflicts, and any lossy projection
- extend the real PostgreSQL migration fixture to cover shared recreated identities, legacy preservation, unsupported inputs, and full transaction rollback

## Why amend migration 0654

[Release run 30016635380](https://github.com/vm0-ai/vm0/actions/runs/30016635380) failed while applying 0654 to the Neon smoke branch, before production migrations or API promotion. Production therefore remains at 0653 and will execute this compatible form of 0654 on the next release.

Some non-production databases already applied the original 0654. Those databases satisfied its stricter guards, and this data-only amendment does not need to rerun there. This PR intentionally uses a one-time migration-immutability exception approved for the production-unapplied migration.

## Verification

- `pnpm --filter @vm0/db lint`
- `pnpm --filter @vm0/db check-types`
- `pnpm --filter @vm0/db test:migration-consistency` on local PostgreSQL 18: the 0654 success and rejection fixtures pass; the final repository-wide comparison reports only PostgreSQL 18 names retained for historical `NOT NULL` constraints, while CI runs the authoritative PostgreSQL 17 job
- pre-commit Prettier, Knip, file-size, generated-firewall, and commitlint checks
- full workspace type checking reached the API package after the DB and eleven other packages passed, then exhausted the local 2 GB Node heap; remote CI remains authoritative
