### PR TITLE
fix(chat): preserve connector copy and support reconnect actions

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -10,6 +10,7 @@ import {
   allConnectorCatalogItems$,
   connectConnectorNoAuth$,
   connectConnectorOAuthAuthCode$,
+  connectorCurrentConnectionStatus,
   getConnectorStatusConnectLaunchMode,
   getOnlyAvailableStatusBrowserAuthMethodDetail,
   getOnlyAvailableStatusNoAuthMethod,
@@ -157,56 +158,31 @@ function getDirectConnectMethod(connector: PublicConnectorCatalogStatusItem) {
   return null;
 }
 
-export function createConnectorSignals(
+type ConnectorActivationSignals = Pick<
+  ConnectorSignals,
+  "available$" | "catalogItem$" | "connected$"
+>;
+
+function createConnectorActivation(
   descriptor: ConnectorActionDescriptor,
-): ConnectorSignals {
-  const catalogItem$ = computed(async (get) => {
-    const statusByRef = await get(connectorCatalogStatusByRef$);
-    return statusByRef.get(descriptor.connectorRef) ?? null;
-  });
-
-  const available$ = computed(async (get): Promise<boolean> => {
-    const catalogItem = await get(catalogItem$);
-    return catalogItem !== null;
-  });
-
-  const connected$ = computed(async (get): Promise<boolean> => {
-    const statusByRef = await get(connectorCatalogStatusByRef$);
-    return statusByRef.get(descriptor.connectorRef)?.connected ?? false;
-  });
-
-  const authorized$ = computed(async (get): Promise<boolean> => {
-    return await get(
-      isAgentConnectorAuthorized({
-        agentId: descriptor.agentId,
-        connectorRef: descriptor.connectorRef,
-      }),
-    );
-  });
-
-  const complete$ = computed(async (get): Promise<boolean> => {
-    const available = await get(available$);
-    if (!available) {
-      return false;
-    }
-
-    const [connected, authorized] = await Promise.all([
-      get(connected$),
-      get(authorized$),
-    ]);
-    return connected && authorized;
-  });
-
-  const activate$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const available = await get(available$);
+  signals: ConnectorActivationSignals,
+): ConnectorSignals["activate$"] {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    const available = await get(signals.available$);
     signal.throwIfAborted();
     if (!available) {
       return;
     }
 
-    const connected = await get(connected$);
+    const [connected, catalogItem] = await Promise.all([
+      get(signals.connected$),
+      get(signals.catalogItem$),
+    ]);
     signal.throwIfAborted();
-    if (connected) {
+    const reconnectRequired =
+      catalogItem !== null &&
+      connectorCurrentConnectionStatus(catalogItem) === "reconnect-required";
+    if (connected && !reconnectRequired) {
       await set(
         authorizeDirectedConnector$,
         descriptor.connectorRef,
@@ -281,6 +257,59 @@ export function createConnectorSignals(
         signal,
       );
     }
+  });
+}
+
+export function createConnectorSignals(
+  descriptor: ConnectorActionDescriptor,
+): ConnectorSignals {
+  const catalogItem$ = computed(async (get) => {
+    const statusByRef = await get(connectorCatalogStatusByRef$);
+    return statusByRef.get(descriptor.connectorRef) ?? null;
+  });
+
+  const available$ = computed(async (get): Promise<boolean> => {
+    const catalogItem = await get(catalogItem$);
+    return catalogItem !== null;
+  });
+
+  const connected$ = computed(async (get): Promise<boolean> => {
+    const statusByRef = await get(connectorCatalogStatusByRef$);
+    return statusByRef.get(descriptor.connectorRef)?.connected ?? false;
+  });
+
+  const authorized$ = computed(async (get): Promise<boolean> => {
+    return await get(
+      isAgentConnectorAuthorized({
+        agentId: descriptor.agentId,
+        connectorRef: descriptor.connectorRef,
+      }),
+    );
+  });
+
+  const complete$ = computed(async (get): Promise<boolean> => {
+    const available = await get(available$);
+    if (!available) {
+      return false;
+    }
+
+    const [connected, authorized, catalogItem] = await Promise.all([
+      get(connected$),
+      get(authorized$),
+      get(catalogItem$),
+    ]);
+    return (
+      connected &&
+      authorized &&
+      catalogItem !== null &&
+      connectorCurrentConnectionStatus(catalogItem) !== "reconnect-required"
+    );
+  });
+
+  const activate$ = createConnectorActivation(descriptor, {
+    available$,
+    catalogItem$,
+    connected$,
   });
 
   return {

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -811,6 +811,29 @@ function createActionBlockFromLine(line: string): Extract<
   return null;
 }
 
+function retainedConnectorActionMarkdown(
+  line: string,
+  action: ConnectorActionDescriptor,
+): string | null {
+  const candidate = stripMarkdownLineDecorations(line);
+  const standaloneMarkdownLink = candidate.match(
+    new RegExp(String.raw`^\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)$`),
+  );
+  const standaloneBareUrl = candidate.match(
+    new RegExp(`^(${URL_TOKEN_PATTERN})$`),
+  );
+  if (standaloneMarkdownLink || standaloneBareUrl) {
+    return null;
+  }
+
+  return line.replace(
+    new RegExp(String.raw`\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)`),
+    (match: string, label: string, url: string) => {
+      return trimPreviewUrl(url) === action.originalUrl ? label : match;
+    },
+  );
+}
+
 function splitMarkdownTableRow(line: string): string[] | null {
   const trimmed = line.trim();
   if (!trimmed.includes("|")) {
@@ -970,6 +993,15 @@ export function parseBodyBlocks(
 
     const actionBlock = createActionBlockFromLine(line);
     if (actionBlock) {
+      if (actionBlock.type === "connector-action") {
+        const retainedMarkdown = retainedConnectorActionMarkdown(
+          line,
+          actionBlock.descriptor,
+        );
+        if (retainedMarkdown) {
+          pushMarkdownLines([retainedMarkdown]);
+        }
+      }
       flushMarkdownBuffer();
       blocks.push(actionBlock);
       continue;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -974,6 +974,134 @@ describe("chat message action cards", () => {
     expect(secondDraftRequests).toBe(3);
   });
 
+  it("preserves assistant copy and reconnects an expired connector", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = `${THREAD_ID}-reconnect`;
+    const callbackPrompt = "Retry the Gmail draft after reconnecting";
+    const connectorUrl = `${window.location.origin}/connectors/gmail/connect?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
+    const assistantCopy = `Gmail needs to be reconnected. [Reconnect Gmail](${connectorUrl}) to continue creating the draft.`;
+    const displayedCopy =
+      "Gmail needs to be reconnected. Reconnect Gmail to continue creating the draft.";
+    const sentPrompts: string[] = [];
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    let reconnectRequired = true;
+
+    context.mocks.data.connectors([
+      connectedConnector({
+        type: "gmail",
+        authMethod: "oauth",
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      }),
+    ]);
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            connectorRef: "gmail",
+            label: "Gmail",
+            connected: true,
+            connectionStatus: reconnectRequired
+              ? "reconnect-required"
+              : "connected",
+            connection: {
+              authMethod: "oauth",
+              externalUsername: null,
+              externalEmail: "sender@example.com",
+              reconnectReason: reconnectRequired
+                ? "authorization_expired_or_revoked"
+                : null,
+            },
+            authMethods: [
+              {
+                id: "oauth",
+                label: "OAuth",
+                description: null,
+                grantKind: "auth-code",
+                manualFields: [],
+                startOptions: [],
+              },
+            ],
+            singleAuthCodeAuthMethodId: "oauth",
+          }),
+        ],
+      });
+    });
+    mockAgentConnectorAuthorizations(["gmail"]);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("gmail");
+        expect(body).toStrictEqual({
+          authMethod: "oauth",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+          callbackTarget: "app",
+        });
+        reconnectRequired = false;
+        context.mocks.data.connectors([
+          connectedConnector({
+            type: "gmail",
+            authMethod: "oauth",
+            externalEmail: "sender@example.com",
+            updatedAt: "2026-01-01T00:00:01Z",
+          }),
+        ]);
+        return respond(200, {
+          authorizationUrl: "https://accounts.google.test/oauth",
+        });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Reconnect connector",
+      chatMessages: [
+        {
+          id: "msg-user-reconnect",
+          role: "user",
+          content: "Create the Gmail draft",
+          runId: "run-reconnect",
+          createdAt: "2026-07-24T09:05:10Z",
+        },
+        {
+          id: "msg-assistant-reconnect",
+          role: "assistant",
+          content: assistantCopy,
+          runId: "run-reconnect",
+          createdAt: "2026-07-24T09:06:19Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        sentPrompts.push(prompt);
+      },
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const displayedCopyElement = await screen.findByText(displayedCopy);
+    expect(displayedCopyElement).toBeInTheDocument();
+    const connectorCard = await screen.findByTestId("connector-action-card");
+    const reconnectButton = await waitForButtonByText(
+      "Reconnect",
+      connectorCard,
+    );
+    await user.click(reconnectButton);
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://accounts.google.test/oauth",
+      );
+      expect(sentPrompts).toStrictEqual([callbackPrompt]);
+      expect(within(connectorCard).getByText("Authorized")).toBeInTheDocument();
+      expect(buttonByText("Authorized", connectorCard)).toBeDisabled();
+    });
+  });
+
   it("connects a single OAuth connector directly and resumes the chat", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = `${THREAD_ID}-direct-oauth`;
@@ -1088,7 +1216,7 @@ describe("chat message action cards", () => {
     ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(sentPrompts).toStrictEqual([callbackPrompt]);
-      expect(within(connectorCard).getByText("Authorize")).toBeInTheDocument();
+      expect(within(connectorCard).getByText("Authorized")).toBeInTheDocument();
     });
   });
 
@@ -1172,7 +1300,7 @@ describe("chat message action cards", () => {
 
     await waitFor(() => {
       expect(connectCalls).toBe(1);
-      expect(within(connectorCard).getByText("Authorize")).toBeInTheDocument();
+      expect(within(connectorCard).getByText("Authorized")).toBeInTheDocument();
     });
     expect(
       screen.queryByRole("dialog", { name: "Public Stripe" }),
@@ -1637,11 +1765,11 @@ describe("chat message action cards", () => {
       "src",
       "https://icons.example.test/action-github.svg",
     );
-    await user.click(within(connectorCard).getByText("Connect"));
+    await user.click(within(connectorCard).getByText("Authorize"));
 
     await waitFor(() => {
       for (const card of connectorCards) {
-        expect(within(card).getByText("Authorize")).toBeInTheDocument();
+        expect(within(card).getByText("Authorized")).toBeInTheDocument();
       }
     });
 
@@ -1976,11 +2104,11 @@ describe("chat message action cards", () => {
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
-    await user.click(await waitForButtonByText("Connect", connectorCard));
+    await user.click(await waitForButtonByText("Authorize", connectorCard));
 
     await waitFor(() => {
       expect(sentPrompts).toStrictEqual([callbackPrompt]);
-      expect(within(connectorCard).getByText("Authorize")).toBeInTheDocument();
+      expect(within(connectorCard).getByText("Authorized")).toBeInTheDocument();
     });
   });
 
@@ -2150,7 +2278,7 @@ describe("chat message action cards", () => {
     await user.click(saveButton);
 
     await waitFor(() => {
-      expect(within(connectorCard).getByText("Authorize")).toBeInTheDocument();
+      expect(within(connectorCard).getByText("Authorized")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -148,6 +148,7 @@ import {
   type ConnectorSignals,
   type CustomConnectorSignals,
 } from "../../signals/chat-page/connector-action-block.ts";
+import { connectorCurrentConnectionStatus } from "../../signals/zero-page/settings/connectors.ts";
 import {
   completedWorkExpandedKeys$,
   toggleCompletedWorkExpanded$,
@@ -4825,6 +4826,7 @@ function BodyRenderBlockView({
 function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
   const pageSignal = useGet(pageSignal$);
   const available = useLastResolved(signals.available$) ?? false;
+  const connected = useLastResolved(signals.connected$) ?? false;
   const completeLoadable = useLoadable(signals.complete$);
   const complete =
     completeLoadable.state === "hasData" && completeLoadable.data;
@@ -4836,6 +4838,15 @@ function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
   if (!available || !catalogItem) {
     return null;
   }
+  const reconnectRequired =
+    connectorCurrentConnectionStatus(catalogItem) === "reconnect-required";
+  const actionLabel = complete
+    ? "Authorized"
+    : reconnectRequired
+      ? "Reconnect"
+      : connected
+        ? "Authorize"
+        : "Connect";
 
   return (
     <div
@@ -4864,7 +4875,7 @@ function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
         className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
       >
         {loading && <IconLoader2 size={15} className="animate-spin" />}
-        {complete ? "Authorize" : "Connect"}
+        {actionLabel}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

- preserve assistant reply text when a connector action URL is embedded in the same Markdown line
- distinguish connected, agent-authorized, and reconnect-required connector states in chat action cards
- route expired connector actions back through the OAuth connection flow and resume the callback prompt afterward
- add a page-level regression test covering the expired Gmail reconnect scenario

## User-visible impact

Expired connector replies now keep their explanatory copy, show an enabled **Reconnect** action, and transition to **Authorized** after reconnection instead of rendering a disabled **Authorize** button.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip --workspace @vm0/app --no-progress`
- `pnpm -F @vm0/app lint` after rebasing onto latest `main`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types` after rebasing
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --maxWorkers=1 --silent=passed-only` (34 tests)
