### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.631.1

### DIFF
--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.626.0"
+  "minimumSupportedVersion": "0.631.1"
 }


### PR DESCRIPTION
## Summary

- Force app.vm0.ai web clients to refresh to the latest verified production build.
- Raise the minimum supported web-client version from `0.626.0` to `0.631.1`.

## Target resolution

The request did not specify a version, so the target was resolved from the build currently running on app.vm0.ai.

- `window._vm0.getBuildVersion()` returned `0.631.1`.
- `window._vm0.getBuildCommitSha()` returned `8e51a0ca316d1cd4d0b0a2a8a280afd6d31a2fac`.
- The live commit is contained in the latest `origin/main`.
- `turbo/apps/platform/package.json` at the live commit declares version `0.631.1`.

## User-visible impact

Web clients below `0.631.1` will receive the compatibility rejection on their next API request and must refresh to load a supported app build.

## Files changed

- `turbo/apps/api/src/lib/web-client-compatibility.json`
  - Set `minimumSupportedVersion` to `0.631.1`.

No test changes were required because the directly coupled API tests read the compatibility floor from this JSON file.

## Verification

- Parsed the JSON and verified canonical two-space formatting.
- Verified the configured floor is exactly `0.631.1`.
- Ran `git diff --check`.
- Left full test, lint, and type-check coverage to the pull request pipeline, as intended for this focused configuration change.
