### PR TITLE
refactor(api): replace credit availability sql with typed drizzle queries

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -1,22 +1,20 @@
 import { randomUUID } from "node:crypto";
 
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
-import { z } from "zod";
+import { and, eq, gt, lte, sql, sum } from "drizzle-orm";
 
-import { executeRawRows, pgInt8ToBigIntSchema } from "../../lib/db-raw-rows";
+import {
+  nullableDriverValueDecoder,
+  pgInt8ToBigIntDecoder,
+} from "../../lib/db-structured-result";
 import { writeDb$ } from "../external/db";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
-
-const creditCheckRowSchema = z.object({
-  credits: pgInt8ToBigIntSchema.nullable(),
-  unsettled_expired: pgInt8ToBigIntSchema.nullable(),
-  unit_price: pgInt8ToBigIntSchema.nullable(),
-  unit_size: pgInt8ToBigIntSchema.nullable(),
-});
 
 export interface ManagedUsageErrorResponse {
   readonly status: 402 | 503;
@@ -93,40 +91,50 @@ export const checkManagedCredits$ = command(
     signal: AbortSignal,
   ): Promise<ManagedUsageErrorResponse | null> => {
     const writeDb = set(writeDb$);
-    const rows = await executeRawRows(
-      writeDb,
-      sql`
-        WITH pricing AS (
-          SELECT unit_price, unit_size FROM usage_pricing
-          WHERE kind = ${args.resource.kind}
-            AND provider = ${args.resource.provider}
-            AND category = ${args.resource.category}
-          LIMIT 1
+    const expired = writeDb.$with("expired").as(
+      writeDb
+        .select({
+          total: sql`COALESCE(${sum(creditExpiresRecord.remaining)}, 0)::bigint`
+            .mapWith(pgInt8ToBigIntDecoder)
+            .as("total"),
+        })
+        .from(creditExpiresRecord)
+        .where(
+          and(
+            eq(creditExpiresRecord.orgId, args.orgId),
+            lte(creditExpiresRecord.expiresAt, sql`now()`),
+            gt(creditExpiresRecord.remaining, sql`0`),
+          ),
         ),
-        org AS (
-          SELECT credits FROM org_metadata
-          WHERE org_id = ${args.orgId}
-          LIMIT 1
-        ),
-        expired AS (
-          SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-          FROM credit_expires_record
-          WHERE org_id = ${args.orgId}
-            AND expires_at <= now()
-            AND remaining > 0
-        )
-        SELECT
-          (SELECT credits FROM org) AS credits,
-          (SELECT total FROM expired) AS unsettled_expired,
-          (SELECT unit_price FROM pricing) AS unit_price,
-          (SELECT unit_size FROM pricing) AS unit_size
-      `,
-      creditCheckRowSchema,
     );
+    const rows = await writeDb
+      .with(expired)
+      .select({
+        credits: sql`${orgMetadata.credits}`.mapWith(
+          nullableDriverValueDecoder(pgInt8ToBigIntDecoder),
+        ),
+        unsettledExpired: expired.total,
+        unitPrice: sql`${usagePricing.unitPrice}`.mapWith(
+          nullableDriverValueDecoder(pgInt8ToBigIntDecoder),
+        ),
+        unitSize: sql`${usagePricing.unitSize}`.mapWith(
+          nullableDriverValueDecoder(pgInt8ToBigIntDecoder),
+        ),
+      })
+      .from(expired)
+      .leftJoin(orgMetadata, eq(orgMetadata.orgId, args.orgId))
+      .leftJoin(
+        usagePricing,
+        and(
+          eq(usagePricing.kind, args.resource.kind),
+          eq(usagePricing.provider, args.resource.provider),
+          eq(usagePricing.category, args.resource.category),
+        ),
+      );
     signal.throwIfAborted();
 
     const row = rows[0];
-    if (row?.unit_price === null || row?.unit_size === null) {
+    if (row?.unitPrice === null || row?.unitSize === null) {
       return pricingNotConfigured(args.label);
     }
 
@@ -135,14 +143,13 @@ export const checkManagedCredits$ = command(
     }
 
     const credits = row.credits;
-    const unsettledExpired = row.unsettled_expired ?? 0n;
     const quantity = args.resource.quantity ?? 1;
     const requiredCredits = estimatedCredits(
-      row.unit_price,
-      row.unit_size,
+      row.unitPrice,
+      row.unitSize,
       quantity,
     );
-    const spendableCredits = credits - unsettledExpired;
+    const spendableCredits = credits - row.unsettledExpired;
     if (spendableCredits >= requiredCredits) {
       return null;
     }

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -1,11 +1,12 @@
-import { sql } from "drizzle-orm";
 import { isLimitedFree1RestrictedRunModel } from "@vm0/api-contracts/contracts/model-providers";
-import { z } from "zod";
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { and, eq, gt, lte, sql, sum } from "drizzle-orm";
 
 import {
-  executeRawRows,
-  pgInt8ToSafeIntegerSchema,
-} from "../../lib/db-raw-rows";
+  nullableDriverValueDecoder,
+  pgInt8ToSafeIntegerDecoder,
+} from "../../lib/db-structured-result";
 import { insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
 import {
@@ -14,12 +15,7 @@ import {
 } from "./org-plan-entitlement-read.service";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 
-type CreditDb = Pick<Db, "execute" | "select">;
-
-const creditCheckRowSchema = z.object({
-  credits: pgInt8ToSafeIntegerSchema.nullable(),
-  unsettled_expired: pgInt8ToSafeIntegerSchema.nullable(),
-});
+type CreditDb = Pick<Db, "$with" | "select" | "with">;
 
 interface OrgCreditAvailability {
   readonly status: OrgPlanCapabilities["status"];
@@ -37,27 +33,32 @@ export async function resolveOrgCreditAvailability(params: {
   readonly db: CreditDb;
   readonly orgId: string;
 }): Promise<OrgCreditAvailability | null> {
-  const rows = await executeRawRows(
-    params.db,
-    sql`
-      WITH org AS (
-        SELECT credits FROM org_metadata
-        WHERE org_id = ${params.orgId}
-        LIMIT 1
+  const expired = params.db.$with("expired").as(
+    params.db
+      .select({
+        total: sql`COALESCE(${sum(creditExpiresRecord.remaining)}, 0)::bigint`
+          .mapWith(pgInt8ToSafeIntegerDecoder)
+          .as("total"),
+      })
+      .from(creditExpiresRecord)
+      .where(
+        and(
+          eq(creditExpiresRecord.orgId, params.orgId),
+          lte(creditExpiresRecord.expiresAt, sql`now()`),
+          gt(creditExpiresRecord.remaining, sql`0`),
+        ),
       ),
-      expired AS (
-        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-        FROM credit_expires_record
-        WHERE org_id = ${params.orgId}
-          AND expires_at <= now()
-          AND remaining > 0
-      )
-      SELECT
-        (SELECT credits FROM org) AS credits,
-        (SELECT total FROM expired) AS unsettled_expired
-    `,
-    creditCheckRowSchema,
   );
+  const rows = await params.db
+    .with(expired)
+    .select({
+      credits: sql`${orgMetadata.credits}`.mapWith(
+        nullableDriverValueDecoder(pgInt8ToSafeIntegerDecoder),
+      ),
+      unsettledExpired: expired.total,
+    })
+    .from(expired)
+    .leftJoin(orgMetadata, eq(orgMetadata.orgId, params.orgId));
 
   const row = rows[0];
   if (!row || row.credits === null) {
@@ -65,8 +66,7 @@ export async function resolveOrgCreditAvailability(params: {
   }
 
   const credits = row.credits;
-  const unsettledExpired = row.unsettled_expired ?? 0;
-  const spendableCredits = credits - unsettledExpired;
+  const spendableCredits = credits - row.unsettledExpired;
   const capabilities = await loadOrgPlanCapabilities(params.db, params.orgId);
   if (!capabilities) {
     return null;

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -238,6 +238,58 @@ const runnerLockingQuery = `
   \`
 `;
 
+const creditAvailabilityQuery = `
+  sql\`
+    WITH org AS (
+      SELECT credits
+      FROM org_metadata
+      WHERE org_id = \${threadId}
+      LIMIT 1
+    ),
+    expired AS (
+      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+      FROM credit_expires_record
+      WHERE org_id = \${threadId}
+        AND expires_at <= now()
+        AND remaining > 0
+    )
+    SELECT
+      (SELECT credits FROM org) AS credits,
+      (SELECT total FROM expired) AS unsettled_expired
+  \`
+`;
+
+const managedCreditAvailabilityQuery = `
+  sql\`
+    WITH pricing AS (
+      SELECT unit_price, unit_size
+      FROM usage_pricing
+      WHERE kind = \${threadId}
+        AND provider = \${threadId}
+        AND category = \${threadId}
+      LIMIT 1
+    ),
+    org AS (
+      SELECT credits
+      FROM org_metadata
+      WHERE org_id = \${threadId}
+      LIMIT 1
+    ),
+    expired AS (
+      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+      FROM credit_expires_record
+      WHERE org_id = \${threadId}
+        AND expires_at <= now()
+        AND remaining > 0
+    )
+    SELECT
+      (SELECT credits FROM org) AS credits,
+      (SELECT total FROM expired) AS unsettled_expired,
+      (SELECT unit_price FROM pricing) AS unit_price,
+      (SELECT unit_size FROM pricing) AS unit_size
+  \`
+`;
+
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
     {
@@ -842,6 +894,115 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
               WHERE \${eq(runs.threadId, threadId)}
               LIMIT 1
             ) AS visible
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql } from "drizzle-orm";
+        const dynamicOrgTable = sql.identifier("org_metadata");
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              ORDER BY credits
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT total FROM expired) AS unsettled_expired
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            pricing AS (
+              SELECT unit_price
+              FROM usage_pricing
+              WHERE kind = \${threadId}
+              LIMIT 1
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT unit_price FROM pricing) AS unit_price
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT org_id, SUM(remaining) AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+              GROUP BY org_id
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT total FROM expired) AS unsettled_expired
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+            )
+            SELECT
+              (SELECT credits FROM org WHERE credits > 0) AS credits,
+              (SELECT total FROM expired) AS unsettled_expired
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM \${dynamicOrgTable}
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT total FROM expired) AS unsettled_expired
           \`,
           rowSchema,
         );
@@ -1590,6 +1751,28 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         \`);
       `,
       errors: [{ messageId: "upsertQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          ${creditAvailabilityQuery},
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "scalarCteQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          ${managedCreditAvailabilityQuery},
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "scalarCteQueryBuilder" }],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -1006,6 +1006,26 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           \`,
           rowSchema,
         );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+            )
+            SELECT
+              (SELECT credits FROM org) AS value,
+              (SELECT total FROM expired) AS value
+          \`,
+          rowSchema,
+        );
       `,
     },
     {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -903,6 +903,7 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       code: `${rawRowsImport}${schemaPreamble}
         import { sql } from "drizzle-orm";
         const dynamicOrgTable = sql.identifier("org_metadata");
+        const groupedAggregate = sql\`GROUP BY org_id\`;
         await executeRawRows(
           db,
           sql\`
@@ -1023,6 +1024,27 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
             SELECT
               (SELECT credits FROM org) AS value,
               (SELECT total FROM expired) AS value
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expired AS (
+              SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+              \${groupedAggregate}
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT total FROM expired) AS unsettled_expired
           \`,
           rowSchema,
         );

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -1048,6 +1048,29 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           \`,
           rowSchema,
         );
+        await executeRawRows(
+          db,
+          sql\`
+            WITH org AS (
+              SELECT credits
+              FROM org_metadata
+              WHERE org_id = \${threadId}
+              LIMIT 1
+            ),
+            expanded AS (
+              SELECT generate_series(
+                1,
+                COALESCE(SUM(remaining), 0)::integer + 2
+              ) AS total
+              FROM credit_expires_record
+              WHERE org_id = \${threadId}
+            )
+            SELECT
+              (SELECT credits FROM org) AS credits,
+              (SELECT total FROM expanded) AS total
+          \`,
+          rowSchema,
+        );
       `,
     },
     {

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -110,6 +110,11 @@ interface ScalarCteBodyMatch {
   readonly guaranteedOneRow: boolean;
 }
 
+interface TopLevelCallMatch {
+  readonly body: string;
+  readonly end: number;
+}
+
 interface CompleteSqlStatement {
   readonly end: number;
   readonly hasTrailingSemicolon: boolean;
@@ -433,23 +438,93 @@ function completeSqlStatement(
   };
 }
 
-function hasUnqualifiedAggregate(selection: string): boolean {
-  const pattern = /\b(?:AVG|COUNT|MAX|MIN|SUM)\s*\(/giu;
-  for (const match of selection.matchAll(pattern)) {
-    let previous = (match.index ?? 0) - 1;
-    while (previous >= 0 && /\s/u.test(selection[previous] ?? "")) {
-      previous -= 1;
-    }
-    const previousCharacter = selection[previous];
-    if (
-      previousCharacter !== "." &&
-      previousCharacter !== '"' &&
-      previousCharacter !== "'"
-    ) {
-      return true;
-    }
+const SCALAR_AGGREGATE_FUNCTIONS = new Set([
+  "AVG",
+  "COUNT",
+  "MAX",
+  "MIN",
+  "SUM",
+]);
+const SCALAR_COALESCE_FUNCTIONS = new Set(["COALESCE"]);
+
+function topLevelCallMatch(
+  source: string,
+  names: ReadonlySet<string>,
+): TopLevelCallMatch | undefined {
+  const tokens = topLevelTokens(source);
+  const name = tokens?.[0];
+  const open = tokens?.[1];
+  const close = tokens?.[2];
+  if (
+    name?.kind !== "word" ||
+    !names.has(name.value) ||
+    open === undefined ||
+    close === undefined ||
+    !isPunctuation(open, "(") ||
+    !isPunctuation(close, ")") ||
+    source.slice(0, name.start).trim() !== "" ||
+    !onlyWhitespaceBetween(source, name, open) ||
+    source.slice(open.end, close.start).trim() === ""
+  ) {
+    return undefined;
   }
-  return false;
+  return {
+    body: source.slice(open.end, close.start),
+    end: close.end,
+  };
+}
+
+function isScalarSelectionSuffix(source: string): boolean {
+  return /^(?:\s*::\s*[A-Za-z_][A-Za-z0-9_$]*)*(?:\s+AS\s+[A-Za-z_][A-Za-z0-9_$]*)?\s*$/iu.test(
+    source,
+  );
+}
+
+function isCompleteScalarAggregateCall(source: string): boolean {
+  const aggregate = topLevelCallMatch(source, SCALAR_AGGREGATE_FUNCTIONS);
+  return aggregate !== undefined && source.slice(aggregate.end).trim() === "";
+}
+
+function isScalarCoalesceFallback(source: string): boolean {
+  const value = source.trim();
+  return (
+    /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/u.test(value) ||
+    /^(?:FALSE|NULL|TRUE)$/iu.test(value) ||
+    value === SQL_TEMPLATE_EXPRESSION_BOUNDARY
+  );
+}
+
+/**
+ * An ungrouped aggregate guarantees one row only while its complete target
+ * expression stays scalar. PostgreSQL target-list set-returning functions can
+ * otherwise expand the aggregate result to zero or multiple rows.
+ */
+function isGuaranteedOneRowAggregateSelection(selection: string): boolean {
+  const aggregate = topLevelCallMatch(selection, SCALAR_AGGREGATE_FUNCTIONS);
+  if (
+    aggregate !== undefined &&
+    isScalarSelectionSuffix(selection.slice(aggregate.end))
+  ) {
+    return true;
+  }
+
+  const coalesce = topLevelCallMatch(selection, SCALAR_COALESCE_FUNCTIONS);
+  if (
+    coalesce === undefined ||
+    !isScalarSelectionSuffix(selection.slice(coalesce.end))
+  ) {
+    return false;
+  }
+  const commas =
+    topLevelTokens(coalesce.body)?.filter((token) => {
+      return isPunctuation(token, ",");
+    }) ?? [];
+  const comma = commas.length === 1 ? commas[0] : undefined;
+  return (
+    comma !== undefined &&
+    isCompleteScalarAggregateCall(coalesce.body.slice(0, comma.start)) &&
+    isScalarCoalesceFallback(coalesce.body.slice(comma.end))
+  );
 }
 
 function scalarCteBodyMatch(
@@ -530,7 +605,7 @@ function scalarCteBodyMatch(
   }
 
   const selection = syntaxSource.slice(selectKeyword.end, fromKeyword.start);
-  const guaranteedOneRow = hasUnqualifiedAggregate(selection);
+  const guaranteedOneRow = isGuaranteedOneRowAggregateSelection(selection);
   if (!guaranteedOneRow && limitIndex === undefined) {
     return undefined;
   }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -2017,6 +2017,27 @@ export const preferDrizzleQueryBuilder = createRule({
       return (type.flags & (TypeFlags.Number | TypeFlags.NumberLiteral)) !== 0;
     }
 
+    function isBoundScalarParameterType(type: Type): boolean {
+      if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+        const constraint = checker.getBaseConstraintOfType(type);
+        return (
+          constraint !== undefined && isBoundScalarParameterType(constraint)
+        );
+      }
+      if (type.isUnion()) {
+        return type.types.every(isBoundScalarParameterType);
+      }
+      return (
+        (type.flags &
+          (TypeFlags.BigIntLike |
+            TypeFlags.BooleanLike |
+            TypeFlags.Null |
+            TypeFlags.NumberLike |
+            TypeFlags.StringLike)) !==
+        0
+      );
+    }
+
     function isDrizzleWrapperExpression(
       node: TSESTree.Expression | undefined,
     ): boolean {
@@ -2628,7 +2649,12 @@ export const preferDrizzleQueryBuilder = createRule({
           .map(quasiText)
           .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
         const syntaxSource = sqlCodeMask(source);
-        if (completeScalarCteProjectionMatch(syntaxSource)) {
+        if (
+          completeScalarCteProjectionMatch(syntaxSource) &&
+          query.quasi.expressions.every((expression) => {
+            return isBoundScalarParameterType(expressionType(expression).type);
+          })
+        ) {
           context.report({ node: query, messageId: "scalarCteQueryBuilder" });
           return;
         }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -636,6 +636,7 @@ function completeScalarCteProjectionMatch(syntaxSource: string): boolean {
   cursor += 1;
 
   const referencedCtes = new Set<string>();
+  const resultAliases = new Set<string>();
   let hasGuaranteedOneRowReference = false;
   previousToken = selectKeyword;
   while (cursor < tokens.length) {
@@ -653,7 +654,8 @@ function completeScalarCteProjectionMatch(syntaxSource: string): boolean {
       !isWord(asKeyword, "AS") ||
       !onlyWhitespaceBetween(syntaxSource, previousToken, open) ||
       !onlyWhitespaceBetween(syntaxSource, close, asKeyword) ||
-      !onlyWhitespaceBetween(syntaxSource, asKeyword, alias)
+      !onlyWhitespaceBetween(syntaxSource, asKeyword, alias) ||
+      resultAliases.has(alias.value)
     ) {
       return false;
     }
@@ -665,6 +667,7 @@ function completeScalarCteProjectionMatch(syntaxSource: string): boolean {
       return false;
     }
     referencedCtes.add(reference);
+    resultAliases.add(alias.value);
     hasGuaranteedOneRowReference ||= cte.guaranteedOneRow;
     cursor += 4;
 

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -106,6 +106,10 @@ interface SimpleUpsertMatch {
   readonly targetTableExpressionIndex: number | undefined;
 }
 
+interface ScalarCteBodyMatch {
+  readonly guaranteedOneRow: boolean;
+}
+
 interface CompleteSqlStatement {
   readonly end: number;
   readonly hasTrailingSemicolon: boolean;
@@ -138,6 +142,34 @@ const UNSUPPORTED_SCALAR_QUERY_KEYWORDS = new Set([
   ...UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS,
   "INTO",
   "OVER",
+]);
+
+const UNSUPPORTED_SCALAR_CTE_KEYWORDS = new Set([
+  "CROSS",
+  "DISTINCT",
+  "EXCEPT",
+  "FETCH",
+  "FOR",
+  "FULL",
+  "GROUP",
+  "HAVING",
+  "INNER",
+  "INTERSECT",
+  "INTO",
+  "JOIN",
+  "LATERAL",
+  "LEFT",
+  "OFFSET",
+  "ORDER",
+  "OUTER",
+  "OVER",
+  "QUALIFY",
+  "RECURSIVE",
+  "RIGHT",
+  "UNION",
+  "USING",
+  "WINDOW",
+  "WITH",
 ]);
 
 const UNSUPPORTED_PAGINATED_JOINED_SELECT_KEYWORDS = new Set([
@@ -399,6 +431,267 @@ function completeSqlStatement(
     hasTrailingSemicolon,
     tokens: statementTokens,
   };
+}
+
+function hasUnqualifiedAggregate(selection: string): boolean {
+  const pattern = /\b(?:AVG|COUNT|MAX|MIN|SUM)\s*\(/giu;
+  for (const match of selection.matchAll(pattern)) {
+    let previous = (match.index ?? 0) - 1;
+    while (previous >= 0 && /\s/u.test(selection[previous] ?? "")) {
+      previous -= 1;
+    }
+    const previousCharacter = selection[previous];
+    if (
+      previousCharacter !== "." &&
+      previousCharacter !== '"' &&
+      previousCharacter !== "'"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function scalarCteBodyMatch(
+  syntaxSource: string,
+): ScalarCteBodyMatch | undefined {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined || statement.hasTrailingSemicolon) {
+    return undefined;
+  }
+  const tokens = statement.tokens;
+  if (
+    !isWord(tokens[0], "SELECT") ||
+    tokens.some((token) => {
+      return (
+        token.kind === "word" &&
+        UNSUPPORTED_SCALAR_CTE_KEYWORDS.has(token.value)
+      );
+    }) ||
+    (syntaxSource.match(/\bSELECT\b/giu)?.length ?? 0) !== 1
+  ) {
+    return undefined;
+  }
+
+  const fromIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "FROM") ? [index] : [];
+  });
+  const whereIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "WHERE") ? [index] : [];
+  });
+  const limitIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "LIMIT") ? [index] : [];
+  });
+  const fromIndex = fromIndexes.length === 1 ? fromIndexes[0] : undefined;
+  const whereIndex = whereIndexes.length === 1 ? whereIndexes[0] : undefined;
+  const limitIndex = limitIndexes.length === 1 ? limitIndexes[0] : undefined;
+  const selectKeyword = tokens[0];
+  const fromKeyword = fromIndex === undefined ? undefined : tokens[fromIndex];
+  const sourceTable =
+    fromIndex === undefined ? undefined : tokens[fromIndex + 1];
+  const whereKeyword =
+    whereIndex === undefined ? undefined : tokens[whereIndex];
+  if (
+    selectKeyword === undefined ||
+    fromIndex === undefined ||
+    whereIndex === undefined ||
+    fromKeyword === undefined ||
+    sourceTable === undefined ||
+    whereKeyword === undefined ||
+    fromIndex <= 1 ||
+    whereIndex !== fromIndex + 2 ||
+    sourceTable.kind !== "word" ||
+    !onlyWhitespaceBetween(syntaxSource, fromKeyword, sourceTable) ||
+    !onlyWhitespaceBetween(syntaxSource, sourceTable, whereKeyword) ||
+    syntaxSource.slice(selectKeyword.end, fromKeyword.start).trim() === ""
+  ) {
+    return undefined;
+  }
+
+  let predicateEnd = statement.end;
+  if (limitIndex !== undefined) {
+    const limitKeyword = tokens[limitIndex];
+    const limitValue = tokens[limitIndex + 1];
+    if (
+      limitKeyword === undefined ||
+      limitValue?.kind !== "number" ||
+      limitValue.value !== "1" ||
+      limitIndex !== tokens.length - 2 ||
+      limitIndex <= whereIndex + 1 ||
+      !onlyWhitespaceBetween(syntaxSource, limitKeyword, limitValue) ||
+      syntaxSource.slice(limitValue.end, statement.end).trim() !== ""
+    ) {
+      return undefined;
+    }
+    predicateEnd = limitKeyword.start;
+  }
+  if (syntaxSource.slice(whereKeyword.end, predicateEnd).trim() === "") {
+    return undefined;
+  }
+
+  const selection = syntaxSource.slice(selectKeyword.end, fromKeyword.start);
+  const guaranteedOneRow = hasUnqualifiedAggregate(selection);
+  if (!guaranteedOneRow && limitIndex === undefined) {
+    return undefined;
+  }
+
+  return { guaranteedOneRow };
+}
+
+function scalarCteReference(syntaxSource: string): string | undefined {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined || statement.hasTrailingSemicolon) {
+    return undefined;
+  }
+  const tokens = statement.tokens;
+  const selectKeyword = tokens[0];
+  const selectedColumn = tokens[1];
+  const fromKeyword = tokens[2];
+  const sourceCte = tokens[3];
+  if (
+    tokens.length !== 4 ||
+    selectKeyword === undefined ||
+    selectedColumn?.kind !== "word" ||
+    fromKeyword === undefined ||
+    sourceCte?.kind !== "word" ||
+    !isWord(selectKeyword, "SELECT") ||
+    !isWord(fromKeyword, "FROM") ||
+    !onlyWhitespaceBetween(syntaxSource, selectKeyword, selectedColumn) ||
+    !onlyWhitespaceBetween(syntaxSource, selectedColumn, fromKeyword) ||
+    !onlyWhitespaceBetween(syntaxSource, fromKeyword, sourceCte) ||
+    syntaxSource.slice(sourceCte.end, statement.end).trim() !== ""
+  ) {
+    return undefined;
+  }
+  return sourceCte.value;
+}
+
+/**
+ * Recognizes a narrow CTE projection that can preserve scalar-subquery
+ * cardinality with one aggregate CTE as the FROM anchor and LIMIT 1 CTEs as
+ * left joins. Unsupported CTE clauses and outer expressions fail closed.
+ */
+function completeScalarCteProjectionMatch(syntaxSource: string): boolean {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined) {
+    return false;
+  }
+  const tokens = statement.tokens;
+  const withKeyword = tokens[0];
+  if (withKeyword === undefined || !isWord(withKeyword, "WITH")) {
+    return false;
+  }
+
+  const ctes = new Map<string, ScalarCteBodyMatch>();
+  let cursor = 1;
+  let previousToken = withKeyword;
+  while (cursor < tokens.length && !isWord(tokens[cursor], "SELECT")) {
+    const name = tokens[cursor];
+    const asKeyword = tokens[cursor + 1];
+    const open = tokens[cursor + 2];
+    const close = tokens[cursor + 3];
+    if (
+      name?.kind !== "word" ||
+      asKeyword === undefined ||
+      open === undefined ||
+      close === undefined ||
+      !isWord(asKeyword, "AS") ||
+      !isPunctuation(open, "(") ||
+      !isPunctuation(close, ")") ||
+      !onlyWhitespaceBetween(syntaxSource, previousToken, name) ||
+      !onlyWhitespaceBetween(syntaxSource, name, asKeyword) ||
+      !onlyWhitespaceBetween(syntaxSource, asKeyword, open) ||
+      ctes.has(name.value)
+    ) {
+      return false;
+    }
+    const body = scalarCteBodyMatch(syntaxSource.slice(open.end, close.start));
+    if (body === undefined) {
+      return false;
+    }
+    ctes.set(name.value, body);
+    cursor += 4;
+
+    const separator = tokens[cursor];
+    if (!isPunctuation(separator, ",")) {
+      previousToken = close;
+      break;
+    }
+    if (!onlyWhitespaceBetween(syntaxSource, close, separator)) {
+      return false;
+    }
+    previousToken = separator;
+    cursor += 1;
+  }
+
+  const selectKeyword = tokens[cursor];
+  if (
+    ctes.size < 2 ||
+    selectKeyword === undefined ||
+    !isWord(selectKeyword, "SELECT") ||
+    !onlyWhitespaceBetween(syntaxSource, previousToken, selectKeyword)
+  ) {
+    return false;
+  }
+  cursor += 1;
+
+  const referencedCtes = new Set<string>();
+  let hasGuaranteedOneRowReference = false;
+  previousToken = selectKeyword;
+  while (cursor < tokens.length) {
+    const open = tokens[cursor];
+    const close = tokens[cursor + 1];
+    const asKeyword = tokens[cursor + 2];
+    const alias = tokens[cursor + 3];
+    if (
+      open === undefined ||
+      close === undefined ||
+      asKeyword === undefined ||
+      alias?.kind !== "word" ||
+      !isPunctuation(open, "(") ||
+      !isPunctuation(close, ")") ||
+      !isWord(asKeyword, "AS") ||
+      !onlyWhitespaceBetween(syntaxSource, previousToken, open) ||
+      !onlyWhitespaceBetween(syntaxSource, close, asKeyword) ||
+      !onlyWhitespaceBetween(syntaxSource, asKeyword, alias)
+    ) {
+      return false;
+    }
+    const reference = scalarCteReference(
+      syntaxSource.slice(open.end, close.start),
+    );
+    const cte = reference === undefined ? undefined : ctes.get(reference);
+    if (reference === undefined || cte === undefined) {
+      return false;
+    }
+    referencedCtes.add(reference);
+    hasGuaranteedOneRowReference ||= cte.guaranteedOneRow;
+    cursor += 4;
+
+    const separator = tokens[cursor];
+    if (separator === undefined) {
+      if (syntaxSource.slice(alias.end, statement.end).trim() !== "") {
+        return false;
+      }
+      previousToken = alias;
+      break;
+    }
+    if (
+      !isPunctuation(separator, ",") ||
+      !onlyWhitespaceBetween(syntaxSource, alias, separator)
+    ) {
+      return false;
+    }
+    previousToken = separator;
+    cursor += 1;
+  }
+
+  return (
+    cursor === tokens.length &&
+    previousToken.kind === "word" &&
+    hasGuaranteedOneRowReference &&
+    referencedCtes.size === ctes.size
+  );
 }
 
 function isSimpleIdentifierList(
@@ -1589,7 +1882,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete schema-backed deletes, updates, upserts, selects, existence checks, locking selects, and scalar result queries",
+        "Prefer Drizzle query builders for complete schema-backed deletes, updates, upserts, selects, existence checks, locking selects, scalar CTE projections, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -1609,6 +1902,8 @@ export const preferDrizzleQueryBuilder = createRule({
         "Use a Drizzle update builder with .from(...) for this complete unnest-backed update.",
       lockingCteUpdateQueryBuilder:
         "Use Drizzle $with(...), select().for(...), and update().from(...) builders for this complete locking CTE update.",
+      scalarCteQueryBuilder:
+        "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -2330,6 +2625,10 @@ export const preferDrizzleQueryBuilder = createRule({
           .map(quasiText)
           .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
         const syntaxSource = sqlCodeMask(source);
+        if (completeScalarCteProjectionMatch(syntaxSource)) {
+          context.report({ node: query, messageId: "scalarCteQueryBuilder" });
+          return;
+        }
         const lockingMatch = simpleLockingSelectMatch(syntaxSource);
         if (lockingMatch !== undefined) {
           const sourceTableExpressionIndex =


### PR DESCRIPTION
## Summary

- replace the two complete raw credit-availability statements with schema-owned Drizzle CTEs, aggregates, predicates, and joins
- preserve the existing safe-number and bigint result-decoding contracts, including nullable outer-join columns
- preserve database-clock expiry semantics, the partial-index-compatible `remaining > 0` predicate, and one-statement snapshot behavior
- extend `api/prefer-drizzle-query-builder` to reject this builder-equivalent scalar CTE projection shape, with fail-closed positive and negative rule tests

## Equivalence and performance

- verified missing-organization, present-organization, missing-pricing, and present-pricing result equivalence against PostgreSQL
- verified both forms use the same primary/partial/unique indexes and produce the same shared-buffer hits (run admission: 6; managed usage: 9)
- over 20 alternating warm diagnostic samples, execution medians remained in the same sub-0.02 ms range:
  - run admission: raw 0.005 ms, Drizzle 0.005 ms
  - managed usage: raw 0.011 ms, Drizzle 0.007 ms
- on the same warm workspace, API type-aware ESLint took 24.97s with the matcher call locally disabled and 24.28s / 24.66s on the submitted implementation

These measurements are local diagnostics rather than production performance claims.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/zero-web-search.test.ts --maxWorkers=1 --silent=passed-only` (78 tests)
- `pnpm knip --workspace api`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test` (47 files, 789 tests)
- `pnpm check-types`
- PostgreSQL result-equivalence and `EXPLAIN (ANALYZE, BUFFERS)` diagnostics
- `git diff --check`

## Scope

No schema, migration, persisted-data, API, feature-switch, deployment-compatibility, or guidance change is included. The lint extension targets only complete scalar CTE projections whose one-row cardinality and builder equivalent can be established statically; unsupported SQL shapes continue to pass through without a suggestion.

Closes #22908
Parent: #22439
Blocks final audit: #22901
