### PR TITLE
fix(e2e): stabilize tcp network log terminal boundary

### DIFF
--- a/e2e/tests/03-runner/t45-vm0-network-logging.bats
+++ b/e2e/tests/03-runner/t45-vm0-network-logging.bats
@@ -47,8 +47,35 @@ EOF
     # 1. github.com:22 — SSH on standard port, non-HTTP protocol
     # 2. ssh.github.com:443 — SSH on port 443 (previously intercepted as HTTPS)
     # Both must pass through mitmproxy as raw TCP without corruption.
+    #
+    # After reading each banner, half-close the client write side and wait for
+    # the SSH server to close its direction. Mitmproxy emits the TCP log row
+    # from its terminal hook, so the peer EOF is the protocol-level boundary
+    # that makes the persisted-log assertion deterministic.
+    local tcp_probe='import socket
+
+def probe(label, host, port):
+    with socket.create_connection((host, port), timeout=5) as connection:
+        connection.settimeout(5)
+        banner = bytearray()
+        while b"\n" not in banner:
+            chunk = connection.recv(4096)
+            if not chunk:
+                raise RuntimeError(f"{host}:{port} closed before the SSH banner")
+            banner.extend(chunk)
+        first_line = bytes(banner).splitlines()[0].decode("utf-8", errors="replace")
+        print(f"{label}={first_line}", flush=True)
+        connection.shutdown(socket.SHUT_WR)
+        try:
+            while connection.recv(4096):
+                pass
+        except ConnectionResetError:
+            pass
+
+probe("PORT22", "github.com", 22)
+probe("PORT443", "ssh.github.com", 443)'
     run run_compose_fixture "$AGENT_NAME" \
-        "echo PORT22=\$(timeout 5 bash -c 'head -1 < /dev/tcp/github.com/22') && echo PORT443=\$(timeout 5 bash -c 'head -1 < /dev/tcp/ssh.github.com/443')" \
+        "python3 -c '$tcp_probe'" \
         "$(jq -nc --arg name "$ARTIFACT_NAME" \
             '{artifacts: [{name: $name, mountPath: "/home/user/workspace"}]}')"
     assert_success


### PR DESCRIPTION
## Summary

- make the raw SSH probes wait for the peer EOF that terminates each mitmproxy TCP flow
- preserve both SSH banner assertions and both persisted `:22` / `:443` network-log assertions
- replace timing-dependent client close behavior with an explicit protocol boundary, without sleeps, retries, or a longer timeout

## Triggering failure

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30080660930 (attempt 1)
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/30080660930/job/89442604929
- Event: `merge_group`
- Failing SHA: `97674f1ba761009f3b82512993e945f4f9968b05`
- Queued PR: #22890
- First substantive failure: `t45-0: non-http tcp passes through mitmproxy`

The test reached its persisted-log assertion after both SSH banner assertions passed. The uploaded network log contained `TCP 140.82.116.35:443` but no `:22` TCP row, so the 30-second log poll could never satisfy `TCP :22 :443`. The aggregate `ci-gate-turbo` failure was downstream only.

## Root cause

Classification: missing test synchronization at the TCP protocol terminal boundary.

The previous probe exited `head` immediately after reading each server-first SSH banner. Mitmproxy creates a TCP network-log row only from `tcp_end` or `tcp_error`; an SSH peer may keep its direction readable after the client closes. The runner's one-shot upload drains rows already admitted to the JSONL writer, so whether that terminal hook ran before upload depended on remote half-close timing.

That explains the intermittent outcome: attempt 1 omitted `:22`, while attempt 2 on the same SHA passed `t45-0` in 9.607 seconds. The queued PR did not modify the E2E test or runner network-log path. This is the same lifecycle signature recorded in #21047, including earlier occurrences where the opposite `:443` row was omitted.

## Fix

The test probe now:

1. reads and prints each SSH banner;
2. half-closes its write side;
3. drains the peer direction to EOF before starting the next connection or completing the run.

Waiting for EOF is the observable protocol completion signal that lets mitmproxy emit the existing terminal TCP row. The production contract and assertions are unchanged.

## Verification

- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t45-vm0-network-logging.bats` (`5`)
- exact SSH EOF probe repeated five times; both `github.com:22` and `ssh.github.com:443` returned `SSH-2.0` on every run
- exact nested `bash -c "python3 -c ..."` command completed with both banner outputs
- `git diff --check`

The full `t45-0` path requires the deployed API preview, CI-only E2E credentials, transparent proxy, and official runner, so it was not runnable locally. The PR Turbo pipeline remains the end-to-end validation boundary.
