### PR TITLE
fix(platform): unify connector card behavior

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -11,9 +11,7 @@ import {
   connectConnectorNoAuth$,
   connectConnectorOAuthAuthCode$,
   connectorCurrentConnectionStatus,
-  getConnectorStatusConnectLaunchMode,
-  getOnlyAvailableStatusBrowserAuthMethodDetail,
-  getOnlyAvailableStatusNoAuthMethod,
+  getConnectorStatusDirectConnectMethod,
   setSelectedConnectorRef$,
 } from "../zero-page/settings/connectors.ts";
 import { resolvePlatformOriginForTarget } from "../api-base.ts";
@@ -145,19 +143,6 @@ function createCustomConnectorSignals(
   return descriptor;
 }
 
-function getDirectConnectMethod(connector: PublicConnectorCatalogStatusItem) {
-  const launchMode = getConnectorStatusConnectLaunchMode(connector);
-  if (launchMode === "browser-auth") {
-    const authMethod = getOnlyAvailableStatusBrowserAuthMethodDetail(connector);
-    return authMethod ? { kind: "browser-auth" as const, authMethod } : null;
-  }
-  if (launchMode === "no-auth") {
-    const authMethod = getOnlyAvailableStatusNoAuthMethod(connector);
-    return authMethod ? { kind: "no-auth" as const, authMethod } : null;
-  }
-  return null;
-}
-
 type ConnectorActivationSignals = Pick<
   ConnectorSignals,
   "available$" | "catalogItem$" | "connected$"
@@ -212,7 +197,8 @@ function createConnectorActivation(
       return;
     }
 
-    const directConnectMethod = getDirectConnectMethod(connector);
+    const directConnectMethod =
+      getConnectorStatusDirectConnectMethod(connector);
     if (!directConnectMethod) {
       set(activeChatConnectorActionState$, descriptor);
       set(setSelectedConnectorRef$, descriptor.connectorRef);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -98,6 +98,16 @@ export type ConnectorCatalogBrowserAuthMethodDetail =
     readonly grantKind: BrowserAuthGrantKind;
   };
 
+type ConnectorStatusDirectConnectMethod =
+  | {
+      readonly kind: "browser-auth";
+      readonly authMethod: PublicConnectorCatalogAuthMethodDetail;
+    }
+  | {
+      readonly kind: "no-auth";
+      readonly authMethod: ConnectorAuthMethodId;
+    };
+
 export function manualGrantInputValuesForMethod(
   method: Pick<PublicConnectorCatalogAuthMethodDetail, "manualFields">,
   values: Readonly<Record<string, string>>,
@@ -201,13 +211,7 @@ export function hasConnectorStatusBrowserAuthGrant(
 export function getConnectorStatusConnectLaunchMode(
   connector: PublicConnectorCatalogStatusItem,
 ): ConnectorConnectLaunchMode {
-  if (getOnlyAvailableStatusBrowserAuthMethod(connector)) {
-    return "browser-auth";
-  }
-  if (getOnlyAvailableStatusNoAuthMethod(connector)) {
-    return "no-auth";
-  }
-  return "modal";
+  return getConnectorStatusDirectConnectMethod(connector)?.kind ?? "modal";
 }
 
 export function getAvailableStatusAuthCodeAuthMethod(
@@ -284,6 +288,18 @@ export function getOnlyAvailableStatusNoAuthMethod(
     return null;
   }
   return getAvailableStatusNoAuthMethod(connector, method.id);
+}
+
+export function getConnectorStatusDirectConnectMethod(
+  connector: PublicConnectorCatalogStatusItem,
+): ConnectorStatusDirectConnectMethod | null {
+  const browserAuthMethod =
+    getOnlyAvailableStatusBrowserAuthMethodDetail(connector);
+  if (browserAuthMethod) {
+    return { kind: "browser-auth", authMethod: browserAuthMethod };
+  }
+  const noAuthMethod = getOnlyAvailableStatusNoAuthMethod(connector);
+  return noAuthMethod ? { kind: "no-auth", authMethod: noAuthMethod } : null;
 }
 
 function connectorTokenExpiresAtMs(

--- a/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-connectors.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
-import { IconCircleCheck, IconLoader2 } from "@tabler/icons-react";
-import { Button, cn } from "@vm0/ui";
+import { cn } from "@vm0/ui";
 import {
   connectorRefSchema,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   allConnectorCatalogItems$,
   connectConnectorNoAuth$,
@@ -19,9 +17,8 @@ import {
   setSelectedConnectorRef$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { ConnectModal } from "../zero-page/components/settings/add-connection-dialog.tsx";
-import { launchConnectorConnect } from "../zero-page/components/settings/launch-connector-connect.ts";
+import { ConnectorCard } from "../zero-page/components/settings/connector-card.tsx";
 
 type ConnectorSetupVariant = "workflow" | "prompt";
 
@@ -30,83 +27,6 @@ function connectorRefs(values: readonly string[]): ConnectorRef[] {
     const parsed = connectorRefSchema.safeParse(value);
     return parsed.success ? [parsed.data] : [];
   });
-}
-function promptHelpText(helpText: string | undefined): string {
-  return (helpText ?? "Connect this account to continue")
-    .replace(/^Connect your \w+ account to /u, "")
-    .replace(/^Connect your Google account to /u, "")
-    .replace(/^Connect /u, "");
-}
-
-function OnboardingConnectorRow({
-  connectorRef,
-  item,
-  connected,
-  connecting,
-  loading,
-  variant,
-  required,
-  onConnect,
-}: {
-  readonly connectorRef: ConnectorRef;
-  readonly item: PublicConnectorCatalogStatusItem | undefined;
-  readonly connected: boolean;
-  readonly connecting: boolean;
-  readonly loading: boolean;
-  readonly variant: ConnectorSetupVariant;
-  readonly required: boolean;
-  readonly onConnect: (item: PublicConnectorCatalogStatusItem) => void;
-}) {
-  const label = item?.label ?? connectorRef;
-  return (
-    <div
-      className={cn(
-        "flex min-w-0 items-center gap-3",
-        variant === "workflow"
-          ? "border-b border-border/40 py-[18px] last:border-b-0"
-          : "rounded-xl border border-border px-4 py-3.5 sm:px-5 sm:py-4",
-      )}
-    >
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/40">
-        <ConnectorIcon icon={item?.icon} size={22} />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium">{label}</p>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-          {variant === "workflow" ? (
-            <span className="text-muted-foreground/70">
-              {required ? "Required" : "Optional"} ·{" "}
-            </span>
-          ) : null}
-          {promptHelpText(item?.description)}
-        </p>
-      </div>
-      {connected ? (
-        <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
-          <IconCircleCheck size={16} aria-hidden="true" />
-          Connected
-        </span>
-      ) : (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-9 shrink-0 rounded-[10px] px-4 text-sm"
-          disabled={loading || !item || connecting}
-          onClick={() => {
-            if (item) {
-              onConnect(item);
-            }
-          }}
-        >
-          {connecting ? (
-            <IconLoader2 className="animate-spin" aria-hidden="true" />
-          ) : null}
-          Connect
-        </Button>
-      )}
-    </div>
-  );
 }
 
 export function OnboardingConnectorSetup({
@@ -166,44 +86,46 @@ export function OnboardingConnectorSetup({
             pollingDeviceAuthRef === connectorRef;
 
           return (
-            <OnboardingConnectorRow
+            <ConnectorCard
               key={connectorRef}
+              variant="onboarding"
               connectorRef={connectorRef}
-              item={item}
+              connector={item}
               connected={connected}
-              connecting={connecting}
+              busy={connecting}
               loading={loading}
-              variant={variant}
+              layout={variant}
               required={requiredSet.has(connectorRef)}
-              onConnect={(connector) => {
-                launchConnectorConnect({
-                  connector,
-                  openModal: () => {
-                    setConnectRef(connectorRef);
-                  },
-                  connectBrowserAuth: (authMethod) => {
-                    return connect(
-                      connectorRef,
-                      authMethod,
-                      {
-                        connectorLabel: connector.label,
-                        connectorIcon: connector.icon,
+              connect={
+                item
+                  ? {
+                      openModal: () => {
+                        setConnectRef(connectorRef);
                       },
-                      pageSignal,
-                    );
-                  },
-                  connectNoAuth: (authMethod) => {
-                    return connectNoAuth(
-                      {
-                        connectorRef,
-                        authMethod,
-                        options: { connectorLabel: connector.label },
+                      connectBrowserAuth: (authMethod) => {
+                        return connect(
+                          connectorRef,
+                          authMethod,
+                          {
+                            connectorLabel: item.label,
+                            connectorIcon: item.icon,
+                          },
+                          pageSignal,
+                        );
                       },
-                      pageSignal,
-                    );
-                  },
-                });
-              }}
+                      connectNoAuth: (authMethod) => {
+                        return connectNoAuth(
+                          {
+                            connectorRef,
+                            authMethod,
+                            options: { connectorLabel: item.label },
+                          },
+                          pageSignal,
+                        );
+                      },
+                    }
+                  : undefined
+              }
             />
           );
         })}

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -14,7 +14,6 @@ import {
   IconUserCircle,
   IconShield,
   IconUsers,
-  IconAdjustmentsHorizontal,
   IconSearch,
   IconX,
   IconMessageCircle,
@@ -40,7 +39,6 @@ import {
   SelectValue,
 } from "@vm0/ui";
 import { ZeroInstructionsTab } from "../zero-page/zero-instructions-tab.tsx";
-import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { ZeroSettingsTab } from "../zero-page/zero-settings-tab.tsx";
 
 import { TONE_OPTIONS, type Tone } from "../zero-page/zero-tone-constants.ts";
@@ -80,7 +78,7 @@ import {
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
 import { ZeroNoPermissionIllustration } from "../zero-page/components/zero-no-permission-illustration.tsx";
-import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
+import { ConnectorCard } from "../zero-page/components/settings/connector-card.tsx";
 import { PermissionsDrawer } from "../zero-page/components/settings/permissions-dialog.tsx";
 import type { PermissionDraftIntent } from "../../signals/zero-page/settings/permission-draft-intent.ts";
 import { savePermissionDraftPolicies } from "../../signals/zero-page/settings/permission-grant-save.ts";
@@ -308,98 +306,6 @@ function resolveSound(sound: string): Tone {
     : "professional";
 }
 
-// ---------------------------------------------------------------------------
-// PermissionRow — single connector toggle row inside the authorization tab
-// ---------------------------------------------------------------------------
-
-function PermissionRow({
-  connector,
-  enabled,
-  onToggle,
-  loading,
-  showManage,
-  onManage,
-  isLast,
-}: {
-  connector: PublicConnectorCatalogStatusItem;
-  enabled: boolean;
-  onToggle: (checked: boolean) => void;
-  loading?: boolean;
-  showManage?: boolean;
-  onManage?: () => void;
-  isLast?: boolean;
-}) {
-  return (
-    <>
-      <div className="flex items-center gap-3 px-5 py-4 w-full text-left transition-colors">
-        <ConnectorIcon icon={connector.icon} size={20} />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-foreground">
-              {connector.label}
-            </span>
-            {connector.connection?.externalUsername && (
-              <span className="text-xs text-muted-foreground">
-                @{connector.connection.externalUsername}
-              </span>
-            )}
-          </div>
-          {connector.description && (
-            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-              {connector.description
-                .replace(/^Connect your \w+ account to /i, "")
-                .replace(/^access /i, "")
-                .replace(/^create /i, "Create ")
-                .replace(/^./, (c) => {
-                  return c.toUpperCase();
-                })}
-            </p>
-          )}
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          {showManage && (
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => {
-                      onManage?.();
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onManage?.();
-                      }
-                    }}
-                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                    aria-label={`Manage ${connector.label} permissions`}
-                  >
-                    <IconAdjustmentsHorizontal size={15} stroke={1.5} />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p className="text-xs">Manage permissions</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          <LoadingSwitch
-            checked={enabled}
-            onCheckedChange={(checked) => {
-              return onToggle(checked);
-            }}
-            loading={loading}
-            ariaLabel={`${enabled ? "Revoke" : "Grant"} ${connector.label} access`}
-          />
-        </div>
-      </div>
-      {!isLast && <div className="mx-5 border-b border-border/50" />}
-    </>
-  );
-}
-
 function PermissionListSkeleton() {
   return (
     <div className="mx-auto max-w-[900px]">
@@ -553,8 +459,9 @@ function ConnectedConnectorPermissions({
         {filteredConnectors.length > 0 ? (
           filteredConnectors.map((c, i) => {
             return (
-              <PermissionRow
+              <ConnectorCard
                 key={c.connectorRef}
+                variant="permission"
                 connector={c}
                 enabled={authorizedSet.has(c.connectorRef)}
                 onToggle={onDomEventFn(async (checked) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -1,0 +1,188 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { beforeEach, describe, expect, it } from "vitest";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
+import {
+  AGENT_ID,
+  context,
+  mockAgent,
+  mockAgentConnectorAuthorizations,
+  mockConnectors,
+  mockOrgModelRoutes,
+  composerElementFrom,
+} from "./chat-composer-test-helpers.ts";
+
+function connectorStatus({
+  connectorRef,
+  label,
+  authMethods,
+  singleAuthCodeAuthMethodId = null,
+}: {
+  readonly connectorRef: PublicConnectorCatalogStatusItem["connectorRef"];
+  readonly label: string;
+  readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
+  readonly singleAuthCodeAuthMethodId?: string | null;
+}): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef,
+    label,
+    description: `Connect ${label}`,
+    icon: {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods,
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId,
+    connectNotice: null,
+  };
+}
+
+function mockCatalog(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [...connectors] });
+  });
+}
+
+function createMockAuthWindow(): Window {
+  const authWindow = context.mocks.browser.authWindow();
+  Object.defineProperty(authWindow, "location", {
+    value: { href: "" },
+    configurable: true,
+  });
+  return authWindow;
+}
+
+async function openAddConnectorsDialog(
+  user: ReturnType<typeof userEvent.setup>,
+): Promise<HTMLElement> {
+  const composer = composerElementFrom(
+    await screen.findByPlaceholderText(PLACEHOLDER),
+  );
+  await user.click(within(composer).getByLabelText("Connectors"));
+  await user.click(await screen.findByText("Add connectors"));
+  return await screen.findByRole("dialog", {
+    name: "Available connectors to connect (1)",
+  });
+}
+
+beforeEach(() => {
+  context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
+  mockOrgModelRoutes("claude-sonnet-4-6");
+  mockAgent();
+  mockConnectors([]);
+  mockAgentConnectorAuthorizations([]);
+});
+
+describe("chat composer connector connection", () => {
+  it("starts a single OAuth connector without an intermediate modal", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockCatalog([
+      connectorStatus({
+        connectorRef: "google-analytics",
+        label: "Google Analytics",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    ]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("google-analytics");
+        expect(body.agentId).toBe(AGENT_ID);
+        return respond(200, {
+          authorizationUrl: "https://accounts.google.test/analytics/authorize",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const dialog = await openAddConnectorsDialog(user);
+    const connectorCard = within(dialog).getByLabelText(
+      "Connect Google Analytics",
+    );
+    expect(dialog).toHaveClass("zero-app");
+    expect(connectorCard).toHaveClass("zero-card");
+    await user.click(connectorCard);
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://accounts.google.test/analytics/authorize",
+      );
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Google Analytics" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the connection modal when connector configuration is required", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockCatalog([
+      connectorStatus({
+        connectorRef: "axiom",
+        label: "Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "API token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "API token",
+                required: true,
+                placeholder: "xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const dialog = await openAddConnectorsDialog(user);
+    await user.click(within(dialog).getByLabelText("Connect Axiom"));
+
+    await expect(
+      screen.findByRole("dialog", { name: "Axiom" }),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -4,7 +4,11 @@ import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import {
+  zeroConnectorNoAuthGrantContract,
+  zeroConnectorOauthStartContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import { beforeEach, describe, expect, it } from "vitest";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
@@ -135,8 +139,6 @@ describe("chat composer connector connection", () => {
     const connectorCard = within(dialog).getByLabelText(
       "Connect Google Analytics",
     );
-    expect(dialog).toHaveClass("zero-app");
-    expect(connectorCard).toHaveClass("zero-card");
     await user.click(connectorCard);
 
     await waitFor(() => {
@@ -146,6 +148,84 @@ describe("chat composer connector connection", () => {
     });
     expect(
       screen.queryByRole("dialog", { name: "Google Analytics" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("enables a single no-auth connector without an intermediate modal", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockCatalog([
+      connectorStatus({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        authMethods: [
+          {
+            id: "api",
+            label: "Public catalog",
+            description: null,
+            grantKind: "none",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    let connectCount = 0;
+    context.mocks.api(
+      zeroConnectorNoAuthGrantContract.connect,
+      ({ body, params, respond }) => {
+        connectCount += 1;
+        expect(params.type).toBe("stripe");
+        expect(body).toStrictEqual({
+          authMethod: "api",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+        });
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: params.type,
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+    let authorizationUpdateCount = 0;
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ body, params, respond }) => {
+        authorizationUpdateCount += 1;
+        expect(params.id).toBe(AGENT_ID);
+        expect(body).toStrictEqual({
+          enabledTypes: ["stripe"],
+          operation: "add",
+        });
+        return respond(200, { enabledTypes: ["stripe"] });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const dialog = await openAddConnectorsDialog(user);
+    await user.click(within(dialog).getByLabelText("Connect Public Stripe"));
+
+    await waitFor(() => {
+      expect(connectCount).toBe(1);
+      expect(authorizationUpdateCount).toBe(1);
+      expect(
+        screen.queryByRole("dialog", {
+          name: "Available connectors to connect (1)",
+        }),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Public Stripe" }),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -808,6 +808,30 @@ describe("connectors page", () => {
     });
   });
 
+  it("disconnects a connected catalog connector from the options menu", async () => {
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+    });
+
+    await waitFor(() => {
+      expect(
+        within(connectorCardByLabel("GitHub")).getByLabelText("More options"),
+      ).toBeInTheDocument();
+    });
+
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText("More options"),
+    );
+    click(menuItemByText("Disconnect"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Connect GitHub")).toBeInTheDocument();
+    });
+  });
+
   it("moves scope review into the connector options menu", async () => {
     const storedScopes = ["https://www.googleapis.com/auth/adwords"];
     const addedScopes = [

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -1,0 +1,531 @@
+import type { ReactNode } from "react";
+import {
+  IconAdjustmentsHorizontal,
+  IconCircleCheck,
+  IconDotsVertical,
+  IconLoader2,
+  IconPlus,
+} from "@tabler/icons-react";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  cn,
+} from "@vm0/ui";
+import {
+  connectorCurrentConnectionStatus,
+  connectorExpiryCountdownText,
+  isStandaloneMode,
+} from "../../../../signals/zero-page/settings/connectors.ts";
+import { DropdownMenuModalItem } from "../../../components/dropdown-menu-modal-item.tsx";
+import { LoadingSwitch } from "../../../components/loading-switch.tsx";
+import { ConnectorIcon } from "./connector-icons.tsx";
+import {
+  launchConnectorConnect,
+  type ConnectorConnectHandlers,
+} from "./launch-connector-connect.ts";
+
+type CatalogConnectorCardProps = {
+  readonly variant: "catalog";
+  readonly connector: PublicConnectorCatalogStatusItem;
+  readonly busy: boolean;
+  readonly connect: ConnectorConnectHandlers;
+};
+
+type ConnectionConnectorCardProps = {
+  readonly variant: "connection";
+  readonly connector: PublicConnectorCatalogStatusItem;
+  readonly connected: boolean;
+  readonly busy: boolean;
+  readonly disconnecting: boolean;
+  readonly connect: ConnectorConnectHandlers;
+  readonly manageAccess?: ReactNode;
+  readonly onDisconnect: () => void;
+  readonly onReviewScopes?: () => void;
+};
+
+type OnboardingConnectorCardProps = {
+  readonly variant: "onboarding";
+  readonly connectorRef: ConnectorRef;
+  readonly connector: PublicConnectorCatalogStatusItem | undefined;
+  readonly connected: boolean;
+  readonly busy: boolean;
+  readonly loading: boolean;
+  readonly layout: "workflow" | "prompt";
+  readonly required: boolean;
+  readonly connect: ConnectorConnectHandlers | undefined;
+};
+
+type ActionConnectorCardProps = {
+  readonly variant: "action";
+  readonly connector: PublicConnectorCatalogStatusItem;
+  readonly connected: boolean;
+  readonly complete: boolean;
+  readonly busy: boolean;
+  readonly onActivate: () => void;
+};
+
+type PermissionConnectorCardProps = {
+  readonly variant: "permission";
+  readonly connector: PublicConnectorCatalogStatusItem;
+  readonly enabled: boolean;
+  readonly loading: boolean;
+  readonly showManage: boolean;
+  readonly isLast: boolean;
+  readonly onManage: () => void;
+  readonly onToggle: (checked: boolean) => void;
+};
+
+type ConnectorCardProps =
+  | CatalogConnectorCardProps
+  | ConnectionConnectorCardProps
+  | OnboardingConnectorCardProps
+  | ActionConnectorCardProps
+  | PermissionConnectorCardProps;
+
+function runConnect(
+  connector: PublicConnectorCatalogStatusItem,
+  connect: ConnectorConnectHandlers,
+  busy: boolean,
+): void {
+  if (busy) {
+    return;
+  }
+  launchConnectorConnect({ connector, ...connect });
+}
+
+function CatalogConnectorCard({
+  connector,
+  busy,
+  connect,
+}: CatalogConnectorCardProps) {
+  const handleConnect = () => {
+    runConnect(connector, connect, busy);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={busy ? -1 : 0}
+      aria-label={`Connect ${connector.label}`}
+      aria-disabled={busy}
+      className={cn(
+        "zero-card overflow-hidden text-left",
+        busy ? "cursor-default" : "cursor-pointer",
+      )}
+      onClick={handleConnect}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleConnect();
+        }
+      }}
+    >
+      <div className="flex items-center gap-2.5 px-5 pb-1 pt-4">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <ConnectorIcon icon={connector.icon} size={20} />
+        </span>
+        <span
+          data-testid="connector-card-label"
+          className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
+        >
+          {connector.label}
+        </span>
+        <span
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+            !busy && "border border-border/60",
+          )}
+          aria-hidden="true"
+        >
+          {busy ? (
+            <IconLoader2 size={16} stroke={1.5} className="animate-spin" />
+          ) : (
+            <IconPlus size={14} stroke={1.5} />
+          )}
+        </span>
+      </div>
+      <div className="px-5 pb-4 pt-1">
+        <div
+          data-testid="connector-help-text"
+          className="line-clamp-2 text-xs text-muted-foreground"
+        >
+          {connector.description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConnectorConnectionStatus({
+  connector,
+  connected,
+  busy,
+  connect,
+}: {
+  readonly connector: PublicConnectorCatalogStatusItem;
+  readonly connected: boolean;
+  readonly busy: boolean;
+  readonly connect: ConnectorConnectHandlers;
+}) {
+  const connectionStatus = connectorCurrentConnectionStatus(connector);
+  if (busy) {
+    const standaloneHint = isStandaloneMode()
+      ? " Switch back here after completing sign-in."
+      : "";
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
+        {`Connecting…${standaloneHint}`}
+      </span>
+    );
+  }
+  if (connected && connectionStatus === "reconnect-required") {
+    return (
+      <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
+        <span className="text-amber-600 dark:text-amber-400">
+          Connection expired
+        </span>
+      </span>
+    );
+  }
+  if (connected && connectionStatus === "scope-mismatch") {
+    return (
+      <span className="flex min-w-0 items-center gap-2 text-[11px]">
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
+        <span className="min-w-0 truncate text-amber-600 dark:text-amber-400">
+          Update permissions
+        </span>
+      </span>
+    );
+  }
+  if (connected) {
+    const expiryText = connectorExpiryCountdownText(connector);
+    const connectedText =
+      expiryText ??
+      (connector.connection?.externalUsername
+        ? `@${connector.connection.externalUsername}`
+        : "Connected");
+    return (
+      <span className="flex items-center gap-2 truncate text-xs text-muted-foreground">
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
+        <span className="truncate">{connectedText}</span>
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        runConnect(connector, connect, busy);
+      }}
+      className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+    >
+      Connect
+    </button>
+  );
+}
+
+function ConnectionConnectorCard({
+  connector,
+  connected,
+  busy,
+  disconnecting,
+  connect,
+  manageAccess,
+  onDisconnect,
+  onReviewScopes,
+}: ConnectionConnectorCardProps) {
+  const connectionStatus = connectorCurrentConnectionStatus(connector);
+  return (
+    <div className="zero-card flex flex-col">
+      <div className="flex h-14 items-center gap-2.5 px-5">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <ConnectorIcon icon={connector.icon} size={20} />
+        </span>
+        <span
+          data-testid="connector-card-label"
+          className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
+        >
+          {connector.label}
+        </span>
+      </div>
+      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
+        <div className="flex shrink-0 items-center gap-2 overflow-hidden">
+          <ConnectorConnectionStatus
+            connector={connector}
+            connected={connected}
+            busy={busy}
+            connect={connect}
+          />
+        </div>
+        {connected ? (
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-0">
+            {manageAccess}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                  aria-label="More options"
+                  disabled={busy}
+                >
+                  <IconDotsVertical size={14} stroke={1.5} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                {connectionStatus === "reconnect-required" ? (
+                  <DropdownMenuModalItem
+                    onModalSelect={() => {
+                      runConnect(connector, connect, busy);
+                    }}
+                  >
+                    Reconnect
+                  </DropdownMenuModalItem>
+                ) : null}
+                {connectionStatus === "scope-mismatch" && onReviewScopes ? (
+                  <DropdownMenuModalItem onModalSelect={onReviewScopes}>
+                    Review permissions
+                  </DropdownMenuModalItem>
+                ) : null}
+                <DropdownMenuItem
+                  onClick={onDisconnect}
+                  disabled={disconnecting || busy}
+                >
+                  Disconnect
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function onboardingHelpText(helpText: string | undefined): string {
+  return (helpText ?? "Connect this account to continue")
+    .replace(/^Connect your \w+ account to /u, "")
+    .replace(/^Connect your Google account to /u, "")
+    .replace(/^Connect /u, "");
+}
+
+function OnboardingConnectorCard({
+  connectorRef,
+  connector,
+  connected,
+  busy,
+  loading,
+  layout,
+  required,
+  connect,
+}: OnboardingConnectorCardProps) {
+  const label = connector?.label ?? connectorRef;
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 items-center gap-3",
+        layout === "workflow"
+          ? "border-b border-border/40 py-[18px] last:border-b-0"
+          : "rounded-xl border border-border px-4 py-3.5 sm:px-5 sm:py-4",
+      )}
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/40">
+        <ConnectorIcon icon={connector?.icon} size={22} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p
+          data-testid="connector-card-label"
+          className="truncate text-sm font-medium"
+        >
+          {label}
+        </p>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          {layout === "workflow" ? (
+            <span className="text-muted-foreground/70">
+              {required ? "Required" : "Optional"} ·{" "}
+            </span>
+          ) : null}
+          {onboardingHelpText(connector?.description)}
+        </p>
+      </div>
+      {connected ? (
+        <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
+          <IconCircleCheck size={16} aria-hidden="true" />
+          Connected
+        </span>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-9 shrink-0 rounded-[10px] px-4 text-sm"
+          disabled={loading || !connector || !connect || busy}
+          onClick={() => {
+            if (connector && connect) {
+              runConnect(connector, connect, busy);
+            }
+          }}
+        >
+          {busy ? (
+            <IconLoader2 className="animate-spin" aria-hidden="true" />
+          ) : null}
+          Connect
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function ActionConnectorCard({
+  connector,
+  connected,
+  complete,
+  busy,
+  onActivate,
+}: ActionConnectorCardProps) {
+  const reconnectRequired =
+    connectorCurrentConnectionStatus(connector) === "reconnect-required";
+  const actionLabel = complete
+    ? "Authorized"
+    : reconnectRequired
+      ? "Reconnect"
+      : connected
+        ? "Authorize"
+        : "Connect";
+
+  return (
+    <div
+      data-testid="connector-action-card"
+      className="zero-card flex min-h-[88px] w-full flex-col gap-3 p-3 text-left sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
+          <ConnectorIcon icon={connector.icon} size={22} />
+        </div>
+        <div className="min-w-0">
+          <div
+            data-testid="connector-card-label"
+            className="truncate text-[0.9375rem] font-medium text-foreground"
+          >
+            {connector.label}
+          </div>
+          <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
+            {connector.description}
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={complete || busy}
+        onClick={onActivate}
+        className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+      >
+        {busy ? <IconLoader2 size={15} className="animate-spin" /> : null}
+        {actionLabel}
+      </button>
+    </div>
+  );
+}
+
+function permissionDescription(description: string): string {
+  return description
+    .replace(/^Connect your \w+ account to /iu, "")
+    .replace(/^access /iu, "")
+    .replace(/^create /iu, "Create ")
+    .replace(/^./u, (character) => {
+      return character.toUpperCase();
+    });
+}
+
+function PermissionConnectorCard({
+  connector,
+  enabled,
+  loading,
+  showManage,
+  isLast,
+  onManage,
+  onToggle,
+}: PermissionConnectorCardProps) {
+  return (
+    <>
+      <div className="flex w-full items-center gap-3 px-5 py-4 text-left transition-colors">
+        <ConnectorIcon icon={connector.icon} size={20} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              data-testid="connector-card-label"
+              className="text-sm font-medium text-foreground"
+            >
+              {connector.label}
+            </span>
+            {connector.connection?.externalUsername ? (
+              <span className="text-xs text-muted-foreground">
+                @{connector.connection.externalUsername}
+              </span>
+            ) : null}
+          </div>
+          {connector.description ? (
+            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+              {permissionDescription(connector.description)}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {showManage ? (
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onManage}
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    aria-label={`Manage ${connector.label} permissions`}
+                  >
+                    <IconAdjustmentsHorizontal size={15} stroke={1.5} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p className="text-xs">Manage permissions</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+          <LoadingSwitch
+            checked={enabled}
+            onCheckedChange={onToggle}
+            loading={loading}
+            ariaLabel={`${enabled ? "Revoke" : "Grant"} ${connector.label} access`}
+          />
+        </div>
+      </div>
+      {!isLast ? <div className="mx-5 border-b border-border/50" /> : null}
+    </>
+  );
+}
+
+export function ConnectorCard(props: ConnectorCardProps) {
+  if (props.variant === "catalog") {
+    return <CatalogConnectorCard {...props} />;
+  }
+  if (props.variant === "connection") {
+    return <ConnectionConnectorCard {...props} />;
+  }
+  if (props.variant === "onboarding") {
+    return <OnboardingConnectorCard {...props} />;
+  }
+  if (props.variant === "action") {
+    return <ActionConnectorCard {...props} />;
+  }
+  return <PermissionConnectorCard {...props} />;
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/launch-connector-connect.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/launch-connector-connect.ts
@@ -4,15 +4,10 @@ import type {
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 
-import {
-  getConnectorStatusConnectLaunchMode,
-  getOnlyAvailableStatusBrowserAuthMethodDetail,
-  getOnlyAvailableStatusNoAuthMethod,
-} from "../../../../signals/zero-page/settings/connectors.ts";
+import { getConnectorStatusDirectConnectMethod } from "../../../../signals/zero-page/settings/connectors.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 
-interface LaunchConnectorConnectOptions {
-  readonly connector: PublicConnectorCatalogStatusItem;
+export interface ConnectorConnectHandlers {
   readonly openModal: () => void;
   readonly connectBrowserAuth: (
     authMethod: PublicConnectorCatalogAuthMethodDetail,
@@ -22,31 +17,28 @@ interface LaunchConnectorConnectOptions {
   ) => Promise<unknown>;
 }
 
+interface LaunchConnectorConnectOptions extends ConnectorConnectHandlers {
+  readonly connector: PublicConnectorCatalogStatusItem;
+}
+
 export function launchConnectorConnect({
   connector,
   openModal,
   connectBrowserAuth,
   connectNoAuth,
 }: LaunchConnectorConnectOptions): void {
-  const launchMode = getConnectorStatusConnectLaunchMode(connector);
-  if (launchMode === "modal") {
+  const directConnectMethod = getConnectorStatusDirectConnectMethod(connector);
+  if (!directConnectMethod) {
     openModal();
     return;
   }
-  if (launchMode === "browser-auth") {
-    const authMethod = getOnlyAvailableStatusBrowserAuthMethodDetail(connector);
-    if (!authMethod) {
-      openModal();
-      return;
-    }
-    detach(connectBrowserAuth(authMethod), Reason.DomCallback);
+  if (directConnectMethod.kind === "browser-auth") {
+    detach(
+      connectBrowserAuth(directConnectMethod.authMethod),
+      Reason.DomCallback,
+    );
     return;
   }
 
-  const authMethod = getOnlyAvailableStatusNoAuthMethod(connector);
-  if (!authMethod) {
-    openModal();
-    return;
-  }
-  detach(connectNoAuth(authMethod), Reason.DomCallback);
+  detach(connectNoAuth(directConnectMethod.authMethod), Reason.DomCallback);
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -150,12 +150,18 @@ import {
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { ConnectorCard } from "./components/settings/connector-card.tsx";
+import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   allConnectorCatalogItems$,
+  connectConnectorNoAuth$,
+  connectConnectorOAuthAuthCode$,
+  connectFlowConnectorRef$,
   matchesConnectorSearch,
   justConnectedRefs$,
   pollingOAuthAuthCodeConnectorRef$,
+  pollingOAuthDeviceAuthConnectorRef$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -5245,15 +5251,17 @@ function ConnectorTriggerIcons({
 function AddConnectorsDialog({
   signals,
   unconnected,
-  pollingConnectorRef,
+  busyConnectorRef,
+  connectHandlers,
   onClose,
-  onSelect,
 }: {
   signals: ComposerConnectorSignals;
   unconnected: PublicConnectorCatalogStatusItem[];
-  pollingConnectorRef: ConnectorRef | null;
+  busyConnectorRef: ConnectorRef | null;
+  connectHandlers: (
+    connector: PublicConnectorCatalogStatusItem,
+  ) => ConnectorConnectHandlers;
   onClose: () => void;
-  onSelect: (connectorRef: ConnectorRef) => void;
 }) {
   const search = useGet(signals.addDialogSearch$);
   const setSearch = useSet(signals.setAddDialogSearch$);
@@ -5269,7 +5277,7 @@ function AddConnectorsDialog({
       }}
     >
       <DialogContent
-        className="max-w-2xl flex flex-col max-h-[80vh]"
+        className="zero-app max-w-2xl flex max-h-[80vh] flex-col"
         aria-describedby={undefined}
       >
         <DialogHeader className="shrink-0">
@@ -5292,42 +5300,13 @@ function AddConnectorsDialog({
           <div className="grid grid-cols-2 gap-3">
             {filtered.map((item) => {
               return (
-                <button
-                  type="button"
+                <ConnectorCard
                   key={item.connectorRef}
-                  onClick={() => {
-                    return onSelect(item.connectorRef);
-                  }}
-                  disabled={pollingConnectorRef === item.connectorRef}
-                  aria-label={`Connect ${item.label}`}
-                  className="rounded-lg bg-card overflow-hidden transition-colors hover:bg-muted/30 cursor-pointer text-left w-full"
-                  style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-                >
-                  <div className="flex items-center gap-2.5 px-4 pt-4 pb-1">
-                    <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-                      <ConnectorIcon icon={item.icon} size={20} />
-                    </span>
-                    <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
-                      {item.label}
-                    </span>
-                    {pollingConnectorRef === item.connectorRef ? (
-                      <IconLoader2
-                        size={16}
-                        stroke={1.5}
-                        className="shrink-0 text-muted-foreground animate-spin"
-                      />
-                    ) : (
-                      <span className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
-                        <IconPlus size={14} stroke={1.5} />
-                      </span>
-                    )}
-                  </div>
-                  <div className="px-4 pb-4 pt-1">
-                    <div className="text-xs text-muted-foreground line-clamp-2">
-                      {item.description}
-                    </div>
-                  </div>
-                </button>
+                  variant="catalog"
+                  connector={item}
+                  busy={busyConnectorRef === item.connectorRef}
+                  connect={connectHandlers(item)}
+                />
               );
             })}
           </div>
@@ -6690,7 +6669,13 @@ export function useZeroChatComposer({
   const setSelectedConnectorRef = useSet(
     composerConnectors.setSelectedConnectorRef$,
   );
-  const pollingConnectorRef = useGet(pollingOAuthAuthCodeConnectorRef$);
+  const pollingAuthCodeRef = useGet(pollingOAuthAuthCodeConnectorRef$);
+  const pollingDeviceAuthRef = useGet(pollingOAuthDeviceAuthConnectorRef$);
+  const connectFlowRef = useGet(connectFlowConnectorRef$);
+  const busyConnectorRef =
+    connectFlowRef ?? pollingAuthCodeRef ?? pollingDeviceAuthRef;
+  const connectBrowserAuth = useSet(connectConnectorOAuthAuthCode$);
+  const connectNoAuth = useSet(connectConnectorNoAuth$);
   const authorizeFn = useSet(composerConnectors.authorizeConnector$);
   const deauthorizeFn = useSet(composerConnectors.deauthorizeConnector$);
   const optimisticConnected = useGet(justConnectedRefs$);
@@ -6764,6 +6749,71 @@ export function useZeroChatComposer({
       id: `connector-connected-${connectorRef}`,
     });
     return true;
+  };
+
+  const completeConnectorAddition = async (
+    connectorRef: ConnectorRef,
+  ): Promise<void> => {
+    if (!authorizedSet.has(connectorRef)) {
+      const authorized = await handleConnectSuccess(connectorRef);
+      if (!authorized) {
+        setPendingConnectorRef(null);
+        return;
+      }
+    }
+    setPendingConnectorRef(null);
+    setShowAddDialog(false);
+  };
+
+  const connectorConnectHandlers = (
+    connector: PublicConnectorCatalogStatusItem,
+  ): ConnectorConnectHandlers => {
+    const connectorRef = connector.connectorRef;
+    return {
+      openModal: () => {
+        setPendingConnectorRef(connectorRef);
+        setSelectedConnectorRef(connectorRef);
+      },
+      connectBrowserAuth: async (authMethod) => {
+        setPendingConnectorRef(connectorRef);
+        const connected = await connectBrowserAuth(
+          connectorRef,
+          authMethod,
+          {
+            connectorLabel: connector.label,
+            connectorIcon: connector.icon,
+            agentId: nullToUndefined(agentRecordId),
+          },
+          pageSignal,
+        );
+        if (connected) {
+          await completeConnectorAddition(connectorRef);
+        } else {
+          setPendingConnectorRef(null);
+        }
+        return connected;
+      },
+      connectNoAuth: async (authMethod) => {
+        setPendingConnectorRef(connectorRef);
+        const connected = await connectNoAuth(
+          {
+            connectorRef,
+            authMethod,
+            options: {
+              connectorLabel: connector.label,
+              agentId: nullToUndefined(agentRecordId),
+            },
+          },
+          pageSignal,
+        );
+        if (connected) {
+          await completeConnectorAddition(connectorRef);
+        } else {
+          setPendingConnectorRef(null);
+        }
+        return connected;
+      },
+    };
   };
 
   const handleToggle = async (connectorRef: ConnectorRef, checked: boolean) => {
@@ -7032,15 +7082,9 @@ export function useZeroChatComposer({
           }}
           onSuccess={async () => {
             const connectorRef = pendingConnectorRef ?? selectedConnectorRef;
-            if (connectorRef && !authorizedSet.has(connectorRef)) {
-              const authorized = await handleConnectSuccess(connectorRef);
-              if (!authorized) {
-                setPendingConnectorRef(null);
-                return;
-              }
+            if (connectorRef) {
+              await completeConnectorAddition(connectorRef);
             }
-            setPendingConnectorRef(null);
-            setShowAddDialog(false);
           }}
         />
       )}
@@ -7048,14 +7092,11 @@ export function useZeroChatComposer({
         <AddConnectorsDialog
           signals={composerConnectors}
           unconnected={unconnectedConnectors}
-          pollingConnectorRef={pollingConnectorRef}
+          busyConnectorRef={busyConnectorRef}
+          connectHandlers={connectorConnectHandlers}
           onClose={() => {
             setPendingConnectorRef(null);
             return setShowAddDialog(false);
-          }}
-          onSelect={(connectorRef) => {
-            setPendingConnectorRef(connectorRef);
-            setSelectedConnectorRef(connectorRef);
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -156,7 +156,6 @@ import {
   type ConnectorSignals,
   type CustomConnectorSignals,
 } from "../../signals/chat-page/connector-action-block.ts";
-import { connectorCurrentConnectionStatus } from "../../signals/zero-page/settings/connectors.ts";
 import {
   completedWorkExpandedKeys$,
   toggleCompletedWorkExpanded$,
@@ -185,6 +184,7 @@ import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { ArtifactThumbnailImage } from "./zero-artifact-thumbnail.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { ConnectorCard } from "./components/settings/connector-card.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -4968,46 +4968,18 @@ function ConnectorActionCard({ signals }: { signals: ConnectorSignals }) {
   if (!available || !catalogItem) {
     return null;
   }
-  const reconnectRequired =
-    connectorCurrentConnectionStatus(catalogItem) === "reconnect-required";
-  const actionLabel = complete
-    ? "Authorized"
-    : reconnectRequired
-      ? "Reconnect"
-      : connected
-        ? "Authorize"
-        : "Connect";
 
   return (
-    <div
-      data-testid="connector-action-card"
-      className="flex min-h-[88px] w-full flex-col gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm sm:flex-row sm:items-center sm:justify-between"
-    >
-      <div className="flex min-w-0 items-center gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <ConnectorIcon icon={catalogItem.icon} size={22} />
-        </div>
-        <div className="min-w-0">
-          <div className="truncate text-[0.9375rem] font-medium text-foreground">
-            {catalogItem.label}
-          </div>
-          <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
-            {catalogItem.description}
-          </div>
-        </div>
-      </div>
-      <button
-        type="button"
-        disabled={complete || loading}
-        onClick={() => {
-          detach(activate(pageSignal), Reason.DomCallback);
-        }}
-        className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
-      >
-        {loading && <IconLoader2 size={15} className="animate-spin" />}
-        {actionLabel}
-      </button>
-    </div>
+    <ConnectorCard
+      variant="action"
+      connector={catalogItem}
+      connected={connected}
+      complete={complete}
+      busy={loading}
+      onActivate={() => {
+        detach(activate(pageSignal), Reason.DomCallback);
+      }}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -11,8 +11,6 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconSearch,
   IconPlus,
-  IconLoader2,
-  IconDotsVertical,
   IconFilter,
   IconChevronDown,
   IconCheck,
@@ -30,7 +28,6 @@ import { connectorCatalogStatus$ } from "../../signals/external/connectors.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agents$ } from "../../signals/agent.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
-import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorCatalogItems$,
   connectConnectorOAuthAuthCode$,
@@ -49,11 +46,8 @@ import {
   justConnectedRefs$,
   scopeReviewConnectorRef$,
   setScopeReviewConnectorRef$,
-  isStandaloneMode,
   getAvailableStatusAuthCodeAuthMethod,
   getConnectorStatusAuthMethod,
-  connectorCurrentConnectionStatus,
-  connectorExpiryCountdownText,
   type ConnectorsConnectionFilter,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
@@ -67,7 +61,8 @@ import {
 } from "../../signals/zero-page/settings/connector-categories.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
-import { launchConnectorConnect } from "./components/settings/launch-connector-connect.ts";
+import { ConnectorCard } from "./components/settings/connector-card.tsx";
+import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { ConnectorAccessManagementDialog } from "./components/settings/connector-access-management-dialog.tsx";
 import {
@@ -77,7 +72,6 @@ import {
   setManagedConnectorAccessRef$,
 } from "../../signals/zero-page/settings/connector-access-management.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -599,217 +593,6 @@ function ConnectorAccessButton({
   );
 }
 
-function GlobalConnectorCard({
-  connector,
-  isConnected,
-  isPolling,
-  onConnect,
-  onDisconnect,
-  onManageAccess,
-  onReviewScopes,
-  isDisconnecting,
-  showManageAccess,
-}: {
-  connector: PublicConnectorCatalogStatusItem;
-  isConnected: boolean;
-  isPolling: boolean;
-  onConnect: () => void;
-  onDisconnect: () => void;
-  onManageAccess: () => void;
-  onReviewScopes?: () => void;
-  isDisconnecting: boolean;
-  showManageAccess: boolean;
-}) {
-  const connectionStatus = connectorCurrentConnectionStatus(connector);
-  const status = (() => {
-    if (isPolling) {
-      const standaloneHint = isStandaloneMode()
-        ? " Switch back here after completing sign-in."
-        : "";
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
-          {`Connecting…${standaloneHint}`}
-        </span>
-      );
-    }
-    if (isConnected && connectionStatus === "reconnect-required") {
-      return (
-        <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
-          <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
-          <span className="text-amber-600 dark:text-amber-400">
-            Connection expired
-          </span>
-        </span>
-      );
-    }
-    if (isConnected && connectionStatus === "scope-mismatch") {
-      return (
-        <span className="flex min-w-0 items-center gap-2 text-[11px]">
-          <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
-          <span className="min-w-0 truncate text-amber-600 dark:text-amber-400">
-            Update permissions
-          </span>
-        </span>
-      );
-    }
-    if (isConnected) {
-      const expiryText = connectorExpiryCountdownText(connector);
-      const connectedText =
-        expiryText ??
-        (connector.connection?.externalUsername
-          ? `@${connector.connection.externalUsername}`
-          : "Connected");
-      return (
-        <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-          <span className="truncate">{connectedText}</span>
-        </span>
-      );
-    }
-    return (
-      <button
-        type="button"
-        onClick={onConnect}
-        className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
-      >
-        Connect
-      </button>
-    );
-  })();
-
-  return (
-    <div className="zero-card flex flex-col">
-      <div className="flex h-14 items-center gap-2.5 px-5">
-        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ConnectorIcon icon={connector.icon} size={20} />
-        </span>
-        <span
-          data-testid="connector-card-label"
-          className="min-w-0 flex-1 text-sm font-medium text-foreground truncate"
-        >
-          {connector.label}
-        </span>
-      </div>
-      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
-        <div className="flex shrink-0 items-center gap-2 overflow-hidden">
-          {status}
-        </div>
-        {isConnected && (
-          <div className="flex min-w-0 flex-1 items-center justify-end gap-0">
-            {showManageAccess && (
-              <ConnectorAccessButton
-                connectorRef={connector.connectorRef}
-                connectorLabel={connector.label}
-                onClick={onManageAccess}
-              />
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                  aria-label="More options"
-                >
-                  <IconDotsVertical size={14} stroke={1.5} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-44">
-                {connectionStatus === "reconnect-required" ? (
-                  <DropdownMenuModalItem onModalSelect={onConnect}>
-                    Reconnect
-                  </DropdownMenuModalItem>
-                ) : null}
-                {connectionStatus === "scope-mismatch" && onReviewScopes ? (
-                  <DropdownMenuModalItem onModalSelect={onReviewScopes}>
-                    Review permissions
-                  </DropdownMenuModalItem>
-                ) : null}
-                <DropdownMenuItem
-                  onClick={onDisconnect}
-                  disabled={isDisconnecting}
-                >
-                  Disconnect
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function AvailableConnectorCard({
-  connector,
-  isPolling,
-  onConnect,
-}: {
-  connector: PublicConnectorCatalogStatusItem;
-  isPolling: boolean;
-  onConnect: () => void;
-}) {
-  const handleConnect = () => {
-    if (isPolling) {
-      return;
-    }
-    onConnect();
-  };
-
-  return (
-    <div
-      role="button"
-      tabIndex={isPolling ? -1 : 0}
-      aria-label={`Connect ${connector.label}`}
-      aria-disabled={isPolling}
-      className={`zero-card overflow-hidden ${isPolling ? "cursor-default" : "cursor-pointer"}`}
-      onClick={handleConnect}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleConnect();
-        }
-      }}
-    >
-      <div className="flex items-center gap-2.5 px-5 pt-4 pb-1">
-        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ConnectorIcon icon={connector.icon} size={20} />
-        </span>
-        <span
-          data-testid="connector-card-label"
-          className="min-w-0 flex-1 text-sm font-medium text-foreground truncate"
-        >
-          {connector.label}
-        </span>
-        {isPolling ? (
-          <span
-            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground"
-            aria-hidden="true"
-          >
-            <IconLoader2 size={16} stroke={1.5} className="animate-spin" />
-          </span>
-        ) : (
-          <span
-            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md border border-border/60 text-muted-foreground"
-            aria-hidden="true"
-          >
-            <IconPlus size={14} stroke={1.5} />
-          </span>
-        )}
-      </div>
-      <div className="px-5 pb-4 pt-1">
-        <div
-          data-testid="connector-help-text"
-          className="text-xs text-muted-foreground line-clamp-2"
-        >
-          {connector.description}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function renderBuiltinList({
   loadingState,
   grouped,
@@ -967,26 +750,21 @@ export function ZeroConnectorsPage() {
   );
   const disconnecting = disconnectLoadable.state === "loading";
 
-  const connectHandler = (connectorRef: ConnectorRef) => {
-    const ct = filteredConnectors.find((c) => {
-      return c.connectorRef === connectorRef;
-    });
-    if (!ct) {
-      return;
-    }
-    launchConnectorConnect({
-      connector: ct,
+  const connectHandlers = (
+    connector: PublicConnectorCatalogStatusItem,
+  ): ConnectorConnectHandlers => {
+    return {
       openModal: () => {
-        setSelected(connectorRef);
+        setSelected(connector.connectorRef);
       },
       connectBrowserAuth: (authMethod) => {
         return connect(
-          connectorRef,
+          connector.connectorRef,
           authMethod,
           {
             authorizeVisibleAgents: true,
-            connectorLabel: ct.label,
-            connectorIcon: ct.icon,
+            connectorLabel: connector.label,
+            connectorIcon: connector.icon,
           },
           signal,
         );
@@ -994,17 +772,17 @@ export function ZeroConnectorsPage() {
       connectNoAuth: (authMethod) => {
         return connectNoAuth(
           {
-            connectorRef,
+            connectorRef: connector.connectorRef,
             authMethod,
             options: {
               authorizeVisibleAgents: true,
-              connectorLabel: ct.label,
+              connectorLabel: connector.label,
             },
           },
           signal,
         );
       },
-    });
+    };
   };
 
   const disconnectHandler = async (
@@ -1025,36 +803,39 @@ export function ZeroConnectorsPage() {
       connectFlowRef === c.connectorRef;
     if (!isConnected) {
       return (
-        <AvailableConnectorCard
+        <ConnectorCard
           key={c.connectorRef}
+          variant="catalog"
           connector={c}
-          isPolling={isPolling}
-          onConnect={() => {
-            return connectHandler(c.connectorRef);
-          }}
+          busy={isPolling}
+          connect={connectHandlers(c)}
         />
       );
     }
     return (
-      <GlobalConnectorCard
+      <ConnectorCard
         key={c.connectorRef}
+        variant="connection"
         connector={c}
-        isConnected={isConnected}
-        isPolling={isPolling}
-        isDisconnecting={disconnecting}
-        showManageAccess
-        onConnect={() => {
-          return connectHandler(c.connectorRef);
-        }}
+        connected={isConnected}
+        busy={isPolling}
+        disconnecting={disconnecting}
+        connect={connectHandlers(c)}
         onDisconnect={() => {
           detach(
             disconnectHandler(c.connectorRef, c.label),
             Reason.DomCallback,
           );
         }}
-        onManageAccess={() => {
-          setManagedConnectorRef(c.connectorRef);
-        }}
+        manageAccess={
+          <ConnectorAccessButton
+            connectorRef={c.connectorRef}
+            connectorLabel={c.label}
+            onClick={() => {
+              setManagedConnectorRef(c.connectorRef);
+            }}
+          />
+        }
         onReviewScopes={() => {
           return setScopeReviewConnectorRef(c.connectorRef);
         }}


### PR DESCRIPTION
## Summary

- introduce a shared `ConnectorCard` with catalog, connected, onboarding, chat-action, and permission variants across all five connector entry points
- centralize direct-connect resolution so single OAuth, OpenID, and no-auth connectors launch immediately while manual or multi-method connectors retain the modal fallback
- preserve composer agent authorization and post-connect continuation, and unify reconnect, disconnect, status, and busy behavior
- add page-level regression coverage for direct composer OAuth, modal fallback, reconnect, and disconnect

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx --maxWorkers=1 --silent=passed-only`
- targeted onboarding, chat action-card, connectors-page, and team-navigation coverage: 120 relevant tests covered; 117 passed in the grouped run and the three timeout-only cases passed individually with one worker
- targeted reconnect and disconnect cases passed with one worker

Closes #22937