### PR TITLE
fix(chat): serialize inline feedback prompts

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -235,6 +235,78 @@ describe("user message document codec", () => {
     expect(messageDocumentToPrompt(structured)).toBe("");
   });
 
+  it("serializes feedback cards with their surrounding prompt sections", () => {
+    const editorDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Before" }],
+        },
+        {
+          type: "feedbackItem",
+          attrs: {
+            feedbackId: 1,
+            quote: "First quote",
+            showDivider: false,
+            fill: false,
+          },
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "First note" }],
+            },
+          ],
+        },
+        {
+          type: "feedbackItem",
+          attrs: {
+            feedbackId: 2,
+            quote: "Second quote",
+            showDivider: true,
+            fill: true,
+          },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Second note" },
+                { type: "hardBreak" },
+                {
+                  type: "chatThreadMention",
+                  attrs: { threadId: THREAD_ID, title: "Project Alpha" },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "After" }],
+        },
+      ],
+    });
+
+    const structured = editorDocToMessageDocument(editorDocument);
+    expect(structured).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "text",
+          text:
+            "Before\n\nFeedback on 2 parts of your reply:\n\n" +
+            "> First quote\n\nFirst note\n\n---\n\n" +
+            `> Second quote\n\nSecond note\n[Project Alpha](/chats/${THREAD_ID})\n\nAfter`,
+        },
+      ],
+    });
+    expect(messageDocumentToPrompt(structured)).toBe(
+      "Before\n\nFeedback on 2 parts of your reply:\n\n" +
+        "> First quote\n\nFirst note\n\n---\n\n" +
+        `> Second quote\n\nSecond note\n[Project Alpha](/chats/${THREAD_ID})\n\nAfter`,
+    );
+  });
+
   it("returns null for malformed or unsupported documents", () => {
     const unsupportedEditorDocument = workflowComposerDocument({
       type: "doc",
@@ -242,17 +314,12 @@ describe("user message document codec", () => {
         {
           type: "feedbackItem",
           attrs: {
-            feedbackId: 1,
+            feedbackId: "invalid",
             quote: "Unsupported",
             showDivider: false,
             fill: false,
           },
-          content: [
-            {
-              type: "paragraph",
-              content: [{ type: "text", text: "Unsupported" }],
-            },
-          ],
+          content: [{ type: "paragraph" }],
         },
       ],
     });

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -9,10 +9,12 @@ import {
   type UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
+import { formatFeedbackPrompt, type FeedbackItem } from "./chat-feedback.ts";
 import { serializeChatThreadMention } from "./chat-thread-suggestion-domain.ts";
 
 export const CHAT_THREAD_MENTION_NODE_NAME = "chatThreadMention";
 export const TEMPLATE_ATTACHMENT_NODE_NAME = "templateAttachment";
+const FEEDBACK_ITEM_NODE_NAME = "feedbackItem";
 
 export interface EditorDocumentContext {
   readonly generationTemplate?: GenerationTemplateRequest;
@@ -122,6 +124,84 @@ function appendFileParts(
   }
 }
 
+function feedbackItem(node: ProseMirrorNode): FeedbackItem | null {
+  const id: unknown = node.attrs.feedbackId;
+  const quote: unknown = node.attrs.quote;
+  if (typeof id !== "number" || typeof quote !== "string") {
+    return null;
+  }
+  let valid = true;
+  const note = node.textBetween(0, node.content.size, "\n", (leafNode) => {
+    if (leafNode.type.name === "hardBreak") {
+      return "\n";
+    }
+    if (leafNode.type.name !== CHAT_THREAD_MENTION_NODE_NAME) {
+      valid = false;
+      return "";
+    }
+    const part = chatThreadPart(leafNode);
+    if (!part || part.type !== "chat_thread") {
+      valid = false;
+      return "";
+    }
+    return serializeChatThreadMention(part.threadId, part.titleSnapshot);
+  });
+  if (!valid) {
+    return null;
+  }
+  return {
+    id,
+    quote,
+    note,
+  };
+}
+
+function templateCount(document: ProseMirrorNode): number | null {
+  let count = 0;
+  for (let index = 0; index < document.childCount; index++) {
+    const nodeName = document.child(index).type.name;
+    if (nodeName === "paragraph" || nodeName === FEEDBACK_ITEM_NODE_NAME) {
+      continue;
+    }
+    if (nodeName !== TEMPLATE_ATTACHMENT_NODE_NAME) {
+      return null;
+    }
+    count += 1;
+  }
+  return count <= 1 ? count : null;
+}
+
+function appendFeedbackGroup(
+  document: ProseMirrorNode,
+  startIndex: number,
+  parts: UserMessagePart[],
+  prependSeparator: boolean,
+): { readonly nextIndex: number; readonly emitted: boolean } | null {
+  const items: FeedbackItem[] = [];
+  let index = startIndex;
+  while (index < document.childCount) {
+    const node = document.child(index);
+    if (node.type.name !== FEEDBACK_ITEM_NODE_NAME) {
+      break;
+    }
+    const item = feedbackItem(node);
+    if (!item) {
+      return null;
+    }
+    if (item.note.trim().length > 0) {
+      items.push(item);
+    }
+    index += 1;
+  }
+  if (items.length > 0) {
+    if (prependSeparator) {
+      appendTextPart(parts, "\n\n");
+    }
+    appendTextPart(parts, formatFeedbackPrompt(items));
+  }
+  return { nextIndex: index, emitted: items.length > 0 };
+}
+
 /**
  * Converts the current composer snapshot into its editor-independent business
  * document. External files are normalized after the leading template chip and
@@ -138,24 +218,12 @@ export function editorDocToMessageDocument(
   const parts: UserMessagePart[] = [];
   const attachments = context.attachments ?? [];
   let filesAppended = false;
-  let templateCount = 0;
-  let paragraphCount = 0;
-  for (let index = 0; index < document.childCount; index++) {
-    const node = document.child(index);
-    if (node.type.name === "paragraph") {
-      paragraphCount += 1;
-      continue;
-    }
-    if (node.type.name !== TEMPLATE_ATTACHMENT_NODE_NAME) {
-      return null;
-    }
-    templateCount += 1;
-  }
-  if (templateCount > 1) {
+  const documentTemplateCount = templateCount(document);
+  if (documentTemplateCount === null) {
     return null;
   }
 
-  let paragraphIndex = 0;
+  let previousPromptSection: "paragraph" | "feedback" | null = null;
   for (let index = 0; index < document.childCount; index++) {
     const node = document.child(index);
     if (node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME) {
@@ -170,18 +238,37 @@ export function editorDocToMessageDocument(
       appendFileParts(parts, attachments);
       filesAppended = true;
     }
+    if (node.type.name === FEEDBACK_ITEM_NODE_NAME) {
+      const feedbackGroup = appendFeedbackGroup(
+        document,
+        index,
+        parts,
+        previousPromptSection !== null,
+      );
+      if (feedbackGroup === null) {
+        return null;
+      }
+      index = feedbackGroup.nextIndex - 1;
+      if (feedbackGroup.emitted) {
+        previousPromptSection = "feedback";
+      }
+      continue;
+    }
+    if (previousPromptSection !== null) {
+      appendTextPart(
+        parts,
+        previousPromptSection === "paragraph" ? "\n" : "\n\n",
+      );
+    }
     if (!appendParagraphParts(node, parts)) {
       return null;
     }
-    paragraphIndex += 1;
-    if (paragraphIndex < paragraphCount) {
-      appendTextPart(parts, "\n");
-    }
+    previousPromptSection = "paragraph";
   }
   if (!filesAppended) {
     appendFileParts(parts, attachments);
   }
-  if (templateCount === 0 && context.generationTemplate !== undefined) {
+  if (documentTemplateCount === 0 && context.generationTemplate !== undefined) {
     return null;
   }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1,10 +1,14 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import type {
+  GenerationTemplateRequest,
+  UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -26,6 +30,7 @@ interface ModelSelectionRequest {
 
 interface RunCreateCapture {
   prompt?: string;
+  structuredPrompt?: UserMessageDocument;
   attachFiles?: {
     id: string;
     filename: string;
@@ -220,7 +225,7 @@ describe("chat inline feedback", () => {
   it("keeps ordinary text and inline feedback in one composer document", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The rollout dates are unclear in this summary.";
-    const sentPrompts: string[] = [];
+    const sentMessages: RunCreateCapture[] = [];
     const successToast = vi.spyOn(toast, "success");
     context.mocks.browser.clipboardWriteText();
 
@@ -244,15 +249,14 @@ describe("chat inline feedback", () => {
         },
       ],
       onRunCreate: (body) => {
-        if (body.prompt !== undefined) {
-          sentPrompts.push(body.prompt);
-        }
+        sentMessages.push(body);
       },
     });
 
     detachedSetupPage({
       context,
       path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
     });
 
     const composerEditor = await findComposerEditor();
@@ -295,16 +299,19 @@ describe("chat inline feedback", () => {
     await user.click(screen.getByLabelText("Send"));
 
     await waitFor(() => {
-      expect(sentPrompts).toHaveLength(1);
+      expect(sentMessages).toHaveLength(1);
     });
-    expect(sentPrompts[0]).toContain("Feedback on this part of your reply:");
-    expect(sentPrompts[0]).toContain(
+    const sentPrompt = sentMessages[0]?.prompt;
+    expect(sentPrompt).toContain("Feedback on this part of your reply:");
+    expect(sentPrompt).toContain(
       "> The rollout dates are unclear in this summary.",
     );
-    expect(sentPrompts[0]).toContain(
-      "Mention the dates before the risk summary.",
-    );
-    expect(sentPrompts[0]).toContain("Make the dates explicit.");
+    expect(sentPrompt).toContain("Mention the dates before the risk summary.");
+    expect(sentPrompt).toContain("Make the dates explicit.");
+    expect(sentMessages[0]?.structuredPrompt).toStrictEqual({
+      version: 1,
+      parts: [{ type: "text", text: sentPrompt }],
+    });
 
     expect(feedbackNotes()).toHaveLength(0);
     await expect(findComposerEditor()).resolves.toBe(composerEditor);


### PR DESCRIPTION
## Summary
- serialize inline feedback cards into structured prompt text
- preserve grouped feedback, surrounding text, hard breaks, and chat thread mentions
- cover the structured-prompt send path with codec and page-level regression tests

## Testing
- pnpm -F @vm0/app exec vitest run src/signals/__tests__/user-message-document-codec.test.ts --silent=passed-only
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx -t 'keeps ordinary text and inline feedback in one composer document' --silent=passed-only
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint