### PR TITLE
refactor(runner): encapsulate cancellation registrations

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -403,7 +403,7 @@ async fn claim_with_local_admission(
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
-        // cancel token so the runner can continue.
+        // cancellation registration so the runner can continue.
         admission.rollback(ctx).await;
         return None;
     };

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -359,7 +359,7 @@ async fn claim_with_local_admission(
             .await?
         }
     };
-    // Insert cancel token before claiming so provider-side cancel channels
+    // Register cancellation before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
     // find the active job. Skip duplicate discoveries; overwriting would break
     // cancel delivery for the executor.

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -4,7 +4,6 @@
 //! module owns the body that turns a discovered job into a claimed spawned job.
 
 use std::collections::BTreeMap;
-use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -35,7 +34,7 @@ use crate::ids::RunId;
 use crate::paths::short_digest;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{
     ExecutionContext, HeldSessionState, SandboxReuseResult, SessionAffinityResource,
@@ -53,16 +52,15 @@ pub(super) struct DiscoveredJobContext<'a> {
     pub(super) idle_pool: &'a SharedIdlePool,
     pub(super) status: &'a StatusTracker,
     pub(super) mode_rx: &'a tokio::sync::watch::Receiver<RunnerMode>,
-    pub(super) cancel_tokens: &'a SharedRunCancellationMap,
+    pub(super) cancel_tokens: &'a RunCancellationRegistry,
     pub(super) spawn_ctx: &'a SpawnContext,
     pub(super) destroy_tasks: &'a mut JoinSet<bool>,
-    pub(super) jobs: &'a mut JoinSet<Option<RunId>>,
+    pub(super) jobs: &'a mut JoinSet<RunCancellationRegistration>,
 }
 
 struct LocalAdmission {
-    run_id: RunId,
     resource: LocalAdmissionResource,
-    cancel: RunCancellationHandle,
+    cancellation: RunCancellationRegistration,
 }
 
 enum LocalAdmissionResource {
@@ -73,7 +71,7 @@ enum LocalAdmissionResource {
 struct AdmittedClaim {
     claimed: ClaimedJob,
     resource: LocalAdmissionResource,
-    cancel: RunCancellationHandle,
+    cancellation: RunCancellationRegistration,
 }
 
 struct PreparedAffinityCandidate {
@@ -101,11 +99,10 @@ struct ReservedActivationRequest<'a> {
 impl LocalAdmission {
     async fn rollback(self, ctx: &mut DiscoveredJobContext<'_>) {
         let Self {
-            run_id,
             resource,
-            cancel: _,
+            cancellation,
         } = self;
-        ctx.cancel_tokens.lock().await.remove(&run_id);
+        cancellation.unregister().await;
         rollback_untracked_resource(resource, ctx).await;
     }
 
@@ -113,7 +110,7 @@ impl LocalAdmission {
         AdmittedClaim {
             claimed,
             resource: self.resource,
-            cancel: self.cancel,
+            cancellation: self.cancellation,
         }
     }
 }
@@ -157,7 +154,7 @@ pub(super) async fn handle_discovered_job(
     let AdmittedClaim {
         claimed,
         resource,
-        cancel: job_cancel,
+        cancellation,
     } = admission;
     let mut pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
     let started_at = Instant::now();
@@ -231,7 +228,7 @@ pub(super) async fn handle_discovered_job(
                     } => {
                         fail_claimed_without_sandbox(
                             claimed,
-                            job_cancel,
+                            cancellation,
                             budget_lease,
                             reuse_result,
                             error,
@@ -250,7 +247,7 @@ pub(super) async fn handle_discovered_job(
             http: &ctx.spawn_ctx.exec_config.http,
             cpu: &ctx.spawn_ctx.exec_config.session_history_cpu,
             context: claimed.context(),
-            cancel: job_cancel.token(),
+            cancel: cancellation.token(),
             reuse_result,
             restored_identity: reuse_entry
                 .as_ref()
@@ -286,7 +283,7 @@ pub(super) async fn handle_discovered_job(
         restore_guest_state: *restore_guest_state,
         device_rate_limits,
         factory: Arc::clone(factory),
-        cancel: job_cancel,
+        cancellation,
     };
     spawn_job(
         SpawnJobRequest {
@@ -366,25 +363,17 @@ async fn claim_with_local_admission(
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
     // find the active job. Skip duplicate discoveries; overwriting would break
     // cancel delivery for the executor.
-    let job_cancel = RunCancellationHandle::new();
-    {
-        let mut tokens = ctx.cancel_tokens.lock().await;
-        match tokens.entry(run_id) {
-            Entry::Occupied(_) => {
-                drop(tokens);
-                rollback_untracked_resource(resource, ctx).await;
-                return None;
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(job_cancel.clone());
-            }
+    let cancellation = match ctx.cancel_tokens.register(run_id).await {
+        Ok(registration) => registration,
+        Err(_) => {
+            rollback_untracked_resource(resource, ctx).await;
+            return None;
         }
-    }
+    };
 
     let admission = LocalAdmission {
-        run_id,
         resource,
-        cancel: job_cancel,
+        cancellation,
     };
 
     // This is the last reversible point before provider-side ownership.
@@ -402,7 +391,7 @@ async fn claim_with_local_admission(
             return None;
         }
         RunnerMode::Stopping => {
-            admission.cancel.cancel().await;
+            admission.cancellation.cancel().await;
         }
         RunnerMode::Stopped => {
             admission.rollback(ctx).await;
@@ -821,7 +810,7 @@ async fn cleanup_reserved_for_fresh_fallback(
 
 async fn fail_claimed_without_sandbox(
     claimed: ClaimedJob,
-    cancel: RunCancellationHandle,
+    cancellation: RunCancellationRegistration,
     budget_lease: BudgetLease,
     reuse_result: SandboxReuseResult,
     error: String,
@@ -842,8 +831,7 @@ async fn fail_claimed_without_sandbox(
             completion_auth,
         )
         .await;
-    ctx.cancel_tokens.lock().await.remove(&run_id);
-    drop(cancel);
+    cancellation.unregister().await;
     drop(budget_lease);
 }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -958,7 +958,7 @@ pub(super) async fn cleanup_panicked_job(
     }
 }
 
-/// Handle a completed job from the JoinSet, cleaning up cancel tokens.
+/// Handle a completed job from the JoinSet, removing its cancellation registration.
 pub(super) async fn handle_job_result(
     result: Option<Result<RunCancellationRegistration, tokio::task::JoinError>>,
 ) {

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -41,7 +41,7 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
 use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistration};
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::telemetry::JobTelemetry;
@@ -57,7 +57,7 @@ pub(super) struct JobProfile {
     pub(super) restore_guest_state: bool,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     pub(super) factory: SharedFactory,
-    pub(super) cancel: RunCancellationHandle,
+    pub(super) cancellation: RunCancellationRegistration,
 }
 
 /// Shared state passed to each spawned job task.
@@ -66,7 +66,6 @@ pub(super) struct SpawnContext {
     pub(super) exec_config: Arc<ExecutorConfig>,
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
-    pub(super) cancel_tokens: SharedRunCancellationMap,
     pub(super) orphaned_active_runs: OrphanedActiveRuns,
     /// Current lifecycle parking permission. This is checked at job
     /// completion so soft-drain/resume races do not depend on a stale
@@ -489,7 +488,7 @@ impl DeferredUploadPhase {
 pub(super) fn spawn_job(
     request: SpawnJobRequest,
     ctx: &SpawnContext,
-    jobs: &mut JoinSet<Option<RunId>>,
+    jobs: &mut JoinSet<RunCancellationRegistration>,
 ) {
     let started_at = Instant::now();
     let SpawnJobRequest {
@@ -515,7 +514,8 @@ pub(super) fn spawn_job(
     let active_lease = job_profile.budget_lease;
     let profile_name = job_profile.profile_name;
     let factory = job_profile.factory;
-    let job_cancel = job_profile.cancel;
+    let cancellation = job_profile.cancellation;
+    let job_cancel = cancellation.handle();
     let params = executor::JobParams {
         profile_name: profile_name.clone(),
         vcpu,
@@ -543,7 +543,6 @@ pub(super) fn spawn_job(
     let cleanup_state = RunCleanupState::new();
     let cleanup_state_for_body = cleanup_state.clone();
     let cleanup_state_for_panic = cleanup_state.clone();
-    let cancel_tokens_for_panic = Arc::clone(&ctx.cancel_tokens);
     let status_for_panic = Arc::clone(&status);
     let idle_pool_for_panic = Arc::clone(&idle_pool);
     let orphaned_active_runs_for_panic = ctx.orphaned_active_runs.clone();
@@ -670,17 +669,15 @@ pub(super) fn spawn_job(
             .complete(completion_ready)
             .await;
             deferred_upload.flush(telemetry).await;
-
-            Some(run_id)
         };
 
         match AssertUnwindSafe(body).catch_unwind().await {
-            Ok(result) => result,
+            Ok(()) => cancellation,
             Err(payload) => {
                 let cleanup = cleanup_panicked_job(
                     run_id,
                     sandbox_id,
-                    cancel_tokens_for_panic,
+                    cancellation,
                     status_for_panic,
                     idle_pool_for_panic,
                     cleanup_state_for_panic,
@@ -931,13 +928,13 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
 pub(super) async fn cleanup_panicked_job(
     run_id: RunId,
     sandbox_id: SandboxId,
-    cancel_tokens: SharedRunCancellationMap,
+    cancellation: RunCancellationRegistration,
     status: Arc<StatusTracker>,
     idle_pool: SharedIdlePool,
     cleanup_state: RunCleanupState,
     orphaned_active_runs: OrphanedActiveRuns,
 ) {
-    cancel_tokens.lock().await.remove(&run_id);
+    cancellation.unregister().await;
     let ownership = OwnershipTransitions::new(status.as_ref());
     let run = RunSandbox::new(run_id, sandbox_id);
 
@@ -963,12 +960,11 @@ pub(super) async fn cleanup_panicked_job(
 
 /// Handle a completed job from the JoinSet, cleaning up cancel tokens.
 pub(super) async fn handle_job_result(
-    result: Option<Result<Option<RunId>, tokio::task::JoinError>>,
-    cancel_tokens: &SharedRunCancellationMap,
+    result: Option<Result<RunCancellationRegistration, tokio::task::JoinError>>,
 ) {
     match result {
-        Some(Ok(Some(run_id))) => {
-            cancel_tokens.lock().await.remove(&run_id);
+        Some(Ok(cancellation)) => {
+            cancellation.unregister().await;
         }
         Some(Err(e)) => {
             error!(error = %e, "job task panicked");
@@ -980,7 +976,6 @@ pub(super) async fn handle_job_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1007,6 +1002,7 @@ mod tests {
     use crate::provider::JobCandidate;
     use crate::resource_budget::ResourceBudget;
     use crate::restored_session_identity::RestoredSessionIdentity;
+    use crate::run_cancellation::RunCancellationRegistry;
     use crate::status::StatusTracker;
     use crate::types::HeartbeatState;
 
@@ -1923,7 +1919,7 @@ mod tests {
         status_path: std::path::PathBuf,
         status: Arc<StatusTracker>,
         idle_pool: SharedIdlePool,
-        tokens: SharedRunCancellationMap,
+        tokens: RunCancellationRegistry,
         orphans: OrphanedActiveRuns,
         _dir: tempfile::TempDir,
     }
@@ -1938,8 +1934,7 @@ mod tests {
                     default_timeout: Duration::from_secs(300),
                     max_idle: 10,
                 })));
-            let tokens: SharedRunCancellationMap =
-                Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let tokens = RunCancellationRegistry::new();
             let orphans = OrphanedActiveRuns::new();
 
             Self {
@@ -1958,10 +1953,22 @@ mod tests {
             sandbox_id: SandboxId,
             cleanup_state: RunCleanupState,
         ) {
+            let cancellation = self.tokens.register(run_id).await.unwrap();
+            self.cleanup_with_registration(run_id, sandbox_id, cleanup_state, cancellation)
+                .await;
+        }
+
+        async fn cleanup_with_registration(
+            &self,
+            run_id: RunId,
+            sandbox_id: SandboxId,
+            cleanup_state: RunCleanupState,
+            cancellation: RunCancellationRegistration,
+        ) {
             cleanup_panicked_job(
                 run_id,
                 sandbox_id,
-                Arc::clone(&self.tokens),
+                cancellation,
                 Arc::clone(&self.status),
                 Arc::clone(&self.idle_pool),
                 cleanup_state,
@@ -1982,16 +1989,11 @@ mod tests {
             .status
             .remove_run_if_matching(run_id, sandbox_id)
             .await;
-        fixture
-            .tokens
-            .lock()
-            .await
-            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_status_removed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
 
-        assert!(!fixture.tokens.lock().await.contains_key(&run_id));
+        assert!(!fixture.tokens.contains(run_id).await);
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert!(active_runs.is_empty());
@@ -2005,16 +2007,10 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         fixture.status.add_run(run_id, sandbox_id).await;
         fixture
-            .tokens
-            .lock()
-            .await
-            .insert(run_id, RunCancellationHandle::new());
-
-        fixture
             .cleanup(run_id, sandbox_id, RunCleanupState::new())
             .await;
 
-        assert!(!fixture.tokens.lock().await.contains_key(&run_id));
+        assert!(!fixture.tokens.contains(run_id).await);
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert_eq!(active_runs, vec![run_id.to_string()]);
@@ -2028,16 +2024,11 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         fixture.status.add_run(run_id, sandbox_id).await;
-        fixture
-            .tokens
-            .lock()
-            .await
-            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_destroy_completed();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
 
-        assert!(!fixture.tokens.lock().await.contains_key(&run_id));
+        assert!(!fixture.tokens.contains(run_id).await);
         let (_idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert!(active_runs.is_empty());
@@ -2053,23 +2044,30 @@ mod tests {
         let current_sandbox_id = SandboxId::new_v4();
         fixture.status.add_run(run_id, completed_sandbox_id).await;
         fixture.status.add_run(run_id, current_sandbox_id).await;
-        fixture
-            .tokens
-            .lock()
-            .await
-            .insert(run_id, RunCancellationHandle::new());
+        let stale_cancellation = fixture.tokens.register(run_id).await.unwrap();
+        assert!(stale_cancellation.unregister().await);
+        let replacement_cancellation = fixture.tokens.register(run_id).await.unwrap();
         cleanup_state.mark_destroy_completed();
 
         fixture
-            .cleanup(run_id, completed_sandbox_id, cleanup_state)
+            .cleanup_with_registration(
+                run_id,
+                completed_sandbox_id,
+                cleanup_state,
+                stale_cancellation,
+            )
             .await;
 
-        assert!(!fixture.tokens.lock().await.contains_key(&run_id));
+        assert!(
+            fixture.tokens.contains(run_id).await,
+            "stale panic cleanup must preserve the replacement registration",
+        );
         assert_eq!(
             status_active_run_records(&fixture.status_path).await,
             vec![(run_id.to_string(), current_sandbox_id.to_string())],
         );
         assert_eq!(fixture.orphans.len(), 0);
+        assert!(replacement_cancellation.unregister().await);
     }
 
     #[tokio::test]
@@ -2089,16 +2087,11 @@ mod tests {
             ParkResult::Parked
         ));
         fixture.status.add_run(run_id, sandbox_id).await;
-        fixture
-            .tokens
-            .lock()
-            .await
-            .insert(run_id, RunCancellationHandle::new());
         cleanup_state.mark_idle_pool_owned();
 
         fixture.cleanup(run_id, sandbox_id, cleanup_state).await;
 
-        assert!(!fixture.tokens.lock().await.contains_key(&run_id));
+        assert!(!fixture.tokens.contains(run_id).await);
         let (idle_sessions, active_runs) =
             status_idle_sessions_and_active_runs(&fixture.status_path).await;
         assert_eq!(idle_sessions, vec!["sess-idle-owned-cleanup"]);

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -30,7 +30,7 @@
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -44,6 +44,7 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::duration::duration_ms as saturated_duration_ms;
+#[cfg(test)]
 use crate::ids::RunId;
 
 use crate::config::{self, ProfileConfig};
@@ -67,7 +68,7 @@ use crate::provider::{
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
-use crate::run_cancellation::SharedRunCancellationMap;
+use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::status::{RunnerMode, StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
@@ -403,7 +404,7 @@ async fn run_start_with_home(
     })?;
     let name = runner_config.name;
     let group = runner_config.group;
-    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let cancel_tokens = RunCancellationRegistry::new();
     let local_group_dir = if args.local {
         let group_dir = home.groups_dir().join(&group);
         crate::local_queue::ensure_group_dir(&group_dir).map_err(|e| {
@@ -642,12 +643,8 @@ async fn run_start_with_home(
         Option<NetworkPolicyRefreshHandle>,
     ) = if let Some(group_dir) = local_group_dir {
         let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
-        let provider = LocalProvider::new(
-            group_dir,
-            profiles,
-            cancel.clone(),
-            Arc::clone(&cancel_tokens),
-        );
+        let provider =
+            LocalProvider::new(group_dir, profiles, cancel.clone(), cancel_tokens.clone());
         (provider, group, None)
     } else {
         let group_name = group.clone();
@@ -665,7 +662,7 @@ async fn run_start_with_home(
                 lock_path: paths.builtin_firewall_catalog_cache_lock(),
             },
             cancel.clone(),
-            Arc::clone(&cancel_tokens),
+            cancel_tokens.clone(),
         );
         let network_policy_refresh = provider.network_policy_refresh_handle();
         (provider, group_name, Some(network_policy_refresh))
@@ -833,7 +830,7 @@ struct ProviderState {
     provider: Arc<dyn JobProvider>,
     /// Per-job cancel tokens shared with the provider for cancel events
     /// (Ably for ApiProvider, `.cancel` files for LocalProvider).
-    cancel_tokens: SharedRunCancellationMap,
+    cancel_tokens: RunCancellationRegistry,
     cancel: CancellationToken,
 }
 
@@ -1198,7 +1195,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let signal = match signals.signal_source {
         SignalSource::Real(signals) => SignalController::spawn(
             provider_state.cancel.clone(),
-            Arc::clone(&provider_state.cancel_tokens),
+            provider_state.cancel_tokens.clone(),
             signals,
             shared.parking_gate.clone(),
         ),
@@ -1272,7 +1269,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let startup_mode = lifecycle.mark_startup_ready();
     shared.status.set_mode(startup_mode).await;
 
-    let mut jobs: JoinSet<Option<RunId>> = JoinSet::new();
+    let mut jobs: JoinSet<RunCancellationRegistration> = JoinSet::new();
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
     // destroys at shutdown so their factory Arcs are released before the
     // exclusive ownership preflight.
@@ -1385,7 +1382,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         exec_config: Arc::clone(&exec_config),
         idle_pool: Arc::clone(&shared.idle_pool),
         status: Arc::clone(&shared.status),
-        cancel_tokens: Arc::clone(&provider_state.cancel_tokens),
         orphaned_active_runs: orphaned_active_runs.clone(),
         parking_gate: shared.parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
@@ -1571,7 +1567,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // normal Running mode can retain completed JoinSet entries and
             // stale cancel tokens until drain, budget exhaustion, or shutdown.
             result = jobs.join_next(), if !jobs.is_empty() => {
-                handle_job_result(result, &provider_state.cancel_tokens).await;
+                handle_job_result(result).await;
                 if !orphaned_active_runs.is_empty() {
                     reap_orphaned_active_runs(
                         &orphaned_active_runs,
@@ -1722,7 +1718,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
             tokio::select! {
                 result = jobs.join_next() => {
-                    handle_job_result(result, &provider_state.cancel_tokens).await;
+                    handle_job_result(result).await;
                     if !orphaned_active_runs.is_empty() {
                         reap_orphaned_active_runs(
                             &orphaned_active_runs,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -828,8 +828,8 @@ struct RunnerSharedState {
 
 struct ProviderState {
     provider: Arc<dyn JobProvider>,
-    /// Per-job cancel tokens shared with the provider for cancel events
-    /// (Ably for ApiProvider, `.cancel` files for LocalProvider).
+    /// Per-job cancellation registrations shared with the provider for cancel
+    /// events (Ably for ApiProvider, `.cancel` files for LocalProvider).
     cancel_tokens: RunCancellationRegistry,
     cancel: CancellationToken,
 }
@@ -1565,7 +1565,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and
-            // stale cancel tokens until drain, budget exhaustion, or shutdown.
+            // stale cancellation registrations until drain, budget exhaustion,
+            // or shutdown.
             result = jobs.join_next(), if !jobs.is_empty() => {
                 handle_job_result(result).await;
                 if !orphaned_active_runs.is_empty() {

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::idle_pool::ParkingGate;
-use crate::run_cancellation::SharedRunCancellationMap;
+use crate::run_cancellation::RunCancellationRegistry;
 use crate::status::RunnerMode;
 
 /// Pre-registered signal streams.
@@ -274,7 +274,7 @@ impl SignalController {
     /// construct a controller with no real handler task.
     pub(super) fn spawn(
         cancel: CancellationToken,
-        cancel_tokens: SharedRunCancellationMap,
+        cancel_tokens: RunCancellationRegistry,
         signals: EarlySignals,
         parking_gate: ParkingGate,
     ) -> Self {
@@ -357,7 +357,7 @@ pub(super) fn handle_resume_signal(lifecycle: &LifecycleController) {
 pub(super) async fn handle_stopping_signal(
     name: &str,
     cancel: &CancellationToken,
-    cancel_tokens: &SharedRunCancellationMap,
+    cancel_tokens: &RunCancellationRegistry,
     lifecycle: &LifecycleController,
 ) {
     if lifecycle.current_mode() == RunnerMode::Stopping {
@@ -366,18 +366,12 @@ pub(super) async fn handle_stopping_signal(
         return;
     }
     info!(signal = name, "initiating hard shutdown");
-    // Close parking and send Stopping *before* locking cancel_tokens so that
-    // the main loop's
-    // post-insert `mode_rx.borrow()` check catches any job claimed after
-    // our iteration but before send would otherwise publish the state.
+    // Publish Stopping before entering the registry's hard-stop barrier.
+    // Registrations before the barrier are included in its snapshot; later
+    // registrations are returned already cancelled. The discovery path also
+    // rechecks mode after registration so cancellation still precedes claim.
     lifecycle.hard_stop();
-    let handles = {
-        let tokens = cancel_tokens.lock().await;
-        tokens
-            .iter()
-            .map(|(run_id, handle)| (*run_id, handle.clone()))
-            .collect::<Vec<_>>()
-    };
+    let handles = cancel_tokens.begin_hard_stop().await;
     let count = handles.len();
     for (run_id, handle) in handles {
         info!(run_id = %run_id, "cancelling active job for hard shutdown");
@@ -389,13 +383,11 @@ pub(super) async fn handle_stopping_signal(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
     use super::*;
     use crate::ids::RunId;
-    use crate::run_cancellation::RunCancellationHandle;
 
     /// Regression test for issue #10416: SIGUSR1 arriving between
     /// `EarlySignals::register()` and `SignalController::spawn` must still
@@ -421,7 +413,7 @@ mod tests {
 
         let controller = SignalController::spawn(
             CancellationToken::new(),
-            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            RunCancellationRegistry::new(),
             signals,
             ParkingGate::new_open(),
         );
@@ -648,7 +640,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
         let lifecycle = LifecycleController::new(tx, gate.clone());
         let cancel = CancellationToken::new();
-        let tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let tokens = RunCancellationRegistry::new();
 
         // First call: transitions, cancels main cancel.
         handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
@@ -656,19 +648,15 @@ mod tests {
         assert_eq!(gate.state(), ParkingState::Closed);
         assert!(cancel.is_cancelled());
 
-        // Insert a sentinel token *after* the first call so we can prove
-        // the repeat did not re-iterate the map.
-        let sentinel = RunCancellationHandle::new();
-        let sentinel_token = sentinel.token();
-        tokens.lock().await.insert(RunId::new_v4(), sentinel);
+        // A registration after the first hard-stop barrier is cancelled by
+        // registration itself; repeat-signal handling need not rescan it.
+        let registration = tokens.register(RunId::new_v4()).await.unwrap();
+        assert!(registration.is_cancelled());
 
         // Repeat call: must early-return on the already-Stopping guard.
         handle_stopping_signal("SIGTERM", &cancel, &tokens, &lifecycle).await;
         assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
         assert_eq!(gate.state(), ParkingState::Closed);
-        assert!(
-            !sentinel_token.is_cancelled(),
-            "repeat must not re-iterate cancel_tokens and cancel late-inserted sentinel",
-        );
+        assert!(cancel.is_cancelled());
     }
 }

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -262,10 +262,10 @@ impl SignalController {
     /// ## Race handling
     ///
     /// `handle_stopping_signal` closes parking and sends Stopping **before**
-    /// locking `cancel_tokens`. This ordering lets the main loop close the
-    /// TOCTOU window where a new job is claimed between the handler's
-    /// iteration and its own token insert: the main loop re-reads `mode_rx`
-    /// after insert and sees Stopping via watch's write/read fence.
+    /// entering the cancellation registry's hard-stop barrier. Registrations
+    /// before the barrier are included in its snapshot; registrations after
+    /// the barrier are returned already cancelled. The main loop also re-reads
+    /// `mode_rx` after registration so Stopping cancellation precedes claim.
     ///
     /// ## Lifetime
     ///

--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -630,8 +630,8 @@ mod tests {
     }
 
     /// `handle_stopping_signal` idempotency: a repeat invocation takes the
-    /// "already Stopping" guard and returns without re-iterating
-    /// `cancel_tokens` or re-cancelling `cancel`.
+    /// "already Stopping" guard and returns without re-entering the registry's
+    /// hard-stop barrier or re-cancelling `cancel`.
     #[tokio::test]
     async fn stopping_signal_repeat_is_idempotent() {
         use crate::idle_pool::ParkingState;

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -91,7 +91,7 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
         "discovery must not be polled while budget is exhausted"
     );
     assert!(
-        !env.cancel_tokens.lock().await.contains_key(&id2),
+        !env.cancel_tokens.contains(id2).await,
         "queued job must not be claimed while budget is exhausted",
     );
     assert!(

--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -78,7 +78,7 @@ async fn cancelled_job_not_parked() {
         mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -128,7 +128,7 @@ async fn create_failure_completes_and_cleans_run_state() {
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -19,7 +19,7 @@ async fn outer_job_panic_after_idle_pool_owned_cleans_token_and_active_status() 
     );
     config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::IdlePoolOwned);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -64,7 +64,7 @@ async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
         proc_scan_complete: true,
         incomplete_for_current_runner: false,
     });
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -106,7 +106,7 @@ async fn outer_job_panic_after_active_stop_panic_preserves_status_for_reconcilia
         incomplete_for_current_runner: false,
     });
     let budget = Arc::clone(&config.capacity.budget);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 
@@ -156,7 +156,7 @@ async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status(
 
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -403,7 +403,7 @@ async fn release_destroy_and_wait_for_successful_completion(
 async fn assert_post_destroy_cleanup(
     budget: &ResourceBudget,
     idle_pool: &SharedIdlePool,
-    cancel_tokens: Option<&SharedRunCancellationMap>,
+    cancel_tokens: Option<&RunCancellationRegistry>,
     run_id: RunId,
     expected_budget_count: usize,
     expected_idle_len: usize,
@@ -443,7 +443,7 @@ async fn assert_workspace_cache_after_late_cancellation(
         .workspace_cache = Some(workspace_cache.clone());
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -693,7 +693,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
@@ -764,7 +764,7 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1135,8 +1135,8 @@ async fn duplicate_discovery_deduplicated() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
     // Push the same run_id again with reusable affinity. The duplicate first
-    // owns the idle reservation, then must restore it when cancel_tokens shows
-    // that the original run already owns local admission.
+    // owns the idle reservation, then must restore it when the cancellation
+    // registry reports that the original run already owns local admission.
     env.handle
         .discover_tx
         .send(reusable_affinity_protected_candidate(run_id, session_id))

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -92,18 +92,19 @@ async fn claim_after_draining_sent_skips_unclaimed_job() {
     );
 }
 
-/// TOCTOU regression: a SIGTERM that iterates `cancel_tokens` *before*
-/// the main loop inserts a newly-claimed job's token would leave that
-/// job running uncancelled. The fix is a post-insert `mode_rx.borrow()`
-/// check that catches Stopping and cancels the token in that window.
+/// Ordering regression: hard shutdown publishes `Stopping` before entering
+/// the cancellation registry's hard-stop barrier. A discovery that registers
+/// in that window must observe Stopping and cancel before provider claim. The
+/// registry independently covers registrations after the barrier begins; this
+/// test isolates the discovery-side mode recheck.
 ///
 /// To reproduce deterministically, we use `send_if_modified` to flip
 /// the watch value to `Stopping` **without** waking `mode_rx.changed()`
-/// — this is exactly what the racy window looks like to the main loop:
-/// its outer select! is still polling discover_fut, unaware that the
-/// value has changed. When discover yields a job, the main loop takes
-/// the claim path, inserts the token, then reads `mode_rx.borrow()`
-/// and catches the Stopping value that was silently written.
+/// or entering the registry barrier. This is what the pre-barrier window
+/// looks like to the main loop: its outer select! is still polling
+/// discover_fut, unaware that the value has changed. When discover yields a
+/// job, the main loop takes the claim path, registers cancellation, then reads
+/// `mode_rx.borrow()` and catches the Stopping value that was silently written.
 #[tokio::test]
 async fn claim_after_stopping_sent_cancels_new_job() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);

--- a/crates/runner/src/cmd/start/tests/main_loop/job_flow.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/job_flow.rs
@@ -29,8 +29,8 @@ async fn main_loop_discover_claim_execute_complete() {
 }
 
 /// Regression for #11157: normal Running mode with available budget must
-/// still reap completed job tasks so their cancel tokens do not remain
-/// until a later drain, shutdown, or budget-exhausted wait.
+/// still reap completed job tasks so their cancellation registrations do not
+/// remain until a later drain, shutdown, or budget-exhausted wait.
 #[tokio::test(start_paused = true)]
 async fn running_reaps_completed_jobs_without_budget_exhaustion() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use crate::executor;
 use crate::provider::mock::{MockJobProvider, MockProviderHandle};
-use crate::run_cancellation::SharedRunCancellationMap;
+use crate::run_cancellation::RunCancellationRegistry;
 use sandbox_mock::MockSandboxRuntime;
 
 pub(in super::super) fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
@@ -34,7 +34,7 @@ pub(in super::super) struct MockRunEnv {
     pub(in super::super) parking_gate: ParkingGate,
     pub(in super::super) start_observer: StartLoopTestObserver,
     pub(in super::super) mode_tx: tokio::sync::watch::Sender<RunnerMode>,
-    pub(in super::super) cancel_tokens: SharedRunCancellationMap,
+    pub(in super::super) cancel_tokens: RunCancellationRegistry,
     pub(in super::super) cancel: CancellationToken,
     pub(in super::super) _temp_dir: tempfile::TempDir,
 }
@@ -173,7 +173,7 @@ fn build_mock_run_config_with_runtime(
     let parking_gate = ParkingGate::new_open();
     let lifecycle = LifecycleController::new(mode_tx, parking_gate.clone());
     let start_observer = StartLoopTestObserver::default();
-    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let cancel_tokens = RunCancellationRegistry::new();
 
     let home = HomePaths::with_root(temp_dir.path().to_path_buf());
     let registry_path = temp_dir.path().join("registry.json");
@@ -240,7 +240,7 @@ fn build_mock_run_config_with_runtime(
         },
         provider: ProviderState {
             provider,
-            cancel_tokens: Arc::clone(&cancel_tokens),
+            cancel_tokens: cancel_tokens.clone(),
             cancel: cancel.clone(),
         },
         proxy: ProxyState {

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -3,7 +3,7 @@ use super::env::MockRunEnv;
 use std::future::Future;
 
 use crate::idle_pool::ParkingState;
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistry};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -217,12 +217,12 @@ pub(in super::super) async fn wait_parking_state(
 }
 
 pub(in super::super) async fn wait_cancel_handle(
-    tokens: &SharedRunCancellationMap,
+    tokens: &RunCancellationRegistry,
     run_id: RunId,
     timeout: Duration,
 ) -> RunCancellationHandle {
     wait_for_probe(timeout, || async {
-        let handle = tokens.lock().await.get(&run_id).cloned();
+        let handle = tokens.handle(run_id).await;
         if let Some(handle) = handle {
             WaitProbe::Ready(handle)
         } else {
@@ -235,7 +235,7 @@ pub(in super::super) async fn wait_cancel_handle(
 }
 
 pub(in super::super) async fn wait_cancel_token(
-    tokens: &SharedRunCancellationMap,
+    tokens: &RunCancellationRegistry,
     run_id: RunId,
     timeout: Duration,
 ) -> CancellationToken {
@@ -243,12 +243,12 @@ pub(in super::super) async fn wait_cancel_token(
 }
 
 pub(in super::super) async fn wait_cancel_token_removed(
-    tokens: &SharedRunCancellationMap,
+    tokens: &RunCancellationRegistry,
     run_id: RunId,
     timeout: Duration,
 ) {
     wait_for_probe(timeout, || async {
-        let present = tokens.lock().await.contains_key(&run_id);
+        let present = tokens.contains(run_id).await;
         if present {
             WaitProbe::Pending(format!(
                 "cancel token for {run_id} still present after {timeout:?}",

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -31,7 +31,7 @@ use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
 use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
-use crate::run_cancellation::SharedRunCancellationMap;
+use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{
     CompleteRequest, ExecutionContext, HeartbeatState, Job, NetworkPolicyRefreshBatchResponse,
     PollResponse, SandboxReuseResult,
@@ -192,7 +192,7 @@ pub struct ApiProvider {
     claim_cooldowns: ClaimCooldowns,
     /// Background Ably control-plane task.
     ably_supervisor: Mutex<Option<AblySupervisor>>,
-    cancel_tokens: SharedRunCancellationMap,
+    cancel_tokens: RunCancellationRegistry,
     network_policy_refresh: NetworkPolicyRefreshHandle,
     builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController,
     /// Shutdown signal.
@@ -218,7 +218,7 @@ impl ApiProvider {
         config: ApiProviderConfig,
         builtin_firewall_catalog_cache_paths: BuiltinFirewallCatalogCachePaths,
         cancel: CancellationToken,
-        cancel_tokens: SharedRunCancellationMap,
+        cancel_tokens: RunCancellationRegistry,
     ) -> Arc<Self> {
         let ApiProviderConfig {
             runner_id,
@@ -408,7 +408,7 @@ impl ApiProvider {
             profiles: self.supported_profiles.clone(),
             poll_wakeups: Arc::clone(&self.poll_wakeups),
             direct_candidates: Arc::clone(&self.direct_candidates),
-            cancel_tokens: Arc::clone(&self.cancel_tokens),
+            cancel_tokens: self.cancel_tokens.clone(),
             network_policy_refresh: self.network_policy_refresh.clone(),
             provider_cancel: self.cancel.clone(),
         }));
@@ -1654,7 +1654,7 @@ mod tests {
             ),
             claim_cooldowns: ClaimCooldowns::new(claim_cooldown_capacity),
             ably_supervisor: Mutex::new(Some(AblySupervisor::disabled())),
-            cancel_tokens: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            cancel_tokens: RunCancellationRegistry::new(),
             cancel,
         })
     }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -14,7 +14,6 @@
 //! Ably connection state all route through `PollWakeups` so a runner can still
 //! discover work through HTTP polling.
 
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant as StdInstant};
 
@@ -31,7 +30,7 @@ use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::SessionAffinityResource;
 
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
@@ -427,7 +426,7 @@ pub(super) struct AblySupervisorConfig {
     pub(super) profiles: Vec<String>,
     pub(super) poll_wakeups: Arc<PollWakeups>,
     pub(super) direct_candidates: Arc<DirectCandidateInbox>,
-    pub(super) cancel_tokens: SharedRunCancellationMap,
+    pub(super) cancel_tokens: RunCancellationRegistry,
     pub(super) network_policy_refresh: NetworkPolicyRefreshHandle,
     pub(super) provider_cancel: CancellationToken,
 }
@@ -438,7 +437,7 @@ struct SupervisorTaskConfig {
     profiles: Vec<String>,
     poll_wakeups: Arc<PollWakeups>,
     direct_candidates: Arc<DirectCandidateInbox>,
-    cancel_tokens: SharedRunCancellationMap,
+    cancel_tokens: RunCancellationRegistry,
     network_policy_refresh: NetworkPolicyRefreshHandle,
     provider_cancel: CancellationToken,
     shutdown: CancellationToken,
@@ -613,7 +612,7 @@ async fn handle_ably_message(
     profiles: &[String],
     poll_wakeups: &PollWakeups,
     direct_candidates: &DirectCandidateInbox,
-    cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
+    cancel_tokens: &RunCancellationRegistry,
 ) {
     handle_ably_message_with_network_policy_refresh(
         msg,
@@ -632,14 +631,14 @@ async fn handle_ably_message_with_network_policy_refresh(
     profiles: &[String],
     poll_wakeups: &PollWakeups,
     direct_candidates: &DirectCandidateInbox,
-    cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
+    cancel_tokens: &RunCancellationRegistry,
     network_policy_refresh: Option<&NetworkPolicyRefreshHandle>,
     network_policy_refresh_cancel: Option<&CancellationToken>,
 ) {
     let notification_received_at = StdInstant::now();
 
     if let Some(run_id) = parse_cancel_notification(msg) {
-        let handle = cancel_tokens.lock().await.get(&run_id).cloned();
+        let handle = cancel_tokens.handle(run_id).await;
         if let Some(handle) = handle {
             info!(run_id = %run_id, "ably: cancel notification, killing job");
             handle.cancel().await;
@@ -1734,9 +1733,9 @@ mod tests {
     #[tokio::test]
     async fn cancel_notification_cancels_token_without_discovery() {
         let run_id: RunId = "00000000-0000-0000-0000-000000000002".parse().unwrap();
-        let handle = RunCancellationHandle::new();
-        let token = handle.token();
-        let tokens = Mutex::new(HashMap::from([(run_id, handle)]));
+        let tokens = RunCancellationRegistry::new();
+        let registration = tokens.register(run_id).await.unwrap();
+        let token = registration.token();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1750,7 +1749,7 @@ mod tests {
 
     #[tokio::test]
     async fn broadcast_supported_job_notification_enqueues_direct_candidate() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1800,7 +1799,7 @@ mod tests {
 
     #[tokio::test]
     async fn unsupported_profile_job_notification_is_ignored() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1829,7 +1828,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_profile_support_job_notification_is_ignored() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = Vec::new();
@@ -1858,7 +1857,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_profile_job_notification_wakes_poll() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1884,7 +1883,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_profile_job_notification_wakes_poll() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -1911,7 +1910,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_direct_candidate_queue_wakes_poll_fallback() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox_with_capacity(1);
         let profiles = default_profiles();
@@ -1954,7 +1953,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_full_direct_candidate_queue_prunes_before_enqueueing() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let stale_after = Duration::from_secs(60);
         let direct_candidates = direct_candidate_inbox_with_stale_after(1, stale_after);
@@ -1998,7 +1997,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_job_notification_does_not_mutate_wakeup_state() {
-        let tokens = Mutex::new(HashMap::new());
+        let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
@@ -2025,9 +2024,9 @@ mod tests {
             malformed_network_policy_refresh_messages("network-policy-refresh-v2")
         {
             let sentinel_run_id: RunId = "00000000-0000-0000-0000-000000000099".parse().unwrap();
-            let sentinel_handle = RunCancellationHandle::new();
-            let sentinel_token = sentinel_handle.token();
-            let tokens = Mutex::new(HashMap::from([(sentinel_run_id, sentinel_handle)]));
+            let tokens = RunCancellationRegistry::new();
+            let sentinel_registration = tokens.register(sentinel_run_id).await.unwrap();
+            let sentinel_token = sentinel_registration.token();
             let wakeups = PollWakeups::new(true);
             let direct_candidates = direct_candidate_inbox();
             let profiles = default_profiles();
@@ -2048,9 +2047,7 @@ mod tests {
             assert!(snapshot.deferred_poll_at.is_none(), "{case}");
             assert!(!sentinel_token.is_cancelled(), "{case}");
 
-            let tokens = tokens.lock().await;
-            assert_eq!(tokens.len(), 1, "{case}");
-            assert!(tokens.contains_key(&sentinel_run_id), "{case}");
+            assert!(tokens.contains(sentinel_run_id).await, "{case}");
         }
     }
 

--- a/crates/runner/src/provider/local/cancel.rs
+++ b/crates/runner/src/provider/local/cancel.rs
@@ -10,7 +10,9 @@ use crate::ids::RunId;
 #[cfg(test)]
 use crate::local_queue;
 use crate::local_queue::{CancelTargetState, LocalQueue};
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+#[cfg(test)]
+use crate::run_cancellation::RunCancellationRegistration;
+use crate::run_cancellation::{RunCancellationHandle, RunCancellationRegistry};
 
 /// Poll interval for scanning local cancel markers.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -18,7 +20,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 #[derive(Clone)]
 pub(super) struct LocalCancelScanner {
     queue: LocalQueue,
-    cancel_tokens: SharedRunCancellationMap,
+    cancel_tokens: RunCancellationRegistry,
     owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
 }
 
@@ -30,7 +32,7 @@ pub(super) struct LocalCancelWatcher {
 impl LocalCancelScanner {
     pub(super) fn new(
         queue: LocalQueue,
-        cancel_tokens: SharedRunCancellationMap,
+        cancel_tokens: RunCancellationRegistry,
         owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
     ) -> Self {
         Self {
@@ -102,11 +104,7 @@ impl LocalCancelScanner {
         &self,
         cancel_ids: &[RunId],
     ) -> HashMap<RunId, RunCancellationHandle> {
-        let tokens = self.cancel_tokens.lock().await;
-        cancel_ids
-            .iter()
-            .filter_map(|run_id| tokens.get(run_id).cloned().map(|token| (*run_id, token)))
-            .collect()
+        self.cancel_tokens.handles_for(cancel_ids).await
     }
 
     async fn snapshot_owned_claims(&self, cancel_ids: &[RunId]) -> HashSet<RunId> {
@@ -134,13 +132,7 @@ impl LocalCancelScanner {
             }
             owned.iter().copied().collect()
         };
-        let stale_ids: Vec<RunId> = {
-            let tokens = self.cancel_tokens.lock().await;
-            owned_ids
-                .into_iter()
-                .filter(|run_id| !tokens.contains_key(run_id))
-                .collect()
-        };
+        let stale_ids = self.cancel_tokens.missing_run_ids(&owned_ids).await;
         if stale_ids.is_empty() {
             return;
         }
@@ -222,11 +214,11 @@ impl Drop for LocalCancelWatcher {
 mod tests {
     use super::*;
 
-    fn empty_cancel_tokens() -> SharedRunCancellationMap {
-        Arc::new(tokio::sync::Mutex::new(HashMap::new()))
+    fn empty_cancel_tokens() -> RunCancellationRegistry {
+        RunCancellationRegistry::new()
     }
 
-    fn scanner(dir: &std::path::Path, tokens: SharedRunCancellationMap) -> LocalCancelScanner {
+    fn scanner(dir: &std::path::Path, tokens: RunCancellationRegistry) -> LocalCancelScanner {
         LocalCancelScanner::new(
             LocalQueue::new(dir.to_path_buf()),
             tokens,
@@ -234,14 +226,11 @@ mod tests {
         )
     }
 
-    async fn insert_cancel_handle(
-        tokens: &SharedRunCancellationMap,
+    async fn insert_cancel_registration(
+        tokens: &RunCancellationRegistry,
         run_id: RunId,
-    ) -> CancellationToken {
-        let handle = RunCancellationHandle::new();
-        let token = handle.token();
-        tokens.lock().await.insert(run_id, handle);
-        token
+    ) -> RunCancellationRegistration {
+        tokens.register(run_id).await.unwrap()
     }
 
     fn write_job(dir: &std::path::Path, run_id: RunId) {
@@ -276,7 +265,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         write_job(dir.path(), run_id);
         write_cancel(dir.path(), run_id);
 
@@ -290,7 +280,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         write_job(dir.path(), run_id);
         let cancel_path = write_cancel(dir.path(), run_id);
         let scanner = scanner(dir.path(), tokens);
@@ -310,7 +301,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         write_job(dir.path(), run_id);
         let cancel_path = write_cancel(dir.path(), run_id);
 
@@ -331,7 +323,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         let cancel_path = write_cancel(dir.path(), run_id);
         write_claim(dir.path(), run_id);
 
@@ -352,7 +345,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         let cancel_path = write_cancel(dir.path(), run_id);
 
         scanner(dir.path(), tokens).scan_cancel_files().await;
@@ -372,7 +366,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         let cancel_path = write_cancel(dir.path(), run_id);
         write_result(dir.path(), run_id, b"terminal");
         write_claim(dir.path(), run_id);
@@ -393,9 +388,10 @@ mod tests {
     async fn cancel_watcher_triggers_owned_token_without_discover() {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
-        let scanner = scanner(dir.path(), Arc::clone(&tokens));
+        let scanner = scanner(dir.path(), tokens.clone());
         let run_id = RunId::new_v4();
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         write_job(dir.path(), run_id);
         write_cancel(dir.path(), run_id);
         scanner.mark_owned_claim(run_id).await;
@@ -426,8 +422,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
         let run_id = RunId::new_v4();
-        let _job_token = insert_cancel_handle(&tokens, run_id).await;
-        let scanner = scanner(dir.path(), Arc::clone(&tokens));
+        let registration = tokens.register(run_id).await.unwrap();
+        let scanner = scanner(dir.path(), tokens.clone());
         scanner.mark_owned_claim(run_id).await;
         assert!(
             scanner
@@ -446,7 +442,7 @@ mod tests {
             "owned claim should stay while its cancel token is still active"
         );
 
-        tokens.lock().await.remove(&run_id);
+        registration.unregister().await;
         scanner.prune_owned_claims_without_tokens().await;
 
         assert!(
@@ -566,7 +562,7 @@ mod tests {
     async fn cancel_file_before_token_survives_until_token_inserted() {
         let dir = tempfile::tempdir().unwrap();
         let tokens = empty_cancel_tokens();
-        let scanner = scanner(dir.path(), Arc::clone(&tokens));
+        let scanner = scanner(dir.path(), tokens.clone());
         let run_id = RunId::new_v4();
         let cancel_path = write_cancel(dir.path(), run_id);
         write_job(dir.path(), run_id);
@@ -577,7 +573,8 @@ mod tests {
             "cancel file should survive while there is no token"
         );
 
-        let job_token = insert_cancel_handle(&tokens, run_id).await;
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let job_token = registration.token();
         scanner.mark_owned_claim(run_id).await;
         scanner.scan_cancel_files().await;
 

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
 use crate::ids::RunId;
 use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
-use crate::run_cancellation::SharedRunCancellationMap;
+use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use cancel::{LocalCancelScanner, LocalCancelWatcher};
 use sandbox::SandboxId;
@@ -52,7 +52,7 @@ impl LocalProvider {
         group_dir: PathBuf,
         supported_profiles: Vec<String>,
         cancel: CancellationToken,
-        cancel_tokens: SharedRunCancellationMap,
+        cancel_tokens: RunCancellationRegistry,
     ) -> Arc<Self> {
         Self::new_inner(group_dir, supported_profiles, cancel, cancel_tokens, true)
     }
@@ -61,7 +61,7 @@ impl LocalProvider {
         group_dir: PathBuf,
         mut supported_profiles: Vec<String>,
         cancel: CancellationToken,
-        cancel_tokens: SharedRunCancellationMap,
+        cancel_tokens: RunCancellationRegistry,
         start_cancel_watcher: bool,
     ) -> Arc<Self> {
         supported_profiles.sort();

--- a/crates/runner/src/provider/local/tests/cancellation.rs
+++ b/crates/runner/src/provider/local/tests/cancellation.rs
@@ -7,7 +7,8 @@ async fn cancel_file_triggers_token() {
     let tokens = empty_cancel_tokens();
 
     let run_id = RunId::new_v4();
-    let job_token = insert_cancel_handle(&tokens, run_id).await;
+    let registration = insert_cancel_registration(&tokens, run_id).await;
+    let job_token = registration.token();
 
     let provider = default_provider(dir.path(), cancel, tokens);
 
@@ -28,7 +29,8 @@ async fn owned_cancel_file_is_deleted_after_provider_claim() {
     let dir = tempfile::tempdir().unwrap();
     let tokens = empty_cancel_tokens();
     let run_id = RunId::new_v4();
-    let job_token = insert_cancel_handle(&tokens, run_id).await;
+    let registration = insert_cancel_registration(&tokens, run_id).await;
+    let job_token = registration.token();
     let provider = default_provider(dir.path(), CancellationToken::new(), tokens);
     write_job(dir.path(), run_id, "owned");
     let candidate = provider.discover().await.unwrap();
@@ -74,7 +76,7 @@ async fn stale_cancel_file_is_deleted_before_provider_discovers_next_job() {
 async fn cancel_file_before_token_survives_until_provider_claim_token_exists() {
     let dir = tempfile::tempdir().unwrap();
     let tokens = empty_cancel_tokens();
-    let provider = default_provider(dir.path(), CancellationToken::new(), Arc::clone(&tokens));
+    let provider = default_provider(dir.path(), CancellationToken::new(), tokens.clone());
     let run_id = RunId::new_v4();
     let cancel_path = local_queue::cancel_path(dir.path(), run_id);
     std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
@@ -88,7 +90,8 @@ async fn cancel_file_before_token_survives_until_provider_claim_token_exists() {
         "cancel file should survive before the token is inserted"
     );
 
-    let job_token = insert_cancel_handle(&tokens, run_id).await;
+    let registration = insert_cancel_registration(&tokens, run_id).await;
+    let job_token = registration.token();
     provider.claim(candidate).await.unwrap();
     let other_job = RunId::new_v4();
     write_job(dir.path(), other_job, "next job");
@@ -114,10 +117,11 @@ async fn provider_cancel_watcher_triggers_owned_token_without_discover() {
         dir.path().to_path_buf(),
         default_profiles(),
         CancellationToken::new(),
-        Arc::clone(&tokens),
+        tokens.clone(),
     );
     let run_id = RunId::new_v4();
-    let job_token = insert_cancel_handle(&tokens, run_id).await;
+    let registration = insert_cancel_registration(&tokens, run_id).await;
+    let job_token = registration.token();
     write_job(dir.path(), run_id, "owned");
     let candidate = provider.discover().await.unwrap();
     provider.claim(candidate).await.unwrap();

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -224,7 +224,7 @@ async fn group_claim_only_one_winner() {
     let cancel = CancellationToken::new();
 
     let tokens = empty_cancel_tokens();
-    let provider_a = default_provider(dir.path(), cancel.clone(), Arc::clone(&tokens));
+    let provider_a = default_provider(dir.path(), cancel.clone(), tokens.clone());
     let provider_b = default_provider(dir.path(), cancel, tokens);
 
     let job_id = RunId::new_v4();

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -11,7 +11,7 @@ pub(super) use crate::local_queue;
 use crate::local_queue::JobRequest;
 pub(super) use crate::local_queue::JobResponse;
 pub(super) use crate::provider::{CompletionAuth, JobCandidate, JobProvider};
-use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 pub(super) use tokio_util::sync::CancellationToken;
 
 pub(super) trait LocalProviderTestExt {
@@ -32,18 +32,15 @@ impl LocalProviderTestExt for LocalProvider {
     }
 }
 
-pub(super) fn empty_cancel_tokens() -> SharedRunCancellationMap {
-    Arc::new(tokio::sync::Mutex::new(HashMap::new()))
+pub(super) fn empty_cancel_tokens() -> RunCancellationRegistry {
+    RunCancellationRegistry::new()
 }
 
-pub(super) async fn insert_cancel_handle(
-    tokens: &SharedRunCancellationMap,
+pub(super) async fn insert_cancel_registration(
+    tokens: &RunCancellationRegistry,
     run_id: RunId,
-) -> CancellationToken {
-    let handle = RunCancellationHandle::new();
-    let token = handle.token();
-    tokens.lock().await.insert(run_id, handle);
-    token
+) -> RunCancellationRegistration {
+    tokens.register(run_id).await.unwrap()
 }
 
 pub(super) fn profiles(names: &[&str]) -> Vec<String> {
@@ -57,7 +54,7 @@ pub(super) fn default_profiles() -> Vec<String> {
 pub(super) fn default_provider(
     dir: &std::path::Path,
     cancel: CancellationToken,
-    tokens: SharedRunCancellationMap,
+    tokens: RunCancellationRegistry,
 ) -> Arc<LocalProvider> {
     LocalProvider::new_inner(dir.to_path_buf(), default_profiles(), cancel, tokens, false)
 }
@@ -66,7 +63,7 @@ pub(super) fn provider_with_profiles(
     dir: &std::path::Path,
     supported_profiles: &[&str],
     cancel: CancellationToken,
-    tokens: SharedRunCancellationMap,
+    tokens: RunCancellationRegistry,
 ) -> Arc<LocalProvider> {
     LocalProvider::new_inner(
         dir.to_path_buf(),

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -6,7 +6,27 @@ use tokio_util::sync::CancellationToken;
 
 use crate::ids::RunId;
 
-pub(crate) type SharedRunCancellationMap = Arc<Mutex<HashMap<RunId, RunCancellationHandle>>>;
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RunCancellationRegistry {
+    inner: Arc<Mutex<RunCancellationRegistryState>>,
+}
+
+#[derive(Debug, Default)]
+struct RunCancellationRegistryState {
+    registrations: HashMap<RunId, RunCancellationHandle>,
+    hard_stopping: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DuplicateRunCancellationRegistration;
+
+#[derive(Debug)]
+#[must_use = "the registration must remain owned until its run is cleaned up"]
+pub(crate) struct RunCancellationRegistration {
+    registry: RunCancellationRegistry,
+    run_id: RunId,
+    handle: RunCancellationHandle,
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct RunCancellationHandle {
@@ -17,6 +37,111 @@ pub(crate) struct RunCancellationHandle {
 struct RunCancellationInner {
     token: CancellationToken,
     transfer_gate: Arc<Mutex<()>>,
+}
+
+impl RunCancellationRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) async fn register(
+        &self,
+        run_id: RunId,
+    ) -> Result<RunCancellationRegistration, DuplicateRunCancellationRegistration> {
+        let handle = RunCancellationHandle::new();
+        let hard_stopping = {
+            let mut state = self.inner.lock().await;
+            if state.registrations.contains_key(&run_id) {
+                return Err(DuplicateRunCancellationRegistration);
+            }
+            state.registrations.insert(run_id, handle.clone());
+            state.hard_stopping
+        };
+        if hard_stopping {
+            handle.cancel().await;
+        }
+        Ok(RunCancellationRegistration {
+            registry: self.clone(),
+            run_id,
+            handle,
+        })
+    }
+
+    pub(crate) async fn handle(&self, run_id: RunId) -> Option<RunCancellationHandle> {
+        self.inner.lock().await.registrations.get(&run_id).cloned()
+    }
+
+    pub(crate) async fn handles_for(
+        &self,
+        run_ids: &[RunId],
+    ) -> HashMap<RunId, RunCancellationHandle> {
+        let state = self.inner.lock().await;
+        run_ids
+            .iter()
+            .filter_map(|run_id| {
+                state
+                    .registrations
+                    .get(run_id)
+                    .cloned()
+                    .map(|handle| (*run_id, handle))
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn contains(&self, run_id: RunId) -> bool {
+        self.inner.lock().await.registrations.contains_key(&run_id)
+    }
+
+    pub(crate) async fn missing_run_ids(&self, run_ids: &[RunId]) -> Vec<RunId> {
+        let state = self.inner.lock().await;
+        run_ids
+            .iter()
+            .copied()
+            .filter(|run_id| !state.registrations.contains_key(run_id))
+            .collect()
+    }
+
+    pub(crate) async fn begin_hard_stop(&self) -> Vec<(RunId, RunCancellationHandle)> {
+        let mut state = self.inner.lock().await;
+        state.hard_stopping = true;
+        state
+            .registrations
+            .iter()
+            .map(|(run_id, handle)| (*run_id, handle.clone()))
+            .collect()
+    }
+}
+
+impl RunCancellationRegistration {
+    pub(crate) fn handle(&self) -> RunCancellationHandle {
+        self.handle.clone()
+    }
+
+    pub(crate) fn token(&self) -> CancellationToken {
+        self.handle.token()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.handle.is_cancelled()
+    }
+
+    pub(crate) async fn cancel(&self) -> bool {
+        self.handle.cancel().await
+    }
+
+    pub(crate) async fn unregister(&self) -> bool {
+        let mut state = self.registry.inner.lock().await;
+        let is_current = state
+            .registrations
+            .get(&self.run_id)
+            .is_some_and(|handle| handle.same_registration(&self.handle));
+        if is_current {
+            state.registrations.remove(&self.run_id);
+        }
+        is_current
+    }
 }
 
 impl RunCancellationHandle {
@@ -50,5 +175,71 @@ impl RunCancellationHandle {
 
     pub(crate) fn try_transfer_guard(&self) -> Option<OwnedMutexGuard<()>> {
         self.inner.transfer_gate.clone().try_lock_owned().ok()
+    }
+
+    fn same_registration(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn duplicate_registration_preserves_the_active_handle() {
+        let registry = RunCancellationRegistry::new();
+        let run_id = RunId::new_v4();
+        let registration = registry.register(run_id).await.unwrap();
+        let token = registration.token();
+
+        assert_eq!(
+            registry.register(run_id).await.unwrap_err(),
+            DuplicateRunCancellationRegistration,
+        );
+
+        registry.handle(run_id).await.unwrap().cancel().await;
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn registration_before_hard_stop_is_included_in_the_snapshot() {
+        let registry = RunCancellationRegistry::new();
+        let run_id = RunId::new_v4();
+        let registration = registry.register(run_id).await.unwrap();
+        let token = registration.token();
+
+        let handles = registry.begin_hard_stop().await;
+
+        assert_eq!(handles.len(), 1);
+        assert_eq!(handles[0].0, run_id);
+        assert!(!token.is_cancelled());
+        handles[0].1.cancel().await;
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn registration_after_hard_stop_is_returned_cancelled() {
+        let registry = RunCancellationRegistry::new();
+        assert!(registry.begin_hard_stop().await.is_empty());
+
+        let registration = registry.register(RunId::new_v4()).await.unwrap();
+
+        assert!(registration.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn stale_registration_does_not_remove_its_replacement() {
+        let registry = RunCancellationRegistry::new();
+        let run_id = RunId::new_v4();
+        let stale = registry.register(run_id).await.unwrap();
+        assert!(stale.unregister().await);
+        let replacement = registry.register(run_id).await.unwrap();
+        let replacement_token = replacement.token();
+
+        assert!(!stale.unregister().await);
+        registry.handle(run_id).await.unwrap().cancel().await;
+
+        assert!(replacement_token.is_cancelled());
     }
 }


### PR DESCRIPTION
## Summary

- replace the exposed runner cancellation map with a private `RunCancellationRegistry`
- carry an owned registration through admission, execution, normal cleanup, and panic cleanup
- make hard-stop registration/snapshot ordering explicit while preserving transfer-gated cancellation
- move Ably and LocalProvider consumers to narrow registry lookup and snapshot APIs

## Behavior and safety

- duplicate registration remains vacant-only and cannot replace the active handle
- registrations created after the hard-stop barrier remain accepted, are cancelled, and continue through the existing claim/completion path
- cleanup removes only the registration identity it owns, so stale cleanup cannot delete a replacement
- no schema, persisted data, API, queue payload, or runner/backend protocol changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_cancellation -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::signals -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_ably_supervisor -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner -- --nocapture`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `git diff --check`

Closes #22915
