### PR TITLE
test(sandbox-fc): make idle pool lock fixture deterministic

### DIFF
--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1843,16 +1843,21 @@ touch "{}"
         let dir = tempfile::tempdir().unwrap();
         let locks = LockPaths::with_dir(dir.path().to_path_buf());
 
-        let (i0, hold0) = acquire_pool_lock(&locks).unwrap();
-        let (i1, _hold1) = acquire_pool_lock(&locks).unwrap();
-        assert_eq!(i0, 0);
-        assert_eq!(i1, 1);
+        let held_idx = 0;
+        let held = Flock::lock(
+            File::create(locks.netns_pool(held_idx)).unwrap(),
+            FlockArg::LockExclusiveNonblock,
+        )
+        .unwrap();
 
-        // Drop lock 0 → index 0 becomes available again.
-        drop(hold0);
+        let (available_idx, _available) = acquire_pool_lock(&locks).unwrap();
+        assert_eq!(available_idx, 1);
 
-        let (reused, _hold) = acquire_pool_lock(&locks).unwrap();
-        assert_eq!(reused, 0);
+        // Flock's explicit LOCK_UN makes release deterministic across forks.
+        drop(held);
+
+        let (reused_idx, _reused) = acquire_pool_lock(&locks).unwrap();
+        assert_eq!(reused_idx, held_idx);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -1877,10 +1877,10 @@ touch "{}"
         let dir = tempfile::tempdir().unwrap();
         let locks = LockPaths::with_dir(dir.path().to_path_buf());
 
-        // Create the lock file by acquiring then releasing — simulates a
-        // prior runner that exited.
-        let (idx, held) = acquire_pool_lock(&locks).unwrap();
-        drop(held);
+        let idx = 0;
+        // Construct the idle state directly. A close-only PoolIndexLock can be
+        // briefly retained by an unrelated concurrent fork.
+        File::create(locks.netns_pool(idx)).unwrap();
 
         let claimed = try_claim_idle_pool_lock(&locks, idx);
         assert!(claimed.is_some());


### PR DESCRIPTION
## Summary

- construct the idle pool-lock fixture as an existing unlocked file
- give the allocator reuse fixture an explicit, deterministic unlock boundary
- remove both tests' dependency on final-close timing across concurrent
  fork/exec
- preserve the close-only production lock semantics required by #22694

## Root cause

`PoolIndexLock` intentionally releases its Linux `flock` only when the final
descriptor for the open file description closes. During the parallel
`sandbox-fc` suite, an unrelated child-process fork can briefly inherit that
descriptor.

Two inline tests previously dropped a close-only guard and immediately expected
the index to be available:

- `try_claim_idle_pool_lock_returns_some_when_idle`
- `acquire_pool_lock_reuses_released_index`

The first now creates its existing unlocked file directly. The second uses nix
`Flock<File>` as an external holder: it verifies the allocator skips the held
index, then relies on nix's explicit `LOCK_UN` drop before verifying reuse.
Neither fixture now depends on when unrelated children exec.

## Scope

This is test-only. It does not change `PoolIndexLock`, pool allocation,
reconciliation, runner behavior, timeouts, APIs, protocols, or persisted data.
The real-host behavior test from #22694 remains the authoritative coverage for
close-only duplicated-descriptor retention.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc network::pool::host::tests::try_claim_idle_pool_lock -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc network::pool::host::tests::acquire_pool_lock_reuses_released_index -- --nocapture`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features`
- repository pre-commit Rust formatting, documentation, and Clippy hooks

Closes #23021
