### PR TITLE
fix: restore devcontainer postgres authentication

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -4,11 +4,6 @@
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
       "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
-    },
-    "ghcr.io/itsmechlark/features/postgresql:1": {
-      "version": "1.9.0",
-      "resolved": "ghcr.io/itsmechlark/features/postgresql@sha256:356d919ede2f7dce3f921b424301f965eeeb63e67840afec26eeb362998f08f9",
-      "integrity": "sha256:356d919ede2f7dce3f921b424301f965eeeb63e67840afec26eeb362998f08f9"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "name": "VM0 Development",
   "image": "ghcr.io/vm0-ai/vm0-dev:20260710",
   "features": {
-    "ghcr.io/itsmechlark/features/postgresql:1": {
-      "version": "17"
-    },
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
     }
@@ -51,7 +48,7 @@
     "source=agent-browser,target=/home/vscode/.local/share/agent-browser"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
-  "postStartCommand": "bash .devcontainer/link-agent-skills.sh && gh auth setup-git && bash .devcontainer/start-vnc.sh",
+  "postStartCommand": "sudo service postgresql start && bash .devcontainer/link-agent-skills.sh && gh auth setup-git && bash .devcontainer/start-vnc.sh",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -75,7 +72,7 @@
             "name": "local",
             "username": "postgres",
             "database": "postgres",
-            "password": ""
+            "password": "postgres"
           }
         ],
         "terminal.integrated.defaultProfile.linux": "zsh",

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -31,11 +31,14 @@ else
   echo "✓ Turbo workspace not found, skipping cache cleanup"
 fi
 
-# PostgreSQL is initialized by the postgresql feature, while pgvector is
-# provided by the vm0-dev image.
-echo "🐘 Checking PostgreSQL pgvector extension..."
-sudo chown -R postgres:postgres /var/lib/postgresql 2>/dev/null || true
-sudo service postgresql start 2>/dev/null || true
+# PostgreSQL and pgvector are provided by the vm0-dev image.
+echo "🐘 Configuring PostgreSQL..."
+sudo service postgresql start
+sudo -u postgres psql -h /var/run/postgresql -d postgres -v ON_ERROR_STOP=1 \
+  -c "ALTER ROLE postgres PASSWORD 'postgres';"
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atqc "SELECT 1" | grep -qx 1
+echo "✓ PostgreSQL password authentication ready"
+
 if sudo -u postgres psql -h /var/run/postgresql -d postgres -Atqc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" | grep -qx 1; then
   echo "✓ pgvector extension available to PostgreSQL"
 else

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -52,9 +52,10 @@ test_skill_link_directory_conflict() {
     || fail "directory conflict was modified"
 }
 
-test_pgvector_probe_uses_unix_socket() {
-  local workspace="$TEST_ROOT/pgvector-probe"
+test_postgresql_setup() {
+  local workspace="$TEST_ROOT/postgresql-setup"
   local fake_bin="$workspace/fake-bin"
+  local psql_log="$workspace/psql.log"
   local sudo_log="$workspace/sudo.log"
 
   copy_script "$workspace" "setup.sh"
@@ -63,27 +64,55 @@ test_pgvector_probe_uses_unix_socket() {
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'printf "%s\\n" "$*" >> "$SUDO_CALLS_LOG"' \
-    'if [[ "$*" == "-u postgres psql "* ]]; then' \
+    'if [[ "$*" == *"pg_available_extensions"* ]]; then' \
     "  printf '1\\n'" \
     'fi' \
     > "$fake_bin/sudo"
   printf '%s\n' \
     '#!/usr/bin/env bash' \
+    'printf "%s\\n" "$*" >> "$PSQL_CALLS_LOG"' \
+    "printf '1\\n'" \
+    > "$fake_bin/psql"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
     'exit 0' \
     > "$fake_bin/lefthook"
-  chmod +x "$fake_bin/sudo" "$fake_bin/lefthook"
+  chmod +x "$fake_bin/sudo" "$fake_bin/psql" "$fake_bin/lefthook"
 
-  HOME="$workspace/home" \
+  DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" \
+    HOME="$workspace/home" \
     PATH="$fake_bin:$PATH" \
+    PSQL_CALLS_LOG="$psql_log" \
     SUDO_CALLS_LOG="$sudo_log" \
     bash "$workspace/.devcontainer/setup.sh" > /dev/null
 
+  grep -Fxq "service postgresql start" "$sudo_log" \
+    || fail "PostgreSQL service was not started"
+  grep -Fq -- "-u postgres psql -h /var/run/postgresql -d postgres -v ON_ERROR_STOP=1 -c ALTER ROLE postgres PASSWORD 'postgres';" "$sudo_log" \
+    || fail "PostgreSQL password was not configured"
+  grep -Fq -- "postgresql://postgres:postgres@localhost:5432/postgres -v ON_ERROR_STOP=1 -Atqc SELECT 1" "$psql_log" \
+    || fail "PostgreSQL password authentication was not verified"
   grep -Fq -- "-u postgres psql -h /var/run/postgresql -d postgres -Atqc" "$sudo_log" \
     || fail "pgvector availability probe did not use the local Unix socket"
 }
 
+test_devcontainer_postgresql_config() {
+  local config="$REPO_ROOT/.devcontainer/devcontainer.json"
+  local lock="$REPO_ROOT/.devcontainer/devcontainer-lock.json"
+
+  jq -e '.features | has("ghcr.io/itsmechlark/features/postgresql:1") | not' "$config" > /dev/null \
+    || fail "PostgreSQL feature should not duplicate the vm0-dev image"
+  jq -e '.features | has("ghcr.io/itsmechlark/features/postgresql:1") | not' "$lock" > /dev/null \
+    || fail "PostgreSQL feature lock should be removed"
+  jq -e '.postStartCommand | startswith("sudo service postgresql start &&")' "$config" > /dev/null \
+    || fail "PostgreSQL service should start with the container"
+  jq -e '.customizations.vscode.settings."sqltools.connections"[0].password == "postgres"' "$config" > /dev/null \
+    || fail "SQLTools password should match DATABASE_URL"
+}
+
 test_skill_link_file_conflict
 test_skill_link_directory_conflict
-test_pgvector_probe_uses_unix_socket
+test_postgresql_setup
+test_devcontainer_postgresql_config
 
 echo "Devcontainer integration tests passed"

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -3,11 +3,13 @@ name: Docker Toolchain Build
 on:
   pull_request:
     paths:
-      - 'docker/toolchain/**'
-      - '.devcontainer/link-agent-skills.sh'
-      - '.devcontainer/setup.sh'
-      - '.devcontainer/test.sh'
-      - '.github/workflows/docker-toolchain.yml'
+      - "docker/toolchain/**"
+      - ".devcontainer/devcontainer.json"
+      - ".devcontainer/devcontainer-lock.json"
+      - ".devcontainer/link-agent-skills.sh"
+      - ".devcontainer/setup.sh"
+      - ".devcontainer/test.sh"
+      - ".github/workflows/docker-toolchain.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- remove the PostgreSQL devcontainer feature that conflicts with the PostgreSQL packages in the vm0-dev image
- configure the local postgres password explicitly and start PostgreSQL on every container start
- verify password authentication in devcontainer setup and extend CI path coverage for devcontainer configuration

## Testing

- `bash .devcontainer/test.sh`
- `bash -n .devcontainer/setup.sh .devcontainer/test.sh`
- JSON validation with `jq`
- Prettier check for changed JSON and YAML files
- password-authenticated `psql` connection
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api db:dev-seed`

Full Vitest was not run per request.