### PR TITLE
docs(mitm-addon): fix proxy registry source reference

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -145,7 +145,8 @@ def load(loader: Loader) -> None:
         typespec=str,
         # This default is a placeholder shown in `mitmdump --help`; the runner
         # always passes `--set vm0_proxy_registry_path=<per-runner path>` (see
-        # crates/runner/src/proxy.rs:362), so the default is never used in
+        # `proxy::process::spawn_mitmdump` in
+        # `crates/runner/src/proxy/process.rs`), so the default is never used in
         # production. Computed via tempfile.gettempdir() so that standalone
         # debugging works on platforms where /tmp is not the system temp dir.
         default=str(Path(tempfile.gettempdir()) / "proxy-registry.json"),


### PR DESCRIPTION
## Summary

- replace the removed `crates/runner/src/proxy.rs:362` pointer in the
  `vm0_proxy_registry_path` option comment
- point contributors to `proxy::process::spawn_mitmdump` in the current
  `crates/runner/src/proxy/process.rs` module
- preserve the distinction between runner-managed production use and the
  placeholder used for help output and standalone debugging

## Scope

This changes explanatory comment text only. It does not change Python or Rust
runtime behavior, APIs, schemas, protocols, dependencies, configuration,
generated artifacts, or tests.

## Validation

- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/`
  (`4210 passed`)
- `cd crates && cargo test -p runner --bin runner proxy::process::tests::addon_scripts_are_embedded`
- `git diff --check`

Closes #22991
