### PR TITLE
test(nbd-cow): cover live foreign cleanup owner

### DIFF
--- a/crates/nbd-cow/src/bin/bench/devices/nbd.rs
+++ b/crates/nbd-cow/src/bin/bench/devices/nbd.rs
@@ -86,6 +86,44 @@ mod tests {
     }
 
     #[test]
+    fn nbd_cleanup_candidate_rejects_live_foreign_owner() {
+        struct ChildGuard(std::process::Child);
+
+        impl Drop for ChildGuard {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+
+        let mut child = ChildGuard(
+            std::process::Command::new("cat")
+                .stdin(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn live foreign owner"),
+        );
+        let pid = child.0.id();
+
+        assert_ne!(pid, std::process::id());
+        assert!(
+            child
+                .0
+                .try_wait()
+                .expect("check live foreign owner")
+                .is_none()
+        );
+        assert!(!nbd_cleanup_candidate_owner(pid));
+        assert!(!nbd_cleanup_candidate(NbdDeviceState { size: 1, pid }));
+        assert!(
+            child
+                .0
+                .try_wait()
+                .expect("recheck live foreign owner")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn nbd_cleanup_candidate_requires_nonzero_size_and_cleanup_owner() {
         assert!(!nbd_cleanup_candidate(NbdDeviceState {
             size: 0,


### PR DESCRIPTION
## Summary

- cover the live-foreign PID branch of the benchmark NBD cleanup ownership predicate
- keep a real helper process alive through a piped stdin lifecycle and verify liveness before and after the assertions
- terminate and reap the helper through a panic-safe test-local guard

## Scope

This changes only the inline tests in `crates/nbd-cow/src/bin/bench/devices/nbd.rs`. Production ownership logic, dependencies, APIs, schemas, persisted data, protocols, workflows, and deployment behavior are unchanged.

## Validation

- `cargo test -p nbd-cow --bin bench --features bench nbd_cleanup_candidate -- --nocapture`
- `cargo test -p nbd-cow --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo doc -p nbd-cow --all-features --no-deps`
- `git diff --check`
- pre-commit workspace Rust formatting, Clippy, documentation, file-size, generated-firewall, and commit-message checks

Closes #22910
