### PR TITLE
refactor(api): detach legacy storage persistence columns

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -188,9 +188,10 @@ After the latest session continuation heads were backfilled and verified,
 application readers require canonical run, session, and checkpoint persistence.
 Legacy API response shapes are still projected from canonical mounts. The
 physical legacy columns remain temporarily for rollback-safe deployment and are
-removed only after API versions that read them have drained. The short-lived
-runner job queue also retains its legacy claim projection until old Runner
-output is removed.
+not selected or written by application code. Remove them only after the detached
+API release is healthy and every rollback-eligible API version that accesses
+them has drained. The short-lived runner job queue also retains its legacy claim
+projection until old Runner output is removed.
 
 Phase 4A contracts the migration denominator to the latest state used by
 session continuation. Every session continuation head must have canonical

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1933,12 +1933,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }),
     ).resolves.toStrictEqual({
       run_canonical: true,
-      run_legacy: false,
       session_canonical: true,
-      session_legacy: false,
       checkpoint_canonical: true,
-      checkpoint_legacy_artifacts: false,
-      checkpoint_legacy_volumes: false,
     });
 
     const sessionRun = await api.createDirectRun(actor, {

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -133,7 +133,7 @@ async function seedRunForAction(
 
   const [session] = await db
     .insert(agentSessions)
-    .values({ userId, orgId, agentComposeId: compose.id, artifacts: [] })
+    .values({ userId, orgId, agentComposeId: compose.id })
     .returning({ id: agentSessions.id });
   signal.throwIfAborted();
   if (!session) {

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-message-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-message-queue-state.ts
@@ -58,7 +58,6 @@ async function seedActiveRun(
       userId: fixture.userId,
       orgId: fixture.orgId,
       agentComposeId: fixture.composeId,
-      artifacts: [],
     })
     .returning({ id: agentSessions.id });
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -320,7 +320,6 @@ async function readStoragePersistenceState(
   const [[run], [session], [checkpoint]] = await Promise.all([
     db
       .select({
-        additionalVolumes: agentRuns.additionalVolumes,
         storageMounts: agentRuns.storageMounts,
       })
       .from(agentRuns)
@@ -328,7 +327,6 @@ async function readStoragePersistenceState(
       .limit(1),
     db
       .select({
-        artifacts: agentSessions.artifacts,
         storageMounts: agentSessions.storageMounts,
       })
       .from(agentSessions)
@@ -336,8 +334,6 @@ async function readStoragePersistenceState(
       .limit(1),
     db
       .select({
-        artifactSnapshots: checkpoints.artifactSnapshots,
-        volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
         storageMounts: checkpoints.storageMounts,
       })
       .from(checkpoints)
@@ -350,13 +346,8 @@ async function readStoragePersistenceState(
   }
   return {
     run_canonical: run.storageMounts !== null,
-    run_legacy: (run.additionalVolumes?.length ?? 0) > 0,
     session_canonical: session.storageMounts !== null,
-    session_legacy: session.artifacts.length > 0,
     checkpoint_canonical: checkpoint.storageMounts !== null,
-    checkpoint_legacy_artifacts:
-      (checkpoint.artifactSnapshots?.length ?? 0) > 0,
-    checkpoint_legacy_volumes: checkpoint.volumeVersionsSnapshot !== null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4601,7 +4601,6 @@ async function insertLaunchRunRows(
       userId: args.userId,
       orgId: args.orgId,
       agentComposeId: args.resolved.composeId,
-      artifacts: [],
       storageMounts: args.sessionStorageMounts
         ? [...args.sessionStorageMounts]
         : null,
@@ -4622,7 +4621,6 @@ async function insertLaunchRunRows(
     appendSystemPrompt: args.body.appendSystemPrompt ?? null,
     vars: args.body.vars ?? null,
     secretNames: args.body.secrets ? Object.keys(args.body.secrets) : null,
-    additionalVolumes: null,
     storageMounts: args.runStorageMounts ? [...args.runStorageMounts] : null,
     continuedFromSessionId: args.resolved.continuedFromAgentSessionId ?? null,
     sessionId: args.identity.sessionId,

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -83,12 +83,8 @@ export const testRuntimeStateActionResponseSchema = z.object({
   storage_persistence: z
     .object({
       run_canonical: z.boolean(),
-      run_legacy: z.boolean(),
       session_canonical: z.boolean(),
-      session_legacy: z.boolean(),
       checkpoint_canonical: z.boolean(),
-      checkpoint_legacy_artifacts: z.boolean(),
-      checkpoint_legacy_volumes: z.boolean(),
     })
     .optional(),
 });

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -492,8 +492,8 @@ export const webhookCheckpointsContract = c.router({
         cliAgentType: z.string().min(1, "cliAgentType is required"),
         cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
         cliAgentSessionHistoryHash: sha256HexSchema,
-        // Multi-artifact snapshots validated by artifactSnapshotsSchema and
-        // persisted to checkpoints.artifact_snapshots.
+        // Multi-artifact snapshots are folded into canonical checkpoint mounts
+        // and projected back into the legacy response shape.
         artifactSnapshots: artifactSnapshotsSchema.optional(),
         volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
       })

--- a/turbo/packages/db/src/schema/agent-run-session-conversation.ts
+++ b/turbo/packages/db/src/schema/agent-run-session-conversation.ts
@@ -54,7 +54,8 @@ export const agentRuns = pgTable(
     vars: jsonb("vars").$type<AgentRunVars>(),
     // Secret names for validation (values never stored - must be provided at runtime)
     secretNames: jsonb("secret_names").$type<AgentRunSecretNames>(),
-    // Historical additional-volume projection retained for legacy row reads.
+    // Physical rollback column retained until pre-detach API versions drain.
+    // Application code must not select or write it.
     additionalVolumes:
       jsonb("additional_volumes").$type<AgentRunAdditionalVolumes>(),
     // Canonical resolved mounts used by new run writers.
@@ -134,12 +135,13 @@ export const agentSessions = pgTable(
         onDelete: "set null",
       },
     ),
+    // Physical rollback column retained until pre-detach API versions drain.
+    // Application code must not select or write it.
     artifacts: jsonb("artifacts")
       .$type<AgentSessionArtifacts>()
       .notNull()
       .default([]),
-    // Canonical writeback mounts used by session continuation. artifacts
-    // contains only historical rollback data; new writers leave it empty.
+    // Canonical writeback mounts used by session continuation.
     storageMounts: jsonb("storage_mounts").$type<AgentSessionStorageMounts>(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/turbo/packages/db/src/schema/checkpoint.ts
+++ b/turbo/packages/db/src/schema/checkpoint.ts
@@ -34,13 +34,14 @@ export const checkpoints = pgTable("checkpoints", {
   agentComposeSnapshot: jsonb("agent_compose_snapshot")
     .$type<CheckpointAgentComposeSnapshot>()
     .notNull(),
+  // Physical rollback columns retained until pre-detach API versions drain.
+  // Application code must not select or write them.
   artifactSnapshots:
     jsonb("artifact_snapshots").$type<CheckpointArtifactSnapshots>(),
   volumeVersionsSnapshot: jsonb(
     "volume_versions_snapshot",
   ).$type<CheckpointVolumeVersionsSnapshot>(),
-  // Canonical exact mount snapshot. Legacy artifact/volume snapshots contain
-  // only historical rollback data; new writers leave them null.
+  // Canonical exact mount snapshot.
   storageMounts: jsonb("storage_mounts").$type<CheckpointStorageMounts>(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- stop API launch writes to `agent_sessions.artifacts` and `agent_runs.additional_volumes`
- remove the test-only reads of all four legacy Storage persistence columns while retaining canonical run, session, and checkpoint assertions
- document the physical columns as rollback-only schema and define the post-drain removal condition

## Compatibility

- keep all four physical legacy columns in the database and Drizzle schema for rollback-safe deployment
- retain public `additionalVolumes`, checkpoint webhook inputs, legacy response projections, and the Runner dual-manifest protocol
- add no database migration in this release

## Verification

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F api lint`
- `NODE_OPTIONS='--max-old-space-size=3072' pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'persists canonical mounts across session continuation' --maxWorkers=1 --silent=passed-only`
- pre-commit hook: Prettier, Knip, and full Turbo type-check passed
- caller audit: no API references to the four legacy columns, implicit full-row selects, or implicit full-row returning clauses
