### PR TITLE
refactor(api): require canonical persisted storage state

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -184,10 +184,13 @@ deployed, the API began sending `storageMounts` only to a Runner that advertises
 the capability; old Runners continue receiving both legacy arrays.
 
 New run, session, and checkpoint writers persist canonical Storage mounts only.
-Readers prefer canonical persistence and fall back to legacy columns for
-historical rows. Legacy API response shapes are projected from canonical mounts
-for new rows. The short-lived runner job queue also retains its legacy claim
-projection until old Runner output is removed.
+After the latest session continuation heads were backfilled and verified,
+application readers require canonical run, session, and checkpoint persistence.
+Legacy API response shapes are still projected from canonical mounts. The
+physical legacy columns remain temporarily for rollback-safe deployment and are
+removed only after API versions that read them have drained. The short-lived
+runner job queue also retains its legacy claim projection until old Runner
+output is removed.
 
 Phase 4A contracts the migration denominator to the latest state used by
 session continuation. Every session continuation head must have canonical

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -118,16 +118,6 @@ export async function removeRunCanonicalStorageState(
   });
 }
 
-export async function removeSessionCanonicalStorageState(
-  context: TestContext,
-  sessionId: string,
-): Promise<void> {
-  await postAction(context, {
-    action: "remove-session-canonical-storage-state",
-    session_id: sessionId,
-  });
-}
-
 export async function readStoragePersistenceState(
   context: TestContext,
   ids: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -81,7 +81,6 @@ import {
   holdOrgAdmissionLock,
   mutateRunnerJobSecretValueEnvironmentKeys,
   removeRunCanonicalStorageState,
-  removeSessionCanonicalStorageState,
   replaceCustomConnectorPrefixes,
   readFakeKmsDecryptCallCount,
   readOrgAdmissionLockState,
@@ -1976,9 +1975,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, sessionRun.runId, [200]);
   });
 
-  it("falls back to legacy run and session Storage state", async () => {
+  it("keeps the short-lived legacy runner queue projection", async () => {
     const api = createRunsApi(context);
-    const storages = createStoragesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, runnerGroup } = await entitledRunActor();
     const composeName = `bdd-legacy-storage-state-${randomUUID().slice(0, 8)}`;
@@ -2007,90 +2005,22 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       expectLegacyStorageManifest(legacyRunClaim.storageManifest)?.artifacts,
     ).toContainEqual(expect.objectContaining({ vasStorageName: "memory" }));
-    await api.requestCancelRun(actor, pendingLegacyRun.runId, [200]);
 
-    const initialRun = await api.createDirectRun(actor, {
-      agentComposeVersionId: compose.versionId,
-      prompt: "create legacy session and checkpoint projections",
-    });
-    const initialClaim = await api.claimRunnerJob(initialRun.runId, {
-      capabilities: [RUNNER_STORAGE_MOUNTS_CAPABILITY],
-    });
-    const initialManifest = initialClaim.storageManifest;
-    if (!initialManifest || !("storageMounts" in initialManifest)) {
-      throw new Error("Expected initial canonical Storage mounts");
-    }
-    const initialMemory = initialManifest.storageMounts.find((mount) => {
-      return mount.name === "memory";
-    });
-    if (!initialMemory) {
-      throw new Error("Expected the initial memory mount");
-    }
-
-    const memoryFile = storageTextFile(
-      "MEMORY.md",
-      `legacy projection ${initialRun.runId}`,
-    );
-    const preparedMemory = await storages.prepareStorage(actor, {
-      storageName: "memory",
-      storageType: "artifact",
-      files: [memoryFile],
-    });
-    await storages.commitStorage(actor, {
-      storageName: "memory",
-      storageType: "artifact",
-      versionId: preparedMemory.versionId,
-      files: [memoryFile],
-    });
-    const historyHash = createHash("sha256")
-      .update(`legacy storage state ${initialRun.runId}`)
-      .digest("hex");
-    const checkpoint = await webhooks.requestAgentCheckpoint(
+    const rejectedCheckpoint = await webhooks.requestAgentCheckpoint(
       {
-        runId: initialRun.runId,
+        runId: pendingLegacyRun.runId,
         cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-legacy-cli-${initialRun.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
-        artifactSnapshots: [
-          {
-            name: initialMemory.name,
-            version: preparedMemory.versionId,
-            mountPath: initialMemory.mountPath,
-          },
-        ],
+        cliAgentSessionId: `bdd-canonical-required-${pendingLegacyRun.runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(`canonical required ${pendingLegacyRun.runId}`)
+          .digest("hex"),
       },
-      { authorization: `Bearer ${initialClaim.sandboxToken}` },
-      [200],
+      { authorization: `Bearer ${legacyRunClaim.sandboxToken}` },
+      [500],
     );
-    if (checkpoint.status !== 200) {
-      throw new Error("Expected the legacy projection checkpoint to succeed");
-    }
-    await webhooks.requestAgentComplete(
-      { runId: initialRun.runId, exitCode: 0 },
-      { authorization: `Bearer ${initialClaim.sandboxToken}` },
-      [200],
-    );
+    expect(rejectedCheckpoint.status).toBe(500);
 
-    await removeSessionCanonicalStorageState(context, initialRun.sessionId);
-    const sessionRun = await api.createDirectRun(actor, {
-      sessionId: initialRun.sessionId,
-      prompt: "continue a pre-canonical Storage session",
-    });
-    const sessionClaim = await api.claimRunnerJob(sessionRun.runId, {
-      capabilities: [RUNNER_STORAGE_MOUNTS_CAPABILITY],
-    });
-    const sessionManifest = sessionClaim.storageManifest;
-    if (!sessionManifest || !("storageMounts" in sessionManifest)) {
-      throw new Error("Expected canonical mounts from legacy session state");
-    }
-    expect(sessionManifest.storageMounts).toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        versionId: preparedMemory.versionId,
-        writeback: true,
-      }),
-    );
-    await api.requestCancelRun(actor, sessionRun.runId, [200]);
+    await api.requestCancelRun(actor, pendingLegacyRun.runId, [200]);
   });
 
   it("keeps a committed artifact head after initial empty artifact creation", async () => {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -37,7 +37,6 @@ import {
 import { testOverride } from "../../lib/singleton";
 import type { RouteEntry } from "../route-entry";
 import { createDeferredPromise, onRejection } from "../utils";
-import { projectLegacyWritebackArtifacts } from "../services/storage-legacy-projection.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -309,36 +308,6 @@ async function removeRunCanonicalStorageState(
   signal.throwIfAborted();
 }
 
-async function removeSessionCanonicalStorageState(
-  db: Db,
-  sessionId: string,
-  signal: AbortSignal,
-): Promise<void> {
-  const [session] = await db
-    .select({
-      artifacts: agentSessions.artifacts,
-      storageMounts: agentSessions.storageMounts,
-    })
-    .from(agentSessions)
-    .where(eq(agentSessions.id, sessionId))
-    .limit(1);
-  signal.throwIfAborted();
-  if (!session) {
-    throw new Error("Agent session not found");
-  }
-  await db
-    .update(agentSessions)
-    .set({
-      artifacts:
-        session.storageMounts === null
-          ? session.artifacts
-          : [...projectLegacyWritebackArtifacts(session.storageMounts)],
-      storageMounts: null,
-    })
-    .where(eq(agentSessions.id, sessionId));
-  signal.throwIfAborted();
-}
-
 async function readStoragePersistenceState(
   db: Db,
   ids: {
@@ -393,11 +362,7 @@ async function readStoragePersistenceState(
 
 type StorageStateAction = Extract<
   TestRuntimeStateActionBody,
-  {
-    action:
-      | "remove-run-canonical-storage-state"
-      | "remove-session-canonical-storage-state";
-  }
+  { action: "remove-run-canonical-storage-state" }
 >;
 
 type ReadStorageStateAction = Extract<
@@ -411,7 +376,6 @@ function isStorageStateAction(
 ): body is AnyStorageStateAction {
   switch (body.action) {
     case "remove-run-canonical-storage-state":
-    case "remove-session-canonical-storage-state":
     case "read-storage-persistence-state": {
       return true;
     }
@@ -426,16 +390,7 @@ async function mutateStorageState(
   body: StorageStateAction,
   signal: AbortSignal,
 ): Promise<void> {
-  switch (body.action) {
-    case "remove-run-canonical-storage-state": {
-      await removeRunCanonicalStorageState(db, body.run_id, signal);
-      return;
-    }
-    case "remove-session-canonical-storage-state": {
-      await removeSessionCanonicalStorageState(db, body.session_id, signal);
-      break;
-    }
-  }
+  await removeRunCanonicalStorageState(db, body.run_id, signal);
   signal.throwIfAborted();
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4186,11 +4186,13 @@ function resumeSessionFromSnapshot(
 }
 
 function resolvedSessionStorage(session: {
-  readonly artifacts: readonly ContextArtifact[] | null;
+  readonly id: string;
   readonly storageMounts: readonly PersistedStorageMount[] | null;
 }): Pick<ResolvedCompose, "artifacts" | "persistedStorageMounts"> {
-  if (!session.storageMounts) {
-    return { artifacts: session.artifacts ?? [] };
+  if (session.storageMounts === null) {
+    throw new Error(
+      `Agent session "${session.id}" is missing canonical Storage mounts`,
+    );
   }
   return {
     artifacts: projectLegacyWritebackArtifacts(session.storageMounts),
@@ -4215,7 +4217,6 @@ function resolveBySessionId(
           .select({
             session: {
               id: agentSessions.id,
-              artifacts: agentSessions.artifacts,
               storageMounts: agentSessions.storageMounts,
             },
             compose: {

--- a/turbo/apps/api/src/signals/services/agent-sessions.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-sessions.service.ts
@@ -65,7 +65,6 @@ export function agentSessionById(
         orgId: agentSessions.orgId,
         agentComposeId: agentSessions.agentComposeId,
         conversationId: agentSessions.conversationId,
-        artifacts: agentSessions.artifacts,
         storageMounts: agentSessions.storageMounts,
         createdAt: agentSessions.createdAt,
         updatedAt: agentSessions.updatedAt,
@@ -86,6 +85,11 @@ export function agentSessionById(
       return { kind: "not-found" };
     }
 
+    if (session.storageMounts === null) {
+      throw new Error(
+        `Agent session "${session.id}" is missing canonical Storage mounts`,
+      );
+    }
     const secretNames = await secretNamesForCompose(db, session.agentComposeId);
 
     return {
@@ -94,9 +98,8 @@ export function agentSessionById(
         id: session.id,
         agentComposeId: session.agentComposeId,
         conversationId: session.conversationId,
-        artifactNames: (session.storageMounts === null
-          ? session.artifacts
-          : projectLegacyWritebackArtifacts(session.storageMounts)
+        artifactNames: projectLegacyWritebackArtifacts(
+          session.storageMounts,
         ).map((artifact) => {
           return artifact.name;
         }),

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -92,9 +92,9 @@ function responseArtifacts(
 function checkpointStorageMounts(args: {
   readonly runStorageMounts: readonly PersistedStorageMount[] | null;
   readonly artifactSnapshots: CheckpointCreateBody["artifactSnapshots"];
-}): PersistedStorageMount[] | null {
-  if (!args.runStorageMounts) {
-    return null;
+}): PersistedStorageMount[] {
+  if (args.runStorageMounts === null) {
+    throw new Error("Agent run is missing canonical Storage mounts");
   }
   const snapshotsByIdentity = new Map(
     (args.artifactSnapshots ?? []).map((snapshot) => {
@@ -359,6 +359,11 @@ export const createAgentCheckpoint$ = command(
       );
     }
 
+    const storageMounts = checkpointStorageMounts({
+      runStorageMounts: run.storageMounts,
+      artifactSnapshots: input.body.artifactSnapshots,
+    });
+
     await db
       .insert(blobs)
       .values({
@@ -403,10 +408,6 @@ export const createAgentCheckpoint$ = command(
       ...(vars ? { vars } : {}),
       ...(run.secretNames ? { secretNames: run.secretNames } : {}),
     };
-    const storageMounts = checkpointStorageMounts({
-      runStorageMounts: run.storageMounts,
-      artifactSnapshots: input.body.artifactSnapshots,
-    });
 
     const checkpointFields = {
       conversationId: conversation.id,

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -58,92 +58,32 @@ interface CompletionResponse {
   readonly sideEffects?: TerminalSideEffectsInput;
 }
 
-interface VolumeVersionsSnapshot {
-  readonly versions: Record<string, string>;
-}
-
 interface RunRecord {
   readonly orgId: string;
   readonly status: string;
   readonly userId: string;
 }
 
-interface ArtifactSnapshot {
-  readonly name: string;
-  readonly version: string;
-  readonly mountPath: string;
-}
-
 const L = logger("webhook:complete");
 
-function isVolumeVersionsSnapshot(
-  value: unknown,
-): value is VolumeVersionsSnapshot {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "versions" in value &&
-    typeof value.versions === "object" &&
-    value.versions !== null &&
-    !Array.isArray(value.versions) &&
-    Object.values(value.versions).every((entry) => {
-      return typeof entry === "string";
-    })
-  );
-}
-
-function isArtifactSnapshot(value: unknown): value is ArtifactSnapshot {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "name" in value &&
-    "version" in value &&
-    "mountPath" in value &&
-    typeof value.name === "string" &&
-    typeof value.version === "string" &&
-    typeof value.mountPath === "string"
-  );
-}
-
-function decodeArtifactSnapshotsToRecord(
-  raw: unknown,
-): Record<string, string> | undefined {
-  if (raw === null || raw === undefined) {
-    return undefined;
-  }
-
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return undefined;
-  }
-
-  const result: Record<string, string> = {};
-  for (const [index, entry] of raw.entries()) {
-    if (!isArtifactSnapshot(entry)) {
-      throw new Error(`Invalid checkpoint artifact snapshot at index ${index}`);
-    }
-    result[entry.name] = entry.version;
-  }
-  return result;
-}
-
 function buildRunResult(
-  checkpoint: typeof checkpoints.$inferSelect,
+  checkpoint: Pick<
+    typeof checkpoints.$inferSelect,
+    "id" | "conversationId" | "storageMounts"
+  >,
   sessionId: string | undefined,
 ): RunResult {
-  const canonicalProjection =
-    checkpoint.storageMounts === null
-      ? null
-      : projectLegacyCheckpointStorage(checkpoint.storageMounts);
-  const artifact =
-    canonicalProjection === null
-      ? decodeArtifactSnapshotsToRecord(checkpoint.artifactSnapshots)
-      : (canonicalProjection.artifactVersions ?? undefined);
+  if (checkpoint.storageMounts === null) {
+    throw new Error(
+      `Checkpoint "${checkpoint.id}" is missing canonical Storage mounts`,
+    );
+  }
+  const canonicalProjection = projectLegacyCheckpointStorage(
+    checkpoint.storageMounts,
+  );
+  const artifact = canonicalProjection.artifactVersions ?? undefined;
   const volumeVersions =
-    canonicalProjection === null
-      ? isVolumeVersionsSnapshot(checkpoint.volumeVersionsSnapshot)
-        ? checkpoint.volumeVersionsSnapshot.versions
-        : undefined
-      : (canonicalProjection.volumeVersionsSnapshot?.versions ?? undefined);
+    canonicalProjection.volumeVersionsSnapshot?.versions ?? undefined;
 
   return {
     checkpointId: checkpoint.id,
@@ -291,7 +231,11 @@ async function handleSuccessfulCompletion(
   signal: AbortSignal,
 ): Promise<CompletionResponse> {
   const [checkpoint] = await db
-    .select()
+    .select({
+      id: checkpoints.id,
+      conversationId: checkpoints.conversationId,
+      storageMounts: checkpoints.storageMounts,
+    })
     .from(checkpoints)
     .where(eq(checkpoints.runId, input.body.runId))
     .limit(1);

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -258,7 +258,20 @@ export function zeroRunById(args: {
 }): Computed<Promise<GetRunResponse | null>> {
   return computed(async (get): Promise<GetRunResponse | null> => {
     const [run] = await get(db$)
-      .select()
+      .select({
+        id: agentRuns.id,
+        agentComposeVersionId: agentRuns.agentComposeVersionId,
+        status: agentRuns.status,
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+        vars: agentRuns.vars,
+        sandboxId: agentRuns.sandboxId,
+        result: agentRuns.result,
+        error: agentRuns.error,
+        createdAt: agentRuns.createdAt,
+        startedAt: agentRuns.startedAt,
+        completedAt: agentRuns.completedAt,
+      })
       .from(agentRuns)
       .where(
         and(

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -38,10 +38,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("remove-session-canonical-storage-state"),
-    session_id: z.uuid(),
-  }),
-  z.object({
     action: z.literal("read-storage-persistence-state"),
     run_id: z.uuid(),
     session_id: z.uuid(),


### PR DESCRIPTION
## Summary

- require canonical Storage mounts for session continuation and session reads after the Phase 4A backfill
- derive run completion results only from canonical checkpoint mounts and reject checkpoint writes when the parent run lacks canonical state
- replace whole-row run and checkpoint reads and remove the obsolete session fallback test action so legacy columns can be dropped in a later release

## Rollout boundary

- keep the physical legacy columns until this API version is released and older API instances have drained
- keep the short-lived Runner queue legacy projection and existing legacy API response projections
- defer Runner and guest capability cleanup, Storage type cleanup, and physical database drops to follow-up changes

## Verification

- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm knip --workspace api
- pnpm knip --workspace @vm0/api-contracts
- targeted API integration coverage for canonical session continuation, canonical session reads, and the retained legacy Runner queue projection with canonical checkpoint rejection

Part of #21983.