### PR TITLE
test: prevent zero email outbox drain timeout under shared backlog

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -4,7 +4,7 @@ import { createStore } from "ccstate";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
-import { mockEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createEmailApi } from "./helpers/api-bdd-email";
@@ -262,6 +262,9 @@ beforeEach(() => {
   mockEnv("RESEND_API_KEY", "test-resend-key");
   mockEnv("RESEND_WEBHOOK_SECRET", INBOUND_SECRET);
   mockEnv("RESEND_FROM_DOMAIN", "mail.example.com");
+  // This route drains a cross-file outbox; Resend pacing is not part of these
+  // transactional delivery assertions.
+  mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
 });
 
 describe("POST /api/zero/email/inbound", () => {


### PR DESCRIPTION
## Summary

- Disable `EMAIL_OUTBOX_DRAIN_DELAY_MS` only in the Zero Email route tests.
- Keep the real global outbox drain, database behavior, provider mocks, and delivery assertions intact.
- Prevent persisted rows from earlier test files from consuming the 5-second Vitest timeout through production Resend pacing.

## User-visible impact

The Turbo API shard no longer flakes when Zero Email tests inherit a shared email-outbox backlog. Production email pacing is unchanged.

## Root cause

The failing test invokes the global outbox drain. In the failed job, earlier tests left eight pending emails; the test added one more. The production 500 ms pacing delay therefore consumed about 4.5 seconds before normal database and export work, producing a 5.017-second timeout.

Failed job: https://github.com/vm0-ai/vm0/actions/runs/30041594831/job/89322664626

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- Targeted test against a fresh migrated PostgreSQL database
- Five consecutive focused passes during diagnosis
- Shared-backlog stress case drained ten pre-existing rows plus the test row in 196 ms