### PR TITLE
perf(guest-agent): reuse serialized event bodies

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -77,7 +77,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
         http.clone(),
         runtime.event_error_flag.to_string(),
         &runtime.run_id,
-    );
+    )?;
 
     let run_result = run_codex_app_server(
         masker,

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -8,6 +8,7 @@
 use crate::error::AgentError;
 use crate::events;
 use crate::http::HttpClient;
+use bytes::Bytes;
 use guest_common::{log_info, log_warn};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -25,7 +26,7 @@ const EVENT_DELIVERY_DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct PreparedEvent {
     sequence: u32,
-    event: serde_json::Value,
+    event: Bytes,
     conservative_bytes: usize,
     byte_budget: OwnedSemaphorePermit,
 }
@@ -34,7 +35,7 @@ pub(super) struct EventDeliverySender {
     tx: mpsc::Sender<PreparedEvent>,
     byte_budget: Arc<Semaphore>,
     pressure: Arc<DeliveryPressure>,
-    run_id: Arc<str>,
+    payload_envelope: Arc<events::EventPayloadEnvelope>,
 }
 
 impl EventDeliverySender {
@@ -43,10 +44,8 @@ impl EventDeliverySender {
         sequence: u32,
         event: serde_json::Value,
     ) -> Result<(), AgentError> {
-        let conservative_bytes = events::serialized_event_payload_size_for_run_id(
-            std::slice::from_ref(&event),
-            &self.run_id,
-        )?;
+        let event = Bytes::from(serde_json::to_vec(&event)?);
+        let conservative_bytes = self.payload_envelope.singleton_bytes(event.len());
         if conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES {
             return Err(AgentError::Execution(format!(
                 "CLI event delivery payload at sequence {sequence} is {conservative_bytes} bytes, exceeding the {EVENT_DELIVERY_MAX_REQUEST_BYTES}-byte request limit"
@@ -99,28 +98,32 @@ pub(super) struct EventDeliveryRuntime {
 }
 
 impl EventDeliveryRuntime {
-    pub(super) fn start(http: HttpClient, event_error_flag: String, run_id: &str) -> Self {
+    pub(super) fn start(
+        http: HttpClient,
+        event_error_flag: String,
+        run_id: &str,
+    ) -> Result<Self, AgentError> {
         let (tx, event_rx) = mpsc::channel(EVENT_DELIVERY_QUEUE_CAPACITY);
         let pressure = Arc::new(DeliveryPressure::default());
-        let run_id: Arc<str> = Arc::from(run_id);
+        let payload_envelope = Arc::new(events::EventPayloadEnvelope::new(run_id)?);
         let sender = EventDeliverySender {
             tx,
             byte_budget: Arc::new(Semaphore::new(EVENT_DELIVERY_MAX_BYTES)),
             pressure: Arc::clone(&pressure),
-            run_id: Arc::clone(&run_id),
+            payload_envelope: Arc::clone(&payload_envelope),
         };
         let worker = tokio::spawn(run_event_sender(
             event_rx,
             http,
             event_error_flag,
-            run_id,
+            payload_envelope,
             Arc::clone(&pressure),
         ));
-        Self {
+        Ok(Self {
             sender,
             worker,
             pressure,
-        }
+        })
     }
 
     pub(super) fn sender(&self) -> &EventDeliverySender {
@@ -277,7 +280,7 @@ async fn run_event_sender(
     mut event_rx: mpsc::Receiver<PreparedEvent>,
     http: HttpClient,
     event_error_flag: String,
-    run_id: Arc<str>,
+    payload_envelope: Arc<events::EventPayloadEnvelope>,
     pressure: Arc<DeliveryPressure>,
 ) -> Option<u32> {
     let mut acked_prefix = AckedEventPrefix::default();
@@ -299,18 +302,15 @@ async fn run_event_sender(
         let (batch, next_carried_event) = collect_batch(first_event, &mut event_rx, &pressure);
         let last_sequence = batch.last().map_or(first_sequence, |event| event.sequence);
         carried_event = next_carried_event;
-        let batch = EventBatch::new(batch, &run_id);
-        let event_count = batch.sequences.len();
-        let send_result =
-            events::post_event_with_error_flag(&http, &batch.payload, &event_error_flag).await;
-
         let EventBatch {
             sequences,
-            payload: _,
+            payload,
             conservative_bytes,
             byte_budgets,
-            ..
-        } = batch;
+        } = EventBatch::new(batch, &payload_envelope);
+        let event_count = sequences.len();
+        let send_result =
+            events::post_serialized_event_with_error_flag(&http, payload, &event_error_flag).await;
         drop(byte_budgets);
         pressure.release_bytes(conservative_bytes);
 
@@ -386,28 +386,28 @@ fn collect_batch(
 
 struct EventBatch {
     sequences: Vec<u32>,
-    payload: serde_json::Value,
+    payload: Bytes,
     conservative_bytes: usize,
     byte_budgets: Vec<OwnedSemaphorePermit>,
 }
 
 impl EventBatch {
-    fn new(events: Vec<PreparedEvent>, run_id: &str) -> Self {
+    fn new(events: Vec<PreparedEvent>, payload_envelope: &events::EventPayloadEnvelope) -> Self {
         let mut sequences = Vec::with_capacity(events.len());
-        let mut values = Vec::with_capacity(events.len());
+        let mut event_bytes = Vec::with_capacity(events.len());
         let mut conservative_bytes = 0usize;
         let mut byte_budgets = Vec::with_capacity(events.len());
 
         for event in events {
             sequences.push(event.sequence);
-            values.push(event.event);
+            event_bytes.push(event.event);
             conservative_bytes += event.conservative_bytes;
             byte_budgets.push(event.byte_budget);
         }
 
         Self {
             sequences,
-            payload: events::event_payload_for_run_id(values, run_id),
+            payload: payload_envelope.payload(&event_bytes),
             conservative_bytes,
             byte_budgets,
         }

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -44,8 +44,9 @@ impl EventDeliverySender {
         sequence: u32,
         event: serde_json::Value,
     ) -> Result<(), AgentError> {
-        let event = serde_json::to_vec(&event)?;
-        let event = Bytes::from(event.into_boxed_slice());
+        let serialized_event = serde_json::to_vec(&event)?;
+        drop(event);
+        let event = Bytes::from(serialized_event.into_boxed_slice());
         let conservative_bytes = self.payload_envelope.singleton_bytes(event.len());
         if conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES {
             return Err(AgentError::Execution(format!(

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -44,7 +44,8 @@ impl EventDeliverySender {
         sequence: u32,
         event: serde_json::Value,
     ) -> Result<(), AgentError> {
-        let event = Bytes::from(serde_json::to_vec(&event)?);
+        let event = serde_json::to_vec(&event)?;
+        let event = Bytes::from(event.into_boxed_slice());
         let conservative_bytes = self.payload_envelope.singleton_bytes(event.len());
         if conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES {
             return Err(AgentError::Execution(format!(

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -799,7 +799,7 @@ async fn execute_cli_inner(
         http.clone(),
         runtime.event_error_flag.to_string(),
         &runtime.run_id,
-    );
+    )?;
 
     let mut heartbeat_done = false;
     let mut cli_exit_at: Option<Instant> = None;

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -14,15 +14,17 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::session_metadata;
+use bytes::Bytes;
 use guest_common::{log_error, log_info};
 use guest_contracts::diagnostics::FailureReason;
-use serde::Serialize;
 use serde_json::{Map, Value, json};
-use std::io::Write;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
 const FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
+const EVENT_PAYLOAD_RUN_ID_PREFIX: &[u8] = b"{\"runId\":";
+const EVENT_PAYLOAD_EVENTS_PREFIX: &[u8] = b",\"events\":[";
+const EVENT_PAYLOAD_SUFFIX: &[u8] = b"]}";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CodexFailureDiagnostic {
@@ -98,35 +100,45 @@ pub(crate) fn event_payload_for_run_id(events: Vec<Value>, run_id: &str) -> Valu
     Value::Object(payload)
 }
 
-pub(crate) fn serialized_event_payload_size_for_run_id(
-    events: &[Value],
-    run_id: &str,
-) -> Result<usize, AgentError> {
-    let mut size = SerializedSize::default();
-    serde_json::to_writer(&mut size, &BorrowedEventPayload { run_id, events })?;
-    Ok(size.bytes)
+pub(crate) struct EventPayloadEnvelope {
+    prefix: Bytes,
 }
 
-#[derive(Serialize)]
-struct BorrowedEventPayload<'a> {
-    #[serde(rename = "runId")]
-    run_id: &'a str,
-    events: &'a [Value],
-}
-
-#[derive(Default)]
-struct SerializedSize {
-    bytes: usize,
-}
-
-impl Write for SerializedSize {
-    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-        self.bytes = self.bytes.saturating_add(buffer.len());
-        Ok(buffer.len())
+impl EventPayloadEnvelope {
+    pub(crate) fn new(run_id: &str) -> Result<Self, AgentError> {
+        let run_id = serde_json::to_vec(run_id)?;
+        let mut prefix = Vec::with_capacity(
+            EVENT_PAYLOAD_RUN_ID_PREFIX.len() + run_id.len() + EVENT_PAYLOAD_EVENTS_PREFIX.len(),
+        );
+        prefix.extend_from_slice(EVENT_PAYLOAD_RUN_ID_PREFIX);
+        prefix.extend_from_slice(&run_id);
+        prefix.extend_from_slice(EVENT_PAYLOAD_EVENTS_PREFIX);
+        Ok(Self {
+            prefix: Bytes::from(prefix),
+        })
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+    pub(crate) fn singleton_bytes(&self, event_bytes: usize) -> usize {
+        self.prefix.len() + event_bytes + EVENT_PAYLOAD_SUFFIX.len()
+    }
+
+    pub(crate) fn payload(&self, events: &[Bytes]) -> Bytes {
+        let event_bytes = events.iter().map(Bytes::len).sum::<usize>();
+        let separators = events.len().saturating_sub(1);
+        let mut payload = Vec::with_capacity(
+            self.prefix.len() + event_bytes + separators + EVENT_PAYLOAD_SUFFIX.len(),
+        );
+        payload.extend_from_slice(&self.prefix);
+        let mut needs_separator = false;
+        for event in events {
+            if needs_separator {
+                payload.push(b',');
+            }
+            payload.extend_from_slice(event);
+            needs_separator = true;
+        }
+        payload.extend_from_slice(EVENT_PAYLOAD_SUFFIX);
+        Bytes::from(payload)
     }
 }
 
@@ -425,10 +437,29 @@ pub async fn post_event_with_error_flag(
     event_error_flag: &str,
 ) -> Result<(), AgentError> {
     let url = http.events_url()?;
-    match http
+    let result = http
         .post_json(url, payload, constants::HTTP_MAX_ATTEMPTS)
-        .await
-    {
+        .await;
+    handle_event_post_result(result, event_error_flag)
+}
+
+pub(crate) async fn post_serialized_event_with_error_flag(
+    http: &HttpClient,
+    payload: Bytes,
+    event_error_flag: &str,
+) -> Result<(), AgentError> {
+    let url = http.events_url()?;
+    let result = http
+        .post_json_bytes(url, payload, constants::HTTP_MAX_ATTEMPTS)
+        .await;
+    handle_event_post_result(result, event_error_flag)
+}
+
+fn handle_event_post_result(
+    result: Result<Option<Value>, AgentError>,
+    event_error_flag: &str,
+) -> Result<(), AgentError> {
+    match result {
         Ok(_) => Ok(()),
         Err(e) => {
             log_error!(LOG_TAG, "Failed to send event after retries");

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -12,6 +12,7 @@ use bytes::{Bytes, BytesMut};
 use guest_common::log_warn;
 use http_body::{Frame, SizeHint};
 use pin_project_lite::pin_project;
+use reqwest::header::CONTENT_TYPE;
 use reqwest::{Client, RequestBuilder, Response};
 use serde::Serialize;
 use serde_json::Value;
@@ -318,6 +319,16 @@ impl HttpClient {
         body: &impl Serialize,
         max_attempts: u32,
     ) -> Result<Option<Value>, AgentError> {
+        let body = Bytes::from(serde_json::to_vec(body)?);
+        self.post_json_bytes(url, body, max_attempts).await
+    }
+
+    pub(crate) async fn post_json_bytes(
+        &self,
+        url: &str,
+        body: Bytes,
+        max_attempts: u32,
+    ) -> Result<Option<Value>, AgentError> {
         let client = self.inner()?;
         let api = self.api_config()?;
         let resp = send_with_retry(
@@ -330,7 +341,8 @@ impl HttpClient {
                 let mut req = client
                     .post(url)
                     .header("Authorization", format!("Bearer {}", api.token))
-                    .json(body);
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(body.clone());
 
                 if !api.vercel_bypass.is_empty() {
                     req = req.header("x-vercel-protection-bypass", &api.vercel_bypass);

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -80,6 +80,7 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
 pub struct RecordedRequest {
     pub path: String,
     pub authorization: Option<String>,
+    pub content_type: Option<String>,
     pub body: String,
 }
 
@@ -364,6 +365,7 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
         .to_string();
 
     let mut authorization = None;
+    let mut content_type = None;
     let mut content_length = 0usize;
     for line in header_lines.lines() {
         let Some((name, value)) = line.split_once(':') else {
@@ -373,6 +375,9 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
         let trimmed_value = value.trim();
         if trimmed_name.eq_ignore_ascii_case("authorization") {
             authorization = Some(trimmed_value.to_string());
+        }
+        if trimmed_name.eq_ignore_ascii_case("content-type") {
+            content_type = Some(trimmed_value.to_string());
         }
         if trimmed_name.eq_ignore_ascii_case("content-length") {
             content_length = trimmed_value
@@ -411,6 +416,7 @@ async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<Recorde
     Ok(RecordedRequest {
         path,
         authorization,
+        content_type,
         body,
     })
 }

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -67,10 +67,12 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
 
     let failed_request = server.next_request(Duration::from_secs(5)).await?;
     let failed_sequences = common::event_request_sequences(&failed_request.request)?;
+    let failed_body = failed_request.request.body.clone();
     assert_eq!(failed_sequences.len(), 32);
     failed_request.respond(500)?;
     for _ in 1..3 {
         let retry = server.next_request(Duration::from_secs(5)).await?;
+        assert_eq!(retry.request.body, failed_body);
         assert_eq!(
             common::event_request_sequences(&retry.request)?,
             failed_sequences

--- a/crates/guest-agent/tests/event_delivery_singleton.rs
+++ b/crates/guest-agent/tests/event_delivery_singleton.rs
@@ -6,6 +6,8 @@ use guest_agent::masker::SecretMasker;
 use serde_json::json;
 use std::time::Duration;
 
+const EVENT_MESSAGE: &str = "quoted \"message\" with slash \\\\ and newline\n你好 🚀";
+
 #[tokio::test]
 async fn ordinary_cli_sends_a_no_backlog_event_without_collection_delay()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -14,7 +16,7 @@ async fn ordinary_cli_sends_a_no_backlog_event_without_collection_delay()
     let mut server = common::ControlledHttpServer::start().await?;
     let prompt = [
         "@ECHO@".to_string(),
-        json!({ "type": "assistant", "message": "singleton" }).to_string(),
+        json!({ "type": "assistant", "message": EVENT_MESSAGE }).to_string(),
     ]
     .join("\n");
 
@@ -43,6 +45,10 @@ async fn ordinary_cli_sends_a_no_backlog_event_without_collection_delay()
         .await
     });
     let request = server.next_request(Duration::from_secs(5)).await?;
+    assert_eq!(
+        request.request.content_type.as_deref(),
+        Some("application/json")
+    );
     let body: serde_json::Value = serde_json::from_str(&request.request.body)?;
     assert_eq!(
         body.get("runId").and_then(serde_json::Value::as_str),
@@ -58,6 +64,10 @@ async fn ordinary_cli_sends_a_no_backlog_event_without_collection_delay()
             .get("sequenceNumber")
             .and_then(serde_json::Value::as_u64),
         Some(0)
+    );
+    assert_eq!(
+        events[0].get("message").and_then(serde_json::Value::as_str),
+        Some(EVENT_MESSAGE)
     );
     request.respond(200)?;
 

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -6,10 +6,28 @@ use api_contracts::generated::constants::client::types::CLIENT_TYPE_GUEST_AGENT;
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
+use serde::{Serialize, Serializer};
 use serde_json::json;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 use std::time::Duration;
 use uuid::Uuid;
+
+struct CountingJsonBody<'a> {
+    serializations: &'a AtomicUsize,
+}
+
+impl Serialize for CountingJsonBody<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.serializations.fetch_add(1, Ordering::SeqCst);
+        json!({ "request": "body" }).serialize(serializer)
+    }
+}
 
 // =========================================================================
 // post_json core
@@ -120,19 +138,27 @@ async fn post_json_retry_then_succeed() {
     let server = api.server();
 
     let mock = server.mock(|when, then| {
-        when.method(POST).path("/test/retry-succeed");
+        when.method(POST)
+            .path("/test/retry-succeed")
+            .header("content-type", "application/json")
+            .json_body(json!({ "request": "body" }));
         then.respond_with(retry_then_response(
             2,
             json_http_response(200, json!({"recovered": true})),
         ));
     });
 
+    let serializations = AtomicUsize::new(0);
+    let body = CountingJsonBody {
+        serializations: &serializations,
+    };
     let url = api.url("/test/retry-succeed");
-    let result = http_client!().post_json(&url, &json!({}), 3).await;
+    let result = http_client!().post_json(&url, &body, 3).await;
 
     let val = result.unwrap().unwrap();
     assert_eq!(val["recovered"], true);
     mock.assert_calls_async(3).await;
+    assert_eq!(serializations.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- serialize masked and sequenced CLI events once during bounded admission and retain their byte representation
- assemble one JSON batch body from retained event fragments while preserving FIFO and conservative size accounting
- reuse the same `Bytes` body across HTTP retries and serialize other JSON requests before entering the retry loop
- cover serializer invocation count, retry-body identity, JSON content type, and escaped/multibyte event delivery

## Compatibility

- preserves the existing event endpoint, JSON schema, headers, retry count, 16 MiB buffer limit, 4 MiB request limit, 32-event batch limit, masking, sequence numbers, and acknowledgement behavior
- does not change database state, persisted payloads, feature switches, or rollout requirements

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features`
- pre-commit Rust formatting, workspace documentation, and workspace Clippy hooks

Closes #22909
