### PR TITLE
fix(workflows): claim queued events atomically with run creation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -478,12 +478,22 @@ describe("workflow queue API", () => {
       }),
       [200],
     );
-    expect(queue.body.running).toBeNull();
+    expect(queue.body.running).toMatchObject({
+      runId: expect.any(String),
+    });
     expect(
       queue.body.pending.map((event) => {
         return event.automationId;
       }),
     ).toStrictEqual([automation.automationId]);
+    const messages = await wf.readThreadMessages(automation.threadId);
+    const claimedUserMessage = messages.find((message) => {
+      return (
+        message.content === "queued user message before manual Run now" &&
+        typeof message.runId === "string"
+      );
+    });
+    expect(claimedUserMessage?.runId).toBe(queue.body.running?.runId);
 
     await flushWaitUntilForTest();
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -7,6 +7,8 @@ import {
   type GenerateDataKeyCommandOutput,
 } from "@aws-sdk/client-kms";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { onTestFinished } from "vitest";
 
@@ -27,7 +29,10 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { holdOrgAdmissionLockFixture } from "../../../test-fixtures/chat-messages";
+import {
+  holdOrgAdmissionLockFixture,
+  rewriteWorkflowQueueEventAsPreviousVersionFixture,
+} from "../../../test-fixtures/chat-messages";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -106,6 +111,14 @@ function automationsClient() {
 
 function chatMessagesClient() {
   return setupApp({ context })(chatMessagesContract);
+}
+
+function queueClient() {
+  return setupApp({ context })(zeroWorkflowQueueContract);
+}
+
+function modelProvidersByTypeClient() {
+  return setupApp({ context })(zeroModelProvidersByTypeContract);
 }
 
 interface Scenario {
@@ -513,6 +526,176 @@ describe("workflow queue", () => {
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
+  });
+
+  it("keeps a failed webhook event accepted without duplicating its retained queue item", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    mockNow(Date.UTC(2026, 6, 25, 12));
+    await accept(
+      modelProvidersByTypeClient().delete({
+        headers: authHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "retained launch failure"),
+    );
+    await expect(
+      postWorkflowWebhook(automation, "retained launch failure"),
+    ).resolves.toStrictEqual({
+      status: 200,
+      body: { success: true, duplicate: true },
+    });
+
+    const paused = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(paused.body.running).toBeNull();
+    expect(paused.body.pausedAt).not.toBeNull();
+    expect(paused.body.pauseReason).not.toBeNull();
+    expect(
+      paused.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([automation.automationId]);
+
+    await runsApi.ensureOrgModelProvider(scenario.actor);
+    const resumed = await accept(
+      queueClient().resume({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(resumed.body.pausedAt).toBeNull();
+    expect(resumed.body.pending).toHaveLength(0);
+    const running = resumed.body.running;
+    if (!running) {
+      throw new Error("Expected the retained event to resume");
+    }
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      running.runId,
+    ]);
+  });
+
+  it("does not re-arm a schedule whose failed launch remains queued", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: { schedule: { type: "loop", intervalSeconds: 3600 } },
+      }),
+      [201],
+    );
+    if (!created.body.chatThreadId || !created.body.nextRunAt) {
+      throw new Error("Expected a thread-bound loop automation");
+    }
+    await accept(
+      modelProvidersByTypeClient().delete({
+        headers: authHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+
+    mockNow(Date.parse(created.body.nextRunAt) + 60_000);
+    await executeDueWorkflowAutomations();
+    await executeDueWorkflowAutomations();
+
+    const automation = await wf.readAutomation(created.body.id);
+    expect(automation.nextRunAt).toBeNull();
+    const paused = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: created.body.chatThreadId },
+      }),
+      [200],
+    );
+    expect(paused.body.running).toBeNull();
+    expect(paused.body.pausedAt).not.toBeNull();
+    expect(
+      paused.body.pending.map((event) => {
+        return event.automationId;
+      }),
+    ).toStrictEqual([created.body.id]);
+
+    await runsApi.ensureOrgModelProvider(scenario.actor);
+    const resumed = await accept(
+      queueClient().resume({
+        headers: authHeaders(),
+        params: { threadId: created.body.chatThreadId },
+      }),
+      [200],
+    );
+    expect(resumed.body.pending).toHaveLength(0);
+    expect(resumed.body.running?.runId).toStrictEqual(expect.any(String));
+  });
+
+  it("drains a previous-version queued one-time event during rollout", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const webhookAutomation = await createWebhookAutomation(scenario);
+    const busyRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(webhookAutomation, "busy"),
+    );
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          schedule: {
+            type: "once",
+            atTime: new Date(now() + 90_000).toISOString(),
+            timezone: "UTC",
+          },
+        },
+      }),
+      [201],
+    );
+    if (!created.body.chatThreadId || !created.body.nextRunAt) {
+      throw new Error("Expected a thread-bound one-time automation");
+    }
+    expect(created.body.chatThreadId).toBe(webhookAutomation.threadId);
+
+    mockNow(Date.parse(created.body.nextRunAt) + 60_000);
+    await executeDueWorkflowAutomations();
+    const claimed = await wf.readAutomation(created.body.id);
+    expect(claimed.enabled).toBeTruthy();
+    expect(claimed.nextRunAt).toBeNull();
+
+    const queued = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: created.body.chatThreadId },
+      }),
+      [200],
+    );
+    const previousEvent = queued.body.pending.find((event) => {
+      return event.automationId === created.body.id;
+    });
+    if (!previousEvent) {
+      throw new Error("Expected the claimed one-time event to remain queued");
+    }
+    await rewriteWorkflowQueueEventAsPreviousVersionFixture({
+      eventId: previousEvent.id,
+      automationId: created.body.id,
+    });
+
+    await completeRunThroughSandbox(scenario, busyRunId);
+    const runIds = await workflowRunIds(created.body.chatThreadId);
+    expect(runIds).toHaveLength(2);
+    const drained = await wf.readAutomation(created.body.id);
+    expect(drained.enabled).toBeFalsy();
+    expect(drained.nextRunAt).toBeNull();
   });
 
   it("drains queued user chat messages before workflow events", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -27,6 +27,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { holdOrgAdmissionLockFixture } from "../../../test-fixtures/chat-messages";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -287,19 +288,19 @@ describe("workflow queue", () => {
 
     const first = await postWorkflowWebhook(automation, "first");
     const firstRunId = expectAcceptedRunId(first);
-    // Runner execution secrets still use one data key; callback persistence no
-    // longer adds a second key for the internal workflow callback.
-    expect(kms.generateDataKeyCalls).toBe(1);
+    // Every workflow event is encrypted before admission; the launched run
+    // then uses a second data key for runner execution secrets.
+    expect(kms.generateDataKeyCalls).toBe(2);
 
     // The workflow is busy: the next two events are accepted into the queue
     // without creating runs.
     const secondApiStartTime = now() + 60_000;
     mockNow(secondApiStartTime);
     expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "second"));
-    expect(kms.generateDataKeyCalls).toBe(2);
+    expect(kms.generateDataKeyCalls).toBe(3);
     mockNow(secondApiStartTime + 1000);
     expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "third"));
-    expect(kms.generateDataKeyCalls).toBe(3);
+    expect(kms.generateDataKeyCalls).toBe(4);
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
@@ -346,12 +347,12 @@ describe("workflow queue", () => {
     const busyRunId = expectAcceptedRunId(
       await postWorkflowWebhook(webhookAutomation, "busy"),
     );
-    expect(kms.generateDataKeyCalls).toBe(1);
+    expect(kms.generateDataKeyCalls).toBe(2);
 
     // Two due ticks while busy: the second coalesces into the pending one.
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
     await executeDueWorkflowAutomations();
-    expect(kms.generateDataKeyCalls).toBe(2);
+    expect(kms.generateDataKeyCalls).toBe(3);
     const updated = await accept(
       automationsClient().update({
         headers: authHeaders(),
@@ -469,7 +470,7 @@ describe("workflow queue", () => {
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
   });
 
-  it("starts directly when failed queue encryption becomes unnecessary", async () => {
+  it("requires queue persistence even when encryption finishes after the thread becomes idle", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const firstRunId = expectAcceptedRunId(
@@ -504,17 +505,13 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, firstRunId);
     releaseKms.resolve(undefined);
 
-    const secondRunId = expectAcceptedRunId(await secondRequest);
-    expect(kms.generateDataKeyCalls).toBe(2);
+    await expect(secondRequest).resolves.toStrictEqual({
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+    expect(kms.generateDataKeyCalls).toBe(1);
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
-      secondRunId,
-    ]);
-
-    await completeRunThroughSandbox(scenario, secondRunId);
-    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
-      firstRunId,
-      secondRunId,
     ]);
   });
 
@@ -570,5 +567,64 @@ describe("workflow queue", () => {
     // The workflow event drains only after the user's run finishes.
     await completeRunThroughSandbox(scenario, userMessage.runId);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
+  });
+
+  it("keeps the workflow event queued when a user message wins final admission", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    chatCallbacks.mockChatOutputEvents([
+      {
+        eventType: "assistant",
+        sequenceNumber: 0,
+        eventData: { message: { content: [{ type: "text", text: "done" }] } },
+      },
+    ]);
+    chatCallbacks.acceptChatObjectStorage();
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowRequest = postWorkflowWebhook(automation, "workflow first");
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+
+    const userRequest = chatMessagesClient().send({
+      headers: authHeaders(),
+      body: {
+        agentId: scenario.agentId,
+        threadId: automation.threadId,
+        prompt: "user wins final admission",
+      },
+    });
+    await expect
+      .poll(async () => {
+        const messages = await wf.readThreadMessages(automation.threadId);
+        return messages.some((message) => {
+          return message.content === "user wins final admission";
+        });
+      })
+      .toBe(true);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+
+    admissionLock.release();
+    const [workflowResult, userResult] = await Promise.all([
+      workflowRequest,
+      accept(userRequest, [201]),
+    ]);
+    await admissionLock.done;
+
+    expectAcceptedWithoutRun(workflowResult);
+    if (!userResult.body.runId) {
+      throw new Error("Expected the user message to win final admission");
+    }
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
+
+    await completeRunThroughSandbox(scenario, userResult.body.runId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(1);
   });
 });

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -3168,6 +3168,7 @@ const createNormalChatRun$ = command(
           {
             ...createRunArgs,
             queueFirstAssociation: {
+              kind: "user_message",
               threadId: prepared.thread.threadId,
               messageId: queueFirstMessageId,
             },

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -149,8 +149,8 @@ const dispatchInternalCallback$ = command(
           handleChatInternalCallback$,
           {
             callback: input.envelope,
-            drainThreadQueue: (chatThreadId, inputSignal, timing) => {
-              return set(
+            drainThreadQueue: async (chatThreadId, inputSignal, timing) => {
+              await set(
                 drainChatThreadQueueForThread$,
                 {
                   chatThreadId,

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -152,14 +152,14 @@ async function pendingTickExistsForAutomation(
   return tick !== undefined;
 }
 
-export type WorkflowQueueAdmission =
+type WorkflowQueueAdmission =
   | { readonly kind: "inserted"; readonly eventId: string }
   | { readonly kind: "coalesced" };
 type WorkflowQueueAdmissionAttempt =
   | WorkflowQueueAdmission
   | { readonly kind: "payload-required" };
 
-export interface WorkflowQueueAdmissionArgs {
+interface WorkflowQueueAdmissionArgs {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
   readonly chatThreadId: string;
   readonly triggerSource: TriggerSource;

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -21,12 +21,16 @@ import {
   type InternalRunCallbackKind,
 } from "./internal-run-callback";
 import { browserCleanupRequiredForChatThread } from "./zero-chat-active-run.service";
-import { hasUnclaimedQueuedUserMessage } from "./zero-chat-queued-message.service";
+import {
+  hasUnclaimedQueuedUserMessage,
+  lockUserMessageQueueThread,
+} from "./zero-chat-queued-message.service";
 
 const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
 
 const workflowQueueEventParamsWireSchema = z.object({
   version: z.literal(1),
+  sessionId: z.string().optional(),
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
   callbacks: z
@@ -40,6 +44,8 @@ const workflowQueueEventParamsWireSchema = z.object({
     .optional(),
   recordLastRunId: z.boolean().optional(),
   recordLastRunAt: z.boolean().optional(),
+  activePreviousRunPolicy: z.enum(["block", "allow"]).optional(),
+  allowClaimedOnceScheduleAutomation: z.boolean().optional(),
 });
 
 /**
@@ -48,8 +54,9 @@ const workflowQueueEventParamsWireSchema = z.object({
  * itself (default prompt, default callbacks) stay undefined and are rebuilt
  * at dequeue time.
  */
-interface WorkflowQueueEventParams {
+export interface WorkflowQueueEventParams {
   readonly version: 1;
+  readonly sessionId?: string;
   readonly prompt?: string;
   readonly appendSystemPrompt?: string;
   readonly callbacks?: readonly {
@@ -59,6 +66,8 @@ interface WorkflowQueueEventParams {
   }[];
   readonly recordLastRunId?: boolean;
   readonly recordLastRunAt?: boolean;
+  readonly activePreviousRunPolicy?: "block" | "allow";
+  readonly allowClaimedOnceScheduleAutomation?: boolean;
 }
 
 async function encryptWorkflowQueueEventParams(
@@ -131,23 +140,6 @@ async function activeRunExistsForWorkflowThread(
   return await browserCleanupRequiredForChatThread(db, threadId);
 }
 
-async function pendingWorkflowEventExists(
-  db: Db,
-  chatThreadId: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ id: chatMessageQueue.id })
-    .from(chatMessageQueue)
-    .where(
-      and(
-        eq(chatMessageQueue.chatThreadId, chatThreadId),
-        eq(chatMessageQueue.itemType, "workflow_event"),
-      ),
-    )
-    .limit(1);
-  return row !== undefined;
-}
-
 async function pendingTickExistsForAutomation(
   db: Db,
   automationId: string,
@@ -160,13 +152,14 @@ async function pendingTickExistsForAutomation(
   return tick !== undefined;
 }
 
-type WorkflowQueueAdmission = "proceed" | "enqueued";
+export type WorkflowQueueAdmission =
+  | { readonly kind: "inserted"; readonly eventId: string }
+  | { readonly kind: "coalesced" };
 type WorkflowQueueAdmissionAttempt =
-  | { readonly kind: "proceed" }
-  | { readonly kind: "enqueued" }
+  | WorkflowQueueAdmission
   | { readonly kind: "payload-required" };
 
-interface WorkflowQueueAdmissionArgs {
+export interface WorkflowQueueAdmissionArgs {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
   readonly chatThreadId: string;
   readonly triggerSource: TriggerSource;
@@ -184,52 +177,42 @@ async function attemptWorkflowQueueAdmission(
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(args.chatThreadId));
 
-    const paused = await queuePausedForThread(tx, args.chatThreadId);
-
-    if (!paused) {
-      const busy = await activeRunExistsForWorkflowThread(
-        tx,
-        args.chatThreadId,
-      );
-      if (
-        !busy &&
-        !(await hasUnclaimedQueuedUserMessage(tx, args.chatThreadId)) &&
-        !(await pendingWorkflowEventExists(tx, args.chatThreadId))
-      ) {
-        return { kind: "proceed" };
-      }
-    }
-
     if (
       args.coalescePendingScheduleRun &&
       automation.kind === "schedule" &&
       (await pendingTickExistsForAutomation(tx, automation.id))
     ) {
-      return { kind: "enqueued" };
+      return { kind: "coalesced" };
     }
 
     if (encryptedParams === undefined) {
       return { kind: "payload-required" };
     }
 
-    await tx.insert(chatMessageQueue).values({
-      orgId: automation.orgId,
-      userId: automation.ownerUserId,
-      chatThreadId: args.chatThreadId,
-      itemType: "workflow_event",
-      automationId: automation.id,
-      triggerSource: args.triggerSource,
-      triggerBrief: args.triggerBrief ?? null,
-      encryptedParams,
-    });
-    return { kind: "enqueued" };
+    const [inserted] = await tx
+      .insert(chatMessageQueue)
+      .values({
+        orgId: automation.orgId,
+        userId: automation.ownerUserId,
+        chatThreadId: args.chatThreadId,
+        itemType: "workflow_event",
+        automationId: automation.id,
+        triggerSource: args.triggerSource,
+        triggerBrief: args.triggerBrief ?? null,
+        encryptedParams,
+      })
+      .returning({ id: chatMessageQueue.id });
+    if (!inserted) {
+      throw new Error("Workflow queue event insert returned no row");
+    }
+    return { kind: "inserted", eventId: inserted.id };
   });
 }
 
 /**
- * Decide whether a fired automation event may create its run now or must wait in
- * the chat message queue. Serialized per chat thread via an advisory lock.
- * Schedule ticks coalesce per automation: at most one pending tick.
+ * Persist every fired automation event before run preparation. Serialized per
+ * chat thread via an advisory lock. Schedule ticks coalesce per automation: at
+ * most one pending tick.
  * Queue payload encryption runs only after a locked attempt requires it and
  * outside the transaction; the subsequent locked attempt owns the final state.
  */
@@ -240,7 +223,7 @@ export async function admitWorkflowAutomationEvent(
   const { automation } = args;
   const initial = await attemptWorkflowQueueAdmission(db, args, undefined);
   if (initial.kind !== "payload-required") {
-    return initial.kind;
+    return initial;
   }
 
   const encryptedParamsResult = await settle(
@@ -256,7 +239,7 @@ export async function admitWorkflowAutomationEvent(
       undefined,
     );
     if (retryWithoutPayload.kind !== "payload-required") {
-      return retryWithoutPayload.kind;
+      return retryWithoutPayload;
     }
     throw encryptedParamsResult.error;
   }
@@ -269,10 +252,10 @@ export async function admitWorkflowAutomationEvent(
   if (final.kind === "payload-required") {
     throw new Error("Workflow queue admission still required encrypted params");
   }
-  return final.kind;
+  return final;
 }
 
-export interface ClaimedWorkflowQueueEvent {
+export interface PendingWorkflowQueueEvent {
   readonly id: string;
   readonly orgId: string;
   readonly userId: string;
@@ -285,16 +268,15 @@ export interface ClaimedWorkflowQueueEvent {
 }
 
 /**
- * Pop the oldest pending workflow event for the thread's queue, or return
+ * Load the oldest pending workflow event for the thread's queue, or return
  * null when the queue must not advance: paused, a queued user chat message
  * waiting (user messages always drain first), or an in-flight run.
- * The claimed row is deleted; a failed dequeue re-inserts it via
- * `restoreWorkflowQueueEventAndPause`.
+ * The row stays pending until the final run persistence transaction claims it.
  */
-export async function claimNextWorkflowQueueEvent(
+export async function loadNextWorkflowQueueEvent(
   db: Db,
   chatThreadId: string,
-): Promise<ClaimedWorkflowQueueEvent | null> {
+): Promise<PendingWorkflowQueueEvent | null> {
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(chatThreadId));
     if (await queuePausedForThread(tx, chatThreadId)) {
@@ -338,7 +320,6 @@ export async function claimNextWorkflowQueueEvent(
       );
     }
 
-    await tx.delete(chatMessageQueue).where(eq(chatMessageQueue.id, item.id));
     return {
       id: item.id,
       orgId: item.orgId,
@@ -372,42 +353,88 @@ async function setPauseState(
     .where(eq(chatThreads.id, chatThreadId));
 }
 
-/**
- * Put a claimed event back at its original queue position (id and createdAt
- * are preserved) and pause the queue so the failure does not burn through
- * the backlog. Used when run creation for a dequeued event fails.
- */
-export async function restoreWorkflowQueueEventAndPause(
+async function workflowQueueEventIsHead(
   db: Db,
   args: {
-    readonly event: ClaimedWorkflowQueueEvent;
+    readonly chatThreadId: string;
+    readonly eventId: string;
+  },
+): Promise<boolean> {
+  const [head] = await db
+    .select({ id: chatMessageQueue.id })
+    .from(chatMessageQueue)
+    .where(
+      and(
+        eq(chatMessageQueue.chatThreadId, args.chatThreadId),
+        eq(chatMessageQueue.itemType, "workflow_event"),
+      ),
+    )
+    .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))
+    .limit(1);
+  return head?.id === args.eventId;
+}
+
+/**
+ * Consume a stale workflow event only while it still owns the runnable queue
+ * head. This uses the same thread row lock as final queue-first run claims.
+ */
+export async function consumeWorkflowQueueEvent(
+  db: Db,
+  args: {
+    readonly chatThreadId: string;
+    readonly eventId: string;
+  },
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    if (!(await lockUserMessageQueueThread(tx, args.chatThreadId))) {
+      return false;
+    }
+    if (
+      (await queuePausedForThread(tx, args.chatThreadId)) ||
+      (await hasUnclaimedQueuedUserMessage(tx, args.chatThreadId)) ||
+      (await activeRunExistsForWorkflowThread(tx, args.chatThreadId)) ||
+      !(await workflowQueueEventIsHead(tx, args))
+    ) {
+      return false;
+    }
+    const deleted = await tx
+      .delete(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.id, args.eventId),
+          eq(chatMessageQueue.chatThreadId, args.chatThreadId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .returning({ id: chatMessageQueue.id });
+    return deleted.length === 1;
+  });
+}
+
+/**
+ * Pause a workflow queue after a run-creation error while preserving the
+ * pending event in place.
+ */
+export async function pauseWorkflowQueueEventAfterRunFailure(
+  db: Db,
+  args: {
+    readonly chatThreadId: string;
+    readonly eventId: string;
     readonly pauseReason: string;
     readonly pausedAt: Date;
   },
 ): Promise<void> {
-  const { event } = args;
   await db.transaction(async (tx) => {
-    await tx.execute(chatMessageQueueLock(event.chatThreadId));
-
-    await tx
-      .insert(chatMessageQueue)
-      .values({
-        id: event.id,
-        orgId: event.orgId,
-        userId: event.userId,
-        chatThreadId: event.chatThreadId,
-        itemType: "workflow_event",
-        automationId: event.automationId,
-        triggerSource: event.triggerSource,
-        triggerBrief: event.triggerBrief,
-        encryptedParams: event.encryptedParams,
-        createdAt: event.createdAt,
-      })
-      .onConflictDoNothing();
+    if (!(await lockUserMessageQueueThread(tx, args.chatThreadId))) {
+      return;
+    }
+    if (!(await workflowQueueEventIsHead(tx, args))) {
+      return;
+    }
 
     await setPauseState(
       tx,
-      event.chatThreadId,
+      args.chatThreadId,
       { pausedAt: args.pausedAt, pauseReason: args.pauseReason },
       args.pausedAt,
     );
@@ -510,7 +537,7 @@ interface WorkflowQueueRunningRun {
   readonly createdAt: Date;
 }
 
-interface PendingWorkflowQueueEvent {
+interface PendingWorkflowQueueEventSummary {
   readonly id: string;
   readonly automationId: string;
   readonly triggerSource: string;
@@ -545,7 +572,7 @@ export async function loadRunningWorkflowThreadRun(
 export async function listPendingWorkflowQueueEvents(
   db: ReadonlyDb,
   thread: WorkflowQueueThreadRow,
-): Promise<readonly PendingWorkflowQueueEvent[]> {
+): Promise<readonly PendingWorkflowQueueEventSummary[]> {
   const rows = await db
     .select({
       id: chatMessageQueue.id,
@@ -561,7 +588,7 @@ export async function listPendingWorkflowQueueEvents(
         eq(chatMessageQueue.itemType, "workflow_event"),
       ),
     );
-  const events: PendingWorkflowQueueEvent[] = [];
+  const events: PendingWorkflowQueueEventSummary[] = [];
   for (const event of rows) {
     if (event.automationId !== null && event.triggerSource !== null) {
       events.push({

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -9,7 +9,11 @@ import {
   drainQueuedUserMessagesForThread$,
   type ChatCallbackPreCreateTimingCollector,
 } from "./internal-chat-run-callback.service";
-import { drainWorkflowQueueForThread$ } from "./zero-workflow-queue-drain.service";
+import {
+  drainWorkflowQueueForThread$,
+  type WorkflowQueueDrainResult,
+} from "./zero-workflow-queue-drain.service";
+import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
 
@@ -17,6 +21,11 @@ interface DrainChatThreadQueueInput {
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
+  readonly workflowEventLaunch?: {
+    readonly eventId: string;
+    readonly apiStartTime: number;
+    readonly timing: ApiDispatchTimingCollector;
+  };
 }
 
 /**
@@ -35,18 +44,21 @@ export const drainChatThreadQueueForThread$ = command(
     { set },
     input: DrainChatThreadQueueInput,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<WorkflowQueueDrainResult | null> => {
     await set(
       drainQueuedUserMessagesForThread$,
       { chatThreadId: input.chatThreadId, timing: input.timing },
       signal,
     );
     signal.throwIfAborted();
-    await set(
+    return await set(
       drainWorkflowQueueForThread$,
       {
         chatThreadId: input.chatThreadId,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        ...(input.workflowEventLaunch
+          ? { workflowEventLaunch: input.workflowEventLaunch }
+          : {}),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -591,6 +591,7 @@ function buildQueuedCreateZeroRunArgs(
     userInfoExtras: input.userInfoExtras,
     dispatchFailedCallbacks,
     queueFirstAssociation: {
+      kind: "user_message" as const,
       threadId: input.threadId,
       messageId: input.queuedMessage.id,
     },

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -17,6 +17,7 @@ import {
 import type { Db } from "../external/db";
 import {
   deleteChatMessage,
+  insertChatMessage,
   updateChatMessage,
 } from "./zero-chat-message.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
@@ -93,10 +94,19 @@ export interface QueuedUserMessage {
   readonly encryptedParams: string | null;
 }
 
-export interface QueueFirstRunAssociation {
-  readonly threadId: string;
-  readonly messageId: string;
-}
+export type QueueFirstRunAssociation =
+  | {
+      readonly kind: "user_message";
+      readonly threadId: string;
+      readonly messageId: string;
+    }
+  | {
+      readonly kind: "workflow_event";
+      readonly threadId: string;
+      readonly eventId: string;
+      readonly prompt: string;
+      readonly runGroupId: string;
+    };
 
 export type QueueFirstRunClaimResult =
   | { readonly kind: "claimed"; readonly createdAt: Date }
@@ -391,6 +401,67 @@ export async function claimQueueFirstRunAssociation(
       if (await chatThreadAdmissionBlocked(db, { threadId: args.threadId })) {
         outcome = "lost";
         return { kind: "lost" };
+      }
+
+      if (args.kind === "workflow_event") {
+        const [thread] = await db
+          .select({ queuePausedAt: chatThreads.queuePausedAt })
+          .from(chatThreads)
+          .where(eq(chatThreads.id, args.threadId))
+          .limit(1);
+        if (
+          thread?.queuePausedAt ||
+          (await hasUnclaimedQueuedUserMessage(db, args.threadId))
+        ) {
+          outcome = "lost";
+          return { kind: "lost" };
+        }
+
+        const [head] = await db
+          .select({
+            id: chatMessageQueue.id,
+            automationId: chatMessageQueue.automationId,
+          })
+          .from(chatMessageQueue)
+          .where(
+            and(
+              eq(chatMessageQueue.chatThreadId, args.threadId),
+              eq(chatMessageQueue.itemType, "workflow_event"),
+            ),
+          )
+          .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))
+          .limit(1);
+        if (
+          head?.id !== args.eventId ||
+          head.automationId !== args.runGroupId
+        ) {
+          outcome = "lost";
+          return { kind: "lost" };
+        }
+
+        const claimed = await insertChatMessage(db, {
+          chatThreadId: args.threadId,
+          role: "user",
+          content: args.prompt,
+          runId: args.runId,
+          runGroupId: args.runGroupId,
+        });
+        const deleted = await db
+          .delete(chatMessageQueue)
+          .where(
+            and(
+              eq(chatMessageQueue.id, args.eventId),
+              eq(chatMessageQueue.chatThreadId, args.threadId),
+              eq(chatMessageQueue.itemType, "workflow_event"),
+            ),
+          )
+          .returning({ id: chatMessageQueue.id });
+        if (!claimed || deleted.length !== 1) {
+          throw new Error("Claimed workflow queue event disappeared");
+        }
+
+        outcome = "claimed";
+        return { kind: "claimed", createdAt: claimed.createdAt };
       }
 
       const headMessageId = await loadNextUnclaimedQueuedUserMessageId(

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -119,13 +119,41 @@ export async function postRunUserMessage(params: {
       createdAfter: inserted?.createdAt ?? nowDate(),
     });
   });
-  await publishUserSignal(
-    [params.userId],
-    `chatThreadMessageCreated:${params.threadId}`,
-  );
-  await publishUserSignal(
-    [params.userId],
-    `chatThreadRunCreated:${params.threadId}`,
-  );
-  await publishThreadListChanged(params.userId);
+  await publishRunUserMessageSignals(params.userId, params.threadId);
+}
+
+async function publishRunUserMessageSignals(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+  await publishUserSignal([userId], `chatThreadRunCreated:${threadId}`);
+  await publishThreadListChanged(userId);
+}
+
+/**
+ * Finish the side effects for a user message inserted by a queue-first run
+ * claim. The claim and run rows already committed atomically; only a queued
+ * marker and realtime notifications remain.
+ */
+export async function finalizeClaimedRunUserMessage(params: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly runId: string;
+  readonly runStatus: string;
+  readonly runGroupId?: string;
+  readonly createdAt: Date;
+}): Promise<void> {
+  if (params.runStatus === "queued") {
+    await params.db.transaction(async (tx): Promise<void> => {
+      await appendQueuedRunAssistantMarker(tx, {
+        chatThreadId: params.threadId,
+        runId: params.runId,
+        runGroupId: params.runGroupId,
+        createdAfter: params.createdAt,
+      });
+    });
+  }
+  await publishRunUserMessageSignals(params.userId, params.threadId);
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -423,6 +423,9 @@ async function recordWorkflowAutomationRunStart(input: {
     .set({
       ...(args.recordLastRunId === false ? {} : { lastRunId: runId }),
       ...(args.recordLastRunAt ? { lastRunAt: nowDate() } : {}),
+      ...(args.due.allowClaimedOnceScheduleAutomation
+        ? { enabled: false }
+        : {}),
       updatedAt: nowDate(),
     })
     .where(eq(zeroWorkflowAutomations.id, automation.id));

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -96,7 +96,7 @@ export interface RunWorkflowAutomationNowArgs {
   readonly timing?: ApiDispatchTimingCollector;
 }
 
-export interface LaunchQueuedWorkflowAutomationArgs extends RunWorkflowAutomationNowArgs {
+interface LaunchQueuedWorkflowAutomationArgs extends RunWorkflowAutomationNowArgs {
   readonly queueEventId: string;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -1,0 +1,568 @@
+import { randomBytes } from "node:crypto";
+
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../external/db";
+import { now, nowDate } from "../external/time";
+import {
+  isQueueFirstRunClaimLost,
+  type DispatchFailedRunCallbacks,
+} from "./agent-run-create.service";
+import type { InternalRunCallbackKind } from "./internal-run-callback";
+import {
+  finalizeClaimedRunUserMessage,
+  resolveRunChatThreadModelContext,
+} from "./zero-chat-run-message.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
+import {
+  ApiDispatchTimingCollector,
+  measureApiDispatchTiming,
+} from "./api-dispatch-timing.service";
+import { createQueueFirstZeroRun$ } from "./zero-runs-create.service";
+import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
+import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
+
+export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
+
+export interface DueWorkflowAutomation {
+  readonly automation: AutomationRow;
+  // The owning agent is derived from the workflow row (hard 1:N); automations no
+  // longer carry an agentId column, so callers resolve it and pass it here.
+  readonly agentId: string;
+  readonly workflowName: string;
+  readonly chatThreadId: string;
+  // One-time schedule automations are disabled as part of the optimistic claim.
+  // That claimed row can still proceed through the run-start readability gate.
+  readonly allowClaimedOnceScheduleAutomation?: boolean;
+}
+
+type RunErrorResponse = {
+  readonly status: number;
+  readonly body: {
+    readonly error: { readonly message: string; readonly code: string };
+  };
+};
+
+export type RunWorkflowAutomationResult =
+  | { readonly kind: "ok"; readonly runId: string }
+  // The event was accepted into the workflow queue instead of starting a run.
+  | { readonly kind: "enqueued" }
+  | { readonly kind: "conflict"; readonly message: string }
+  | { readonly kind: "run_error"; readonly response: RunErrorResponse };
+
+export type RunFailure = Exclude<
+  RunWorkflowAutomationResult,
+  { kind: "ok" } | { kind: "enqueued" }
+>;
+type ActivePreviousRunPolicy = "block" | "allow";
+
+interface InternalRunCallbackInput {
+  readonly internalKind: InternalRunCallbackKind;
+  readonly secret: string;
+  readonly payload: unknown;
+}
+
+type ModelContext =
+  | {
+      readonly ok: true;
+      readonly modelPin: ModelFirstPin;
+      readonly effectiveModelProvider: string | null | undefined;
+      readonly codexServiceTier: "fast" | undefined;
+    }
+  | { readonly ok: false; readonly failure: RunFailure };
+
+export interface RunWorkflowAutomationNowArgs {
+  readonly due: DueWorkflowAutomation;
+  readonly apiStartTime: number;
+  readonly sessionId?: string;
+  // Overrides the default `/<workflowName>` slash-command prompt.
+  readonly prompt?: string;
+  // Display-only source context surfaced through workflowSnapshot.triggerBrief.
+  readonly triggerBrief?: string;
+  readonly triggerSource?: TriggerSource;
+  readonly appendSystemPrompt?: string;
+  readonly callbacks?: readonly InternalRunCallbackInput[];
+  readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
+  // Automated schedule ticks coalesce while pending. Explicit manual runs set
+  // this false so every user action remains a distinct queue item.
+  readonly coalescePendingScheduleRun?: boolean;
+  readonly recordLastRunId?: boolean;
+  readonly recordLastRunAt?: boolean;
+  readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly timing?: ApiDispatchTimingCollector;
+}
+
+export interface LaunchQueuedWorkflowAutomationArgs extends RunWorkflowAutomationNowArgs {
+  readonly queueEventId: string;
+}
+
+interface WorkflowAutomationRunInput {
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+  readonly callbacks: readonly InternalRunCallbackInput[];
+  readonly zeroRunMetadata: ReturnType<typeof workflowAutomationRunMetadata>;
+}
+
+type ComputerUseHostGrant = Awaited<
+  ReturnType<typeof loadComputerUseHostGrantForAutoSend>
+>;
+
+function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function isActivePreviousRunStatus(status: string): boolean {
+  return status === "pending" || status === "running";
+}
+
+function workflowAutomationRunMetadata(
+  automation: AutomationRow,
+  triggerBrief: string | undefined,
+) {
+  return {
+    workflowAutomationId: automation.id,
+    triggerBrief,
+    // The automation id is the run group id: all runs fired by the same automation
+    // share a group for chat folding and carry the same row-level association.
+    runGroupId: automation.id,
+  };
+}
+
+/**
+ * The recurrence reschedule callback (advances `next_run_at` / failure
+ * bookkeeping on completion) plus the chat callback (drives the web-chat
+ * render). Cron and once both use the cron callback; once carries no
+ * cronExpression so it does not recur.
+ */
+function buildWorkflowAutomationCallbacks(
+  automation: AutomationRow,
+  agentId: string,
+  chatThreadId: string,
+): InternalRunCallbackInput[] {
+  const callbacks: InternalRunCallbackInput[] = [];
+  if (automation.scheduleType === "loop") {
+    callbacks.push({
+      internalKind: "workflow-automation:loop",
+      secret: generateCallbackSecret(),
+      payload: {
+        automationId: automation.id,
+      },
+    });
+  } else {
+    callbacks.push({
+      internalKind: "workflow-automation:cron",
+      secret: generateCallbackSecret(),
+      payload: {
+        automationId: automation.id,
+        timezone: automation.timezone,
+        ...(automation.cronExpression
+          ? { cronExpression: automation.cronExpression }
+          : {}),
+      },
+    });
+  }
+  callbacks.push({
+    internalKind: "chat",
+    secret: generateCallbackSecret(),
+    payload: { threadId: chatThreadId, agentId },
+  });
+  return callbacks;
+}
+
+function buildAppendSystemPrompt(workflowName: string): string {
+  return [
+    "# Current context",
+    `You are running on a schedule for the "${workflowName}" workflow.`,
+    "The workflow's procedure is available as a skill - execute it now.",
+    "This run is linked to a web chat thread; everything you output is shown to the user there.",
+    "Connector permissions use the same agent-run permission settings as chat runs. If a connector request fails, do not retry blindly or assume an HTTP error came from Zero permission policy. Run `zero connector check --url <FAILED_URL> --method <METHOD> [--connector <connector-ref>]`; only when it reports a deny or ask outcome, request access with `zero connector permission-request <connector-ref> --permission <name>` and tell the user which permission this automation needs. The user chooses the grant duration in the confirmation UI. Omit query strings or fragments when they may contain secrets because permission matching does not need them.",
+  ].join("\n");
+}
+
+function appendComputerUseSystemPrompt(
+  prompt: string,
+  grant: ComputerUseHostGrant,
+): string {
+  if (!grant) {
+    return prompt;
+  }
+  return [
+    prompt,
+    "# Computer Use",
+    `Computer Use is enabled for this run on ${grant.displayName}.`,
+  ].join("\n\n");
+}
+
+export function buildChatOnlyWorkflowAutomationCallbacks(
+  chatThreadId: string,
+  agentId: string,
+): InternalRunCallbackInput[] {
+  return [
+    {
+      internalKind: "chat",
+      secret: generateCallbackSecret(),
+      payload: {
+        threadId: chatThreadId,
+        agentId,
+      },
+    },
+  ];
+}
+
+async function resolveModelContext(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly signal: AbortSignal;
+}): Promise<ModelContext> {
+  const threadModelContext = await resolveRunChatThreadModelContext({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    threadId: args.chatThreadId,
+  });
+  args.signal.throwIfAborted();
+  if ("status" in threadModelContext) {
+    return {
+      ok: false,
+      failure: {
+        kind: "run_error",
+        response: {
+          status: threadModelContext.status,
+          body: threadModelContext.body,
+        },
+      },
+    };
+  }
+
+  const { pin, providerAdmission, runCodexServiceTier } = threadModelContext;
+  args.signal.throwIfAborted();
+  if (providerAdmission.error) {
+    return {
+      ok: false,
+      failure: { kind: "run_error", response: providerAdmission.error },
+    };
+  }
+
+  return {
+    ok: true,
+    modelPin: pin,
+    effectiveModelProvider: providerAdmission.effectiveModelProvider,
+    codexServiceTier: runCodexServiceTier,
+  };
+}
+
+function workflowAutomationTiming(
+  args: LaunchQueuedWorkflowAutomationArgs,
+): ApiDispatchTimingCollector {
+  const timing = args.timing ?? new ApiDispatchTimingCollector();
+  if (!args.timing) {
+    timing.recordElapsed(
+      "api_dispatch_pre_create_zero_workflow_automation_entrypoint_gap",
+      "nested",
+      args.apiStartTime,
+    );
+  }
+  return timing;
+}
+
+async function checkActivePreviousWorkflowRun(args: {
+  readonly db: Db;
+  readonly automation: AutomationRow;
+  readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<RunFailure | undefined> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_workflow_automation_check_active_run",
+    "nested",
+    async (): Promise<RunFailure | undefined> => {
+      if (
+        args.activePreviousRunPolicy !== "allow" &&
+        args.automation.lastRunId
+      ) {
+        const [lastRun] = await args.db
+          .select({ status: agentRuns.status })
+          .from(agentRuns)
+          .where(eq(agentRuns.id, args.automation.lastRunId))
+          .limit(1);
+        args.signal.throwIfAborted();
+        if (lastRun && isActivePreviousRunStatus(lastRun.status)) {
+          return {
+            kind: "conflict",
+            message: "Previous run is still active",
+          };
+        }
+      }
+      return undefined;
+    },
+  );
+}
+
+async function checkWorkflowAutomationTargetReadable(args: {
+  readonly db: Db;
+  readonly automation: AutomationRow;
+  readonly agentId: string;
+  readonly allowClaimedOnceScheduleAutomation: boolean;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<RunFailure | undefined> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_workflow_automation_check_target_access",
+    "nested",
+    async (): Promise<RunFailure | undefined> => {
+      const canFire = await workflowAutomationCanFire(args.db, {
+        automation: args.automation,
+        agentId: args.agentId,
+        allowClaimedOnceScheduleAutomation:
+          args.allowClaimedOnceScheduleAutomation,
+        signal: args.signal,
+      });
+      args.signal.throwIfAborted();
+      if (!canFire) {
+        return {
+          kind: "conflict",
+          message: "Workflow automation is paused or no longer readable",
+        };
+      }
+      return undefined;
+    },
+  );
+}
+
+async function resolveTimedWorkflowModelContext(args: {
+  readonly db: Db;
+  readonly automation: AutomationRow;
+  readonly chatThreadId: string;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<ModelContext> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_workflow_automation_resolve_model_context",
+    "nested",
+    async () => {
+      return await resolveModelContext({
+        db: args.db,
+        orgId: args.automation.orgId,
+        userId: args.automation.ownerUserId,
+        chatThreadId: args.chatThreadId,
+        signal: args.signal,
+      });
+    },
+  );
+}
+
+async function buildTimedWorkflowAutomationRunInput(args: {
+  readonly command: RunWorkflowAutomationNowArgs;
+  readonly automation: AutomationRow;
+  readonly agentId: string;
+  readonly workflowName: string;
+  readonly chatThreadId: string;
+  readonly computerUseHostGrant: ComputerUseHostGrant;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<WorkflowAutomationRunInput> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_pre_create_zero_workflow_automation_build_run_input",
+    "nested",
+    () => {
+      return {
+        prompt: args.command.prompt ?? `/${args.workflowName}`,
+        appendSystemPrompt: appendComputerUseSystemPrompt(
+          args.command.appendSystemPrompt ??
+            buildAppendSystemPrompt(args.workflowName),
+          args.computerUseHostGrant,
+        ),
+        callbacks:
+          args.command.callbacks ??
+          buildWorkflowAutomationCallbacks(
+            args.automation,
+            args.agentId,
+            args.chatThreadId,
+          ),
+        zeroRunMetadata: workflowAutomationRunMetadata(
+          args.automation,
+          args.command.triggerBrief,
+        ),
+      };
+    },
+  );
+}
+
+async function recordWorkflowAutomationRunStart(input: {
+  readonly db: Db;
+  readonly args: RunWorkflowAutomationNowArgs;
+  readonly runId: string;
+  readonly runStatus: string;
+  readonly claimedMessageCreatedAt: Date;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const { db, args, runId, signal } = input;
+  const { automation, chatThreadId } = args.due;
+  await finalizeClaimedRunUserMessage({
+    db,
+    threadId: chatThreadId,
+    userId: automation.ownerUserId,
+    runId,
+    runStatus: input.runStatus,
+    runGroupId: automation.id,
+    createdAt: input.claimedMessageCreatedAt,
+  });
+  signal.throwIfAborted();
+
+  await db
+    .update(zeroWorkflowAutomations)
+    .set({
+      ...(args.recordLastRunId === false ? {} : { lastRunId: runId }),
+      ...(args.recordLastRunAt ? { lastRunAt: nowDate() } : {}),
+      updatedAt: nowDate(),
+    })
+    .where(eq(zeroWorkflowAutomations.id, automation.id));
+  signal.throwIfAborted();
+}
+
+export const launchQueuedWorkflowAutomation$ = command(
+  async (
+    { set },
+    args: LaunchQueuedWorkflowAutomationArgs,
+    signal: AbortSignal,
+  ): Promise<RunWorkflowAutomationResult> => {
+    const db = set(writeDb$);
+    const { automation, agentId, workflowName, chatThreadId } = args.due;
+    const timing = workflowAutomationTiming(args);
+
+    const activePreviousRunFailure = await checkActivePreviousWorkflowRun({
+      db,
+      automation,
+      activePreviousRunPolicy: args.activePreviousRunPolicy,
+      timing,
+      signal,
+    });
+    if (activePreviousRunFailure) {
+      return activePreviousRunFailure;
+    }
+
+    const targetAccessFailure = await checkWorkflowAutomationTargetReadable({
+      db,
+      automation,
+      agentId,
+      allowClaimedOnceScheduleAutomation:
+        args.due.allowClaimedOnceScheduleAutomation === true,
+      timing,
+      signal,
+    });
+    if (targetAccessFailure) {
+      return targetAccessFailure;
+    }
+
+    const modelContext = await resolveTimedWorkflowModelContext({
+      db,
+      automation,
+      chatThreadId,
+      timing,
+      signal,
+    });
+    if (!modelContext.ok) {
+      return modelContext.failure;
+    }
+    const { modelPin, effectiveModelProvider, codexServiceTier } = modelContext;
+
+    const computerUseHostGrant = await loadComputerUseHostGrantForAutoSend({
+      db,
+      threadId: chatThreadId,
+      orgId: automation.orgId,
+      userId: automation.ownerUserId,
+    });
+    signal.throwIfAborted();
+
+    const runInput = await buildTimedWorkflowAutomationRunInput({
+      command: args,
+      automation,
+      agentId,
+      workflowName,
+      chatThreadId,
+      computerUseHostGrant,
+      timing,
+    });
+    signal.throwIfAborted();
+    timing.recordElapsed(
+      "api_dispatch_pre_create_zero_workflow_automation_create_run",
+      "nested",
+      now(),
+    );
+    const result = await set(
+      createQueueFirstZeroRun$,
+      {
+        auth: {
+          orgId: automation.orgId,
+          orgRole: "member",
+          userId: automation.ownerUserId,
+          tokenType: "session",
+        },
+        body: {
+          prompt: runInput.prompt,
+          agentId,
+          ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+          ...(effectiveModelProvider
+            ? { modelProvider: effectiveModelProvider }
+            : {}),
+        },
+        apiStartTime: args.apiStartTime,
+        triggerSource: args.triggerSource ?? "workflow-schedule",
+        chatThreadId,
+        computerUseHostId: computerUseHostGrant?.hostId,
+        modelProviderId: modelPin.modelProviderId ?? undefined,
+        modelProviderCredentialScope:
+          modelPin.modelProviderCredentialScope ?? undefined,
+        selectedModelOverride: modelPin.selectedModel ?? undefined,
+        codexServiceTier,
+        appendSystemPrompt: runInput.appendSystemPrompt,
+        callbacks: runInput.callbacks,
+        zeroRunMetadata: runInput.zeroRunMetadata,
+        queueFirstAssociation: {
+          kind: "workflow_event",
+          threadId: chatThreadId,
+          eventId: args.queueEventId,
+          prompt: runInput.prompt,
+          runGroupId: automation.id,
+        },
+        zeroRunModelPin: {
+          modelProvider: effectiveModelProvider ?? null,
+          modelProviderId: modelPin.modelProviderId,
+          modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
+          selectedModel: modelPin.selectedModel,
+        },
+        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+        timing,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (isQueueFirstRunClaimLost(result)) {
+      return { kind: "enqueued" };
+    }
+    if (result.status !== 201) {
+      return { kind: "run_error", response: result };
+    }
+
+    await recordWorkflowAutomationRunStart({
+      db,
+      args,
+      runId: result.body.runId,
+      runStatus: result.body.status,
+      claimedMessageCreatedAt: result.queueFirstClaim.createdAt,
+      signal,
+    });
+
+    return { kind: "ok", runId: result.body.runId };
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -89,9 +89,11 @@ async function hasOrgMembership(
 
 /**
  * Claim a due workflow automation via an optimistic lock on `next_run_at`: clear
- * the next run, stamp `last_run_at`, and disable one-time automations. Recurrence
- * advance happens in the completion callback. Returns the claimed row, or null
- * when another tick won the race.
+ * the next run and stamp `last_run_at`. A one-time automation stays readable
+ * until its queued event claims a run, so a draining previous API version does
+ * not discard the event during rollout. Recurrence advance happens in the
+ * completion callback. Returns the claimed row, or null when another tick won
+ * the race.
  */
 async function claimAutomation(
   db: Db,
@@ -107,7 +109,6 @@ async function claimAutomation(
       nextRunAt: null,
       lastRunAt: currentTime,
       updatedAt: currentTime,
-      ...(automation.scheduleType === "once" ? { enabled: false } : {}),
     })
     .where(
       and(
@@ -345,8 +346,7 @@ export const executeDueWorkflowAutomations$ = command(
         agentId: row.agentId,
         workflowName: row.workflowName,
         chatThreadId,
-        allowClaimedOnceScheduleAutomation:
-          claimed.scheduleType === "once" && !claimed.enabled,
+        allowClaimedOnceScheduleAutomation: claimed.scheduleType === "once",
       };
 
       const result = await tapError(

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -1,496 +1,62 @@
-import { randomBytes } from "node:crypto";
-
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
-import { agentRuns } from "@vm0/db/schema/agent-run";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { command } from "ccstate";
-import { eq } from "drizzle-orm";
 
-import { writeDb$, type Db } from "../external/db";
+import { writeDb$ } from "../external/db";
 import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
-import { now, nowDate } from "../external/time";
-import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
-import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
-  postRunUserMessage,
-  resolveRunChatThreadModelContext,
-} from "./zero-chat-run-message.service";
-import type { ModelFirstPin } from "./zero-model-selection.service";
+  admitWorkflowAutomationEvent,
+  type WorkflowQueueEventParams,
+} from "./chat-message-queue.service";
+import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
-import { createZeroRun$ } from "./zero-runs-create.service";
-import { admitWorkflowAutomationEvent } from "./chat-message-queue.service";
-import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
-import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
-
-export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
-
-export interface DueWorkflowAutomation {
-  readonly automation: AutomationRow;
-  // The owning agent is derived from the workflow row (hard 1:N); automations no
-  // longer carry an agentId column, so callers resolve it and pass it here.
-  readonly agentId: string;
-  readonly workflowName: string;
-  readonly chatThreadId: string;
-  // One-time schedule automations are disabled as part of the optimistic claim.
-  // That claimed row can still proceed through the run-start readability gate.
-  readonly allowClaimedOnceScheduleAutomation?: boolean;
-}
-
-type RunErrorResponse = {
-  readonly status: number;
-  readonly body: {
-    readonly error: { readonly message: string; readonly code: string };
-  };
-};
-
-export type RunWorkflowAutomationResult =
-  | { readonly kind: "ok"; readonly runId: string }
-  // The event was accepted into the workflow queue instead of starting a run.
-  | { readonly kind: "enqueued" }
-  | { readonly kind: "conflict"; readonly message: string }
-  | { readonly kind: "run_error"; readonly response: RunErrorResponse };
-
-export type RunFailure = Exclude<
+import type {
+  RunWorkflowAutomationNowArgs,
   RunWorkflowAutomationResult,
-  { kind: "ok" } | { kind: "enqueued" }
->;
-type ActivePreviousRunPolicy = "block" | "allow";
+} from "./zero-workflow-automation-launch.service";
 
-interface InternalRunCallbackInput {
-  readonly internalKind: InternalRunCallbackKind;
-  readonly secret: string;
-  readonly payload: unknown;
-}
+export {
+  buildChatOnlyWorkflowAutomationCallbacks,
+  type AutomationRow,
+  type DueWorkflowAutomation,
+  type RunFailure,
+  type RunWorkflowAutomationNowArgs,
+  type RunWorkflowAutomationResult,
+} from "./zero-workflow-automation-launch.service";
 
-type ModelContext =
-  | {
-      readonly ok: true;
-      readonly modelPin: ModelFirstPin;
-      readonly effectiveModelProvider: string | null | undefined;
-      readonly codexServiceTier: "fast" | undefined;
-    }
-  | { readonly ok: false; readonly failure: RunFailure };
-
-export interface RunWorkflowAutomationNowArgs {
-  readonly due: DueWorkflowAutomation;
-  readonly apiStartTime: number;
-  readonly sessionId?: string;
-  // Overrides the default `/<workflowName>` slash-command prompt.
-  readonly prompt?: string;
-  // Display-only source context surfaced through workflowSnapshot.triggerBrief.
-  readonly triggerBrief?: string;
-  readonly triggerSource?: TriggerSource;
-  readonly appendSystemPrompt?: string;
-  readonly callbacks?: readonly InternalRunCallbackInput[];
-  readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
-  // Set only by the queue drain after it claims an event: skip a second
-  // workflow-queue admission and create the claimed run.
-  readonly bypassWorkflowQueue?: boolean;
-  // Automated schedule ticks coalesce while pending. Explicit manual runs set
-  // this false so every user action remains a distinct queue item.
-  readonly coalescePendingScheduleRun?: boolean;
-  readonly recordLastRunId?: boolean;
-  readonly recordLastRunAt?: boolean;
-  readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
-  readonly timing?: ApiDispatchTimingCollector;
-}
-
-interface WorkflowAutomationRunInput {
-  readonly prompt: string;
-  readonly appendSystemPrompt: string;
-  readonly callbacks: readonly InternalRunCallbackInput[];
-  readonly zeroRunMetadata: ReturnType<typeof workflowAutomationRunMetadata>;
-}
-
-type ComputerUseHostGrant = Awaited<
-  ReturnType<typeof loadComputerUseHostGrantForAutoSend>
->;
-
-function generateCallbackSecret(): string {
-  return randomBytes(32).toString("hex");
-}
-
-function isActivePreviousRunStatus(status: string): boolean {
-  return status === "pending" || status === "running";
-}
-
-function workflowAutomationRunMetadata(
-  automation: AutomationRow,
-  triggerBrief: string | undefined,
-) {
-  return {
-    workflowAutomationId: automation.id,
-    triggerBrief,
-    // The automation id is the run group id: all runs fired by the same automation
-    // share a group for chat folding and carry the same row-level association.
-    runGroupId: automation.id,
-  };
-}
-
-/**
- * The recurrence reschedule callback (advances `next_run_at` / failure
- * bookkeeping on completion) plus the chat callback (drives the web-chat
- * render). Cron and once both use the cron callback; once carries no
- * cronExpression so it does not recur.
- */
-function buildWorkflowAutomationCallbacks(
-  automation: AutomationRow,
-  agentId: string,
-  chatThreadId: string,
-): InternalRunCallbackInput[] {
-  const callbacks: InternalRunCallbackInput[] = [];
-  if (automation.scheduleType === "loop") {
-    callbacks.push({
-      internalKind: "workflow-automation:loop",
-      secret: generateCallbackSecret(),
-      payload: {
-        automationId: automation.id,
-      },
-    });
-  } else {
-    callbacks.push({
-      internalKind: "workflow-automation:cron",
-      secret: generateCallbackSecret(),
-      payload: {
-        automationId: automation.id,
-        timezone: automation.timezone,
-        ...(automation.cronExpression
-          ? { cronExpression: automation.cronExpression }
-          : {}),
-      },
-    });
-  }
-  callbacks.push({
-    internalKind: "chat",
-    secret: generateCallbackSecret(),
-    payload: { threadId: chatThreadId, agentId },
-  });
-  return callbacks;
-}
-
-function buildAppendSystemPrompt(workflowName: string): string {
-  return [
-    "# Current context",
-    `You are running on a schedule for the "${workflowName}" workflow.`,
-    "The workflow's procedure is available as a skill - execute it now.",
-    "This run is linked to a web chat thread; everything you output is shown to the user there.",
-    "Connector permissions use the same agent-run permission settings as chat runs. If a connector request fails, do not retry blindly or assume an HTTP error came from Zero permission policy. Run `zero connector check --url <FAILED_URL> --method <METHOD> [--connector <connector-ref>]`; only when it reports a deny or ask outcome, request access with `zero connector permission-request <connector-ref> --permission <name>` and tell the user which permission this automation needs. The user chooses the grant duration in the confirmation UI. Omit query strings or fragments when they may contain secrets because permission matching does not need them.",
-  ].join("\n");
-}
-
-function appendComputerUseSystemPrompt(
-  prompt: string,
-  grant: ComputerUseHostGrant,
-): string {
-  if (!grant) {
-    return prompt;
-  }
-  return [
-    prompt,
-    "# Computer Use",
-    `Computer Use is enabled for this run on ${grant.displayName}.`,
-  ].join("\n\n");
-}
-
-export function buildChatOnlyWorkflowAutomationCallbacks(
-  chatThreadId: string,
-  agentId: string,
-): InternalRunCallbackInput[] {
-  return [
-    {
-      internalKind: "chat",
-      secret: generateCallbackSecret(),
-      payload: {
-        threadId: chatThreadId,
-        agentId,
-      },
-    },
-  ];
-}
-
-async function resolveModelContext(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly chatThreadId: string;
-  readonly signal: AbortSignal;
-}): Promise<ModelContext> {
-  const threadModelContext = await resolveRunChatThreadModelContext({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    threadId: args.chatThreadId,
-  });
-  args.signal.throwIfAborted();
-  if ("status" in threadModelContext) {
-    return {
-      ok: false,
-      failure: {
-        kind: "run_error",
-        response: {
-          status: threadModelContext.status,
-          body: threadModelContext.body,
-        },
-      },
-    };
-  }
-
-  const { pin, providerAdmission, runCodexServiceTier } = threadModelContext;
-  args.signal.throwIfAborted();
-  if (providerAdmission.error) {
-    return {
-      ok: false,
-      failure: { kind: "run_error", response: providerAdmission.error },
-    };
-  }
-
-  return {
-    ok: true,
-    modelPin: pin,
-    effectiveModelProvider: providerAdmission.effectiveModelProvider,
-    codexServiceTier: runCodexServiceTier,
-  };
-}
-
-function workflowAutomationTiming(
+function queueEventParams(
   args: RunWorkflowAutomationNowArgs,
-): ApiDispatchTimingCollector {
-  const timing = args.timing ?? new ApiDispatchTimingCollector();
-  if (!args.timing) {
-    timing.recordElapsed(
-      "api_dispatch_pre_create_zero_workflow_automation_entrypoint_gap",
-      "nested",
-      args.apiStartTime,
-    );
-  }
-  return timing;
-}
-
-async function checkActivePreviousWorkflowRun(args: {
-  readonly db: Db;
-  readonly automation: AutomationRow;
-  readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
-  readonly timing: ApiDispatchTimingCollector;
-  readonly signal: AbortSignal;
-}): Promise<RunFailure | undefined> {
-  return await measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_workflow_automation_check_active_run",
-    "nested",
-    async (): Promise<RunFailure | undefined> => {
-      if (
-        args.activePreviousRunPolicy !== "allow" &&
-        args.automation.lastRunId
-      ) {
-        const [lastRun] = await args.db
-          .select({ status: agentRuns.status })
-          .from(agentRuns)
-          .where(eq(agentRuns.id, args.automation.lastRunId))
-          .limit(1);
-        args.signal.throwIfAborted();
-        if (lastRun && isActivePreviousRunStatus(lastRun.status)) {
-          return {
-            kind: "conflict",
-            message: "Previous run is still active",
-          };
+): WorkflowQueueEventParams {
+  return {
+    version: 1,
+    ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+    ...(args.prompt !== undefined ? { prompt: args.prompt } : {}),
+    ...(args.appendSystemPrompt !== undefined
+      ? { appendSystemPrompt: args.appendSystemPrompt }
+      : {}),
+    ...(args.callbacks ? { callbacks: args.callbacks } : {}),
+    ...(args.recordLastRunId !== undefined
+      ? { recordLastRunId: args.recordLastRunId }
+      : {}),
+    ...(args.recordLastRunAt !== undefined
+      ? { recordLastRunAt: args.recordLastRunAt }
+      : {}),
+    activePreviousRunPolicy: args.activePreviousRunPolicy ?? "block",
+    ...(args.due.allowClaimedOnceScheduleAutomation !== undefined
+      ? {
+          allowClaimedOnceScheduleAutomation:
+            args.due.allowClaimedOnceScheduleAutomation,
         }
-      }
-      return undefined;
-    },
-  );
-}
-
-async function checkWorkflowAutomationTargetReadable(args: {
-  readonly db: Db;
-  readonly automation: AutomationRow;
-  readonly agentId: string;
-  readonly allowClaimedOnceScheduleAutomation: boolean;
-  readonly timing: ApiDispatchTimingCollector;
-  readonly signal: AbortSignal;
-}): Promise<RunFailure | undefined> {
-  return await measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_workflow_automation_check_target_access",
-    "nested",
-    async (): Promise<RunFailure | undefined> => {
-      const canFire = await workflowAutomationCanFire(args.db, {
-        automation: args.automation,
-        agentId: args.agentId,
-        allowClaimedOnceScheduleAutomation:
-          args.allowClaimedOnceScheduleAutomation,
-        signal: args.signal,
-      });
-      args.signal.throwIfAborted();
-      if (!canFire) {
-        return {
-          kind: "conflict",
-          message: "Workflow automation is paused or no longer readable",
-        };
-      }
-      return undefined;
-    },
-  );
-}
-
-async function resolveTimedWorkflowModelContext(args: {
-  readonly db: Db;
-  readonly automation: AutomationRow;
-  readonly chatThreadId: string;
-  readonly timing: ApiDispatchTimingCollector;
-  readonly signal: AbortSignal;
-}): Promise<ModelContext> {
-  return await measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_workflow_automation_resolve_model_context",
-    "nested",
-    async () => {
-      return await resolveModelContext({
-        db: args.db,
-        orgId: args.automation.orgId,
-        userId: args.automation.ownerUserId,
-        chatThreadId: args.chatThreadId,
-        signal: args.signal,
-      });
-    },
-  );
-}
-
-async function buildTimedWorkflowAutomationRunInput(args: {
-  readonly command: RunWorkflowAutomationNowArgs;
-  readonly automation: AutomationRow;
-  readonly agentId: string;
-  readonly workflowName: string;
-  readonly chatThreadId: string;
-  readonly computerUseHostGrant: ComputerUseHostGrant;
-  readonly timing: ApiDispatchTimingCollector;
-}): Promise<WorkflowAutomationRunInput> {
-  return await measureApiDispatchTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_workflow_automation_build_run_input",
-    "nested",
-    () => {
-      return {
-        prompt: args.command.prompt ?? `/${args.workflowName}`,
-        appendSystemPrompt: appendComputerUseSystemPrompt(
-          args.command.appendSystemPrompt ??
-            buildAppendSystemPrompt(args.workflowName),
-          args.computerUseHostGrant,
-        ),
-        callbacks:
-          args.command.callbacks ??
-          buildWorkflowAutomationCallbacks(
-            args.automation,
-            args.agentId,
-            args.chatThreadId,
-          ),
-        zeroRunMetadata: workflowAutomationRunMetadata(
-          args.automation,
-          args.command.triggerBrief,
-        ),
-      };
-    },
-  );
+      : {}),
+  };
 }
 
 /**
- * Workflow-queue admission: an event fired while the workflow is busy (or its
- * queue is paused/non-empty) is persisted as a queue event instead of creating
- * a run. Returns true when the event was enqueued.
+ * Durable workflow-event ingress. Every event enters the chat thread queue
+ * before the shared scheduler prepares a run; the run persistence transaction
+ * later owns the authoritative queue claim.
  */
-async function enqueueWorkflowAutomationEventIfBusy(input: {
-  readonly db: Db;
-  readonly args: RunWorkflowAutomationNowArgs;
-  readonly timing: ApiDispatchTimingCollector;
-  readonly signal: AbortSignal;
-}): Promise<boolean> {
-  const { db, args, signal, timing } = input;
-  const { automation, chatThreadId } = args.due;
-  if (args.bypassWorkflowQueue === true) {
-    return false;
-  }
-  const admission = await measureApiDispatchTiming(
-    timing,
-    "api_dispatch_pre_create_zero_workflow_automation_queue_admission",
-    "nested",
-    async () => {
-      return await admitWorkflowAutomationEvent(db, {
-        automation,
-        chatThreadId,
-        triggerSource: args.triggerSource ?? "workflow-schedule",
-        triggerBrief: args.triggerBrief,
-        coalescePendingScheduleRun: args.coalescePendingScheduleRun !== false,
-        params: {
-          version: 1,
-          prompt: args.prompt,
-          appendSystemPrompt: args.appendSystemPrompt,
-          callbacks: args.callbacks,
-          recordLastRunId: args.recordLastRunId,
-          recordLastRunAt: args.recordLastRunAt,
-        },
-      });
-    },
-  );
-  signal.throwIfAborted();
-  if (admission === "enqueued") {
-    await publishChatThreadWorkflowQueueChangedSafely(
-      automation.ownerUserId,
-      chatThreadId,
-    );
-    signal.throwIfAborted();
-    return true;
-  }
-  return false;
-}
-
-async function recordWorkflowAutomationRunStart(input: {
-  readonly db: Db;
-  readonly args: RunWorkflowAutomationNowArgs;
-  readonly runId: string;
-  readonly runStatus: string;
-  readonly prompt: string;
-  readonly modelPin: ModelFirstPin;
-  readonly effectiveModelProvider: string | null | undefined;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  const { db, args, runId, signal } = input;
-  const { automation, chatThreadId } = args.due;
-  await postRunUserMessage({
-    db,
-    threadId: chatThreadId,
-    userId: automation.ownerUserId,
-    runId,
-    prompt: input.prompt,
-    appendQueueMarker: input.runStatus === "queued",
-    runGroupId: automation.id,
-  });
-  signal.throwIfAborted();
-
-  await db
-    .update(zeroRuns)
-    .set({
-      modelProvider: input.effectiveModelProvider,
-      modelProviderId: input.modelPin.modelProviderId,
-      modelProviderCredentialScope: input.modelPin.modelProviderCredentialScope,
-      selectedModel: input.modelPin.selectedModel,
-    })
-    .where(eq(zeroRuns.id, runId));
-  signal.throwIfAborted();
-
-  await db
-    .update(zeroWorkflowAutomations)
-    .set({
-      ...(args.recordLastRunId === false ? {} : { lastRunId: runId }),
-      ...(args.recordLastRunAt ? { lastRunAt: nowDate() } : {}),
-      updatedAt: nowDate(),
-    })
-    .where(eq(zeroWorkflowAutomations.id, automation.id));
-  signal.throwIfAborted();
-}
-
 export const runWorkflowAutomationNow$ = command(
   async (
     { set },
@@ -498,129 +64,64 @@ export const runWorkflowAutomationNow$ = command(
     signal: AbortSignal,
   ): Promise<RunWorkflowAutomationResult> => {
     const db = set(writeDb$);
-    const { automation, agentId, workflowName, chatThreadId } = args.due;
-    const timing = workflowAutomationTiming(args);
-
-    const enqueued = await enqueueWorkflowAutomationEventIfBusy({
-      db,
-      args,
-      timing,
-      signal,
-    });
-    if (enqueued) {
-      return { kind: "enqueued" };
+    const { automation, chatThreadId } = args.due;
+    const timing = args.timing ?? new ApiDispatchTimingCollector();
+    if (!args.timing) {
+      timing.recordElapsed(
+        "api_dispatch_pre_create_zero_workflow_automation_entrypoint_gap",
+        "nested",
+        args.apiStartTime,
+      );
     }
 
-    const activePreviousRunFailure = await checkActivePreviousWorkflowRun({
-      db,
-      automation,
-      activePreviousRunPolicy: args.activePreviousRunPolicy,
+    const admission = await measureApiDispatchTiming(
       timing,
-      signal,
-    });
-    if (activePreviousRunFailure) {
-      return activePreviousRunFailure;
-    }
-
-    const targetAccessFailure = await checkWorkflowAutomationTargetReadable({
-      db,
-      automation,
-      agentId,
-      allowClaimedOnceScheduleAutomation:
-        args.due.allowClaimedOnceScheduleAutomation === true,
-      timing,
-      signal,
-    });
-    if (targetAccessFailure) {
-      return targetAccessFailure;
-    }
-
-    const modelContext = await resolveTimedWorkflowModelContext({
-      db,
-      automation,
-      chatThreadId,
-      timing,
-      signal,
-    });
-    if (!modelContext.ok) {
-      return modelContext.failure;
-    }
-    const { modelPin, effectiveModelProvider, codexServiceTier } = modelContext;
-
-    const computerUseHostGrant = await loadComputerUseHostGrantForAutoSend({
-      db,
-      threadId: chatThreadId,
-      orgId: automation.orgId,
-      userId: automation.ownerUserId,
-    });
-    signal.throwIfAborted();
-
-    const runInput = await buildTimedWorkflowAutomationRunInput({
-      command: args,
-      automation,
-      agentId,
-      workflowName,
-      chatThreadId,
-      computerUseHostGrant,
-      timing,
-    });
-    signal.throwIfAborted();
-    timing.recordElapsed(
-      "api_dispatch_pre_create_zero_workflow_automation_create_run",
+      "api_dispatch_pre_create_zero_workflow_automation_queue_admission",
       "nested",
-      now(),
+      async () => {
+        return await admitWorkflowAutomationEvent(db, {
+          automation,
+          chatThreadId,
+          triggerSource: args.triggerSource ?? "workflow-schedule",
+          triggerBrief: args.triggerBrief,
+          coalescePendingScheduleRun: args.coalescePendingScheduleRun !== false,
+          params: queueEventParams(args),
+        });
+      },
     );
-    const result = await set(
-      createZeroRun$,
+    signal.throwIfAborted();
+
+    await publishChatThreadWorkflowQueueChangedSafely(
+      automation.ownerUserId,
+      chatThreadId,
+    );
+    signal.throwIfAborted();
+
+    const drained = await set(
+      drainChatThreadQueueForThread$,
       {
-        auth: {
-          orgId: automation.orgId,
-          orgRole: "member",
-          userId: automation.ownerUserId,
-          tokenType: "session",
-        },
-        body: {
-          prompt: runInput.prompt,
-          agentId,
-          ...(args.sessionId ? { sessionId: args.sessionId } : {}),
-          ...(effectiveModelProvider
-            ? { modelProvider: effectiveModelProvider }
-            : {}),
-        },
-        apiStartTime: args.apiStartTime,
-        triggerSource: args.triggerSource ?? "workflow-schedule",
         chatThreadId,
-        computerUseHostId: computerUseHostGrant?.hostId,
-        modelProviderId: modelPin.modelProviderId ?? undefined,
-        modelProviderCredentialScope:
-          modelPin.modelProviderCredentialScope ?? undefined,
-        selectedModelOverride: modelPin.selectedModel ?? undefined,
-        codexServiceTier,
-        appendSystemPrompt: runInput.appendSystemPrompt,
-        callbacks: runInput.callbacks,
-        zeroRunMetadata: runInput.zeroRunMetadata,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
-        timing,
+        ...(admission.kind === "inserted"
+          ? {
+              workflowEventLaunch: {
+                eventId: admission.eventId,
+                apiStartTime: args.apiStartTime,
+                timing,
+              },
+            }
+          : {}),
       },
       signal,
     );
     signal.throwIfAborted();
 
-    if (result.status !== 201) {
-      return { kind: "run_error", response: result };
+    if (
+      admission.kind === "inserted" &&
+      drained?.eventId === admission.eventId
+    ) {
+      return drained.result;
     }
-
-    await recordWorkflowAutomationRunStart({
-      db,
-      args,
-      runId: result.body.runId,
-      runStatus: result.body.status,
-      prompt: runInput.prompt,
-      modelPin,
-      effectiveModelProvider,
-      signal,
-    });
-
-    return { kind: "ok", runId: result.body.runId };
+    return { kind: "enqueued" };
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -12,12 +12,17 @@ import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtim
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import {
-  claimNextWorkflowQueueEvent,
+  consumeWorkflowQueueEvent,
   decryptWorkflowQueueEventParams,
-  restoreWorkflowQueueEventAndPause,
-  type ClaimedWorkflowQueueEvent,
+  loadNextWorkflowQueueEvent,
+  pauseWorkflowQueueEventAfterRunFailure,
+  type PendingWorkflowQueueEvent,
 } from "./chat-message-queue.service";
-import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
+import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
+import {
+  launchQueuedWorkflowAutomation$,
+  type RunWorkflowAutomationResult,
+} from "./zero-workflow-automation-launch.service";
 
 const log = logger("ZeroWorkflowQueueDrain");
 
@@ -33,7 +38,7 @@ interface DequeueTarget {
 
 async function loadDequeueTarget(
   db: Db,
-  event: ClaimedWorkflowQueueEvent,
+  event: PendingWorkflowQueueEvent,
 ): Promise<DequeueTarget | null> {
   const [row] = await db
     .select({
@@ -58,41 +63,147 @@ async function loadDequeueTarget(
 
 /**
  * Advance the thread's workflow queue: as long as user queued messages always
- * win (enforced inside `claimNextWorkflowQueueEvent`), pop the oldest event
- * and turn it into a run. Events whose automation disappeared or can no longer
- * fire are consumed and skipped; a run-creation failure restores the event to
- * the queue head and pauses the queue so the backlog is preserved.
+ * win (enforced inside `loadNextWorkflowQueueEvent`), prepare the oldest event
+ * and turn it into a run. The final run persistence transaction consumes the
+ * event. Stale events are serialized and removed; a run-creation failure
+ * leaves the event in place and pauses the queue.
  */
+export interface WorkflowQueueDrainResult {
+  readonly eventId: string;
+  readonly result: RunWorkflowAutomationResult;
+}
+
+interface WorkflowEventLaunch {
+  readonly eventId: string;
+  readonly apiStartTime: number;
+  readonly timing: ApiDispatchTimingCollector;
+}
+
+interface DrainWorkflowQueueArgs {
+  readonly chatThreadId: string;
+  readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly workflowEventLaunch?: WorkflowEventLaunch;
+}
+
+const CONTINUE_DRAIN = Symbol("continue-workflow-queue-drain");
+type WorkflowQueueDrainStep =
+  | WorkflowQueueDrainResult
+  | null
+  | typeof CONTINUE_DRAIN;
+
+async function publishQueueChanged(
+  event: PendingWorkflowQueueEvent,
+  signal: AbortSignal,
+): Promise<void> {
+  await publishChatThreadWorkflowQueueChangedSafely(
+    event.userId,
+    event.chatThreadId,
+  );
+  signal.throwIfAborted();
+}
+
+async function consumeInvalidWorkflowEvent(
+  db: Db,
+  event: PendingWorkflowQueueEvent,
+  conflictMessage: string,
+  launchHint: WorkflowEventLaunch | undefined,
+  signal: AbortSignal,
+): Promise<WorkflowQueueDrainStep> {
+  const consumed = await consumeWorkflowQueueEvent(db, {
+    eventId: event.id,
+    chatThreadId: event.chatThreadId,
+  });
+  signal.throwIfAborted();
+  if (!consumed) {
+    return null;
+  }
+  await publishQueueChanged(event, signal);
+  if (launchHint?.eventId !== event.id) {
+    return CONTINUE_DRAIN;
+  }
+  return {
+    eventId: event.id,
+    result: { kind: "conflict", message: conflictMessage },
+  };
+}
+
+async function handleWorkflowLaunchResult(
+  db: Db,
+  event: PendingWorkflowQueueEvent,
+  result: RunWorkflowAutomationResult,
+  launchHint: WorkflowEventLaunch | undefined,
+  signal: AbortSignal,
+): Promise<WorkflowQueueDrainStep> {
+  if (result.kind === "ok" || result.kind === "enqueued") {
+    await publishQueueChanged(event, signal);
+    return { eventId: event.id, result };
+  }
+  if (result.kind === "conflict") {
+    log.debug("Consuming unfireable workflow queue event", {
+      eventId: event.id,
+      automationId: event.automationId,
+      message: result.message,
+    });
+    const consumed = await consumeWorkflowQueueEvent(db, {
+      eventId: event.id,
+      chatThreadId: event.chatThreadId,
+    });
+    signal.throwIfAborted();
+    if (!consumed) {
+      return null;
+    }
+    await publishQueueChanged(event, signal);
+    return launchHint ? { eventId: event.id, result } : CONTINUE_DRAIN;
+  }
+
+  await pauseWorkflowQueueEventAfterRunFailure(db, {
+    eventId: event.id,
+    chatThreadId: event.chatThreadId,
+    pauseReason: result.response.body.error.message,
+    pausedAt: nowDate(),
+  });
+  signal.throwIfAborted();
+  log.warn("Workflow queue paused after run creation failure", {
+    eventId: event.id,
+    chatThreadId: event.chatThreadId,
+    code: result.response.body.error.code,
+  });
+  await publishQueueChanged(event, signal);
+  return { eventId: event.id, result };
+}
+
 export const drainWorkflowQueueForThread$ = command(
   async (
     { set },
-    args: {
-      readonly chatThreadId: string;
-      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
-    },
+    args: DrainWorkflowQueueArgs,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<WorkflowQueueDrainResult | null> => {
     const db = set(writeDb$);
 
     for (let attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
-      const event = await claimNextWorkflowQueueEvent(db, args.chatThreadId);
+      const event = await loadNextWorkflowQueueEvent(db, args.chatThreadId);
       signal.throwIfAborted();
       if (!event) {
-        return;
+        return null;
       }
 
       const target = await loadDequeueTarget(db, event);
       signal.throwIfAborted();
       if (!target) {
-        log.debug("Dropping workflow queue event without automation", {
+        log.debug("Consuming workflow queue event without automation", {
           eventId: event.id,
           automationId: event.automationId,
         });
-        await publishChatThreadWorkflowQueueChangedSafely(
-          event.userId,
-          event.chatThreadId,
+        const step = await consumeInvalidWorkflowEvent(
+          db,
+          event,
+          "Workflow automation no longer exists",
+          args.workflowEventLaunch,
+          signal,
         );
-        signal.throwIfAborted();
+        if (step !== CONTINUE_DRAIN) {
+          return step;
+        }
         continue;
       }
 
@@ -102,73 +213,70 @@ export const drainWorkflowQueueForThread$ = command(
       );
       signal.throwIfAborted();
       if (!params) {
-        log.error("Dropping undecryptable workflow queue event", {
+        log.error("Consuming undecryptable workflow queue event", {
           eventId: event.id,
           automationId: event.automationId,
         });
+        const step = await consumeInvalidWorkflowEvent(
+          db,
+          event,
+          "Workflow queue event payload is unreadable",
+          args.workflowEventLaunch,
+          signal,
+        );
+        if (step !== CONTINUE_DRAIN) {
+          return step;
+        }
         continue;
       }
 
       const triggerSource = triggerSourceSchema.safeParse(event.triggerSource);
+      const launchHint =
+        args.workflowEventLaunch?.eventId === event.id
+          ? args.workflowEventLaunch
+          : undefined;
       const result = await set(
-        runWorkflowAutomationNow$,
+        launchQueuedWorkflowAutomation$,
         {
           due: {
             automation: target.automation,
             agentId: target.agentId,
             workflowName: target.workflowName,
             chatThreadId: event.chatThreadId,
+            allowClaimedOnceScheduleAutomation:
+              params.allowClaimedOnceScheduleAutomation,
           },
-          apiStartTime: now(),
+          queueEventId: event.id,
+          apiStartTime: launchHint?.apiStartTime ?? now(),
+          sessionId: params.sessionId,
           prompt: params.prompt,
           triggerBrief: event.triggerBrief ?? undefined,
           triggerSource: triggerSource.success ? triggerSource.data : undefined,
           appendSystemPrompt: params.appendSystemPrompt,
           callbacks: params.callbacks,
-          activePreviousRunPolicy: "allow",
+          // Rows written before queue-first ingress always dequeued with
+          // "allow"; new rows persist their caller policy explicitly.
+          activePreviousRunPolicy: params.activePreviousRunPolicy ?? "allow",
           recordLastRunId: params.recordLastRunId,
           recordLastRunAt: params.recordLastRunAt,
-          bypassWorkflowQueue: true,
           dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+          timing: launchHint?.timing,
         },
         signal,
       );
       signal.throwIfAborted();
 
-      if (result.kind === "ok" || result.kind === "enqueued") {
-        await publishChatThreadWorkflowQueueChangedSafely(
-          event.userId,
-          event.chatThreadId,
-        );
-        signal.throwIfAborted();
-        return;
-      }
-      if (result.kind === "conflict") {
-        log.debug("Skipping unfireable workflow queue event", {
-          eventId: event.id,
-          automationId: event.automationId,
-          message: result.message,
-        });
-        continue;
-      }
-
-      await restoreWorkflowQueueEventAndPause(db, {
+      const step = await handleWorkflowLaunchResult(
+        db,
         event,
-        pauseReason: result.response.body.error.message,
-        pausedAt: nowDate(),
-      });
-      signal.throwIfAborted();
-      log.warn("Workflow queue paused after run creation failure", {
-        eventId: event.id,
-        chatThreadId: event.chatThreadId,
-        code: result.response.body.error.code,
-      });
-      await publishChatThreadWorkflowQueueChangedSafely(
-        event.userId,
-        event.chatThreadId,
+        result,
+        launchHint,
+        signal,
       );
-      signal.throwIfAborted();
-      return;
+      if (step !== CONTINUE_DRAIN) {
+        return step;
+      }
     }
+    return null;
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -17,6 +17,7 @@ import {
   loadNextWorkflowQueueEvent,
   pauseWorkflowQueueEventAfterRunFailure,
   type PendingWorkflowQueueEvent,
+  type WorkflowQueueEventParams,
 } from "./chat-message-queue.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import {
@@ -83,6 +84,29 @@ interface DrainWorkflowQueueArgs {
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
   readonly workflowEventLaunch?: WorkflowEventLaunch;
+}
+
+function allowClaimedOnceScheduleAutomation(
+  target: DequeueTarget,
+  params: WorkflowQueueEventParams,
+): boolean | undefined {
+  if (params.allowClaimedOnceScheduleAutomation !== undefined) {
+    return params.allowClaimedOnceScheduleAutomation;
+  }
+
+  const automation = target.automation;
+  if (
+    automation.kind === "schedule" &&
+    automation.scheduleType === "once" &&
+    !automation.enabled &&
+    automation.nextRunAt === null &&
+    automation.lastRunAt !== null
+  ) {
+    // Previous writers disabled a claimed one-time automation before inserting
+    // its v1 queue payload, which did not carry the explicit claim marker.
+    return true;
+  }
+  return undefined;
 }
 
 const CONTINUE_DRAIN = Symbol("continue-workflow-queue-drain");
@@ -169,7 +193,12 @@ async function handleWorkflowLaunchResult(
     code: result.response.body.error.code,
   });
   await publishQueueChanged(event, signal);
-  return { eventId: event.id, result };
+  return {
+    eventId: event.id,
+    // The failed launch did not consume the durable event. Report accepted
+    // ownership so ingress callers do not retry or reschedule a retained event.
+    result: { kind: "enqueued" },
+  };
 }
 
 export const drainWorkflowQueueForThread$ = command(
@@ -244,7 +273,7 @@ export const drainWorkflowQueueForThread$ = command(
             workflowName: target.workflowName,
             chatThreadId: event.chatThreadId,
             allowClaimedOnceScheduleAutomation:
-              params.allowClaimedOnceScheduleAutomation,
+              allowClaimedOnceScheduleAutomation(target, params),
           },
           queueEventId: event.id,
           apiStartTime: launchHint?.apiStartTime ?? now(),

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,11 +1,16 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { and, count, eq, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
+import {
+  decryptPersistentSecretsMap,
+  encryptPersistentSecretsMap,
+} from "../signals/services/crypto.utils";
 import { insertChatMessage } from "../signals/services/zero-chat-message.service";
 import { createDeferredPromise } from "../signals/utils";
 
@@ -20,6 +25,96 @@ const VM0_BDD_API_KEY_PREFIXES = [
 ] as const;
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
+const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
+const previousWorkflowQueueEventParamsSchema = z.object({
+  version: z.literal(1),
+  prompt: z.string().optional(),
+  appendSystemPrompt: z.string().optional(),
+  callbacks: z.array(z.unknown()).optional(),
+  recordLastRunId: z.boolean().optional(),
+  recordLastRunAt: z.boolean().optional(),
+});
+
+/**
+ * Rewrites one current workflow event to the persisted shape and automation
+ * state produced by the previous API version.
+ *
+ * Why product APIs cannot construct this state: the current writer always
+ * includes its new v1 fields and keeps a claimed one-time automation enabled
+ * until final run claim. This fixture is limited to one exact queue event and
+ * one exact one-time automation so the cross-version reader path can be tested.
+ */
+export async function rewriteWorkflowQueueEventAsPreviousVersionFixture(args: {
+  readonly eventId: string;
+  readonly automationId: string;
+}): Promise<void> {
+  const [event] = await db()
+    .select({
+      orgId: chatMessageQueue.orgId,
+      userId: chatMessageQueue.userId,
+      encryptedParams: chatMessageQueue.encryptedParams,
+    })
+    .from(chatMessageQueue)
+    .where(
+      and(
+        eq(chatMessageQueue.id, args.eventId),
+        eq(chatMessageQueue.automationId, args.automationId),
+        eq(chatMessageQueue.itemType, "workflow_event"),
+      ),
+    )
+    .limit(1);
+  if (!event?.encryptedParams) {
+    throw new Error("Expected a persisted workflow queue event");
+  }
+
+  const ctx = { orgId: event.orgId, userId: event.userId };
+  const decrypted = await decryptPersistentSecretsMap(
+    event.encryptedParams,
+    ctx,
+  );
+  const raw = decrypted?.[WORKFLOW_QUEUE_EVENT_PARAMS_KEY];
+  if (!raw) {
+    throw new Error("Expected workflow queue event params");
+  }
+  const previousParams = previousWorkflowQueueEventParamsSchema.parse(
+    JSON.parse(raw) as unknown,
+  );
+  const encryptedParams = await encryptPersistentSecretsMap(
+    { [WORKFLOW_QUEUE_EVENT_PARAMS_KEY]: JSON.stringify(previousParams) },
+    ctx,
+  );
+  if (!encryptedParams) {
+    throw new Error("Failed to encrypt previous workflow queue event params");
+  }
+
+  await db().transaction(async (tx) => {
+    const rewritten = await tx
+      .update(chatMessageQueue)
+      .set({ encryptedParams })
+      .where(
+        and(
+          eq(chatMessageQueue.id, args.eventId),
+          eq(chatMessageQueue.automationId, args.automationId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .returning({ id: chatMessageQueue.id });
+    const disabled = await tx
+      .update(zeroWorkflowAutomations)
+      .set({ enabled: false })
+      .where(
+        and(
+          eq(zeroWorkflowAutomations.id, args.automationId),
+          eq(zeroWorkflowAutomations.kind, "schedule"),
+          eq(zeroWorkflowAutomations.scheduleType, "once"),
+        ),
+      )
+      .returning({ id: zeroWorkflowAutomations.id });
+    if (rewritten.length !== 1 || disabled.length !== 1) {
+      throw new Error("Failed to reproduce previous workflow queue state");
+    }
+  });
+}
 
 async function transitiveBlockedWaiterCount(
   holderPid: number,


### PR DESCRIPTION
## Summary

- persist every workflow automation event in the chat-thread queue before run preparation
- claim the FIFO workflow event, append its immutable chat message, and persist the run in one final transaction
- remove the internal workflow-queue bypass and delete-before-create/restore window
- preserve queued user-message priority, workflow FIFO ordering, schedule coalescing, paused queues, and compatibility with pre-deploy queue payloads

## User impact

Workflow events can no longer disappear or race ahead of a user message between dequeue and run creation. Manual Run Now and automated workflow events now use the same durable thread scheduler all the way through final run admission.

## Scope

This is the first implementation PR for chat-thread/session unification. It only fixes workflow queue correctness; the authoritative chat-thread session binding is intentionally deferred to the next PR.

## Verification

- `pnpm format`
- `pnpm -F api lint`
- `node --max-old-space-size=6144 ../../node_modules/typescript/bin/tsc --noEmit` from `turbo/apps/api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts` — 7 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue-api.test.ts src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts` — 20 passed

The targeted tests include a deterministic final-admission race where a user message arrives while a workflow launch waits on the organization lock; the user run wins and the workflow event remains queued for the next drain.
