### PR TITLE
chore(rust): update aws sdk and build dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b50a43f3ccdf331521c6d6c68b7cc9668b6e09d439ebda9569df5722324d76"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.139.0"
+version = "1.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a159b9721a6a41468f967d1029bece78f410b0beb0594498435deb6ff72bfe48"
+checksum = "e9660cf991e512fbe6094f1041ff3d3282bc5aeeeb6184e8de437ec2de024a10"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1041,9 +1041,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"


### PR DESCRIPTION
## Summary

- Update aws-runtime from 1.9.0 to 1.9.1.
- Update aws-sdk-s3 from 1.139.0 to 1.140.0.
- Update cc from 1.3.0 to 1.4.0.
- Update either from 1.16.0 to 1.17.0.
- Keep this as a lockfile-only dependency refresh.

## Dependencies not updated

- generic-array remains at 0.14.7 although 0.14.9 is available because crypto-common 0.1.7 requires exactly generic-array 0.14.7.

## Manual version bumps

- None. No Cargo.toml constraints required changes.

## Test status

- PASS: cargo test --workspace --exclude runner -j 1 --quiet
- PASS: cargo test -p runner -j 1 --quiet -- --test-threads=1 (2,829 passed, 13 existing ignored; the additional runner integration test also passed)
- The initial combined cargo test --workspace attempt was killed by the local memory limit while linking the large runner test binary. Validation was rerun with the resource-safe split above, and both commands passed.
