### PR TITLE
test(core): cover feishu staff rollout

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -123,6 +123,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.FeishuIntegration]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
@@ -156,6 +157,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.FeishuIntegration]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );


### PR DESCRIPTION
## Summary

- lock the Feishu integration rollout on for staff organizations
- verify the integration remains off by default for non-staff organizations
- preserve the existing staff-only runtime configuration introduced with the Feishu integration

## Verification

- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm exec prettier --check packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm knip --workspace @vm0/core`
- pre-commit repository type checks
