### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.218"
+CLAUDE_CODE_VERSION="2.1.220"
 CODEX_CLI_VERSION="0.145.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.218` to `2.1.220`.

Go, Codex CLI, Google Workspace CLI, xurl, agent-browser, pnpm, Chromium, Node.js 24 LTS, and PostgreSQL 18 remain at their current selected releases. Ubuntu remains unchanged.

## Verification

- Confirmed Claude Code `2.1.220` through the official latest-release endpoint.
- Confirmed the `linux-x64` and `linux-arm64` manifests and binaries are available.
- Audited the remaining pins against their official release endpoints, npm registry metadata, or package repositories.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
- Ran `git diff --check`.