### PR TITLE
fix(feishu): shorten file ids in run prompts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -21,6 +21,7 @@ import { now } from "../../external/time";
 import { zeroFeishuBrowserConnectRoutes } from "../zero-feishu-browser-connect";
 import { zeroFeishuEventsRoutes } from "../zero-feishu-events";
 import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
+import { zeroIntegrationsFeishuFileRoutes } from "../zero-integrations-feishu-files";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
@@ -1393,29 +1394,101 @@ describe("Feishu integration", () => {
     const fixture = await setupFeishuRunFixture();
     const { actor, runnerGroup, appId, callbackUrl } = fixture;
     await connectFixtureUser(fixture);
-    const prompt = [
-      "[Feishu file] quarterly-report.pdf",
-      "   [MESSAGE_ID] om_file_message",
-      "   [FILE_KEY] file_quarterly_report",
-      "   [TYPE] file",
-    ].join("\n");
+    const fileKey = `file_v2_${"a".repeat(1400)}`;
     await postEvent(
       callbackUrl,
       directFileMessage(appId, {
         messageId: "om_file_message",
-        fileKey: "file_quarterly_report",
+        fileKey,
         filename: "quarterly-report.pdf",
       }),
       { encrypted: true },
     );
     await flushWaitUntilForTest();
 
-    const run = await findRun(actor, prompt);
+    const listed = await runsApi.listAgentRuns(actor, { limit: 20 });
+    const run = requireValue(
+      listed.runs.find((candidate) => {
+        return candidate.prompt.includes("[Feishu file] quarterly-report.pdf");
+      }),
+      "Expected Feishu file run",
+    );
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
-    expect(claim.prompt).toBe(prompt);
+    const fileId = claim.prompt.match(/ {3}\[FILE_KEY\] ([^\n]+)/u)?.[1];
+    expect(fileId).toMatch(/^feishu_file_[A-Za-z0-9_-]{22}$/u);
+    expect(fileId?.length).toBeLessThan(64);
+    expect(claim.prompt).not.toContain(fileKey);
+    expect(claim.prompt).toContain("   [MESSAGE_ID] om_file_message");
+    expect(claim.prompt).toContain("   [TYPE] file");
     expect(claim.appendSystemPrompt).toContain("zero feishu download-file -h");
     expect(claim.appendSystemPrompt).toContain("zero feishu upload-file -h");
+
+    const fileBytes = Buffer.from("feishu file bytes");
+    server.use(
+      http.get(
+        "https://open.feishu.cn/open-apis/im/v1/messages/:messageId/resources/:fileKey",
+        ({ params, request }) => {
+          expect(params.messageId).toBe("om_file_message");
+          expect(params.fileKey).toBe(fileKey);
+          expect(new URL(request.url).searchParams.get("type")).toBe("file");
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "application/pdf",
+              "content-length": String(fileBytes.length),
+              "content-disposition":
+                'attachment; filename="quarterly-report.pdf"',
+            },
+          });
+        },
+      ),
+    );
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: zeroIntegrationsFeishuFileRoutes,
+    });
+    const downloadResponse = await app.request(
+      `/api/zero/integrations/feishu/download-file?${new URLSearchParams({
+        message_id: "om_misquoted_by_model",
+        file_key: fileId ?? "",
+        type: "image",
+      }).toString()}`,
+      {
+        headers: {
+          authorization: `Bearer ${runsApi.zeroTokenForRunWithCapabilities(
+            actor,
+            run.id,
+            ["feishu:write"],
+          )}`,
+        },
+      },
+    );
+    expect(downloadResponse.status).toBe(200);
+    expect(downloadResponse.headers.get("x-file-name")).toBe(
+      "quarterly-report.pdf",
+    );
+    expect(
+      Buffer.from(await downloadResponse.arrayBuffer()).equals(fileBytes),
+    ).toBeTruthy();
+
+    const wrongRunResponse = await app.request(
+      `/api/zero/integrations/feishu/download-file?${new URLSearchParams({
+        message_id: "om_file_message",
+        file_key: fileId ?? "",
+        type: "file",
+      }).toString()}`,
+      {
+        headers: {
+          authorization: `Bearer ${runsApi.zeroTokenForRunWithCapabilities(
+            actor,
+            randomUUID(),
+            ["feishu:write"],
+          )}`,
+        },
+      },
+    );
+    expect(wrongRunResponse.status).toBe(400);
   });
 
   it("runs a Feishu DM with history, audit metadata, and session resume", async () => {
@@ -1450,6 +1523,7 @@ describe("Feishu integration", () => {
     }
     outboundMessages = [];
     context.mocks.ably.publish.mockClear();
+    const historyFileKey = `file_v2_${"b".repeat(200)}`;
     historyMessages = [
       {
         message_id: "om_history_context",
@@ -1463,6 +1537,22 @@ describe("Feishu integration", () => {
         body: {
           content: JSON.stringify({
             text: "Earlier Feishu conversation context",
+          }),
+        },
+      },
+      {
+        message_id: "om_history_file",
+        msg_type: "file",
+        create_time: "2",
+        sender: {
+          id: "ou_previous_user",
+          sender_name: "Previous User",
+          sender_type: "user",
+        },
+        body: {
+          content: JSON.stringify({
+            file_key: historyFileKey,
+            file_name: "history-report.pdf",
           }),
         },
       },
@@ -1490,6 +1580,13 @@ describe("Feishu integration", () => {
     expect(claim.appendSystemPrompt).toContain(
       "Earlier Feishu conversation context",
     );
+    expect(claim.appendSystemPrompt).toContain(
+      "[Feishu file] history-report.pdf",
+    );
+    expect(claim.appendSystemPrompt).toMatch(
+      / {3}\[FILE_KEY\] feishu_file_[A-Za-z0-9_-]{22}/u,
+    );
+    expect(claim.appendSystemPrompt).not.toContain(historyFileKey);
     expect(claim.appendSystemPrompt).toContain("Previous User");
     expect(claim.appendSystemPrompt).toContain(
       "zero feishu message send --help",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1583,9 +1583,10 @@ describe("Feishu integration", () => {
     expect(claim.appendSystemPrompt).toContain(
       "[Feishu file] history-report.pdf",
     );
-    expect(claim.appendSystemPrompt).toMatch(
-      / {3}\[FILE_KEY\] feishu_file_[A-Za-z0-9_-]{22}/u,
-    );
+    const historyFileId = (claim.appendSystemPrompt ?? "").match(
+      / {3}\[FILE_KEY\] (feishu_file_[A-Za-z0-9_-]{22})/u,
+    )?.[1];
+    expect(historyFileId).toBeTruthy();
     expect(claim.appendSystemPrompt).not.toContain(historyFileKey);
     expect(claim.appendSystemPrompt).toContain("Previous User");
     expect(claim.appendSystemPrompt).toContain(
@@ -1593,6 +1594,56 @@ describe("Feishu integration", () => {
     );
     expect(claim.appendSystemPrompt).toContain("zero feishu download-file -h");
     expect(claim.appendSystemPrompt).toContain("zero feishu upload-file -h");
+
+    const historyFileBytes = Buffer.from("feishu history file bytes");
+    server.use(
+      http.get(
+        "https://open.feishu.cn/open-apis/im/v1/messages/:messageId/resources/:fileKey",
+        ({ params, request }) => {
+          expect(params.messageId).toBe("om_history_file");
+          expect(params.fileKey).toBe(historyFileKey);
+          expect(new URL(request.url).searchParams.get("type")).toBe("file");
+          return new HttpResponse(historyFileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "application/pdf",
+              "content-length": String(historyFileBytes.length),
+              "content-disposition":
+                'attachment; filename="history-report.pdf"',
+            },
+          });
+        },
+      ),
+    );
+    const fileApp = createAppWithRoutes({
+      signal: context.signal,
+      routes: zeroIntegrationsFeishuFileRoutes,
+    });
+    const historyDownloadResponse = await fileApp.request(
+      `/api/zero/integrations/feishu/download-file?${new URLSearchParams({
+        message_id: "om_misquoted_by_model",
+        file_key: historyFileId ?? "",
+        type: "image",
+      }).toString()}`,
+      {
+        headers: {
+          authorization: `Bearer ${runsApi.zeroTokenForRunWithCapabilities(
+            actor,
+            run.id,
+            ["feishu:write"],
+          )}`,
+        },
+      },
+    );
+    expect(historyDownloadResponse.status).toBe(200);
+    expect(historyDownloadResponse.headers.get("x-file-name")).toBe(
+      "history-report.pdf",
+    );
+    expect(
+      Buffer.from(await historyDownloadResponse.arrayBuffer()).equals(
+        historyFileBytes,
+      ),
+    ).toBeTruthy();
 
     const cliAgentSessionId = `bdd-feishu-cli-${run.id}`;
     await completeRunSession({

--- a/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-feishu-files.ts
@@ -5,8 +5,10 @@ import {
   integrationsFeishuDownloadFileContract,
   integrationsFeishuUploadCompleteContract,
   integrationsFeishuUploadInitContract,
+  type FeishuResourceType,
   type FeishuUploadCompleteBody,
 } from "@vm0/api-contracts/contracts/integrations";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
 
@@ -35,17 +37,26 @@ import {
   generatePresignedPutUrl,
   listS3Objects,
 } from "../external/s3";
+import { feishuOrgCallbackPayloadSchema } from "../services/feishu-org-callback-payload";
 import { recordFeishuUploadedFile$ } from "../services/run-uploaded-files.service";
 import type { RouteEntry } from "../route-entry";
 import { safeUriComponentDecode, settle } from "../utils";
 
 const DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024;
 const PUT_URL_TTL_SECONDS = 3600;
+const FEISHU_FILE_ID_PREFIX = "feishu_file_";
 
 type InstallationResolution =
   | { readonly kind: "resolved"; readonly id: string }
   | { readonly kind: "not_found" }
   | { readonly kind: "ambiguous" };
+
+interface FeishuDownloadTarget {
+  readonly installationId: string | undefined;
+  readonly messageId: string;
+  readonly fileKey: string;
+  readonly type: FeishuResourceType;
+}
 
 function apiError(
   status: 400 | 404 | 413 | 502,
@@ -91,6 +102,52 @@ async function resolveInstallation(args: {
     return { kind: "ambiguous" };
   }
   return { kind: "resolved", id: installation.id };
+}
+
+async function resolveDownloadTarget(args: {
+  readonly db: Db;
+  readonly runId: string | undefined;
+  readonly installationId: string | undefined;
+  readonly messageId: string;
+  readonly fileKey: string;
+  readonly type: FeishuResourceType;
+}): Promise<FeishuDownloadTarget | null> {
+  if (!args.fileKey.startsWith(FEISHU_FILE_ID_PREFIX)) {
+    return {
+      installationId: args.installationId,
+      messageId: args.messageId,
+      fileKey: args.fileKey,
+      type: args.type,
+    };
+  }
+  if (!args.runId) {
+    return null;
+  }
+  const [callback] = await args.db
+    .select({ payload: agentRunCallbacks.payload })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, args.runId),
+        eq(agentRunCallbacks.internalKind, "feishu:org"),
+      ),
+    )
+    .limit(1);
+  const parsed = feishuOrgCallbackPayloadSchema.safeParse(callback?.payload);
+  if (!parsed.success) {
+    return null;
+  }
+  const file = parsed.data.files?.find((candidate) => {
+    return candidate.fileId === args.fileKey;
+  });
+  return file
+    ? {
+        installationId: parsed.data.installationId,
+        messageId: file.messageId,
+        fileKey: file.fileKey,
+        type: file.type,
+      }
+    : null;
 }
 
 function installationError(
@@ -241,23 +298,35 @@ const download$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(integrationsFeishuDownloadFileContract.download));
   const db = set(writeDb$);
+  const target = await resolveDownloadTarget({
+    db,
+    runId: "runId" in auth ? auth.runId : undefined,
+    installationId: query.installation_id,
+    messageId: query.message_id,
+    fileKey: query.file_key,
+    type: query.type,
+  });
+  signal.throwIfAborted();
+  if (!target) {
+    return apiError(400, "BAD_REQUEST", "Invalid Feishu file id");
+  }
   const installation = await resolveInstallation({
     db,
     orgId: auth.orgId,
-    installationId: query.installation_id,
+    installationId: target.installationId,
     signal,
   });
   if (installation.kind !== "resolved") {
-    return installationError(installation, query.installation_id);
+    return installationError(installation, target.installationId);
   }
 
   const downloaded = await settle(
     downloadFeishuMessageResource({
       db,
       installationId: installation.id,
-      messageId: query.message_id,
-      fileKey: query.file_key,
-      resourceType: query.type,
+      messageId: target.messageId,
+      fileKey: target.fileKey,
+      resourceType: target.type,
       signal,
     }),
     signal,
@@ -284,7 +353,7 @@ const download$ = command(async ({ get, set }, signal: AbortSignal) => {
   const filename = sanitizeDownloadFilename(
     filenameFromContentDisposition(
       downloaded.value.headers.get("content-disposition"),
-    ) ?? `feishu-${query.file_key}`,
+    ) ?? `feishu-${target.fileKey}`,
   );
   const contentType =
     downloaded.value.headers.get("content-type") ?? inferMimetype(filename);

--- a/turbo/apps/api/src/signals/services/feishu-org-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/feishu-org-callback-payload.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+const feishuOrgCallbackFileSchema = z.object({
+  fileId: z.string().min(1),
+  messageId: z.string().min(1),
+  fileKey: z.string().min(1),
+  type: z.enum(["file", "image"]),
+});
+
 export const feishuOrgCallbackPayloadSchema = z
   .object({
     installationId: z.string().uuid(),
@@ -11,6 +18,7 @@ export const feishuOrgCallbackPayloadSchema = z
     existingSessionId: z.string().uuid().optional(),
     reactionId: z.string().optional(),
     replyInThread: z.boolean().optional(),
+    files: z.array(feishuOrgCallbackFileSchema).optional(),
   })
   .passthrough();
 

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -61,6 +61,19 @@ const resourceContentSchema = z.object({
   file_name: z.string().optional(),
 });
 
+export interface FeishuPromptFile {
+  readonly fileId: string;
+  readonly messageId: string;
+  readonly fileKey: string;
+  readonly type: "file" | "image";
+  readonly filename: string;
+}
+
+interface FeishuPromptContext {
+  readonly text: string;
+  readonly files: readonly FeishuPromptFile[];
+}
+
 export interface FeishuInboundMessage {
   readonly installationId: string;
   readonly eventId: string;
@@ -74,6 +87,7 @@ export interface FeishuInboundMessage {
   readonly threadId: string | null;
   readonly openId: string;
   readonly text: string;
+  readonly file: FeishuPromptFile | null;
 }
 
 interface FeishuAgent {
@@ -369,11 +383,11 @@ async function resolveSession(args: {
   return thread.agentSessionId;
 }
 
-export function formatFeishuFileContext(args: {
+export function feishuPromptFile(args: {
   readonly messageId: string;
   readonly messageType: string;
   readonly content: string;
-}): string | null {
+}): FeishuPromptFile | null {
   if (!["audio", "file", "image", "media"].includes(args.messageType)) {
     return null;
   }
@@ -397,57 +411,88 @@ export function formatFeishuFileContext(args: {
           : "file";
   const filename =
     parsed.data.file_name?.replace(/\s+/gu, " ").trim() || fallbackName;
+  return {
+    fileId: `feishu_file_${randomBytes(16).toString("base64url")}`,
+    messageId: args.messageId,
+    fileKey,
+    type: resourceType,
+    filename,
+  };
+}
+
+export function formatFeishuFileContext(file: FeishuPromptFile): string {
   return [
-    `[Feishu file] ${filename}`,
-    `   [MESSAGE_ID] ${args.messageId}`,
-    `   [FILE_KEY] ${fileKey}`,
-    `   [TYPE] ${resourceType}`,
+    `[Feishu file] ${file.filename}`,
+    `   [MESSAGE_ID] ${file.messageId}`,
+    `   [FILE_KEY] ${file.fileId}`,
+    `   [TYPE] ${file.type}`,
   ].join("\n");
 }
 
-function historyMessageText(message: FeishuHistoryMessage): string {
-  const fileContext = message.body?.content
-    ? formatFeishuFileContext({
+function historyMessageContext(
+  message: FeishuHistoryMessage,
+): FeishuPromptContext {
+  const file = message.body?.content
+    ? feishuPromptFile({
         messageId: message.message_id,
         messageType: message.msg_type,
         content: message.body.content,
       })
     : null;
-  if (fileContext) {
-    return fileContext;
+  if (file) {
+    return { text: formatFeishuFileContext(file), files: [file] };
   }
   if (message.msg_type !== "text" || !message.body?.content) {
-    return `[${message.msg_type} message]`;
+    return { text: `[${message.msg_type} message]`, files: [] };
   }
   const parsed = textContentSchema.safeParse(
     safeJsonParse(message.body.content),
   );
   if (!parsed.success) {
-    return "[text message]";
+    return { text: "[text message]", files: [] };
   }
-  return (message.mentions ?? []).reduce((text, mention) => {
-    return mention.key
-      ? text.replaceAll(
-          mention.key,
-          mention.name ? `@${mention.name}` : "@user",
-        )
-      : text;
-  }, parsed.data.text);
+  return {
+    text: (message.mentions ?? []).reduce((text, mention) => {
+      return mention.key
+        ? text.replaceAll(
+            mention.key,
+            mention.name ? `@${mention.name}` : "@user",
+          )
+        : text;
+    }, parsed.data.text),
+    files: [],
+  };
 }
 
-function formatHistoryLine(message: FeishuHistoryMessage): string {
+function formatHistoryLine(message: FeishuHistoryMessage): FeishuPromptContext {
   const sender =
     message.sender?.sender_name ??
     message.sender?.id ??
     message.sender?.sender_type ??
     "Unknown sender";
-  return `- ${sender}: ${historyMessageText(message)}`;
+  const context = historyMessageContext(message);
+  return { text: `- ${sender}: ${context.text}`, files: context.files };
+}
+
+function formatHistoryLines(messages: readonly FeishuHistoryMessage[]): {
+  readonly lines: readonly string[];
+  readonly files: readonly FeishuPromptFile[];
+} {
+  const contexts = messages.map(formatHistoryLine);
+  return {
+    lines: contexts.map((context) => {
+      return context.text;
+    }),
+    files: contexts.flatMap((context) => {
+      return context.files;
+    }),
+  };
 }
 
 function formatConversationHistory(
   history: readonly FeishuHistoryMessage[],
   current: FeishuInboundMessage,
-): string {
+): FeishuPromptContext {
   const messages = [...history]
     .filter((message) => {
       return !message.deleted && message.message_id !== current.messageId;
@@ -456,14 +501,18 @@ function formatConversationHistory(
       return Number(left.create_time ?? 0) - Number(right.create_time ?? 0);
     });
   if (messages.length === 0) {
-    return "";
+    return { text: "", files: [] };
   }
   if (current.chatType === "p2p") {
-    return [
-      "# Recent Feishu conversation",
-      "Use this history only as conversation context. The current user message remains the task to answer.",
-      ...messages.slice(-30).map(formatHistoryLine),
-    ].join("\n");
+    const formatted = formatHistoryLines(messages.slice(-30));
+    return {
+      text: [
+        "# Recent Feishu conversation",
+        "Use this history only as conversation context. The current user message remains the task to answer.",
+        ...formatted.lines,
+      ].join("\n"),
+      files: formatted.files,
+    };
   }
 
   const threadKeys = new Set(
@@ -500,23 +549,28 @@ function formatConversationHistory(
       return !threadIds.has(message.message_id);
     })
     .slice(-10);
-  return [
-    "# Feishu conversation context",
-    "Use this history only as context. The current mention remains the task to answer.",
-    ...(recentChat.length > 0
-      ? ["## Recent chat", ...recentChat.map(formatHistoryLine)]
-      : []),
-    ...(threadMessages.length > 0
-      ? ["## Current thread", ...threadMessages.map(formatHistoryLine)]
-      : []),
-  ].join("\n");
+  const recentContext = formatHistoryLines(recentChat);
+  const threadContext = formatHistoryLines(threadMessages);
+  return {
+    text: [
+      "# Feishu conversation context",
+      "Use this history only as context. The current mention remains the task to answer.",
+      ...(recentContext.lines.length > 0
+        ? ["## Recent chat", ...recentContext.lines]
+        : []),
+      ...(threadContext.lines.length > 0
+        ? ["## Current thread", ...threadContext.lines]
+        : []),
+    ].join("\n"),
+    files: [...recentContext.files, ...threadContext.files],
+  };
 }
 
 async function conversationHistory(args: {
   readonly db: Db;
   readonly message: FeishuInboundMessage;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<FeishuPromptContext> {
   const history = await tapError(
     listFeishuChatMessages({
       db: args.db,
@@ -533,7 +587,9 @@ async function conversationHistory(args: {
     },
   );
   args.signal.throwIfAborted();
-  return history ? formatConversationHistory(history, args.message) : "";
+  return history
+    ? formatConversationHistory(history, args.message)
+    : { text: "", files: [] };
 }
 
 function systemPrompt(args: {
@@ -964,7 +1020,7 @@ const runFeishuAgent$ = command(
       readonly agent: FeishuAgent;
       readonly sessionId: string | undefined;
       readonly sessionKey: string;
-      readonly history: string;
+      readonly history: FeishuPromptContext;
       readonly modelRoute: IntegrationModelRoutePin | undefined;
       readonly reactionId: string | undefined;
     },
@@ -991,7 +1047,7 @@ const runFeishuAgent$ = command(
         triggerSource: "feishu",
         appendSystemPrompt: systemPrompt({
           message: args.message,
-          history: args.history,
+          history: args.history.text,
         }),
         modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
         modelProviderCredentialScope:
@@ -1012,6 +1068,17 @@ const runFeishuAgent$ = command(
               existingSessionId: args.sessionId,
               reactionId: args.reactionId,
               replyInThread: args.message.chatType !== "p2p",
+              files: [
+                ...(args.message.file ? [args.message.file] : []),
+                ...args.history.files,
+              ].map((file) => {
+                return {
+                  fileId: file.fileId,
+                  messageId: file.messageId,
+                  fileKey: file.fileKey,
+                  type: file.type,
+                };
+              }),
             }),
           },
         ],

--- a/turbo/apps/api/src/signals/services/zero-feishu-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-webhooks.service.ts
@@ -24,8 +24,10 @@ import {
 } from "./feishu-config";
 import {
   dispatchFeishuMessage$,
+  feishuPromptFile,
   formatFeishuFileContext,
   type FeishuInboundMessage,
+  type FeishuPromptFile,
 } from "./zero-feishu-dispatch.service";
 import { publishFeishuOrgChanged } from "./zero-feishu-realtime.service";
 
@@ -78,6 +80,11 @@ const FEISHU_REPLAY_WINDOW_SECONDS = 60 * 5;
 
 type FeishuEventMessage = z.infer<typeof v2MessageEventSchema>["message"];
 type FeishuEventMention = NonNullable<FeishuEventMessage["mentions"]>[number];
+
+interface FeishuInboundContent {
+  readonly text: string;
+  readonly file: FeishuPromptFile | null;
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -156,26 +163,31 @@ function decryptPayload(encrypted: string, encryptKey: string): unknown {
   return JSON.parse(decrypted) as unknown;
 }
 
-function inboundMessageText(
+function inboundMessageContent(
   message: FeishuEventMessage,
   botMention: FeishuEventMention | undefined,
-): string {
+): FeishuInboundContent {
   if (message.message_type !== "text") {
-    return (
-      formatFeishuFileContext({
-        messageId: message.message_id,
-        messageType: message.message_type,
-        content: message.content,
-      }) ?? ""
-    );
+    const file = feishuPromptFile({
+      messageId: message.message_id,
+      messageType: message.message_type,
+      content: message.content,
+    });
+    return {
+      text: file ? formatFeishuFileContext(file) : "",
+      file,
+    };
   }
   const content = textContentSchema.safeParse(safeJsonParse(message.content));
   if (!content.success) {
-    return "";
+    return { text: "", file: null };
   }
-  return botMention
-    ? content.data.text.replaceAll(botMention.key, "")
-    : content.data.text;
+  return {
+    text: botMention
+      ? content.data.text.replaceAll(botMention.key, "")
+      : content.data.text,
+    file: null,
+  };
 }
 
 function inboundMessage(
@@ -206,7 +218,8 @@ function inboundMessage(
   if (chatType !== "p2p" && !botMention) {
     return null;
   }
-  const text = inboundMessageText(event.data.message, botMention).trim();
+  const content = inboundMessageContent(event.data.message, botMention);
+  const text = content.text.trim();
   if (!text) {
     return null;
   }
@@ -223,6 +236,7 @@ function inboundMessage(
     threadId: event.data.message.thread_id ?? null,
     openId: event.data.sender.sender_id.open_id,
     text,
+    file: content.file,
   };
 }
 


### PR DESCRIPTION
## Summary

- replace raw Feishu file keys in current-message and history prompts with short `feishu_file_...` aliases
- persist each alias and its real Feishu resource coordinates in the run callback, then resolve it only for the authenticated run
- keep the existing CLI/query shape and legacy raw file-key downloads working during runner/backend rollout

## Test plan

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-feishu-message.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (168 files, 2372 tests)
- pre-commit repository Knip and type checks