### PR TITLE
fix(ui): keep stalled mobile running indicators distinct from unread

### DIFF
--- a/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
@@ -66,6 +66,20 @@ describe("RunningIndicator", () => {
     expect(rippleKeyframes).not.toMatch(/transform:(?![^;]*translate\()/);
   });
 
+  it("keeps a distinct resting state before animations start", () => {
+    render(<RunningIndicator />);
+
+    const centerRule = getCssBlock(".running-indicator-center");
+    const rippleRule = getCssBlock(".running-indicator-ripple");
+
+    expect(centerRule).toContain(
+      "transform: translate(-50%, -50%) scale(0.64)",
+    );
+    expect(centerRule).toContain("opacity: 0.34");
+    expect(rippleRule).toContain("transform: translate(-50%, -50%) scale(0.8)");
+    expect(rippleRule).toContain("opacity: 0");
+  });
+
   it("keeps indicators mounted at different times on one pulse phase", () => {
     const now = vi.spyOn(Date, "now");
 

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -442,6 +442,8 @@
     border-radius: 9999px;
     color: var(--color-sky-600, #0284c7);
   }
+  /* Match the 0% keyframes when iOS WebKit has not started the animations
+     after the mobile sidebar changes from hidden to visible. */
   .running-indicator-center {
     position: absolute;
     top: 50%;
@@ -450,8 +452,9 @@
     height: calc(100% - 5px);
     border-radius: inherit;
     background: currentColor;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(0.64);
     transform-origin: center;
+    opacity: 0.34;
     animation: running-indicator-center 2400ms cubic-bezier(0.33, 0, 0.66, 1)
       infinite;
     animation-delay: var(--running-indicator-delay, 0ms);
@@ -464,8 +467,9 @@
     height: calc(100% - 3px);
     border-radius: inherit;
     border: 1px solid currentColor;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(0.8);
     transform-origin: center;
+    opacity: 0;
     animation: running-indicator-ripple 2400ms ease-out infinite;
     animation-delay: var(--running-indicator-delay, 0ms);
   }


### PR DESCRIPTION
## Summary

- keep the running indicator's non-animated center and ripple styles aligned with the existing `0%` keyframes
- preserve the current animation timing, breathing range, ripple, and wall-clock phase synchronization
- add regression coverage for the distinct resting state used when an animation has not started

## User-visible impact

When iOS WebKit fails to start the running-indicator animation as the mobile sidebar becomes visible, the thread now remains identifiable as running through a small, dim dot instead of falling back to the same large, solid blue appearance as an unread thread.

## Verification

- `pnpm -F @vm0/ui exec vitest run src/components/ui/__tests__/running-indicator.test.tsx` — 3 passed
- `pnpm -F @vm0/ui lint` — passed
- `pnpm -F @vm0/ui check-types` — passed
- `npx --yes prettier@3.8.1 --check packages/ui/src/styles/globals.css packages/ui/src/components/ui/__tests__/running-indicator.test.tsx` — passed
- browser and real-device verification not run per the repository PR verification policy

Fixes #22850
