### PR TITLE
fix(mitm-addon): capture structured json bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -29,6 +29,7 @@ _TEXT_APPLICATION_SUBTYPES = frozenset(
 )
 
 _HTTP_FIELD_NAME_PATTERN = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+# RFC 6838 section 4.2 limits registered media type names to 127 ASCII characters.
 _MEDIA_TYPE_NAME_PATTERN = re.compile(r"[0-9A-Za-z][!#$&+\-.^_0-9A-Za-z]{0,126}")
 _HTTP_KNOWN_CONTENT_CODING_PATTERN = r"(?:br|compress|deflate|gzip|identity|zstd)"
 _HTTP_OPTIONAL_WHITESPACE_PATTERN = r"[ \t]*"

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -16,16 +16,20 @@ from body_limits import BODY_CAPTURE_LIMIT
 
 _REDACTED_HEADER_VALUE = "***"
 
-_TEXT_CONTENT_TYPES = (
-    "text/",
-    "application/json",
-    "application/xml",
-    "application/javascript",
-    "application/x-www-form-urlencoded",
-    "application/graphql",
+_TEXT_APPLICATION_SUBTYPES = frozenset(
+    {
+        "graphql",
+        "javascript",
+        "json",
+        "json-seq",
+        "x-ndjson",
+        "x-www-form-urlencoded",
+        "xml",
+    }
 )
 
 _HTTP_FIELD_NAME_PATTERN = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+_MEDIA_TYPE_NAME_PATTERN = re.compile(r"[0-9A-Za-z][!#$&+\-.^_0-9A-Za-z]{0,126}")
 _HTTP_KNOWN_CONTENT_CODING_PATTERN = r"(?:br|compress|deflate|gzip|identity|zstd)"
 _HTTP_OPTIONAL_WHITESPACE_PATTERN = r"[ \t]*"
 _HTTP_ENCODING_PATTERN = (
@@ -95,8 +99,22 @@ def _is_text_content(content_type: str) -> bool:
     """Check if content-type indicates text-like content worth capturing."""
     if not content_type:
         return True  # assume text when unspecified
-    ct = content_type.lower().split(";")[0].strip()
-    return any(ct.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
+    media_type = content_type.partition(";")[0].strip()
+    type_name, separator, subtype_name = media_type.partition("/")
+    if (
+        separator != "/"
+        or _MEDIA_TYPE_NAME_PATTERN.fullmatch(type_name) is None
+        or _MEDIA_TYPE_NAME_PATTERN.fullmatch(subtype_name) is None
+    ):
+        return False
+
+    normalized_type = type_name.lower()
+    normalized_subtype = subtype_name.lower()
+    return (
+        normalized_type == "text"
+        or (normalized_type == "application" and normalized_subtype in _TEXT_APPLICATION_SUBTYPES)
+        or normalized_subtype.endswith("+json")
+    )
 
 
 def _encode_body(

--- a/crates/runner/mitm-addon/tests/test_body_capture_encoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_encoding.py
@@ -2,6 +2,8 @@
 
 import base64
 
+import pytest
+
 from body_capture import _encode_body, _is_text_content
 
 
@@ -33,12 +35,48 @@ class TestIsTextContent:
     def test_graphql(self):
         assert _is_text_content("application/graphql") is True
 
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "application/problem+json",
+            "application/vnd.api+json; charset=utf-8",
+            "Application/Problem+JSON; Charset=UTF-8",
+            "application/json-seq",
+            "application/x-ndjson",
+            "application/" + ("a" * 122) + "+json",
+        ],
+    )
+    def test_json_media_types(self, content_type):
+        assert _is_text_content(content_type) is True
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "application/jsonp",
+            "application/problem+jsonx",
+            "application/+json",
+            "application/*+json",
+            "application/problem~+json",
+            "application/problem +json",
+            "application/problem+json/extra",
+            "application/" + ("a" * 123) + "+json",
+        ],
+    )
+    def test_json_media_type_lookalikes(self, content_type):
+        assert _is_text_content(content_type) is False
+
 
 class TestEncodeBody:
     def test_utf8_text(self):
         body = b'{"key": "value"}'
         encoded, encoding = _encode_body(body, "application/json")
         assert encoded == '{"key": "value"}'
+        assert encoding == "utf-8"
+
+    def test_utf8_structured_json(self):
+        body = b'{"type": "https://example.com/problem"}'
+        encoded, encoding = _encode_body(body, "application/problem+json")
+        assert encoded == '{"type": "https://example.com/problem"}'
         assert encoding == "utf-8"
 
     def test_binary_content_type_returns_none(self):

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -39,6 +39,19 @@ class TestAddCaptureFields:
         assert entry["response_body"] == '{"result": "ok"}'
         assert entry["response_body_encoding"] == "utf-8"
 
+    def test_captures_structured_json_response_without_preserving_header_value(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_body=b'{"title": "Invalid request"}',
+            response_content_type="application/problem+json",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["response_body"] == '{"title": "Invalid request"}'
+        assert entry["response_body_encoding"] == "utf-8"
+        assert entry["response_headers"]["Content-Type"] == "***"
+
     def test_captures_request_headers(self, real_flow):
         flow = real_flow(
             method="POST",


### PR DESCRIPTION
## Summary

- replace broad network-body content-type prefixes with an RFC 6838
  registered-name boundary
- capture valid `+json`, `application/json-seq`, and
  `application/x-ndjson` bodies while rejecting malformed JSON lookalikes
- preserve the independent default-redact captured-header policy and prove the
  behavior through a real mitmproxy `HTTPFlow`

## Compatibility and scope

- reuses the existing optional network-log body and encoding fields
- keeps `captureNetworkBodies`, body limits, decompression, truncation, and
  invalid UTF-8/base64 behavior unchanged
- does not change schemas, persisted field shapes, APIs, queue payloads,
  runner protocols, feature switches, migrations, or header allowlists
- old and new runners remain compatible during deployment overlap

## Validation

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_capture_encoding.py tests/test_body_capture_fields.py tests/test_body_capture_headers.py`
- `uv run --no-sync python -m pytest -q tests/` (`4226 passed`)

Closes #22998
