### PR TITLE
refactor(api): use builders for unnest-backed bulk updates

### DIFF
--- a/turbo/apps/api/src/signals/services/usage-allowance.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-allowance.service.ts
@@ -793,17 +793,20 @@ async function persistUsageAllowanceWindowConsumption(
   const unitDeltas = changedWindows.map((window) => {
     return window.consumedUnits - window.initialConsumedUnits;
   });
-  await tx.execute(sql`
-    UPDATE ${orgUsageAllowanceWindows}
-    SET
-      "consumed_units" = ${orgUsageAllowanceWindows.consumedUnits} + consumption.units_applied,
-      "updated_at" = ${nowDate()}
-    FROM unnest(
+  const consumptionSource = sql`
+    unnest(
       ${sql.param(windowIds)}::uuid[],
       ${sql.param(unitDeltas)}::bigint[]
     ) AS consumption(window_id, units_applied)
-    WHERE ${orgUsageAllowanceWindows.id} = consumption.window_id
-  `);
+  `;
+  await tx
+    .update(orgUsageAllowanceWindows)
+    .set({
+      consumedUnits: sql`${orgUsageAllowanceWindows.consumedUnits} + consumption.units_applied`,
+      updatedAt: nowDate(),
+    })
+    .from(consumptionSource)
+    .where(eq(orgUsageAllowanceWindows.id, sql`consumption.window_id`));
 }
 
 async function insertUsageAllowanceAllocations(

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -252,20 +252,23 @@ async function markUsageEventsProcessed(
   const billingErrors = outcomes.map((outcome) => {
     return outcome.billingError;
   });
-  await tx.execute(sql`
-    UPDATE ${usageEvent}
-    SET
-      "credits_charged" = settlement.credits_charged,
-      "status" = 'processed',
-      "processed_at" = ${nowDate()},
-      "billing_error" = settlement.billing_error
-    FROM unnest(
+  const settlementSource = sql`
+    unnest(
       ${sql.param(usageEventIds)}::uuid[],
       ${sql.param(creditsCharged)}::bigint[],
       ${sql.param(billingErrors)}::varchar(50)[]
     ) AS settlement(usage_event_id, credits_charged, billing_error)
-    WHERE ${usageEvent.id} = settlement.usage_event_id
-  `);
+  `;
+  await tx
+    .update(usageEvent)
+    .set({
+      creditsCharged: sql`settlement.credits_charged`,
+      status: "processed",
+      processedAt: nowDate(),
+      billingError: sql`settlement.billing_error`,
+    })
+    .from(settlementSource)
+    .where(eq(usageEvent.id, sql`settlement.usage_event_id`));
 }
 
 async function processOrgUsageEventsInTransaction(

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -87,6 +87,24 @@ const deletePreamble = `
   declare const cutoff: Date;
 `;
 
+const unnestUpdatePreamble = `
+  import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+  const allowanceWindows = pgTable("allowance_windows", {
+    id: text("id").primaryKey(),
+    consumedUnits: integer("consumed_units").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+  });
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      allowanceWindows: typeof allowanceWindows;
+    }>;
+  declare const db: DrizzleDatabase;
+  declare const windowIds: readonly string[];
+  declare const unitDeltas: readonly number[];
+  declare const updatedAt: Date;
+`;
+
 const upsertPreamble = `
   import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
@@ -190,6 +208,128 @@ const runnerLockingQuery = `
 
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        const query = sql\`
+          UPDATE \${allowanceWindows}
+          SET
+            "consumed_units" = \${allowanceWindows.consumedUnits} + consumption.units_applied,
+            "updated_at" = \${updatedAt}
+          FROM unnest(
+            \${sql.param(windowIds)}::uuid[],
+            \${sql.param(unitDeltas)}::bigint[]
+          ) AS consumption(window_id, units_applied)
+          WHERE \${allowanceWindows.id} = consumption.window_id
+        \`;
+        await db.execute(query);
+      `,
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        const fakeDb = {
+          async execute(query: unknown) {
+            return query;
+          },
+        };
+        await fakeDb.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(windowIds)}::uuid[]) AS consumption(window_id)
+          WHERE \${allowanceWindows.id} = consumption.window_id
+        \`);
+      `,
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        function sql(
+          strings: TemplateStringsArray,
+          ...values: readonly unknown[]
+        ) {
+          return { strings, values };
+        }
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${windowIds}) AS consumption(window_id)
+          WHERE \${allowanceWindows.id} = consumption.window_id
+        \`);
+      `,
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        const notATable = sql\`allowance_windows\`;
+        await db.execute(sql\`
+          UPDATE \${notATable}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE true
+        \`);
+      `,
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          WITH changed AS (SELECT 1)
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE true
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE true
+          RETURNING id
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE true;
+          SELECT 1
+        \`);
+      `,
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows} AS target
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE target.id = consumption.window_id
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = incoming.units_applied
+          FROM (VALUES (1)) AS incoming(units_applied)
+          WHERE true
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units[1] = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[]) AS consumption(units_applied)
+          WHERE true
+        \`);
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(\${sql.param(unitDeltas)}::bigint[])
+            AS consumption(units_applied bigint)
+          WHERE true
+        \`);
+      `,
+    },
     {
       code: `${deletePreamble}
         import { sql } from "drizzle-orm";
@@ -1086,6 +1226,53 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
     },
   ],
   invalid: [
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          UPDATE \${allowanceWindows}
+          SET
+            "consumed_units" = \${allowanceWindows.consumedUnits} + consumption.units_applied,
+            "updated_at" = \${updatedAt}
+          FROM unnest(
+            \${sql.param(windowIds)}::uuid[],
+            \${sql.param(unitDeltas)}::bigint[]
+          ) AS consumption(window_id, units_applied)
+          WHERE \${allowanceWindows.id} = consumption.window_id
+        \`);
+      `,
+      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql as query } from "drizzle-orm";
+        await db.execute(query\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(
+            \${query.param(windowIds)}::uuid[],
+            \${query.param(unitDeltas)}::bigint[]
+          ) AS consumption(window_id, units_applied)
+          WHERE \${allowanceWindows.id} = consumption.window_id;
+        \`);
+      `,
+      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import * as drizzle from "drizzle-orm";
+        await db["execute"](drizzle.sql\`
+          UPDATE \${allowanceWindows}
+          SET consumed_units = consumption.units_applied
+          FROM unnest(
+            \${drizzle.sql.param(windowIds)}::uuid[],
+            \${drizzle.sql.param(unitDeltas)}::bigint[]
+          ) AS consumption(window_id, units_applied)
+          WHERE \${allowanceWindows.id} = consumption.window_id
+        \`);
+      `,
+      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+    },
     {
       code: `${deletePreamble}
         import { lte, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -95,13 +95,24 @@ const unnestUpdatePreamble = `
     consumedUnits: integer("consumed_units").notNull(),
     updatedAt: timestamp("updated_at").notNull(),
   });
+  const usageEvents = pgTable("usage_events", {
+    id: text("id").primaryKey(),
+    creditsCharged: integer("credits_charged"),
+    status: text("status").notNull(),
+    processedAt: timestamp("processed_at"),
+    billingError: text("billing_error"),
+  });
   type DrizzleDatabase =
     import("drizzle-orm/node-postgres").NodePgDatabase<{
       allowanceWindows: typeof allowanceWindows;
+      usageEvents: typeof usageEvents;
     }>;
   declare const db: DrizzleDatabase;
   declare const windowIds: readonly string[];
   declare const unitDeltas: readonly number[];
+  declare const eventIds: readonly string[];
+  declare const creditsCharged: readonly number[];
+  declare const billingErrors: readonly (string | null)[];
   declare const updatedAt: Date;
 `;
 
@@ -1239,6 +1250,26 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
             \${sql.param(unitDeltas)}::bigint[]
           ) AS consumption(window_id, units_applied)
           WHERE \${allowanceWindows.id} = consumption.window_id
+        \`);
+      `,
+      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+    },
+    {
+      code: `${unnestUpdatePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`
+          UPDATE \${usageEvents}
+          SET
+            "credits_charged" = settlement.credits_charged,
+            "status" = 'processed',
+            "processed_at" = \${updatedAt},
+            "billing_error" = settlement.billing_error
+          FROM unnest(
+            \${sql.param(eventIds)}::uuid[],
+            \${sql.param(creditsCharged)}::bigint[],
+            \${sql.param(billingErrors)}::varchar(50)[]
+          ) AS settlement(usage_event_id, credits_charged, billing_error)
+          WHERE \${usageEvents.id} = settlement.usage_event_id
         \`);
       `,
       errors: [{ messageId: "unnestUpdateQueryBuilder" }],

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -89,6 +89,10 @@ interface SimpleDeleteMatch {
   readonly targetTableExpressionIndex: number | undefined;
 }
 
+interface SimpleUnnestUpdateMatch {
+  readonly targetTableExpressionIndex: number;
+}
+
 interface SimpleUpsertMatch {
   readonly targetTableExpressionIndex: number | undefined;
 }
@@ -181,7 +185,19 @@ const UNSUPPORTED_DELETE_PREDICATE_KEYWORDS = new Set([
   "USING",
 ]);
 
+const UNSUPPORTED_UNNEST_UPDATE_PREDICATE_KEYWORDS = new Set([
+  "CURRENT",
+  "FETCH",
+  "LIMIT",
+  "ORDER",
+  "RETURNING",
+]);
+
 const UNSUPPORTED_UPSERT_ASSIGNMENT_KEYWORDS = new Set(["RETURNING", "WHERE"]);
+
+const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_$]*$/u;
+const SIMPLE_OR_QUOTED_IDENTIFIER_PATTERN =
+  /^(?:[A-Za-z_][A-Za-z0-9_$]*|"(?:""|[^"])+")$/u;
 
 function quasiText(node: TSESTree.TemplateElement): string {
   return node.value.cooked ?? node.value.raw;
@@ -391,6 +407,7 @@ function hasSimpleAssignments(
   syntaxSource: string,
   start: number,
   end: number,
+  targetPattern: RegExp,
 ): boolean {
   const segments: Array<{ readonly start: number; readonly end: number }> = [];
   let depth = 0;
@@ -426,9 +443,9 @@ function hasSimpleAssignments(
     if (assignmentOffset === -1) {
       return false;
     }
-    const target = syntaxSource.slice(segment.start, assignmentOffset).trim();
+    const target = source.slice(segment.start, assignmentOffset).trim();
     const value = source.slice(assignmentOffset + 1, segment.end).trim();
-    return /^[A-Za-z_][A-Za-z0-9_$]*$/u.test(target) && value !== "";
+    return targetPattern.test(target) && value !== "";
   });
 }
 
@@ -483,6 +500,123 @@ function simpleDeleteMatch(
       targetTable.kind === "expression"
         ? targetTable.expressionIndex
         : undefined,
+  };
+}
+
+function simpleUnnestUpdateMatch(
+  source: string,
+  syntaxSource: string,
+  statement: CompleteSqlStatement,
+): SimpleUnnestUpdateMatch | undefined {
+  const tokens = statement.tokens;
+  const trailingToken = tokens[tokens.length - 1];
+  if (
+    !statement.hasTrailingSemicolon &&
+    (trailingToken === undefined ||
+      syntaxSource.slice(trailingToken.end, statement.end).trim() !== "")
+  ) {
+    return undefined;
+  }
+
+  const setIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "SET") ? [index] : [];
+  });
+  const fromIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "FROM") ? [index] : [];
+  });
+  const whereIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "WHERE") ? [index] : [];
+  });
+  if (
+    setIndexes.length !== 1 ||
+    fromIndexes.length !== 1 ||
+    whereIndexes.length !== 1
+  ) {
+    return undefined;
+  }
+
+  const setIndex = setIndexes[0];
+  const fromIndex = fromIndexes[0];
+  const whereIndex = whereIndexes[0];
+  if (
+    setIndex === undefined ||
+    fromIndex === undefined ||
+    whereIndex === undefined
+  ) {
+    return undefined;
+  }
+
+  const updateKeyword = tokens[0];
+  const targetTable = tokens[1];
+  const setKeyword = tokens[setIndex];
+  const fromKeyword = tokens[fromIndex];
+  const unnestKeyword = tokens[fromIndex + 1];
+  const sourceOpen = tokens[fromIndex + 2];
+  const sourceClose = tokens[fromIndex + 3];
+  const asKeyword = tokens[fromIndex + 4];
+  const sourceAlias = tokens[fromIndex + 5];
+  const sourceColumnsOpen = tokens[fromIndex + 6];
+  const sourceColumnsClose = tokens[fromIndex + 7];
+  const whereKeyword = tokens[whereIndex];
+  if (
+    setIndex !== 2 ||
+    whereIndex !== fromIndex + 8 ||
+    !isWord(updateKeyword, "UPDATE") ||
+    targetTable?.kind !== "expression" ||
+    !isWord(setKeyword, "SET") ||
+    !isWord(fromKeyword, "FROM") ||
+    !isWord(unnestKeyword, "UNNEST") ||
+    !isPunctuation(sourceOpen, "(") ||
+    !isPunctuation(sourceClose, ")") ||
+    !isWord(asKeyword, "AS") ||
+    sourceAlias?.kind !== "word" ||
+    !isPunctuation(sourceColumnsOpen, "(") ||
+    !isPunctuation(sourceColumnsClose, ")") ||
+    !isWord(whereKeyword, "WHERE") ||
+    updateKeyword === undefined ||
+    setKeyword === undefined ||
+    fromKeyword === undefined ||
+    unnestKeyword === undefined ||
+    sourceOpen === undefined ||
+    sourceClose === undefined ||
+    asKeyword === undefined ||
+    sourceColumnsOpen === undefined ||
+    sourceColumnsClose === undefined ||
+    whereKeyword === undefined ||
+    !onlyWhitespaceBetween(syntaxSource, updateKeyword, targetTable) ||
+    !onlyWhitespaceBetween(syntaxSource, targetTable, setKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, fromKeyword, unnestKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, unnestKeyword, sourceOpen) ||
+    !onlyWhitespaceBetween(syntaxSource, sourceClose, asKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, asKeyword, sourceAlias) ||
+    !onlyWhitespaceBetween(syntaxSource, sourceAlias, sourceColumnsOpen) ||
+    !onlyWhitespaceBetween(syntaxSource, sourceColumnsClose, whereKeyword) ||
+    syntaxSource.slice(sourceOpen.end, sourceClose.start).trim() === "" ||
+    !isSimpleIdentifierList(
+      syntaxSource,
+      sourceColumnsOpen,
+      sourceColumnsClose,
+    ) ||
+    !hasSimpleAssignments(
+      source,
+      syntaxSource,
+      setKeyword.end,
+      fromKeyword.start,
+      SIMPLE_OR_QUOTED_IDENTIFIER_PATTERN,
+    ) ||
+    syntaxSource.slice(whereKeyword.end, statement.end).trim() === "" ||
+    tokens.slice(whereIndex + 1).some((token) => {
+      return (
+        token.kind === "word" &&
+        UNSUPPORTED_UNNEST_UPDATE_PREDICATE_KEYWORDS.has(token.value)
+      );
+    })
+  ) {
+    return undefined;
+  }
+
+  return {
+    targetTableExpressionIndex: targetTable.expressionIndex,
   };
 }
 
@@ -567,7 +701,13 @@ function simpleUpsertMatch(
         UNSUPPORTED_UPSERT_ASSIGNMENT_KEYWORDS.has(token.value)
       );
     }) ||
-    !hasSimpleAssignments(source, syntaxSource, setKeyword.end, statement.end)
+    !hasSimpleAssignments(
+      source,
+      syntaxSource,
+      setKeyword.end,
+      statement.end,
+      SIMPLE_IDENTIFIER_PATTERN,
+    )
   ) {
     return undefined;
   }
@@ -1281,7 +1421,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete schema-backed deletes, upserts, selects, existence checks, locking selects, and scalar result queries",
+        "Prefer Drizzle query builders for complete schema-backed deletes, unnest-backed updates, upserts, selects, existence checks, locking selects, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -1297,6 +1437,8 @@ export const preferDrizzleQueryBuilder = createRule({
         "Use a Drizzle delete builder for this complete single-target query.",
       upsertQueryBuilder:
         "Use a Drizzle insert builder with .onConflictDoUpdate(...) for this complete single-row upsert.",
+      unnestUpdateQueryBuilder:
+        "Use a Drizzle update builder with .from(...) for this complete unnest-backed update.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -1882,11 +2024,15 @@ export const preferDrizzleQueryBuilder = createRule({
         return;
       }
       const deleteMatch = simpleDeleteMatch(syntaxSource, statement);
-      const upsertMatch =
+      const unnestUpdateMatch =
         deleteMatch === undefined
+          ? simpleUnnestUpdateMatch(source, syntaxSource, statement)
+          : undefined;
+      const upsertMatch =
+        deleteMatch === undefined && unnestUpdateMatch === undefined
           ? simpleUpsertMatch(source, syntaxSource, statement)
           : undefined;
-      const match = deleteMatch ?? upsertMatch;
+      const match = deleteMatch ?? unnestUpdateMatch ?? upsertMatch;
       if (
         match === undefined ||
         !isDrizzleSqlTag(checker, services, query.tag) ||
@@ -1916,9 +2062,11 @@ export const preferDrizzleQueryBuilder = createRule({
       context.report({
         node: query,
         messageId:
-          deleteMatch === undefined
-            ? "upsertQueryBuilder"
-            : "deleteQueryBuilder",
+          deleteMatch !== undefined
+            ? "deleteQueryBuilder"
+            : unnestUpdateMatch !== undefined
+              ? "unnestUpdateQueryBuilder"
+              : "upsertQueryBuilder",
       });
     }
 


### PR DESCRIPTION
## Summary

- replace both complete usage-settlement `UPDATE ... FROM unnest(...)`
  statements with Drizzle update builders
- retain the fixed-shape zipped-array `unnest(...)` sources as the irreducible
  SQL leaves, preserving one statement and one round trip per batch
- use schema encoders for status and timestamps, including UTC-stable
  `timestamp without time zone` writes
- extend `api/prefer-drizzle-query-builder` with a conservative type-aware
  diagnostic for direct complete unnest-backed updates

## Scope

- no schema, migration, persisted-data rewrite, API, feature-switch,
  transaction, lock, or deployment compatibility change
- the partial-column allowance-allocation insert remains raw because the
  installed Drizzle insert-select builder cannot preserve both its omitted
  defaults and fixed statement shape
- parent delivery context: #22439

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test` (47 files, 778 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/usage-allowance.test.ts`
  (15 tests)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only`
  (167 files, 2342 tests)
- `pnpm knip --workspace @vm0/eslint-rules --workspace api`
- `git diff --check`
- rendered old/new SQL and parameter comparison under a non-UTC Node process
- rolled-back PostgreSQL 17 `EXPLAIN (ANALYZE, BUFFERS)` checks for one-row and
  multi-row sources
- pre-commit hook, including full Turbo type checking and full cached Knip

Closes #22828
