### PR TITLE
docs(python): clarify path pattern validation boundary

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/patterns.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/patterns.py
@@ -219,7 +219,13 @@ def _compile_segments(segments: list[str] | tuple[str, ...]) -> tuple[ParsedSegm
 
 
 def compile_path_pattern(pattern: str) -> CompiledPathPattern | None:
-    """Compile a URL path pattern for repeated matching."""
+    """Compile a URL path pattern for repeated matching.
+
+    Compilation validates segment syntax only. It does not validate the complete firewall-rule
+    grammar: greedy parameters must be terminal and occupy a whole segment, and parameter names
+    must be unique. Callers validating firewall rules must also apply
+    ``_compiled_rule_path_is_valid()`` (as ``matching._compile_rule()`` does).
+    """
     segments = _compile_segments(tuple(_split_path_segments(pattern)))
     if segments is None:
         return None
@@ -344,7 +350,13 @@ def _compiled_path_segments_match(
 
 
 def match_compiled_path(path: str, pattern: CompiledPathPattern) -> dict | None:
-    """Match a URL path against a compiled rule path pattern."""
+    """Match a URL path against a compiled path pattern without revalidating it.
+
+    A pattern accepted by ``compile_path_pattern()`` can still be invalid as a firewall rule. A
+    non-terminal or mixed greedy parameter therefore returns ``None`` during matching, while
+    duplicate parameter names can match with the later capture replacing the earlier value. Use
+    the firewall-rule validator before treating a compiled pattern as a rule.
+    """
     return _match_compiled_path_segments(_split_path_segments(path), pattern.segments)
 
 

--- a/crates/runner/mitm-addon/tests/test_matching_path.py
+++ b/crates/runner/mitm-addon/tests/test_matching_path.py
@@ -138,3 +138,9 @@ class TestMatchPath:
         assert compiled is not None
 
         assert matching.match_compiled_path("/api/file-123", compiled) is None
+
+    def test_compiled_duplicate_params_keep_the_later_capture(self):
+        compiled = matching.compile_path_pattern("/{id}/{id}")
+        assert compiled is not None
+
+        assert matching.match_compiled_path("/first/second", compiled) == {"id": "second"}


### PR DESCRIPTION
## Summary

- clarify that `compile_path_pattern()` validates segment syntax, not complete firewall-rule invariants
- document `match_compiled_path()` behavior for compiled-but-rule-invalid patterns
- lock duplicate-parameter capture behavior with a focused test

## Scope

This preserves existing matching behavior. It does not change firewall rule compilation, schemas,
persistence, protocols, or deployment behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_matching_path.py`

Closes #22994
