### PR TITLE
perf(mitm-addon): avoid zstd frame-tail copies

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -450,20 +450,20 @@ def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
     if max_output <= 0:
         return DECODED_BODY_LIMIT_EXCEEDED if data else None
 
-    remaining_data = data
+    source = memoryview(data)
+    source_offset = 0
+    pending_input = b""
     decoded_size = 0
-    while remaining_data:
+    while source_offset < len(source) or pending_input:
         obj = zstandard.ZstdDecompressor().decompressobj()
-        offset = 0
-        unconsumed_tail = b""
 
-        while offset < len(remaining_data) or unconsumed_tail:
-            if unconsumed_tail:
-                chunk = unconsumed_tail
-                unconsumed_tail = b""
+        while source_offset < len(source) or pending_input:
+            if pending_input:
+                chunk = pending_input
+                pending_input = b""
             else:
-                chunk = remaining_data[offset : offset + _ZSTD_VALIDATE_INPUT_CHUNK_SIZE]
-                offset += len(chunk)
+                chunk = source[source_offset : source_offset + _ZSTD_VALIDATE_INPUT_CHUNK_SIZE]
+                source_offset += len(chunk)
             try:
                 decoded = obj.decompress(chunk)
             except zstandard.ZstdError:
@@ -473,9 +473,9 @@ def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
             if decoded_size > max_output:
                 return DECODED_BODY_LIMIT_EXCEEDED
             if obj.eof:
-                remaining_data = obj.unused_data + remaining_data[offset:]
+                pending_input = obj.unused_data
                 break
-            unconsumed_tail = obj.unconsumed_tail
+            pending_input = obj.unconsumed_tail
         else:
             return INCOMPLETE_COMPRESSED_BODY
     return None

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -825,7 +825,7 @@ class TestDecompressJsonUsageBody:
 
         class NonConcatenableUnusedData(bytes):
             def __add__(self, _other: object) -> bytes:
-                raise AssertionError("zstd unused data must not be concatenated")
+                raise TypeError("zstd unused data must not be concatenated")
 
         class TrackingDecompressionObj:
             def __init__(self, wrapped):

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -18,6 +18,7 @@ from body_decoding import (
 )
 from body_limits import (
     DEFAULT_BODY_DECODE_LIMIT,
+    STREAM_BUFFER_LIMIT,
     STREAM_DECODE_CHUNK_LIMIT,
     STREAM_DECODE_EXPANSION_GRACE,
     STREAM_DECODE_MAX_EXPANSION_RATIO,
@@ -811,15 +812,20 @@ class TestDecompressJsonUsageBody:
         assert decoded == body
         assert error is None
 
-    def test_zstd_validation_does_not_decompress_full_remaining_input_at_once(
+    def test_zstd_validation_carries_bounded_unused_data_without_rebuilding_tail(
         self, headers, monkeypatch
     ):
-        frame_body = b"A" * 1024
-        compressed = b"".join(zstandard.ZstdCompressor().compress(frame_body) for _ in range(200))
-        body = frame_body * 200
+        frame_count = 7000
+        frame = zstandard.ZstdCompressor().compress(b"")
+        compressed = frame * frame_count
+        assert len(compressed) < STREAM_BUFFER_LIMIT
         hdrs = headers(("Content-Encoding", "zstd"))
         validation_input_sizes: list[int] = []
         real_factory = zstandard.ZstdDecompressor
+
+        class NonConcatenableUnusedData(bytes):
+            def __add__(self, _other: object) -> bytes:
+                raise AssertionError("zstd unused data must not be concatenated")
 
         class TrackingDecompressionObj:
             def __init__(self, wrapped):
@@ -835,7 +841,7 @@ class TestDecompressJsonUsageBody:
 
             @property
             def unused_data(self):
-                return self._wrapped.unused_data
+                return NonConcatenableUnusedData(self._wrapped.unused_data)
 
             @property
             def unconsumed_tail(self):
@@ -859,10 +865,10 @@ class TestDecompressJsonUsageBody:
         decoded, error = decompress_json_usage_body(
             compressed,
             hdrs,
-            max_output=len(body),
+            max_output=1,
         )
 
-        assert decoded == body
+        assert decoded == b""
         assert error is None
         assert validation_input_sizes
         assert max(validation_input_sizes) <= 32


### PR DESCRIPTION
## Summary

- traverse strict zstd validation with one monotonic cursor into the original compressed input
- carry only bounded decompressor leftovers across frame boundaries instead of rebuilding the unread suffix
- add a production-sized 7,000-frame regression that rejects unused-data concatenation while retaining the 32-byte validation-input contract

Local measurement for 7,000 valid empty frames (63 KB compressed) reduced the validator median from the issue's approximately 30 ms baseline to approximately 3.7 ms in the final worktree.

## Preserved behavior

- keep the optimized `stream_reader` body-production pass and strict second validation pass
- preserve valid concatenated frames and invalid, incomplete, trailing-data, and decoded-limit classifications
- preserve compressed and decoded limits, returned decoded prefixes, callers, dependencies, and deployment contracts

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_decoding.py` — 94 passed
- `uv run --no-sync python -m pytest tests/test_model_provider_json_fallback.py tests/test_model_provider_json_streaming.py tests/test_x_connector_pipeline.py` — 113 passed
- `uv run --no-sync python -m pytest tests/` — 4,210 passed

Closes #22990
