### PR TITLE
fix(chat): keep user message links as links

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -968,7 +968,7 @@ export function parseBodyBlocks(
       continue;
     }
 
-    const actionBlock = createActionBlockFromLine(line);
+    const actionBlock = previews ? createActionBlockFromLine(line) : null;
     if (actionBlock) {
       flushMarkdownBuffer();
       blocks.push(actionBlock);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -653,7 +653,7 @@ describe("chat message action cards", () => {
     });
   });
 
-  it("renders canonical connector actions on alternate production origins", async () => {
+  it("keeps user links and renders assistant actions on alternate origins", async () => {
     const previousUrl = window.location.href;
     const threadId = `${THREAD_ID}-alternate-production-origin`;
     window.location.href = `https://app.okou.ai/chats/${threadId}`;
@@ -680,7 +680,7 @@ describe("chat message action cards", () => {
         {
           id: "msg-user-alternate-production-origin",
           role: "user",
-          content: "Authorize Slack",
+          content: `[User connector link](${canonicalUrl})`,
           runId: "run-alternate-production-origin",
           createdAt: "2026-07-23T10:00:00Z",
         },
@@ -701,6 +701,11 @@ describe("chat message action cards", () => {
 
     const connectorCard = await screen.findByTestId("connector-action-card");
     expect(within(connectorCard).getByText("Slack")).toBeInTheDocument();
+    expect(screen.getAllByTestId("connector-action-card")).toHaveLength(1);
+    const userConnectorLink = queryAllByRoleFast("link").find((link) => {
+      return link.textContent === "User connector link";
+    });
+    expect(userConnectorLink).toHaveAttribute("href", canonicalUrl);
     const untrustedLink = queryAllByRoleFast("link").find((link) => {
       return link.textContent === "Untrusted connector";
     });


### PR DESCRIPTION
## Summary

- restrict link-derived action cards to assistant messages
- preserve action URLs in user messages as normal Markdown links
- add page-level regression coverage for user and assistant connector links

## Testing

- `pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm exec prettier --check apps/platform/src/signals/chat-page/parse-body-blocks.ts apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx`