### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.626.0

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -15,9 +15,13 @@ import { z } from "zod";
 import { vi } from "vitest";
 import { createApp } from "../app-factory";
 import { mockEnv } from "../lib/env";
+import webClientCompatibility from "../lib/web-client-compatibility.json";
 import { flushWaitUntilForTest } from "../signals/context/wait-until";
 import { ROUTES } from "../signals/route";
 import { accept, setupApp, testContext } from "./test-helpers";
+
+const MINIMUM_WEB_CLIENT_VERSION =
+  webClientCompatibility.minimumSupportedVersion;
 
 // eslint-disable-next-line api/no-test-vi-mocks
 const { mockFlushLogs } = vi.hoisted(() => {
@@ -896,7 +900,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.622.0",
+          [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
         },
       });
 
@@ -910,7 +914,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.622.0",
+          [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
         },
       });
 
@@ -923,7 +927,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.622.0",
+          [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
           [ZERO_MAIL_CLIENT_VERSION_HEADER]: "2",
         },
       });
@@ -936,7 +940,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.622.0",
+          [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
           [ZERO_MAIL_CLIENT_VERSION_HEADER]: ZERO_MAIL_CLIENT_VERSION,
         },
       });
@@ -966,7 +970,7 @@ describe("createApp", () => {
         headers: {
           "user-agent": "zero-test-agent",
           "x-forwarded-for": "203.0.113.10, 198.51.100.5",
-          "x-client-version": "0.622.0",
+          "x-client-version": MINIMUM_WEB_CLIENT_VERSION,
           "x-client-type": "App",
           "x-client-session-id": "session-test",
           "x-client-request-id": "request-test",
@@ -984,7 +988,7 @@ describe("createApp", () => {
         path_template: "/health",
         remote_addr: "203.0.113.10",
         user_agent: "zero-test-agent",
-        x_client_version: "0.622.0",
+        x_client_version: MINIMUM_WEB_CLIENT_VERSION,
         x_client_type: "App",
         x_client_session_id: "session-test",
         x_client_request_id: "request-test",

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.622.0"
+  "minimumSupportedVersion": "0.626.0"
 }


### PR DESCRIPTION
## Summary

Raises `minimumSupportedVersion` in `turbo/apps/api/src/lib/web-client-compatibility.json` from `0.622.0` to `0.626.0` to force-upgrade all app.vm0.ai web sessions to the latest release.

## User-visible impact

Once this deploys, any browser session running an app build older than `0.626.0` receives HTTP 426 from `webClientCompatibilityMiddleware` on its next API request, which opens the non-dismissible "Update required" dialog; the only action is Refresh, which loads the latest bundle. Sessions already on `0.626.0` are unaffected.

## Safety check

- Latest app release is `app-v0.626.0` (released 2026-07-24) and Axiom `vm0-request-log-prod` already shows live production traffic with `x_client_version=0.626.0`, satisfying the in-code requirement that the matching app build is live before raising the floor.
- Per the last 6h of Axiom data, roughly 1.7-1.9万 requests came from sessions on `0.607.0`-`0.625.0`; those sessions will see the upgrade dialog once. Only `X-Client-Type: App` traffic is affected — Desktop, CLI, Runner, GuestAgent, and Zero-Mail clients are out of scope.

## Verification

Config-only change; enforcement logic and the 426 dialog flow are pre-existing and unchanged. Relying on the PR pipeline for checks per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)