### PR TITLE
fix: bind managed browser stop retry to the correct test session

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -281,7 +281,7 @@ describe("zero browser route", () => {
           });
           providerStops += 1;
           const providerId = String(params.id);
-          if (providerId === providerIds[0]) {
+          if (providerId === firstThreadProviderId) {
             if (!firstStopStarted.settled()) {
               firstStopStarted.resolve(undefined);
             }
@@ -295,7 +295,7 @@ describe("zero browser route", () => {
             }
           }
           return HttpResponse.json(
-            providerId === providerIds[0]
+            providerId === firstThreadProviderId
               ? providerBrowser(providerId, {
                   status: "stopped",
                   browserCost: "0.00333",
@@ -334,6 +334,10 @@ describe("zero browser route", () => {
       accept(firstCreateRequest, [201]),
       accept(otherCreateRequest, [201]),
     ]);
+    const firstThreadProviderId = z
+      .string()
+      .uuid()
+      .parse(new URL(created.body.cdpUrl).hostname.split(".")[0]);
     expect(created.body.browser).toMatchObject({
       name: "booking",
       status: "active",


### PR DESCRIPTION
## Summary

- bind the injected Browser Use stop failure to the provider ID returned for the first chat thread
- remove the assumption that the first of two concurrent provider requests always belongs to the first thread
- preserve the intended 503-to-reconciler coverage regardless of request arrival order

## Root cause

[Turbo run 30150305424](https://github.com/vm0-ai/vm0/actions/runs/30150305424) failed on main at `6b074ebc62a6c1bba9c0c99c4f672b13f5633655` because `zero-browser.test.ts` timed out after 120 seconds.

The test starts browser creation for two threads concurrently, while the mock assigned provider IDs by request arrival order. It then treated `providerIds[0]` as the first thread browser. When the other thread reached the provider first, the injected 503 and `firstStopStarted` signal were attached to the wrong browser. Completing the first run stopped its actual browser successfully, so the test waited forever for a signal that could no longer occur.

Successful runs contained the expected `Managed browser finalization deferred to reconciler` warning; both observed timeout runs stopped after the completion webhook log without that warning, matching the reversed-arrival path.

## Verification

- target test passed 6 consecutive times against fresh UTC PostgreSQL databases
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/zero-browser.test.ts`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `git diff --check`