### PR TITLE
fix(vsock-host): bound frame-builder request lifecycle

### DIFF
--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -226,16 +226,20 @@ async fn write_registered_request_and_wait_with_frame_builder(
     shared: &Arc<Shared>,
     seq: u32,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
-    response_timeout: Duration,
+    deadline: Instant,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
     let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
 
-    write_request_frame_with_builder(shared, seq, build_frame, before_write).await?;
+    time::timeout_at(
+        deadline,
+        write_request_frame_with_builder(shared, seq, build_frame, before_write),
+    )
+    .await
+    .map_err(|_| request_timeout_error())??;
 
-    let response_deadline = deadline_after(response_timeout, "request timeout overflowed")?;
-    await_pending_response(rx, response_deadline).await
+    await_pending_response(rx, deadline).await
 }
 
 async fn await_pending_response(
@@ -290,6 +294,10 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
     write_observer: FrameWriteObserver,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
+    if timeout.is_zero() {
+        return Err(request_timeout_error());
+    }
+    let deadline = deadline_after(timeout, "request timeout overflowed")?;
     let seq = shared.next_seq();
     let normal_operation = shared.reserve_normal_operation()?;
     let rx = register_pending_response(shared, seq, |tx| {
@@ -304,7 +312,7 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
         shared,
         seq,
         build_frame,
-        timeout,
+        deadline,
         || {
             mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
             write_observer.record_write_start()
@@ -322,6 +330,10 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
     write_observer: FrameWriteObserver,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
+    if timeout.is_zero() {
+        return Err(request_timeout_error());
+    }
+    let deadline = deadline_after(timeout, "request timeout overflowed")?;
     let seq = shared.next_seq();
     let rx = register_pending_response(shared, seq, |tx| {
         Ok(PendingResponse {
@@ -337,7 +349,7 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
         shared,
         seq,
         build_frame,
-        timeout,
+        deadline,
         || {
             mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
             write_observer.record_write_start()

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -1,8 +1,12 @@
+use std::future::Future;
 use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::Poll;
 use std::time::Duration;
 
+use nix::sys::socket::{setsockopt, sockopt};
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     MSG_ERROR, MSG_EXEC_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE_RESULT,
@@ -10,8 +14,8 @@ use vsock_proto::{
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
-    make_pair, normal_operation_readiness, pending_request_count, setup_host_and_guest,
-    setup_host_and_mock_guest,
+    is_connected, make_pair, mock_handshake, normal_operation_readiness, pending_request_count,
+    setup_host_and_guest, setup_host_and_mock_guest,
 };
 use super::support::{
     expect_write_file, expect_write_files, send_guest_error, send_write_file_failure,
@@ -23,6 +27,29 @@ use crate::{
     file::test_support::{WRITE_FILES_BATCH_CONTENT_LIMIT, WRITE_FILES_BATCH_FILE_LIMIT},
     operation_tracker::NormalOperationReadiness,
 };
+
+const FRAME_BUILDER_REQUEST_TIMEOUT: Duration = Duration::from_millis(50);
+
+async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
+    std::future::poll_fn(|cx| {
+        assert!(
+            future.as_mut().poll(cx).is_pending(),
+            "request future unexpectedly completed"
+        );
+        Poll::Ready(())
+    })
+    .await;
+}
+
+fn encode_test_write_file_frame(
+    seq: u32,
+    frame: &mut Vec<u8>,
+    path: &str,
+    content: &[u8],
+) -> io::Result<()> {
+    vsock_proto::encode_write_file_frame_into(frame, seq, path, content, false, false)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))
+}
 
 #[tokio::test]
 async fn test_write_file() {
@@ -749,6 +776,157 @@ async fn write_file_rejects_protocol_path_too_long_before_waiting_for_writer() {
 
     drop(writer_guard);
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_file_frame_builder_request_zero_timeout_does_not_send_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let build_count = Arc::new(AtomicUsize::new(0));
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let err = crate::normal_request_on_shared_with_write_observer_frame_builder(
+        &host.shared,
+        &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+        Duration::ZERO,
+        FrameWriteObserver::new({
+            let write_start_count = Arc::clone(&write_start_count);
+            move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }),
+        {
+            let build_count = Arc::clone(&build_count);
+            move |seq, frame| {
+                build_count.fetch_add(1, Ordering::SeqCst);
+                encode_test_write_file_frame(seq, frame, "/tmp/zero-timeout.txt", b"hello")
+            }
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(build_count.load(Ordering::SeqCst), 0);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(is_connected(&host));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("zero-timeout request must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after zero-timeout request: {err}"),
+    }
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_file_frame_builder_request_times_out_waiting_for_builder() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let frame_builder_guard = host.shared.frame_builder.lock().await;
+    let build_count = Arc::new(AtomicUsize::new(0));
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let request = crate::normal_request_on_shared_with_write_observer_frame_builder(
+        &host.shared,
+        &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+        FRAME_BUILDER_REQUEST_TIMEOUT,
+        FrameWriteObserver::new({
+            let write_start_count = Arc::clone(&write_start_count);
+            move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }),
+        {
+            let build_count = Arc::clone(&build_count);
+            move |seq, frame| {
+                build_count.fetch_add(1, Ordering::SeqCst);
+                encode_test_write_file_frame(seq, frame, "/tmp/builder-timeout.txt", b"hello")
+            }
+        },
+    );
+    tokio::pin!(request);
+
+    poll_once_pending(request.as_mut()).await;
+    assert_eq!(pending_request_count(&host), 1);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    let err = tokio::time::timeout(Duration::from_secs(5), request.as_mut())
+        .await
+        .expect("request should respect its builder-lock deadline")
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(build_count.load(Ordering::SeqCst), 0);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(is_connected(&host));
+
+    drop(frame_builder_guard);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out builder request must not send later; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after builder timeout: {err}"),
+    }
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_file_frame_builder_request_blocked_write_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
+    mock_handshake(&mut guest).await;
+    let host = host_task.await.unwrap();
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let content = vec![0xAB; 1024 * 1024];
+    let request = crate::normal_request_on_shared_with_write_observer_frame_builder(
+        &host.shared,
+        &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+        FRAME_BUILDER_REQUEST_TIMEOUT,
+        FrameWriteObserver::new({
+            let write_start_count = Arc::clone(&write_start_count);
+            move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }),
+        move |seq, frame| {
+            encode_test_write_file_frame(seq, frame, "/tmp/blocked-write.bin", &content)
+        },
+    );
+    tokio::pin!(request);
+
+    poll_once_pending(request.as_mut()).await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
+
+    let err = tokio::time::timeout(Duration::from_secs(5), request.as_mut())
+        .await
+        .expect("blocked write should respect its request deadline")
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(!is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
+    assert!(host.shared.frame_builder.try_lock().is_ok());
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -28,6 +28,8 @@ use crate::{
     operation_tracker::NormalOperationReadiness,
 };
 
+// Public file APIs intentionally use a fixed 300-second request timeout. Use
+// their shared request seam here so timeout lifecycle coverage remains fast.
 const FRAME_BUILDER_REQUEST_TIMEOUT: Duration = Duration::from_millis(50);
 
 async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -284,6 +284,83 @@ async fn write_file_chunked_connection_close_while_waiting_for_writer_returns_co
 }
 
 #[tokio::test]
+async fn write_file_chunked_frame_builder_request_times_out_waiting_for_writer() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let (frame_built_tx, frame_built_rx) = oneshot::channel();
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let mut normal_operation = crate::CompositeNormalOperation::reserve(&host.shared).unwrap();
+
+    let err = {
+        let request = crate::request_on_shared_with_composite_operation_and_observer_frame_builder(
+            &host.shared,
+            &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+            Duration::from_millis(50),
+            &mut normal_operation,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+            move |seq, frame| {
+                vsock_proto::encode_write_file_frame_into(
+                    frame,
+                    seq,
+                    "/tmp/chunked-writer-timeout.txt",
+                    b"hello",
+                    false,
+                    false,
+                )
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+                frame_built_tx.send(()).unwrap();
+                Ok(())
+            },
+        );
+        tokio::pin!(request);
+
+        poll_once_pending(request.as_mut()).await;
+        tokio::time::timeout(Duration::from_secs(5), frame_built_rx)
+            .await
+            .expect("frame should be built before waiting for the writer")
+            .unwrap();
+        assert_eq!(pending_request_count(&host), 1);
+        assert_eq!(
+            normal_operation_readiness(&host),
+            NormalOperationReadiness::Busy
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), request.as_mut())
+            .await
+            .expect("request should respect its writer-lock deadline")
+            .unwrap_err()
+    };
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    drop(normal_operation);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out writer request must not send later; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after writer timeout: {err}"),
+    }
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -285,6 +285,8 @@ async fn write_file_chunked_connection_close_while_waiting_for_writer_returns_co
 
 #[tokio::test]
 async fn write_file_chunked_frame_builder_request_times_out_waiting_for_writer() {
+    // The public chunked-write path fixes each request timeout at 300 seconds,
+    // so exercise its composite request seam with a practical test deadline.
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let writer_guard = host.shared.writer.lock().await;


### PR DESCRIPTION
## Summary

- establish one absolute deadline before frame-builder requests reserve/register their operation
- apply that deadline to the frame-builder lock, writer lock, socket write, and response wait
- preserve lifecycle safety: pre-write timeouts clean up without poisoning, while interrupted writes poison the connection
- cover owned and composite file-write requests with real lock contention and socket backpressure tests

## Scope

This changes the per-frame request timeout used by file writes. It does not make the outer file-write gate, path-lock queue, or an entire multi-chunk write share one 300-second deadline. It does not change the wire protocol, public API, database, or persisted state.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::file::write -- --nocapture`
- frame-builder timeout tests passed 20 consecutive runs and a serial run
- repository pre-commit Rust fmt, Clippy, and documentation hooks

Closes #22979
