### PR TITLE
perf: add first-output coverage and codex lifecycle timings

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -19,7 +19,10 @@ use crate::paths;
 use super::codex_app_server::{
     CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, ServerNotification,
 };
-use super::codex_app_server_events::{IGNORED_NOTIFICATION_METHODS, notification_to_codex_event};
+use super::codex_app_server_events::{
+    CodexOutputItemKind, CodexOutputItemStart, IGNORED_NOTIFICATION_METHODS,
+    codex_output_item_start, notification_to_codex_event,
+};
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
     CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
@@ -29,6 +32,8 @@ use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
 
 const TURN_NOTIFICATION_LABEL: &str = "turn notification";
+const API_TO_CODEX_OUTPUT_ITEM_STARTED: &str = "api_to_codex_output_item_started";
+const API_TO_CODEX_AGENT_MESSAGE_ITEM_STARTED: &str = "api_to_codex_agent_message_item_started";
 
 struct NotificationIngestResult {
     emitted_thread_started: bool,
@@ -36,6 +41,7 @@ struct NotificationIngestResult {
 
 struct PreparedNotificationIngest {
     event: Option<Value>,
+    output_item_start: Option<CodexOutputItemStart>,
     emitted_thread_started: bool,
     terminal_exit_code: Option<i32>,
 }
@@ -47,10 +53,36 @@ struct ThreadIdentity {
 
 struct EventIngestSink<'a> {
     ingestor: &'a mut CliEventIngestor,
+    output_timing: &'a mut CodexOutputTiming,
     log_file: &'a mut tokio::fs::File,
     masker: &'a SecretMasker,
     should_send_events: bool,
     event_tx: &'a EventDeliverySender,
+}
+
+#[derive(Default)]
+struct CodexOutputTiming {
+    output_item_started: bool,
+    agent_message_item_started: bool,
+}
+
+impl CodexOutputTiming {
+    fn record(&mut self, start: &CodexOutputItemStart, ingestor: &CliEventIngestor) {
+        if !self.output_item_started {
+            self.output_item_started = true;
+            ingestor.record_e2e_from_api_start_at(
+                API_TO_CODEX_OUTPUT_ITEM_STARTED,
+                start.started_at_ms,
+            );
+        }
+        if start.kind == CodexOutputItemKind::AgentMessage && !self.agent_message_item_started {
+            self.agent_message_item_started = true;
+            ingestor.record_e2e_from_api_start_at(
+                API_TO_CODEX_AGENT_MESSAGE_ITEM_STARTED,
+                start.started_at_ms,
+            );
+        }
+    }
 }
 
 struct CodexTurnScope<'a> {
@@ -112,6 +144,7 @@ async fn run_codex_app_server(
     let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new(runtime);
+    let mut output_timing = CodexOutputTiming::default();
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
     let mut client = CodexAppServerClient::spawn(codex_app_server_config(runtime))
         .map_err(|error| app_server_error(masker, error))?;
@@ -139,6 +172,7 @@ async fn run_codex_app_server(
         while let Some(notification) = client.pop_notification() {
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
+                output_timing: &mut output_timing,
                 log_file: &mut log_file,
                 masker,
                 should_send_events,
@@ -159,6 +193,7 @@ async fn run_codex_app_server(
         if !thread_started_emitted {
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
+                output_timing: &mut output_timing,
                 log_file: &mut log_file,
                 masker,
                 should_send_events,
@@ -201,6 +236,7 @@ async fn run_codex_app_server(
                 CodexRunEvent::Notification(notification) => {
                     let mut sink = EventIngestSink {
                         ingestor: &mut ingestor,
+                        output_timing: &mut output_timing,
                         log_file: &mut log_file,
                         masker,
                         should_send_events,
@@ -244,6 +280,7 @@ async fn run_codex_app_server(
                     .await?;
                     let mut sink = EventIngestSink {
                         ingestor: &mut ingestor,
+                        output_timing: &mut output_timing,
                         log_file: &mut log_file,
                         masker,
                         should_send_events,
@@ -620,6 +657,7 @@ async fn drain_queued_notifications(
         }
     }
     for prepared in prepared_notifications {
+        record_output_item_start(prepared.output_item_start.as_ref(), sink);
         if let Some(event) = prepared.event {
             ingest_event(event, sink).await?;
         }
@@ -644,6 +682,7 @@ async fn ingest_run_notification(
         scope.thread_id,
         scope.turn_id,
     )?;
+    record_output_item_start(prepared.output_item_start.as_ref(), sink);
     // Close before any ingest await so the control path cannot accept input
     // after this run has already observed a terminal turn event.
     if prepared.terminal_exit_code.is_some() {
@@ -699,6 +738,7 @@ async fn ingest_notification(
         expected_thread_id,
         active_turn_id,
     )?;
+    record_output_item_start(prepared.output_item_start.as_ref(), sink);
     if prepared.terminal_exit_code.is_some()
         && let Some(active_input) = terminal_active_input
     {
@@ -718,11 +758,22 @@ fn prepare_notification_ingest(
     expected_thread_id: &str,
     active_turn_id: &str,
 ) -> Result<PreparedNotificationIngest, AgentError> {
+    let output_item_start = codex_output_item_start(&notification)
+        .map_err(|error| AgentError::Execution(error.to_string()))?;
+    if let Some(start) = &output_item_start {
+        validate_scope(
+            Some(&start.thread_id),
+            Some(&start.turn_id),
+            expected_thread_id,
+            active_turn_id,
+        )?;
+    }
     let Some(event) = notification_to_codex_event(&notification)
         .map_err(|error| AgentError::Execution(error.to_string()))?
     else {
         return Ok(PreparedNotificationIngest {
             event: None,
+            output_item_start,
             emitted_thread_started: false,
             terminal_exit_code: None,
         });
@@ -731,6 +782,7 @@ fn prepare_notification_ingest(
     if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
         return Ok(PreparedNotificationIngest {
             event: None,
+            output_item_start,
             emitted_thread_started: false,
             terminal_exit_code: None,
         });
@@ -739,6 +791,7 @@ fn prepare_notification_ingest(
     let terminal_exit_code = terminal_exit_code(&event, expected_thread_id, active_turn_id);
     Ok(PreparedNotificationIngest {
         event: Some(event),
+        output_item_start,
         emitted_thread_started,
         terminal_exit_code,
     })
@@ -749,14 +802,28 @@ fn validate_event_scope(
     expected_canonical_thread_id: &str,
     active_turn_id: &str,
 ) -> Result<(), AgentError> {
-    if let Some(thread_id) = event_thread_id(event)
+    validate_scope(
+        event_thread_id(event),
+        event_turn_id(event),
+        expected_canonical_thread_id,
+        active_turn_id,
+    )
+}
+
+fn validate_scope(
+    thread_id: Option<&str>,
+    turn_id: Option<&str>,
+    expected_canonical_thread_id: &str,
+    active_turn_id: &str,
+) -> Result<(), AgentError> {
+    if let Some(thread_id) = thread_id
         && !thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
     {
         return Err(AgentError::Execution(
             "codex app-server reported unexpected thread id in event".to_string(),
         ));
     }
-    if let Some(turn_id) = event_turn_id(event) {
+    if let Some(turn_id) = turn_id {
         if active_turn_id.is_empty() {
             return Err(AgentError::Execution(
                 "codex app-server reported turn-scoped event before turn/start".to_string(),
@@ -769,6 +836,12 @@ fn validate_event_scope(
         }
     }
     Ok(())
+}
+
+fn record_output_item_start(start: Option<&CodexOutputItemStart>, sink: &mut EventIngestSink<'_>) {
+    if let Some(start) = start {
+        sink.output_timing.record(start, sink.ingestor);
+    }
 }
 
 fn event_thread_id(event: &Value) -> Option<&str> {

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -121,7 +121,6 @@ pub(super) fn codex_output_item_start(
         "agentMessage" => CodexOutputItemKind::AgentMessage,
         _ => return Ok(None),
     };
-    required_non_empty_string_key(item, &notification.method, "id", "item.id")?;
     let thread_id =
         required_non_empty_string_key(params, &notification.method, "threadId", "threadId")?;
     let turn_id = required_non_empty_string_key(params, &notification.method, "turnId", "turnId")?;
@@ -1737,7 +1736,6 @@ mod tests {
                     "turnId": "turn-1",
                     "startedAtMs": 1_700_000_000_123_u64,
                     "item": {
-                        "id": "item-1",
                         "type": item_type
                     }
                 }),

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -24,6 +24,21 @@ pub(super) const IGNORED_NOTIFICATION_METHODS: &[&str] = &[
 
 const MAX_GENERIC_COLLECTION_ITEMS: usize = 16;
 const MAX_GENERIC_OBJECT_FIELDS: usize = 24;
+const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CodexOutputItemKind {
+    Reasoning,
+    AgentMessage,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct CodexOutputItemStart {
+    pub(super) thread_id: String,
+    pub(super) turn_id: String,
+    pub(super) started_at_ms: u64,
+    pub(super) kind: CodexOutputItemKind,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TurnStatus {
@@ -89,6 +104,40 @@ pub(super) enum CodexAppServerEventError {
     MissingField { method: String, field: &'static str },
     #[error("codex app-server notification {method} has invalid field {field}")]
     InvalidField { method: String, field: &'static str },
+}
+
+pub(super) fn codex_output_item_start(
+    notification: &ServerNotification,
+) -> Result<Option<CodexOutputItemStart>, CodexAppServerEventError> {
+    if notification.method != "item/started" {
+        return Ok(None);
+    }
+
+    let params = required_params_object(notification)?;
+    let item = required_object_key(params, &notification.method, "item", "item")?;
+    let item_type = required_non_empty_string_key(item, &notification.method, "type", "item.type")?;
+    let kind = match item_type {
+        "reasoning" => CodexOutputItemKind::Reasoning,
+        "agentMessage" => CodexOutputItemKind::AgentMessage,
+        _ => return Ok(None),
+    };
+    required_non_empty_string_key(item, &notification.method, "id", "item.id")?;
+    let thread_id =
+        required_non_empty_string_key(params, &notification.method, "threadId", "threadId")?;
+    let turn_id = required_non_empty_string_key(params, &notification.method, "turnId", "turnId")?;
+    let started_at_ms = params
+        .get("startedAtMs")
+        .ok_or_else(|| missing_field(&notification.method, "startedAtMs"))?
+        .as_u64()
+        .filter(|value| *value >= MIN_EPOCH_MS_TIMESTAMP)
+        .ok_or_else(|| invalid_field_for_method(&notification.method, "startedAtMs"))?;
+
+    Ok(Some(CodexOutputItemStart {
+        thread_id: thread_id.to_string(),
+        turn_id: turn_id.to_string(),
+        started_at_ms,
+        kind,
+    }))
 }
 
 /// Convert a Codex app-server notification into the existing Codex JSONL event shape.
@@ -1672,6 +1721,57 @@ mod tests {
             .expect("ignored notification should not error");
             assert_eq!(result, None, "method {method}");
         }
+    }
+
+    #[test]
+    fn output_item_start_selects_reasoning_and_agent_message_only() {
+        for (item_type, expected_kind) in [
+            ("reasoning", Some(CodexOutputItemKind::Reasoning)),
+            ("agentMessage", Some(CodexOutputItemKind::AgentMessage)),
+            ("commandExecution", None),
+        ] {
+            let start = codex_output_item_start(&notification(
+                "item/started",
+                json!({
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "startedAtMs": 1_700_000_000_123_u64,
+                    "item": {
+                        "id": "item-1",
+                        "type": item_type
+                    }
+                }),
+            ))
+            .expect("valid item start should parse");
+
+            assert_eq!(start.map(|start| start.kind), expected_kind);
+        }
+    }
+
+    #[test]
+    fn output_item_start_rejects_non_epoch_timestamp() {
+        let error = codex_output_item_start(&notification(
+            "item/started",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "startedAtMs": 42,
+                "item": {
+                    "id": "item-1",
+                    "type": "agentMessage",
+                    "text": ""
+                }
+            }),
+        ))
+        .expect_err("non-epoch item start should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/started".to_string(),
+                field: "startedAtMs",
+            }
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -482,6 +482,10 @@ impl CliEventIngestor {
         }
     }
 
+    fn record_e2e_from_api_start_at(&self, op_name: &str, observed_at_ms: u64) {
+        timing::record_e2e_from_api_start_at(op_name, &self.api_start_time, observed_at_ms);
+    }
+
     async fn write_raw_line(log_file: &mut tokio::fs::File, raw_line: impl AsRef<[u8]>) {
         let _ = log_file.write_all(raw_line.as_ref()).await;
         let _ = log_file.write_all(b"\n").await;

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -11,8 +11,12 @@ static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Record an E2E duration from an already captured API start timestamp.
 pub fn record_e2e_from_api_start(op_name: &str, api_start: &str) {
-    let now_ms = current_epoch_ms();
-    if let Some(duration) = e2e_duration_from_api_start(api_start, now_ms) {
+    record_e2e_from_api_start_at(op_name, api_start, current_epoch_ms());
+}
+
+/// Record an E2E duration ending at an observed Unix epoch timestamp.
+pub fn record_e2e_from_api_start_at(op_name: &str, api_start: &str, observed_at_ms: u64) {
+    if let Some(duration) = e2e_duration_from_api_start(api_start, observed_at_ms) {
         record_sandbox_op(op_name, duration, true, None);
         log_info!(LOG_TAG, "E2E {op_name}: {}ms", duration.as_millis());
     } else if !api_start.is_empty() {

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -8,7 +8,7 @@ mod common;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
 async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_started()
@@ -29,6 +29,11 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
                 resume_session_id: None,
             },
         )?;
+        let api_start_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .saturating_sub(10_000);
+        std::env::set_var("VM0_API_START_TIME", api_start_time.to_string());
         let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)
             .map_err(|error| format!("resolve runtime dir: {error}"))?;
         common::set_run_payload_file_env_for_test(
@@ -85,10 +90,50 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
         ],
     );
 
+    let sandbox_ops = read_sandbox_ops(&runtime.paths)?;
+    let output_item_started = sandbox_ops
+        .iter()
+        .filter(|event| {
+            event.get("action_type").and_then(Value::as_str)
+                == Some("api_to_codex_output_item_started")
+        })
+        .collect::<Vec<_>>();
+    let agent_message_item_started = sandbox_ops
+        .iter()
+        .filter(|event| {
+            event.get("action_type").and_then(Value::as_str)
+                == Some("api_to_codex_agent_message_item_started")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(output_item_started.len(), 1);
+    assert_eq!(agent_message_item_started.len(), 1);
+    let output_duration = output_item_started[0]["duration_ms"]
+        .as_u64()
+        .ok_or("output item timing missing duration_ms")?;
+    let agent_message_duration = agent_message_item_started[0]["duration_ms"]
+        .as_u64()
+        .ok_or("agent message item timing missing duration_ms")?;
+    assert!(output_duration <= agent_message_duration);
+
     let thread_id = events[0]
         .get("thread_id")
         .and_then(Value::as_str)
         .ok_or("thread.started missing thread_id")?;
+    let serialized_timings =
+        serde_json::to_string(&[output_item_started[0], agent_message_item_started[0]])?;
+    for excluded in [
+        thread_id,
+        "mock-reasoning-item-0",
+        "mock-reasoning-item-1",
+        "mock-agent-message-item-0",
+        "mock-agent-message-item-1",
+        "mock reasoning content must not enter timing telemetry",
+    ] {
+        assert!(
+            !serialized_timings.contains(excluded),
+            "timing telemetry must not contain {excluded:?}: {serialized_timings}"
+        );
+    }
     let stored_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert_eq!(stored_id, thread_id);
     let marker = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
@@ -154,6 +199,15 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     );
 
     Ok(())
+}
+
+fn read_sandbox_ops(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(paths.sandbox_ops_file())?;
+    log.lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
 }
 
 fn read_agent_log_events(

--- a/crates/guest-agent/tests/codex_app_server_backend_output_timing_stale_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_output_timing_stale_scope.rs
@@ -1,4 +1,4 @@
-//! Scope validation coverage for the experimental Codex app-server backend.
+//! Stale-turn output timing coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary to isolate process env, working directory,
 //! and guest runtime path overrides used during setup.
@@ -6,11 +6,10 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
-use serde_json::Value;
 use std::time::Duration;
 
 #[tokio::test]
-async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
+async fn codex_app_server_backend_rejects_stale_turn_output_timing()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
@@ -20,9 +19,9 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
             &mock,
             tmp.path(),
             common::CodexAppServerEnvConfig {
-                run_id: "codex-app-server-backend-scope-test",
-                prompt: "drive the app-server backend scope failure path",
-                scenario: Some("unexpected-thread-output-item-started"),
+                run_id: "codex-app-server-backend-output-timing-stale-scope-test",
+                prompt: "drive the app-server output timing stale-turn path",
+                scenario: Some("unexpected-turn-output-item-started"),
                 resume_session_id: None,
             },
         )?;
@@ -39,32 +38,16 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
     .await
     .expect("execute_cli should return promptly");
 
-    let error = result.expect_err("unexpected thread event should fail the app-server backend");
+    let error = result.expect_err("stale-turn output item should fail the app-server backend");
     let message = error.to_string();
     assert!(
-        message.contains("unexpected thread id"),
+        message.contains("unexpected turn id"),
         "unexpected error: {message}"
     );
 
-    let events = read_agent_log_events(&runtime.paths)?;
-    assert!(
-        events.iter().all(|event| {
-            event.get("thread_id").and_then(Value::as_str) != Some("unexpected-thread-id")
-        }),
-        "unexpected-thread-id event should not be written to the agent log: {events:?}"
-    );
     let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap_or_default();
     assert!(!sandbox_ops.contains("api_to_codex_output_item_started"));
     assert!(!sandbox_ops.contains("api_to_codex_agent_message_item_started"));
 
     Ok(())
-}
-
-fn read_agent_log_events(
-    paths: &guest_agent::paths::GuestPaths,
-) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let log = std::fs::read_to_string(paths.agent_log_file())?;
-    log.lines()
-        .map(|line| serde_json::from_str(line).map_err(Into::into))
-        .collect()
 }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -1,9 +1,10 @@
 use super::messages::{
     initialize_response, large_server_notification, large_warning_notification,
-    server_notification, server_notification_with_index, server_request, thread_response,
-    thread_started_notification, turn, turn_completed_notification, turn_started_notification,
-    warning_notification, write_error, write_json_line, write_split_json_line_prefix,
-    write_success, write_turn_completion_notifications, write_turn_notifications,
+    reasoning_item_started_notification, server_notification, server_notification_with_index,
+    server_request, thread_response, thread_started_notification, turn,
+    turn_completed_notification, turn_started_notification, warning_notification, write_error,
+    write_json_line, write_split_json_line_prefix, write_success,
+    write_turn_completion_notifications, write_turn_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
@@ -271,6 +272,30 @@ impl AppServerState {
             &inputs,
         )?;
         write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
+        if self.scenario == Scenario::UnexpectedThreadOutputItemStarted {
+            write_json_line(
+                output,
+                &reasoning_item_started_notification(
+                    "unexpected-thread-id",
+                    &turn_id,
+                    "unexpected-thread-reasoning-item",
+                    1_700_000_000_000,
+                ),
+            )?;
+            return Ok(ServerAction::Stop);
+        }
+        if self.scenario == Scenario::UnexpectedTurnOutputItemStarted {
+            write_json_line(
+                output,
+                &reasoning_item_started_notification(
+                    &thread_id,
+                    "unexpected-turn-id",
+                    "unexpected-turn-reasoning-item",
+                    1_700_000_000_000,
+                ),
+            )?;
+            return Ok(ServerAction::Stop);
+        }
         if self.scenario == Scenario::UnexpectedThreadTurnCompleted {
             write_json_line(
                 output,

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -1,6 +1,7 @@
 use crate::session;
 use serde_json::{Value, json};
 use std::io::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const LARGE_NOTIFICATION_MESSAGE_BYTES: usize = 17 * 1024 * 1024;
@@ -80,6 +81,49 @@ pub(super) fn turn_started_notification(thread_id: &str, turn_id: &str) -> Value
     })
 }
 
+pub(super) fn reasoning_item_started_notification(
+    thread_id: &str,
+    turn_id: &str,
+    item_id: &str,
+    started_at_ms: u64,
+) -> Value {
+    json!({
+        "method": "item/started",
+        "params": {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "startedAtMs": started_at_ms,
+            "item": {
+                "id": item_id,
+                "type": "reasoning",
+                "summary": ["mock reasoning content must not enter timing telemetry"],
+                "content": []
+            }
+        }
+    })
+}
+
+pub(super) fn agent_message_item_started_notification(
+    thread_id: &str,
+    turn_id: &str,
+    item_id: &str,
+    started_at_ms: u64,
+) -> Value {
+    json!({
+        "method": "item/started",
+        "params": {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "startedAtMs": started_at_ms,
+            "item": {
+                "id": item_id,
+                "type": "agentMessage",
+                "text": ""
+            }
+        }
+    })
+}
+
 fn assistant_item_completed_notification(thread_id: &str, turn_id: &str) -> Value {
     json!({
         "method": "item/completed",
@@ -141,6 +185,33 @@ pub(super) fn write_turn_notifications<W: Write>(
     turn_id: &str,
 ) -> io::Result<()> {
     write_json_line(output, &turn_started_notification(thread_id, turn_id))?;
+    let started_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_millis();
+    let started_at_ms = u64::try_from(started_at_ms).map_err(io::Error::other)?;
+    for (index, offset_ms) in [0_u64, 1].into_iter().enumerate() {
+        write_json_line(
+            output,
+            &reasoning_item_started_notification(
+                thread_id,
+                turn_id,
+                &format!("mock-reasoning-item-{index}"),
+                started_at_ms + offset_ms,
+            ),
+        )?;
+    }
+    for (index, offset_ms) in [2_u64, 3].into_iter().enumerate() {
+        write_json_line(
+            output,
+            &agent_message_item_started_notification(
+                thread_id,
+                turn_id,
+                &format!("mock-agent-message-item-{index}"),
+                started_at_ms + offset_ms,
+            ),
+        )?;
+    }
     write_turn_completion_notifications(output, thread_id, turn_id)
 }
 

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -37,6 +37,8 @@ pub(super) enum Scenario {
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
     ThreadStartInvalidThreadId,
+    UnexpectedThreadOutputItemStarted,
+    UnexpectedTurnOutputItemStarted,
     UnexpectedThreadTurnCompleted,
 }
 
@@ -89,6 +91,10 @@ impl Scenario {
                 "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "thread-start-invalid-thread-id" => Ok(Self::ThreadStartInvalidThreadId),
+                "unexpected-thread-output-item-started" => {
+                    Ok(Self::UnexpectedThreadOutputItemStarted)
+                }
+                "unexpected-turn-output-item-started" => Ok(Self::UnexpectedTurnOutputItemStarted),
                 "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -365,12 +365,29 @@ fn app_server_turn_steer_can_complete_runtime_turn_after_success() -> std::io::R
     )?;
     assert_eq!(steered["result"]["turnId"], turn_id);
 
-    let turn_started_notification = server.read_required()?;
-    let item_completed_notification = server.read_required()?;
-    let turn_completed_notification = server.read_required()?;
-    assert_eq!(turn_started_notification["method"], "turn/started");
-    assert_eq!(item_completed_notification["method"], "item/completed");
-    assert_eq!(turn_completed_notification["method"], "turn/completed");
+    let mut notification_methods = Vec::new();
+    loop {
+        let notification = server.read_required()?;
+        let method = notification["method"]
+            .as_str()
+            .ok_or_else(|| std::io::Error::other("notification is missing method"))?;
+        notification_methods.push(method.to_string());
+        if method == "turn/completed" {
+            break;
+        }
+    }
+    assert_eq!(
+        notification_methods,
+        [
+            "turn/started",
+            "item/started",
+            "item/started",
+            "item/started",
+            "item/started",
+            "item/completed",
+            "turn/completed",
+        ]
+    );
 
     let session_path = require_session_file(dir.path())?;
     let events = read_session_file(&session_path)?;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -369,6 +369,14 @@ function firstAssistantMessageEventsForRun(
   });
 }
 
+function firstAssistantMessageEligibilityEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return sandboxOperationEventsForRun(runId).filter((event) => {
+    return event.op_type === "first_assistant_message_eligible";
+  });
+}
+
 function apiDispatchTimingEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
@@ -1530,6 +1538,18 @@ describe("CHAT-02: dispatch failure", () => {
       throw new Error("Expected the failed dispatch to still create a run");
     }
     expect(sent.body.status).toBe("failed");
+    await flushWaitUntilForTest();
+    expect(
+      firstAssistantMessageEligibilityEventsForRun(sent.body.runId),
+    ).toStrictEqual([
+      expect.objectContaining({
+        op_type: "first_assistant_message_eligible",
+        sandbox_type: "runner",
+        duration_ms: 0,
+        success: true,
+        run_id: sent.body.runId,
+      }),
+    ]);
 
     const run = await api.readRun(actor, sent.body.runId);
     expect(run.status).toBe("failed");
@@ -1581,6 +1601,10 @@ describe("CHAT-02: dispatch failure", () => {
       threadId: sent.body.threadId,
       status: "failed",
     });
+    await flushWaitUntilForTest();
+    expect(
+      firstAssistantMessageEligibilityEventsForRun(sent.body.runId),
+    ).toHaveLength(1);
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).not.toContainEqual(
       expect.objectContaining({ runId: sent.body.runId }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1005,6 +1005,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       prompt,
       modelProvider: "anthropic-api-key",
     });
+    expect(
+      sandboxOperationEventsForRunByAction(
+        created.runId,
+        "first_assistant_message_eligible",
+      ),
+    ).toStrictEqual([]);
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
@@ -9314,6 +9320,23 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       agentId,
       prompt: "bdd assistant events",
     });
+    await flushWaitUntilForTest();
+    expect(
+      sandboxOperationEventsForRunByAction(
+        runId,
+        "first_assistant_message_eligible",
+      ),
+    ).toStrictEqual([
+      {
+        _time: new Date(apiStartedAt).toISOString(),
+        source: "api",
+        op_type: "first_assistant_message_eligible",
+        sandbox_type: "runner",
+        duration_ms: 0,
+        success: true,
+        run_id: runId,
+      },
+    ]);
 
     const pending = await api.readRun(actor, runId);
     expect(pending.status).toBe("pending");
@@ -9815,10 +9838,33 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     });
     expect((await api.readRun(actor, queued.runId)).status).toBe("queued");
     await expect(readRunApiStart(context, queued.runId)).resolves.toBeNull();
+    expect(
+      sandboxOperationEventsForRunByAction(
+        queued.runId,
+        "first_assistant_message_eligible",
+      ),
+    ).toStrictEqual([]);
 
     mockNow(promotedAt);
     await api.requestCancelRun(actor, first.runId, [200]);
     await waitForRunStatus(api, actor, queued.runId, "pending");
+    await flushWaitUntilForTest();
+    expect(
+      sandboxOperationEventsForRunByAction(
+        queued.runId,
+        "first_assistant_message_eligible",
+      ),
+    ).toStrictEqual([
+      {
+        _time: new Date(promotedAt).toISOString(),
+        source: "api",
+        op_type: "first_assistant_message_eligible",
+        sandbox_type: "runner",
+        duration_ms: 0,
+        success: true,
+        run_id: queued.runId,
+      },
+    ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
     expect(claim.apiStartTime).toBe(promotedAt);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -189,6 +189,7 @@ import {
   type QueueFirstRunAssociation,
   type QueueFirstRunClaimResult,
 } from "./zero-chat-queued-message.service";
+import { recordFirstAssistantMessageEligibility } from "./zero-chat-first-assistant-message-metric.service";
 import {
   activePaidConcurrencySlots,
   cappedBaseConcurrencyLimit,
@@ -5398,6 +5399,13 @@ async function commitFailedLaunch(args: {
     return committed;
   }
 
+  if (args.createArgs.chatThreadId) {
+    recordFirstAssistantMessageEligibility({
+      runId: args.identity.runId,
+      apiStartedAt: args.createArgs.apiStartTime,
+    });
+  }
+
   await publishRunChangedForUserSafely(
     args.createArgs.userId,
     args.identity.runId,
@@ -6605,6 +6613,13 @@ async function committedAtomicLaunchResponse(args: {
     return args.committed.queueFirstClaim
       ? { ...response, queueFirstClaim: args.committed.queueFirstClaim }
       : response;
+  }
+
+  if (args.createArgs.chatThreadId) {
+    recordFirstAssistantMessageEligibility({
+      runId: args.committed.run.id,
+      apiStartedAt: args.createArgs.apiStartTime,
+    });
   }
 
   ingestRunContextSnapshot(args.committed.runContextSnapshot);

--- a/turbo/apps/api/src/signals/services/zero-chat-first-assistant-message-metric.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-first-assistant-message-metric.service.ts
@@ -12,6 +12,20 @@ import { tapError } from "../utils";
 
 const L = logger("api:zero:chat-first-assistant-message-metric");
 
+export function recordFirstAssistantMessageEligibility(args: {
+  readonly runId: string;
+  readonly apiStartedAt: number;
+}): void {
+  recordSandboxOperation({
+    sandboxType: "runner",
+    actionType: "first_assistant_message_eligible",
+    durationMs: 0,
+    success: true,
+    runId: args.runId,
+    timestamp: new Date(args.apiStartedAt).toISOString(),
+  });
+}
+
 async function recordFirstAssistantMessageAcknowledgement(args: {
   readonly db: Db;
   readonly runId: string;

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -33,6 +33,7 @@ import {
   revokeQueuedRunAssistantMarkers,
   type QueueMarkerRevokeNotification,
 } from "./zero-chat-queue-marker.service";
+import { recordFirstAssistantMessageEligibility } from "./zero-chat-first-assistant-message-metric.service";
 import {
   activePaidConcurrencySlots,
   cappedBaseConcurrencyLimit,
@@ -71,6 +72,7 @@ interface QueueCandidate {
   readonly createdAt: Date;
   readonly encryptedParams: string | null;
   readonly runStatus: string | null;
+  readonly chatThreadId: string | null;
 }
 
 interface RunnerNotification {
@@ -82,11 +84,22 @@ interface RunnerNotification {
   readonly createdAt: Date;
 }
 
+interface FirstAssistantMessageEligibility {
+  readonly runId: string;
+  readonly apiStartedAt: number;
+}
+
+interface PromotedRunnerJob {
+  readonly createdAt: Date;
+  readonly apiStartedAt: number;
+}
+
 type PromoteQueuedCandidateResult =
   | {
       readonly status: "promoted";
       readonly runnerNotification: RunnerNotification | null;
       readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+      readonly firstAssistantMessageEligibility: FirstAssistantMessageEligibility | null;
     }
   | { readonly status: "full" }
   | { readonly status: "removed-stale" }
@@ -161,7 +174,7 @@ async function insertPromotedRunnerJob(
     readonly queuedAt: Date;
     readonly payload: QueuedRunnerJobPayload;
   },
-): Promise<Date> {
+): Promise<PromotedRunnerJob> {
   const promotedAt = now();
   const [remainingRow] = await tx
     .select({ depth: count() })
@@ -202,7 +215,10 @@ async function insertPromotedRunnerJob(
   if (!runnerJob) {
     throw new Error("Promoted runner job queue insert returned no row");
   }
-  return runnerJob.createdAt;
+  return {
+    createdAt: runnerJob.createdAt,
+    apiStartedAt: promotedAt,
+  };
 }
 
 async function loadDrainCandidates(
@@ -226,9 +242,11 @@ async function loadDrainCandidates(
         createdAt: agentRunQueue.createdAt,
         encryptedParams: agentRunQueue.encryptedParams,
         runStatus: agentRuns.status,
+        chatThreadId: zeroRuns.chatThreadId,
       })
       .from(agentRunQueue)
       .leftJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
+      .leftJoin(zeroRuns, eq(agentRunQueue.runId, zeroRuns.id))
       .where(eq(agentRunQueue.orgId, orgId))
       .orderBy(agentRunQueue.createdAt);
   });
@@ -324,10 +342,11 @@ async function promoteQueuedCandidate(
         status: "promoted",
         runnerNotification: null,
         queueMarkerNotification,
+        firstAssistantMessageEligibility: null,
       };
     }
 
-    const runnerJobCreatedAt = await insertPromotedRunnerJob(tx, {
+    const runnerJob = await insertPromotedRunnerJob(tx, {
       orgId: args.orgId,
       runId: args.row.runId,
       queuedAt: args.row.createdAt,
@@ -336,13 +355,19 @@ async function promoteQueuedCandidate(
     return {
       status: "promoted",
       queueMarkerNotification,
+      firstAssistantMessageEligibility: args.row.chatThreadId
+        ? {
+            runId: args.row.runId,
+            apiStartedAt: runnerJob.apiStartedAt,
+          }
+        : null,
       runnerNotification: {
         runId: args.row.runId,
         runnerGroup: args.payload.runnerGroup,
         profile: args.payload.profile,
         cliAgentSessionId: args.payload.cliAgentSessionId,
         historyGenerationRunId: args.payload.historyGenerationRunId,
-        createdAt: runnerJobCreatedAt,
+        createdAt: runnerJob.createdAt,
       },
     };
   });
@@ -431,6 +456,12 @@ async function promoteQueuedCandidateWithSideEffects(
       runId: args.row.runId,
     });
     return "skipped";
+  }
+
+  if (result.firstAssistantMessageEligibility) {
+    recordFirstAssistantMessageEligibility(
+      result.firstAssistantMessageEligibility,
+    );
   }
 
   await publishPromotedQueueSideEffects(db, {


### PR DESCRIPTION
## Summary

- emit `first_assistant_message_eligible` for committed direct, durable failed, and promoted queued chat runs across supported chat frameworks using the trusted effective API start
- record the first active-turn Codex reasoning-or-agent-message item start and the first Codex agent-message item start without enabling content-bearing deltas
- validate canonical thread/turn scope, record each guest milestone once, and keep the forwarded agent-event sequence unchanged

## Scope

This is the first delivery slice of #22917:

- the eligible-run denominator and existing `api_to_first_assistant_message` outcome are framework-independent and cover Codex and Claude Code
- the new internal lifecycle timings in this PR are Codex-specific
- Claude Code phase observability is not implemented here and remains required before #22917 is complete

The planned Claude slice will observe bounded, content-free lifecycle metadata from the Anthropic SSE stream already visible to the runner proxy. It will not enable `--include-partial-messages` solely for telemetry, because doing so would change the measured path and increase content-bearing event volume.

## Dependency

- #22953 fixes the Runner Image cache-miss compile false-green path and should merge before this PR so runner-image validation remains trustworthy

## Compatibility and exclusions

- preserves `api_to_first_assistant_message`, required sessions Axiom flush ordering, chat persistence, and Ably publication semantics
- adds no database schema, public API, runner payload, feature switch, persisted message state, or cleanup requirement
- treats API telemetry as best effort; production coverage queries must deduplicate by `run_id`
- does not claim that Codex lifecycle starts are non-empty tokens or UI-visible messages

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-codex --all-targets --all-features --quiet`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip --workspace api`
- targeted Prettier checks for all changed TypeScript files

Part of #22917

Parent objective: #22892
