### PR TITLE
fix(mitm-addon): reject null host policy fields

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -292,9 +292,9 @@ def _normalize_host_policy_hostname(hostname: str) -> str:
 
 
 def _host_policy_string_list(policy: dict, key: str) -> list[str]:
-    value = policy.get(key)
-    if value is None:
+    if key not in policy:
         return []
+    value = policy[key]
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise BuiltinHostPolicyError(f"builtin firewall hostPolicy.{key} must be a string list")
     return value
@@ -315,9 +315,9 @@ def _validate_host_policy_keys(
 
 
 def _host_policy_optional_bool(*, firewall_name: str, policy: dict, key: str) -> bool:
-    value = policy.get(key)
-    if value is None:
+    if key not in policy:
         return False
+    value = policy[key]
     if not isinstance(value, bool):
         raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" hostPolicy.{key} must be a boolean'

--- a/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
@@ -49,12 +49,42 @@ _AUTH_CONFIG: dict[str, object] = {
         pytest.param(
             {
                 "kind": "providerOwned",
+                "exactHosts": None,
+                "suffixes": ["example.com"],
+            },
+            "https://api.example.com",
+            "api.example.com",
+            id="null-exact-hosts",
+        ),
+        pytest.param(
+            {
+                "kind": "providerOwned",
+                "exactHosts": ["api.example.com"],
+                "suffixes": None,
+            },
+            "https://api.example.com",
+            "api.example.com",
+            id="null-suffixes",
+        ),
+        pytest.param(
+            {
+                "kind": "providerOwned",
                 "suffixes": ["example.com"],
                 "allowNonDefaultPort": "false",
             },
             "https://api.example.com",
             "api.example.com",
             id="invalid-boolean-type",
+        ),
+        pytest.param(
+            {
+                "kind": "providerOwned",
+                "suffixes": ["example.com"],
+                "allowNonDefaultPort": None,
+            },
+            "https://api.example.com",
+            "api.example.com",
+            id="null-allow-non-default-port",
         ),
         pytest.param(
             {"kind": "unsupported"},


### PR DESCRIPTION
## Summary

- distinguish omitted builtin host-policy fields from fields explicitly set to `null`
- retain the existing defaults only for missing ownership-list and port-policy keys
- reject null `exactHosts`, `suffixes`, and `allowNonDefaultPort` values across cache, resolved-base,
  and raw runtime validation
- cover all three malformed values through the existing cross-stage policy contract test

## Scope

This PR changes only optional members inside a present Python `providerOwned` host policy.
Top-level `hostPolicy` absence semantics and other optional catalog fields are unchanged.

There are no TypeScript schema, API, protocol, dependency, database, migration, persisted-state, or
documentation changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_builtin_host_policy_contract.py` (11 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4213 passed)
- repository pre-commit hooks and commitlint

Closes #22992
