### PR TITLE
test(ci): prevent runner binary fixture cleanup race

### DIFF
--- a/.github/scripts/tests/runner-binary-build-test.sh
+++ b/.github/scripts/tests/runner-binary-build-test.sh
@@ -137,6 +137,7 @@ weird_relative=$'crates/guest-one/src/odd\tname\nline.txt'
 printf 'odd tracked input\n' > "${repo}/${weird_relative}"
 
 git -C "$repo" init -q
+git -C "$repo" config maintenance.auto false
 git -C "$repo" config user.email test@example.com
 git -C "$repo" config user.name test
 commit_all "$repo" baseline
@@ -329,6 +330,7 @@ cp -a \
   "${REPO_ROOT}/.github/scripts/runner-binary-build" \
   "${actual_repo}/.github/scripts/runner-binary-build"
 git -C "$actual_repo" init -q
+git -C "$actual_repo" config maintenance.auto false
 git -C "$actual_repo" config user.email test@example.com
 git -C "$actual_repo" config user.name test
 commit_all "$actual_repo" actual-workspace


### PR DESCRIPTION
## Summary

- disable automatic Git maintenance in both disposable repositories created by the runner binary build test
- prevent detached maintenance from racing the test's `EXIT` cleanup
- preserve all digest, materialization, and actual-workspace assertions

## Scope

This changes only test fixture repository configuration. It does not add cleanup retries or sleeps, alter workflow-wide Git configuration, or change production runner binary build behavior. There are no API, schema, migration, or persisted-data changes.

## Validation

- `bash -n` over `.github/scripts/*.sh` and `.github/scripts/tests/*.sh`
- `shellcheck -S warning .github/scripts/tests/runner-binary-build-test.sh`
- repository-configured Workflow Lint ShellCheck targets
- `bash .github/scripts/tests/runner-binary-build-test.sh`
- forced-GC regression with `GIT_CONFIG_COUNT=1`, `gc.auto=1`
- 50 serial forced-GC regression iterations
- `.github/scripts/check-workflow-shell-compatibility.sh`
- complete serial `.github/scripts/tests/*.sh` loop
- pre-commit and commit-message hooks

Direct all-severity ShellCheck on the legacy test still reports its two existing information-level SC1091 findings for unchanged dynamic `source` paths; no lint suppression was added.

Closes #23009
