### PR TITLE
perf(runner): instrument codex provider output timing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -1,0 +1,150 @@
+"""Content-free provider-output timing observations for default Codex runs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from mitmproxy import http
+
+import flow_metadata
+import usage
+from usage.json_probe import probe_top_level_string_field
+from usage.reporting_context import usage_reporting_context
+
+FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
+FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
+FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
+
+_RESPONSE_CREATED_EVENT = "response.created"
+_OUTPUT_ITEM_ADDED_EVENT = "response.output_item.added"
+_OUTPUT_TEXT_DELTA_EVENT = "response.output_text.delta"
+_TERMINAL_EVENTS = frozenset(
+    ("response.completed", "response.done", "response.incomplete", "response.failed")
+)
+_MAX_TRACKED_RUNS = 10_000
+_LOG_TYPE = "codex_output_timing"
+
+
+@dataclass
+class _RunTimingState:
+    candidate_response_created_at: str | None = None
+    generated_response_selected: bool = False
+    first_text_observed: bool = False
+    pending_operations: dict[str, str] = field(default_factory=dict)
+
+
+_run_states: OrderedDict[str, _RunTimingState] = OrderedDict()
+
+
+def observe_server_event(flow: http.HTTPFlow, content: bytes | str) -> None:
+    """Observe one server-originated Codex Responses WebSocket event."""
+    body = content.encode() if isinstance(content, str) else content
+    event_type_result = probe_top_level_string_field(body)
+    if event_type_result.status != "found" or event_type_result.value is None:
+        return
+
+    event_type = event_type_result.value
+    run_id = flow_metadata.run_id(flow.metadata)
+    if not run_id:
+        return
+
+    if event_type == _RESPONSE_CREATED_EVENT:
+        state = _state_for_run(run_id)
+        if not state.generated_response_selected:
+            state.candidate_response_created_at = _observation_time()
+        _admit_pending(flow, run_id, state)
+        return
+
+    state = _run_states.get(run_id)
+    if event_type == _OUTPUT_ITEM_ADDED_EVENT:
+        if state is None:
+            state = _state_for_run(run_id)
+        else:
+            _touch_run(run_id)
+        if not state.generated_response_selected:
+            state.generated_response_selected = True
+            if state.candidate_response_created_at is not None:
+                state.pending_operations[FIRST_GENERATED_RESPONSE_CREATED] = (
+                    state.candidate_response_created_at
+                )
+            state.candidate_response_created_at = None
+            state.pending_operations[FIRST_OUTPUT_ITEM_ADDED] = _observation_time()
+            _admit_pending(flow, run_id, state)
+        return
+
+    if event_type == _OUTPUT_TEXT_DELTA_EVENT:
+        if state is None or not state.generated_response_selected:
+            return
+        _touch_run(run_id)
+        if not state.first_text_observed:
+            state.first_text_observed = True
+            state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = _observation_time()
+            _admit_pending(flow, run_id, state)
+        return
+
+    if event_type not in _TERMINAL_EVENTS or state is None:
+        return
+
+    _touch_run(run_id)
+    if not state.generated_response_selected:
+        _run_states.pop(run_id)
+        return
+    _admit_pending(flow, run_id, state)
+
+
+def _observation_time() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _state_for_run(run_id: str) -> _RunTimingState:
+    state = _run_states.get(run_id)
+    if state is None:
+        state = _RunTimingState()
+        _run_states[run_id] = state
+        if len(_run_states) > _MAX_TRACKED_RUNS:
+            _run_states.popitem(last=False)
+        return state
+
+    _touch_run(run_id)
+    return state
+
+
+def _touch_run(run_id: str) -> None:
+    _run_states.move_to_end(run_id)
+
+
+def _admit_pending(flow: http.HTTPFlow, run_id: str, state: _RunTimingState) -> None:
+    if not state.pending_operations:
+        return
+
+    context = usage_reporting_context(flow)
+    if not context.is_complete:
+        return
+
+    operations = [
+        {
+            "ts": observed_at,
+            "action_type": action_type,
+            "duration_ms": 0,
+            "success": True,
+        }
+        for action_type, observed_at in state.pending_operations.items()
+    ]
+    payload: dict[str, object] = {
+        "runId": run_id,
+        "sandboxOperations": operations,
+    }
+    if usage.webhook.enqueue_webhook_delivery(
+        context.telemetry_url(),
+        context.sandbox_token,
+        payload,
+        context.proxy_log_path,
+        _LOG_TYPE,
+    ):
+        state.pending_operations.clear()
+
+
+def reset_for_tests() -> None:
+    _run_states.clear()

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -42,6 +42,7 @@ from mitmproxy.addonmanager import Loader
 import auth_base_forwarder
 import body_capture
 import builtin_host_policy
+import codex_output_timing
 import connector_diagnostics
 import connector_intent
 import flow_metadata
@@ -1116,6 +1117,8 @@ def websocket_message(flow: http.HTTPFlow) -> None:
         return
     if getattr(message, "from_client", False):
         return
+    if response_streaming.uses_openai_responses_usage_protocol(flow):
+        codex_output_timing.observe_server_event(flow, message.content)
     response_streaming.feed_model_websocket_usage(flow, message.content)
 
 

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -7,6 +7,7 @@ from platform_api import get_api_url
 
 USAGE_EVENT_WEBHOOK_PATH = "/api/webhooks/agent/usage-event"
 MODEL_USAGE_OBSERVATION_WEBHOOK_PATH = "/api/webhooks/agent/model-usage-observation"
+AGENT_TELEMETRY_WEBHOOK_PATH = "/api/webhooks/agent/telemetry"
 
 
 class UsageReportingContext:
@@ -39,6 +40,9 @@ class UsageReportingContext:
 
     def model_usage_observation_url(self) -> str:
         return self._url_for(MODEL_USAGE_OBSERVATION_WEBHOOK_PATH)
+
+    def telemetry_url(self) -> str:
+        return self._url_for(AGENT_TELEMETRY_WEBHOOK_PATH)
 
 
 def usage_reporting_context(flow: http.HTTPFlow) -> UsageReportingContext:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -28,6 +28,7 @@ from mitmproxy.test import tflow, tutils
 import auth
 import auth_base_forwarder
 import builtin_connector_diagnostics
+import codex_output_timing
 import logging_utils
 import mitm_addon
 import platform_api
@@ -65,10 +66,12 @@ def _reset_module_state() -> Iterator[None]:
     usage.counters.reset_for_tests()
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.reset_usage_buffer_for_tests()
+    codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     yield
     runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     usage.reset_usage_buffer_for_tests()
+    codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -184,12 +184,6 @@ def test_irrelevant_websocket_messages_do_not_report_timings(
         feed_websocket_server_message(flow, _event("future.unknown"))
         feed_websocket_server_message(flow, _event("response.output_text.delta"))
 
-        non_codex = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        non_codex.metadata[metadata_keys.CLI_AGENT_TYPE] = "claude"
-        mitm_addon.responseheaders(non_codex)
-        non_codex.metadata["model_websocket_usage_enabled"] = True
-        _feed_generated_response(non_codex)
-
         unobservable = make_openai_responses_websocket_flow(real_flow, tmp_path)
         set_websocket_message(
             unobservable,
@@ -250,5 +244,5 @@ def test_saturated_delivery_retries_with_original_observation_times(
     created_at = datetime.fromisoformat(str(operations[0]["ts"]))
     output_at = datetime.fromisoformat(str(operations[1]["ts"]))
     text_at = datetime.fromisoformat(str(operations[2]["ts"]))
-    assert created_at <= output_at < retry_started_at <= text_at
+    assert created_at <= output_at <= retry_started_at <= text_at
     assert usage.webhook.pending_delivery_payload_count_for_tests() == 0

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -1,0 +1,254 @@
+"""Tests for default Codex provider-output timing observations."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import usage
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
+from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
+from tests.model_provider_websocket_helpers import (
+    ScheduledWebSocketTrim,
+    capture_deferred_websocket_trims,
+    feed_websocket_server_message,
+    set_websocket_message,
+)
+from tests.usage_helpers import CapturedWebhookRequest, UsageWebhookServer
+from tests.webhook_test_helpers import QueuedUsageExecutor
+
+_TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
+_FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
+_FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
+_FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
+
+
+@pytest.fixture(autouse=True)
+def deferred_websocket_trim_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[ScheduledWebSocketTrim]:
+    return capture_deferred_websocket_trims(monkeypatch)
+
+
+def _event(event_type: str, *, secret: str | None = None) -> bytes:
+    event: dict[str, object] = {"type": event_type}
+    if secret is not None:
+        event["content"] = {
+            "text": secret,
+            "response_id": "sensitive-response-id",
+        }
+    return json.dumps(event).encode()
+
+
+def _timing_requests(webhook: UsageWebhookServer) -> list[CapturedWebhookRequest]:
+    return [request for request in webhook.requests if request.path == _TELEMETRY_PATH]
+
+
+def _operations(requests: list[CapturedWebhookRequest]) -> list[dict[str, object]]:
+    operations: list[dict[str, object]] = []
+    for request in requests:
+        body = request.json_body()
+        request_operations = body.get("sandboxOperations")
+        assert isinstance(request_operations, list)
+        for operation in request_operations:
+            assert isinstance(operation, dict)
+            operations.append(operation)
+    return operations
+
+
+def _feed_generated_response(
+    flow: http.HTTPFlow,
+    *,
+    include_text: bool = True,
+    secret: str | None = None,
+) -> None:
+    feed_websocket_server_message(flow, _event("response.created", secret=secret))
+    feed_websocket_server_message(flow, _event("response.output_item.added", secret=secret))
+    if include_text:
+        feed_websocket_server_message(flow, _event("response.output_text.delta", secret=secret))
+
+
+def test_default_codex_excludes_prewarm_and_reports_content_free_milestones(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    secret = "provider-secret-that-must-not-be-reported"
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        feed_websocket_server_message(flow, _event("response.created", secret=secret))
+        feed_websocket_server_message(flow, _event("response.completed", secret=secret))
+        assert _timing_requests(usage_webhook_server) == []
+
+        _feed_generated_response(flow, secret=secret)
+
+    requests = _timing_requests(usage_webhook_server)
+    assert len(requests) == 2
+    assert [len(request.json_body()["sandboxOperations"]) for request in requests] == [2, 1]
+    assert all(request.header("authorization") == "Bearer tok-xyz" for request in requests)
+
+    operations = _operations(requests)
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+    ]
+    assert all(operation["duration_ms"] == 0 for operation in operations)
+    assert all(operation["success"] is True for operation in operations)
+    timestamps = [datetime.fromisoformat(str(operation["ts"])) for operation in operations]
+    assert timestamps == sorted(timestamps)
+    assert all(request.json_body()["runId"] == "run-abc-123" for request in requests)
+
+    serialized_requests = b"".join(request.body for request in requests)
+    assert secret.encode() not in serialized_requests
+    assert secret not in read_jsonl_text_after_flush(proxy_log)
+
+
+def test_tool_turns_reconnects_and_reused_sandboxes_preserve_run_boundaries(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed_generated_response(flow, include_text=False)
+        feed_websocket_server_message(flow, _event("response.completed"))
+
+        _feed_generated_response(flow)
+        feed_websocket_server_message(flow, _event("response.output_text.delta"))
+
+        reconnect = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(reconnect)
+        _feed_generated_response(reconnect)
+
+        reused_sandbox_run = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        reused_sandbox_run.metadata[metadata_keys.VM_RUN_ID] = "run-reused-sandbox"
+        mitm_addon.responseheaders(reused_sandbox_run)
+        _feed_generated_response(reused_sandbox_run)
+
+    requests = _timing_requests(usage_webhook_server)
+    operations_by_run: dict[str, list[dict[str, object]]] = {}
+    for request in requests:
+        body = request.json_body()
+        run_id = body["runId"]
+        assert isinstance(run_id, str)
+        operations_by_run.setdefault(run_id, []).extend(_operations([request]))
+
+    expected_actions = [
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+    ]
+    assert {
+        run_id: [operation["action_type"] for operation in operations]
+        for run_id, operations in operations_by_run.items()
+    } == {
+        "run-abc-123": expected_actions,
+        "run-reused-sandbox": expected_actions,
+    }
+
+
+def test_irrelevant_websocket_messages_do_not_report_timings(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+
+        set_websocket_message(
+            flow,
+            from_client=True,
+            content=_event("response.output_item.added"),
+        )
+        mitm_addon.websocket_message(flow)
+        feed_websocket_server_message(flow, b'{"type":')
+        feed_websocket_server_message(flow, _event("future.unknown"))
+        feed_websocket_server_message(flow, _event("response.output_text.delta"))
+
+        non_codex = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        non_codex.metadata[metadata_keys.CLI_AGENT_TYPE] = "claude"
+        mitm_addon.responseheaders(non_codex)
+        non_codex.metadata["model_websocket_usage_enabled"] = True
+        _feed_generated_response(non_codex)
+
+        unobservable = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        set_websocket_message(
+            unobservable,
+            from_client=False,
+            content=_event("response.output_item.added"),
+        )
+        mitm_addon.websocket_message(unobservable)
+
+    assert _timing_requests(usage_webhook_server) == []
+
+
+def test_saturated_delivery_retries_with_original_observation_times(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    executor = QueuedUsageExecutor()
+
+    with (
+        mitm_ctx(api_url=usage_webhook_server.api_url),
+        patch.object(usage.webhook, "usage_executor", executor),
+    ):
+        mitm_addon.responseheaders(flow)
+        for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+            assert usage.webhook.enqueue_webhook_delivery(
+                usage_webhook_server.url("/filler"),
+                "tok-xyz",
+                {"runId": f"filler-{index}", "events": []},
+                str(tmp_path / "filler.jsonl"),
+                "usage_event",
+            )
+
+        feed_websocket_server_message(flow, _event("response.created"))
+        feed_websocket_server_message(flow, _event("response.output_item.added"))
+        assert _timing_requests(usage_webhook_server) == []
+
+        first_delivery, first_args, first_kwargs = executor.submissions.pop(0)
+        assert callable(first_delivery)
+        first_delivery(*first_args, **first_kwargs)
+        retry_started_at = datetime.now(UTC)
+        feed_websocket_server_message(flow, _event("response.output_text.delta"))
+
+        submissions = list(executor.submissions)
+        executor.submissions.clear()
+        for delivery, args, kwargs in submissions:
+            assert callable(delivery)
+            delivery(*args, **kwargs)
+
+    [request] = _timing_requests(usage_webhook_server)
+    operations = _operations([request])
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+    ]
+    created_at = datetime.fromisoformat(str(operations[0]["ts"]))
+    output_at = datetime.fromisoformat(str(operations[1]["ts"]))
+    text_at = datetime.fromisoformat(str(operations[2]["ts"]))
+    assert created_at <= output_at < retry_started_at <= text_at
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -175,6 +175,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_model_provider_sse_usage.py`                      | Model provider SSE usage pipeline                                                                                    |
 | `test_model_provider_websocket_usage.py`                | Model provider WebSocket usage reporting and source reconciliation                                                   |
 | `test_model_provider_websocket_lifecycle.py`            | Model provider WebSocket HTTP upgrade and terminal usage lifecycle                                                   |
+| `test_codex_output_timing.py`                           | Default Codex provider-output timing observations over WebSocket                                                     |
 | `test_websocket_retention.py`                           | Registered WebSocket message retention and cleanup                                                                   |
 | `test_model_provider_websocket_metadata.py`             | Model provider WebSocket usage metadata parsing                                                                      |
 | `test_model_provider_usage.py`                          | Model provider usage reporter                                                                                        |


### PR DESCRIPTION
## Summary

- observe the first generated Codex Responses WebSocket lifecycle milestones in the runner proxy
- exclude the `generate:false` startup prewarm by qualifying a response on its first output item
- preserve content-free observation timestamps and deliver them through the existing bounded telemetry webhook executor
- keep run-scoped bounded state across WebSocket reconnects while isolating reused sandboxes by run ID

## Behavior

The proxy reports these fixed sandbox operations for qualifying default `codex exec --json` runs:

- `codex_proxy_first_generated_response_created`
- `codex_proxy_first_output_item_added`
- `codex_proxy_first_output_text_delta`

The response-created and output-item observations are batched when the first output item qualifies the generated response. The first text observation is sent separately and may come from a later provider response after a tool-only first response. Local state prevents later tool turns and reconnects from replacing the first observations.

Only the bounded top-level server event type is inspected. Prompts, response text, reasoning, response IDs, provider URLs, headers, and credentials are not retained or sent.

Webhook delivery remains best effort and potentially at-least-once. Analysis should select the earliest event per run and operation. Missing signals are not inferred.

## Exclusions

- no Codex execution-path or provider-request changes
- no HTTP/SSE fallback instrumentation
- no API handler, database schema, persisted state, public contract, migration, or feature switch changes
- no change to `api_to_first_assistant_message`

## Validation

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4,210 passed

Closes #22981
Parent context: #22892
