### PR TITLE
fix(goals): unify goal capabilities across run sources

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -215,7 +215,7 @@ describe("auth tokens", () => {
     );
   });
 
-  it("grants goal capabilities by default", () => {
+  it("grants all goal capabilities", () => {
     const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
 
     expect(verifyZeroToken(defaultToken)?.capabilities).toContain("goal:read");
@@ -224,36 +224,6 @@ describe("auth tokens", () => {
     );
     expect(verifyZeroToken(defaultToken)?.capabilities).toContain(
       "goal:user-control:write",
-    );
-  });
-
-  it("excludes user-control goal writes for workflow-event runs but keeps agent result writes", () => {
-    const userDrivenToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      "org_zero",
-      {},
-      { triggerSource: "web" },
-    );
-    const continuationToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      "org_zero",
-      {},
-      { triggerSource: "workflow-event" },
-    );
-
-    expect(verifyZeroToken(userDrivenToken)?.capabilities).toContain(
-      "goal:user-control:write",
-    );
-    expect(verifyZeroToken(continuationToken)?.capabilities).not.toContain(
-      "goal:user-control:write",
-    );
-    expect(verifyZeroToken(continuationToken)?.capabilities).toContain(
-      "goal:read",
-    );
-    expect(verifyZeroToken(continuationToken)?.capabilities).toContain(
-      "goal:agent-result:write",
     );
   });
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -4,7 +4,6 @@ import {
   ZERO_CAPABILITIES,
   ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   isFeatureEnabled,
@@ -299,21 +298,12 @@ export function generateZeroToken(
   overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
   options?: {
     readonly computerUseHostId?: string;
-    readonly triggerSource?: TriggerSource;
   },
 ): string {
   const nowSeconds = Math.floor(now() / 1000);
   const capabilities: ZeroCapability[] = [];
   for (const capability of ZERO_CAPABILITIES) {
     if (capability === "computer-use:write" && !options?.computerUseHostId) {
-      continue;
-    }
-    // Workflow-event runs are autonomous and must not create, edit, pause,
-    // resume, or clear goals. They can still report terminal agent results.
-    if (
-      capability === "goal:user-control:write" &&
-      options?.triggerSource === "workflow-event"
-    ) {
       continue;
     }
     if (

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -10,6 +10,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
+import { verifyZeroToken } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createGithubBddApi } from "./helpers/api-bdd-github";
@@ -670,6 +671,13 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       throw new Error("Expected a GitHub workflow run automation");
     }
     const claim = await runsApi.claimRunnerJob(runId);
+    const zeroToken = claim.environment?.ZERO_TOKEN;
+    if (!zeroToken) {
+      throw new Error("Expected the workflow event run to expose ZERO_TOKEN");
+    }
+    expect(verifyZeroToken(zeroToken)?.capabilities).toContain(
+      "goal:user-control:write",
+    );
     expect(claim.appendSystemPrompt).toContain(
       'GitHub Actions workflow "Turbo" completed with conclusion "failure"',
     );

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5163,14 +5163,9 @@ function buildRunnerJobPayload(
             args.run.id,
             args.orgId,
             featureSwitchOverrides,
-            {
-              ...(args.zeroTokenComputerUseHostId
-                ? { computerUseHostId: args.zeroTokenComputerUseHostId }
-                : {}),
-              ...(args.body.triggerSource
-                ? { triggerSource: args.body.triggerSource }
-                : {}),
-            },
+            args.zeroTokenComputerUseHostId
+              ? { computerUseHostId: args.zeroTokenComputerUseHostId }
+              : undefined,
           ),
         )
       : args.body;


### PR DESCRIPTION
## Summary

- remove trigger-source-specific goal capability filtering from run-scoped Zero tokens
- stop plumbing `triggerSource` into token generation while preserving computer-use host scoping
- verify that a GitHub workflow event run receives `goal:user-control:write`

## User impact

Event automation runs can create and manage goals just like web and scheduled runs, so workflows can compose with goal-backed operations such as `pr-auto`.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts`
- `PGTZ=UTC DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-github-workflow.test.ts`
