### PR TITLE
chore(rust): update base64 and compatible lockfile dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "ably-subscriber"
 version = "1.0.9"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "futures-util",
  "hmac",
  "httpmock",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -598,6 +598,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64-simd"
@@ -1260,7 +1266,7 @@ version = "0.56.0"
 dependencies = [
  "aho-corasick",
  "api-contracts",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "flate2",
@@ -1453,7 +1459,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.4.2",
@@ -1568,7 +1574,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crossbeam-utils",
  "form_urlencoded",
@@ -1670,7 +1676,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2486,7 +2492,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http 1.4.2",
@@ -2577,7 +2583,7 @@ dependencies = [
  "async-trait",
  "aws-sdk-s3",
  "aws-smithy-mocks",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "clap",
@@ -2688,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2794,7 +2800,7 @@ name = "sandbox-fc"
 version = "0.37.149"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "clap",
  "futures-util",
  "guest-contracts",
@@ -3649,7 +3655,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -3667,7 +3673,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.2",
  "httparse",
  "log",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -58,7 +58,7 @@ aho-corasick = "1"
 async-trait = "0.1"
 aws-sdk-s3 = { version = "1", default-features = false }
 aws-smithy-mocks = "0.3"
-base64 = "0.22"
+base64 = "0.23"
 bitvec = "1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false }


### PR DESCRIPTION
## Summary

- Bump the workspace `base64` requirement from `0.22` to `0.23`.
- Refresh `Cargo.lock` to `aws-smithy-runtime` 1.12.1, `aws-smithy-runtime-api` 1.14.0, and `rustls-pki-types` 1.15.1.
- Keep `base64` 0.22.1 in the lockfile only for third-party crates that still require the 0.22 line.

## Manual constraint updates

- `base64`: `0.22` → `0.23`. Reviewed the 0.23 release notes and the workspace call sites; the existing `Engine` and `general_purpose` APIs remain compatible.

## Dependencies not updated

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`. A precise update to 0.14.9 was verified to be unresolvable through the current dependency graph.

## Verification

- `cargo update --verbose` — pass; no further compatible updates on Rust 1.97.1.
- `cargo test --workspace --exclude runner` — pass.
- `cargo test -p runner -- --test-threads=1` — pass: 2,814 passed, 13 ignored, plus the runner integration test.
- Validation used one build job, disabled test debug symbols, a private workspace-backed temporary directory, and `umask 0022` to fit the 3.8 GiB/no-swap runner environment.
