### PR TITLE
fix(platform): preserve run finish time with follow-ups

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -48,6 +48,13 @@ describe("chat lifecycle", () => {
   it("sends a recommended follow-up from the latest assistant reply", async () => {
     const assistantReply = "I can turn this into a launch package.";
     const followupPrompt = "Create a presentation outline";
+    const completedAt = "2026-06-09T10:01:01Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
     const sendGate = context.mocks.deferred<void>();
     const sentMessages: {
       prompt?: string;
@@ -110,7 +117,7 @@ describe("chat lifecycle", () => {
               kind: "talk",
             },
           ],
-          createdAt: "2026-06-09T10:01:01Z",
+          createdAt: completedAt,
         },
       ],
       onRunCreate: (body) => {
@@ -126,7 +133,9 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText(assistantReply)).toBeInTheDocument();
-      expect(screen.getByText("Keep going")).toBeInTheDocument();
+      expect(
+        screen.getByText(`Keep going · ${completedAtLabel}`),
+      ).toBeInTheDocument();
       expect(buttonByText(followupPrompt)).toBeInTheDocument();
       expect(buttonByText("Generate hero image")).toBeInTheDocument();
       expect(buttonByText("Generate launch video")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -763,6 +763,13 @@ describe("chat lifecycle", () => {
   it("keeps the established completed-run layout across container sizes", async () => {
     const finalReply = "The launch plan is ready.";
     const followupPrompt = "Turn it into a presentation";
+    const completedAt = "2026-06-09T10:00:21Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
 
     mockChatLifecycle(context, {
       threadId: "thread-completed-run-layout",
@@ -790,6 +797,12 @@ describe("chat lifecycle", () => {
           content: null,
           runId: "run-completed-run-layout",
           runLifecycleEvent: "completed",
+          createdAt: completedAt,
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-completed-run-layout",
           recommendedFollowups: [
             {
               prompt: followupPrompt,
@@ -797,7 +810,7 @@ describe("chat lifecycle", () => {
               generationType: "presentation",
             },
           ],
-          createdAt: "2026-06-09T10:00:21Z",
+          createdAt: "2026-06-09T10:00:30Z",
         },
       ],
     });
@@ -853,7 +866,7 @@ describe("chat lifecycle", () => {
     expect(followupList).not.toHaveClass("flex", "gap-1");
     expect(followupButton).not.toHaveClass("border", "bg-background");
 
-    const finishedLabel = screen.getByText("Keep going");
+    const finishedLabel = screen.getByText(`Keep going · ${completedAtLabel}`);
     const finishedLabelRow = finishedLabel.parentElement;
     const finishedDivider = finishedLabelRow!.parentElement;
     const finishedRunRow = finishedDivider!.parentElement;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -802,7 +802,7 @@ function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
-function formatArtifactTime(value: string): string {
+function formatChatTimestamp(value: string): string {
   return new Date(value).toLocaleString("en-US", {
     month: "short",
     day: "numeric",
@@ -1461,7 +1461,7 @@ function ArtifactInboxRow({
           <span aria-hidden>·</span>
           <span>{formatBytes(file.size)}</span>
           <span aria-hidden>·</span>
-          <span>{formatArtifactTime(file.createdAt)}</span>
+          <span>{formatChatTimestamp(file.createdAt)}</span>
         </span>
       </span>
       <IconChevronRight
@@ -4449,7 +4449,13 @@ function FinishedRunRow({
   source: RecommendedFollowupSource | null;
 }) {
   const donePhrase = useLastResolved(thread.donePhrase$) ?? "Done";
-  const label = source ? "Keep going" : donePhrase;
+  const runFinishedAt = useLastResolved(thread.latestRunFinishCreatedAt$);
+  const label =
+    source && runFinishedAt
+      ? `Keep going · ${formatChatTimestamp(runFinishedAt)}`
+      : source
+        ? "Keep going"
+        : donePhrase;
 
   return (
     <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

- show Keep going and the run-finished timestamp on the same marker line
- source the timestamp from the lifecycle marker instead of the later follow-up message
- cover both inline and separately persisted recommended follow-ups

## Testing

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx src/views/zero-page/__tests__/chat-run-results.test.tsx --maxWorkers=1 --silent=passed-only` (26 tests passed)
- pre-commit Prettier and Knip checks
- full repository TypeScript check
- full local Vitest suite not run, per request