### PR TITLE
fix(runner): reject forbidden provider host characters

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -41,7 +41,7 @@ from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 BUILTIN_HOST_POLICY_RUNTIME_MARKER = "_builtinHostPolicyRuntime"
 _DEFAULT_HTTPS_PORT = 443
 _MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
-_HOST_POLICY_HOST_FORBIDDEN_CHARS = frozenset("%*[]/?#@\\:{}")
+_HOST_POLICY_HOST_FORBIDDEN_CHARS = frozenset("%*[]/?#@\\:{}<>^|")
 _IPV4_LITERAL_COMPONENT_PATTERN = re.compile(r"(?:0[xX][0-9a-fA-F]+|[0-9]+)")
 _IPV4_LITERAL_MAX_COMPONENTS = 4
 _PROVIDER_OWNED_HOST_POLICY_KEYS = frozenset(

--- a/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
@@ -68,6 +68,16 @@ _AUTH_CONFIG: dict[str, object] = {
             "api.example.com",
             id="non-object-policy",
         ),
+        *[
+            pytest.param(
+                {"kind": "providerOwned", field: [f"evil{character}host.example.com"]},
+                "https://api.example.com",
+                "api.example.com",
+                id=f"forbidden-{field}-{ord(character):x}",
+            )
+            for field in ("exactHosts", "suffixes")
+            for character in "<>^|"
+        ],
     ],
 )
 def test_malformed_policy_is_rejected_by_every_validation_stage(


### PR DESCRIPTION
## Summary

- Align the Python builtin host-policy forbidden-character set with the connector schema and shared hostname normalization.
- Reject `<`, `>`, `^`, and `|` in provider-owned `exactHosts` and `suffixes` across the existing validation contract tests.

## Scope

This is a fail-closed validation correction. It does not change APIs, database schema, migrations, persisted state, runner protocols, or deployment ordering.

Closes #22995

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_builtin_host_policy_contract.py`
