### PR TITLE
fix(guest-agent): classify oversized session history failures

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -303,12 +303,26 @@ fn fail(
     msg: impl Into<String>,
 ) -> AgentError {
     let msg = msg.into();
+    record_failure(mode, op, start, &msg);
+    AgentError::Checkpoint(msg)
+}
+
+fn fail_preserving_error(
+    mode: CheckpointMode,
+    op: &str,
+    start: std::time::Instant,
+    error: AgentError,
+) -> AgentError {
+    record_failure(mode, op, start, &error.to_string());
+    error
+}
+
+fn record_failure(mode: CheckpointMode, op: &str, start: std::time::Instant, msg: &str) {
     match mode {
         CheckpointMode::Success => log_error!(LOG_TAG, "{msg}"),
         CheckpointMode::Recovery => log_warn!(LOG_TAG, "{msg}"),
     }
-    record_sandbox_op(op, start.elapsed(), false, Some(&msg));
-    AgentError::Checkpoint(msg)
+    record_sandbox_op(op, start.elapsed(), false, Some(msg));
 }
 
 /// Build an artifact snapshot using the type generated from the canonical
@@ -768,11 +782,11 @@ fn prepare_session_history(
     ) {
         Ok(source) => source,
         Err(e) => {
-            return Err(fail(
+            return Err(fail_preserving_error(
                 mode,
                 "session_history_read",
                 history_read_start,
-                e.to_string(),
+                e,
             ));
         }
     };
@@ -863,14 +877,7 @@ fn prepare_reused_zstd_session_history(
         RESUME_SESSION_HISTORY_MAX_BYTES,
         mode.validate_history(),
     )
-    .map_err(|e| {
-        fail(
-            mode,
-            "session_history_read",
-            history_read_start,
-            e.to_string(),
-        )
-    })?;
+    .map_err(|e| fail_preserving_error(mode, "session_history_read", history_read_start, e))?;
 
     if let Some(msg) = &analysis.invalid_utf8 {
         if mode.validate_history() {
@@ -1273,6 +1280,20 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
 
     const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn checkpoint_failure_recording_preserves_typed_history_limit_error() {
+        let error = fail_preserving_error(
+            CheckpointMode::Success,
+            "session_history_read",
+            std::time::Instant::now(),
+            AgentError::CheckpointHistoryTooLarge { max_bytes: 1 },
+        );
+        assert!(matches!(
+            error,
+            AgentError::CheckpointHistoryTooLarge { max_bytes: 1 }
+        ));
+    }
 
     #[test]
     fn zstd_checkpoint_analysis_returns_typed_history_limit_error() {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -970,15 +970,11 @@ fn analyze_decoded_session_history_reader(
             break;
         }
 
-        raw_size = raw_size.checked_add(bytes_read as u64).ok_or_else(|| {
-            AgentError::Checkpoint(format!(
-                "Session history exceeds maximum size of {max_bytes} bytes"
-            ))
-        })?;
+        raw_size = raw_size
+            .checked_add(bytes_read as u64)
+            .ok_or(AgentError::CheckpointHistoryTooLarge { max_bytes })?;
         if raw_size > max_bytes {
-            return Err(AgentError::Checkpoint(format!(
-                "Session history exceeds maximum size of {max_bytes} bytes"
-            )));
+            return Err(AgentError::CheckpointHistoryTooLarge { max_bytes });
         }
         hasher.update(&line);
         if line.iter().any(|byte| !byte.is_ascii_whitespace()) {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -970,11 +970,13 @@ fn analyze_decoded_session_history_reader(
             break;
         }
 
-        raw_size = raw_size
-            .checked_add(bytes_read as u64)
-            .ok_or(AgentError::CheckpointHistoryTooLarge { max_bytes })?;
+        raw_size = raw_size.checked_add(bytes_read as u64).ok_or(
+            session_history::session_history_exceeds_max_error(max_bytes),
+        )?;
         if raw_size > max_bytes {
-            return Err(AgentError::CheckpointHistoryTooLarge { max_bytes });
+            return Err(session_history::session_history_exceeds_max_error(
+                max_bytes,
+            ));
         }
         hasher.update(&line);
         if line.iter().any(|byte| !byte.is_ascii_whitespace()) {
@@ -1271,6 +1273,19 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
 
     const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn zstd_checkpoint_analysis_returns_typed_history_limit_error() {
+        let encoded = zstd_session_history(b"{}\n").unwrap();
+        let error = match analyze_zstd_session_history(&encoded, 1, false) {
+            Ok(_) => panic!("expected zstd history to exceed the decoded limit"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            AgentError::CheckpointHistoryTooLarge { max_bytes: 1 }
+        ));
+    }
 
     async fn start_artifact_checkpoint_test_server(
         artifact_count: usize,

--- a/crates/guest-agent/src/error.rs
+++ b/crates/guest-agent/src/error.rs
@@ -33,6 +33,10 @@ pub enum AgentError {
     #[error("checkpoint: {0}")]
     Checkpoint(String),
 
+    /// Session history exceeded the checkpoint size limit.
+    #[error("checkpoint: Session history exceeds maximum size of {max_bytes} bytes")]
+    CheckpointHistoryTooLarge { max_bytes: u64 },
+
     /// Telemetry flush channel is unavailable because the uploader task was not
     /// initialized, has exited, or dropped the per-flush response channel.
     #[error("telemetry uploader unavailable")]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -6,6 +6,7 @@ use guest_agent::cli;
 use guest_agent::complete;
 use guest_agent::control;
 use guest_agent::env;
+use guest_agent::error::AgentError;
 use guest_agent::failure_diagnostics;
 use guest_agent::heartbeat;
 use guest_agent::http::HttpClient;
@@ -34,11 +35,9 @@ use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-fn checkpoint_failure_reason(error: &str) -> Option<FailureReason> {
-    let error = error.to_ascii_lowercase();
-    (error.contains("session history")
-        && (error.contains("exceeds maximum size") || error.contains("is too large")))
-    .then_some(FailureReason::SessionHistoryLimit)
+fn checkpoint_failure_reason(error: &AgentError) -> Option<FailureReason> {
+    matches!(error, AgentError::CheckpointHistoryTooLarge { .. })
+        .then_some(FailureReason::SessionHistoryLimit)
 }
 
 #[tokio::main]
@@ -672,8 +671,7 @@ async fn complete_execution(
                         FailureClass::CheckpointFailed,
                     )
                     .with_cli_exit_code(cli_exit_code);
-                    let error = e.to_string();
-                    if let Some(reason) = checkpoint_failure_reason(&error) {
+                    if let Some(reason) = checkpoint_failure_reason(&e) {
                         diagnostic = diagnostic.with_failure_reason(reason);
                     }
                     let diagnostic = diagnostic.with_session_history_status(
@@ -823,20 +821,21 @@ mod tests {
     #[test]
     fn checkpoint_history_limit_errors_have_a_stable_failure_reason() {
         assert_eq!(
-            checkpoint_failure_reason(
-                "session history is too large after decompression: 134217729 bytes"
-            ),
+            checkpoint_failure_reason(&AgentError::CheckpointHistoryTooLarge { max_bytes: 1 }),
             Some(FailureReason::SessionHistoryLimit)
         );
         assert_eq!(
-            checkpoint_failure_reason("session history exceeds maximum size of 134217728 bytes"),
-            Some(FailureReason::SessionHistoryLimit)
+            checkpoint_failure_reason(&AgentError::Checkpoint(
+                "Session history exceeds maximum size of 134217728 bytes".to_string(),
+            )),
+            None
         );
         assert_eq!(
-            checkpoint_failure_reason("Session history exceeds maximum size of 134217728 bytes"),
-            Some(FailureReason::SessionHistoryLimit)
+            checkpoint_failure_reason(&AgentError::Checkpoint(
+                "artifact upload failed".to_string()
+            )),
+            None
         );
-        assert_eq!(checkpoint_failure_reason("artifact upload failed"), None);
     }
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
     static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -19,7 +19,9 @@ use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
-use guest_contracts::diagnostics::{CliTerminationReason, FailureClass, FailureDiagnostic};
+use guest_contracts::diagnostics::{
+    CliTerminationReason, FailureClass, FailureDiagnostic, FailureReason,
+};
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
@@ -31,6 +33,12 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+
+fn checkpoint_failure_reason(error: &str) -> Option<FailureReason> {
+    (error.contains("session history")
+        && (error.contains("exceeds maximum size") || error.contains("is too large")))
+    .then_some(FailureReason::SessionHistoryLimit)
+}
 
 #[tokio::main]
 async fn main() {
@@ -658,12 +666,16 @@ async fn complete_execution(
                     &msg,
                 );
                 if !wrote_failure_diagnostic {
-                    let diagnostic = failure_diagnostics::base_failure_diagnostic_for_config(
+                    let mut diagnostic = failure_diagnostics::base_failure_diagnostic_for_config(
                         config,
                         FailureClass::CheckpointFailed,
                     )
-                    .with_cli_exit_code(cli_exit_code)
-                    .with_session_history_status(
+                    .with_cli_exit_code(cli_exit_code);
+                    let error = e.to_string();
+                    if let Some(reason) = checkpoint_failure_reason(&error) {
+                        diagnostic = diagnostic.with_failure_reason(reason);
+                    }
+                    let diagnostic = diagnostic.with_session_history_status(
                         failure_diagnostics::diagnostic_session_history_status_for_config(
                             config,
                             runtime_paths,
@@ -806,6 +818,21 @@ mod tests {
     use std::sync::LazyLock;
 
     static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn checkpoint_history_limit_errors_have_a_stable_failure_reason() {
+        assert_eq!(
+            checkpoint_failure_reason(
+                "session history is too large after decompression: 134217729 bytes"
+            ),
+            Some(FailureReason::SessionHistoryLimit)
+        );
+        assert_eq!(
+            checkpoint_failure_reason("session history exceeds maximum size of 134217728 bytes"),
+            Some(FailureReason::SessionHistoryLimit)
+        );
+        assert_eq!(checkpoint_failure_reason("artifact upload failed"), None);
+    }
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
     static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
         let timestamp_nanos = std::time::SystemTime::now()

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -35,6 +35,7 @@ use tokio_util::sync::CancellationToken;
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 fn checkpoint_failure_reason(error: &str) -> Option<FailureReason> {
+    let error = error.to_ascii_lowercase();
     (error.contains("session history")
         && (error.contains("exceeds maximum size") || error.contains("is too large")))
     .then_some(FailureReason::SessionHistoryLimit)
@@ -829,6 +830,10 @@ mod tests {
         );
         assert_eq!(
             checkpoint_failure_reason("session history exceeds maximum size of 134217728 bytes"),
+            Some(FailureReason::SessionHistoryLimit)
+        );
+        assert_eq!(
+            checkpoint_failure_reason("Session history exceeds maximum size of 134217728 bytes"),
             Some(FailureReason::SessionHistoryLimit)
         );
         assert_eq!(checkpoint_failure_reason("artifact upload failed"), None);

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -109,7 +109,7 @@ pub(crate) fn read_session_history_from_payload_bounded(
     read_session_history_from_payload_impl(payload, Some(max_bytes))
 }
 
-fn session_history_exceeds_max_error(max_bytes: u64) -> AgentError {
+pub(crate) fn session_history_exceeds_max_error(max_bytes: u64) -> AgentError {
     AgentError::CheckpointHistoryTooLarge { max_bytes }
 }
 
@@ -894,13 +894,12 @@ mod tests {
     }
 
     fn assert_over_limit(error: AgentError, max_bytes: u64) {
-        let message = error.to_string();
-        assert!(
-            message.contains(&format!(
-                "Session history exceeds maximum size of {max_bytes} bytes"
-            )),
-            "expected over-limit error for cap {max_bytes}, got: {message}"
-        );
+        match error {
+            AgentError::CheckpointHistoryTooLarge {
+                max_bytes: actual_max_bytes,
+            } => assert_eq!(actual_max_bytes, max_bytes),
+            other => panic!("expected typed over-limit error, got: {other}"),
+        }
     }
 
     #[test]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -110,9 +110,7 @@ pub(crate) fn read_session_history_from_payload_bounded(
 }
 
 fn session_history_exceeds_max_error(max_bytes: u64) -> AgentError {
-    AgentError::Checkpoint(format!(
-        "Session history exceeds maximum size of {max_bytes} bytes"
-    ))
+    AgentError::CheckpointHistoryTooLarge { max_bytes }
 }
 
 pub(crate) struct SessionHistoryDigest {

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -961,6 +961,30 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_serializes_session_history_limit_reason() {
+        assert_eq!(
+            FailureReason::SessionHistoryLimit.as_str(),
+            "session_history_limit"
+        );
+
+        for framework in [AgentFramework::Codex, AgentFramework::ClaudeCode] {
+            let diagnostic = FailureDiagnostic::new(
+                FailureClass::CheckpointFailed,
+                framework,
+                PromptMetadata::from_prompt("continue"),
+            )
+            .with_cli_exit_code(0)
+            .with_failure_reason(FailureReason::SessionHistoryLimit);
+
+            let json = serde_json::to_value(&diagnostic).unwrap();
+            assert_eq!(json["failureReason"], "session_history_limit");
+
+            let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+            assert_eq!(round_trip, diagnostic);
+        }
+    }
+
+    #[test]
     fn failure_diagnostic_serializes_output_token_limit_reason() {
         assert_eq!(
             FailureReason::OutputTokenLimit.as_str(),

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -416,6 +416,8 @@ impl FailureClass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FailureReason {
+    /// The session history exceeded the checkpoint size limit.
+    SessionHistoryLimit,
     /// The provider account has insufficient credits.
     InsufficientCredits,
     /// The configured API key is invalid.
@@ -443,6 +445,7 @@ impl FailureReason {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::SessionHistoryLimit => "session_history_limit",
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",


### PR DESCRIPTION
## Summary

- add a stable `session_history_limit` failure reason for checkpoint failures caused by oversized session history
- classify decoded-history and retained Codex zstd size-limit errors through the typed `CheckpointHistoryTooLarge` error
- cover the shared Claude Code/Codex diagnostic serialization and both checkpoint input paths

## Scope

This PR only improves failure diagnostics. It keeps the 128 MiB limit and existing terminal failure behavior unchanged. Session reuse invalidation and completion semantics are intentionally left for follow-up work.

Runner and guest binaries ship in the same runner artifact, so the internal typed error and diagnostic enum are deployed together.

## Validation

- `cargo fmt --all`
- `cargo test -p guest-contracts --lib`
- `cargo test -p guest-agent --lib`
- `cargo test -p guest-agent --bin guest-agent`
- pre-commit Rust formatting, documentation, and Clippy checks

Related: #23004
