### PR TITLE
refactor(mitm-addon): centralize diagnostic candidate metadata

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -10,6 +10,7 @@ import matching
 _DYNAMIC_BASE_MARKERS: Final = ("{", "}")
 _DIAGNOSTIC_ANY_PERMISSION: Final = "__connector_diagnostic_any__"
 _DIAGNOSTIC_ANY_RULES: Final = ("ANY /", "ANY /{path+}")
+_DIAGNOSTIC_CANDIDATE_KEY: Final = "_diagnostic_candidate"
 _MODEL_PROVIDER_PREFIX: Final = "model-provider:"
 _REFERENCE_NAME_PATTERN: Final = re.compile(r"\b(?:secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)")
 _SHARED_BASE_MIN_CANDIDATES: Final = 2
@@ -336,28 +337,12 @@ def _hint_status(
 def _candidate_from_match(
     match: matching.FirewallAllow,
 ) -> ConnectorDiagnosticCandidate | None:
-    api_entry = match.api_entry
-    env_names = api_entry.get("_diagnostic_env_names")
-    auth_header_names = api_entry.get("_diagnostic_auth_header_names")
-    auth_query_param_names = api_entry.get("_diagnostic_auth_query_param_names")
-    if (
-        not isinstance(env_names, tuple)
-        or not isinstance(auth_header_names, tuple)
-        or not isinstance(auth_query_param_names, tuple)
-    ):
+    candidate = match.api_entry.get(_DIAGNOSTIC_CANDIDATE_KEY)
+    if not isinstance(candidate, ConnectorDiagnosticCandidate):
         return None
-    base = match.api_entry.get("base")
-    if not isinstance(base, str):
+    if candidate.connector_type != match.name or candidate.base != match.api_entry.get("base"):
         return None
-
-    return ConnectorDiagnosticCandidate(
-        connector_type=match.name,
-        reason="not_configured_for_run",
-        env_names=env_names,
-        base=base,
-        auth_header_names=auth_header_names,
-        auth_query_param_names=auth_query_param_names,
-    )
+    return candidate
 
 
 def _cached_diagnostic_snapshot(
@@ -579,7 +564,11 @@ def project_diagnostic_catalog(firewalls: dict[str, dict]) -> DiagnosticCatalogP
             continue
 
         for api in raw_apis:
-            projected_api = _project_connector_api(api, shared_base_keys=shared_base_keys)
+            projected_api = _project_connector_api(
+                api,
+                connector_type=raw_name,
+                shared_base_keys=shared_base_keys,
+            )
             if projected_api is not None:
                 projected_apis.append(projected_api)
         if projected_apis:
@@ -595,6 +584,7 @@ def project_diagnostic_catalog(firewalls: dict[str, dict]) -> DiagnosticCatalogP
 def _project_connector_api(
     api: dict,
     *,
+    connector_type: str,
     shared_base_keys: frozenset[str],
 ) -> dict | None:
     raw_base = api.get("base")
@@ -609,12 +599,15 @@ def _project_connector_api(
     if not env_names:
         return None
 
-    projected = {
-        "base": raw_base,
-        "envNames": list(env_names),
-        "authHeaderNames": list(_auth_mapping_names(auth, "headers")),
-        "authQueryParamNames": list(_auth_mapping_names(auth, "query")),
-    }
+    candidate = ConnectorDiagnosticCandidate(
+        connector_type=connector_type,
+        reason="not_configured_for_run",
+        env_names=env_names,
+        base=raw_base,
+        auth_header_names=_auth_mapping_names(auth, "headers"),
+        auth_query_param_names=_auth_mapping_names(auth, "query"),
+    )
+    projected: dict[str, object] = {_DIAGNOSTIC_CANDIDATE_KEY: candidate}
     if base_key in shared_base_keys:
         permissions = _catalog_permissions(api.get("permissions"))
         if permissions:
@@ -634,21 +627,17 @@ def _project_model_provider_api(api: dict) -> dict | None:
     }
 
 
-def _projection_str_tuple(value: object) -> tuple[str, ...]:
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise TypeError("diagnostic projection string-list shape changed")
-    return tuple(value)
+def _projected_connector_candidate(api: dict) -> ConnectorDiagnosticCandidate:
+    candidate = api.get(_DIAGNOSTIC_CANDIDATE_KEY)
+    if not isinstance(candidate, ConnectorDiagnosticCandidate):
+        raise TypeError("diagnostic connector projection candidate shape changed")
+    return candidate
 
 
 def _diagnostic_firewall_from_projection(firewall: dict) -> dict | None:
     raw_name, raw_apis = _catalog_firewall_fields(firewall)
 
-    apis: list[dict] = []
-    for api in raw_apis:
-        diagnostic_api = _diagnostic_api_from_projection(api)
-        if diagnostic_api is not None:
-            apis.append(diagnostic_api)
-
+    apis = [_diagnostic_api_from_projection(api) for api in raw_apis]
     if not apis:
         return None
     return {"name": raw_name, "apis": apis}
@@ -689,19 +678,24 @@ def _model_provider_exclusion_firewall_from_projection(firewall: dict) -> dict |
     return {"name": raw_name, "apis": apis}
 
 
-def _diagnostic_api_from_projection(api: dict) -> dict | None:
-    raw_base = api.get("base")
-    if not isinstance(raw_base, str):
-        raise TypeError("diagnostic projection base shape changed")
-
+def _diagnostic_matcher_api(
+    candidate: ConnectorDiagnosticCandidate,
+    *,
+    permissions: list[dict],
+) -> dict:
     return {
-        "base": raw_base,
+        "base": candidate.base,
         "auth": {},
-        "permissions": _base_match_permissions(),
-        "_diagnostic_env_names": _projection_str_tuple(api.get("envNames")),
-        "_diagnostic_auth_header_names": _projection_str_tuple(api.get("authHeaderNames")),
-        "_diagnostic_auth_query_param_names": _projection_str_tuple(api.get("authQueryParamNames")),
+        "permissions": permissions,
+        _DIAGNOSTIC_CANDIDATE_KEY: candidate,
     }
+
+
+def _diagnostic_api_from_projection(api: dict) -> dict:
+    return _diagnostic_matcher_api(
+        _projected_connector_candidate(api),
+        permissions=_base_match_permissions(),
+    )
 
 
 def _route_aware_diagnostic_api_from_projection(
@@ -709,21 +703,15 @@ def _route_aware_diagnostic_api_from_projection(
     *,
     shared_base_keys: frozenset[str],
 ) -> dict | None:
-    raw_base = api.get("base")
-    if not isinstance(raw_base, str):
-        raise TypeError("diagnostic projection base shape changed")
-    base_key = _diagnostic_static_base_key(raw_base)
+    candidate = _projected_connector_candidate(api)
+    base_key = _diagnostic_static_base_key(candidate.base)
     if base_key is None or base_key not in shared_base_keys:
         return None
 
-    return {
-        "base": raw_base,
-        "auth": {},
-        "permissions": _catalog_permissions(api.get("permissions")),
-        "_diagnostic_env_names": _projection_str_tuple(api.get("envNames")),
-        "_diagnostic_auth_header_names": _projection_str_tuple(api.get("authHeaderNames")),
-        "_diagnostic_auth_query_param_names": _projection_str_tuple(api.get("authQueryParamNames")),
-    }
+    return _diagnostic_matcher_api(
+        candidate,
+        permissions=_catalog_permissions(api.get("permissions")),
+    )
 
 
 def _model_provider_exclusion_api_from_projection(api: dict) -> dict | None:

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -85,13 +85,14 @@ def test_classifies_static_connector_without_permission_method_enforcement():
         active_firewall_names=set(),
     )
 
-    assert candidate is not None
-    assert candidate.connector_type == "catalog-connector"
-    assert candidate.reason == "not_configured_for_run"
-    assert candidate.base == "https://service.example.com/api"
-    assert candidate.env_names == ("SERVICE_TOKEN", "TENANT_ID")
-    assert candidate.auth_header_names == ("Authorization",)
-    assert candidate.auth_query_param_names == ("tenant",)
+    assert candidate == builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
+        connector_type="catalog-connector",
+        reason="not_configured_for_run",
+        env_names=("SERVICE_TOKEN", "TENANT_ID"),
+        base="https://service.example.com/api",
+        auth_header_names=("Authorization",),
+        auth_query_param_names=("tenant",),
+    )
 
 
 def test_skips_active_connector_name():
@@ -236,6 +237,14 @@ def test_find_candidate_selects_unique_shared_base_route_owner():
             _firewall(
                 "inactive",
                 "INACTIVE_TOKEN",
+                auth={
+                    "headers": {
+                        "X-Inactive-Token": "${{ secrets.INACTIVE_HEADER_TOKEN }}",
+                    },
+                    "query": {
+                        "inactive_token": "${{ secrets.INACTIVE_QUERY_TOKEN }}",
+                    },
+                },
                 permissions=[{"name": "read", "rules": ["GET /messages/{id}"]}],
             ),
         ]
@@ -248,9 +257,14 @@ def test_find_candidate_selects_unique_shared_base_route_owner():
         active_firewall_names={"active"},
     )
 
-    assert candidate is not None
-    assert candidate.connector_type == "inactive"
-    assert candidate.env_names == ("INACTIVE_TOKEN",)
+    assert candidate == builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
+        connector_type="inactive",
+        reason="not_configured_for_run",
+        env_names=("INACTIVE_HEADER_TOKEN", "INACTIVE_QUERY_TOKEN"),
+        base="https://shared.example.com",
+        auth_header_names=("X-Inactive-Token",),
+        auth_query_param_names=("inactive_token",),
+    )
 
 
 def test_find_candidate_suppresses_multiple_shared_base_route_owners():

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -79,8 +79,21 @@ def _shared_base_catalog_firewall(
     name: str,
     token_name: str,
     *,
+    auth: dict[str, object] | None = None,
     permissions: list[dict[str, object]] | None = None,
 ) -> dict:
+    resolved_auth = (
+        {
+            "headers": {
+                "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
+            },
+            "query": {
+                "api_key": f"${{{{ secrets.{token_name} }}}}",
+            },
+        }
+        if auth is None
+        else auth
+    )
     return {
         "name": name,
         "apis": [
@@ -90,14 +103,7 @@ def _shared_base_catalog_firewall(
                     "kind": "providerOwned",
                     "exactHosts": ["shared.example.com"],
                 },
-                "auth": {
-                    "headers": {
-                        "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
-                    },
-                    "query": {
-                        "api_key": f"${{{{ secrets.{token_name} }}}}",
-                    },
-                },
+                "auth": resolved_auth,
                 "permissions": permissions or [],
             }
         ],
@@ -108,6 +114,7 @@ def _write_shared_base_diagnostic_catalog(
     tmp_path,
     *,
     active_permissions: list[dict[str, object]] | None = None,
+    inactive_auth: dict[str, object] | None = None,
     inactive_permissions: list[dict[str, object]] | None = None,
 ) -> None:
     firewalls = {
@@ -119,6 +126,7 @@ def _write_shared_base_diagnostic_catalog(
         "inactive-shared": _shared_base_catalog_firewall(
             "inactive-shared",
             "INACTIVE_TOKEN",
+            auth=inactive_auth,
             permissions=inactive_permissions,
         ),
     }
@@ -253,12 +261,34 @@ async def test_shared_base_active_connector_intent_keeps_active_auth_path(
     assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
 
 
-async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+@pytest.mark.parametrize(
+    ("path", "request_header_pairs"),
+    [
+        ("/inactive", [("X-Inactive-Session", "user-provided")]),
+        ("/inactive?inactive_session=user-provided", []),
+    ],
+    ids=["configured-header", "configured-query"],
+)
+async def test_shared_base_unknown_endpoint_with_configured_auth_keeps_active_auth_path(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    path,
+    request_header_pairs,
 ):
     _write_shared_base_diagnostic_catalog(
         tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_auth={
+            "headers": {
+                "X-Inactive-Session": "${{ secrets.INACTIVE_TOKEN }}",
+            },
+            "query": {
+                "inactive_session": "${{ secrets.INACTIVE_TOKEN }}",
+            },
+        },
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
     )
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
@@ -266,11 +296,11 @@ async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_pat
         with_response=False,
         client_ip="10.200.0.5",
         host="shared.example.com",
-        path="/inactive",
+        path=path,
         request_headers=headers(
             ("Host", "shared.example.com"),
             ("X-VM0-Connector-Intent", "inactive-shared"),
-            ("Authorization", "Bearer user-provided"),
+            *request_header_pairs,
         ),
     )
 
@@ -466,6 +496,69 @@ async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
         request_headers=headers(
             ("Host", "fal.run"),
             ("Authorization", "Key user-provided"),
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    ("path", "request_header_pairs"),
+    [
+        ("/items", [("X-Workspace-Session", "user-provided")]),
+        ("/items?workspace_session=user-provided", []),
+    ],
+    ids=["configured-header", "configured-query"],
+)
+async def test_inactive_connector_url_with_configured_auth_allows_upstream(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    path,
+    request_header_pairs,
+):
+    write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls={
+            "configured-auth": {
+                "name": "configured-auth",
+                "apis": [
+                    {
+                        "base": "https://configured.example.com",
+                        "hostPolicy": {
+                            "kind": "providerOwned",
+                            "exactHosts": ["configured.example.com"],
+                        },
+                        "auth": {
+                            "headers": {
+                                "X-Workspace-Session": "${{ secrets.WORKSPACE_TOKEN }}",
+                            },
+                            "query": {
+                                "workspace_session": "${{ secrets.WORKSPACE_TOKEN }}",
+                            },
+                        },
+                        "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                    }
+                ],
+            }
+        },
+    )
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="configured.example.com",
+        path=path,
+        request_headers=headers(
+            ("Host", "configured.example.com"),
+            *request_header_pairs,
         ),
     )
 


### PR DESCRIPTION
## Summary

- build one frozen connector diagnostic candidate during catalog projection
- carry the same typed candidate through ordinary and shared-base matcher entries
- centralize matcher conversion and remove independent private metadata fields
- verify complete candidate parity and configured header/query auth suppression on both request paths

## Scope

This is an internal mitm-addon refactor. It preserves ordinary base-wide matching, shared-base route ownership, model-provider exclusions, and user-visible diagnostic behavior. It does not change API schemas, persisted catalog formats, runner protocols, database state, dependencies, or deployment configuration.

## Validation

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_builtin_connector_diagnostics.py tests/test_request_handler_connector_diagnostics.py` (35 passed)
- `uv run --no-sync python -m pytest tests/ --quiet` (4206 passed)

Closes #22916
