### PR TITLE
fix(python): normalize x billing method casing

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -935,8 +935,9 @@ def _response_usage_context(flow: http.HTTPFlow) -> _ResponseUsageContext | None
     permission = flow_metadata.firewall_permission(flow.metadata)
     if not permission:
         return None
+    method = flow.request.method.upper()
     request_path = _strip_request_target_query(flow.request.path)
-    endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
+    endpoint_bucket = classify_bucket(permission, method, request_path)
     if endpoint_bucket is None:
         return None
     return _ResponseUsageContext(permission, request_path, endpoint_bucket)
@@ -974,13 +975,14 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         return
     firewall_name = flow_metadata.firewall_name(flow.metadata)
     permission = response_context.permission
+    method = flow.request.method.upper()
     # mitmproxy's ``flow.request.path`` is the raw request-target — it
     # includes the query string.  Strip it without parsing query params so
     # literal-suffix overrides (e.g. ``/2/tweets/{id}/retweeted_by``) still
     # match requests that carry ``?max_results=10`` or similar.
     request_path = response_context.request_path
     endpoint_bucket = response_context.endpoint_bucket
-    if bucket_needs_body_refinement(endpoint_bucket, flow.request.method, request_path):
+    if bucket_needs_body_refinement(endpoint_bucket, method, request_path):
         request_body = billing_body.decode_request_body_for_billing(
             _request_body_for_billing_refinement(flow),
             flow.request.headers,
@@ -989,7 +991,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         )
         endpoint_bucket = refine_bucket_with_body(
             endpoint_bucket,
-            flow.request.method,
+            method,
             request_path,
             request_body,
         )
@@ -1001,7 +1003,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     req_meta.update(
         _parse_request_query_fallback_hints(original_url)
         if (
-            flow.request.method == "GET"
+            method == "GET"
             and not req_meta["is_count_endpoint"]
             and not resp_meta.get("body_parsed")
         )
@@ -1028,7 +1030,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         log_proxy_entry(proxy_log_path, "warn", message, **{**log_context, **extra})
 
     billable_counts = _compute_billable_counts(
-        flow.request.method, req_meta, resp_meta, endpoint_bucket, log_warn=_log_warn
+        method, req_meta, resp_meta, endpoint_bucket, log_warn=_log_warn
     )
 
     ndjson_lines_failed = resp_meta.get("ndjson_lines_failed", 0)
@@ -1051,11 +1053,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     missing_count_visibility = bool(req_meta.get("is_count_endpoint")) or (
         req_meta.get("request_ids_count") is None and req_meta.get("max_results") is None
     )
-    if (
-        flow.request.method == "GET"
-        and not resp_meta.get("body_parsed")
-        and missing_count_visibility
-    ):
+    if method == "GET" and not resp_meta.get("body_parsed") and missing_count_visibility:
         log_extra: dict[str, object] = {
             "body_truncated": bool(resp_meta.get("body_truncated")),
         }
@@ -1076,7 +1074,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         )
 
     if (
-        flow.request.method == "GET"
+        method == "GET"
         and req_meta.get("is_count_endpoint")
         and resp_meta.get("body_parsed")
         and _as_non_bool_int(resp_meta.get("response_total_tweet_count")) is None

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
@@ -34,6 +34,16 @@ def test_logs_batch_ids(x_usage, tmp_path, real_flow):
     assert p["quantity"] == 3
 
 
+def test_logs_lowercase_get_using_response_count(x_usage, tmp_path, real_flow):
+    """Lowercase GET methods use the same response-count billing as GET."""
+    body = json.dumps({"data": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}).encode()
+    flow = x_usage.make_flow(real_flow, tmp_path, body=body)
+    flow.request.method = "get"
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "posts.read"
+    assert p["quantity"] == 3
+
+
 def test_logs_batch_ids_with_deletions(x_usage, tmp_path, real_flow):
     """Batch with some missing ids -> bills actual data returned."""
     body = json.dumps({"data": [{"id": "1"}, {"id": "3"}]}).encode()

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -95,6 +95,24 @@ def test_tweet_create_plain_text_downgrades_to_content_create(x_usage, tmp_path,
     assert p["quantity"] == 1
 
 
+def test_lowercase_post_tweet_create_plain_text_downgrades(x_usage, tmp_path, real_flow):
+    """Lowercase POST methods still refine plain-text tweet creation."""
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "post"
+    flow.request.content = json.dumps({"text": "hello world"}).encode()
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
 @pytest.mark.parametrize(
     ("request_encoding", "request_body"),
     [


### PR DESCRIPTION
## Summary

- normalize X request methods before classification and billing decisions
- preserve raw method logging
- add lowercase GET and POST billing regressions

## Validation

- `python3 -m pytest tests/x_connector_usage/test_reads.py tests/x_connector_usage/test_writes.py tests/test_x_billing.py` (129 passed)
- `ruff format --check ...`
- `ruff check ...`

The repository pre-commit hook still reports the pre-existing `S310` finding in `scripts/update_x_tlds.py`; it is unrelated to this change.

Closes #22863