### PR TITLE
test(api): deterministically order recall-first queue drain

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -5087,27 +5087,56 @@ describe("CHAT-02: shared user message queue", () => {
       messageId,
       signal: context.signal,
     });
+
+    // Stage the callback drain at org admission before recall reaches the queue
+    // row. The direct waiter proves recall is first; the transitive count after
+    // admission opens proves the drain is queued behind it.
+    const callbackQueryStarted = createDeferredPromise<void>(context.signal);
+    const releaseCallbackQuery = createDeferredPromise<void>(context.signal);
     onTestFinished(async () => {
+      if (!releaseCallbackQuery.settled()) {
+        releaseCallbackQuery.resolve(undefined);
+      }
       admissionLock.release();
       messageQueueLock.release();
       await Promise.all([admissionLock.done, messageQueueLock.done]);
     });
 
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
-    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (!apl.includes("['agent-run-events']")) {
+        return Promise.resolve([]);
+      }
+      if (!callbackQueryStarted.settled()) {
+        callbackQueryStarted.resolve(undefined);
+      }
+      return releaseCallbackQuery.promise.then(() => {
+        return [assistantEvent(0, "recall-first queue race complete")];
+      });
+    });
 
-    const recall = chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        revokesMessageId: messageId,
-        clientMessageId: randomUUID(),
-      },
-      [201],
-    );
-    await expect.poll(messageQueueLock.blockedWaiterCount).toBe(1);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await callbackQueryStarted.promise;
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+
+    releaseCallbackQuery.resolve(undefined);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+
+    const recall = Promise.allSettled([
+      chat.requestSendMessage(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          revokesMessageId: messageId,
+          clientMessageId: randomUUID(),
+        },
+        [201],
+      ),
+    ]);
+    await expect.poll(messageQueueLock.directBlockedWaiterCount).toBe(1);
 
     admissionLock.release();
     await admissionLock.done;
@@ -5116,7 +5145,11 @@ describe("CHAT-02: shared user message queue", () => {
       .toBeGreaterThanOrEqual(2);
     messageQueueLock.release();
 
-    const recalled = await recall;
+    const [recallResult] = await recall;
+    if (recallResult.status === "rejected") {
+      throw recallResult.reason;
+    }
+    const recalled = recallResult.value;
     expect(recalled.body).toMatchObject({
       runId: null,
       threadId: anchor.threadId,

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -47,6 +47,19 @@ async function transitiveBlockedWaiterCount(
   return rows[0]?.waiterCount ?? 0;
 }
 
+async function directBlockedWaiterCount(holderPid: number): Promise<number> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT ${count()}::int AS "waiterCount"
+      FROM pg_stat_activity AS activity
+      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+    `,
+    waiterCountRowSchema,
+  );
+  return rows[0]?.waiterCount ?? 0;
+}
+
 function bddVm0ApiKeyFilter(vendor: string, model: string) {
   const [fakePrefix, devSeedPrefix] = VM0_BDD_API_KEY_PREFIXES;
   return and(
@@ -217,6 +230,7 @@ export async function holdChatMessageQueueItemFixture(args: {
 }): Promise<{
   readonly release: () => void;
   readonly done: Promise<void>;
+  readonly directBlockedWaiterCount: () => Promise<number>;
   readonly blockedWaiterCount: () => Promise<number>;
 }> {
   const started = createDeferredPromise<number>(args.signal);
@@ -260,6 +274,9 @@ export async function holdChatMessageQueueItemFixture(args: {
       }
     },
     done,
+    directBlockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(holderPid);
+    },
     blockedWaiterCount: async () => {
       return await transitiveBlockedWaiterCount(holderPid);
     },


### PR DESCRIPTION
## Summary

- deterministically stage the terminal chat callback at org admission before launching the recall-first queue race
- distinguish the recall's direct queue-row wait from scheduler-dependent transitive waiters
- own the concurrent recall promise immediately so a failing request cannot surface as a delayed unhandled rejection

## Failure evidence

- Trigger: [Turbo run 30144379004](https://github.com/vm0-ai/vm0/actions/runs/30144379004), `push` to `main` at `0cba6a6abde97022866a1a6d76368b6c01149bd3`
- First substantive failure: [`test-api (8)` job 89643374365](https://github.com/vm0-ai/vm0/actions/runs/30144379004/job/89643374365)
- Failing test: `CHAT-02: shared user message queue > lets recall win without deadlocking an atomic queue-first drain`
- First causal event: the test expected one blocked waiter on the held queue item but observed two; `blockedWaiterCount` recursively includes transitive waiters, so a scheduler-dependent callback arrival changed the intermediate total without changing the product outcome
- The later `PromiseRejectionHandledWarning` and teardown `AbortError` messages were secondary effects of the failed synchronization assertion and delayed ownership of the recall promise
- Intermittency: the same shard and test passed in adjacent main run 30144155134 and PR run 30143040814; the triggering commit changed SQL predicate construction and did not touch this queue path
- Classification: flaky test synchronization and promise ownership, not a deterministic product regression

## Fix

- gate the callback's Axiom query so the test can prove the org admission waiters are staged in a known order
- add a direct queue-row waiter count alongside the existing transitive lock-chain count
- assert recall is the single direct waiter before opening admission, then assert the drain joins the transitive chain behind recall
- wrap the concurrent recall request in `Promise.allSettled` immediately and rethrow an owned rejection
- preserve all final product assertions for recall success, claim-lost telemetry, tombstoning, and absence of a replacement run

## Validation

- failing focused test passed 5 consecutive times after the final synchronization change, then passed again after rebasing onto latest `main`
- adjacent `preserves an appended claim when recall races the queue drain` regression test passed
- `pnpm format`
- `pnpm turbo run lint --log-order grouped` (12/12 packages)
- `pnpm -F api lint`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api check-types`
- `git diff --check`

## Limitations

- The full Vitest suite was not run locally, following the repository PR policy; PR CI remains the full-suite verification source.
- The default-heap workspace type-check reached an API TypeScript OOM without diagnostics. The API type-check passed when rerun with a 4 GB Node heap.
