### PR TITLE
fix(guest-agent): classify no-chunks stream timeouts

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -354,7 +354,7 @@ fn is_claude_result_provider_stream_timeout(source: FailureDetailSource, normali
 
 fn is_claude_result_stream_idle_timeout(trimmed: &str) -> bool {
     trimmed.starts_with("api error: stream idle timeout")
-        && trimmed.contains("partial response received")
+        && (trimmed.contains("partial response received") || trimmed.contains("no chunks received"))
 }
 
 fn is_claude_result_stalled_mid_stream(trimmed: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -524,14 +524,23 @@ fn cli_failure_reason_ignores_simple_claude_overloaded_from_stderr() {
 }
 
 #[test]
-fn cli_failure_reason_classifies_claude_result_stream_idle_timeout() {
-    let reason = super::classify_cli_failure_reason(
-        AgentFramework::ClaudeCode,
-        FailureDetailSource::ClaudeResult,
+fn cli_failure_reason_classifies_claude_result_stream_idle_timeouts() {
+    for message in [
         "API Error: Stream idle timeout - partial response received",
-    );
+        "API Error: Stream idle timeout - no chunks received",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            message,
+        );
 
-    assert_eq!(reason, Some(FailureReason::ProviderStreamTimeout));
+        assert_eq!(
+            reason,
+            Some(FailureReason::ProviderStreamTimeout),
+            "message: {message}"
+        );
+    }
 }
 
 #[test]
@@ -546,37 +555,49 @@ fn cli_failure_reason_classifies_claude_result_stalled_mid_stream() {
 }
 
 #[test]
-fn cli_failure_reason_classifies_claude_result_stalled_mid_stream_diagnostic() {
-    let message = "API Error: Response stalled mid-stream. The response above may be incomplete.";
-    let msg = cli_failure_message(
-        1,
-        &["background stderr noise".to_string()],
-        Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
-    );
-    let diagnostic = FailureDiagnostic::new(
-        FailureClass::CliNonzero,
-        AgentFramework::ClaudeCode,
-        PromptMetadata::from_prompt("plain prompt"),
-    )
-    .with_cli_exit_code(1)
-    .with_failure_detail_source(msg.source);
-    let diagnostic = with_cli_failure_reason(diagnostic, &msg);
+fn cli_failure_reason_classifies_claude_result_stream_timeout_diagnostics() {
+    for message in [
+        "API Error: Stream idle timeout - partial response received",
+        "API Error: Stream idle timeout - no chunks received",
+        "API Error: Response stalled mid-stream. The response above may be incomplete.",
+    ] {
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
-    assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
-    assert_eq!(
-        diagnostic.failure_reason,
-        Some(FailureReason::ProviderStreamTimeout)
-    );
-    assert_eq!(
-        diagnostic.failure_detail_source,
-        Some(FailureDetailSource::ClaudeResult)
-    );
+        assert_eq!(
+            msg.source,
+            FailureDetailSource::ClaudeResult,
+            "message: {message}"
+        );
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::ProviderStreamTimeout),
+            "message: {message}"
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult),
+            "message: {message}"
+        );
+    }
 }
 
 #[test]
 fn cli_failure_reason_ignores_claude_result_stream_timeout_messages_from_stderr() {
     for message in [
         "API Error: Stream idle timeout - partial response received",
+        "API Error: Stream idle timeout - no chunks received",
         "API Error: Response stalled mid-stream. The response above may be incomplete.",
     ] {
         let reason = super::classify_cli_failure_reason(
@@ -593,6 +614,7 @@ fn cli_failure_reason_ignores_claude_result_stream_timeout_messages_from_stderr(
 fn cli_failure_reason_ignores_non_claude_stream_timeout_messages() {
     for message in [
         "API Error: Stream idle timeout - partial response received",
+        "API Error: Stream idle timeout - no chunks received",
         "API Error: Response stalled mid-stream. The response above may be incomplete.",
     ] {
         let reason = super::classify_cli_failure_reason(
@@ -606,20 +628,26 @@ fn cli_failure_reason_ignores_non_claude_stream_timeout_messages() {
 }
 
 #[test]
-fn cli_failure_reason_ignores_generic_claude_timeout() {
-    let reason = super::classify_cli_failure_reason(
-        AgentFramework::ClaudeCode,
-        FailureDetailSource::ClaudeResult,
+fn cli_failure_reason_ignores_unrecognized_claude_timeouts() {
+    for message in [
         "API Error: request timed out",
-    );
+        "API Error: Stream idle timeout - connection reset",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            message,
+        );
 
-    assert_eq!(reason, None);
+        assert_eq!(reason, None, "message: {message}");
+    }
 }
 
 #[test]
 fn cli_failure_reason_ignores_explanatory_stream_timeout_text() {
     for message in [
         "Observed API Error: Stream idle timeout - partial response received in an earlier run",
+        "Observed API Error: Stream idle timeout - no chunks received in an earlier run",
         "Observed API Error: Response stalled mid-stream. The response above may be incomplete in an earlier run",
     ] {
         let reason = super::classify_cli_failure_reason(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1477,7 +1477,7 @@ mod tests {
         .with_failure_reason(FailureReason::ProviderStreamTimeout);
         let failure = executor::ExecutionFailure::new(
             1,
-            "API Error: Stream idle timeout - partial response received",
+            "API Error: Stream idle timeout - no chunks received",
             Some(diagnostic),
         );
 
@@ -1491,7 +1491,7 @@ mod tests {
         assert_field_eq(
             &event,
             "error",
-            "API Error: Stream idle timeout - partial response received",
+            "API Error: Stream idle timeout - no chunks received",
         );
         assert_field_eq(&event, "failure_reason", "provider_stream_timeout");
         assert_field_eq(&event, "failure_class", "cli_nonzero");


### PR DESCRIPTION
## Summary

- classify Claude Code `Stream idle timeout - no chunks received` terminal results as the existing `provider_stream_timeout` reason
- preserve the Claude Code, `ClaudeResult`, and known-detail boundaries so stderr, other frameworks, generic timeouts, and unknown stream-idle variants remain unclassified
- verify the selected diagnostic path and the existing runner info-level structured log outcome

The run still fails with the original CLI error. This change does not add retry, replay, resume, schema, API, or runner policy changes.

Closes #23008

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason -- --test-threads=1`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider_stream_timeout -- --test-threads=1`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -p runner`
- pre-commit: full Rust formatting, Clippy, and documentation checks
