### PR TITLE
fix(zero): restore managed people search requests

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
@@ -400,12 +400,33 @@ describe("zero people-search route", () => {
           name: "PeopleSearchProfiles",
           schema: {
             properties: {
-              profiles: { maxItems: 20 },
+              profiles: {
+                maxItems: 20,
+                items: {
+                  properties: {
+                    sourceIds: {
+                      type: "array",
+                      minItems: 1,
+                      maxItems: 5,
+                      items: { type: "integer", minimum: 1 },
+                    },
+                  },
+                },
+              },
             },
           },
         },
       },
     });
+    expect(requestBody).toHaveProperty(
+      "instructions",
+      expect.stringContaining(
+        "Use only distinct positive integer result IDs from people_search_results in sourceIds.",
+      ),
+    );
+    expect(requestBody).not.toHaveProperty(
+      "response_format.json_schema.schema.properties.profiles.items.properties.sourceIds.uniqueItems",
+    );
     expect(authorization).toBe("Bearer test-people-search-token");
     expect(response.body).toStrictEqual({
       query: "platform engineering leaders at Notion",
@@ -569,6 +590,9 @@ describe("zero people-search route", () => {
       },
       providerResponse({
         profiles: [structuredProfile({ sourceIds: [999] })],
+      }),
+      providerResponse({
+        profiles: [structuredProfile({ sourceIds: [1, 1] })],
       }),
       providerResponse({
         results: [providerResult(), providerResult()],
@@ -737,6 +761,43 @@ describe("zero people-search route", () => {
     const afterCredits = await credits(actor);
     expectApiError(oversized.body);
     expect(oversized.body.error.code).toBe("PEOPLE_SEARCH_OUTPUT_TOO_LARGE");
+    expect(afterCredits).toBe(beforeCredits);
+  });
+
+  it("maps and bounds nested provider errors without billing", async () => {
+    const actor = staffActor();
+    configureProvider();
+    await seedPeopleSearchPricing();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    server.use(
+      http.post(PERPLEXITY_AGENT_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: `\u001b]52;c;clipboard\u0007${"x".repeat(5000)}`,
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const response = await accept(
+      client()(zeroPeopleSearchContract).search({
+        headers: authenticate(actor),
+        body: defaultRequest(),
+      }),
+      [502],
+    );
+    const afterCredits = await credits(actor);
+
+    expectApiError(response.body);
+    expect(response.body.error.code).toBe("PERPLEXITY_ERROR");
+    expect(response.body.error.message).toHaveLength(4096);
+    expect(response.body.error.message.endsWith("...")).toBeTruthy();
+    expect(response.body.error.message).not.toContain("\u001b");
+    expect(response.body.error.message).not.toContain("\u0007");
     expect(afterCredits).toBe(beforeCredits);
   });
 

--- a/turbo/apps/api/src/signals/services/zero-people-search.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-people-search.service.ts
@@ -145,10 +145,11 @@ const PEOPLE_SEARCH_JSON_SCHEMA = {
             ],
           },
           sourceIds: {
+            // Perplexity rejects JSON Schema uniqueItems; vm0 enforces
+            // uniqueness after generation with structuredProfileSchema.
             type: "array",
             minItems: 1,
             maxItems: ZERO_PEOPLE_SEARCH_MAX_SOURCES,
-            uniqueItems: true,
             items: { type: "integer", minimum: 1 },
           },
         },
@@ -289,6 +290,10 @@ function perplexityErrorMessage(body: unknown): string {
         return boundedErrorMessage(value);
       }
     }
+    const providerError = body.error;
+    if (isRecord(providerError) && typeof providerError.message === "string") {
+      return boundedErrorMessage(providerError.message);
+    }
   }
   if (typeof body === "string" && body.trim()) {
     return boundedErrorMessage(body);
@@ -322,7 +327,7 @@ function providerRequestBody(request: ZeroPeopleSearchRequest) {
       `Return at most ${request.limit} profiles.`,
       "Extract concise profile fields from the tool results.",
       "Keep extracted fields limited to public professional information; do not return email addresses, phone numbers, home addresses, or other personal contact details.",
-      "Use only positive integer result IDs from people_search_results in sourceIds.",
+      "Use only distinct positive integer result IDs from people_search_results in sourceIds.",
       "Do not include URLs in the structured output.",
     ].join(" "),
     response_format: {


### PR DESCRIPTION
## Summary

- stop sending Perplexity the unsupported `uniqueItems` JSON Schema keyword
- keep source ID uniqueness enforced locally and instruct the model to return distinct IDs
- surface bounded, sanitized messages from Perplexity's nested error envelope
- cover request compatibility, duplicate rejection, error mapping, and no-billing behavior at the API route

## Scope

- no public API contract, billing behavior, or persisted data changes

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-people-search.test.ts`
- pre-commit full Turbo type check and Knip

Closes #22885
