### PR TITLE
feat(workflows): enable github workflow run automations for all organizations

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -297,8 +297,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Enable GitHub Actions workflow run completed event automations.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- Enable GitHub Actions workflow-run-completed automations for all organizations by making `githubWorkflowRunAutomations` default-on.
- Remove the staff-org-only rollout restriction while keeping the feature switch available for overrides.

## Verification

- `git diff --check`
- Local Vitest was not run; this configuration-only change relies on the PR pipeline per the vm0 PR verification policy.
