### PR TITLE
fix(workflows): route manual runs through the chat queue

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -2342,6 +2342,9 @@ describe("zero workflow automations", () => {
     );
 
     expect(run.body.chatThreadId).toBe(threadId);
+    if (!run.body.runId) {
+      throw new Error("Expected an idle manual automation run to start");
+    }
     const timingEvents = sandboxOperationEventsForRun(run.body.runId);
     expect(timingEvents).toStrictEqual(
       expect.arrayContaining([

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
@@ -29,6 +30,10 @@ function authHeaders() {
 
 function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
+}
+
+function chatMessagesClient() {
+  return setupApp({ context })(chatMessagesContract);
 }
 
 function queueClient() {
@@ -418,6 +423,69 @@ describe("workflow queue API", () => {
       }),
     ).toStrictEqual([automation.automationId]);
     expect(queue.body.pausedAt).not.toBeNull();
+  });
+
+  it("queues manual Run now behind an unclaimed user message on an idle thread", async () => {
+    const scenario = await setup();
+    const automation = await createScheduleAutomation(scenario);
+    const first = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: automation.automationId },
+      }),
+      [201],
+    );
+    if (!first.body.runId) {
+      throw new Error("Expected the first manual run to start");
+    }
+
+    const userMessage = await accept(
+      chatMessagesClient().send({
+        headers: authHeaders(),
+        body: {
+          agentId: scenario.agentId,
+          threadId: automation.threadId,
+          prompt: "queued user message before manual Run now",
+        },
+      }),
+      [201],
+    );
+    expect(userMessage.body.runId).toBeNull();
+
+    // Cancel the first run without flushing its deferred chat callback.
+    // This leaves an idle thread whose oldest unclaimed work is the user message.
+    await runsApi.requestCancelRun(scenario.actor, first.body.runId, [200]);
+    await expect(
+      runsApi.readRun(scenario.actor, first.body.runId),
+    ).resolves.toMatchObject({ status: "cancelled" });
+
+    const manual = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: automation.automationId },
+      }),
+      [201],
+    );
+    expect(manual.body).toStrictEqual({
+      runId: null,
+      chatThreadId: automation.threadId,
+    });
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running).toBeNull();
+    expect(
+      queue.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([automation.automationId]);
+
+    await flushWaitUntilForTest();
   });
 
   it("keeps each explicit schedule Run now as a distinct queued event", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -77,6 +77,11 @@ interface WebhookAutomation {
   readonly secret: string;
 }
 
+interface ScheduleAutomation {
+  readonly automationId: string;
+  readonly threadId: string;
+}
+
 async function createWebhookAutomation(
   scenario: Scenario,
 ): Promise<WebhookAutomation> {
@@ -106,6 +111,26 @@ async function createWebhookAutomation(
     threadId: created.body.chatThreadId,
     token,
     secret: created.body.webhookSecret,
+  };
+}
+
+async function createScheduleAutomation(
+  scenario: Scenario,
+): Promise<ScheduleAutomation> {
+  const created = await accept(
+    automationsClient().create({
+      headers: authHeaders(),
+      params: { workflowId: scenario.workflowId },
+      body: { schedule: { type: "loop", intervalSeconds: 3600 } },
+    }),
+    [201],
+  );
+  if (!created.body.chatThreadId) {
+    throw new Error("Expected a thread-bound schedule automation");
+  }
+  return {
+    automationId: created.body.id,
+    threadId: created.body.chatThreadId,
   };
 }
 
@@ -305,5 +330,131 @@ describe("workflow queue API", () => {
     expect(resumed.body.pausedAt).toBeNull();
     expect(resumed.body.running).not.toBeNull();
     expect(resumed.body.pending).toHaveLength(1);
+  });
+
+  it("queues manual Run now behind the active run and existing backlog", async () => {
+    const scenario = await setup();
+    const webhookAutomation = await createWebhookAutomation(scenario);
+    const runningRunId = await postWorkflowWebhook(
+      webhookAutomation,
+      "running",
+    );
+    if (!runningRunId) {
+      throw new Error("Expected the first webhook event to create a run");
+    }
+    await expect(
+      postWorkflowWebhook(webhookAutomation, "already-pending"),
+    ).resolves.toBeNull();
+
+    const scheduleAutomation = await createScheduleAutomation(scenario);
+    expect(scheduleAutomation.threadId).toBe(webhookAutomation.threadId);
+    const manual = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: scheduleAutomation.automationId },
+      }),
+      [201],
+    );
+
+    expect(manual.body).toStrictEqual({
+      runId: null,
+      chatThreadId: webhookAutomation.threadId,
+    });
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: webhookAutomation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running?.runId).toBe(runningRunId);
+    expect(
+      queue.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([
+      webhookAutomation.automationId,
+      scheduleAutomation.automationId,
+    ]);
+    await expect(
+      workflowRunIds(webhookAutomation.threadId),
+    ).resolves.toStrictEqual([runningRunId]);
+  });
+
+  it("queues manual Run now while the workflow queue is paused", async () => {
+    const scenario = await setup();
+    const automation = await createScheduleAutomation(scenario);
+    await accept(
+      queueClient().pause({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+
+    const manual = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: automation.automationId },
+      }),
+      [201],
+    );
+    expect(manual.body).toStrictEqual({
+      runId: null,
+      chatThreadId: automation.threadId,
+    });
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running).toBeNull();
+    expect(
+      queue.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([automation.automationId]);
+    expect(queue.body.pausedAt).not.toBeNull();
+  });
+
+  it("keeps each explicit schedule Run now as a distinct queued event", async () => {
+    const scenario = await setup();
+    const automation = await createScheduleAutomation(scenario);
+
+    const first = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: automation.automationId },
+      }),
+      [201],
+    );
+    expect(first.body.runId).toStrictEqual(expect.any(String));
+
+    for (let index = 0; index < 2; index++) {
+      const queued = await accept(
+        automationsClient().run({
+          headers: authHeaders(),
+          params: { id: automation.automationId },
+        }),
+        [201],
+      );
+      expect(queued.body.runId).toBeNull();
+    }
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(
+      queue.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([automation.automationId, automation.automationId]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -509,7 +509,22 @@ describe("zero workflows", () => {
 
     expect(run.body.chatThreadId).toStrictEqual(expect.any(String));
     expect(run.body.runId).toStrictEqual(expect.any(String));
+    if (!run.body.runId) {
+      throw new Error("Expected an idle workflow invocation to create a run");
+    }
     expectZeroPreCreateSource(run.body.runId, "workflow_slash_command");
+
+    const queued = await accept(
+      detailClient().run({
+        headers: authHeaders(actor),
+        params: { workflowId: created.body.id },
+      }),
+      [200],
+    );
+    expect(queued.body).toStrictEqual({
+      chatThreadId: run.body.chatThreadId,
+      runId: null,
+    });
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.body.runId);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -3223,7 +3223,7 @@ const createNormalChatRun$ = command(
   },
 );
 
-const sendNormalMessage$ = command(
+export const sendNormalMessage$ = command(
   async ({ set }, args: NormalSendArgs, signal: AbortSignal) => {
     const prepared = await measureApiDispatchTiming(
       args.timing,

--- a/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
@@ -317,11 +317,11 @@ const runAutomationInner$ = command(
       signal,
     );
     signal.throwIfAborted();
-    if (result.kind === "ok") {
+    if (result.kind === "ok" || result.kind === "enqueued") {
       return {
         status: 201 as const,
         body: {
-          runId: result.runId,
+          runId: result.kind === "ok" ? result.runId : null,
           chatThreadId: result.chatThreadId,
         },
       };

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-
 import { command, computed } from "ccstate";
 import {
   zeroWorkflowsCollectionContract,
@@ -16,7 +14,6 @@ import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -41,12 +38,6 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { requireAgentPermission } from "../../lib/require-agent-permission";
 import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
-import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import {
-  postRunUserMessage,
-  resolveRunChatThreadModelContext,
-} from "../services/zero-chat-run-message.service";
-import { createZeroRun$ } from "../services/zero-runs-create.service";
 import { deleteZeroWorkflow$ } from "../services/zero-workflow-delete.service";
 import { zeroWorkflowDetail } from "../services/zero-workflow-detail.service";
 import { ensureWorkflowUserAutomationThread } from "../services/zero-workflow-user-automation-thread.service";
@@ -72,6 +63,7 @@ import {
   type WorkflowRow,
 } from "../services/zero-workflow-data.service";
 import type { RouteEntry } from "../route-entry";
+import { sendNormalMessage$ } from "./zero-chat-messages";
 
 const log = logger("api:zero:workflow-connector-readiness");
 
@@ -1013,10 +1005,6 @@ const copyWorkflowInner$ = command(
   },
 );
 
-function generateCallbackSecret(): string {
-  return randomBytes(32).toString("hex");
-}
-
 function workflowSlashPrompt(workflow: Pick<WorkflowRow, "name">): string {
   return `/${workflow.name}`;
 }
@@ -1107,56 +1095,21 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
   signal.throwIfAborted();
 
-  const modelContext = await resolveRunChatThreadModelContext({
-    db: writeDb,
-    orgId: auth.orgId,
-    userId: auth.userId,
-    threadId: chatThreadId,
-  });
-  signal.throwIfAborted();
-  if ("status" in modelContext) {
-    return modelContext;
-  }
-  const { pin, providerAdmission, runCodexServiceTier } = modelContext;
-  if (providerAdmission.error) {
-    return providerAdmission.error;
-  }
-
   // Invoking a workflow is exactly typing its slash command in chat.
   const prompt = workflowSlashPrompt(workflow);
   const result = await set(
-    createZeroRun$,
+    sendNormalMessage$,
     {
-      auth: {
-        orgId: auth.orgId,
-        orgRole: auth.orgRole ?? "member",
-        userId: auth.userId,
-        tokenType: "session",
-      },
+      auth,
       body: {
         prompt,
         agentId: agent.id,
-        ...(providerAdmission.effectiveModelProvider
-          ? { modelProvider: providerAdmission.effectiveModelProvider }
-          : {}),
+        threadId: chatThreadId,
       },
+      userId: auth.userId,
+      orgId: auth.orgId,
       apiStartTime: now.getTime(),
-      triggerSource: "web",
       zeroPreCreateSource: "workflow_slash_command",
-      chatThreadId,
-      modelProviderId: pin.modelProviderId ?? undefined,
-      modelProviderCredentialScope:
-        pin.modelProviderCredentialScope ?? undefined,
-      selectedModelOverride: pin.selectedModel ?? undefined,
-      codexServiceTier: runCodexServiceTier,
-      callbacks: [
-        {
-          internalKind: "chat",
-          secret: generateCallbackSecret(),
-          payload: { threadId: chatThreadId, agentId: agent.id },
-        },
-      ],
-      dispatchFailedCallbacks: dispatchFailedRunCallbacks,
     },
     signal,
   );
@@ -1166,30 +1119,9 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return result;
   }
 
-  await postRunUserMessage({
-    db: writeDb,
-    threadId: chatThreadId,
-    userId: auth.userId,
-    runId: result.body.runId,
-    prompt,
-    appendQueueMarker: result.body.status === "queued",
-  });
-  signal.throwIfAborted();
-
-  await writeDb
-    .update(zeroRuns)
-    .set({
-      modelProvider: providerAdmission.effectiveModelProvider,
-      modelProviderId: pin.modelProviderId,
-      modelProviderCredentialScope: pin.modelProviderCredentialScope,
-      selectedModel: pin.selectedModel,
-    })
-    .where(eq(zeroRuns.id, result.body.runId));
-  signal.throwIfAborted();
-
   return {
     status: 200 as const,
-    body: { chatThreadId, runId: result.body.runId },
+    body: { chatThreadId: result.body.threadId, runId: result.body.runId },
   };
 });
 

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -167,6 +167,7 @@ interface WorkflowQueueAdmissionArgs {
   readonly chatThreadId: string;
   readonly triggerSource: TriggerSource;
   readonly triggerBrief: string | undefined;
+  readonly coalescePendingScheduleRun: boolean;
   readonly params: WorkflowQueueEventParams;
 }
 
@@ -192,6 +193,7 @@ async function attemptWorkflowQueueAdmission(
     }
 
     if (
+      args.coalescePendingScheduleRun &&
       automation.kind === "schedule" &&
       (await pendingTickExistsForAutomation(tx, automation.id))
     ) {

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -187,7 +187,11 @@ async function attemptWorkflowQueueAdmission(
         tx,
         args.chatThreadId,
       );
-      if (!busy && !(await pendingWorkflowEventExists(tx, args.chatThreadId))) {
+      if (
+        !busy &&
+        !(await hasUnclaimedQueuedUserMessage(tx, args.chatThreadId)) &&
+        !(await pendingWorkflowEventExists(tx, args.chatThreadId))
+      ) {
         return { kind: "proceed" };
       }
     }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -87,9 +87,12 @@ export interface RunWorkflowAutomationNowArgs {
   readonly appendSystemPrompt?: string;
   readonly callbacks?: readonly InternalRunCallbackInput[];
   readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
-  // Set by the queue drain (and manual "Run now"): skip workflow-queue
-  // admission and always create the run.
+  // Set only by the queue drain after it claims an event: skip a second
+  // workflow-queue admission and create the claimed run.
   readonly bypassWorkflowQueue?: boolean;
+  // Automated schedule ticks coalesce while pending. Explicit manual runs set
+  // this false so every user action remains a distinct queue item.
+  readonly coalescePendingScheduleRun?: boolean;
   readonly recordLastRunId?: boolean;
   readonly recordLastRunAt?: boolean;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
@@ -419,6 +422,7 @@ async function enqueueWorkflowAutomationEventIfBusy(input: {
         chatThreadId,
         triggerSource: args.triggerSource ?? "workflow-schedule",
         triggerBrief: args.triggerBrief,
+        coalescePendingScheduleRun: args.coalescePendingScheduleRun !== false,
         params: {
           version: 1,
           prompt: args.prompt,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -188,6 +188,10 @@ type WorkflowAutomationRunNowResult =
       readonly runId: string;
       readonly chatThreadId: string;
     }
+  | {
+      readonly kind: "enqueued";
+      readonly chatThreadId: string;
+    }
   | AutomationActionFailure
   | Exclude<
       RunWorkflowAutomationResult,
@@ -2449,16 +2453,14 @@ export const runOwnedWorkflowAutomationNow$ = command(
           target.agentId,
         ),
         recordLastRunAt: true,
-        // Manual "Run now" is the user's explicit choice to run immediately,
-        // even while the workflow queue is busy.
-        bypassWorkflowQueue: true,
+        coalescePendingScheduleRun: false,
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
       },
       signal,
     );
     signal.throwIfAborted();
     if (result.kind === "enqueued") {
-      throw new Error("Bypassed workflow queue run cannot be enqueued");
+      return { kind: "enqueued", chatThreadId };
     }
     if (result.kind !== "ok") {
       return result;

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -872,7 +872,7 @@ export const runWorkflow$ = command(
     { get },
     workflowId: string,
     signal: AbortSignal,
-  ): Promise<{ chatThreadId: string; runId: string }> => {
+  ): Promise<{ chatThreadId: string; runId: string | null }> => {
     const client = get(zeroClient$)(zeroWorkflowsDetailContract);
     const result = await accept(
       client.run({
@@ -1551,7 +1551,7 @@ export const runWorkflowAutomationNow$ = command(
     { get },
     automationId: string,
     signal: AbortSignal,
-  ): Promise<{ chatThreadId: string; runId: string }> => {
+  ): Promise<{ chatThreadId: string; runId: string | null }> => {
     const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
     const result = await accept(
       client.run({

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1078,7 +1078,7 @@ function mockRunWorkflowAutomation(
     ({ params, respond }) => {
       onRun(params.id);
       return respond(201, {
-        runId: "workflow-automation-run-now",
+        runId: null,
         chatThreadId: AUTOMATION_RUN_THREAD_ID,
       });
     },
@@ -2229,7 +2229,7 @@ describe("workflow detail page", () => {
     expect(screen.getAllByText("Next")).toHaveLength(1);
   });
 
-  it("runs an automation immediately and navigates to the bound chat thread", async () => {
+  it("submits an automation run and navigates to the bound chat thread", async () => {
     const runAutomationIds: string[] = [];
     mockWorkflowApis([salesResearch()]);
     mockChatLifecycle(context, { threadId: AUTOMATION_RUN_THREAD_ID });

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -1304,7 +1304,9 @@ export const zeroWorkflowCopyRequestSchema = z.object({
 
 export const zeroWorkflowRunResponseSchema = z.object({
   chatThreadId: z.string().uuid(),
-  runId: z.string(),
+  // Null means the manual invocation is waiting in the chat thread queue and
+  // no run has been created for it yet.
+  runId: z.string().nullable(),
 });
 
 export const zeroWorkflowChatThreadResponseSchema = z.object({
@@ -1681,7 +1683,7 @@ export const zeroWorkflowAutomationsContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Run a workflow automation immediately in its bound chat thread",
+    summary: "Submit a workflow automation run in its bound chat thread",
   },
   revealWebhookSecret: {
     method: "POST",


### PR DESCRIPTION
## Summary

- route workflow automation **Run now** through the shared chat message queue instead of bypassing queue admission
- keep each explicit schedule Run now click as a distinct queue event while preserving coalescing for automatic schedule ticks
- route direct workflow slash-command runs through the normal queue-first user-message path
- return `runId: null` when a manual invocation is waiting in the thread queue, while preserving the existing response status and chat-thread navigation

## User impact

Manual workflow runs can no longer overtake an active run, existing backlog, or a paused queue. An idle thread still starts immediately through the queue's inline drain.

## Verification

- `NODE_OPTIONS=--max-old-space-size=3000 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=3000 pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=3000 pnpm -F @vm0/app check-types`
- API workflow integration tests: 71 passed
- Platform workflow-page tests: 46 passed
- API, Platform, and API-contract lint checks
- Prettier check
- `pnpm knip`
