### PR TITLE
test(app): deflake chat history backfill progress rendering

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -23,8 +23,11 @@ function messageForSeq(seqId: number): PagedChatMessage {
   return {
     id: `00000000-0000-4000-8000-${String(seqId).padStart(12, "0")}`,
     role: "assistant",
-    content: `History message ${seqId}`,
+    // Control rows participate in history pagination without rendering
+    // hundreds of unrelated transcript nodes in this progress-only test.
+    content: null,
     seqId,
+    goalEvent: { type: "cleared" },
     createdAt: new Date(
       Date.parse("2026-03-10T00:00:00.000Z") + seqId * 1000,
     ).toISOString(),


### PR DESCRIPTION
## Summary

- keep the chat history backfill regression at the production six-page, 300-message flush boundary
- represent synthetic history rows as valid non-rendering goal control events so the test does not build hundreds of unrelated transcript nodes
- preserve the exact 87% progress assertion, completion behavior, feature-switch coverage, and all production code

## Root cause

The first test rendered 400 synthetic assistant messages while running with coverage alongside the rest of its CI shard. Its observed CI duration clustered between 5.005s and 5.255s around Vitest's 5-second timeout, so worker scheduling determined whether the assertion completed before the timeout callback.

Original failure: https://github.com/vm0-ai/vm0/actions/runs/30068375984/job/89403805488

## Verification

- targeted test file passed in 5 consecutive runs (10/10 tests); test time stayed between 1.32s and 1.47s
- targeted test file passed with V8 coverage enabled
- Prettier check passed
- ESLint passed
- Oxlint passed
- `@vm0/app` production and test TypeScript checks passed
