### PR TITLE
fix(ci): preserve runner compile after skipped barrier

### DIFF
--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -62,6 +62,8 @@ jq -e '
 jq -e '
   .jobs.compile["runs-on"] == "ubuntu-latest-8-cores" and
   (.jobs.compile.container.image | startswith("ghcr.io/vm0-ai/vm0-toolchain-rust@sha256:")) and
+  (.jobs.compile.if | contains("!cancelled()")) and
+  (.jobs.compile.if | contains("needs.prepare.result == '\''success'\''")) and
   (.jobs.compile.if | contains("runner-binary-miss-count != '\''0'\''")) and
   .jobs.compile.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
   any(.jobs.compile.steps[];

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -295,6 +295,8 @@ jobs:
     needs: [prepare]
     if: >-
       ${{
+        !cancelled() &&
+        needs.prepare.result == 'success' &&
         needs.prepare.outputs.current-runner-image-needed == 'true' &&
         needs.prepare.outputs.runner-binary-miss-count != '0'
       }}


### PR DESCRIPTION
## Summary

- allow the Runner Image compile job to run when its merge-group cancellation barrier is intentionally skipped
- require `prepare` to succeed and stop compilation when the workflow is cancelled
- extend the workflow contract test to preserve both conditions

## Problem

PR workflows intentionally skip `cancel-superseded`, while `prepare` explicitly runs after that skipped dependency. GitHub Actions still applied an implicit success gate to the downstream `compile` job.

In [run 30099685696](https://github.com/vm0-ai/vm0/actions/runs/30099685696), `prepare` reported:

- `current-runner-image-needed=true`
- `runner-binary-miss-count=2`

Both architecture compile jobs and all downstream image jobs were nevertheless skipped, and the workflow concluded successfully. The explicit status functions remove that false-green path while preserving fail-closed behavior for failed preparation and cancellation.

## Scope

- CI workflow behavior only
- no runtime, application, runner, schema, protocol, or persisted-state change
- split out of #22946 so its observability diff remains focused

## Validation

- `bash .github/scripts/tests/runner-image-workflow-test.sh`
- `actionlint .github/workflows/runner-image.yml`
- `shellcheck .github/scripts/tests/runner-image-workflow-test.sh`
- `pnpm --dir turbo exec prettier --check ../.github/workflows/runner-image.yml`
- `git diff --check origin/main...HEAD`

Unblocks #22946
