### PR TITLE
docs(python): document firewall auth probe failure

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -61,6 +61,10 @@ Firewall and auth context
 - ``FIREWALL_AUTH_CACHE_KEY``: opaque typed auth cache key written by matched
   auth handling after the full auth input identity is known. Read by 401 cache
   invalidation; stores only a digest of auth inputs and sandbox token.
+- ``FIREWALL_AUTH_PROBE_FAILURE``: ``Exception`` caught by header-phase auth
+  probing after restoring the probe snapshot. Popped by request-phase auth
+  handling to produce the same local auth failure without resolving auth a
+  second time; removed by terminal cleanup when it was not consumed.
 - ``FIREWALL_NAME``: ``str`` firewall connector/model name. Read by logging,
   model-provider gates, and connector usage dispatch.
 - ``FIREWALL_PERMISSION``: ``str`` matched permission name or empty string.


### PR DESCRIPTION
## Summary

- document the `FIREWALL_AUTH_PROBE_FAILURE` shared metadata lifecycle
- clarify request-phase consumption avoids a second auth resolution

## Scope

Documentation-only change; no runtime metadata, persistence, API, or deployment behavior changes.

## Validation

- `git diff --check`
- `ruff format --check crates/runner/mitm-addon/src`
- `ruff check crates/runner/mitm-addon/src`

The repository pre-commit `crates` hook also scans `scripts/` and is blocked by the existing `S310` finding in `scripts/update_x_tlds.py:62`, unrelated to this change.

Closes #22859