### PR TITLE
perf(platform): skip backward chat history fetch at seq one

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2112,12 +2112,14 @@ function createSyncRemoteMessagesCommand({
   threadId,
   persistentMessages$,
   hasReachedOldestMessage$,
+  hasServerConfirmedOldestMessage$,
   mergePersistentMessages$,
   dataSource,
 }: {
   threadId: string;
   persistentMessages$: PersistentChatMessages$;
-  hasReachedOldestMessage$: State<boolean>;
+  hasReachedOldestMessage$: Computed<boolean>;
+  hasServerConfirmedOldestMessage$: State<boolean>;
   mergePersistentMessages$: Command<void, [PagedChatMessage[]]>;
   dataSource: ChatThreadRemote;
 }): Command<Promise<void>, [AbortSignal]> {
@@ -2179,7 +2181,7 @@ function createSyncRemoteMessagesCommand({
         oldestMessage === undefined
       ) {
         if (initialHasHistoryBefore === false) {
-          set(hasReachedOldestMessage$, true);
+          set(hasServerConfirmedOldestMessage$, true);
         }
       } else {
         let beforeSeqId = oldestMessage.seqId;
@@ -2222,7 +2224,7 @@ function createSyncRemoteMessagesCommand({
           }
 
           if (!result.hasHistoryBefore) {
-            set(hasReachedOldestMessage$, true);
+            set(hasServerConfirmedOldestMessage$, true);
             return;
           }
 
@@ -2484,7 +2486,13 @@ function createPagedMessages(
     registerBodyBlocks(entry.parsedBodyBlocks);
   }
   const persistentChatMessages$ = state<RegisteredChatMessage[]>([]);
-  const hasReachedOldestMessage$ = state(false);
+  const hasServerConfirmedOldestMessage$ = state(false);
+  const hasReachedOldestMessage$ = computed((get): boolean => {
+    return (
+      get(hasServerConfirmedOldestMessage$) ||
+      get(persistentChatMessages$)[0]?.message.seqId === 1
+    );
+  });
   const optimisticMessages$ = createOptimisticChatMessagesForThread(threadId);
   const appendOptimisticMessage$ = command(
     ({ set }, input: OptimisticChatMessageInput): void => {
@@ -2501,8 +2509,8 @@ function createPagedMessages(
   });
   // Approximate backfill progress from the loaded seqId range. The thread's
   // true max seqId is not exposed to the client, so the newest loaded message
-  // stands in for it. seqIds are allocated from 1, so a first seqId <= 1 means
-  // the full history is already loaded. Null hides the progress bar.
+  // stands in for it. The reached-oldest computed hides progress once the
+  // first persistent seqId is 1. Null hides the progress bar.
   const historyBackfillProgress$ = computed((get): Promise<number | null> => {
     if (get(hasReachedOldestMessage$)) {
       return Promise.resolve(null);
@@ -2510,7 +2518,7 @@ function createPagedMessages(
     const messages = get(persistentChatMessages$);
     const first = messages[0];
     const last = messages.at(-1);
-    if (first === undefined || last === undefined || first.message.seqId <= 1) {
+    if (first === undefined || last === undefined) {
       return Promise.resolve(null);
     }
     return Promise.resolve(
@@ -2561,6 +2569,7 @@ function createPagedMessages(
     threadId,
     persistentMessages$: persistentChatMessages$,
     hasReachedOldestMessage$,
+    hasServerConfirmedOldestMessage$,
     mergePersistentMessages$,
     dataSource,
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -47,6 +47,53 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 describe("chat lifecycle", () => {
+  it("skips backward history fetch when persistent messages start at seq one", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000729";
+    const initialMessage = {
+      id: "00000000-0000-4000-8000-000000000729",
+      role: "assistant",
+      content: "Complete history starts here",
+      createdAt: "2026-06-09T10:00:00.000Z",
+      seqId: 1,
+    } satisfies PagedChatMessage;
+    const beforeSeqIds: number[] = [];
+    const messageRefreshCompleted = context.mocks.deferred<void>();
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Complete history",
+      onMessageGet: (messageId) => {
+        if (messageId === initialMessage.id) {
+          messageRefreshCompleted.resolve();
+        }
+      },
+    });
+    context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
+      if (query.beforeSeqId !== undefined) {
+        beforeSeqIds.push(query.beforeSeqId);
+        return respond(200, { messages: [], hasHistoryBefore: false });
+      }
+      if (query.sinceSeqId === initialMessage.seqId) {
+        return respond(200, { messages: [] });
+      }
+      if (query.sinceSeqId === undefined) {
+        return respond(200, {
+          messages: [initialMessage],
+          hasHistoryBefore: true,
+        });
+      }
+      throw new Error(`Unexpected message cursor: ${JSON.stringify(query)}`);
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await messageRefreshCompleted.promise;
+    await expect(
+      screen.findByText(initialMessage.content),
+    ).resolves.toBeInTheDocument();
+    expect(beforeSeqIds).toStrictEqual([]);
+  });
+
   it("publishes the initial page before batching the remaining history", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000730";
     const messages = Array.from({ length: 70 }, (_, index) => {


### PR DESCRIPTION
## Summary

- derive the reached-oldest state from the first persistent message when its `seqId` is `1`
- retain the server-confirmed fallback so threads with sequence gaps stop backfilling after `hasHistoryBefore=false`
- reuse the computed state for history backfill progress and cover the skipped `beforeSeqId=1` request with a regression test

## User impact

Opening a chat thread whose persistent messages already begin at sequence 1 no longer sends a guaranteed-empty backward history request. Threads whose earliest retained message is greater than 1 still rely on the server response and do not repeatedly refetch a gap.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-navigation.test.tsx -t "skips backward history fetch" --testTimeout=15000 --reporter=verbose`
- `pnpm -F @vm0/app check-types`
- targeted Prettier, Oxlint (including type-aware), and ESLint checks

Full Vitest was not run locally; the PR pipeline will provide the full repository checks.