### PR TITLE
fix(chat): keep cancelled run work history visible and drop paused run group auto-expansion

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -3,7 +3,6 @@ import type {
   EnrichedChatMessage,
   GroupedChatMessageGroup,
 } from "./chat-message.ts";
-import { isCancelledAssistantMessage } from "./chat-run-lifecycle.ts";
 import type { ChatMessageUsagePayload } from "@vm0/api-contracts/contracts/chat-threads";
 
 interface RunSegment {
@@ -521,9 +520,6 @@ function buildFoldSection(
   }
 
   const key = `${latestSegment.runGroupId}:${firstHiddenRunId}:${latestSegment.runId}`;
-  const defaultExpanded = latestSegment.messages.some(
-    isCancelledAssistantMessage,
-  );
 
   return {
     fold: {
@@ -532,7 +528,7 @@ function buildFoldSection(
       hiddenRunCount: hiddenSegments.length,
       hiddenGroups,
       labelGroups: expandedGroups,
-      expanded: expansionOverrides?.get(key) ?? defaultExpanded,
+      expanded: expansionOverrides?.get(key) ?? false,
     },
     expandedNextGroupId,
     collapsedNextGroupId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1043,6 +1043,47 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps chat work visible when the run was cancelled", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-cancelled",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the launch status",
+          runId: "run-work-folding-cancelled",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Checking launch status.",
+          runId: "run-work-folding-cancelled",
+          createdAt: "2026-06-09T10:00:25Z",
+        },
+        {
+          role: "assistant",
+          content: "Run cancelled",
+          error: "Run cancelled",
+          runId: "run-work-folding-cancelled",
+          runLifecycleEvent: "cancelled",
+          createdAt: "2026-06-09T10:00:55Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-cancelled",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Checking launch status.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Paused mid-thought — pick it back up whenever."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Expand work history")).toBeNull();
+  });
+
   it("does not fold a completed run with only a user message and final reply", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-user-final-only",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -960,7 +960,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
-  it("shows a paused latest workflow run group expanded by default", async () => {
+  it("keeps a paused latest workflow run group collapsed by default", async () => {
     const threadId = "thread-paused-workflow-run-group";
     const runGroupId = "f0000001-0000-4000-a000-00000000074b";
     const workflowPrompt = "/daily-workflow";
@@ -1026,18 +1026,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
 
     await waitFor(() => {
-      expect(screen.getByText("First workflow result")).toBeInTheDocument();
-      expect(
-        screen.getByText("Paused mid-thought — pick it back up whenever."),
-      ).toBeInTheDocument();
-      expect(buttonByLabel("Collapse grouped run history")).toHaveTextContent(
-        "1 run for Daily workflow summary",
-      );
-    });
-
-    fireEvent.click(buttonByLabel("Collapse grouped run history"));
-
-    await waitFor(() => {
       expect(
         screen.queryByText("First workflow result"),
       ).not.toBeInTheDocument();
@@ -1045,6 +1033,18 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
         screen.getByText("Paused mid-thought — pick it back up whenever."),
       ).toBeInTheDocument();
       expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
+        "1 run for Daily workflow summary",
+      );
+    });
+
+    fireEvent.click(buttonByLabel("Expand grouped run history"));
+
+    await waitFor(() => {
+      expect(screen.getByText("First workflow result")).toBeInTheDocument();
+      expect(
+        screen.getByText("Paused mid-thought — pick it back up whenever."),
+      ).toBeInTheDocument();
+      expect(buttonByLabel("Collapse grouped run history")).toHaveTextContent(
         "1 run for Daily workflow summary",
       );
     });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -152,6 +152,7 @@ import {
   completedWorkExpandedKeys$,
   toggleCompletedWorkExpanded$,
 } from "../../signals/chat-page/completed-work-folding.ts";
+import { isCancelledAssistantMessage } from "../../signals/chat-page/chat-run-lifecycle.ts";
 import {
   buildRunGroupFolding,
   runGroupExpansionOverrides$,
@@ -3147,7 +3148,10 @@ function buildCompletedWorkFolding(
     }
 
     const runMessages = messages.slice(index, endIndex);
-    if (!terminatedRunIds.has(runId)) {
+    if (
+      !terminatedRunIds.has(runId) ||
+      runMessages.some(isCancelledAssistantMessage)
+    ) {
       visibleMessages.push(...runMessages);
       index = endIndex;
       continue;


### PR DESCRIPTION
## Summary

- stop folding a run's work history into "Worked for Xm" when the run was manually cancelled, so the context behind a "Paused mid-thought" message stays visible (`buildCompletedWorkFolding` now exempts runs containing a cancelled assistant message, reusing `isCancelledAssistantMessage`)
- revert the paused-run-group auto-expansion introduced in #22784: grouped run history now collapses by default even when the latest run in the group was cancelled. That policy targeted the wrong folding layer — the collapse reported by users was the per-run completed-work fold, not the run-group fold — and is unnecessary now that the cancelled run's own work stays expanded

## Context

Users cancelling a run mid-flight saw the run's entire work history auto-collapse into "Worked for 2m" above the "Paused mid-thought — pick it back up whenever." bubble, hiding the interrupted context they most likely want to resume from. #22784 attempted to address this but changed run-group folding (multiple runs in one group), a different mechanism from the per-run completed-work fold that actually produced the reported behavior.

## Verification

- `pnpm exec prettier --check` on touched files
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx src/signals/chat-page/__tests__/run-group-folding.test.ts` (51 tests passed), including a new test asserting a cancelled run's work stays unfolded and an updated test asserting the paused run group collapses by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)