### PR TITLE
fix(runner): make version config gc retryable

### DIFF
--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -4,7 +4,10 @@ use super::*;
 use crate::cmd::gc::GC_MIN_AGE;
 use crate::cmd::gc::images::gc_nested_images_with_protected_refs;
 use crate::cmd::gc::test_support::{old_gc_time, set_mtime, test_home};
-use crate::cmd::gc::versions::{analyze_version_gc, analyze_version_gc_with_injected_scan_error};
+use crate::cmd::gc::versions::{
+    analyze_version_gc, analyze_version_gc_with_injected_config_scan_error,
+    analyze_version_gc_with_injected_scan_error,
+};
 
 fn age_version_past_gc_min_age(home: &HomePaths, name: &str) {
     let old_time = SystemTime::now() - Duration::from_secs(GC_MIN_AGE.as_secs() + 60);
@@ -137,6 +140,28 @@ async fn protected_version_config_ref_keeps_image_snapshot() {
         "protect-version config refs must keep the referenced snapshot"
     );
     assert!(home.images_dir().join(&rootfs_hash).exists());
+}
+
+#[tokio::test]
+async fn protected_config_only_version_ref_keeps_image_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let rootfs_hash = test_hash('a');
+    let snapshot_hash = test_hash('b');
+    let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+    write_test_runner_config(&home, version, &rootfs_hash, &snapshot_hash);
+    let refs = protected_refs_from_versions(&home, Some(version), None).await;
+
+    let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+        .await
+        .unwrap();
+
+    assert_eq!(freed.freed_bytes, 0);
+    assert!(
+        snapshot_dir.exists(),
+        "retained config-only version must protect its referenced snapshot"
+    );
 }
 
 #[tokio::test]
@@ -340,6 +365,21 @@ async fn incomplete_version_scan_makes_protection_inventory_incomplete() {
 
     let refs = protected_image_refs_for_gc(&home, &analysis).await;
 
+    assert!(!refs.is_complete());
+}
+
+#[tokio::test]
+async fn incomplete_config_scan_makes_protection_inventory_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.runners_dir()).unwrap();
+    let analysis = analyze_version_gc_with_injected_config_scan_error(&home, None, None, 0)
+        .await
+        .unwrap();
+
+    let refs = protected_image_refs_for_gc(&home, &analysis).await;
+
+    assert!(!analysis.directory_scan_complete());
     assert!(!refs.is_complete());
 }
 

--- a/crates/runner/src/cmd/gc/version_service_locks.rs
+++ b/crates/runner/src/cmd/gc/version_service_locks.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use tracing::warn;
 
 use crate::error::RunnerResult;
@@ -19,12 +17,24 @@ fn version_from_service_lock_name(name: &str) -> Option<&str> {
     Some(version)
 }
 
-async fn version_bin_is_gc_enumerable_dir(path: &Path) -> Result<bool, String> {
-    match tokio::fs::symlink_metadata(path).await {
-        Ok(meta) => Ok(meta.file_type().is_dir()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(e) => Err(format!("stat version bin {}: {e}", path.display())),
+async fn version_has_gc_enumerable_dir(home: &HomePaths, version: &str) -> Result<bool, String> {
+    for (kind, path) in [
+        ("binary", home.bin_dir().join(version)),
+        ("config", home.runners_dir().join(version)),
+    ] {
+        match tokio::fs::symlink_metadata(&path).await {
+            Ok(meta) if meta.file_type().is_dir() => return Ok(true),
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(format!(
+                    "stat version {kind} directory {}: {e}",
+                    path.display()
+                ));
+            }
+        }
     }
+    Ok(false)
 }
 
 pub(super) async fn gc_orphaned_version_service_locks(
@@ -37,8 +47,6 @@ pub(super) async fn gc_orphaned_version_service_locks(
     };
 
     let mut removed = 0u64;
-    let bin_dir = home.bin_dir();
-
     while let Some(entry) = next_entry_warn_or_stop(
         &mut entries,
         "gc_orphaned_version_service_locks",
@@ -52,8 +60,7 @@ pub(super) async fn gc_orphaned_version_service_locks(
             continue;
         };
 
-        let version_bin = bin_dir.join(version);
-        match version_bin_is_gc_enumerable_dir(&version_bin).await {
+        match version_has_gc_enumerable_dir(home, version).await {
             Ok(true) => continue,
             Ok(false) => {}
             Err(e) => {
@@ -67,7 +74,7 @@ pub(super) async fn gc_orphaned_version_service_locks(
             ExistingLockProbe::Free(lock) => {
                 // A version can be recreated between the initial stat and
                 // acquiring the free service lock.
-                match version_bin_is_gc_enumerable_dir(&version_bin).await {
+                match version_has_gc_enumerable_dir(home, version).await {
                     Ok(true) => continue,
                     Ok(false) => {}
                     Err(e) => {
@@ -160,6 +167,37 @@ mod tests {
         assert!(
             service_lock.exists(),
             "existing version dir should keep its service lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_orphaned_version_service_locks_tracks_config_only_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let version = "v1.0.0";
+        let service_lock = create_test_version_service_lock(&home, version);
+        let version_config = home.runners_dir().join(version);
+        std::fs::create_dir_all(&version_config).unwrap();
+
+        let first_removed = gc_orphaned_version_service_locks(&home, false)
+            .await
+            .unwrap();
+
+        assert_eq!(first_removed.version_service_locks_removed, 0);
+        assert!(
+            service_lock.exists(),
+            "config-only version should keep its lifecycle lock"
+        );
+
+        std::fs::remove_dir_all(version_config).unwrap();
+        let second_removed = gc_orphaned_version_service_locks(&home, false)
+            .await
+            .unwrap();
+
+        assert_eq!(second_removed.version_service_locks_removed, 1);
+        assert!(
+            !service_lock.exists(),
+            "lock should become removable after both managed directories are absent"
         );
     }
 

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
@@ -15,15 +15,21 @@ use crate::lock;
 use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
-use super::filesystem::{GcDirEntryReader, read_dir_or_missing};
+use super::filesystem::{GcDirEntryReader, GcDirStatus, gc_path_dir_status, read_dir_or_missing};
 use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_lock_after_probe};
 use super::report::GcReport;
 
 type ServiceUninstallFuture<'a> = Pin<Box<dyn Future<Output = RunnerResult<()>> + 'a>>;
 type ServiceUninstallFn = for<'a> fn(&'a service::RunnerServiceUnit) -> ServiceUninstallFuture<'a>;
+type RemoveDirAllFuture<'a> = Pin<Box<dyn Future<Output = std::io::Result<()>> + 'a>>;
+type RemoveDirAllFn = for<'a> fn(&'a Path) -> RemoveDirAllFuture<'a>;
 
 fn real_uninstall_service_unit(unit: &service::RunnerServiceUnit) -> ServiceUninstallFuture<'_> {
     Box::pin(service::uninstall_service_unit(unit))
+}
+
+fn real_remove_dir_all(path: &Path) -> RemoveDirAllFuture<'_> {
+    Box::pin(tokio::fs::remove_dir_all(path))
 }
 
 /// Parse `v<major>.<minor>.<patch>` into a tuple for ordering. Returns `None`
@@ -40,8 +46,8 @@ pub(super) fn parse_semver(name: &str) -> Option<(u32, u32, u32)> {
     Some((major, minor, patch))
 }
 
-async fn version_newest_mtime(home: &HomePaths, bin_dir: &Path, name: &str) -> SystemTime {
-    let version_bin = bin_dir.join(name);
+async fn version_newest_mtime(home: &HomePaths, name: &str) -> SystemTime {
+    let version_bin = home.bin_dir().join(name);
     let version_config = home.runners_dir().join(name);
     let version_binary = version_bin.join("runner");
     let version_config_file = version_config.join("runner.yaml");
@@ -52,7 +58,7 @@ async fn version_newest_mtime(home: &HomePaths, bin_dir: &Path, name: &str) -> S
         &version_config,
         &version_config_file,
     ] {
-        if let Ok(meta) = tokio::fs::metadata(path).await
+        if let Ok(meta) = tokio::fs::symlink_metadata(path).await
             && let Ok(mtime) = meta.modified()
             && mtime > newest_mtime
         {
@@ -62,10 +68,79 @@ async fn version_newest_mtime(home: &HomePaths, bin_dir: &Path, name: &str) -> S
     newest_mtime
 }
 
-async fn version_gc_age(home: &HomePaths, bin_dir: &Path, name: &str) -> Duration {
+async fn version_gc_age(home: &HomePaths, name: &str) -> Duration {
     SystemTime::now()
-        .duration_since(version_newest_mtime(home, bin_dir, name).await)
+        .duration_since(version_newest_mtime(home, name).await)
         .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+enum VersionArtifactState {
+    #[default]
+    Missing,
+    Directory,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum VersionArtifactKind {
+    Binary,
+    Config,
+}
+
+impl VersionArtifactKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Binary => "binary",
+            Self::Config => "config",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct VersionArtifacts {
+    version: (u32, u32, u32),
+    binary: VersionArtifactState,
+    config: VersionArtifactState,
+}
+
+impl VersionArtifacts {
+    const fn new(version: (u32, u32, u32)) -> Self {
+        Self {
+            version,
+            binary: VersionArtifactState::Missing,
+            config: VersionArtifactState::Missing,
+        }
+    }
+
+    const fn state(&self, kind: VersionArtifactKind) -> VersionArtifactState {
+        match kind {
+            VersionArtifactKind::Binary => self.binary,
+            VersionArtifactKind::Config => self.config,
+        }
+    }
+
+    const fn set_state(&mut self, kind: VersionArtifactKind, state: VersionArtifactState) {
+        match kind {
+            VersionArtifactKind::Binary => self.binary = state,
+            VersionArtifactKind::Config => self.config = state,
+        }
+    }
+
+    const fn has_directory(&self) -> bool {
+        matches!(self.binary, VersionArtifactState::Directory)
+            || matches!(self.config, VersionArtifactState::Directory)
+    }
+
+    const fn has_unexpected_type(&self) -> bool {
+        matches!(self.binary, VersionArtifactState::Other)
+            || matches!(self.config, VersionArtifactState::Other)
+    }
+}
+
+struct VersionArtifactScan {
+    entries: Vec<(String, (u32, u32, u32), VersionArtifactState)>,
+    complete: bool,
 }
 
 /// Why a version survives the current GC pass.
@@ -73,6 +148,8 @@ async fn version_gc_age(home: &HomePaths, bin_dir: &Path, name: &str) -> Duratio
 enum VersionRetentionReason {
     ProtectVersion,
     KeepLatest,
+    IncompleteBinaryScan,
+    UnexpectedArtifactType,
     Recent(Duration),
     InvalidServiceSuffix(String),
     ServiceLockHeld,
@@ -88,6 +165,12 @@ impl VersionRetentionReason {
             }
             Self::KeepLatest => {
                 info!("version {name}: within --keep-latest, skipping");
+            }
+            Self::IncompleteBinaryScan => {
+                warn!("version {name}: binary directory scan incomplete, skipping");
+            }
+            Self::UnexpectedArtifactType => {
+                warn!("version {name}: managed version path is not a directory, skipping");
             }
             Self::Recent(age) => {
                 info!("version {name}: too recent ({}s), skipping", age.as_secs());
@@ -111,13 +194,15 @@ impl VersionRetentionReason {
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct VersionGcEntry {
     name: String,
+    artifacts: VersionArtifacts,
     retained: Option<VersionRetentionReason>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) struct VersionGcAnalysis {
     entries: Vec<VersionGcEntry>,
-    directory_scan_complete: bool,
+    binary_scan_complete: bool,
+    config_scan_complete: bool,
 }
 
 impl VersionGcAnalysis {
@@ -129,7 +214,7 @@ impl VersionGcAnalysis {
     }
 
     pub(super) const fn directory_scan_complete(&self) -> bool {
-        self.directory_scan_complete
+        self.binary_scan_complete && self.config_scan_complete
     }
 }
 
@@ -138,59 +223,115 @@ pub(super) async fn analyze_version_gc(
     protect: Option<&str>,
     keep_latest: Option<usize>,
 ) -> RunnerResult<VersionGcAnalysis> {
-    let mut entry_reader = GcDirEntryReader::new();
-    analyze_version_gc_with_reader(home, protect, keep_latest, &mut entry_reader).await
+    let mut binary_reader = GcDirEntryReader::new();
+    let mut config_reader = GcDirEntryReader::new();
+    analyze_version_gc_with_readers(
+        home,
+        protect,
+        keep_latest,
+        &mut binary_reader,
+        &mut config_reader,
+    )
+    .await
 }
 
-async fn analyze_version_gc_with_reader(
-    home: &HomePaths,
-    protect: Option<&str>,
-    keep_latest: Option<usize>,
+async fn scan_version_artifacts(
+    root: &Path,
+    kind: VersionArtifactKind,
     entry_reader: &mut GcDirEntryReader,
-) -> RunnerResult<VersionGcAnalysis> {
-    let bin_dir = home.bin_dir();
-    let Some(mut entries) = read_dir_or_missing(&bin_dir).await? else {
-        return Ok(VersionGcAnalysis {
+) -> RunnerResult<VersionArtifactScan> {
+    let Some(mut entries) = (match read_dir_or_missing(root).await {
+        Ok(entries) => entries,
+        Err(error) if kind == VersionArtifactKind::Binary => return Err(error),
+        Err(error) => {
+            warn!(
+                "gc_versions: cannot scan {} root {} ({error}), marking inventory incomplete",
+                kind.label(),
+                root.display()
+            );
+            return Ok(VersionArtifactScan {
+                entries: Vec::new(),
+                complete: false,
+            });
+        }
+    }) else {
+        return Ok(VersionArtifactScan {
             entries: Vec::new(),
-            directory_scan_complete: true,
+            complete: true,
         });
     };
 
-    // First pass: collect all semver-named dirs. We need the full set to
-    // pick the top `keep_latest` by version, so we can't decide-and-delete
-    // in one pass.
-    let mut semver_dirs: Vec<(String, (u32, u32, u32))> = Vec::new();
-    let mut directory_scan_complete = true;
+    let mut version_entries = Vec::new();
+    let mut complete = true;
     loop {
         let entry = match entry_reader
-            .next_entry_warn(&mut entries, "gc_versions", &bin_dir)
+            .next_entry_warn(&mut entries, "gc_versions", root)
             .await
         {
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(_) => {
-                directory_scan_complete = false;
+                complete = false;
                 break;
             }
+        };
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(version) = parse_semver(name) else {
+            continue;
         };
         let file_type = match entry.file_type().await {
             Ok(file_type) => file_type,
             Err(e) => {
-                directory_scan_complete = false;
+                complete = false;
                 warn!(
-                    "version entry {}: cannot read file type ({e}), skipping",
+                    "{} version entry {}: cannot read file type ({e}), skipping",
+                    kind.label(),
                     entry.path().display()
                 );
                 continue;
             }
         };
-        if !file_type.is_dir() {
-            continue;
-        }
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if let Some(ver) = parse_semver(name) {
-            semver_dirs.push((name.to_string(), ver));
+        let state = if file_type.is_dir() {
+            VersionArtifactState::Directory
+        } else {
+            VersionArtifactState::Other
+        };
+        version_entries.push((name.to_string(), version, state));
+    }
+
+    Ok(VersionArtifactScan {
+        entries: version_entries,
+        complete,
+    })
+}
+
+async fn analyze_version_gc_with_readers(
+    home: &HomePaths,
+    protect: Option<&str>,
+    keep_latest: Option<usize>,
+    binary_reader: &mut GcDirEntryReader,
+    config_reader: &mut GcDirEntryReader,
+) -> RunnerResult<VersionGcAnalysis> {
+    let binary_scan =
+        scan_version_artifacts(&home.bin_dir(), VersionArtifactKind::Binary, binary_reader).await?;
+    let config_scan = scan_version_artifacts(
+        &home.runners_dir(),
+        VersionArtifactKind::Config,
+        config_reader,
+    )
+    .await?;
+
+    let mut inventory: BTreeMap<String, VersionArtifacts> = BTreeMap::new();
+    for (kind, scan) in [
+        (VersionArtifactKind::Binary, &binary_scan),
+        (VersionArtifactKind::Config, &config_scan),
+    ] {
+        for (name, version, state) in &scan.entries {
+            inventory
+                .entry(name.clone())
+                .or_insert_with(|| VersionArtifacts::new(*version))
+                .set_state(kind, *state);
         }
     }
 
@@ -200,28 +341,47 @@ async fn analyze_version_gc_with_reader(
     let kept_by_latest: HashSet<String> = if keep_count == 0 {
         HashSet::new()
     } else {
-        let mut sorted = semver_dirs.clone();
-        sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
+        let mut sorted: Vec<_> = inventory
+            .iter()
+            .filter(|(_, artifacts)| {
+                artifacts.state(VersionArtifactKind::Binary) == VersionArtifactState::Directory
+            })
+            .map(|(name, artifacts)| (name.clone(), artifacts.version))
+            .collect();
+        sorted.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         sorted
             .into_iter()
             .take(keep_count)
-            .map(|(n, _)| n)
+            .map(|(name, _)| name)
             .collect()
     };
 
     let mut entries = Vec::new();
-    for (name, _) in &semver_dirs {
-        let retained =
-            version_retention_reason(home, &bin_dir, name, protect, &kept_by_latest).await;
+    for (name, artifacts) in inventory {
+        if !artifacts.has_directory() {
+            continue;
+        }
+        let retained = if artifacts.has_unexpected_type() {
+            Some(VersionRetentionReason::UnexpectedArtifactType)
+        } else if !binary_scan.complete
+            && artifacts.binary == VersionArtifactState::Missing
+            && artifacts.config == VersionArtifactState::Directory
+        {
+            Some(VersionRetentionReason::IncompleteBinaryScan)
+        } else {
+            version_retention_reason(home, &name, protect, &kept_by_latest).await
+        };
         entries.push(VersionGcEntry {
-            name: name.clone(),
+            name,
+            artifacts,
             retained,
         });
     }
 
     Ok(VersionGcAnalysis {
         entries,
-        directory_scan_complete,
+        binary_scan_complete: binary_scan.complete,
+        config_scan_complete: config_scan.complete,
     })
 }
 
@@ -232,13 +392,39 @@ pub(super) async fn analyze_version_gc_with_injected_scan_error(
     keep_latest: Option<usize>,
     successful_entries: usize,
 ) -> RunnerResult<VersionGcAnalysis> {
-    let mut entry_reader = GcDirEntryReader::failing_after(successful_entries);
-    analyze_version_gc_with_reader(home, protect, keep_latest, &mut entry_reader).await
+    let mut binary_reader = GcDirEntryReader::failing_after(successful_entries);
+    let mut config_reader = GcDirEntryReader::new();
+    analyze_version_gc_with_readers(
+        home,
+        protect,
+        keep_latest,
+        &mut binary_reader,
+        &mut config_reader,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(super) async fn analyze_version_gc_with_injected_config_scan_error(
+    home: &HomePaths,
+    protect: Option<&str>,
+    keep_latest: Option<usize>,
+    successful_entries: usize,
+) -> RunnerResult<VersionGcAnalysis> {
+    let mut binary_reader = GcDirEntryReader::new();
+    let mut config_reader = GcDirEntryReader::failing_after(successful_entries);
+    analyze_version_gc_with_readers(
+        home,
+        protect,
+        keep_latest,
+        &mut binary_reader,
+        &mut config_reader,
+    )
+    .await
 }
 
 async fn version_retention_reason(
     home: &HomePaths,
-    bin_dir: &Path,
     name: &str,
     protect: Option<&str>,
     kept_by_latest: &HashSet<String>,
@@ -251,7 +437,7 @@ async fn version_retention_reason(
         return Some(VersionRetentionReason::KeepLatest);
     }
 
-    let age = version_gc_age(home, bin_dir, name).await;
+    let age = version_gc_age(home, name).await;
     if age < GC_MIN_AGE {
         return Some(VersionRetentionReason::Recent(age));
     }
@@ -289,6 +475,49 @@ async fn version_retention_reason(
     }
 }
 
+async fn version_paths_are_removable(
+    version_bin: &Path,
+    version_config: &Path,
+    name: &str,
+) -> bool {
+    for (kind, path) in [
+        (VersionArtifactKind::Config, version_config),
+        (VersionArtifactKind::Binary, version_bin),
+    ] {
+        match gc_path_dir_status(path).await {
+            Ok(GcDirStatus::RealDir(_) | GcDirStatus::Missing) => {}
+            Ok(GcDirStatus::NotDirectory) => {
+                warn!(
+                    "version {name}: {} path {} is not a directory, skipping",
+                    kind.label(),
+                    path.display()
+                );
+                return false;
+            }
+            Err(error) => {
+                warn!(
+                    "version {name}: cannot inspect {} path {} ({error}), skipping",
+                    kind.label(),
+                    path.display()
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+async fn remove_version_dir(path: &Path, remove_dir_all: RemoveDirAllFn) -> bool {
+    match remove_dir_all(path).await {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(error) => {
+            warn!("cannot remove {}: {error}", path.display());
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 fn successful_fake_uninstall_service_unit(
     _unit: &service::RunnerServiceUnit,
@@ -301,6 +530,23 @@ fn failing_fake_uninstall_service_unit(
     _unit: &service::RunnerServiceUnit,
 ) -> ServiceUninstallFuture<'_> {
     Box::pin(async { Err(RunnerError::Internal("fake uninstall failed".to_string())) })
+}
+
+#[cfg(test)]
+fn failing_fake_remove_config_dir(path: &Path) -> RemoveDirAllFuture<'_> {
+    Box::pin(async move {
+        if path
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == "runners")
+        {
+            Err(std::io::Error::other(
+                "injected runner config removal failure",
+            ))
+        } else {
+            tokio::fs::remove_dir_all(path).await
+        }
+    })
 }
 
 #[cfg(test)]
@@ -322,15 +568,15 @@ async fn gc_versions(
 
 /// Remove old deployment version directories that are not actively running.
 ///
-/// Scans `home.bin_dir()` for semver-named subdirectories (e.g. `v0.2.0`) and
-/// deletes inactive versions (bin dir, runner config dir, and systemd unit).
+/// Scans the binary and runner-config roots for semver-named subdirectories
+/// (e.g. `v0.2.0`) and deletes inactive versions and their systemd units.
 ///
 /// Survival rules (any one keeps the version):
 /// - `--protect-version` matches the name.
-/// - The version is in the top `keep_latest` by semver descending. This covers
-///   the "staged but not yet installed" case where two overlapping releases
-///   race: the older release's promote must not wipe the newer release's
-///   just-staged binary even though the newer unit isn't active yet.
+/// - A binary version is in the top `keep_latest` by semver descending. This
+///   covers the "staged but not yet installed" case where two overlapping
+///   releases race: the older release's promote must not wipe the newer
+///   release's just-staged binary even though the newer unit isn't active yet.
 /// - The version binary, config file, or their directories are too recent to
 ///   safely delete.
 /// - The corresponding service lifecycle lock is held by another install,
@@ -357,9 +603,27 @@ async fn gc_versions_with_analysis_and_uninstall(
     analysis: VersionGcAnalysis,
     uninstall_service: ServiceUninstallFn,
 ) -> RunnerResult<Vec<String>> {
+    gc_versions_with_analysis_and_operations(
+        home,
+        dry_run,
+        analysis,
+        uninstall_service,
+        real_remove_dir_all,
+    )
+    .await
+}
+
+async fn gc_versions_with_analysis_and_operations(
+    home: &HomePaths,
+    dry_run: bool,
+    analysis: VersionGcAnalysis,
+    uninstall_service: ServiceUninstallFn,
+    remove_dir_all: RemoveDirAllFn,
+) -> RunnerResult<Vec<String>> {
     let bin_dir = home.bin_dir();
     let mut removed: Vec<String> = Vec::new();
     for entry in &analysis.entries {
+        debug_assert!(entry.artifacts.has_directory());
         let name = &entry.name;
         if let Some(reason) = &entry.retained {
             reason.log_skip(name);
@@ -368,7 +632,7 @@ async fn gc_versions_with_analysis_and_uninstall(
 
         let version_bin = bin_dir.join(name);
         let version_config = home.runners_dir().join(name);
-        let age = version_gc_age(home, &bin_dir, name).await;
+        let age = version_gc_age(home, name).await;
         if age < GC_MIN_AGE {
             info!("version {name}: too recent ({}s), skipping", age.as_secs());
             continue;
@@ -422,7 +686,11 @@ async fn gc_versions_with_analysis_and_uninstall(
             }
         };
 
-        let age = version_gc_age(home, &bin_dir, name).await;
+        if !version_paths_are_removable(&version_bin, &version_config, name).await {
+            continue;
+        }
+
+        let age = version_gc_age(home, name).await;
         if age < GC_MIN_AGE {
             info!(
                 "version {name}: became too recent before delete ({}s), skipping",
@@ -463,16 +731,15 @@ async fn gc_versions_with_analysis_and_uninstall(
                 continue;
             }
 
-            // Remove bin directory.
-            if let Err(e) = tokio::fs::remove_dir_all(&version_bin).await
-                && e.kind() != std::io::ErrorKind::NotFound
-            {
-                warn!("cannot remove {}: {e}", version_bin.display());
+            // Remove credential-bearing config before its binary discovery
+            // anchor. Failures leave the version visible for a later GC pass.
+            if !remove_version_dir(&version_config, remove_dir_all).await {
                 continue;
             }
 
-            // Best-effort remove runner config directory.
-            let _ = tokio::fs::remove_dir_all(&version_config).await;
+            if !remove_version_dir(&version_bin, remove_dir_all).await {
+                continue;
+            }
 
             info!("removed version {name}");
             remove_unused_lock_after_probe(

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -74,9 +74,8 @@ async fn version_gc_age(home: &HomePaths, name: &str) -> Duration {
         .unwrap_or_default()
 }
 
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum VersionArtifactState {
-    #[default]
     Missing,
     Directory,
     Other,
@@ -97,7 +96,6 @@ impl VersionArtifactKind {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
 struct VersionArtifacts {
     version: (u32, u32, u32),
     binary: VersionArtifactState,
@@ -110,13 +108,6 @@ impl VersionArtifacts {
             version,
             binary: VersionArtifactState::Missing,
             config: VersionArtifactState::Missing,
-        }
-    }
-
-    const fn state(&self, kind: VersionArtifactKind) -> VersionArtifactState {
-        match kind {
-            VersionArtifactKind::Binary => self.binary,
-            VersionArtifactKind::Config => self.config,
         }
     }
 
@@ -194,7 +185,6 @@ impl VersionRetentionReason {
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct VersionGcEntry {
     name: String,
-    artifacts: VersionArtifacts,
     retained: Option<VersionRetentionReason>,
 }
 
@@ -343,9 +333,7 @@ async fn analyze_version_gc_with_readers(
     } else {
         let mut sorted: Vec<_> = inventory
             .iter()
-            .filter(|(_, artifacts)| {
-                artifacts.state(VersionArtifactKind::Binary) == VersionArtifactState::Directory
-            })
+            .filter(|(_, artifacts)| artifacts.binary == VersionArtifactState::Directory)
             .map(|(name, artifacts)| (name.clone(), artifacts.version))
             .collect();
         sorted.sort_by_key(|entry| std::cmp::Reverse(entry.1));
@@ -371,11 +359,7 @@ async fn analyze_version_gc_with_readers(
         } else {
             version_retention_reason(home, &name, protect, &kept_by_latest).await
         };
-        entries.push(VersionGcEntry {
-            name,
-            artifacts,
-            retained,
-        });
+        entries.push(VersionGcEntry { name, retained });
     }
 
     Ok(VersionGcAnalysis {
@@ -623,7 +607,6 @@ async fn gc_versions_with_analysis_and_operations(
     let bin_dir = home.bin_dir();
     let mut removed: Vec<String> = Vec::new();
     for entry in &analysis.entries {
-        debug_assert!(entry.artifacts.has_directory());
         let name = &entry.name;
         if let Some(reason) = &entry.retained {
             reason.log_skip(name);

--- a/crates/runner/src/cmd/gc/versions/tests.rs
+++ b/crates/runner/src/cmd/gc/versions/tests.rs
@@ -96,6 +96,73 @@ async fn analyze_version_gc_marks_partial_directory_scan_incomplete() {
 }
 
 #[tokio::test]
+async fn analyze_version_gc_retains_config_only_entry_when_binary_scan_is_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v2.0.0";
+    std::fs::create_dir_all(home.bin_dir()).unwrap();
+    std::fs::create_dir_all(home.runners_dir().join(version)).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let analysis = analyze_version_gc_with_injected_scan_error(&home, None, None, 0)
+        .await
+        .unwrap();
+
+    assert!(!analysis.directory_scan_complete());
+    assert_eq!(analysis.entries.len(), 1);
+    assert_eq!(
+        analysis.entries[0].retained,
+        Some(VersionRetentionReason::IncompleteBinaryScan)
+    );
+
+    let removed = gc_versions_with_analysis_and_uninstall(
+        &home,
+        false,
+        analysis,
+        successful_fake_uninstall_service_unit,
+    )
+    .await
+    .unwrap();
+    assert!(removed.is_empty());
+    assert!(home.runners_dir().join(version).exists());
+}
+
+#[tokio::test]
+async fn analyze_version_gc_treats_config_iteration_failure_as_nonfatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+    std::fs::create_dir_all(home.runners_dir()).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let analysis = analyze_version_gc_with_injected_config_scan_error(&home, None, None, 0)
+        .await
+        .unwrap();
+
+    assert!(!analysis.directory_scan_complete());
+    assert_eq!(analysis.entries.len(), 1);
+    assert_eq!(analysis.entries[0].name, version);
+}
+
+#[tokio::test]
+async fn analyze_version_gc_treats_config_root_open_failure_as_nonfatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+    std::fs::create_dir_all(home.runners_dir().parent().unwrap()).unwrap();
+    std::fs::write(home.runners_dir(), "not a directory").unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let analysis = analyze_version_gc(&home, None, None).await.unwrap();
+
+    assert!(!analysis.directory_scan_complete());
+    assert_eq!(analysis.entries.len(), 1);
+    assert_eq!(analysis.entries[0].name, version);
+}
+
+#[tokio::test]
 async fn gc_versions_removes_inactive_semver_dirs() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
@@ -158,6 +225,84 @@ async fn gc_versions_keeps_version_when_service_uninstall_fails() {
 }
 
 #[tokio::test]
+async fn gc_versions_keeps_binary_config_and_lock_when_config_removal_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_bin = home.bin_dir().join(version);
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_bin).unwrap();
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let analysis = analyze_version_gc(&home, None, None).await.unwrap();
+    let removed = gc_versions_with_analysis_and_operations(
+        &home,
+        false,
+        analysis,
+        successful_fake_uninstall_service_unit,
+        failing_fake_remove_config_dir,
+    )
+    .await
+    .unwrap();
+
+    assert!(removed.is_empty());
+    assert!(
+        version_config.exists(),
+        "failed config removal must leave credentials retryable"
+    );
+    assert!(
+        version_bin.exists(),
+        "config removal failure must preserve the binary discovery anchor"
+    );
+    assert!(
+        home.service_lock(&test_version_service_unit_name(version))
+            .exists(),
+        "partial cleanup must preserve its lifecycle lock"
+    );
+}
+
+#[tokio::test]
+async fn gc_versions_retries_config_only_cleanup_after_removal_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_config = home.runners_dir().join(version);
+    let service_lock = home.service_lock(&test_version_service_unit_name(version));
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let first_analysis = analyze_version_gc(&home, None, None).await.unwrap();
+    let first_removed = gc_versions_with_analysis_and_operations(
+        &home,
+        false,
+        first_analysis,
+        successful_fake_uninstall_service_unit,
+        failing_fake_remove_config_dir,
+    )
+    .await
+    .unwrap();
+
+    assert!(first_removed.is_empty());
+    assert!(version_config.exists());
+    assert!(service_lock.exists());
+
+    let retry_analysis = analyze_version_gc(&home, None, None).await.unwrap();
+    let retry_removed = gc_versions_with_analysis_and_uninstall(
+        &home,
+        false,
+        retry_analysis,
+        successful_fake_uninstall_service_unit,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(retry_removed, [version]);
+    assert!(!version_config.exists());
+    assert!(!service_lock.exists());
+}
+
+#[tokio::test]
 async fn gc_versions_skips_version_when_service_lock_is_held() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
@@ -194,6 +339,24 @@ async fn gc_versions_dry_run() {
     assert!(
         !service_lock_path.exists(),
         "dry-run should not leave a service lock it created"
+    );
+}
+
+#[tokio::test]
+async fn gc_versions_dry_run_reports_config_only_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let removed = gc_versions(&home, true, None, None).await.unwrap();
+
+    assert_eq!(removed, [version]);
+    assert!(
+        version_config.exists(),
+        "dry-run must preserve config-only versions"
     );
 }
 
@@ -333,6 +496,20 @@ async fn gc_versions_keeps_recent_version() {
 }
 
 #[tokio::test]
+async fn gc_versions_keeps_recent_config_only_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_config).unwrap();
+
+    let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+    assert!(removed.is_empty());
+    assert!(version_config.exists());
+}
+
+#[tokio::test]
 async fn gc_versions_keeps_recent_runner_binary_file() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
@@ -407,10 +584,12 @@ async fn gc_versions_ignores_semver_named_symlink() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
     let bin_dir = home.bin_dir();
+    let runners_dir = home.runners_dir();
     let target_dir = dir.path().join("external-version");
 
     std::fs::create_dir_all(&bin_dir).unwrap();
     std::fs::create_dir_all(&target_dir).unwrap();
+    std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
     std::os::unix::fs::symlink(&target_dir, bin_dir.join("v1.0.0")).unwrap();
 
     let removed = gc_versions(&home, false, None, None).await.unwrap();
@@ -422,6 +601,10 @@ async fn gc_versions_ignores_semver_named_symlink() {
             .file_type()
             .is_symlink(),
         "semver-named symlinks are not version dirs"
+    );
+    assert!(
+        runners_dir.join("v1.0.0").exists(),
+        "a config dir paired with a suspicious binary path must remain untouched"
     );
 }
 
@@ -451,6 +634,25 @@ async fn gc_versions_skips_when_service_lock_is_held() {
         runners_dir.join("v1.0.0").exists(),
         "locked version config dir should survive"
     );
+}
+
+#[tokio::test]
+async fn gc_versions_keeps_config_only_version_when_service_lock_is_held() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let unit = test_version_service_unit_name(version);
+    let lock_file = lock::open_lock_file(&home.service_lock(&unit)).unwrap();
+    let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+    let removed = gc_versions(&home, false, None, None).await.unwrap();
+
+    assert!(removed.is_empty());
+    assert!(version_config.exists());
 }
 
 #[tokio::test]
@@ -518,6 +720,23 @@ async fn gc_versions_protect_keeps_named_version() {
     assert!(!bin_dir.join("v2.0.0").exists());
 }
 
+#[tokio::test]
+async fn gc_versions_protect_keeps_config_only_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+
+    let removed = gc_versions(&home, false, Some(version), None)
+        .await
+        .unwrap();
+
+    assert!(removed.is_empty());
+    assert!(version_config.exists());
+}
+
 /// Two overlapping release pipelines can interleave: v0.88.2's promote
 /// runs `gc --keep-latest 6 --protect-version v0.88.2` after v0.88.3 has
 /// already staged its binary. `--keep-latest` must cover semver dirs so
@@ -565,4 +784,24 @@ async fn gc_versions_keep_latest_numeric_ordering() {
     let removed = gc_versions(&home, false, None, Some(1)).await.unwrap();
     assert_eq!(removed, ["v0.9.0"]);
     assert!(bin_dir.join("v0.10.0").exists());
+}
+
+#[tokio::test]
+async fn gc_versions_config_only_version_does_not_consume_keep_latest_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let binary_version = "v1.0.0";
+    let config_only_version = "v9.0.0";
+    std::fs::create_dir_all(home.bin_dir().join(binary_version)).unwrap();
+    std::fs::create_dir_all(home.runners_dir().join(config_only_version)).unwrap();
+    age_versions_past_gc_min_age(&home, &[binary_version, config_only_version]);
+
+    let removed = gc_versions(&home, false, None, Some(1)).await.unwrap();
+
+    assert_eq!(removed, [config_only_version]);
+    assert!(
+        home.bin_dir().join(binary_version).exists(),
+        "the newest real binary must receive the keep-latest slot"
+    );
+    assert!(!home.runners_dir().join(config_only_version).exists());
 }

--- a/crates/runner/src/cmd/gc/versions/tests.rs
+++ b/crates/runner/src/cmd/gc/versions/tests.rs
@@ -303,6 +303,41 @@ async fn gc_versions_retries_config_only_cleanup_after_removal_failure() {
 }
 
 #[tokio::test]
+async fn gc_versions_rechecks_artifact_type_before_removal() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let version = "v1.0.0";
+    let version_bin = home.bin_dir().join(version);
+    let version_config = home.runners_dir().join(version);
+    std::fs::create_dir_all(&version_bin).unwrap();
+    std::fs::create_dir_all(&version_config).unwrap();
+    age_version_past_gc_min_age(&home, version);
+    let analysis = analyze_version_gc(&home, None, None).await.unwrap();
+
+    std::fs::remove_dir(&version_config).unwrap();
+    std::fs::write(&version_config, "replacement file").unwrap();
+
+    let removed = gc_versions_with_analysis_and_uninstall(
+        &home,
+        false,
+        analysis,
+        successful_fake_uninstall_service_unit,
+    )
+    .await
+    .unwrap();
+
+    assert!(removed.is_empty());
+    assert!(
+        version_bin.exists(),
+        "a replacement path must stop the whole version cleanup"
+    );
+    assert!(
+        version_config.is_file(),
+        "the replacement path must remain untouched"
+    );
+}
+
+#[tokio::test]
 async fn gc_versions_skips_version_when_service_lock_is_held() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());


### PR DESCRIPTION
## Summary

- inventory semver runner versions from both binary and configuration roots while keeping `--keep-latest` scoped to real binary directories
- remove credential-bearing configuration before binaries and only report success or remove the lifecycle lock after both paths are absent
- preserve config-only versions across protection, age, service-lock, active-service, and image-reference checks so partial cleanup is retryable
- treat runner-config inventory failures as non-fatal but incomplete, keeping image GC fail-closed
- add filesystem regression coverage for partial cleanup, suspicious path types, scan failures, rollback retention, image references, and lock liveness

## Compatibility

- no API, runner protocol, queue payload, database schema, or persisted format changes
- binary-root scan failures keep their existing fatal behavior
- config-root scan failures do not add a new runner promotion failure path

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #22846
