### PR TITLE
test(api): fix hanging concurrent managed browser test by keying the stop gate on the first thread's provider session

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -83,6 +83,14 @@ function providerBrowser(
   };
 }
 
+function providerSessionIdFromCdpUrl(cdpUrl: string): string {
+  const [providerSessionId] = new URL(cdpUrl).hostname.split(".");
+  if (!providerSessionId) {
+    throw new Error(`Unexpected provider CDP URL: ${cdpUrl}`);
+  }
+  return providerSessionId;
+}
+
 async function claimChatRun(
   runs: ReturnType<typeof createRunsApi>,
   actor: ApiTestUser,
@@ -219,6 +227,10 @@ describe("zero browser route", () => {
         releaseFirstStop.resolve(undefined);
       }
     });
+    // Both threads create their browser concurrently, so the provider session
+    // that belongs to the first thread is only known from its create response,
+    // never from the order the provider handed out sessions.
+    let firstThreadProviderSessionId: string | null = null;
     let profileCreates = 0;
     let providerCreates = 0;
     let providerStops = 0;
@@ -281,7 +293,7 @@ describe("zero browser route", () => {
           });
           providerStops += 1;
           const providerId = String(params.id);
-          if (providerId === providerIds[0]) {
+          if (providerId === firstThreadProviderSessionId) {
             if (!firstStopStarted.settled()) {
               firstStopStarted.resolve(undefined);
             }
@@ -295,7 +307,7 @@ describe("zero browser route", () => {
             }
           }
           return HttpResponse.json(
-            providerId === providerIds[0]
+            providerId === firstThreadProviderSessionId
               ? providerBrowser(providerId, {
                   status: "stopped",
                   browserCost: "0.00333",
@@ -342,6 +354,9 @@ describe("zero browser route", () => {
     });
     expect(created.body.cdpUrl).toMatch(
       /^https:\/\/[0-9a-f-]{36}\.cdp\.browser-use\.com\/$/u,
+    );
+    firstThreadProviderSessionId = providerSessionIdFromCdpUrl(
+      created.body.cdpUrl,
     );
     expect(createdInOtherThread.body.browser).toMatchObject({
       name: "research",


### PR DESCRIPTION
## Problem

`zero browser route > shares one profile across concurrent thread browser sessions` hangs for the full 120s test timeout on roughly 15-20% of runs, failing `test-api (5)` on main since #22940 merged (observed in runs [30150305424](https://github.com/vm0-ai/vm0/actions/runs/30150305424), [30150655610](https://github.com/vm0-ai/vm0/actions/runs/30150655610), [30151338659](https://github.com/vm0-ai/vm0/actions/runs/30151338659)).

The test issues both threads' `POST /api/zero/browsers` concurrently through `Promise.all`, and the mocked Browser Use create handler hands out provider session ids by arrival order:

```js
const id = providerIds[providerCreates];
providerCreates += 1;
```

The stop handler then used `providerId === providerIds[0]` to mean "the first thread's browser", gating `firstStopStarted` / `releaseFirstStop`, the injected 503 outage, and the browser/proxy cost branch on it.

Both creates contend on the `zero_browser_profile:<org>:<user>` advisory lock and the profile-create gate, so arrival order is not deterministic. When the *other* thread reaches the provider first, the first thread's browser gets `providerIds[1]`; the run-end stop then takes the ungated branch, completes immediately, and `await firstStopStarted.promise` never resolves — the test hangs until the timeout.

This is a test-side identity assumption. The product behaves identically under both interleavings: in the hanging runs the first thread's browser was still correctly `suspended` / `run_end` with its instance `stopped` and settled.

## Change

Bind the gate to the provider session the first thread actually received, taken from its own create response:

- add `providerSessionIdFromCdpUrl()` to read the provider session id out of `created.body.cdpUrl`
- track it in `firstThreadProviderSessionId`, assigned after both creates resolve and before any stop can occur
- use that variable for both the stop gate and the cost branch

No business assertion changes: `grossCredits: 124`, `suspensionReason: "run_end"`, the `providerStops` counts, and the "503 → deferred to reconciler → cron recovery" path are all preserved, and now hold regardless of which thread reaches the provider first. No retries, added timeouts, sleeps, or skips.

## Verification

Reproduced and validated locally against a fresh Postgres per iteration:

- before the fix: 2/12 fresh-DB runs hung with the same `Test timed out in 120000ms`; instrumentation showed the stall at `await firstStopStarted.promise`, with no Postgres backend blocked, and a controlled experiment confirmed the hang occurs exactly when the other thread wins the provider-create race
- after the fix: 26/26 clean runs pass, 3 of which exercised the previously fatal interleaving
- full shard as CI runs it (`--project=api --shard=5/8`): 21 files / 233 tests pass
- `prettier --check`, `eslint`, and `tsc --noEmit` for `apps/api` pass

## Note (not part of this change)

`runner_job_queue.expires_at` is a naive `timestamp` written as `clock_timestamp() AT TIME ZONE 'UTC' + interval '2 hours'` but compared with `expires_at > now()` (a `timestamptz`), so the claim query depends on the database session timezone. CI and production run UTC, so this is latent, but it makes every queued job look expired on a non-UTC session. Worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)