### PR TITLE
fix(artifacts): suppress toast for cancelled refresh

### DIFF
--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -42,13 +42,21 @@ function requestErrorMessage(error: unknown): string {
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
  * Otherwise shows a toast and throws an `ApiError`.
+ *
+ * When `signal` is provided, a rejection after that signal aborts propagates
+ * as cancellation without showing a toast.
  */
 async function accept<
   T extends { status: number; body: unknown },
   S extends number,
->(promise: Promise<T>, codes: S[]): Promise<Extract<T, { status: S }>> {
+>(
+  promise: Promise<T>,
+  codes: S[],
+  signal?: AbortSignal,
+): Promise<Extract<T, { status: S }>> {
   const result = await onRejection(promise, (error) => {
     if (!isAbortError(error)) {
+      signal?.throwIfAborted();
       toast.error(requestErrorMessage(error));
     }
   });

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -343,6 +343,7 @@ const internalArtifactsSync$ = computed(
             fetchOptions: { signal },
           }),
           [200],
+          signal,
         );
         signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -7,7 +7,6 @@ import {
 import { zeroAgentDraftContract } from "@vm0/api-contracts/contracts/zero-agents";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { toast } from "@vm0/ui/components/ui/sonner";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
@@ -18,8 +17,6 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
-import { detachedNavigateTo$ } from "../../../signals/route.ts";
-import { ROUTES } from "../../../signals/route-paths.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { openChatIdb } from "../../../signals/external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../../../signals/external/idb-artifact-item-store.ts";
@@ -1920,28 +1917,22 @@ describe("artifacts page", () => {
       );
       return response.promise;
     });
-    const toastError = vi.spyOn(toast, "error");
 
-    try {
-      setupArtifactsPage({ scope });
+    setupArtifactsPage({ scope });
 
-      await requestStarted.promise;
-      await expect(
-        screen.findByText("cached-before-cancel.html"),
-      ).resolves.toBeInTheDocument();
+    await requestStarted.promise;
+    await expect(
+      screen.findByText("cached-before-cancel.html"),
+    ).resolves.toBeInTheDocument();
 
-      context.store.set(detachedNavigateTo$, ROUTES.agents);
-      await requestRejected.promise;
-      await waitFor(() => {
-        expect(pathname()).toBe(ROUTES.agents);
-      });
-      await screen.findByText("Research Agent");
+    click(linkByText("Agents"));
+    await requestRejected.promise;
+    await waitFor(() => {
+      expect(pathname()).toBe("/agents");
+    });
+    await screen.findByRole("heading", { name: "Agents" });
 
-      expect(toastError).not.toHaveBeenCalled();
-      expect(screen.queryByText("Request failed")).not.toBeInTheDocument();
-    } finally {
-      toastError.mockRestore();
-    }
+    expect(screen.queryByText("Request failed")).not.toBeInTheDocument();
   });
 
   it("loads every artifact by following keyset pagination cursors", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -7,6 +7,8 @@ import {
 import { zeroAgentDraftContract } from "@vm0/api-contracts/contracts/zero-agents";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -16,6 +18,8 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { openChatIdb } from "../../../signals/external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../../../signals/external/idb-artifact-item-store.ts";
@@ -1853,7 +1857,91 @@ describe("artifacts page", () => {
     await expect(
       screen.findByText("cached-after-error.html"),
     ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText("Could not load artifacts"),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("falls back to cached artifacts and toasts when refresh is unavailable", async () => {
+    setupTeam();
+    const scope = testAuthScope("remote-network-error");
+    await seedCachedArtifacts(
+      scope,
+      [
+        createArtifact({
+          artifactItemId: "cached-network-error-run:file-1",
+          runId: "cached-network-error-run",
+          filename: "cached-after-network-error.html",
+        }),
+      ],
+      "2026-01-02T00:00:00.000Z",
+    );
+    context.mocks.http.get("*/api/zero/artifacts", () => {
+      return HttpResponse.error();
+    });
+
+    setupArtifactsPage({ scope });
+
+    await expect(
+      screen.findByText("cached-after-network-error.html"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText("Failed to fetch"),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("does not toast when an in-flight refresh is cancelled", async () => {
+    setupTeam();
+    const scope = testAuthScope("cancelled-refresh");
+    await seedCachedArtifacts(
+      scope,
+      [
+        createArtifact({
+          artifactItemId: "cancelled-refresh-run:file-1",
+          runId: "cancelled-refresh-run",
+          filename: "cached-before-cancel.html",
+        }),
+      ],
+      "2026-01-02T00:00:00.000Z",
+    );
+    const requestStarted = Promise.withResolvers<void>();
+    const requestRejected = Promise.withResolvers<void>();
+    context.mocks.http.get("*/api/zero/artifacts", ({ signal }) => {
+      const response = Promise.withResolvers<Response>();
+      requestStarted.resolve();
+      signal.addEventListener(
+        "abort",
+        () => {
+          requestRejected.resolve();
+          response.reject(new Error("Request failed"));
+        },
+        { once: true },
+      );
+      return response.promise;
+    });
+    const toastError = vi.spyOn(toast, "error");
+
+    try {
+      setupArtifactsPage({ scope });
+
+      await requestStarted.promise;
+      await expect(
+        screen.findByText("cached-before-cancel.html"),
+      ).resolves.toBeInTheDocument();
+
+      context.store.set(detachedNavigateTo$, ROUTES.agents);
+      await requestRejected.promise;
+      await waitFor(() => {
+        expect(pathname()).toBe(ROUTES.agents);
+      });
+      await screen.findByText("Research Agent");
+
+      expect(toastError).not.toHaveBeenCalled();
+      expect(screen.queryByText("Request failed")).not.toBeInTheDocument();
+    } finally {
+      toastError.mockRestore();
+    }
   });
 
   it("loads every artifact by following keyset pagination cursors", async () => {


### PR DESCRIPTION
## Summary

- treat an Artifacts refresh rejection as cancellation when its request signal has already aborted
- keep HTTP and active network failures visible through the existing error toast
- add regression coverage for cancelled, HTTP-error, and transport-error refreshes while preserving cached artifacts

## User impact

Navigating away from Artifacts while its incremental refresh is in flight no longer shows a spurious "Request failed" toast. Genuine refresh failures remain visible.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx --maxWorkers=1` (31 passed)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm exec prettier --check apps/platform/src/lib/accept.ts apps/platform/src/signals/artifacts-page/artifacts-signals.ts apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx`

## Browser verification

- Not run: local platform startup requires `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW`, which is unavailable in this environment.
