### PR TITLE
test(app): deflake voice segment test racing the vitest silence auto-stop timer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -587,6 +587,7 @@ describe("chat lifecycle", () => {
     const threadId = "voice-input-segment-thread";
     const draftPatches: unknown[] = [];
     const uploadedAudio: string[] = [];
+    const transcriptionRequested = context.mocks.deferred<void>();
     let transcriptionCalls = 0;
     context.mocks.browser.voiceInput({ rms: [0.1, 0.1, 0, 0, 0] });
     mockChatLifecycle(context, { threadId });
@@ -605,6 +606,7 @@ describe("chat lifecycle", () => {
       }
       uploadedAudio.push(await file.text());
       transcriptionCalls += 1;
+      transcriptionRequested.resolve(undefined);
       return new Response(JSON.stringify({ text: "First sentence" }), {
         headers: { "Content-Type": "application/json" },
       });
@@ -621,10 +623,15 @@ describe("chat lifecycle", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
     });
+    // The silence-triggered segment upload reaching the server proves the
+    // capture rotated recorders instead of ending the session; recording may
+    // legitimately auto-stop moments later, so check the label now rather
+    // than after the transcription response renders.
+    await transcriptionRequested.promise;
+    expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
     await waitFor(() => {
       expect(composer).toHaveTextContent("First sentence");
     });
-    expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
     expect(transcriptionCalls).toBe(1);
     expect(uploadedAudio).toStrictEqual(["voice-1"]);
     await waitFor(() => {


### PR DESCRIPTION
## Problem

`chat-computer-use-and-voice.test.tsx > chat lifecycle > transcribes a voice input segment after silence while recording` is flaky on loaded CI shards. It ejected PR #22822 from the merge queue once (run [30062939490](https://github.com/vm0-ai/vm0/actions/runs/30062939490), attempt 1, `test-app (1)`) with `Unable to find a label with the text of: Stop recording`.

## Root cause

In vitest, the silence auto-stop timer is 50ms (`VOICE_ACTIVITY_AUTO_STOP_MS = IN_VITEST ? 50 : 10_000` in `voice-io-stt.ts`). When silence flips, the product both enqueues the segment transcription (which rotates recorders and keeps recording) and starts that 50ms auto-stop timer. The test asserted `Stop recording` was still present only **after** waiting for the transcription text to render — a window that had to fit the STT mock round-trip, a React commit, and up to a full 50ms `waitFor` poll interval. On a busy shard (91s for 168 tests) the auto-stop fired first and the label was already back to `Voice input`. Both interleavings are valid product behavior; the test asserted a ~50ms transient state.

## Fix

Use the deferred gate pattern already used by the sibling test (`context.mocks.deferred`): the STT mock resolves `transcriptionRequested` when the upload arrives, and the test asserts `Stop recording` immediately after awaiting it. The upload reaching the server proves the silence capture rotated recorders rather than ending the session, and the assertion now runs microtasks after that event instead of racing the timer through render and polling. All business assertions are preserved: transcribed text lands in the composer, draft is patched, exactly one upload (`voice-1`), and recording still auto-stops back to `Voice input` afterwards.

## Verification

- Target test passed 5/5 consecutive runs; full file 19/19.
- Prettier, ESLint, and `check-types` (production + tests tsconfigs) pass. Local lefthook `check-types` hook times out in this sandbox, so the commit used the manually-run equivalent checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)