### PR TITLE
fix(runner): honor systemd-selected service config

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -755,16 +755,21 @@ async fn find_installed_services() -> Vec<InstalledService> {
         let Some(name_str) = name.to_str() else {
             continue;
         };
-        if !name_str.starts_with("vm0-runner-") || !name_str.ends_with(".service") {
+        let Some(unit) = super::service::RunnerServiceUnit::from_file_name(name_str) else {
             continue;
-        }
-        let unit_name = name_str
-            .strip_suffix(".service")
-            .unwrap_or(name_str)
-            .to_string();
-        let config_path = super::service::read_unit_config_path(&entry.path()).await;
+        };
+        let config_path = match super::service::read_unit_config_path(&unit).await {
+            Ok(config_path) => config_path,
+            Err(e) => {
+                tracing::warn!(
+                    "find_installed_services: cannot read effective config for {}: {e}",
+                    unit.service_name()
+                );
+                None
+            }
+        };
         services.push(InstalledService {
-            unit_name,
+            unit_name: unit.unit_name().to_string(),
             config_path,
         });
     }

--- a/crates/runner/src/cmd/gc/image_refs.rs
+++ b/crates/runner/src/cmd/gc/image_refs.rs
@@ -112,16 +112,23 @@ async fn collect_retained_version_image_refs(
 }
 
 async fn collect_enabled_service_image_refs(refs: &mut ProtectedImageRefs) -> bool {
-    let scan = enabled_runner_service_config_paths(Path::new("/etc/systemd/system")).await;
+    collect_enabled_service_image_refs_from_dir(Path::new("/etc/systemd/system"), refs).await
+}
+
+async fn collect_enabled_service_image_refs_from_dir(
+    system_dir: &Path,
+    refs: &mut ProtectedImageRefs,
+) -> bool {
+    let scan = enabled_runner_service_config_paths(system_dir).await;
     for config_path in scan.paths {
         collect_config_image_refs(&config_path, "enabled service", refs).await;
     }
-    scan.directory_scan_complete
+    scan.inventory_complete
 }
 
 struct EnabledRunnerServiceConfigPaths {
     paths: Vec<PathBuf>,
-    directory_scan_complete: bool,
+    inventory_complete: bool,
 }
 
 async fn enabled_runner_service_config_paths(system_dir: &Path) -> EnabledRunnerServiceConfigPaths {
@@ -142,18 +149,18 @@ async fn enabled_runner_service_config_paths_with_reader(
             );
             return EnabledRunnerServiceConfigPaths {
                 paths: Vec::new(),
-                directory_scan_complete: false,
+                inventory_complete: false,
             };
         }
     }) else {
         return EnabledRunnerServiceConfigPaths {
             paths: Vec::new(),
-            directory_scan_complete: true,
+            inventory_complete: true,
         };
     };
 
     let mut paths = Vec::new();
-    let mut directory_scan_complete = true;
+    let mut inventory_complete = true;
     loop {
         let entry = match entry_reader
             .next_entry_warn(&mut entries, "runner_service_config_refs", system_dir)
@@ -162,7 +169,7 @@ async fn enabled_runner_service_config_paths_with_reader(
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(_) => {
-                directory_scan_complete = false;
+                inventory_complete = false;
                 break;
             }
         };
@@ -170,7 +177,7 @@ async fn enabled_runner_service_config_paths_with_reader(
         let Some(file_name) = file_name.to_str() else {
             continue;
         };
-        let Some(unit) = runner_service_unit_from_file_name(file_name) else {
+        let Some(unit) = service::RunnerServiceUnit::from_file_name(file_name) else {
             continue;
         };
         match service::is_unit_enabled(&unit).await {
@@ -178,32 +185,37 @@ async fn enabled_runner_service_config_paths_with_reader(
             Ok(false) => continue,
             Err(e) => {
                 warn!(
-                    "runner service image refs: cannot check whether {} is enabled ({e}), skipping",
+                    "runner service image refs: cannot check whether {} is enabled ({e}), protection inventory incomplete",
+                    unit.service_name()
+                );
+                inventory_complete = false;
+                continue;
+            }
+        }
+        let config_path = match service::read_unit_config_path(&unit).await {
+            Ok(Some(config_path)) => config_path,
+            Ok(None) => {
+                warn!(
+                    "runner service image refs: enabled service {} has no parseable config path, skipping",
                     unit.service_name()
                 );
                 continue;
             }
-        }
-        let Some(config_path) = service::read_unit_config_path(&entry.path()).await else {
-            warn!(
-                "runner service image refs: enabled service {} has no parseable config path, skipping",
-                unit.service_name()
-            );
-            continue;
+            Err(e) => {
+                warn!(
+                    "runner service image refs: cannot read effective config for enabled service {} ({e}), protection inventory incomplete",
+                    unit.service_name()
+                );
+                inventory_complete = false;
+                continue;
+            }
         };
         paths.push(config_path);
     }
     EnabledRunnerServiceConfigPaths {
         paths,
-        directory_scan_complete,
+        inventory_complete,
     }
-}
-
-fn runner_service_unit_from_file_name(file_name: &str) -> Option<service::RunnerServiceUnit> {
-    let suffix = file_name
-        .strip_prefix("vm0-runner-")?
-        .strip_suffix(".service")?;
-    service::RunnerServiceUnit::from_suffix(suffix).ok()
 }
 
 async fn collect_config_image_refs(

--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -1,3 +1,5 @@
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use super::*;
@@ -8,6 +10,63 @@ use crate::cmd::gc::versions::{
     analyze_version_gc, analyze_version_gc_with_injected_config_scan_error,
     analyze_version_gc_with_injected_scan_error,
 };
+use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+const ENABLED_SERVICE_SCENARIO_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_SCENARIO";
+const ENABLED_SERVICE_CONFIG_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_CONFIG";
+const ENABLED_SERVICE_HOME_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_HOME";
+const ENABLED_SERVICE_SYSTEM_DIR_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_SYSTEM_DIR";
+const ENABLED_SERVICE_INVOCATIONS_ENV: &str = "VM0_RUN_GC_ENABLED_SERVICE_INVOCATIONS";
+const ENABLED_SERVICE_CHILD_TEST: &str =
+    "cmd::gc::image_refs::tests::enabled_service_systemctl_child";
+const FAKE_SYSTEMCTL: &str = r#"#!/bin/sh
+printf '%s\n' "$*" >> "$VM0_RUN_GC_ENABLED_SERVICE_INVOCATIONS"
+
+if [ "$1" = "is-enabled" ]; then
+  if [ "$VM0_RUN_GC_ENABLED_SERVICE_SCENARIO" = "enablement-error" ]; then
+    printf '%s\n' 'cannot determine unit file state' >&2
+    exit 1
+  fi
+  printf '%s\n' 'enabled'
+  exit 0
+fi
+
+if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
+  case "$VM0_RUN_GC_ENABLED_SERVICE_SCENARIO" in
+    cat-error)
+      printf '%s\n' 'cannot read selected drop-in' >&2
+      exit 1
+      ;;
+    cat-warning)
+      printf '%s\n' '[Service]' 'ExecStart=/usr/bin/runner start --config /etc/stale.yaml'
+      printf '%s\n' 'unit files changed on disk; daemon-reload required' >&2
+      exit 0
+      ;;
+    unparseable)
+      printf '%s\n' '[Service]' 'ExecStart=/usr/bin/true'
+      exit 0
+      ;;
+    effective)
+      printf '%s\n' \
+        '# /etc/systemd/system/vm0-runner-test.service' \
+        '[Service]' \
+        'ExecStart=/usr/bin/runner start --config /etc/base.yaml' \
+        '# /usr/lib/systemd/system/vm0-runner-.service.d/10-vendor.conf' \
+        '[Service]' \
+        'ExecStart=' \
+        'ExecStart=/usr/bin/runner start --config /etc/vendor.yaml' \
+        '# /run/systemd/system/vm0-runner-test.service.d/20-runtime.conf' \
+        '[Service]' \
+        'ExecStart=' \
+        "ExecStart=/usr/bin/runner start --config $VM0_RUN_GC_ENABLED_SERVICE_CONFIG"
+      exit 0
+      ;;
+  esac
+fi
+
+printf '%s\n' "unexpected fake systemctl invocation: $*" >&2
+exit 2
+"#;
 
 fn age_version_past_gc_min_age(home: &HomePaths, name: &str) {
     let old_time = SystemTime::now() - Duration::from_secs(GC_MIN_AGE.as_secs() + 60);
@@ -326,19 +385,6 @@ async fn service_config_image_ref_keeps_image_snapshot() {
     );
 }
 
-#[test]
-fn runner_service_unit_from_file_name_accepts_only_runner_services() {
-    assert_eq!(
-        runner_service_unit_from_file_name("vm0-runner-v1.0.0.service")
-            .unwrap()
-            .service_name(),
-        "vm0-runner-v1.0.0.service"
-    );
-    assert!(runner_service_unit_from_file_name("other-v1.0.0.service").is_none());
-    assert!(runner_service_unit_from_file_name("vm0-runner-v1.0.0.timer").is_none());
-    assert!(runner_service_unit_from_file_name("vm0-runner-.service").is_none());
-}
-
 #[tokio::test]
 async fn enabled_service_directory_scan_reports_iteration_error() {
     let dir = tempfile::tempdir().unwrap();
@@ -348,8 +394,131 @@ async fn enabled_service_directory_scan_reports_iteration_error() {
 
     let scan = enabled_runner_service_config_paths_with_reader(dir.path(), &mut entry_reader).await;
 
-    assert!(!scan.directory_scan_complete);
+    assert!(!scan.inventory_complete);
     assert!(scan.paths.is_empty());
+}
+
+#[tokio::test]
+async fn effective_enabled_service_config_ref_keeps_image_snapshot() {
+    let invocations = run_enabled_service_scenario("effective").await;
+
+    assert_eq!(
+        invocations,
+        vec![
+            "is-enabled vm0-runner-test.service",
+            "--no-pager cat -- vm0-runner-test.service",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn enabled_service_discovery_failures_make_inventory_incomplete() {
+    for scenario in ["enablement-error", "cat-error", "cat-warning"] {
+        run_enabled_service_scenario(scenario).await;
+    }
+}
+
+#[tokio::test]
+async fn readable_unit_without_runner_config_remains_best_effort() {
+    run_enabled_service_scenario("unparseable").await;
+}
+
+async fn run_enabled_service_scenario(scenario: &str) -> Vec<String> {
+    let dir = tempfile::tempdir().unwrap();
+    let fake_systemctl = dir.path().join("systemctl");
+    std::fs::write(&fake_systemctl, FAKE_SYSTEMCTL).unwrap();
+    let mut permissions = std::fs::metadata(&fake_systemctl).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_systemctl, permissions).unwrap();
+
+    let system_dir = dir.path().join("system");
+    std::fs::create_dir(&system_dir).unwrap();
+    std::fs::write(system_dir.join("vm0-runner-test.service"), "").unwrap();
+
+    let home_root = dir.path().join("home");
+    let home = test_home(&home_root);
+    let rootfs_hash = test_hash('a');
+    let snapshot_hash = test_hash('b');
+    create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+    let config_path = write_test_runner_config(&home, "effective", &rootfs_hash, &snapshot_hash);
+
+    let invocations_path = dir.path().join("invocations");
+    run_ignored_child_test(
+        ENABLED_SERVICE_CHILD_TEST,
+        (ENABLED_SERVICE_SCENARIO_ENV, scenario),
+        &[
+            ("PATH", Some(utf8_path(dir.path()))),
+            (ENABLED_SERVICE_CONFIG_ENV, Some(utf8_path(&config_path))),
+            (ENABLED_SERVICE_HOME_ENV, Some(utf8_path(&home_root))),
+            (ENABLED_SERVICE_SYSTEM_DIR_ENV, Some(utf8_path(&system_dir))),
+            (
+                ENABLED_SERVICE_INVOCATIONS_ENV,
+                Some(utf8_path(&invocations_path)),
+            ),
+        ],
+        Duration::from_secs(10),
+    )
+    .await;
+
+    std::fs::read_to_string(invocations_path)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn utf8_path(path: &Path) -> &str {
+    path.to_str().expect("temporary path must be UTF-8")
+}
+
+#[tokio::test]
+#[ignore = "spawned by enabled service image ref systemctl tests"]
+async fn enabled_service_systemctl_child() {
+    let Ok(scenario) = std::env::var(ENABLED_SERVICE_SCENARIO_ENV) else {
+        return;
+    };
+    if !ignored_child_test_env_guard_enabled((ENABLED_SERVICE_SCENARIO_ENV, &scenario)) {
+        return;
+    }
+
+    let system_dir = PathBuf::from(std::env::var(ENABLED_SERVICE_SYSTEM_DIR_ENV).unwrap());
+    match scenario.as_str() {
+        "effective" => {
+            let home = test_home(Path::new(&std::env::var(ENABLED_SERVICE_HOME_ENV).unwrap()));
+            let rootfs_hash = test_hash('a');
+            let snapshot_hash = test_hash('b');
+            let snapshot_dir = home
+                .images_dir()
+                .join(&rootfs_hash)
+                .join("snapshots")
+                .join(&snapshot_hash);
+            let mut refs = ProtectedImageRefs::new();
+
+            assert!(collect_enabled_service_image_refs_from_dir(&system_dir, &mut refs).await);
+            let report = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+                .await
+                .unwrap();
+
+            assert_eq!(report.freed_bytes, 0);
+            assert!(
+                snapshot_dir.exists(),
+                "effective enabled-service config must protect its image pair"
+            );
+        }
+        "enablement-error" | "cat-error" | "cat-warning" => {
+            let scan = enabled_runner_service_config_paths(&system_dir).await;
+
+            assert!(!scan.inventory_complete);
+            assert!(scan.paths.is_empty());
+        }
+        "unparseable" => {
+            let scan = enabled_runner_service_config_paths(&system_dir).await;
+
+            assert!(scan.inventory_complete);
+            assert!(scan.paths.is_empty());
+        }
+        unexpected => panic!("unexpected enabled service scenario: {unexpected}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -12,7 +12,7 @@ use super::diagnostic::status_field_preview;
 use super::target::RunnerServiceUnit;
 
 const BOUNDED_COMMAND_KILL_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
-const SERVICE_UNIT_STATE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+const SYSTEMCTL_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(super) fn journalctl_logs_status(svc: &str, status: ExitStatus) -> RunnerResult<()> {
     if status.success() {
@@ -357,8 +357,7 @@ pub(super) async fn read_service_unit_state(
 ) -> RunnerResult<ServiceUnitState> {
     let svc = unit.service_name();
     let properties = ["LoadState", "ActiveState", "SubState", "Result"];
-    let output =
-        run_systemctl_show_bounded(svc, &properties, SERVICE_UNIT_STATE_QUERY_TIMEOUT).await?;
+    let output = run_systemctl_show_bounded(svc, &properties, SYSTEMCTL_QUERY_TIMEOUT).await?;
     service_unit_state_from_output(svc, &properties, &output)
 }
 
@@ -377,7 +376,7 @@ pub(super) async fn cat_unit_content(unit: &RunnerServiceUnit) -> RunnerResult<S
     let output = run_command_output_bounded(
         "systemctl",
         &["--no-pager", "cat", "--", svc],
-        SERVICE_UNIT_STATE_QUERY_TIMEOUT,
+        SYSTEMCTL_QUERY_TIMEOUT,
     )
     .await?;
     unit_content_from_systemctl_cat(svc, &output)
@@ -420,13 +419,7 @@ fn cleanup_unit_active_state_from_output(
 /// `enabled-runtime` state. This does not indicate whether the unit is active
 /// or whether it will remain enabled after a reboot.
 pub(crate) async fn is_unit_enabled(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
-    let svc = unit.service_name();
-    let output = tokio::process::Command::new("systemctl")
-        .args(["is-enabled", svc])
-        .output()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn systemctl is-enabled: {e}")))?;
-    unit_enabled_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
+    is_unit_enabled_bounded(unit, SYSTEMCTL_QUERY_TIMEOUT).await
 }
 
 /// Check whether systemd reports a unit file as enabled.

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -371,6 +371,18 @@ fn service_unit_state_from_output(
     service_unit_state_from_systemctl_show(svc, properties, &output.status, &values, &output.stderr)
 }
 
+/// Read the fragment and drop-ins selected by the running systemd manager.
+pub(super) async fn cat_unit_content(unit: &RunnerServiceUnit) -> RunnerResult<String> {
+    let svc = unit.service_name();
+    let output = run_command_output_bounded(
+        "systemctl",
+        &["--no-pager", "cat", "--", svc],
+        SERVICE_UNIT_STATE_QUERY_TIMEOUT,
+    )
+    .await?;
+    unit_content_from_systemctl_cat(svc, &output)
+}
+
 /// Read the systemd ActiveState using cleanup semantics.
 ///
 /// Normal health checks intentionally treat `deactivating` as inactive because
@@ -705,6 +717,38 @@ fn service_restart_policy_from_systemctl_show(
     Ok(restart)
 }
 
+fn unit_content_from_systemctl_cat(svc: &str, output: &Output) -> RunnerResult<String> {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if !output.status.success() {
+        return Err(systemctl_cat_status_error(svc, &output.status, stderr));
+    }
+    if !stderr.is_empty() {
+        return Err(RunnerError::Internal(format!(
+            "systemctl cat {svc} emitted stderr: {:?}",
+            status_field_preview(stderr)
+        )));
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout).map_err(|e| {
+        RunnerError::Internal(format!(
+            "systemctl cat {svc} returned non-UTF-8 output: {e}"
+        ))
+    })?;
+    Ok(stdout.to_string())
+}
+
+fn systemctl_cat_status_error(svc: &str, status: &ExitStatus, stderr: &str) -> RunnerError {
+    if stderr.is_empty() {
+        RunnerError::Internal(format!("systemctl cat {svc} exited with {status}"))
+    } else {
+        RunnerError::Internal(format!(
+            "systemctl cat {svc} exited with {status}: stderr={:?}",
+            status_field_preview(stderr)
+        ))
+    }
+}
+
 fn unit_enabled_from_systemctl_is_enabled(
     svc: &str,
     status: &ExitStatus,
@@ -839,6 +883,68 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn systemctl_cat_returns_successful_content() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0),
+            b"[Service]\nExecStart=/usr/bin/runner\n",
+            b"",
+        );
+
+        assert_eq!(
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap(),
+            "[Service]\nExecStart=/usr/bin/runner\n"
+        );
+    }
+
+    #[test]
+    fn systemctl_cat_rejects_successful_stderr_with_bounded_diagnostic() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let stderr = "reload required ".repeat(20);
+        let output =
+            systemctl_show_output(ExitStatus::from_raw(0), b"[Service]\n", stderr.as_bytes());
+        let message =
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap_err();
+        let message = message.to_string();
+
+        assert!(message.contains("emitted stderr"));
+        assert!(message.contains("[truncated]"));
+        assert!(message.len() < stderr.len());
+    }
+
+    #[test]
+    fn systemctl_cat_failure_does_not_expose_stdout() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = systemctl_show_output(
+            ExitStatus::from_raw(0x100),
+            b"ExecStart=/usr/bin/runner --token should-not-appear",
+            b"failed to read selected unit",
+        );
+        let message =
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap_err();
+        let message = message.to_string();
+
+        assert!(message.contains("failed to read selected unit"));
+        assert!(!message.contains("should-not-appear"));
+    }
+
+    #[test]
+    fn systemctl_cat_rejects_non_utf8_stdout_without_exposing_content() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = systemctl_show_output(ExitStatus::from_raw(0), b"secret\xffcontent", b"");
+        let message =
+            unit_content_from_systemctl_cat("vm0-runner-test.service", &output).unwrap_err();
+        let message = message.to_string();
+
+        assert!(message.contains("non-UTF-8 output"));
+        assert!(!message.contains("secret"));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/runner/src/cmd/service/target.rs
+++ b/crates/runner/src/cmd/service/target.rs
@@ -39,6 +39,13 @@ impl RunnerServiceUnit {
         })
     }
 
+    pub(crate) fn from_file_name(file_name: &str) -> Option<Self> {
+        let suffix = file_name
+            .strip_prefix(UNIT_PREFIX)?
+            .strip_suffix(".service")?;
+        Self::from_suffix(suffix).ok()
+    }
+
     pub(crate) fn suffix(&self) -> &str {
         &self.suffix
     }
@@ -128,5 +135,19 @@ mod tests {
     fn test_unit_name_error_mentions_service() {
         let msg = unit_name("UPPER").unwrap_err().to_string();
         assert!(msg.contains("service name suffix"), "got: {msg}");
+    }
+
+    #[test]
+    fn from_file_name_accepts_only_valid_runner_services() {
+        assert_eq!(
+            RunnerServiceUnit::from_file_name("vm0-runner-v1.0.0.service")
+                .unwrap()
+                .service_name(),
+            "vm0-runner-v1.0.0.service"
+        );
+        assert!(RunnerServiceUnit::from_file_name("other-v1.0.0.service").is_none());
+        assert!(RunnerServiceUnit::from_file_name("vm0-runner-v1.0.0.timer").is_none());
+        assert!(RunnerServiceUnit::from_file_name("vm0-runner-.service").is_none());
+        assert!(RunnerServiceUnit::from_file_name("vm0-runner-UPPER.service").is_none());
     }
 }

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -1,76 +1,15 @@
-use std::collections::BTreeMap;
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-/// Parse the ExecStart line of a systemd unit file for a runner `--config` path.
-pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
-    let mut content = tokio::fs::read_to_string(unit_path).await.ok()?;
-    content.push_str(&read_unit_dropin_content(unit_path).await);
-    parse_unit_config_path(&content)
-}
+use crate::error::RunnerResult;
 
-async fn read_unit_dropin_content(unit_path: &Path) -> String {
-    let mut dropins = BTreeMap::new();
-    for (specificity, dir) in unit_dropin_dirs(unit_path).into_iter().enumerate() {
-        let mut entries = match tokio::fs::read_dir(&dir).await {
-            Ok(entries) => entries,
-            Err(_) => continue,
-        };
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if path.extension().is_none_or(|extension| extension != "conf") {
-                continue;
-            }
-            let Some(file_name) = path.file_name() else {
-                continue;
-            };
-            dropins
-                .entry(file_name.to_os_string())
-                .and_modify(|(current_specificity, current_path)| {
-                    if specificity >= *current_specificity {
-                        *current_specificity = specificity;
-                        *current_path = path.clone();
-                    }
-                })
-                .or_insert((specificity, path));
-        }
-    }
+use super::target::RunnerServiceUnit;
 
-    let mut content = String::new();
-    for (_, path) in dropins.into_values() {
-        if let Ok(dropin) = tokio::fs::read_to_string(path).await {
-            content.push('\n');
-            content.push_str(&dropin);
-        }
-    }
-    content
-}
-
-fn unit_dropin_dirs(unit_path: &Path) -> Vec<PathBuf> {
-    let Some(parent) = unit_path.parent() else {
-        return vec![path_with_suffix(unit_path, ".d")];
-    };
-    let Some(file_name) = unit_path.file_name().and_then(|name| name.to_str()) else {
-        return vec![path_with_suffix(unit_path, ".d")];
-    };
-    let Some((unit_name, unit_type)) = file_name.rsplit_once('.') else {
-        return vec![path_with_suffix(unit_path, ".d")];
-    };
-
-    let mut dirs = vec![parent.join(format!("{unit_type}.d"))];
-    for (idx, ch) in unit_name.char_indices() {
-        if ch == '-' {
-            dirs.push(parent.join(format!("{}.{unit_type}.d", &unit_name[..=idx])));
-        }
-    }
-    dirs.push(parent.join(format!("{file_name}.d")));
-    dirs
-}
-
-fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
-    let mut value = OsString::from(path.as_os_str());
-    value.push(suffix);
-    PathBuf::from(value)
+/// Read systemd's selected unit content and extract the runner `--config` path.
+pub(crate) async fn read_unit_config_path(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<Option<PathBuf>> {
+    let content = super::systemctl::cat_unit_content(unit).await?;
+    Ok(parse_unit_config_path(&content))
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
@@ -512,156 +451,27 @@ ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
         );
     }
 
-    #[tokio::test]
-    async fn read_unit_config_path_applies_dropin_exec_start_override() {
-        let dir = tempfile::tempdir().unwrap();
-        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
-        std::fs::write(
-            &unit_path,
-            r#"
+    #[test]
+    fn parse_unit_config_path_applies_systemd_selected_content_in_order() {
+        let content = r#"
+# /etc/systemd/system/vm0-runner-v1.0.0.service
 [Service]
-ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
-"#,
-        )
-        .unwrap();
-        let dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
-        std::fs::create_dir(&dropin_dir).unwrap();
-        std::fs::write(
-            dropin_dir.join("10-override.conf"),
-            r#"
+ExecStart="/usr/bin/runner" start --config "/etc/base-runner.yaml"
+
+# /usr/lib/systemd/system/vm0-runner-.service.d/10-vendor.conf
 [Service]
 ExecStart=
-ExecStart="/usr/bin/runner" start --config "/etc/new-runner.yaml"
-"#,
-        )
-        .unwrap();
+ExecStart="/usr/bin/runner" start --config "/etc/vendor-runner.yaml"
 
-        assert_eq!(
-            read_unit_config_path(&unit_path).await,
-            Some(PathBuf::from("/etc/new-runner.yaml"))
-        );
-    }
-
-    #[tokio::test]
-    async fn read_unit_config_path_applies_prefix_dropin_override() {
-        let dir = tempfile::tempdir().unwrap();
-        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
-        std::fs::write(
-            &unit_path,
-            r#"
-[Service]
-ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
-"#,
-        )
-        .unwrap();
-        let dropin_dir = dir.path().join("vm0-runner-.service.d");
-        std::fs::create_dir(&dropin_dir).unwrap();
-        std::fs::write(
-            dropin_dir.join("10-override.conf"),
-            r#"
+# /run/systemd/system/vm0-runner-v1.0.0.service.d/20-runtime.conf
 [Service]
 ExecStart=
-ExecStart="/usr/bin/runner" start --config "/etc/prefix-runner.yaml"
-"#,
-        )
-        .unwrap();
+ExecStart="/usr/bin/runner" start --config "/etc/runtime-runner.yaml"
+"#;
 
         assert_eq!(
-            read_unit_config_path(&unit_path).await,
-            Some(PathBuf::from("/etc/prefix-runner.yaml"))
-        );
-    }
-
-    #[tokio::test]
-    async fn read_unit_config_path_applies_service_type_dropin_override() {
-        let dir = tempfile::tempdir().unwrap();
-        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
-        std::fs::write(
-            &unit_path,
-            r#"
-[Service]
-ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
-"#,
-        )
-        .unwrap();
-        let dropin_dir = dir.path().join("service.d");
-        std::fs::create_dir(&dropin_dir).unwrap();
-        std::fs::write(
-            dropin_dir.join("10-override.conf"),
-            r#"
-[Service]
-ExecStart=
-ExecStart="/usr/bin/runner" start --config "/etc/type-runner.yaml"
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            read_unit_config_path(&unit_path).await,
-            Some(PathBuf::from("/etc/type-runner.yaml"))
-        );
-    }
-
-    #[tokio::test]
-    async fn read_unit_config_path_applies_most_specific_same_named_dropin() {
-        let dir = tempfile::tempdir().unwrap();
-        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
-        std::fs::write(
-            &unit_path,
-            r#"
-[Service]
-ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
-"#,
-        )
-        .unwrap();
-        let prefix_dropin_dir = dir.path().join("vm0-runner-.service.d");
-        std::fs::create_dir(&prefix_dropin_dir).unwrap();
-        std::fs::write(
-            prefix_dropin_dir.join("10-override.conf"),
-            r#"
-[Service]
-ExecStart=
-ExecStart="/usr/bin/runner" start --config "/etc/prefix-runner.yaml"
-"#,
-        )
-        .unwrap();
-        let exact_dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
-        std::fs::create_dir(&exact_dropin_dir).unwrap();
-        std::fs::write(
-            exact_dropin_dir.join("10-override.conf"),
-            r#"
-[Service]
-ExecStart=
-ExecStart="/usr/bin/runner" start --config "/etc/exact-runner.yaml"
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            read_unit_config_path(&unit_path).await,
-            Some(PathBuf::from("/etc/exact-runner.yaml"))
-        );
-    }
-
-    #[tokio::test]
-    async fn read_unit_config_path_ignores_unreadable_dropin_entries() {
-        let dir = tempfile::tempdir().unwrap();
-        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
-        std::fs::write(
-            &unit_path,
-            r#"
-[Service]
-ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
-"#,
-        )
-        .unwrap();
-        let dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
-        std::fs::create_dir(&dropin_dir).unwrap();
-        std::fs::create_dir(dropin_dir.join("10-broken.conf")).unwrap();
-
-        assert_eq!(
-            read_unit_config_path(&unit_path).await,
-            Some(PathBuf::from("/etc/runner.yaml"))
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runtime-runner.yaml"))
         );
     }
 }


### PR DESCRIPTION
## Summary

- resolve runner service config paths from the fragment and ordered drop-ins selected by the running systemd manager
- remove the incomplete local drop-in directory selector while retaining VM0's existing `ExecStart --config` parser
- keep doctor best effort, but make image protection fail closed when service enablement or effective unit content cannot be established
- share validated installed runner service filename handling between doctor and GC
- add child-process integration coverage for effective overrides, exact image protection, command arguments, warnings, failures, and readable irrelevant content

## Scope

This is a runner-only change. It does not change schemas, APIs, protocols, persisted state, deployment configuration, or runner config format.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner 'cmd::service::'`
- `cargo test --manifest-path crates/Cargo.toml -p runner 'cmd::gc::image_refs::tests'`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- repository pre-commit and commit-message hooks

Closes #22976
