### PR TITLE
test(ably-subscriber): assert pre-connected close error

### DIFF
--- a/crates/ably-subscriber/tests/integration/connection_messages.rs
+++ b/crates/ably-subscriber/tests/integration/connection_messages.rs
@@ -495,11 +495,23 @@ async fn connection_closed_before_connected() {
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
-    tokio::spawn(async move {
-        let conn = ws.accept_raw().await.unwrap();
-        drop(conn);
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_raw().await.unwrap();
+        conn.close(None).await.unwrap();
+        expect_websocket_close_frame(&mut conn).await.unwrap();
     });
 
     let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
-    assert!(result.is_err());
+    match result {
+        Err(ably_subscriber::Error::Protocol { code, message }) => {
+            assert_eq!(code, error_code::FAILED);
+            assert_eq!(message, "Connection closed before CONNECTED received");
+        }
+        Err(other) => panic!("expected Protocol error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+
+    join_server_task(server_task, "pre-CONNECTED close server")
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

- model a complete WebSocket closing handshake before Ably sends `CONNECTED`
- assert the exact crate-owned protocol error instead of accepting any setup or transport failure
- retain and await the mock server task so close-handshake failures are surfaced

## Scope

This is an integration-test-only change. It does not change production behavior, APIs, schemas, persisted data, timeouts, or deployment compatibility. It intentionally does not add a separate test that pins tungstenite's abrupt-reset error.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test integration connection_messages::connection_closed_before_connected -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test integration connection_messages`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- 100 repeated executions of the current-head focused integration test

Closes #22977
