### PR TITLE
fix(platform): show product names for managed api credit usage

### DIFF
--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -1,8 +1,24 @@
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 
-const CONNECTOR_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  scrape: "Web Fetch",
+  maps: "Maps",
+  "web-search": "Web Search",
+  finance: "Finance",
+  weather: "Weather",
+};
+
+// Chat usage keeps the managed usage kind, while Settings currently groups
+// these kinds under `other` and only retains the provider. Keep the provider
+// aliases here so both surfaces show the same product-facing capability name.
+const MANAGED_USAGE_PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   firecrawl: "Web Fetch",
+  "google-maps": "Maps",
+  openstreetmap: "Maps",
   perplexity: "Web Search",
+  apidojo: "Finance",
+  "google-weather": "Weather",
+  "google-air-quality": "Weather",
 };
 
 const MODEL_DISPLAY_NAMES: Readonly<Record<string, string>> = {
@@ -75,21 +91,25 @@ export function getCreditUsageDisplayName(
   kind: string,
   provider: string,
 ): string {
+  const baseKind = usageKindBase(kind);
+  const managedKindDisplayName = MANAGED_USAGE_KIND_DISPLAY_NAMES[baseKind];
+  if (managedKindDisplayName) {
+    return managedKindDisplayName;
+  }
+
   if (!provider || provider === "unknown") {
     return formatUsageIdentifier(kind);
   }
 
   const normalizedProvider = provider.trim();
-  const baseKind = usageKindBase(kind);
-  if (baseKind === "connector") {
-    const connectorDisplayName = CONNECTOR_DISPLAY_NAMES[normalizedProvider];
-    if (connectorDisplayName) {
-      return connectorDisplayName;
-    }
-  }
-
   if (baseKind === "model" || baseKind === "image" || baseKind === "video") {
     return usageModelDisplayName(normalizedProvider);
+  }
+
+  const managedProviderDisplayName =
+    MANAGED_USAGE_PROVIDER_DISPLAY_NAMES[normalizedProvider];
+  if (managedProviderDisplayName) {
+    return managedProviderDisplayName;
   }
 
   return formatUsageIdentifier(normalizedProvider);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -276,49 +276,65 @@ describe("chat lifecycle", () => {
     expect(screen.queryByLabelText("Credit usage 12")).not.toBeInTheDocument();
   });
 
-  it("keeps connector usage visible when completed work is folded", async () => {
+  it("keeps managed API usage visible when completed work is folded", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-usage-chip-folded-connector",
+      threadId: "thread-usage-chip-folded-managed-api",
       chatMessages: [
         {
           id: "msg-usage-folded-user",
           role: "user",
-          content: "Use the connector",
-          runId: "run-usage-folded-connector",
+          content: "Use the managed APIs",
+          runId: "run-usage-folded-managed-api",
           createdAt: "2026-06-09T10:00:00Z",
         },
         {
           id: "msg-usage-folded-work",
           role: "assistant",
-          content: "Inspecting connector results.",
-          runId: "run-usage-folded-connector",
+          content: "Inspecting managed API results.",
+          runId: "run-usage-folded-managed-api",
           createdAt: "2026-06-09T10:00:01Z",
         },
         {
           id: "msg-usage-folded-final",
           role: "assistant",
-          content: "Connector usage is ready.",
-          runId: "run-usage-folded-connector",
+          content: "Managed API usage is ready.",
+          runId: "run-usage-folded-managed-api",
           createdAt: "2026-06-09T10:00:02Z",
         },
         {
           id: "msg-usage-folded-usage",
           role: "assistant",
           content: null,
-          runId: "run-usage-folded-connector",
+          runId: "run-usage-folded-managed-api",
           usage: {
             version: 1,
-            totalCredits: 108,
+            totalCredits: 180,
             settledAt: "2026-06-09T10:00:03Z",
             breakdown: [
               {
-                kind: "connector",
-                credits: 108,
-                providers: [
-                  { provider: "firecrawl", credits: 36 },
-                  { provider: "perplexity", credits: 36 },
-                  { provider: "google-map", credits: 36 },
-                ],
+                kind: "scrape",
+                credits: 36,
+                providers: [{ provider: "firecrawl", credits: 36 }],
+              },
+              {
+                kind: "maps",
+                credits: 36,
+                providers: [{ provider: "google-maps", credits: 36 }],
+              },
+              {
+                kind: "web-search",
+                credits: 36,
+                providers: [{ provider: "perplexity", credits: 36 }],
+              },
+              {
+                kind: "finance",
+                credits: 36,
+                providers: [{ provider: "apidojo", credits: 36 }],
+              },
+              {
+                kind: "weather",
+                credits: 36,
+                providers: [{ provider: "google-weather", credits: 36 }],
               },
             ],
           },
@@ -328,7 +344,7 @@ describe("chat lifecycle", () => {
           id: "msg-usage-folded-completed",
           role: "assistant",
           content: null,
-          runId: "run-usage-folded-connector",
+          runId: "run-usage-folded-managed-api",
           runLifecycleEvent: "completed",
           createdAt: "2026-06-09T10:00:04Z",
         },
@@ -337,24 +353,31 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-chip-folded-connector",
+      path: "/chats/thread-usage-chip-folded-managed-api",
     });
 
     await expect(
-      screen.findByText("Connector usage is ready."),
+      screen.findByText("Managed API usage is ready."),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.queryByText("Inspecting connector results."),
+      screen.queryByText("Inspecting managed API results."),
     ).not.toBeInTheDocument();
 
-    const connectorCredit = await screen.findByLabelText("Credit usage 108");
-    click(connectorCredit);
+    const managedApiCredit = await screen.findByLabelText("Credit usage 180");
+    click(managedApiCredit);
 
     await waitFor(() => {
       expect(screen.getByText("Web Fetch")).toBeInTheDocument();
+      expect(screen.getByText("Maps")).toBeInTheDocument();
       expect(screen.getByText("Web Search")).toBeInTheDocument();
-      expect(screen.getByText("Google Map")).toBeInTheDocument();
-      expect(screen.getAllByText("36")).toHaveLength(3);
+      expect(screen.getByText("Finance")).toBeInTheDocument();
+      expect(screen.getByText("Weather")).toBeInTheDocument();
+      expect(screen.getAllByText("36")).toHaveLength(5);
+      expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();
+      expect(screen.queryByText("Google Maps")).not.toBeInTheDocument();
+      expect(screen.queryByText("Perplexity")).not.toBeInTheDocument();
+      expect(screen.queryByText("Apidojo")).not.toBeInTheDocument();
+      expect(screen.queryByText("Google Weather")).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -23,12 +23,14 @@ function usageRows(): UsageRecordRow[] {
       tokens: 2200,
       breakdown: [
         {
-          kind: "connector",
+          kind: "other",
           credits: 980,
           providers: [
-            { provider: "firecrawl", credits: 300 },
-            { provider: "perplexity", credits: 300 },
-            { provider: "google-map", credits: 380 },
+            { provider: "firecrawl", credits: 180 },
+            { provider: "google-maps", credits: 200 },
+            { provider: "perplexity", credits: 200 },
+            { provider: "apidojo", credits: 200 },
+            { provider: "google-weather", credits: 200 },
           ],
         },
       ],
@@ -186,17 +188,21 @@ describe("personal usage settings", () => {
     expect(screen.queryByText("All sources")).not.toBeInTheDocument();
     expect(requestedRanges).toContain("today");
 
-    await user.hover(screen.getByTestId("usage-kind-segment-connector"));
+    await user.hover(screen.getByTestId("usage-kind-segment-other"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Web Fetch").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Maps").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Web Search").length).toBeGreaterThanOrEqual(
         1,
       );
-      expect(screen.getAllByText("Google Map").length).toBeGreaterThanOrEqual(
-        1,
-      );
-      expect(screen.queryByText("google-map")).not.toBeInTheDocument();
+      expect(screen.getAllByText("Finance").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Weather").length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();
+      expect(screen.queryByText("Google Maps")).not.toBeInTheDocument();
+      expect(screen.queryByText("Perplexity")).not.toBeInTheDocument();
+      expect(screen.queryByText("Apidojo")).not.toBeInTheDocument();
+      expect(screen.queryByText("Google Weather")).not.toBeInTheDocument();
     });
 
     click(screen.getByText("Load more"));


### PR DESCRIPTION
## Summary

- replace backend vendor identifiers in credit usage details with product-facing capability names
- resolve both raw managed API usage kinds in chat and provider-only breakdowns in Settings through the shared formatter
- cover alternate Maps and Weather providers and update UI tests to match production payload shapes

## User impact

Settings and chat message credit usage now show `Web Fetch`, `Maps`, `Web Search`, `Finance`, and `Weather` instead of Firecrawl, Google Maps, Perplexity, APIDojo, or Google Weather.

## Verification

- `pnpm exec prettier --check apps/platform/src/lib/credit-usage-display.ts apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx src/views/zero-page/__tests__/chat-run-results.test.tsx --maxWorkers=4 --silent=passed-only` (23 passed)

Browser verification was not run; the vm0 PR workflow delegates runtime UI verification to the PR preview pipeline.
