### PR TITLE
test(mitm-addon): cover registry read size bounds

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -1,7 +1,11 @@
 """Tests for built-in registry catalog payload and trust validation."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
+import builtin_firewall_cache
 import registry
 from tests.registry_builtin_helpers import cache_firewall, write_catalog_cache
 from tests.registry_helpers import (
@@ -60,6 +64,83 @@ def _assert_cache_firewall_is_invalid(
 
 
 class TestRegistryBuiltinCatalogValidation:
+    def test_runner_catalog_cache_accepts_exact_size_limit(self, tmp_path):
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"fallback": cache_firewall("fallback", "https://cache.example.com")},
+        )
+        exact_size = cache_path.stat().st_size
+
+        with patch.object(
+            builtin_firewall_cache,
+            "MAX_BUILTIN_FIREWALL_CATALOG_BYTES",
+            exact_size,
+        ):
+            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.catalog is not None
+        assert snapshot.catalog.firewalls["fallback"]["name"] == "fallback"
+        assert snapshot.unavailable_reason is None
+
+    def test_runner_catalog_cache_rejects_initial_oversize_before_parsing(self, tmp_path, mitm_ctx):
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"fallback": cache_firewall("fallback", "https://cache.example.com")},
+        )
+        actual_size = cache_path.stat().st_size
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                builtin_firewall_cache,
+                "MAX_BUILTIN_FIREWALL_CATALOG_BYTES",
+                actual_size - 1,
+            ),
+            patch.object(
+                builtin_firewall_cache.json,
+                "loads",
+                wraps=builtin_firewall_cache.json.loads,
+            ) as spy,
+        ):
+            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.dependency_file_key is not None
+        assert snapshot.dependency_file_key.st_size == actual_size
+        assert snapshot.catalog is None
+        assert snapshot.unavailable_reason == "cache_invalid"
+        assert spy.call_count == 0
+
+    def test_runner_catalog_cache_rejects_underreported_size_before_parsing(self, mitm_ctx):
+        cache_path = Path("/proc/self/status")
+        assert cache_path.stat().st_size == 0
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                builtin_firewall_cache,
+                "MAX_BUILTIN_FIREWALL_CATALOG_BYTES",
+                1,
+            ),
+            patch.object(
+                builtin_firewall_cache.json,
+                "loads",
+                wraps=builtin_firewall_cache.json.loads,
+            ) as spy,
+        ):
+            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.dependency_file_key is not None
+        assert snapshot.dependency_file_key.st_size == 0
+        assert snapshot.catalog is None
+        assert snapshot.unavailable_reason == "cache_invalid"
+        assert spy.call_count == 0
+
     def test_runner_catalog_cache_accepts_valid_template_base(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -3,6 +3,7 @@
 import json
 import os
 import queue
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,15 @@ class TestLoadRegistry:
 
         assert "10.200.0.1" in result
         assert result["10.200.0.1"]["runId"] == "run-abc-123"
+
+    def test_loads_valid_registry_at_exact_size_limit(self, registry_file):
+        exact_size = registry_file.stat().st_size
+
+        with patch.object(registry, "MAX_REGISTRY_BYTES", exact_size):
+            state = registry.load_registry_state(str(registry_file))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert state.vms["10.200.0.1"]["runId"] == "run-abc-123"
 
     def test_classifies_invalid_registered_vm_entries(self, tmp_path):
         path = tmp_path / "registry.json"
@@ -262,10 +272,12 @@ class TestLoadRegistry:
 
     def test_oversized_registry_is_unavailable_before_parsing(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_bytes(b" " * (registry.MAX_REGISTRY_BYTES + 1))
+        max_registry_bytes = 5
+        path.write_bytes(b" " * (max_registry_bytes + 1))
         log = MagicMock()
         with (
             patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry, "MAX_REGISTRY_BYTES", max_registry_bytes),
             patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
         ):
             state = registry.load_registry_state(str(path))
@@ -275,6 +287,22 @@ class TestLoadRegistry:
         assert spy.call_count == 0
         assert log.warn.call_count == 1
         assert "exceeds" in log.warn.call_args_list[0].args[0]
+
+    def test_underreported_registry_is_unavailable_before_parsing(self):
+        path = Path("/proc/self/status")
+        assert path.stat().st_size == 0
+        log = MagicMock()
+
+        with (
+            patch.object(registry.ctx, "log", log, create=True),
+            patch.object(registry, "MAX_REGISTRY_BYTES", 1),
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as spy,
+        ):
+            state = registry.load_registry_state(str(path))
+
+        assert isinstance(state, registry.RegistryUnavailable)
+        assert state.reason == "read_failed"
+        assert spy.call_count == 0
 
     def test_parse_failure_logs_once_and_does_not_reparse(self, tmp_path):
         """Parse failure on a fixed file: key match short-circuits re-parse."""


### PR DESCRIPTION
## Summary

- cover exact byte-limit acceptance for the built-in firewall catalog and proxy registry readers
- cover real underreported-size descriptors through public loaders and verify rejection occurs
  before JSON decoding
- keep the existing proxy-registry initial-oversize assertion while replacing its 16 MiB fixture
  with an equivalent patched small limit

## Exclusions

- no production code, runtime limit, schema, protocol, or deployment behavior changes
- no private reader tests or mocked filesystem reads

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_registry_builtin_catalog_validation.py tests/test_registry_loading.py` (53 passed)
- `uv run --no-sync python -m pytest tests/` (4,227 passed)
- `git diff --check`

Closes #22999
