### PR TITLE
fix: clear structured thread drafts from composer

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -28,6 +28,7 @@ import {
   createRestoredAttachment,
   type DraftSignals,
 } from "../zero-page/chat-draft.ts";
+import { buildDraftPersistencePayload } from "../zero-page/draft-persistence.ts";
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
@@ -981,8 +982,6 @@ function createDraftSync(
         return;
       }
 
-      const input = get(draft.input$);
-      const content = input.trim() || null;
       const attachments = get(draft.attachments$);
 
       const infos = await Promise.allSettled(
@@ -1004,28 +1003,20 @@ function createDraftSync(
         };
       });
       const features = get(featureSwitch$);
-      const editorDocument = set(draft.readEditorDocument$);
-      let structuredPrompt: UserMessageDocument | null = null;
-      if (
-        (features[FeatureSwitchKey.StructuredPrompt] ?? false) &&
-        editorDocument
-      ) {
-        structuredPrompt = editorDocument.toMessageDocument({
-          generationTemplate: get(draft.generationTemplate$),
-          attachments: persisted,
-        });
-        if (!structuredPrompt) {
-          throw new Error("Failed to serialize structured draft");
-        }
-      }
+      const payload = buildDraftPersistencePayload({
+        input: get(draft.input$),
+        structuredPromptEnabled:
+          features[FeatureSwitchKey.StructuredPrompt] ?? false,
+        editorDocument: set(draft.readEditorDocument$),
+        generationTemplate: get(draft.generationTemplate$),
+        attachments: persisted,
+      });
 
       await set(
         dataSource.patchDraft$,
         {
           threadId,
-          content,
-          structuredPrompt,
-          attachments: persisted.length > 0 ? persisted : null,
+          ...payload,
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -19,6 +19,10 @@ import {
   type DraftSignals,
 } from "./chat-draft.ts";
 import {
+  buildDraftPersistencePayload,
+  type DraftPersistencePayload,
+} from "./draft-persistence.ts";
+import {
   messageDocumentToEditorDoc,
   messageDocumentToPrompt,
 } from "./user-message-document-codec.ts";
@@ -109,21 +113,15 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
   const draftSyncReset$ = resetSignal();
 
   const patchDraft$ = command(
-    async (
-      { get },
-      content: string | null,
-      structuredPrompt: UserMessageDocument | null,
-      attachments: PersistedAttachment[],
-      signal: AbortSignal,
-    ) => {
+    async ({ get }, payload: DraftPersistencePayload, signal: AbortSignal) => {
       const client = get(zeroClient$)(zeroAgentDraftContract);
       await accept(
         client.patch({
           params: { id: agentId },
           body: {
-            draftContent: content,
-            draftStructuredPrompt: structuredPrompt,
-            draftAttachments: attachments.length > 0 ? attachments : null,
+            draftContent: payload.content,
+            draftStructuredPrompt: payload.structuredPrompt,
+            draftAttachments: payload.attachments,
           },
           fetchOptions: { signal },
         }),
@@ -137,7 +135,6 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
       await delay(DRAFT_SYNC_DEBOUNCE_MS, { signal });
       signal.throwIfAborted();
 
-      const content = get(draft.input$).trim() || null;
       const draftAttachments = get(draft.attachments$);
       const infos = await Promise.allSettled(
         draftAttachments.map((attachment) => {
@@ -145,7 +142,7 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
         }),
       );
       signal.throwIfAborted();
-      const persistedAttachments = collectSuccessfulAttachmentInfos(
+      const attachments = collectSuccessfulAttachmentInfos(
         draftAttachments,
         infos,
       ).map((result) => {
@@ -158,34 +155,16 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
         };
       });
       const features = get(featureSwitch$);
-      const editorDocument = set(draft.readEditorDocument$);
-      const generationTemplate = get(draft.generationTemplate$);
-      const hasStructuredDraft =
-        content !== null ||
-        generationTemplate !== undefined ||
-        persistedAttachments.length > 0;
-      let structuredPrompt: UserMessageDocument | null = null;
-      if (
-        (features[FeatureSwitchKey.StructuredPrompt] ?? false) &&
-        editorDocument &&
-        hasStructuredDraft
-      ) {
-        structuredPrompt = editorDocument.toMessageDocument({
-          generationTemplate,
-          attachments: persistedAttachments,
-        });
-        if (!structuredPrompt) {
-          throw new Error("Failed to serialize structured agent draft");
-        }
-      }
+      const payload = buildDraftPersistencePayload({
+        input: get(draft.input$),
+        structuredPromptEnabled:
+          features[FeatureSwitchKey.StructuredPrompt] ?? false,
+        editorDocument: set(draft.readEditorDocument$),
+        generationTemplate: get(draft.generationTemplate$),
+        attachments,
+      });
 
-      await set(
-        patchDraft$,
-        content,
-        structuredPrompt,
-        persistedAttachments,
-        signal,
-      );
+      await set(patchDraft$, payload, signal);
     },
   );
 
@@ -200,7 +179,11 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
 
   const flushDraftClear$ = command(async ({ set }, signal: AbortSignal) => {
     set(draftSyncReset$);
-    await set(patchDraft$, null, null, [], signal);
+    await set(
+      patchDraft$,
+      { content: null, structuredPrompt: null, attachments: null },
+      signal,
+    );
   });
 
   return { queueDraftSync$, cancelDraftSync$, flushDraftClear$ };

--- a/turbo/apps/platform/src/signals/zero-page/draft-persistence.ts
+++ b/turbo/apps/platform/src/signals/zero-page/draft-persistence.ts
@@ -1,0 +1,49 @@
+import type {
+  GenerationTemplateRequest,
+  PersistedAttachment,
+  UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
+
+export interface DraftPersistencePayload {
+  readonly content: string | null;
+  readonly structuredPrompt: UserMessageDocument | null;
+  readonly attachments: PersistedAttachment[] | null;
+}
+
+interface DraftPersistenceSource {
+  readonly input: string;
+  readonly structuredPromptEnabled: boolean;
+  readonly editorDocument: EditorDocumentSnapshot | null;
+  readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly attachments: readonly PersistedAttachment[];
+}
+
+export function buildDraftPersistencePayload(
+  source: DraftPersistenceSource,
+): DraftPersistencePayload {
+  const content = source.input.trim() || null;
+  const attachments =
+    source.attachments.length > 0 ? [...source.attachments] : null;
+  const hasStructuredDraft =
+    content !== null ||
+    source.generationTemplate !== undefined ||
+    attachments !== null;
+
+  let structuredPrompt: UserMessageDocument | null = null;
+  if (
+    source.structuredPromptEnabled &&
+    source.editorDocument &&
+    hasStructuredDraft
+  ) {
+    structuredPrompt = source.editorDocument.toMessageDocument({
+      generationTemplate: source.generationTemplate,
+      attachments: source.attachments,
+    });
+    if (!structuredPrompt) {
+      throw new Error("Failed to serialize structured draft");
+    }
+  }
+
+  return { content, structuredPrompt, attachments };
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -362,6 +362,49 @@ describe("chat drafts", () => {
     }
   });
 
+  it("persists and clears typed thread drafts when structured prompts are enabled", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b1000000-0000-4000-a000-000000000107";
+    const draftPatches: Record<string, unknown>[] = [];
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
+
+    const editor = await findComposerEditor();
+    await fill(editor, "thread-level draft");
+
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual({
+        draftContent: "thread-level draft",
+        draftStructuredPrompt: {
+          version: 1,
+          parts: [{ type: "text", text: "thread-level draft" }],
+        },
+        draftAttachments: null,
+      });
+    });
+
+    await user.click(editor);
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual({
+        draftContent: null,
+        draftStructuredPrompt: null,
+        draftAttachments: null,
+      });
+    });
+    expect(editor.textContent ?? "").toBe("");
+  });
+
   it("preserves per-thread text drafts while navigating", async () => {
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

- Clear persisted thread drafts when users delete all composer content while `StructuredPrompt` is enabled, preventing stale drafts from reappearing.
- Reuse one draft persistence payload builder across agent and thread paths for content normalization, structured draft presence detection, serialization, and attachment null normalization.
- Keep the agent/thread storage adapters and page lifecycles separate while covering the missing thread clear flow through the real page setup.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-draft.test.tsx` (18 tests passed)