### PR TITLE
refactor(api): replace builder-owned sql predicates

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -55,7 +55,7 @@ import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { variables as variablesTable } from "@vm0/db/schema/variable";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows, pgInt8ToBigIntSchema } from "../../lib/db-raw-rows";
@@ -2962,7 +2962,7 @@ async function syncCustomConnectorRuntimeSecrets(args: {
       and(
         eq(agentRunCustomConnectorAuthRefs.runId, args.runId),
         inArray(agentRunCustomConnectorAuthRefs.secretName, missingKeys),
-        sql`${agentRunCustomConnectorAuthRefs.expiresAt} > now()`,
+        gt(agentRunCustomConnectorAuthRefs.expiresAt, sql`now()`),
       ),
     );
 

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -225,14 +225,7 @@ async function suppressedEmailKeys(
   const rows = await db
     .select({ emailAddress: emailSuppressions.emailAddress })
     .from(emailSuppressions)
-    .where(
-      sql`lower(${emailSuppressions.emailAddress}) IN (${sql.join(
-        lowerEmails.map((email) => {
-          return sql`${email}`;
-        }),
-        sql`, `,
-      )})`,
-    );
+    .where(inArray(sql`lower(${emailSuppressions.emailAddress})`, lowerEmails));
 
   return new Set(
     rows.map((row) => {

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -2,7 +2,18 @@ import type StripeSDK from "stripe";
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
-import { and, eq, exists, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  exists,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -94,14 +105,14 @@ async function resolvePaymentMethod(
  * Atomically claims the recharge slot via UPDATE … RETURNING with a
  * WHERE clause that filters on:
  *  - autoRechargeEnabled = true
- *  - tier can use auto-recharge (pro/team/custom)
+ *  - plan entitlement allows auto-recharge (or legacy tier fallback)
  *  - stripeCustomerId / threshold / amount NOT NULL
  *  - credits <= threshold
  *  - pendingAt IS NULL OR pendingAt < now() - 10 minutes
  *
- * Verbatim same WHERE shape as web so api and web don't double-claim
- * during rollout. The 10-minute stale-threshold lets a hung Stripe call
- * release the slot eventually.
+ * The conditional UPDATE uses the database clock so concurrent workers
+ * cannot double-claim. The 10-minute stale threshold lets a hung Stripe
+ * call release the slot eventually.
  *
  * On Stripe error: clearPendingFlag so retry can fire on the next
  * legitimate processOrgUsageEvents call.
@@ -132,7 +143,7 @@ export const triggerAutoRecharge$ = command(
               ),
             ),
         )
-      : sql`${orgMetadata.tier} IN ('pro', 'team', 'custom')`;
+      : inArray(orgMetadata.tier, ["pro", "team", "custom"]);
 
     const clearPendingFlag = async (): Promise<void> => {
       await writeDb
@@ -145,15 +156,22 @@ export const triggerAutoRecharge$ = command(
       .update(orgMetadata)
       .set({ autoRechargePendingAt: nowDate(), updatedAt: nowDate() })
       .where(
-        sql`${eq(orgMetadata.orgId, orgId)}
-            AND ${orgMetadata.autoRechargeEnabled} = true
-            AND ${planEligibility}
-            AND ${isNotNull(orgMetadata.stripeCustomerId)}
-            AND ${isNotNull(orgMetadata.autoRechargeThreshold)}
-            AND ${isNotNull(orgMetadata.autoRechargeAmount)}
-            AND ${lte(orgMetadata.credits, orgMetadata.autoRechargeThreshold)}
-            AND (${isNull(orgMetadata.autoRechargePendingAt)}
-                 OR ${orgMetadata.autoRechargePendingAt} < now() - make_interval(mins => ${STALE_THRESHOLD_MINUTES}))`,
+        and(
+          eq(orgMetadata.orgId, orgId),
+          eq(orgMetadata.autoRechargeEnabled, true),
+          planEligibility,
+          isNotNull(orgMetadata.stripeCustomerId),
+          isNotNull(orgMetadata.autoRechargeThreshold),
+          isNotNull(orgMetadata.autoRechargeAmount),
+          lte(orgMetadata.credits, orgMetadata.autoRechargeThreshold),
+          or(
+            isNull(orgMetadata.autoRechargePendingAt),
+            lt(
+              orgMetadata.autoRechargePendingAt,
+              sql`now() - make_interval(mins => ${STALE_THRESHOLD_MINUTES})`,
+            ),
+          ),
+        ),
       )
       .returning({
         credits: orgMetadata.credits,

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -7,7 +7,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { users } from "@vm0/db/schema/user";
 import { command } from "ccstate";
-import { and, asc, eq, isNull, lt, lte, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { Resend } from "resend";
 import { delay } from "signal-timers";
 import { Webhook } from "svix";
@@ -383,12 +383,7 @@ async function findSuppressedAddress(
     .select({ emailAddress: emailSuppressions.emailAddress })
     .from(emailSuppressions)
     .where(
-      sql`lower(${emailSuppressions.emailAddress}) IN (${sql.join(
-        lowerAddresses.map((address) => {
-          return sql`${address}`;
-        }),
-        sql`, `,
-      )})`,
+      inArray(sql`lower(${emailSuppressions.emailAddress})`, lowerAddresses),
     )
     .limit(1);
 

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -140,6 +140,79 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
+        import { eq, sql as query } from "drizzle-orm";
+        const names = ["one", "two"];
+        const nameList = query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        );
+        const subquery = query\`SELECT \${users.name} FROM \${users}\`;
+        function nameSqlList() {
+          return query.join(
+            names.map((name) => query\`\${name}\`),
+            query\`, \`,
+          );
+        }
+        const otherSql = {
+          join(values: string[]) {
+            return query.join(
+              values.map((value) => query\`\${value}\`),
+              query\`, \`,
+            );
+          },
+        };
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        sql.join = (values: unknown[], separator: unknown) => ({
+          values,
+          separator,
+        });
+        const condition = eq(users.id, 1);
+        sql\`lower(\${users.name}) IN (\${sql.join(
+          names.map((name) => sql\`\${name}\`),
+          sql\`, \`,
+        )})\`;
+        query\`upper(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )})\`;
+        query\`lower(\${users.name}) NOT IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )})\`;
+        query\`lower(\${users.name}) IN (\${nameList})\`;
+        query\`lower(\${users.name}) IN (\${nameSqlList()})\`;
+        query\`lower(\${users.name}) IN (\${otherSql.join(names)})\`;
+        query\`lower(\${users.name}) IN (\${subquery})\`;
+        query\`lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name.toUpperCase()}\`),
+          query\`, \`,
+        )})\`;
+        query\`lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`; \`,
+        )})\`;
+        query\`SELECT lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )}) FROM \${users}\`;
+        query\`prefix_lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )})\`;
+        query\`lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )}) IS TRUE\`;
+        query\`lower(\${condition}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )})\`;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
         import { and, eq, isNotNull, or, sql } from "drizzle-orm";
         const selected = db
           .select({ id: users.id })
@@ -295,6 +368,19 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "emptyFragment" },
         { messageId: "emptyFragment" },
       ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const names = ["one", "two"];
+        sql\`lower(\${users.name}) IN (\${sql.join(
+          names.map((name) => {
+            return sql\`\${name}\`;
+          }),
+          sql\`, \`,
+        )})\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "inArray" } }],
     },
     {
       code: `${drizzlePreamble}
@@ -682,6 +768,32 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "max" } },
         { messageId: "typedApi", data: { helper: "or" } },
         { messageId: "typedApi", data: { helper: "arrayContains" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql as query } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        const names = ["one", "two"];
+        const condition = eq(users.id, 1);
+        const tag = drizzle.sql;
+        query\`lower(\${users.name}) IN (\${query.join(
+          names.map((name) => query\`\${name}\`),
+          query\`, \`,
+        )})\`;
+        drizzle.sql\`WHERE LOWER (\${users.name}) in (\${drizzle.sql.join(
+          names.map((name) => drizzle.sql\`\${name}\`),
+          drizzle.sql\`, \`,
+        )}) AND \${condition}\`;
+        tag\`NOT lower(\${users.name}) IN (\${tag.join(
+          names.map((name) => tag\`\${name}\`),
+          tag\`, \`,
+        )})\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "inArray" } },
       ],
     },
     {

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -264,6 +264,14 @@ function membershipRightBoundary(quasi: string): boolean {
   );
 }
 
+function lowerCallStart(quasi: string): number | undefined {
+  const match = /\bLOWER\s*\(\s*$/i.exec(quasi);
+  if (match === null || hasSqlIdentifierPrefix(quasi, match.index)) {
+    return undefined;
+  }
+  return match.index;
+}
+
 function hasOrderingLeftBoundary(quasi: string): boolean {
   const prefix = quasi.trimEnd();
   return (
@@ -1205,6 +1213,11 @@ export const preferDrizzleApis = createRule({
       );
     }
 
+    function isInlineParameterListSqlJoin(node: TSESTree.Expression): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return isExpression(tsNode) && isParameterListSqlJoin(tsNode);
+    }
+
     return {
       CallExpression(node: TSESTree.CallExpression): void {
         if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
@@ -1299,6 +1312,29 @@ export const preferDrizzleApis = createRule({
             data: { helper: existence.helper },
           });
           return;
+        }
+        for (let index = 0; index < expressions.length - 1; index += 1) {
+          const columnNode = expressions[index];
+          const valuesNode = expressions[index + 1];
+          if (columnNode === undefined || valuesNode === undefined) {
+            continue;
+          }
+          const prefix = syntaxQuasis[index] ?? "";
+          const lowerStart = lowerCallStart(prefix);
+          if (
+            lowerStart !== undefined &&
+            hasPredicateLeftBoundary(prefix.slice(0, lowerStart)) &&
+            /^\s*\)\s+IN\s*\(\s*$/i.test(syntaxQuasis[index + 1] ?? "") &&
+            membershipRightBoundary(syntaxQuasis[index + 2] ?? "") &&
+            isDrizzleColumnType(
+              checker,
+              expressionType(columnNode).type,
+              expressionType(columnNode).location,
+            ) &&
+            isInlineParameterListSqlJoin(valuesNode)
+          ) {
+            report(columnNode, "inArray");
+          }
         }
         for (let index = 0; index < expressions.length - 1; index += 1) {
           const leftNode = expressions[index];


### PR DESCRIPTION
## Summary

- replace the two handwritten case-insensitive suppression memberships with
  `inArray(...)`
- move the auto-recharge claim's fixed boolean tree and legacy tier membership
  to typed Drizzle helpers while retaining the PostgreSQL clock interval
- replace the connector-ref expiry comparison with `gt(...)`
- extend `api/prefer-drizzle-apis` with a conservative, diagnostic-only matcher
  for the exact recurring inline `lower(column) IN (...)` shape

## Query verification

- email rendering keeps identical parameters and
  `email_suppressions_email_lower_idx`
- auto-recharge remains one conditional `UPDATE ... RETURNING` using
  `org_metadata_pkey`; the boolean and tier values are now bound parameters,
  with the same normalized filter and database-clock stale threshold
- connector rendering and parameters are identical and retain
  `agent_run_custom_connector_auth_refs_run_id_secret_name_pk`

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-apis.test.ts`
  (34 passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts`
  (6 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts`
  (19 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "resolves custom connector auth from run-scoped refs when encrypted secrets omit aliases"`
  (1 passed)
- `pnpm knip --workspace api --workspace @vm0/eslint-rules`
- pre-commit full Knip and workspace type checks
- local Drizzle rendering and real PostgreSQL `EXPLAIN` comparisons
- full API ESLint: 25.0s versus 27.22s baseline

## Scope

No schema, migration, persisted-data, API, feature-switch, or
cross-deployment compatibility change.

Closes #22912

Parent: #22439
