### PR TITLE
feat: show connector catalog diagnostics in debug settings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -84,6 +84,8 @@ const OFFICIAL_RUNNER_AUTHORIZATION =
   "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 const ACTIVE_KEY = "connectors/v1/active.json";
 const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
+const DIAGNOSTICS_USER_ID = `user_${randomUUID()}`;
+const DIAGNOSTICS_ORG_ID = `org_${randomUUID()}`;
 const PRIVATE_VALUE = "SECRET_TOKEN";
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -1301,6 +1303,10 @@ function cronClient() {
   return setupApp({ context })(cronConnectorCatalogContract);
 }
 
+function diagnosticsClient() {
+  return setupApp({ context })(zeroConnectorCatalogContract);
+}
+
 function runnerFirewallClient() {
   return setupApp({ context })(runnersBuiltinFirewallsResolveContract);
 }
@@ -1375,8 +1381,34 @@ async function syncCatalog() {
   return await accept(cronClient().sync({ headers: cronHeaders() }), [200]);
 }
 
+async function enableDiagnosticsFeatureSwitch(): Promise<void> {
+  zeroMocks.clerk.session(DIAGNOSTICS_USER_ID, DIAGNOSTICS_ORG_ID);
+  await accept(
+    setupApp({ context })(zeroFeatureSwitchesContract).update({
+      headers: { authorization: "Bearer clerk-session" },
+      body: { switches: { [FeatureSwitchKey.ZeroDebug]: true } },
+    }),
+    [200],
+  );
+  onTestFinished(async () => {
+    zeroMocks.clerk.session(DIAGNOSTICS_USER_ID, DIAGNOSTICS_ORG_ID);
+    await accept(
+      setupApp({ context })(zeroFeatureSwitchesContract).delete({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+  });
+}
+
 async function readStatus() {
-  return await accept(cronClient().status({ headers: cronHeaders() }), [200]);
+  await enableDiagnosticsFeatureSwitch();
+  return await accept(
+    diagnosticsClient().diagnostics({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
 }
 
 async function rawCronRequest(path: string): Promise<Response> {
@@ -1412,23 +1444,17 @@ afterEach(() => {
 });
 
 describe("connector catalog cron authentication and initial state", () => {
-  it("rejects missing and invalid cron credentials for both operations", async () => {
-    for (const operation of [cronClient().sync, cronClient().status]) {
-      const response = await accept(
-        operation({ headers: cronHeaders("wrong-secret") }),
-        [401],
-      );
-      expect(response.body).toStrictEqual({
-        error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-      });
-    }
-    for (const path of [
-      "/api/cron/sync-connector-catalog",
-      "/api/cron/connector-catalog-status",
-    ]) {
-      const response = await rawCronRequest(path);
-      expect(response.status).toBe(401);
-    }
+  it("rejects missing and invalid cron credentials", async () => {
+    const response = await accept(
+      cronClient().sync({ headers: cronHeaders("wrong-secret") }),
+      [401],
+    );
+    expect(response.body).toStrictEqual({
+      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+    });
+
+    const missing = await rawCronRequest("/api/cron/sync-connector-catalog");
+    expect(missing.status).toBe(401);
   });
 
   it("reports never-synced without reading the shared storage bucket", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -335,6 +335,112 @@ describe("GET /api/zero/connector-catalog", () => {
     );
   });
 
+  it("returns 401 for diagnostics when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(client.diagnostics({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 for diagnostics when the session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.diagnostics({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects diagnostics ZERO_TOKEN calls even with connector:read", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["connector:read"],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.diagnostics({
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 403 for diagnostics when ZeroDebug is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.diagnostics({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: "Connector catalog diagnostics are not enabled",
+      code: "FORBIDDEN",
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("returns sanitized DB diagnostics when ZeroDebug is enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enableConnectorFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.ZeroDebug]: true,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.diagnostics({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      state: expect.stringMatching(/^(?:current|never-synced|stale)$/u),
+      filtering: {
+        capabilityDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+        stale: expect.any(Boolean),
+        filteredAuthMethods: expect.any(Array),
+      },
+      credentialStorage: {
+        missingConnectorVersions: expect.any(Number),
+        unownedConnectorSecrets: expect.any(Number),
+        unownedConnectorVariables: expect.any(Number),
+        unresolvedBridgeCredentials: expect.any(Number),
+      },
+    });
+    expect(response.body).not.toHaveProperty("sourceId");
+    expect(response.body).not.toHaveProperty("catalog");
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
   it("returns 401 for catalog status when not authenticated", async () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(client.status({ headers: {} }), [401]);

--- a/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
@@ -2,21 +2,10 @@ import { cronConnectorCatalogContract } from "@vm0/api-contracts/contracts/cron"
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { db$, type ReadonlyDb } from "../external/db";
-import {
-  connectorCatalogCompatibilityStatus$,
-  reconcileConnectorCatalogCompatibility$,
-} from "../services/connector-catalog-compatibility.service";
-import {
-  connectorCatalogStatus$,
-  syncConnectorCatalog$,
-} from "../services/connector-catalog-sync.service";
-import { loadConnectorCredentialReadiness } from "../services/connector-credential-readiness.service";
+import { reconcileConnectorCatalogCompatibility$ } from "../services/connector-catalog-compatibility.service";
+import { connectorCatalogDiagnostics$ } from "../services/connector-catalog-diagnostics.service";
+import { syncConnectorCatalog$ } from "../services/connector-catalog-sync.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
-
-async function connectorCredentialReadiness(db: ReadonlyDb) {
-  return await loadConnectorCredentialReadiness(db);
-}
 
 const syncConnectorCatalogRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -26,45 +15,13 @@ const syncConnectorCatalogRoute$ = command(
 
     const result = await set(syncConnectorCatalog$, signal);
     await set(reconcileConnectorCatalogCompatibility$, signal);
-    const status = await set(connectorCatalogStatus$, signal);
-    const compatibility = await set(
-      connectorCatalogCompatibilityStatus$,
-      status.active,
-      signal,
-    );
-    const db = get(db$);
-    const credentialStorage = await connectorCredentialReadiness(db);
-    signal.throwIfAborted();
+    const diagnostics = await set(connectorCatalogDiagnostics$, signal);
     return {
       status: 200 as const,
       body: {
         outcome: result.outcome,
-        ...status,
-        filtering: compatibility,
-        credentialStorage,
+        ...diagnostics,
       },
-    };
-  },
-);
-
-const connectorCatalogStatusRoute$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    if (!get(hasValidCronSecret$)) {
-      return cronUnauthorized();
-    }
-
-    const result = await set(connectorCatalogStatus$, signal);
-    const compatibility = await set(
-      connectorCatalogCompatibilityStatus$,
-      result.active,
-      signal,
-    );
-    const db = get(db$);
-    const credentialStorage = await connectorCredentialReadiness(db);
-    signal.throwIfAborted();
-    return {
-      status: 200 as const,
-      body: { ...result, filtering: compatibility, credentialStorage },
     };
   },
 );
@@ -73,9 +30,5 @@ export const cronConnectorCatalogRoutes: readonly RouteEntry[] = [
   {
     route: cronConnectorCatalogContract.sync,
     handler: syncConnectorCatalogRoute$,
-  },
-  {
-    route: cronConnectorCatalogContract.status,
-    handler: connectorCatalogStatusRoute$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -1,5 +1,6 @@
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command } from "ccstate";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -8,6 +9,7 @@ import { pathParamsOf } from "../context/request";
 import { db$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { connectorCatalogDiagnostics$ } from "../services/connector-catalog-diagnostics.service";
 import {
   getPublicConnectorCatalogDetail,
   getPublicConnectorCatalogPermissionDetail,
@@ -24,6 +26,22 @@ const connectorCatalogAuth = {
   missingOrganizationStatus: 401,
   requiredCapability: "connector:read",
 } as const;
+
+const connectorCatalogDiagnosticsAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  accept: ["session"],
+} as const;
+
+const connectorCatalogDiagnosticsDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Connector catalog diagnostics are not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
 
 function connectorCatalogNotFound() {
   return notFound("Connector catalog item not found");
@@ -116,6 +134,19 @@ const listConnectorCatalogStatusInner$ = command(
   },
 );
 
+const getConnectorCatalogDiagnosticsInner$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const context = await set(connectorCatalogRequestContext$);
+    signal.throwIfAborted();
+    if (!context.featureStates[FeatureSwitchKey.ZeroDebug]) {
+      return connectorCatalogDiagnosticsDisabled;
+    }
+
+    const diagnostics = await set(connectorCatalogDiagnostics$, signal);
+    return { status: 200 as const, body: diagnostics };
+  },
+);
+
 const getConnectorCatalogInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const context = await set(connectorCatalogRequestContext$);
@@ -176,6 +207,13 @@ export const zeroConnectorCatalogRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorCatalogContract.status,
     handler: authRoute(connectorCatalogAuth, listConnectorCatalogStatusInner$),
+  },
+  {
+    route: zeroConnectorCatalogContract.diagnostics,
+    handler: authRoute(
+      connectorCatalogDiagnosticsAuth,
+      getConnectorCatalogDiagnosticsInner$,
+    ),
   },
   {
     route: zeroConnectorCatalogContract.get,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
 
-import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
+import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import { z } from "zod";
 
 import { safeJsonParse, safeSync } from "../../utils";

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -5,7 +5,7 @@ import {
   type ConnectorCatalogCompatibilityReason,
   type ConnectorCatalogFilteredAuthMethod,
   type ConnectorCatalogFilteringStatus,
-} from "@vm0/api-contracts/contracts/cron";
+} from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import {
   CONNECTOR_GENERIC_AUTH_CAPABILITY_VERSIONS,
   getConnectorAuthProviderRegistrationCapabilities,

--- a/turbo/apps/api/src/signals/services/connector-catalog-diagnostics.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-diagnostics.service.ts
@@ -1,0 +1,24 @@
+import type { ConnectorCatalogDiagnostics } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import { command } from "ccstate";
+
+import { db$ } from "../external/db";
+import { connectorCatalogCompatibilityStatus$ } from "./connector-catalog-compatibility.service";
+import { connectorCatalogStatus$ } from "./connector-catalog-sync.service";
+import { loadConnectorCredentialReadiness } from "./connector-credential-readiness.service";
+
+export const connectorCatalogDiagnostics$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<ConnectorCatalogDiagnostics> => {
+    const status = await set(connectorCatalogStatus$, signal);
+    const filtering = await set(
+      connectorCatalogCompatibilityStatus$,
+      status.active,
+      signal,
+    );
+    const credentialStorage = await loadConnectorCredentialReadiness(get(db$));
+    signal.throwIfAborted();
+    return { ...status, filtering, credentialStorage };
+  },
+);

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -2,7 +2,7 @@ import {
   connectorCatalogFilteredAuthMethodsSchema,
   type ConnectorCatalogCompatibilityReason,
   type ConnectorCatalogFilteredAuthMethod,
-} from "@vm0/api-contracts/contracts/cron";
+} from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -1,4 +1,4 @@
-import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
+import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { and, eq, inArray, sql } from "drizzle-orm";

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -1,8 +1,8 @@
 import type {
   ConnectorCatalogSyncFailureCode,
-  ConnectorCatalogSyncResponse,
-  ConnectorCatalogSyncStatus,
-} from "@vm0/api-contracts/contracts/cron";
+  ConnectorCatalogDiagnostics,
+} from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import type { ConnectorCatalogSyncResponse } from "@vm0/api-contracts/contracts/cron";
 import {
   connectorCatalogActiveSnapshot,
   connectorCatalogSyncState,
@@ -54,7 +54,7 @@ import {
 const log = logger("connector-catalog:sync");
 
 type ConnectorCatalogRawSyncStatus = Omit<
-  ConnectorCatalogSyncStatus,
+  ConnectorCatalogDiagnostics,
   "filtering" | "credentialStorage"
 >;
 type ConnectorCatalogRawSyncResponse = Omit<

--- a/turbo/apps/api/src/signals/services/connector-credential-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-readiness.service.ts
@@ -1,3 +1,4 @@
+import type { ConnectorCredentialStorageReadiness } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
@@ -7,13 +8,6 @@ import { z } from "zod";
 
 import { zodEnumDriverValueDecoder } from "../../lib/db-structured-result";
 import type { ReadonlyDb } from "../external/db";
-
-interface ConnectorCredentialReadiness {
-  readonly missingConnectorVersions: number;
-  readonly unownedConnectorSecrets: number;
-  readonly unownedConnectorVariables: number;
-  readonly unresolvedBridgeCredentials: number;
-}
 
 const readinessCountKindSchema = z.enum([
   "missing-connector-versions",
@@ -31,7 +25,7 @@ function readinessCountKind(kind: ReadinessCountKind) {
 
 export async function loadConnectorCredentialReadiness(
   db: ReadonlyDb,
-): Promise<ConnectorCredentialReadiness> {
+): Promise<ConnectorCredentialStorageReadiness> {
   // One UNION statement gives every count the same PostgreSQL statement
   // snapshot. The hard constraints make every unowned connector credential an
   // unresolved invariant violation, independent of catalog source selection.

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -448,6 +448,41 @@ export const apiConnectorsHandlers = [
     });
   }),
 
+  mockApi(zeroConnectorCatalogContract.diagnostics, ({ respond }) => {
+    return respond(200, {
+      state: "current",
+      active: {
+        catalogVersion: "2026-07-25.1",
+        catalogDigest: `sha256:${"a".repeat(64)}`,
+        activatedAt: "2026-07-25T01:00:00.000Z",
+      },
+      lastAttempt: {
+        at: "2026-07-25T02:00:00.000Z",
+        outcome: "unchanged",
+        failureCode: null,
+      },
+      lastSuccessAt: "2026-07-25T02:00:00.000Z",
+      filtering: {
+        capabilityDigest: `sha256:${"b".repeat(64)}`,
+        evaluatedAt: "2026-07-25T01:00:00.000Z",
+        stale: false,
+        filteredAuthMethods: [
+          {
+            connectorRef: "github",
+            authMethodId: "oauth",
+            reasons: ["missing-revoke-provider"],
+          },
+        ],
+      },
+      credentialStorage: {
+        missingConnectorVersions: 1,
+        unownedConnectorSecrets: 2,
+        unownedConnectorVariables: 3,
+        unresolvedBridgeCredentials: 5,
+      },
+    });
+  }),
+
   mockApi(
     zeroConnectorCatalogContract.permissions,
     async ({ params, respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
@@ -1,0 +1,16 @@
+import type { ConnectorCatalogDiagnostics } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { computed } from "ccstate";
+
+import { accept } from "../../../lib/accept.ts";
+import { zeroClient$ } from "../../api-client.ts";
+
+export const connectorCatalogDiagnostics$ = computed(
+  async (get): Promise<ConnectorCatalogDiagnostics | null> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroConnectorCatalogContract);
+    const result = await accept(client.diagnostics(), [200, 403, 404]);
+
+    return result.status === 200 ? result.body : null;
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -1,4 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
+import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -10,7 +12,10 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-async function openDialog(role: "admin" | "member" = "admin"): Promise<void> {
+async function openDialog(
+  role: "admin" | "member" = "admin",
+  section: "debug" | "general" = "general",
+): Promise<void> {
   context.mocks.data.org({
     id: "org_1",
     slug: "test-org",
@@ -25,7 +30,13 @@ async function openDialog(role: "admin" | "member" = "admin"): Promise<void> {
     membershipRequests: [],
     createdAt: "2026-01-01T00:00:00Z",
   });
-  detachedSetupPage({ context, path: "/?settings=general" });
+  detachedSetupPage({
+    context,
+    path: `/?settings=${section}`,
+    ...(section === "debug"
+      ? { featureSwitches: { [FeatureSwitchKey.ZeroDebug]: true } }
+      : {}),
+  });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
@@ -68,5 +79,54 @@ describe("settings dialog", () => {
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).queryByText("Workspace")).not.toBeInTheDocument();
     expect(screen.getByText("Theme")).toBeInTheDocument();
+  });
+
+  it("shows connector catalog diagnostics in Debug settings", async () => {
+    await openDialog("admin", "debug");
+
+    const diagnostics = await screen.findByRole("region", {
+      name: "Connector catalog",
+    });
+    expect(within(diagnostics).getAllByText("Current")).toHaveLength(2);
+    expect(within(diagnostics).getByText("2026-07-25.1")).toBeInTheDocument();
+    expect(within(diagnostics).getByText("github / oauth")).toBeInTheDocument();
+    expect(
+      within(diagnostics).getByText("Missing revoke provider"),
+    ).toBeInTheDocument();
+    expect(
+      within(diagnostics).getByText("Missing versions"),
+    ).toBeInTheDocument();
+    expect(
+      within(diagnostics).getByText("Unowned secrets"),
+    ).toBeInTheDocument();
+    expect(
+      within(diagnostics).getByText("Unowned variables"),
+    ).toBeInTheDocument();
+    expect(
+      within(diagnostics).getByText("Unresolved bridge credentials"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps Debug settings usable when diagnostics are unavailable", async () => {
+    context.mocks.api(
+      zeroConnectorCatalogContract.diagnostics,
+      ({ respond }) => {
+        return respond(404, {
+          error: {
+            message: "Connector catalog diagnostics are unavailable",
+            code: "NOT_FOUND",
+          },
+        });
+      },
+    );
+
+    await openDialog("admin", "debug");
+
+    const diagnostics = await screen.findByRole("region", {
+      name: "Connector catalog",
+    });
+    expect(within(diagnostics).getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Build information")).toBeInTheDocument();
+    expect(screen.getByText("Capture network bodies")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -1,0 +1,221 @@
+import type { ConnectorCatalogDiagnostics } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import { IconDatabase } from "@tabler/icons-react";
+import { useLoadable } from "ccstate-react";
+import type { ReactNode } from "react";
+
+import { connectorCatalogDiagnostics$ } from "../../../../signals/zero-page/settings/connector-catalog-diagnostics.ts";
+
+const EMPTY_VALUE = "None";
+
+function formatEnumValue(value: string): string {
+  const words = value.replaceAll("-", " ");
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return EMPTY_VALUE;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  }).format(new Date(value));
+}
+
+function DiagnosticField({
+  label,
+  value,
+  code = false,
+}: {
+  readonly label: string;
+  readonly value: ReactNode;
+  readonly code?: boolean;
+}) {
+  const Value = code ? "code" : "div";
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <Value
+        className={
+          code
+            ? "min-w-0 break-all text-xs leading-5 text-foreground"
+            : "min-w-0 break-words text-sm font-medium text-foreground"
+        }
+      >
+        {value}
+      </Value>
+    </div>
+  );
+}
+
+function DiagnosticsContent({
+  diagnostics,
+}: {
+  readonly diagnostics: ConnectorCatalogDiagnostics;
+}) {
+  const active = diagnostics.active;
+  const lastAttempt = diagnostics.lastAttempt;
+  const filteredAuthMethods = diagnostics.filtering.filteredAuthMethods;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-5">
+      <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+        <DiagnosticField
+          label="Sync state"
+          value={formatEnumValue(diagnostics.state)}
+        />
+        <DiagnosticField
+          label="Last attempt"
+          value={
+            lastAttempt ? formatEnumValue(lastAttempt.outcome) : EMPTY_VALUE
+          }
+        />
+        <DiagnosticField
+          label="Active version"
+          value={active?.catalogVersion ?? EMPTY_VALUE}
+          code={active !== null}
+        />
+        <DiagnosticField
+          label="Activated"
+          value={formatTimestamp(active?.activatedAt ?? null)}
+        />
+        <DiagnosticField
+          label="Last attempt at"
+          value={formatTimestamp(lastAttempt?.at ?? null)}
+        />
+        <DiagnosticField
+          label="Last success"
+          value={formatTimestamp(diagnostics.lastSuccessAt)}
+        />
+        <DiagnosticField
+          label="Failure code"
+          value={
+            lastAttempt?.failureCode
+              ? formatEnumValue(lastAttempt.failureCode)
+              : EMPTY_VALUE
+          }
+        />
+      </div>
+
+      <DiagnosticField
+        label="Active catalog digest"
+        value={active?.catalogDigest ?? EMPTY_VALUE}
+        code={active !== null}
+      />
+
+      <div className="border-t border-border/60 pt-4">
+        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Compatibility
+        </div>
+        <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+          <DiagnosticField
+            label="Evaluation"
+            value={diagnostics.filtering.stale ? "Stale" : "Current"}
+          />
+          <DiagnosticField
+            label="Evaluated"
+            value={formatTimestamp(diagnostics.filtering.evaluatedAt)}
+          />
+        </div>
+        <div className="mt-4">
+          <DiagnosticField
+            label="Executable capability digest"
+            value={diagnostics.filtering.capabilityDigest}
+            code
+          />
+        </div>
+        <div className="mt-4 flex min-w-0 flex-col gap-2">
+          <div className="text-xs text-muted-foreground">
+            Filtered auth methods
+          </div>
+          {filteredAuthMethods.length === 0 ? (
+            <div className="text-sm font-medium text-foreground">
+              {EMPTY_VALUE}
+            </div>
+          ) : (
+            <div className="flex min-w-0 flex-col gap-2">
+              {filteredAuthMethods.map((method) => {
+                return (
+                  <div
+                    key={`${method.connectorRef}:${method.authMethodId}`}
+                    className="min-w-0 rounded-lg bg-muted/40 px-3 py-2"
+                  >
+                    <code className="block break-all text-xs font-medium text-foreground">
+                      {method.connectorRef} / {method.authMethodId}
+                    </code>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {method.reasons.map(formatEnumValue).join(", ")}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-border/60 pt-4">
+        <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Credential storage
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <DiagnosticField
+            label="Missing versions"
+            value={diagnostics.credentialStorage.missingConnectorVersions}
+          />
+          <DiagnosticField
+            label="Unowned secrets"
+            value={diagnostics.credentialStorage.unownedConnectorSecrets}
+          />
+          <DiagnosticField
+            label="Unowned variables"
+            value={diagnostics.credentialStorage.unownedConnectorVariables}
+          />
+          <DiagnosticField
+            label="Unresolved bridge credentials"
+            value={diagnostics.credentialStorage.unresolvedBridgeCredentials}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ConnectorCatalogDiagnosticsBlock() {
+  const diagnosticsLoadable = useLoadable(connectorCatalogDiagnostics$);
+  const loading = diagnosticsLoadable.state === "loading";
+  const diagnostics =
+    diagnosticsLoadable.state === "hasData" ? diagnosticsLoadable.data : null;
+
+  return (
+    <section
+      aria-labelledby="connector-catalog-diagnostics-title"
+      className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border"
+    >
+      <div className="shrink-0">
+        <div className="flex h-7 w-7 items-center justify-center">
+          <IconDatabase
+            size={22}
+            stroke={1.5}
+            className="text-muted-foreground"
+          />
+        </div>
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
+        <div
+          id="connector-catalog-diagnostics-title"
+          className="text-sm font-medium text-foreground"
+        >
+          Connector catalog
+        </div>
+        {diagnostics ? (
+          <DiagnosticsContent diagnostics={diagnostics} />
+        ) : (
+          <div className="text-sm text-muted-foreground">
+            {loading ? "Loading" : "Unavailable"}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
@@ -10,6 +10,7 @@ import {
   updateCaptureNetworkBodies$,
 } from "../../../../../signals/zero-page/settings/preferences-page.ts";
 import { BuildInfoBlock } from "../build-info-block.tsx";
+import { ConnectorCatalogDiagnosticsBlock } from "../connector-catalog-diagnostics-block.tsx";
 
 const CAPTURE_RUN_COUNT = 3;
 
@@ -63,6 +64,7 @@ export function DebugSection() {
   return (
     <div className="flex flex-col gap-6">
       <BuildInfoBlock />
+      <ConnectorCatalogDiagnosticsBlock />
       <CaptureNetworkBodiesBlock />
     </div>
   );

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog-diagnostics.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+import {
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
+} from "./connector-identity";
+
+export const connectorCatalogSyncFailureCodeSchema = z.enum([
+  "source-unavailable",
+  "object-too-large",
+  "invalid-json",
+  "invalid-pointer",
+  "invalid-reference",
+  "digest-mismatch",
+  "unsupported-schema",
+  "invalid-artifact",
+  "public-leakage",
+  "relationship-mismatch",
+  "invalid-compression",
+]);
+
+export const connectorCatalogCompatibilityReasonSchema = z.enum([
+  "missing-grant-provider",
+  "missing-access-provider",
+  "missing-revoke-provider",
+  "provider-contract-mismatch",
+  "missing-platform-configuration",
+]);
+
+export const connectorCatalogFilteredAuthMethodSchema = z.object({
+  connectorRef: connectorRefSchema,
+  authMethodId: connectorAuthMethodIdSchema,
+  reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
+});
+
+export const connectorCatalogFilteredAuthMethodsSchema = z.array(
+  connectorCatalogFilteredAuthMethodSchema,
+);
+
+export const connectorCatalogFilteringStatusSchema = z.object({
+  capabilityDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+  evaluatedAt: z.string().datetime().nullable(),
+  stale: z.boolean(),
+  filteredAuthMethods: connectorCatalogFilteredAuthMethodsSchema,
+});
+
+export const connectorCredentialStorageReadinessSchema = z.object({
+  missingConnectorVersions: z.number().int().nonnegative(),
+  unownedConnectorSecrets: z.number().int().nonnegative(),
+  unownedConnectorVariables: z.number().int().nonnegative(),
+  unresolvedBridgeCredentials: z.number().int().nonnegative(),
+});
+
+export const connectorCatalogDiagnosticsSchema = z.object({
+  state: z.enum(["never-synced", "current", "stale"]),
+  active: z
+    .object({
+      catalogVersion: z.string(),
+      catalogDigest: z.string(),
+      activatedAt: z.string().datetime(),
+    })
+    .nullable(),
+  lastAttempt: z
+    .object({
+      at: z.string().datetime(),
+      outcome: z.enum(["accepted", "unchanged", "rejected"]),
+      failureCode: connectorCatalogSyncFailureCodeSchema.nullable(),
+    })
+    .nullable(),
+  lastSuccessAt: z.string().datetime().nullable(),
+  filtering: connectorCatalogFilteringStatusSchema,
+  credentialStorage: connectorCredentialStorageReadinessSchema,
+});
+
+export type ConnectorCatalogSyncFailureCode = z.infer<
+  typeof connectorCatalogSyncFailureCodeSchema
+>;
+export type ConnectorCatalogCompatibilityReason = z.infer<
+  typeof connectorCatalogCompatibilityReasonSchema
+>;
+export type ConnectorCatalogFilteredAuthMethod = z.infer<
+  typeof connectorCatalogFilteredAuthMethodSchema
+>;
+export type ConnectorCatalogFilteringStatus = z.infer<
+  typeof connectorCatalogFilteringStatusSchema
+>;
+export type ConnectorCredentialStorageReadiness = z.infer<
+  typeof connectorCredentialStorageReadinessSchema
+>;
+export type ConnectorCatalogDiagnostics = z.infer<
+  typeof connectorCatalogDiagnosticsSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import {
-  connectorAuthMethodIdSchema,
-  connectorRefSchema,
-} from "./connector-identity";
+import { connectorCatalogDiagnosticsSchema } from "./connector-catalog-diagnostics";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -109,93 +106,11 @@ const cronSyncSkillsResponseSchema = z.object({
   total: z.number(),
 });
 
-export const connectorCatalogSyncFailureCodeSchema = z.enum([
-  "source-unavailable",
-  "object-too-large",
-  "invalid-json",
-  "invalid-pointer",
-  "invalid-reference",
-  "digest-mismatch",
-  "unsupported-schema",
-  "invalid-artifact",
-  "public-leakage",
-  "relationship-mismatch",
-  "invalid-compression",
-]);
-
-export const connectorCatalogCompatibilityReasonSchema = z.enum([
-  "missing-grant-provider",
-  "missing-access-provider",
-  "missing-revoke-provider",
-  "provider-contract-mismatch",
-  "missing-platform-configuration",
-]);
-
-export const connectorCatalogFilteredAuthMethodSchema = z.object({
-  connectorRef: connectorRefSchema,
-  authMethodId: connectorAuthMethodIdSchema,
-  reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
-});
-
-export const connectorCatalogFilteredAuthMethodsSchema = z.array(
-  connectorCatalogFilteredAuthMethodSchema,
-);
-
-const connectorCatalogFilteringStatusSchema = z.object({
-  capabilityDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
-  evaluatedAt: z.string().datetime().nullable(),
-  stale: z.boolean(),
-  filteredAuthMethods: connectorCatalogFilteredAuthMethodsSchema,
-});
-
-const connectorCredentialStorageReadinessSchema = z.object({
-  missingConnectorVersions: z.number().int().nonnegative(),
-  unownedConnectorSecrets: z.number().int().nonnegative(),
-  unownedConnectorVariables: z.number().int().nonnegative(),
-  unresolvedBridgeCredentials: z.number().int().nonnegative(),
-});
-
-const connectorCatalogSyncStatusSchema = z.object({
-  state: z.enum(["never-synced", "current", "stale"]),
-  active: z
-    .object({
-      catalogVersion: z.string(),
-      catalogDigest: z.string(),
-      activatedAt: z.string().datetime(),
-    })
-    .nullable(),
-  lastAttempt: z
-    .object({
-      at: z.string().datetime(),
-      outcome: z.enum(["accepted", "unchanged", "rejected"]),
-      failureCode: connectorCatalogSyncFailureCodeSchema.nullable(),
-    })
-    .nullable(),
-  lastSuccessAt: z.string().datetime().nullable(),
-  filtering: connectorCatalogFilteringStatusSchema,
-  credentialStorage: connectorCredentialStorageReadinessSchema,
-});
-
 const connectorCatalogSyncResponseSchema =
-  connectorCatalogSyncStatusSchema.extend({
+  connectorCatalogDiagnosticsSchema.extend({
     outcome: z.enum(["accepted", "unchanged", "rejected"]),
   });
 
-export type ConnectorCatalogSyncFailureCode = z.infer<
-  typeof connectorCatalogSyncFailureCodeSchema
->;
-export type ConnectorCatalogCompatibilityReason = z.infer<
-  typeof connectorCatalogCompatibilityReasonSchema
->;
-export type ConnectorCatalogFilteredAuthMethod = z.infer<
-  typeof connectorCatalogFilteredAuthMethodSchema
->;
-export type ConnectorCatalogFilteringStatus = z.infer<
-  typeof connectorCatalogFilteringStatusSchema
->;
-export type ConnectorCatalogSyncStatus = z.infer<
-  typeof connectorCatalogSyncStatusSchema
->;
 export type ConnectorCatalogSyncResponse = z.infer<
   typeof connectorCatalogSyncResponseSchema
 >;
@@ -448,16 +363,6 @@ export const cronConnectorCatalogContract = c.router({
       401: apiErrorSchema,
     },
     summary: "Sync the validated connector catalog snapshot",
-  },
-  status: {
-    method: "GET",
-    path: "/api/cron/connector-catalog-status",
-    headers: authHeadersSchema,
-    responses: {
-      200: connectorCatalogSyncStatusSchema,
-      401: apiErrorSchema,
-    },
-    summary: "Read connector catalog sync status",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
+import { connectorCatalogDiagnosticsSchema } from "./connector-catalog-diagnostics";
 import {
   connectorAuthMethodIdSchema,
   connectorRefSchema,
@@ -259,6 +260,18 @@ export const zeroConnectorCatalogContract = c.router({
       503: apiErrorSchema,
     },
     summary: "List public connector catalog metadata with connection status",
+  },
+  diagnostics: {
+    method: "GET",
+    path: "/api/zero/connector-catalog/diagnostics",
+    headers: authHeadersSchema,
+    responses: {
+      200: connectorCatalogDiagnosticsSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Read connector catalog diagnostics",
   },
   get: {
     method: "GET",

--- a/turbo/packages/db/src/jsonb-contracts/connector-catalog.ts
+++ b/turbo/packages/db/src/jsonb-contracts/connector-catalog.ts
@@ -1,4 +1,4 @@
-import type { ConnectorCatalogFilteredAuthMethod } from "@vm0/api-contracts/contracts/cron";
+import type { ConnectorCatalogFilteredAuthMethod } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 
 export type ConnectorCatalogFilteredAuthMethods =
   ConnectorCatalogFilteredAuthMethod[];


### PR DESCRIPTION
## Summary

- add a session-authenticated, `ZeroDebug`-gated connector catalog diagnostics
  API backed only by PostgreSQL and current executable capability metadata
- move the operational response schema out of the cron contract and share one
  read composer between diagnostics and the existing sync response
- show sync, compatibility, filtered auth method, and credential readiness
  state in Settings → Debug, including non-fatal `403`/`404` rollout behavior
- remove the unused standalone cron status route while preserving the sync cron
  URL and response

## Deployment compatibility

- an old frontend continues using unchanged APIs
- a new frontend treats an old backend's `404` as unavailable diagnostics
- the removed cron read route has no repository or deployment caller
- diagnostics performs no R2 read, synchronization, reconciliation, or database
  write

## Out of scope

- enabling or changing external connector catalog source selection
- publishing, fetching, or validating catalog artifacts
- changing connector execution or credential behavior
- adding polling, historical diagnostics, or new persistence

## Validation

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/db lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm check-types`
- `pnpm -F @vm0/api-contracts test -- --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx --silent=passed-only`
- `pnpm knip`

Closes #22957

Parent objective: https://github.com/vm0-ai/vm0-connectors/issues/1
