### PR TITLE
fix(mail): preserve draft links after gmail deletion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -381,7 +381,7 @@ describe("POST /api/zero/mail/drafts/link", () => {
     expect(refreshCalls).toBe(0);
   });
 
-  it("deletes Gmail only for an explicit draft deletion", async () => {
+  it("deletes Gmail without removing the linked mail draft", async () => {
     const fixture = await seedGmailMailCardFixture();
     const gmail = mockGmailDraftApi();
     const linked = await linkDraft(fixture);
@@ -395,13 +395,13 @@ describe("POST /api/zero/mail/drafts/link", () => {
     );
     expect(gmail.deleteCount).toBe(1);
 
-    const deleted = await accept(
+    const preserved = await accept(
       stateClient().get({
         params: { mailDraftId: linked.body.mailDraftId },
       }),
       [200],
     );
-    expect(deleted.body.exists).toBeFalsy();
+    expect(preserved.body.exists).toBeTruthy();
   });
 
   it("only removes the link when its chat thread is deleted", async () => {

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -1163,8 +1163,6 @@ export const deleteZeroMailDraft$ = command(
       details: null,
       detailAvailable: false,
     });
-    await set(writeDb$).delete(mailDrafts).where(eq(mailDrafts.id, row.id));
-    signal.throwIfAborted();
     return okResult(row.id, deletedDraft);
   },
 );


### PR DESCRIPTION
## Summary

- keep the linked `mail_drafts` record unchanged when an explicit Gmail draft deletion succeeds
- let the existing draft read path synchronize the missing Gmail draft and preserve the chat card lifecycle
- update the mail route integration test to assert that Gmail is deleted while the local link remains

## Verification

- `./node_modules/.bin/prettier --write apps/api/src/signals/services/zero-mail.service.ts apps/api/src/signals/routes/__tests__/zero-mail.test.ts`
- `npx -y pnpm@10.33.4 -F api lint`
- `npx -y pnpm@10.33.4 -F api check-types`
- `npx -y pnpm@10.33.4 knip --workspace api`
- `npx -y pnpm@10.33.4 -F api exec vitest run src/signals/routes/__tests__/zero-mail.test.ts` (6 tests passed)
