### PR TITLE
refactor: reduce fallback slop in slack asset delivery

### DIFF
--- a/turbo/apps/api/src/signals/services/canonical-slack-asset-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-asset-delivery.service.ts
@@ -54,6 +54,13 @@ type CanonicalSlackDeliveryResult =
       readonly retryable: boolean;
     };
 
+function requiredSlackFileId(externalId: string | null): string {
+  if (!externalId) {
+    throw new Error("Delivered Slack asset is missing its external file ID");
+  }
+  return externalId;
+}
+
 async function canonicalSlackDeliveryRow(
   db: Db,
   args: {
@@ -102,7 +109,7 @@ function deliveredResult(
 ): CanonicalSlackDeliveryResult {
   return {
     status: "delivered",
-    fileId: row.externalId ?? "",
+    fileId: requiredSlackFileId(row.externalId),
     permalink: row.deliveryUrl ?? "",
   };
 }
@@ -166,7 +173,7 @@ async function deliveryResultAfterTransitionConflict(
   if (current?.status === "delivered") {
     return {
       status: "delivered",
-      fileId: current.externalId ?? "",
+      fileId: requiredSlackFileId(current.externalId),
       permalink: current.deliveryUrl ?? "",
     };
   }
@@ -204,6 +211,7 @@ async function markDeliveryDelivered(
   row: CanonicalSlackDeliveryRow,
   permalink: string,
 ): Promise<CanonicalSlackDeliveryResult> {
+  const fileId = requiredSlackFileId(row.externalId);
   const [delivered] = await db
     .update(canonicalAssetDeliveries)
     .set({
@@ -217,7 +225,7 @@ async function markDeliveryDelivered(
   return delivered
     ? {
         status: "delivered",
-        fileId: row.externalId ?? "",
+        fileId,
         permalink,
       }
     : await deliveryResultAfterTransitionConflict(db, row);


### PR DESCRIPTION
## Summary

Canonical Slack delivery now rejects a `delivered` row that lacks its Slack file ID instead of returning an empty identifier. The check is shared by cached delivery results, transition-conflict reconciliation, and the successful delivery transition, so corrupted internal state fails clearly across every delivered-result path.

## Scan

- Timestamp: `2026-07-23T20:01:41.364Z`
- Base commit: `bb79fc415971bfb8845b10ca5795d53f72107b79`
- Files scanned: `4331`
- Total matches: `19684`
- Scanner high-confidence production actionable matches: `234`
- Scanner suggested 5% budget: `12`
- Manual `actionable_total`: `1` semantic internal-state invariant after surrounding-code review
- Adjusted `edit_budget`: `1`
- Candidates changed: `1` semantic candidate across `3` empty-ID fallback occurrences

Total matches by category:

```text
nullish: 6075
nullish-chain: 136
field-fallback-chain: 108
optional-prop: 5900
zod-optional: 2457
zod-loose-optional: 2
loose-record: 1095
loose-index-signature: 3
as-any: 0
as-unknown-as: 31
empty-fallback: 725
string-fallback: 769
null-undefined-fallback: 1581
empty-catch: 3
promise-catch-swallow: 14
rust-unwrap-or: 645
rust-ok-discard: 140
```

## Files changed

- `turbo/apps/api/src/signals/services/canonical-slack-asset-delivery.service.ts`: require a non-empty external Slack file ID before returning or persisting a delivered result. This is safe because every valid delivery first reserves the Slack file and stores that ID; completion also verifies the stored ID against the requested file. A missing ID therefore represents corrupted internal state, not an optional provider field. Permalink fallbacks remain unchanged because Slack delivery can succeed even when file-info lookup does not return a URL.

## Verification

- `git diff --check`
- Re-ran the repository scanner: `nullish` decreased from `6075` to `6072`, and `string-fallback` decreased from `769` to `766`.
- Package lint, typecheck, and targeted Vitest were not run because the fresh checkout has no installed workspace dependencies; the PR pipeline will run the full required checks.

This workflow intentionally leaves the remaining candidates for later daily runs.