### PR TITLE
fix(api): preserve preview override for queued chat runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -4377,6 +4377,98 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, runId);
   }, 90_000);
 
+  it("preserves real-agent preview mode across queued auto-sends", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "preview override queue anchor",
+    });
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+
+    const previewMessageId = randomUUID();
+    const previewQueued = await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "queued real-agent preview run",
+        clientMessageId: previewMessageId,
+        realAgentInPreview: true,
+      },
+      [201],
+    );
+    expect(previewQueued.body).toMatchObject({ runId: null });
+
+    const mockMessageId = randomUUID();
+    const mockQueued = await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "queued preview mock run",
+        clientMessageId: mockMessageId,
+      },
+      [201],
+    );
+    expect(mockQueued.body).toMatchObject({ runId: null });
+
+    // Terminal callbacks and the cleanup safety sweep use the same queued
+    // auto-send builder; finishing the anchor guarantees that builder owns both.
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    const previewMessages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === previewMessageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const previewRunId = userMessages(previewMessages.messages).find(
+      (message) => {
+        return message.revokesMessageId === previewMessageId;
+      },
+    )?.runId;
+    if (!previewRunId) {
+      throw new Error("Expected the preview override message to auto-send");
+    }
+
+    const previewClaim = await claimChatRun(runnerGroup, previewRunId);
+    expect(previewClaim.claim.prompt).toBe("queued real-agent preview run");
+    expect(previewClaim.claim.realAgentInPreview).toBeTruthy();
+    await cancelChatRun(actor, previewRunId);
+
+    const mockMessages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === mockMessageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const mockRunId = userMessages(mockMessages.messages).find((message) => {
+      return message.revokesMessageId === mockMessageId;
+    })?.runId;
+    if (!mockRunId) {
+      throw new Error("Expected the default preview message to auto-send");
+    }
+
+    const mockClaim = await claimChatRun(runnerGroup, mockRunId);
+    expect(mockClaim.claim.prompt).toBe("queued preview mock run");
+    expect(mockClaim.claim.realAgentInPreview).toBeUndefined();
+    await cancelChatRun(actor, mockRunId);
+  }, 90_000);
+
   it("appends a claimed queued message after messages that are still queued", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -158,6 +158,7 @@ type BddSendMessageBody =
       readonly computerUseHostId?: string | null;
       readonly clientMessageId?: string;
       readonly chatThreadSortEventId?: string;
+      readonly realAgentInPreview?: boolean;
       readonly revokesMessageId?: string;
     }
   | {
@@ -1285,6 +1286,9 @@ export function createChatFilesBddApi(context: TestContext) {
                 ...(body.chatThreadSortEventId === undefined
                   ? {}
                   : { chatThreadSortEventId: body.chatThreadSortEventId }),
+                ...(body.realAgentInPreview === undefined
+                  ? {}
+                  : { realAgentInPreview: body.realAgentInPreview }),
                 ...(body.revokesMessageId === undefined
                   ? {}
                   : { revokesMessageId: body.revokesMessageId }),

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -109,6 +109,7 @@ import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-mark
 import {
   deleteUserMessageQueueItem,
   discardUnclaimedUserMessage,
+  encryptQueuedUserMessageRunParams,
   enqueueUserMessageQueueItem,
   loadNextUnclaimedQueuedUserMessageId,
   lockUserMessageQueueThread,
@@ -1525,6 +1526,7 @@ function appendUnassociatedUserMessage(params: {
   readonly structuredPrompt: UserMessageDocument | undefined;
   readonly generationTemplate: IncomingGenerationTemplate;
   readonly orgId: string;
+  readonly encryptedParams: string | undefined;
 }): Promise<ClientMessageIdResolution> {
   return params.db.transaction(async (tx) => {
     await tx
@@ -1565,6 +1567,7 @@ function appendUnassociatedUserMessage(params: {
         userId: params.userId,
         chatThreadId: params.threadId,
         chatMessageId: inserted.id,
+        encryptedParams: params.encryptedParams,
       });
       if (params.touchThreadSort) {
         await touchChatThreadLastMessageAt(
@@ -2418,6 +2421,17 @@ async function queueUnassociatedNormalMessage(params: {
   /** Set when this call inserted a queue-first message. */
   readonly queuedMessageId: string | undefined;
 }> {
+  const encryptedParams = params.body.realAgentInPreview
+    ? await encryptQueuedUserMessageRunParams(
+        {
+          version: 1,
+          prompt: params.prepared.body.agentPrompt,
+          appendSystemPrompt: buildWebChatPrompt(),
+          realAgentInPreview: true,
+        },
+        { orgId: params.orgId, userId: params.userId },
+      )
+    : undefined;
   const message = await appendUnassociatedUserMessage({
     db: params.prepared.db,
     threadId: params.prepared.thread.threadId,
@@ -2430,6 +2444,7 @@ async function queueUnassociatedNormalMessage(params: {
     structuredPrompt: params.body.structuredPrompt,
     generationTemplate: params.body.generationTemplate,
     orgId: params.orgId,
+    encryptedParams,
   });
   if (message.kind === "queued" && message.inserted) {
     waitUntil(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -447,6 +447,7 @@ interface CreateQueuedChatRunInput {
     readonly displayName: string;
   } | null;
   readonly triggerSource: "web" | "slack";
+  readonly realAgentInPreview?: boolean;
   readonly slackDelivery?: {
     readonly channelId: string;
     readonly threadTs: string;
@@ -548,6 +549,7 @@ function buildQueuedCreateZeroRunArgs(
       ...(input.effectiveModelProvider
         ? { modelProvider: input.effectiveModelProvider }
         : {}),
+      ...(input.realAgentInPreview ? { realAgentInPreview: true } : {}),
     },
   };
 }
@@ -2030,6 +2032,7 @@ async function buildCreateQueuedChatRunInput(
     codexServiceTier: modelRoute.codexServiceTier,
     computerUseHostGrant,
     triggerSource: args.queuedMessage.triggerSource,
+    realAgentInPreview: sourceParams?.realAgentInPreview,
     slackDelivery: sourceParams?.slackDelivery,
     userInfoExtras: sourceParams?.userInfoExtras,
   };

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -37,6 +37,7 @@ const queuedUserMessageRunParamsSchema = z.object({
   version: z.literal(1),
   prompt: z.string(),
   appendSystemPrompt: z.string(),
+  realAgentInPreview: z.boolean().optional(),
   slackDelivery: z
     .object({
       channelId: z.string(),


### PR DESCRIPTION
## Summary

- persist the true real-agent preview override in the existing encrypted queued-message parameters
- forward the override through queued auto-send into the runner execution context
- cover both the explicit override and the default behavior with an API integration test

## Exclusions

- no database schema, runner, cleanup concurrency, or workflow changes
- ordinary web sends continue without queued-parameter KMS work

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts --maxWorkers=4` (49 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit checks, including full-repository Knip and type checking

Closes #22825
