### PR TITLE
refactor(api): replace usage insight sql with typed drizzle builders

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -327,15 +327,9 @@ function activityTimeWindowPredicate(p: UsageInsightSqlParams) {
 }
 
 function usageRowTokenExpr() {
-  const modelTokenCondition = and(
-    eq(usageEvent.kind, MODEL_USAGE_KIND),
-    inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES),
-  );
-  if (!modelTokenCondition) {
-    throw new Error("Expected model token condition");
-  }
   return sql`CASE
-    WHEN ${modelTokenCondition}
+    WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)}
+      AND ${inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES)}
     THEN ${usageEvent.quantity}
     ELSE 0
   END::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -1,17 +1,44 @@
 import { command } from "ccstate";
-import { count, sql } from "drizzle-orm";
 import type {
   UsageInsightBucket,
   UsageInsightChatRow,
   UsageInsightResponse,
 } from "@vm0/api-contracts/contracts/zero-usage-insight";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { usageAllowanceAllocations } from "@vm0/db/schema/org-usage-allowance";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  sql,
+  sum,
+  type SQLWrapper,
+} from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import {
-  executeRawRows,
-  pgInt8ToSafeIntegerSchema,
-  pgTimestampWithoutTimezoneToDateSchema,
-} from "../../lib/db-raw-rows";
+  nullableDriverValueDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 
@@ -22,6 +49,8 @@ const MODEL_TOKEN_CATEGORIES = [
   "tokens.cache_read",
   "tokens.cache_creation",
 ] as const;
+const CHANNEL_SOURCES = ["email", "slack"] as const;
+const channelSourceDecoder = zodEnumDriverValueDecoder(z.enum(CHANNEL_SOURCES));
 
 interface UsageInsightOptions {
   range: "today" | "yesterday" | "day" | "7d" | "28d" | "30d";
@@ -48,36 +77,12 @@ interface UsageInsightSqlParams {
   readonly tz: string;
 }
 
-const usageInsightBucketRowSchema = z.object({
-  ts: pgTimestampWithoutTimezoneToDateSchema,
-  bucket: z.string(),
-  credits: pgInt8ToSafeIntegerSchema,
-  tokens: pgInt8ToSafeIntegerSchema,
-});
-type UsageInsightBucketRow = z.output<typeof usageInsightBucketRowSchema>;
-
-const usageInsightGrandTotalRowSchema = z.object({
-  grand_credits: pgInt8ToSafeIntegerSchema,
-  grand_tokens: pgInt8ToSafeIntegerSchema,
-});
-
-const usageInsightChannelTotalRowSchema = z.object({
-  source: z.enum(["email", "slack"]),
-  credits: pgInt8ToSafeIntegerSchema,
-  tokens: pgInt8ToSafeIntegerSchema,
-});
-
-const usageInsightTopChatRowSchema = z.object({
-  thread_id: z.string().nullable(),
-  thread_title: z.string().nullable(),
-  credits: pgInt8ToSafeIntegerSchema,
-  tokens: pgInt8ToSafeIntegerSchema,
-  rn: pgInt8ToSafeIntegerSchema,
-});
-
-const usageInsightCountRowSchema = z.object({
-  cnt: pgInt8ToSafeIntegerSchema,
-});
+interface UsageInsightBucketRow {
+  readonly ts: Date;
+  readonly bucket: string;
+  readonly credits: number;
+  readonly tokens: number;
+}
 
 interface UsageInsightArgs {
   readonly userId: string;
@@ -307,57 +312,103 @@ function rangeToWindow(
   }
 }
 
-function usageBucketExpr(p: UsageInsightSqlParams) {
-  return sql`date_trunc(${p.trunc}, ur.activity_time AT TIME ZONE 'UTC' AT TIME ZONE ${p.tz})`;
+function usageBucketExpr(activityTime: SQLWrapper, p: UsageInsightSqlParams) {
+  return sql`date_trunc(${p.trunc}, ${activityTime} AT TIME ZONE 'UTC' AT TIME ZONE ${p.tz})`.mapWith(
+    usageEvent.createdAt,
+  );
 }
 
 function activityTimeWindowPredicate(p: UsageInsightSqlParams) {
-  return sql`ue.created_at AT TIME ZONE 'UTC' >= ${p.startTs}::timestamptz
-        AND ue.created_at AT TIME ZONE 'UTC' < ${p.endTs}::timestamptz`;
+  const activityTime = sql`${usageEvent.createdAt} AT TIME ZONE 'UTC'`;
+  return and(
+    gte(activityTime, sql`${p.startTs}::timestamptz`),
+    lt(activityTime, sql`${p.endTs}::timestamptz`),
+  );
 }
 
 function usageRowTokenExpr() {
-  const tokenCategoryList = sql.join(
-    MODEL_TOKEN_CATEGORIES.map((category) => {
-      return sql`${category}`;
-    }),
-    sql`, `,
+  const modelTokenCondition = and(
+    eq(usageEvent.kind, MODEL_USAGE_KIND),
+    inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES),
   );
-  return sql`CASE WHEN ue.kind = ${MODEL_USAGE_KIND} AND ue.category IN (${tokenCategoryList}) THEN ue.quantity ELSE 0 END`;
+  if (!modelTokenCondition) {
+    throw new Error("Expected model token condition");
+  }
+  return sql`CASE
+    WHEN ${modelTokenCondition}
+    THEN ${usageEvent.quantity}
+    ELSE 0
+  END::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 
 function usageCreditsExpr() {
-  return sql`COALESCE(ue.credits_charged, 0) + COALESCE(uaa.units_applied, 0)`;
+  return sql`COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)::bigint`.mapWith(
+    pgInt8ToSafeIntegerDecoder,
+  );
 }
 
-function usageRowsCte(p: UsageInsightSqlParams) {
-  return sql`
-    usage_rows AS (
-      SELECT
-        ue.created_at AS activity_time,
-        ue.run_id,
-        ue.user_id,
-        ue.org_id,
-        ${usageCreditsExpr()}::bigint AS credits_charged,
-        ${usageRowTokenExpr()}::bigint AS tokens
-      FROM usage_event ue
-      LEFT JOIN usage_allowance_allocations uaa ON uaa.usage_event_id = ue.id
-      WHERE ue.user_id = ${p.userId}
-        AND ue.org_id = ${p.orgId}
-        AND ue.status = 'processed'
-        AND ${activityTimeWindowPredicate(p)}
-    )`;
+function usageRowsCte(db: Db, p: UsageInsightSqlParams) {
+  return db.$with("usage_rows").as(
+    db
+      .select({
+        activityTime: usageEvent.createdAt,
+        runId: usageEvent.runId,
+        userId: usageEvent.userId,
+        orgId: usageEvent.orgId,
+        creditsCharged: usageCreditsExpr().as("credits_charged"),
+        tokens: usageRowTokenExpr().as("tokens"),
+      })
+      .from(usageEvent)
+      .leftJoin(
+        usageAllowanceAllocations,
+        eq(usageAllowanceAllocations.usageEventId, usageEvent.id),
+      )
+      .where(
+        and(
+          eq(usageEvent.userId, p.userId),
+          eq(usageEvent.orgId, p.orgId),
+          eq(usageEvent.status, "processed"),
+          activityTimeWindowPredicate(p),
+        ),
+      ),
+  );
 }
 
-function usageRowsWith(p: UsageInsightSqlParams) {
-  return sql`WITH ${usageRowsCte(p)}`;
+function safeIntegerSum(value: SQLWrapper) {
+  return sql`COALESCE(${sum(value)}, 0)::bigint`.mapWith(
+    pgInt8ToSafeIntegerDecoder,
+  );
+}
+
+function sourceBucketExpr() {
+  return sql`CASE
+    WHEN ${eq(zeroRuns.triggerSource, "web")} THEN 'chat'
+    WHEN ${eq(zeroRuns.triggerSource, "slack")} THEN 'slack'
+    WHEN ${eq(zeroRuns.triggerSource, "email")} THEN 'email'
+    WHEN ${inArray(zeroRuns.triggerSource, [
+      "workflow-schedule",
+      "workflow-event",
+    ])} THEN 'automation'
+    ELSE 'others'
+  END`.mapWith(pgTextDecoder);
 }
 
 function agentNameExpr() {
   return sql`CASE
-    WHEN ar.id IS NULL THEN 'others'
-    ELSE COALESCE(za.display_name, za.name, acv_compose.name, 'unknown')
-  END`;
+    WHEN ${isNull(agentRuns.id)} THEN 'others'
+    ELSE COALESCE(
+      ${zeroAgents.displayName},
+      ${zeroAgents.name},
+      ${agentComposes.name},
+      'unknown'
+    )
+  END`.mapWith(pgTextDecoder);
+}
+
+function chatRankExpr(credits: SQLWrapper) {
+  return sql`ROW_NUMBER() OVER (
+    ORDER BY ${desc(sum(credits))} NULLS LAST
+  )`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 
 function pivotBucketRows(
@@ -388,90 +439,122 @@ function pivotBucketRows(
     });
 }
 
-function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
-  return executeRawRows(
-    db,
-    sql`
-      ${usageRowsWith(p)}
-      SELECT
-        ${usageBucketExpr(p)} AS ts,
-        CASE
-          WHEN zr.trigger_source = 'web' THEN 'chat'
-          WHEN zr.trigger_source = 'slack' THEN 'slack'
-          WHEN zr.trigger_source = 'email' THEN 'email'
-          WHEN zr.trigger_source IN ('workflow-schedule', 'workflow-event') THEN 'automation'
-          ELSE 'others'
-        END AS bucket,
-        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
-      FROM usage_rows ur
-      LEFT JOIN zero_runs zr ON zr.id = ur.run_id
-      GROUP BY 1, 2
-      ORDER BY 1
-    `,
-    usageInsightBucketRowSchema,
-  );
+async function queryUsageInsightSourceBuckets(
+  db: Db,
+  p: UsageInsightSqlParams,
+): Promise<UsageInsightBucketRow[]> {
+  const usageRows = usageRowsCte(db, p);
+  return await db
+    .with(usageRows)
+    .select({
+      ts: usageBucketExpr(usageRows.activityTime, p).as("ts"),
+      bucket: sourceBucketExpr().as("bucket"),
+      credits: safeIntegerSum(usageRows.creditsCharged).as("credits"),
+      tokens: safeIntegerSum(usageRows.tokens).as("tokens"),
+    })
+    .from(usageRows)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, usageRows.runId))
+    .groupBy(({ bucket, ts }) => {
+      return [ts, bucket];
+    })
+    .orderBy(({ ts }) => {
+      return ts;
+    });
 }
 
-function queryUsageInsightAgentBuckets(db: Db, p: UsageInsightSqlParams) {
-  const agentName = agentNameExpr();
-
-  return executeRawRows(
-    db,
-    sql`
-      ${usageRowsWith(p)},
-      agent_totals AS (
-        SELECT
-          ${agentName} AS agent_name,
-          COALESCE(SUM(ur.credits_charged), 0)::bigint AS total_credits
-        FROM usage_rows ur
-        LEFT JOIN agent_runs ar ON ar.id = ur.run_id
-        LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
-        LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
-        LEFT JOIN zero_agents za ON za.id = acv_compose.id
-        GROUP BY 1
-        ORDER BY 2 DESC
-      ),
-      top7 AS (SELECT agent_name FROM agent_totals LIMIT 7)
-      SELECT
-        ${usageBucketExpr(p)} AS ts,
-        CASE
-          WHEN ${agentName} IN (SELECT agent_name FROM top7)
-          THEN ${agentName}
-          ELSE 'others'
-        END AS bucket,
-        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
-      FROM usage_rows ur
-      LEFT JOIN agent_runs ar ON ar.id = ur.run_id
-      LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
-      LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
-      LEFT JOIN zero_agents za ON za.id = acv_compose.id
-      GROUP BY 1, 2
-      ORDER BY 1
-    `,
-    usageInsightBucketRowSchema,
+async function queryUsageInsightAgentBuckets(
+  db: Db,
+  p: UsageInsightSqlParams,
+): Promise<UsageInsightBucketRow[]> {
+  const usageRows = usageRowsCte(db, p);
+  const agentTotals = db.$with("agent_totals").as(
+    db
+      .select({
+        agentName: agentNameExpr().as("agent_name"),
+        totalCredits: safeIntegerSum(usageRows.creditsCharged).as(
+          "total_credits",
+        ),
+      })
+      .from(usageRows)
+      .leftJoin(agentRuns, eq(agentRuns.id, usageRows.runId))
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposes.id, agentComposeVersions.composeId),
+      )
+      .leftJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
+      .groupBy(({ agentName }) => {
+        return agentName;
+      })
+      .orderBy(({ totalCredits }) => {
+        return desc(totalCredits);
+      }),
   );
+  const topSeven = db
+    .$with("top7")
+    .as(
+      db
+        .select({ agentName: agentTotals.agentName })
+        .from(agentTotals)
+        .limit(7),
+    );
+  const agentName = agentNameExpr();
+  const bucket = sql`CASE
+    WHEN ${inArray(
+      agentName,
+      db.select({ agentName: topSeven.agentName }).from(topSeven),
+    )}
+    THEN ${agentName}
+    ELSE 'others'
+  END`.mapWith(pgTextDecoder);
+
+  return await db
+    .with(usageRows, agentTotals, topSeven)
+    .select({
+      ts: usageBucketExpr(usageRows.activityTime, p).as("ts"),
+      bucket: bucket.as("bucket"),
+      credits: safeIntegerSum(usageRows.creditsCharged).as("credits"),
+      tokens: safeIntegerSum(usageRows.tokens).as("tokens"),
+    })
+    .from(usageRows)
+    .leftJoin(agentRuns, eq(agentRuns.id, usageRows.runId))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposes.id, agentComposeVersions.composeId),
+    )
+    .leftJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
+    .groupBy(({ bucket: selectedBucket, ts }) => {
+      return [ts, selectedBucket];
+    })
+    .orderBy(({ ts }) => {
+      return ts;
+    });
 }
 
 async function queryUsageInsightGrandTotal(
   db: Db,
   p: UsageInsightSqlParams,
 ): Promise<{ grandTotalCredits: number; grandTotalTokens: number }> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      ${usageRowsWith(p)}
-      SELECT
-        COALESCE(SUM(ur.credits_charged), 0)::bigint AS grand_credits,
-        COALESCE(SUM(ur.tokens), 0)::bigint AS grand_tokens
-      FROM usage_rows ur
-    `,
-    usageInsightGrandTotalRowSchema,
-  );
+  const usageRows = usageRowsCte(db, p);
+  const rows = await db
+    .with(usageRows)
+    .select({
+      grandCredits: safeIntegerSum(usageRows.creditsCharged).as(
+        "grand_credits",
+      ),
+      grandTokens: safeIntegerSum(usageRows.tokens).as("grand_tokens"),
+    })
+    .from(usageRows);
   return {
-    grandTotalCredits: rows[0]?.grand_credits ?? 0,
-    grandTotalTokens: rows[0]?.grand_tokens ?? 0,
+    grandTotalCredits: rows[0]?.grandCredits ?? 0,
+    grandTotalTokens: rows[0]?.grandTokens ?? 0,
   };
 }
 
@@ -484,21 +567,20 @@ async function queryUsageInsightChannelTotals(
   slackCredits: number;
   slackTokens: number;
 }> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      ${usageRowsWith(p)}
-      SELECT
-        zr.trigger_source AS source,
-        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
-      FROM usage_rows ur
-      LEFT JOIN zero_runs zr ON zr.id = ur.run_id
-      WHERE zr.trigger_source IN ('email', 'slack')
-      GROUP BY 1
-    `,
-    usageInsightChannelTotalRowSchema,
-  );
+  const usageRows = usageRowsCte(db, p);
+  const rows = await db
+    .with(usageRows)
+    .select({
+      source: sql`${zeroRuns.triggerSource}`
+        .mapWith(channelSourceDecoder)
+        .as("source"),
+      credits: safeIntegerSum(usageRows.creditsCharged).as("credits"),
+      tokens: safeIntegerSum(usageRows.tokens).as("tokens"),
+    })
+    .from(usageRows)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, usageRows.runId))
+    .where(inArray(zeroRuns.triggerSource, CHANNEL_SOURCES))
+    .groupBy(zeroRuns.triggerSource);
   let emailCredits = 0;
   let emailTokens = 0;
   let slackCredits = 0;
@@ -523,37 +605,58 @@ async function queryUsageInsightTopChats(
   chatOtherCount: number;
   chatOtherCredits: number;
 }> {
-  const rows = await executeRawRows(
-    db,
-    sql`
-      ${usageRowsWith(p)},
-      agg AS (
-        SELECT
-          zr.chat_thread_id,
-          ct.title AS thread_title,
-          COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
-          COALESCE(SUM(ur.tokens), 0)::bigint AS tokens,
-          ROW_NUMBER() OVER (ORDER BY SUM(ur.credits_charged) DESC NULLS LAST) AS rn
-        FROM usage_rows ur
-        INNER JOIN zero_runs zr ON zr.id = ur.run_id
-        LEFT JOIN chat_threads ct ON ct.id = zr.chat_thread_id
-        WHERE zr.chat_thread_id IS NOT NULL
-        GROUP BY zr.chat_thread_id, ct.title
-      )
-      SELECT chat_thread_id AS thread_id, thread_title, credits, tokens, rn
-      FROM agg WHERE rn <= 100
-      UNION ALL
-      SELECT
-        NULL AS thread_id,
-        'others' AS thread_title,
-        COALESCE(SUM(credits), 0)::bigint AS credits,
-        COALESCE(SUM(tokens), 0)::bigint AS tokens,
-        101 AS rn
-      FROM agg WHERE rn > 100
-      ORDER BY rn
-    `,
-    usageInsightTopChatRowSchema,
+  const usageRows = usageRowsCte(db, p);
+  const aggregateChats = db.$with("agg").as(
+    db
+      .select({
+        threadId: zeroRuns.chatThreadId,
+        threadTitle: chatThreads.title,
+        credits: safeIntegerSum(usageRows.creditsCharged).as("credits"),
+        tokens: safeIntegerSum(usageRows.tokens).as("tokens"),
+        rn: chatRankExpr(usageRows.creditsCharged).as("rn"),
+      })
+      .from(usageRows)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, usageRows.runId))
+      .leftJoin(chatThreads, eq(chatThreads.id, zeroRuns.chatThreadId))
+      .where(isNotNull(zeroRuns.chatThreadId))
+      .groupBy(zeroRuns.chatThreadId, chatThreads.title),
   );
+  const topChatRows = db
+    .select({
+      threadId: aggregateChats.threadId,
+      threadTitle: aggregateChats.threadTitle,
+      credits: aggregateChats.credits,
+      tokens: aggregateChats.tokens,
+      rn: aggregateChats.rn,
+    })
+    .from(aggregateChats)
+    .where(lte(aggregateChats.rn, 100));
+  const overflowRows = db
+    .select({
+      threadId: sql`NULL::uuid`
+        .mapWith(nullableDriverValueDecoder(chatThreads.id))
+        .as("thread_id"),
+      threadTitle: sql`'others'::text`
+        .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+        .as("thread_title"),
+      credits: safeIntegerSum(aggregateChats.credits).as("credits"),
+      tokens: safeIntegerSum(aggregateChats.tokens).as("tokens"),
+      rn: sql`101::bigint`.mapWith(pgInt8ToSafeIntegerDecoder).as("rn"),
+    })
+    .from(aggregateChats)
+    .where(gt(aggregateChats.rn, 100));
+  const chatRows = unionAll(topChatRows, overflowRows).as("chat_rows");
+  const rows = await db
+    .with(usageRows, aggregateChats)
+    .select({
+      threadId: chatRows.threadId,
+      threadTitle: chatRows.threadTitle,
+      credits: chatRows.credits,
+      tokens: chatRows.tokens,
+      rn: chatRows.rn,
+    })
+    .from(chatRows)
+    .orderBy(chatRows.rn);
 
   const chats: UsageInsightChatRow[] = [];
   let chatOtherCredits = 0;
@@ -562,10 +665,10 @@ async function queryUsageInsightTopChats(
     if (row.rn > 100) {
       chatOtherCredits = row.credits;
       hasChatOverflow = true;
-    } else if (row.thread_id) {
+    } else if (row.threadId) {
       chats.push({
-        threadId: row.thread_id,
-        threadTitle: row.thread_title ?? null,
+        threadId: row.threadId,
+        threadTitle: row.threadTitle ?? null,
         credits: row.credits,
         tokens: row.tokens,
       });
@@ -574,23 +677,28 @@ async function queryUsageInsightTopChats(
 
   let chatOtherCount = 0;
   if (hasChatOverflow) {
-    const countRows = await executeRawRows(
-      db,
-      sql`
-        ${usageRowsWith(p)},
-        agg AS (
-          SELECT zr.chat_thread_id,
-            ROW_NUMBER() OVER (ORDER BY SUM(ur.credits_charged) DESC NULLS LAST) AS rn
-          FROM usage_rows ur
-          INNER JOIN zero_runs zr ON zr.id = ur.run_id
-          WHERE zr.chat_thread_id IS NOT NULL
-          GROUP BY zr.chat_thread_id
-        )
-        SELECT ${count()}::bigint AS cnt FROM agg WHERE rn > 100
-      `,
-      usageInsightCountRowSchema,
+    const countUsageRows = usageRowsCte(db, p);
+    const rankedChats = db.$with("agg").as(
+      db
+        .select({
+          threadId: zeroRuns.chatThreadId,
+          rn: chatRankExpr(countUsageRows.creditsCharged).as("rn"),
+        })
+        .from(countUsageRows)
+        .innerJoin(zeroRuns, eq(zeroRuns.id, countUsageRows.runId))
+        .where(isNotNull(zeroRuns.chatThreadId))
+        .groupBy(zeroRuns.chatThreadId),
     );
-    chatOtherCount = countRows[0]?.cnt ?? 0;
+    const countRows = await db
+      .with(countUsageRows, rankedChats)
+      .select({
+        count: sql`${count()}::bigint`
+          .mapWith(pgInt8ToSafeIntegerDecoder)
+          .as("cnt"),
+      })
+      .from(rankedChats)
+      .where(gt(rankedChats.rn, 100));
+    chatOtherCount = countRows[0]?.count ?? 0;
   }
 
   return { chats, chatOtherCount, chatOtherCredits };

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -904,6 +904,19 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
             )
           \`;
         }
+        function unionRows(userId: number) {
+          return sql\`
+            WITH rows AS (
+              SELECT run_id
+              FROM usage_event
+              WHERE user_id = \${userId}
+              UNION ALL
+              SELECT run_id
+              FROM archived_usage_event
+              WHERE user_id = \${userId}
+            )
+          \`;
+        }
         function deletingRows(userId: number) {
           return sql\`
             WITH rows AS (
@@ -942,6 +955,11 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         await executeRawRows(
           db,
           sql\`\${materializedRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${unionRows(threadId)} SELECT run_id FROM rows\`,
           rowSchema,
         );
         await executeRawRows(

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -290,6 +290,30 @@ const managedCreditAvailabilityQuery = `
   \`
 `;
 
+const composedReadCtePreamble = `
+  function usageCreditsExpr() {
+    return sql\`COALESCE(ue.credits_charged, 0)\`;
+  }
+
+  function usageRowsCte(userId: number) {
+    return sql\`
+      usage_rows AS (
+        SELECT
+          ue.run_id,
+          \${usageCreditsExpr()}::bigint AS credits
+        FROM usage_event ue
+        LEFT JOIN usage_allowance_allocations uaa
+          ON uaa.usage_event_id = ue.id
+        WHERE ue.user_id = \${userId}
+      )
+    \`;
+  }
+
+  function usageRowsWith(userId: number) {
+    return sql\`WITH \${usageRowsCte(userId)}\`;
+  }
+`;
+
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
     {
@@ -851,6 +875,95 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         }
         const eq = (...values: unknown[]) => values;
         await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const opaqueCte: SQL;
+
+        function recursiveRows(userId: number) {
+          return sql\`
+            WITH RECURSIVE rows AS (
+              SELECT run_id, user_id
+              FROM usage_event
+              WHERE user_id = \${userId}
+              UNION ALL
+              SELECT usage_event.run_id, usage_event.user_id
+              FROM usage_event
+              INNER JOIN rows ON rows.run_id = usage_event.run_id
+            )
+          \`;
+        }
+        function materializedRows(userId: number) {
+          return sql\`
+            WITH rows AS MATERIALIZED (
+              SELECT run_id
+              FROM usage_event
+              WHERE user_id = \${userId}
+            )
+          \`;
+        }
+        function deletingRows(userId: number) {
+          return sql\`
+            WITH rows AS (
+              DELETE FROM usage_event
+              WHERE user_id = \${userId}
+              RETURNING run_id
+            )
+          \`;
+        }
+        function lockingRows(userId: number) {
+          return sql\`
+            WITH rows AS (
+              SELECT run_id
+              FROM usage_event
+              WHERE user_id = \${userId}
+              FOR UPDATE
+            )
+          \`;
+        }
+        function statefulRows(userId: number) {
+          const selectedUserId = userId;
+          return sql\`
+            WITH rows AS (
+              SELECT run_id
+              FROM usage_event
+              WHERE user_id = \${selectedUserId}
+            )
+          \`;
+        }
+
+        await executeRawRows(
+          db,
+          sql\`\${recursiveRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${materializedRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${deletingRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${lockingRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${statefulRows(threadId)} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`\${opaqueCte} SELECT run_id FROM rows\`,
+          rowSchema,
+        );
       `,
     },
     {
@@ -1838,6 +1951,131 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         );
       `,
       errors: [{ messageId: "scalarCteQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql } from "drizzle-orm";
+        ${composedReadCtePreamble}
+
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)}
+            SELECT
+              date_trunc('day', ur.created_at) AS ts,
+              COALESCE(SUM(ur.credits), 0)::bigint AS credits
+            FROM usage_rows ur
+            LEFT JOIN zero_runs zr ON zr.id = ur.run_id
+            GROUP BY 1
+            ORDER BY 1
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)},
+            agent_totals AS (
+              SELECT
+                ar.agent_name,
+                COALESCE(SUM(ur.credits), 0)::bigint AS total_credits
+              FROM usage_rows ur
+              LEFT JOIN agent_runs ar ON ar.id = ur.run_id
+              GROUP BY 1
+              ORDER BY 2 DESC
+            ),
+            top_agents AS (
+              SELECT agent_name
+              FROM agent_totals
+              LIMIT 7
+            )
+            SELECT
+              ur.run_id,
+              COALESCE(SUM(ur.credits), 0)::bigint AS credits
+            FROM usage_rows ur
+            LEFT JOIN agent_runs ar ON ar.id = ur.run_id
+            WHERE ar.agent_name IN (SELECT agent_name FROM top_agents)
+            GROUP BY 1
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)}
+            SELECT
+              COALESCE(SUM(ur.credits), 0)::bigint AS grand_credits
+            FROM usage_rows ur
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)}
+            SELECT
+              zr.trigger_source AS source,
+              COALESCE(SUM(ur.credits), 0)::bigint AS credits
+            FROM usage_rows ur
+            LEFT JOIN zero_runs zr ON zr.id = ur.run_id
+            WHERE zr.trigger_source IN ('email', 'slack')
+            GROUP BY 1
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)},
+            ranked AS (
+              SELECT
+                ur.run_id,
+                COALESCE(SUM(ur.credits), 0)::bigint AS credits,
+                ROW_NUMBER() OVER (
+                  ORDER BY SUM(ur.credits) DESC NULLS LAST
+                ) AS rn
+              FROM usage_rows ur
+              GROUP BY ur.run_id
+            )
+            SELECT run_id, credits, rn
+            FROM ranked
+            WHERE rn <= 100
+            UNION ALL
+            SELECT NULL AS run_id, COALESCE(SUM(credits), 0), 101 AS rn
+            FROM ranked
+            WHERE rn > 100
+            ORDER BY rn
+          \`,
+          rowSchema,
+        );
+        await executeRawRows(
+          db,
+          sql\`
+            \${usageRowsWith(threadId)},
+            ranked AS (
+              SELECT
+                ur.run_id,
+                ROW_NUMBER() OVER (
+                  ORDER BY SUM(ur.credits) DESC NULLS LAST
+                ) AS rn
+              FROM usage_rows ur
+              GROUP BY ur.run_id
+            )
+            SELECT COUNT(*)::bigint AS count
+            FROM ranked
+            WHERE rn > 100
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        { messageId: "composedCteQueryBuilder" },
+        { messageId: "composedCteQueryBuilder" },
+        { messageId: "composedCteQueryBuilder" },
+        { messageId: "composedCteQueryBuilder" },
+        { messageId: "composedCteQueryBuilder" },
+        { messageId: "composedCteQueryBuilder" },
+      ],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -121,6 +121,17 @@ interface CompleteSqlStatement {
   readonly tokens: readonly SqlToken[];
 }
 
+interface ComposedSqlTemplate {
+  readonly expandedFactory: boolean;
+  readonly expressions: readonly TSESTree.Expression[];
+  readonly source: string;
+}
+
+interface RelationMatch {
+  readonly cursor: number;
+  readonly endToken: SqlToken;
+}
+
 const RESULT_FIELD_ARGUMENT = new Map<string, number>([
   ["returning", 0],
   ["select", 0],
@@ -240,6 +251,36 @@ const UNSUPPORTED_UPDATE_PREDICATE_KEYWORDS = new Set([
 ]);
 
 const UNSUPPORTED_UPSERT_ASSIGNMENT_KEYWORDS = new Set(["RETURNING", "WHERE"]);
+
+const BUILDER_SELECT_CLAUSE_KEYWORDS = new Set([
+  "GROUP",
+  "LIMIT",
+  "ORDER",
+  "WHERE",
+]);
+
+const BUILDER_SELECT_JOIN_KEYWORDS = new Set(["INNER", "JOIN", "LEFT"]);
+
+const UNSUPPORTED_BUILDER_SELECT_KEYWORDS = new Set([
+  "CROSS",
+  "DISTINCT",
+  "EXCEPT",
+  "FETCH",
+  "FOR",
+  "FULL",
+  "HAVING",
+  "INTERSECT",
+  "INTO",
+  "LATERAL",
+  "MERGE",
+  "NATURAL",
+  "OFFSET",
+  "QUALIFY",
+  "RETURNING",
+  "RIGHT",
+  "USING",
+  "WINDOW",
+]);
 
 const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_$]*$/u;
 const SIMPLE_OR_QUOTED_IDENTIFIER_PATTERN =
@@ -436,6 +477,421 @@ function completeSqlStatement(
     hasTrailingSemicolon,
     tokens: statementTokens,
   };
+}
+
+function isBuilderSelectBoundary(token: SqlToken | undefined): boolean {
+  return (
+    token?.kind === "word" &&
+    (BUILDER_SELECT_CLAUSE_KEYWORDS.has(token.value) ||
+      BUILDER_SELECT_JOIN_KEYWORDS.has(token.value))
+  );
+}
+
+function builderSelectRelationMatch(
+  syntaxSource: string,
+  tokens: readonly SqlToken[],
+  start: number,
+): RelationMatch | undefined {
+  const relation = tokens[start];
+  if (
+    relation === undefined ||
+    (relation.kind !== "expression" && relation.kind !== "word")
+  ) {
+    return undefined;
+  }
+
+  let cursor = start + 1;
+  let endToken = relation;
+  const possibleAsKeyword = tokens[cursor];
+  if (isWord(possibleAsKeyword, "AS")) {
+    const alias = tokens[cursor + 1];
+    if (
+      possibleAsKeyword === undefined ||
+      alias?.kind !== "word" ||
+      !onlyWhitespaceBetween(syntaxSource, endToken, possibleAsKeyword) ||
+      !onlyWhitespaceBetween(syntaxSource, possibleAsKeyword, alias)
+    ) {
+      return undefined;
+    }
+    cursor += 2;
+    endToken = alias;
+  } else {
+    const possibleAlias = tokens[cursor];
+    if (
+      possibleAlias?.kind === "word" &&
+      !isBuilderSelectBoundary(possibleAlias)
+    ) {
+      if (!onlyWhitespaceBetween(syntaxSource, endToken, possibleAlias)) {
+        return undefined;
+      }
+      cursor += 1;
+      endToken = possibleAlias;
+    }
+  }
+
+  return { cursor, endToken };
+}
+
+function builderSelectClauseEnd(
+  tokens: readonly SqlToken[],
+  start: number,
+): number {
+  let cursor = start;
+  while (cursor < tokens.length && !isBuilderSelectBoundary(tokens[cursor])) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+/**
+ * Recognizes only read-only SELECT graphs whose statement-level structure is
+ * directly represented by Drizzle's select, join, predicate, grouping,
+ * ordering, limit, and unionAll builders. Expressions may remain SQL leaves.
+ */
+function builderReadSelectMatch(
+  syntaxSource: string,
+  allowUnionAll: boolean,
+): boolean {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined) {
+    return false;
+  }
+  const tokens = statement.tokens;
+  const compoundIndexes = tokens.flatMap((token, index) => {
+    return isWord(token, "UNION") ||
+      isWord(token, "INTERSECT") ||
+      isWord(token, "EXCEPT")
+      ? [index]
+      : [];
+  });
+  if (!allowUnionAll && compoundIndexes.length > 0) {
+    return false;
+  }
+
+  const arms: Array<{
+    readonly end: number;
+    readonly tokens: readonly SqlToken[];
+  }> = [];
+  let armStart = 0;
+  for (const compoundIndex of compoundIndexes) {
+    const compoundKeyword = tokens[compoundIndex];
+    const allKeyword = tokens[compoundIndex + 1];
+    if (
+      compoundKeyword === undefined ||
+      allKeyword === undefined ||
+      !isWord(compoundKeyword, "UNION") ||
+      !isWord(allKeyword, "ALL") ||
+      !onlyWhitespaceBetween(syntaxSource, compoundKeyword, allKeyword)
+    ) {
+      return false;
+    }
+    arms.push({
+      end: compoundKeyword.start,
+      tokens: tokens.slice(armStart, compoundIndex),
+    });
+    armStart = compoundIndex + 2;
+  }
+  arms.push({
+    end: statement.end,
+    tokens: tokens.slice(armStart),
+  });
+
+  return arms.every((arm) => {
+    const armTokens = arm.tokens;
+    const selectKeyword = armTokens[0];
+    if (
+      selectKeyword === undefined ||
+      !isWord(selectKeyword, "SELECT") ||
+      armTokens.some((token) => {
+        return (
+          token.kind === "word" &&
+          UNSUPPORTED_BUILDER_SELECT_KEYWORDS.has(token.value)
+        );
+      })
+    ) {
+      return false;
+    }
+
+    const fromIndexes = armTokens.flatMap((token, index) => {
+      return isWord(token, "FROM") ? [index] : [];
+    });
+    const fromIndex = fromIndexes.length === 1 ? fromIndexes[0] : undefined;
+    const fromKeyword =
+      fromIndex === undefined ? undefined : armTokens[fromIndex];
+    if (
+      fromIndex === undefined ||
+      fromIndex <= 1 ||
+      fromKeyword === undefined ||
+      syntaxSource.slice(selectKeyword.end, fromKeyword.start).trim() === ""
+    ) {
+      return false;
+    }
+
+    const source = builderSelectRelationMatch(
+      syntaxSource,
+      armTokens,
+      fromIndex + 1,
+    );
+    if (
+      source === undefined ||
+      !onlyWhitespaceBetween(
+        syntaxSource,
+        fromKeyword,
+        armTokens[fromIndex + 1],
+      )
+    ) {
+      return false;
+    }
+    let cursor = source.cursor;
+    let previousToken = source.endToken;
+
+    while (
+      isWord(armTokens[cursor], "INNER") ||
+      isWord(armTokens[cursor], "LEFT") ||
+      isWord(armTokens[cursor], "JOIN")
+    ) {
+      const joinStart = armTokens[cursor];
+      if (
+        joinStart === undefined ||
+        !onlyWhitespaceBetween(syntaxSource, previousToken, joinStart)
+      ) {
+        return false;
+      }
+
+      let joinKeyword = joinStart;
+      if (isWord(joinStart, "INNER") || isWord(joinStart, "LEFT")) {
+        cursor += 1;
+        let prefixEnd = joinStart;
+        if (isWord(joinStart, "LEFT") && isWord(armTokens[cursor], "OUTER")) {
+          const outerKeyword = armTokens[cursor];
+          if (
+            outerKeyword === undefined ||
+            !onlyWhitespaceBetween(syntaxSource, prefixEnd, outerKeyword)
+          ) {
+            return false;
+          }
+          prefixEnd = outerKeyword;
+          cursor += 1;
+        }
+        joinKeyword = armTokens[cursor];
+        if (
+          joinKeyword === undefined ||
+          !isWord(joinKeyword, "JOIN") ||
+          !onlyWhitespaceBetween(syntaxSource, prefixEnd, joinKeyword)
+        ) {
+          return false;
+        }
+      }
+      cursor += 1;
+
+      const joined = builderSelectRelationMatch(
+        syntaxSource,
+        armTokens,
+        cursor,
+      );
+      if (
+        joined === undefined ||
+        !onlyWhitespaceBetween(syntaxSource, joinKeyword, armTokens[cursor])
+      ) {
+        return false;
+      }
+      cursor = joined.cursor;
+      const onKeyword = armTokens[cursor];
+      if (
+        onKeyword === undefined ||
+        !isWord(onKeyword, "ON") ||
+        !onlyWhitespaceBetween(syntaxSource, joined.endToken, onKeyword)
+      ) {
+        return false;
+      }
+      cursor += 1;
+      const conditionEnd = builderSelectClauseEnd(armTokens, cursor);
+      const conditionEndOffset =
+        conditionEnd === armTokens.length
+          ? arm.end
+          : armTokens[conditionEnd]?.start;
+      if (
+        conditionEndOffset === undefined ||
+        syntaxSource.slice(onKeyword.end, conditionEndOffset).trim() === ""
+      ) {
+        return false;
+      }
+      cursor = conditionEnd;
+      previousToken = armTokens[cursor - 1] ?? onKeyword;
+    }
+
+    if (isWord(armTokens[cursor], "WHERE")) {
+      const whereKeyword = armTokens[cursor];
+      if (
+        whereKeyword === undefined ||
+        !onlyWhitespaceBetween(syntaxSource, previousToken, whereKeyword)
+      ) {
+        return false;
+      }
+      cursor += 1;
+      const predicateEnd = builderSelectClauseEnd(armTokens, cursor);
+      const predicateEndOffset =
+        predicateEnd === armTokens.length
+          ? arm.end
+          : armTokens[predicateEnd]?.start;
+      if (
+        predicateEndOffset === undefined ||
+        syntaxSource.slice(whereKeyword.end, predicateEndOffset).trim() === ""
+      ) {
+        return false;
+      }
+      cursor = predicateEnd;
+      previousToken = armTokens[cursor - 1] ?? whereKeyword;
+    }
+
+    if (isWord(armTokens[cursor], "GROUP")) {
+      const groupKeyword = armTokens[cursor];
+      const byKeyword = armTokens[cursor + 1];
+      if (
+        groupKeyword === undefined ||
+        byKeyword === undefined ||
+        !isWord(byKeyword, "BY") ||
+        !onlyWhitespaceBetween(syntaxSource, previousToken, groupKeyword) ||
+        !onlyWhitespaceBetween(syntaxSource, groupKeyword, byKeyword)
+      ) {
+        return false;
+      }
+      cursor += 2;
+      const groupingEnd = builderSelectClauseEnd(armTokens, cursor);
+      const groupingEndOffset =
+        groupingEnd === armTokens.length
+          ? arm.end
+          : armTokens[groupingEnd]?.start;
+      if (
+        groupingEndOffset === undefined ||
+        syntaxSource.slice(byKeyword.end, groupingEndOffset).trim() === ""
+      ) {
+        return false;
+      }
+      cursor = groupingEnd;
+      previousToken = armTokens[cursor - 1] ?? byKeyword;
+    }
+
+    if (isWord(armTokens[cursor], "ORDER")) {
+      const orderKeyword = armTokens[cursor];
+      const byKeyword = armTokens[cursor + 1];
+      if (
+        orderKeyword === undefined ||
+        byKeyword === undefined ||
+        !isWord(byKeyword, "BY") ||
+        !onlyWhitespaceBetween(syntaxSource, previousToken, orderKeyword) ||
+        !onlyWhitespaceBetween(syntaxSource, orderKeyword, byKeyword)
+      ) {
+        return false;
+      }
+      cursor += 2;
+      const orderingEnd = builderSelectClauseEnd(armTokens, cursor);
+      const orderingEndOffset =
+        orderingEnd === armTokens.length
+          ? arm.end
+          : armTokens[orderingEnd]?.start;
+      if (
+        orderingEndOffset === undefined ||
+        syntaxSource.slice(byKeyword.end, orderingEndOffset).trim() === ""
+      ) {
+        return false;
+      }
+      cursor = orderingEnd;
+      previousToken = armTokens[cursor - 1] ?? byKeyword;
+    }
+
+    if (isWord(armTokens[cursor], "LIMIT")) {
+      const limitKeyword = armTokens[cursor];
+      const limitValue = armTokens[cursor + 1];
+      if (
+        limitKeyword === undefined ||
+        limitValue === undefined ||
+        (limitValue.kind !== "expression" && limitValue.kind !== "number") ||
+        cursor + 2 !== armTokens.length ||
+        !onlyWhitespaceBetween(syntaxSource, previousToken, limitKeyword) ||
+        !onlyWhitespaceBetween(syntaxSource, limitKeyword, limitValue) ||
+        syntaxSource.slice(limitValue.end, arm.end).trim() !== ""
+      ) {
+        return false;
+      }
+      return true;
+    }
+
+    return (
+      cursor === armTokens.length &&
+      syntaxSource.slice(previousToken.end, arm.end).trim() === ""
+    );
+  });
+}
+
+/**
+ * Recognizes a complete local-helper-composed WITH query only when every CTE
+ * is a read-only builder-owned SELECT and the final graph is a SELECT or
+ * UNION ALL. Unsupported CTE modifiers and data-modifying bodies fail closed.
+ */
+function completeBuilderCteSelectMatch(syntaxSource: string): boolean {
+  const statement = completeSqlStatement(syntaxSource);
+  if (statement === undefined) {
+    return false;
+  }
+  const tokens = statement.tokens;
+  const withKeyword = tokens[0];
+  if (withKeyword === undefined || !isWord(withKeyword, "WITH")) {
+    return false;
+  }
+
+  const cteNames = new Set<string>();
+  let cursor = 1;
+  let previousToken = withKeyword;
+  while (cursor < tokens.length && !isWord(tokens[cursor], "SELECT")) {
+    const name = tokens[cursor];
+    const asKeyword = tokens[cursor + 1];
+    const open = tokens[cursor + 2];
+    const close = tokens[cursor + 3];
+    if (
+      name?.kind !== "word" ||
+      asKeyword === undefined ||
+      open === undefined ||
+      close === undefined ||
+      !isWord(asKeyword, "AS") ||
+      !isPunctuation(open, "(") ||
+      !isPunctuation(close, ")") ||
+      cteNames.has(name.value) ||
+      !onlyWhitespaceBetween(syntaxSource, previousToken, name) ||
+      !onlyWhitespaceBetween(syntaxSource, name, asKeyword) ||
+      !onlyWhitespaceBetween(syntaxSource, asKeyword, open) ||
+      !builderReadSelectMatch(syntaxSource.slice(open.end, close.start), false)
+    ) {
+      return false;
+    }
+    cteNames.add(name.value);
+    cursor += 4;
+
+    const separator = tokens[cursor];
+    if (!isPunctuation(separator, ",")) {
+      previousToken = close;
+      break;
+    }
+    if (!onlyWhitespaceBetween(syntaxSource, close, separator)) {
+      return false;
+    }
+    previousToken = separator;
+    cursor += 1;
+  }
+
+  const selectKeyword = tokens[cursor];
+  if (
+    cteNames.size === 0 ||
+    selectKeyword === undefined ||
+    !isWord(selectKeyword, "SELECT") ||
+    !onlyWhitespaceBetween(syntaxSource, previousToken, selectKeyword)
+  ) {
+    return false;
+  }
+  return builderReadSelectMatch(
+    syntaxSource.slice(selectKeyword.start, statement.end),
+    true,
+  );
 }
 
 const SCALAR_AGGREGATE_FUNCTIONS = new Set([
@@ -1960,7 +2416,7 @@ export const preferDrizzleQueryBuilder = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Prefer Drizzle query builders for complete schema-backed deletes, updates, upserts, selects, existence checks, locking selects, scalar CTE projections, and scalar result queries",
+        "Prefer Drizzle query builders for complete schema-backed deletes, updates, upserts, selects, existence checks, locking selects, composed read-only CTEs, scalar CTE projections, and scalar result queries",
       recommended: true,
       requiresTypeChecking: true,
     },
@@ -1982,6 +2438,8 @@ export const preferDrizzleQueryBuilder = createRule({
         "Use Drizzle $with(...), select().for(...), and update().from(...) builders for this complete locking CTE update.",
       scalarCteQueryBuilder:
         "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
+      composedCteQueryBuilder:
+        "Use Drizzle $with(...), select(), joins, grouping, ordering, and set-operation builders for this complete locally composed read query.",
       structuredScalarQuery:
         "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
     },
@@ -2440,6 +2898,162 @@ export const preferDrizzleQueryBuilder = createRule({
       return services.tsNodeToESTreeNodeMap.get(statement.expression);
     }
 
+    function hasOnlyDirectCallReferences(node: TSESTree.Identifier): boolean {
+      const variable = variableInScope(node);
+      return (
+        variable !== null &&
+        variable.references.every((reference) => {
+          if (reference.init === true) {
+            return true;
+          }
+          const identifier = reference.identifier;
+          if (identifier.type !== AST_NODE_TYPES.Identifier) {
+            return false;
+          }
+          const callee = outerTransparentExpression(identifier);
+          return (
+            callee.parent?.type === AST_NODE_TYPES.CallExpression &&
+            callee.parent.callee === callee
+          );
+        })
+      );
+    }
+
+    function localSqlFactoryTemplate(node: TSESTree.Expression): {
+      readonly declaration: Node;
+      readonly template: TSESTree.TaggedTemplateExpression;
+    } | null {
+      let call: TSESTree.Node = node;
+      let transparentCall = transparentExpression(call);
+      while (transparentCall !== null) {
+        call = transparentCall;
+        transparentCall = transparentExpression(call);
+      }
+      if (
+        call.type !== AST_NODE_TYPES.CallExpression ||
+        call.callee.type !== AST_NODE_TYPES.Identifier ||
+        call.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        }) ||
+        !hasOnlyDirectCallReferences(call.callee) ||
+        !isDrizzleWrapperType(checker, expressionType(call).type)
+      ) {
+        return null;
+      }
+
+      const tsCallee = services.esTreeNodeToTSNodeMap.get(call.callee);
+      const declaration = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(tsCallee),
+      )?.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isFunctionDeclaration(declaration) ||
+        declaration.getSourceFile() !== tsCallee.getSourceFile() ||
+        declaration.body === undefined ||
+        declaration.body.statements.length !== 1 ||
+        hasExportModifier(declaration)
+      ) {
+        return null;
+      }
+      const statement = declaration.body.statements[0];
+      if (
+        statement === undefined ||
+        !isReturnStatement(statement) ||
+        statement.expression === undefined
+      ) {
+        return null;
+      }
+
+      let returned = services.tsNodeToESTreeNodeMap.get(statement.expression);
+      let transparent = transparentExpression(returned);
+      while (transparent !== null) {
+        returned = transparent;
+        transparent = transparentExpression(returned);
+      }
+      return returned.type === AST_NODE_TYPES.TaggedTemplateExpression
+        ? { declaration, template: returned }
+        : null;
+    }
+
+    function composeSqlTemplate(
+      template: TSESTree.TaggedTemplateExpression,
+      activeFactories: Set<Node>,
+    ): ComposedSqlTemplate | null {
+      if (!isDrizzleSqlTag(checker, services, template.tag)) {
+        return null;
+      }
+      const firstQuasi = template.quasi.quasis[0];
+      if (firstQuasi === undefined) {
+        return null;
+      }
+
+      let source = quasiText(firstQuasi);
+      let expandedFactory = false;
+      const expressions: TSESTree.Expression[] = [];
+      for (
+        let index = 0;
+        index < template.quasi.expressions.length;
+        index += 1
+      ) {
+        const expression = template.quasi.expressions[index];
+        const followingQuasi = template.quasi.quasis[index + 1];
+        if (expression === undefined || followingQuasi === undefined) {
+          return null;
+        }
+
+        const factory = localSqlFactoryTemplate(expression);
+        if (factory !== null && !activeFactories.has(factory.declaration)) {
+          activeFactories.add(factory.declaration);
+          const nested = composeSqlTemplate(factory.template, activeFactories);
+          activeFactories.delete(factory.declaration);
+          if (nested !== null) {
+            source += nested.source;
+            expressions.push(...nested.expressions);
+            expandedFactory = true;
+          } else {
+            source += SQL_TEMPLATE_EXPRESSION_BOUNDARY;
+            expressions.push(expression);
+          }
+        } else {
+          source += SQL_TEMPLATE_EXPRESSION_BOUNDARY;
+          expressions.push(expression);
+        }
+        source += quasiText(followingQuasi);
+      }
+
+      return { expandedFactory, expressions, source };
+    }
+
+    function isComposedBuilderCteQuery(
+      query: TSESTree.TaggedTemplateExpression,
+    ): boolean {
+      const firstQuasi = query.quasi.quasis[0];
+      const firstExpression = query.quasi.expressions[0];
+      if (
+        firstQuasi === undefined ||
+        firstExpression === undefined ||
+        sqlCodeMask(quasiText(firstQuasi)).trim() !== "" ||
+        localSqlFactoryTemplate(firstExpression) === null
+      ) {
+        return false;
+      }
+
+      const composition = composeSqlTemplate(query, new Set<Node>());
+      return (
+        composition !== null &&
+        composition.expandedFactory &&
+        completeBuilderCteSelectMatch(sqlCodeMask(composition.source)) &&
+        composition.expressions.every((expression) => {
+          const type = expressionType(expression).type;
+          return (
+            isBoundScalarParameterType(type) ||
+            isDrizzleWrapperType(checker, type)
+          );
+        })
+      );
+    }
+
     function isDrizzleResultWrapper(node: TSESTree.CallExpression): boolean {
       if (
         node.callee.type !== AST_NODE_TYPES.MemberExpression ||
@@ -2724,6 +3338,13 @@ export const preferDrizzleQueryBuilder = createRule({
           .map(quasiText)
           .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
         const syntaxSource = sqlCodeMask(source);
+        if (isComposedBuilderCteQuery(query)) {
+          context.report({
+            node: query,
+            messageId: "composedCteQueryBuilder",
+          });
+          return;
+        }
         if (
           completeScalarCteProjectionMatch(syntaxSource) &&
           query.quasi.expressions.every((expression) => {


### PR DESCRIPTION
## Summary

- replace all six usage-insight raw statement graphs with typed Drizzle CTE, select, join, predicate, grouping, ordering, limit, and `unionAll` builders
- retain only PostgreSQL-specific expression leaves and map every raw selected value through schema or structured-result decoders
- remove the service `executeRawRows` boundary and raw-row Zod schemas while preserving safe `int8`, timestamp, enum, and nullable decoding
- extend `api/prefer-drizzle-query-builder` so the former local-helper-composed read-only CTE shape cannot silently bypass query-structure lint

## Behavior and performance

- preserve source and agent grouping, top-seven folding, UTC input windows, requested-time-zone buckets, channel totals, top-100 chats, overflow credits/count, statement count, and abort boundaries
- compare every old and new query variant on existing fixtures and a temporary rich PostgreSQL fixture covering 103 chats, duplicate/null agent data, a null thread title, allowance credits, token categories, pending usage, and time-zone/window edges; all results matched
- verify both implementations reject aggregates above JavaScript safe-integer range
- compare `EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)` plans: five variants have identical plan structure; the top-chat builder plan removes one wrapper `Subquery Scan` while retaining the same scans, joins, aggregate, window, append, and sort operations

## Lint boundary

- resolve only local, non-exported, single-return Drizzle SQL factories whose bindings are used only through direct calls
- recognize only complete read-only CTE/select graphs made from supported joins, predicates, grouping, ordering, limits, and final `UNION ALL`
- fail closed for recursive, materialized, data-modifying, locking, opaque, multi-statement helper, and CTE-body set-operation shapes
- use no file/location matcher, allowlist, suppression, or general PostgreSQL parser
- measured API ESLint at 37.6s locally; `api/prefer-drizzle-query-builder` used 75.5ms (0.6%)

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules test` (47 files, 794 tests)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts` (14 tests)
- `pnpm knip --workspace api --workspace @vm0/eslint-rules`
- six-query result, edge-case, safe-integer, and representative-plan comparison
- `git diff --check`
- pre-commit full Turbo Knip and workspace type checks

## Scope

- no schema, migration, persisted-data, API-contract, feature-switch, or compatibility changes
- retained SQL tags are PostgreSQL expression leaves
- usage-record and model-ranking query families remain separate work under the parent issue

Closes #22983

Parent: #22439