### PR TITLE
fix(ci): reject stale release pull requests in merge queue

### DIFF
--- a/.github/scripts/check-release-please-component-releases.sh
+++ b/.github/scripts/check-release-please-component-releases.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "release presence check: $1" >&2
+  exit 1
+}
+
+if [ "$#" -ne 3 ]; then
+  fail "usage: check-release-please-component-releases.sh <merge-group-base> <merge-group-head> <release-pr-head>"
+fi
+
+merge_group_base=$1
+merge_group_head=$2
+release_pr_head=$3
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) ||
+  fail "current directory is not inside a Git repository"
+cd "$repo_root"
+
+resolve_commit() {
+  local revision=$1 label=$2
+  git rev-parse --verify "${revision}^{commit}" 2>/dev/null ||
+    fail "${label} is not an available commit: ${revision}"
+}
+
+merge_group_base=$(resolve_commit "$merge_group_base" "merge-group base")
+merge_group_head=$(resolve_commit "$merge_group_head" "merge-group head")
+release_pr_head=$(resolve_commit "$release_pr_head" "release PR head")
+
+mapfile -t merge_group_commit < <(
+  git rev-list --parents --max-count=1 "$merge_group_head"
+)
+read -r -a merge_group_commit <<<"${merge_group_commit[0]}"
+if [ "${#merge_group_commit[@]}" -ne 2 ]; then
+  fail "merge-group head must have exactly one parent"
+fi
+if [ "${merge_group_commit[1]}" != "$merge_group_base" ]; then
+  fail "merge-group base is not the direct parent of merge-group head"
+fi
+
+mapfile -t release_commit < <(
+  git rev-list --parents --max-count=1 "$release_pr_head"
+)
+read -r -a release_commit <<<"${release_commit[0]}"
+if [ "${#release_commit[@]}" -ne 2 ]; then
+  fail "release PR head must have exactly one parent"
+fi
+generation_base=${release_commit[1]}
+
+git merge-base --is-ancestor "$generation_base" "$merge_group_base" ||
+  fail "release PR generation base is not an ancestor of merge-group base"
+
+read_git_json() {
+  local revision=$1 path=$2 label=$3
+  local content
+
+  content=$(git show "${revision}:${path}" 2>/dev/null) ||
+    fail "missing ${label} at ${revision}: ${path}"
+  jq -ceS . <<<"$content" 2>/dev/null ||
+    fail "invalid ${label} at ${revision}: ${path}"
+}
+
+release_config=$(
+  read_git_json \
+    "$merge_group_base" \
+    "release-please-config.json" \
+    "Release Please config"
+)
+generation_manifest=$(
+  read_git_json \
+    "$generation_base" \
+    ".release-please-manifest.json" \
+    "generation manifest"
+)
+release_manifest=$(
+  read_git_json \
+    "$release_pr_head" \
+    ".release-please-manifest.json" \
+    "release PR manifest"
+)
+merge_group_manifest=$(
+  read_git_json \
+    "$merge_group_head" \
+    ".release-please-manifest.json" \
+    "merge-group manifest"
+)
+
+if [ "$release_manifest" != "$merge_group_manifest" ]; then
+  fail "release PR manifest does not match merge-group head"
+fi
+
+components_json=$(jq -ce '
+  .packages
+  | select(type == "object")
+  | keys
+  | select(length > 0)
+' <<<"$release_config" 2>/dev/null) ||
+  fail "Release Please config must contain a non-empty packages object"
+mapfile -t components < <(jq -r '.[]' <<<"$components_json")
+
+missing_releases=()
+for component in "${components[@]}"; do
+  if [[ ! "$component" =~ ^[A-Za-z0-9._/-]+$ ]] ||
+    [[ "$component" == /* || "$component" == */ ||
+      "/$component/" == *"/../"* || "/$component/" == *"/./"* ||
+      "/$component/" == *"//"* ]]; then
+    fail "unsafe component path in Release Please config: ${component}"
+  fi
+
+  pathspec=":(top,glob)${component}/**/src/**"
+  if git diff --quiet "$generation_base" "$merge_group_base" -- "$pathspec"; then
+    continue
+  else
+    diff_status=$?
+    if [ "$diff_status" -ne 1 ]; then
+      fail "could not compare source changes for ${component}"
+    fi
+  fi
+
+  generation_version=$(jq -er --arg component "$component" '
+    .[$component]
+    | select(type == "string" and length > 0)
+  ' <<<"$generation_manifest" 2>/dev/null) ||
+    fail "generation manifest is missing a version for ${component}"
+  release_version=$(jq -er --arg component "$component" '
+    .[$component]
+    | select(type == "string" and length > 0)
+  ' <<<"$release_manifest" 2>/dev/null) ||
+    fail "release PR manifest is missing a version for ${component}"
+
+  if [ "$generation_version" = "$release_version" ]; then
+    missing_releases+=("$component")
+  else
+    echo "release presence check: ${component} source changed and release advances ${generation_version} -> ${release_version}"
+  fi
+done
+
+if [ "${#missing_releases[@]}" -ne 0 ]; then
+  for component in "${missing_releases[@]}"; do
+    echo "::error title=Missing component release::${component} has intervening source changes but no new release" >&2
+  done
+  fail "${#missing_releases[@]} component release(s) missing"
+fi
+
+echo "release presence check: all intervening component source changes have releases"

--- a/.github/scripts/tests/check-release-please-component-releases-test.sh
+++ b/.github/scripts/tests/check-release-please-component-releases-test.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_RELEASES="${SCRIPT_DIR}/check-release-please-component-releases.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local text=$1 expected=$2
+  grep -Fq -- "$expected" <<<"$text" ||
+    fail "expected output to contain: ${expected}"
+}
+
+expect_success() {
+  local repo=$1 merge_base=$2 merge_head=$3 release_head=$4
+  local output
+
+  if ! output=$(
+    cd "$repo"
+    "$CHECK_RELEASES" "$merge_base" "$merge_head" "$release_head" 2>&1
+  ); then
+    echo "$output" >&2
+    fail "expected release presence check to succeed"
+  fi
+  assert_contains \
+    "$output" \
+    "all intervening component source changes have releases"
+}
+
+expect_failure() {
+  local repo=$1 merge_base=$2 merge_head=$3 release_head=$4 expected=$5
+  local output
+
+  if output=$(
+    cd "$repo"
+    "$CHECK_RELEASES" "$merge_base" "$merge_head" "$release_head" 2>&1
+  ); then
+    fail "expected release presence check to fail"
+  fi
+  assert_contains "$output" "$expected"
+}
+
+setup_repo() {
+  local name=$1
+  REPO="${TMPDIR}/${name}"
+  mkdir -p \
+    "${REPO}/crates/runner/mitm-addon/src" \
+    "${REPO}/crates/runner/tests" \
+    "${REPO}/turbo/apps/api/src" \
+    "${REPO}/turbo/apps/app/src" \
+    "${REPO}/docs"
+
+  printf 'runner runtime\n' \
+    >"${REPO}/crates/runner/mitm-addon/src/runtime.py"
+  printf 'runner test\n' >"${REPO}/crates/runner/tests/runtime.test.py"
+  printf 'api runtime\n' >"${REPO}/turbo/apps/api/src/index.ts"
+  printf 'app runtime\n' >"${REPO}/turbo/apps/app/src/index.ts"
+  printf 'documentation\n' >"${REPO}/docs/README.md"
+
+  printf '%s\n' \
+    '{"packages":{"crates/runner":{"release-type":"rust","component":"runner-rs"},"turbo/apps/api":{"release-type":"node"},"turbo/apps/app":{"release-type":"node"}}}' \
+    >"${REPO}/release-please-config.json"
+  printf '%s\n' \
+    '{"crates/runner":"1.0.0","turbo/apps/api":"1.0.0","turbo/apps/app":"1.0.0"}' \
+    >"${REPO}/.release-please-manifest.json"
+
+  git -C "$REPO" init -q -b main
+  git -C "$REPO" config user.email test@example.com
+  git -C "$REPO" config user.name Test
+  git -C "$REPO" add --all
+  git -C "$REPO" commit -qm "baseline"
+  BASE=$(git -C "$REPO" rev-parse HEAD)
+}
+
+update_manifest() {
+  local repo=$1 filter=$2
+  local output="${repo}/.release-please-manifest.next.json"
+
+  jq -c "$filter" "${repo}/.release-please-manifest.json" >"$output"
+  mv "$output" "${repo}/.release-please-manifest.json"
+}
+
+create_release_head() {
+  local repo=$1 branch=$2 filter=$3
+
+  git -C "$repo" switch -q -C "$branch" "$BASE"
+  update_manifest "$repo" "$filter"
+  git -C "$repo" add .release-please-manifest.json
+  git -C "$repo" commit -qm "chore: release main"
+  git -C "$repo" rev-parse HEAD
+}
+
+create_merge_head() {
+  local repo=$1 branch=$2 merge_base=$3 filter=$4
+
+  git -C "$repo" switch -q -C "$branch" "$merge_base"
+  update_manifest "$repo" "$filter"
+  git -C "$repo" add .release-please-manifest.json
+  git -C "$repo" commit -qm "chore: release main"
+  git -C "$repo" rev-parse HEAD
+}
+
+setup_repo "missing-runner-release"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+printf 'runner source change\n' \
+  >>"${REPO}/crates/runner/mitm-addon/src/runtime.py"
+printf 'api source change\n' >>"${REPO}/turbo/apps/api/src/index.ts"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "feat: change runner and api"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$release_head" \
+  "crates/runner has intervening source changes but no new release"
+
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api-runner \
+    '.["turbo/apps/api"] = "1.0.1" | .["crates/runner"] = "1.0.1"'
+)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api-runner \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1" | .["crates/runner"] = "1.0.1"'
+)
+expect_success "$REPO" "$merge_base" "$merge_head" "$release_head"
+
+setup_repo "multiple-missing-releases"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+printf 'runner source change\n' \
+  >>"${REPO}/crates/runner/mitm-addon/src/runtime.py"
+printf 'app source change\n' >>"${REPO}/turbo/apps/app/src/index.ts"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "feat: change runner and app"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+output=""
+if output=$(
+  cd "$REPO"
+  "$CHECK_RELEASES" "$merge_base" "$merge_head" "$release_head" 2>&1
+); then
+  fail "expected multiple missing releases to fail"
+fi
+assert_contains "$output" "crates/runner has intervening source changes"
+assert_contains "$output" "turbo/apps/app has intervening source changes"
+assert_contains "$output" "2 component release(s) missing"
+
+setup_repo "non-source-change"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+printf 'documentation change\n' >>"${REPO}/docs/README.md"
+printf 'test change\n' >>"${REPO}/crates/runner/tests/runtime.test.py"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "docs: update runner documentation and tests"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_success "$REPO" "$merge_base" "$merge_head" "$release_head"
+
+setup_repo "no-intervening-change"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+merge_base=$BASE
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_success "$REPO" "$merge_base" "$merge_head" "$release_head"
+
+setup_repo "unreleased-config-only-component"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+jq -c \
+  '.packages["turbo/apps/new-service"] = {"release-type":"node"}' \
+  "${REPO}/release-please-config.json" \
+  >"${REPO}/release-please-config.next.json"
+mv \
+  "${REPO}/release-please-config.next.json" \
+  "${REPO}/release-please-config.json"
+git -C "$REPO" add release-please-config.json
+git -C "$REPO" commit -qm "build: configure new component"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_success "$REPO" "$merge_base" "$merge_head" "$release_head"
+
+setup_repo "manifest-race"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api-runner \
+    '.["turbo/apps/api"] = "1.0.1" | .["crates/runner"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+printf 'runner source change\n' \
+  >>"${REPO}/crates/runner/mitm-addon/src/runtime.py"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "feat: change runner"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$release_head" \
+  "release PR manifest does not match merge-group head"
+
+setup_repo "invalid-inputs"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+merge_base=$BASE
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_failure \
+  "$REPO" \
+  missing-revision \
+  "$merge_head" \
+  "$release_head" \
+  "merge-group base is not an available commit"
+
+setup_repo "missing-config"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+git -C "$REPO" rm -q release-please-config.json
+git -C "$REPO" commit -qm "build: remove release config"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$release_head" \
+  "missing Release Please config"
+
+setup_repo "missing-manifest-entry"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    'del(.["crates/runner"]) | .["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q main
+printf 'runner source change\n' \
+  >>"${REPO}/crates/runner/mitm-addon/src/runtime.py"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "feat: change runner"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    'del(.["crates/runner"]) | .["turbo/apps/api"] = "1.0.1"'
+)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$release_head" \
+  "release PR manifest is missing a version for crates/runner"
+
+setup_repo "multi-parent-release-head"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+merge_base=$BASE
+merge_head=$(
+  create_merge_head \
+    "$REPO" \
+    merge-api \
+    "$merge_base" \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q -C release-side "$BASE"
+printf 'side\n' >>"${REPO}/docs/README.md"
+git -C "$REPO" add --all
+git -C "$REPO" commit -qm "docs: side"
+git -C "$REPO" switch -q release-api
+git -C "$REPO" merge -q --no-ff release-side -m "merge side"
+multi_parent_release_head=$(git -C "$REPO" rev-parse HEAD)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$multi_parent_release_head" \
+  "release PR head must have exactly one parent"
+
+setup_repo "non-ancestor-generation-base"
+release_head=$(
+  create_release_head \
+    "$REPO" \
+    release-api \
+    '.["turbo/apps/api"] = "1.0.1"'
+)
+git -C "$REPO" switch -q --orphan unrelated-main
+printf 'unrelated\n' >"${REPO}/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -qm "chore: unrelated history"
+merge_base=$(git -C "$REPO" rev-parse HEAD)
+printf 'merge group\n' >>"${REPO}/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -qm "chore: merge group"
+merge_head=$(git -C "$REPO" rev-parse HEAD)
+expect_failure \
+  "$REPO" \
+  "$merge_base" \
+  "$merge_head" \
+  "$release_head" \
+  "release PR generation base is not an ancestor of merge-group base"
+
+echo "check-release-please-component-releases-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -275,9 +275,11 @@ jobs:
           bash -n "${script_files[@]}"
           shellcheck \
             .github/scripts/check-connector-source-freeze.sh \
+            .github/scripts/check-release-please-component-releases.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/tests/check-connector-source-freeze-test.sh \
+            .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -49,7 +49,9 @@ jobs:
           if [[ "$EVENT_NAME" == "merge_group" ]] && [[ -n "$MQ_HEAD_REF" ]]; then
             PR_NUM=$(echo "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [[ -n "$PR_NUM" ]]; then
-              PR_BRANCH=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || echo "")
+              # Fail closed because a missed release classification would bypass
+              # release-presence validation.
+              PR_BRANCH=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq .headRefName)
               if [[ "$PR_BRANCH" == release-please--branches--* ]]; then
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 echo "Release-please merge queue entry detected (PR #$PR_NUM, branch: $PR_BRANCH)"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -61,6 +61,54 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "Not a release-please context"
 
+  validate-release-presence:
+    name: Validate release presence
+    needs: [detect-release]
+    if: ${{ github.event_name == 'merge_group' && needs.detect-release.outputs.skip == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check intervening component releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          pr_number=$(
+            printf '%s\n' "$MERGE_GROUP_HEAD_REF" |
+              grep -oE 'pr-[0-9]+' |
+              head -1 |
+              sed 's/pr-//'
+          )
+          if [ -z "$pr_number" ]; then
+            echo "::error::Could not resolve pull request number from merge queue ref: $MERGE_GROUP_HEAD_REF"
+            exit 1
+          fi
+
+          release_pr_head=$(
+            gh pr view "$pr_number" \
+              --repo "$REPO" \
+              --json headRefOid \
+              --jq .headRefOid
+          )
+          git fetch --no-tags origin "$release_pr_head"
+
+          .github/scripts/check-release-please-component-releases.sh \
+            "$MERGE_GROUP_BASE_SHA" \
+            "$MERGE_GROUP_HEAD_SHA" \
+            "$release_pr_head"
+
   detect-turbo-ts-checks:
     needs: [detect-release]
     if: needs.detect-release.outputs.skip != 'true'
@@ -2525,6 +2573,7 @@ jobs:
     # Runner cleanup is handled by cleanup.yml (pull_request_target:closed).
     needs:
       - detect-release
+      - validate-release-presence
       - detect-turbo-ts-checks
       - prepare
       - file-size-check
@@ -2558,10 +2607,16 @@ jobs:
     steps:
       - name: Validate CI results
         env:
+          EVENT_NAME: ${{ github.event_name }}
           IS_RELEASE: ${{ needs.detect-release.outputs.skip }}
+          RELEASE_PRESENCE_RESULT: ${{ needs.validate-release-presence.result }}
         run: |
           # Auto-pass for release-please PRs, commits, and merge queue entries
           if [[ "$IS_RELEASE" == "true" ]]; then
+            if [[ "$EVENT_NAME" == "merge_group" && "$RELEASE_PRESENCE_RESULT" != "success" ]]; then
+              echo "::error::validate-release-presence: expected success, got $RELEASE_PRESENCE_RESULT"
+              exit 1
+            fi
             if [[ "${{ needs.block-connector-source-changes.result }}" != "success" ]]; then
               echo "::error::block-connector-source-changes: expected success, got ${{ needs.block-connector-source-changes.result }}"
               exit 1


### PR DESCRIPTION
## Summary

- reject Release Please merge groups when source changes queued after release generation do not have a component version bump
- derive managed components from `release-please-config.json` and validate release presence from `.release-please-manifest.json`
- fail closed on invalid Git topology, concurrent Release Please branch refreshes, and merge-group classification errors
- add real-Git regression coverage and include the new scripts in Workflow Lint

This checks only whether a component has a new release. It intentionally does not inspect or validate changelog content.

## Validation

- `bash .github/scripts/tests/check-release-please-component-releases-test.sh`
- Workflow Lint's complete `.github/scripts/tests/*.sh` suite under `bash -euo pipefail`
- `shellcheck .github/scripts/check-release-please-component-releases.sh .github/scripts/tests/check-release-please-component-releases-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint`
- `pnpm exec prettier --check ../.github/workflows/turbo.yml ../.github/workflows/security.yml`
- `git diff --check`

Closes #22879
