### PR TITLE
docs(runner): clarify gc command cleanup scope

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -358,7 +358,7 @@ mod tests {
 
         assert!(
             normalized_help
-                .contains("Clean up unused runner resources, artifacts, logs, and caches")
+                .contains("gc Clean up unused runner resources, artifacts, logs, and caches")
         );
     }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -95,7 +95,7 @@ enum Command {
     Service(cmd::ServiceArgs),
     /// Kill a running sandbox
     Kill(cmd::KillArgs),
-    /// Clean up unused image directories
+    /// Clean up unused runner resources, artifacts, logs, and caches
     Gc(cmd::GcArgs),
     /// Inspect and clean up session workspace image cache entries
     WorkspaceImageCache(cmd::WorkspaceImageCacheArgs),
@@ -312,6 +312,7 @@ mod tests {
 
     use super::*;
     use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+    use clap::CommandFactory;
 
     const HELP_TOKEN_CHILD_SCENARIO_ENV: &str = "VM0_RUNNER_HELP_TOKEN_CHILD_SCENARIO";
     const HELP_TOKEN_CHILD_TEST: &str = "tests::runner_help_hides_token_environment_values_child";
@@ -347,6 +348,17 @@ mod tests {
         assert_eq!(
             runner_name_from_config(Path::new("/nonexistent.yaml")),
             "default"
+        );
+    }
+
+    #[test]
+    fn runner_gc_help_describes_full_cleanup_scope() {
+        let help = Cli::command().render_help().to_string();
+        let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert!(
+            normalized_help
+                .contains("Clean up unused runner resources, artifacts, logs, and caches")
         );
     }
 


### PR DESCRIPTION
## Summary

- replace the image-only `runner gc` summary with durable resource, artifact, log, and cache categories
- add a regression test against the generated top-level Clap help

## Scope

- no changes to GC behavior, arguments, cleanup ordering, retention, or deployment configuration

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner runner_gc_help_describes_full_cleanup_scope`
- `cargo test -p runner --bin runner`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`

Closes #22974
