### PR TITLE
feat(billing): enable plan upgrade guidance globally

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7988,7 +7988,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     ]) {
       expect(appendSystemPrompt).toContain(toolHint);
     }
-    expect(appendSystemPrompt).not.toContain("zero upgrade pro");
+    expect(appendSystemPrompt).toContain("zero upgrade pro");
     for (const otherIntegrationHint of [
       "zero slack download-file -h",
       "zero github download-file -h",
@@ -8003,7 +8003,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain("Timezone: America/Los_Angeles");
 
     expect(claim.featureFlags).toMatchObject({
-      [FeatureSwitchKey.PlanUpgradeGuidance]: false,
+      [FeatureSwitchKey.PlanUpgradeGuidance]: true,
       [FeatureSwitchKey.ZeroFinance]: true,
     });
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -151,12 +151,12 @@ describe("registerZeroCommands", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should not register default-disabled feature commands when ZERO_TOKEN is absent", () => {
+  it("should register globally enabled commands when ZERO_TOKEN is absent", () => {
     vi.stubEnv("ZERO_TOKEN", undefined);
 
     const prog = buildProgram();
     expect(hiddenCommandNames(prog)).toEqual([]);
-    expect(registeredCommandNames(prog)).not.toContain("upgrade");
+    expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
 
@@ -173,6 +173,7 @@ describe("registerZeroCommands", () => {
       "model",
       "model-provider",
       "agent",
+      "upgrade",
       "resource",
       "whoami",
       "generate",
@@ -212,7 +213,7 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toEqual([]);
-    expect(registeredCommandNames(prog)).not.toContain("upgrade");
+    expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
 
@@ -226,11 +227,11 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toEqual([]);
-    expect(registeredCommandNames(prog)).not.toContain("upgrade");
+    expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(registeredCommandNames(prog)).not.toContain("browser");
   });
 
-  it("should only show whoami when capabilities array is empty", () => {
+  it("should show globally enabled commands when capabilities array is empty", () => {
     const token = buildZeroToken({
       scope: "zero",
       capabilities: [],
@@ -242,6 +243,7 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toEqual([
       "model",
       "model-provider",
+      "upgrade",
       "resource",
       "whoami",
       "generate",
@@ -652,7 +654,7 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
-  it("should hide credit and not register default-disabled upgrade guidance when billing capabilities are missing", () => {
+  it("should hide credit but keep globally enabled upgrade guidance when billing capabilities are missing", () => {
     const token = buildZeroToken({
       scope: "zero",
       capabilities: ["agent:read"],
@@ -662,7 +664,7 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toContain("credit");
-    expect(registeredCommandNames(prog)).not.toContain("upgrade");
+    expect(registeredCommandNames(prog)).toContain("upgrade");
   });
 
   it("should show upgrade guidance when its feature switch is enabled", () => {
@@ -1042,6 +1044,7 @@ describe("registerZeroCommands", () => {
       "model",
       "model-provider",
       "connector",
+      "upgrade",
       "resource",
       "whoami",
       "generate",

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -345,7 +345,7 @@ describe("zero generate video command", () => {
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
     expect(stderr).toContain("Paid plan required");
-    expect(stderr).not.toContain("zero upgrade pro");
+    expect(stderr).toContain("zero upgrade pro");
     expect(generationRequests).toBe(0);
   });
 });

--- a/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
+++ b/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
@@ -99,7 +99,7 @@ describe("withErrorHandler", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  it("should hide default-disabled plan upgrade guidance for PRO_REQUIRED", async () => {
+  it("should show globally enabled plan upgrade guidance for PRO_REQUIRED", async () => {
     const handler = withErrorHandler(async () => {
       throw new ApiRequestError(
         "Built-in video generation requires a paid plan",
@@ -116,8 +116,8 @@ describe("withErrorHandler", () => {
       })
       .join("\n");
     expect(output).toContain("Paid plan required");
-    expect(output).not.toContain("Return the plan upgrade link");
-    expect(output).not.toContain("zero upgrade pro");
+    expect(output).toContain("Return the plan upgrade link");
+    expect(output).toContain("zero upgrade pro");
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -166,7 +166,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.PlanUpgradeGuidance]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.PlanUpgradeGuidance]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -492,8 +492,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show plan-upgrade guidance in Zero CLI help and render billing plan links as rich chat cards.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.OrgPlanEntitlementReads]: {


### PR DESCRIPTION
## Summary
- enable `PlanUpgradeGuidance` for every organization
- keep the switch non-user-overridable
- update feature-state and runner lifecycle expectations for global availability

## User impact
Plan-upgrade guidance is available globally in Zero CLI help, runner guidance, and billing plan chat cards.

## Verification
- `pnpm -F @vm0/core test -- --run src/__tests__/feature-switch.test.ts` passed: 16 core test files, 213 tests
- `pnpm -F @vm0/core check-types` passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types` passed
- targeted Prettier check and `git diff --check` passed
- the API lifecycle test command could not complete locally because the API test process reached database-backed tests while PostgreSQL was unavailable (`ECONNREFUSED`); CI should provide the database-backed verification
- the repository pre-commit hook passed formatting and knip, but its full repository `check-types` step hit the configured 120-second timeout; the affected core and API packages passed their targeted type checks