### PR TITLE
fix(mitm-addon): remove stale ruff suppression

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -57,10 +57,9 @@ class SnapshotComparison(NamedTuple):
 
 
 def fetch_source() -> str:
-    # S310 (suspicious-url-open-usage): SOURCE_URL is a fixed https:// IANA
-    # endpoint, not user input. The opener below uses the default CA-verifying
-    # SSL context and disables redirects so the fixed host cannot drift.
-    request = urllib.request.Request(  # noqa: S310
+    # SOURCE_URL is a fixed https:// IANA endpoint, not user input. The opener
+    # uses the default CA-verifying SSL context and disables redirects.
+    request = urllib.request.Request(
         SOURCE_URL,
         headers={"User-Agent": "vm0-mitm-addon-tld-updater"},
         method="GET",


### PR DESCRIPTION
## Summary

- remove the obsolete `S310` suppression rejected by Ruff 0.16.0
- retain the security rationale for the fixed IANA HTTPS request

## Scope

- no runtime behavior or dependency constraints change

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest` (4190 passed)

Observed in https://github.com/vm0-ai/vm0/actions/runs/30060270328/job/89380462636.
