### PR TITLE
perf(runner): instrument claude output lifecycle timings

### DIFF
--- a/crates/runner/mitm-addon/src/claude_output_timing.py
+++ b/crates/runner/mitm-addon/src/claude_output_timing.py
@@ -1,0 +1,149 @@
+"""Content-free provider-output timing observations for Claude Code runs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from mitmproxy import http
+
+import flow_metadata
+import usage
+from usage.reporting_context import usage_reporting_context
+
+FIRST_MESSAGE_START = "claude_proxy_first_message_start"
+FIRST_THINKING_OR_TEXT_BLOCK_START = "claude_proxy_first_thinking_or_text_block_start"
+FIRST_TEXT_BLOCK_START = "claude_proxy_first_text_block_start"
+
+_MESSAGE_START_EVENT = "message_start"
+_CONTENT_BLOCK_START_EVENT = "content_block_start"
+_THINKING_OR_TEXT_BLOCK_TYPES = frozenset(("thinking", "redacted_thinking", "text"))
+_MAX_TRACKED_RUNS = 10_000
+_LOG_TYPE = "claude_output_timing"
+
+
+@dataclass
+class _RunTimingState:
+    first_message_start_observed: bool = False
+    first_thinking_or_text_block_observed: bool = False
+    first_text_block_observed: bool = False
+    pending_operations: dict[str, str] = field(default_factory=dict)
+
+
+_run_states: OrderedDict[str, _RunTimingState] = OrderedDict()
+
+
+def observe_lifecycle_event(
+    flow: http.HTTPFlow,
+    event_type: str,
+    content_block_type: str | None,
+) -> None:
+    """Observe one complete, content-free Anthropic SSE lifecycle event."""
+    run_id = flow_metadata.run_id(flow.metadata)
+    if not run_id:
+        return
+
+    state = _run_states.get(run_id)
+    if event_type == _MESSAGE_START_EVENT:
+        if state is None:
+            state = _state_for_run(run_id)
+        else:
+            _touch_run(run_id)
+        if not state.first_message_start_observed:
+            state.first_message_start_observed = True
+            state.pending_operations[FIRST_MESSAGE_START] = _observation_time()
+        _admit_pending(flow, run_id, state)
+        return
+
+    if event_type != _CONTENT_BLOCK_START_EVENT:
+        return
+
+    is_thinking_or_text = content_block_type in _THINKING_OR_TEXT_BLOCK_TYPES
+    is_text = content_block_type == "text"
+    if state is None:
+        if not is_thinking_or_text:
+            return
+        state = _state_for_run(run_id)
+    else:
+        _touch_run(run_id)
+
+    observed_at: str | None = None
+    if is_thinking_or_text and not state.first_thinking_or_text_block_observed:
+        observed_at = _observation_time()
+        state.first_thinking_or_text_block_observed = True
+        state.pending_operations[FIRST_THINKING_OR_TEXT_BLOCK_START] = observed_at
+    if is_text and not state.first_text_block_observed:
+        if observed_at is None:
+            observed_at = _observation_time()
+        state.first_text_block_observed = True
+        state.pending_operations[FIRST_TEXT_BLOCK_START] = observed_at
+    _admit_pending(flow, run_id, state)
+
+
+def retry_pending(flow: http.HTTPFlow) -> None:
+    """Retry admission for pending observations when an SSE flow terminates."""
+    run_id = flow_metadata.run_id(flow.metadata)
+    if not run_id:
+        return
+    state = _run_states.get(run_id)
+    if state is None:
+        return
+    _touch_run(run_id)
+    _admit_pending(flow, run_id, state)
+
+
+def _observation_time() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _state_for_run(run_id: str) -> _RunTimingState:
+    state = _run_states.get(run_id)
+    if state is None:
+        state = _RunTimingState()
+        _run_states[run_id] = state
+        if len(_run_states) > _MAX_TRACKED_RUNS:
+            _run_states.popitem(last=False)
+        return state
+
+    _touch_run(run_id)
+    return state
+
+
+def _touch_run(run_id: str) -> None:
+    _run_states.move_to_end(run_id)
+
+
+def _admit_pending(flow: http.HTTPFlow, run_id: str, state: _RunTimingState) -> None:
+    if not state.pending_operations:
+        return
+
+    context = usage_reporting_context(flow)
+    if not context.is_complete:
+        return
+
+    operations = [
+        {
+            "ts": observed_at,
+            "action_type": action_type,
+            "duration_ms": 0,
+            "success": True,
+        }
+        for action_type, observed_at in state.pending_operations.items()
+    ]
+    payload: dict[str, object] = {
+        "runId": run_id,
+        "sandboxOperations": operations,
+    }
+    if usage.webhook.enqueue_webhook_delivery(
+        context.telemetry_url(),
+        context.sandbox_token,
+        payload,
+        context.proxy_log_path,
+        _LOG_TYPE,
+    ):
+        state.pending_operations.clear()
+
+
+def reset_for_tests() -> None:
+    _run_states.clear()

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -24,6 +24,7 @@ from mitmproxy import http
 from wsproto.utilities import generate_accept_token
 
 import body_decoding
+import claude_output_timing
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import usage
@@ -48,6 +49,7 @@ _HTTP_OWS_CHARS = " \t"
 
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
+_AnthropicLifecycleObserver = Callable[[str, str | None], None]
 
 
 class CapturedResponseStreamBody(NamedTuple):
@@ -129,6 +131,22 @@ def _make_model_sse_parse_error_logger(
     return log_parse_error
 
 
+def _anthropic_lifecycle_observer(
+    flow: http.HTTPFlow,
+) -> _AnthropicLifecycleObserver | None:
+    if flow_metadata.cli_agent_type(flow.metadata) != "claude-code":
+        return None
+
+    def observe(event_type: str, content_block_type: str | None) -> None:
+        claude_output_timing.observe_lifecycle_event(
+            flow,
+            event_type,
+            content_block_type,
+        )
+
+    return observe
+
+
 def _response_can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
     """Return whether HTTP semantics permit content on this response."""
     status_code = response.status_code
@@ -190,6 +208,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     if is_observable_model_provider:
         content_type = response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
+            lifecycle_observer: _AnthropicLifecycleObserver | None = None
             if uses_openai_responses_usage_protocol(flow):
                 usage_protocol = "openai_responses_sse"
                 log_parse_error = _make_model_sse_parse_error_logger(
@@ -205,8 +224,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                     flow,
                     usage_protocol=usage_protocol,
                 )
+                lifecycle_observer = _anthropic_lifecycle_observer(flow)
                 parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
-                    on_parse_error=log_parse_error
+                    on_parse_error=log_parse_error,
+                    on_lifecycle_event=lifecycle_observer,
                 )
             decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
@@ -219,8 +240,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                 if decode_error is not None:
                     usage_dict.clear()
                     log_parse_error("compressed_body", decode_error)
-                    return
-                parser_fn.finish()
+                else:
+                    parser_fn.finish()
+                if lifecycle_observer is not None:
+                    claude_output_timing.retry_pending(flow)
 
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
             return _ResponseUsageStreamSetup(decode_session.feed, False)

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -16,6 +16,7 @@ from .sse import SseUsageScanner
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _SseUsageParseErrorCallback = Callable[[str, str], None]
+AnthropicMessagesLifecycleCallback = Callable[[str, str | None], None]
 
 _MODEL_JSON_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
@@ -28,6 +29,7 @@ _MODEL_JSON_SCALAR_FIELDS = {
 
 _ANTHROPIC_SSE_SCALAR_FIELDS = {
     ("type",): ScalarField("string", max_bytes=1024),
+    ("content_block", "type"): ScalarField("string", max_bytes=1024),
     ("message", "id"): ScalarField("string", max_bytes=1024),
     ("message", "model"): ScalarField("string", max_bytes=1024),
     **{
@@ -60,6 +62,7 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
 
 def create_anthropic_messages_sse_usage_extractor(
     on_parse_error: _SseUsageParseErrorCallback | None = None,
+    on_lifecycle_event: AnthropicMessagesLifecycleCallback | None = None,
 ) -> tuple[SseUsageScanner, dict]:
     """Create an incremental SSE parser that extracts usage from Anthropic API streams.
 
@@ -80,7 +83,11 @@ def create_anthropic_messages_sse_usage_extractor(
     """
     usage: dict = {}
     parser = SseUsageScanner(
-        _AnthropicMessagesSseUsageHandler(usage, on_parse_error=on_parse_error),
+        _AnthropicMessagesSseUsageHandler(
+            usage,
+            on_parse_error=on_parse_error,
+            on_lifecycle_event=on_lifecycle_event,
+        ),
         # Anthropic-shaped streams can omit SSE event names and rely on JSON
         # "type" fields to classify message_start/message_delta payloads.
         capture_data_without_event=True,
@@ -94,13 +101,17 @@ class _AnthropicMessagesSseUsageHandler:
         usage: dict,
         *,
         on_parse_error: _SseUsageParseErrorCallback | None = None,
+        on_lifecycle_event: AnthropicMessagesLifecycleCallback | None = None,
     ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
         self._on_parse_error = on_parse_error
+        self._on_lifecycle_event = on_lifecycle_event
 
     def should_capture_event(self, event_name: str | None) -> bool:
-        return event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS
+        return event_name in _ANTHROPIC_MESSAGES_USAGE_EVENTS or (
+            event_name == "content_block_start" and self._on_lifecycle_event is not None
+        )
 
     def on_event_start(self, event_name: str | None) -> None:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_ANTHROPIC_SSE_SCALAR_FIELDS)
@@ -134,11 +145,10 @@ class _AnthropicMessagesSseUsageHandler:
                 self._on_parse_error(event_type, result.error)
             return
 
+        data_type = result.values.get(("type",))
         event_type = event_name
-        if event_type is None:
-            data_type = result.values.get(("type",))
-            if isinstance(data_type, str):
-                event_type = data_type
+        if event_type is None and isinstance(data_type, str):
+            event_type = data_type
 
         if event_type == "message_start":
             model = result.values.get(("message", "model"))
@@ -150,6 +160,19 @@ class _AnthropicMessagesSseUsageHandler:
             _store_selected_usage_values(result.values, self._usage, ("message", "usage"))
         elif event_type == "message_delta":
             _store_selected_usage_values(result.values, self._usage, ("usage",))
+
+        if self._on_lifecycle_event is None:
+            return
+        if isinstance(data_type, str) and event_name is not None and data_type != event_name:
+            return
+        if event_type == "message_start":
+            self._on_lifecycle_event(event_type, None)
+        elif event_type == "content_block_start":
+            block_type = result.values.get(("content_block", "type"))
+            self._on_lifecycle_event(
+                event_type,
+                block_type if isinstance(block_type, str) else None,
+            )
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._extractor = None

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -28,6 +28,7 @@ from mitmproxy.test import tflow, tutils
 import auth
 import auth_base_forwarder
 import builtin_connector_diagnostics
+import claude_output_timing
 import codex_output_timing
 import logging_utils
 import mitm_addon
@@ -66,11 +67,13 @@ def _reset_module_state() -> Iterator[None]:
     usage.counters.reset_for_tests()
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.reset_usage_buffer_for_tests()
+    claude_output_timing.reset_for_tests()
     codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     yield
     runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     usage.reset_usage_buffer_for_tests()
+    claude_output_timing.reset_for_tests()
     codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -22,6 +22,18 @@ def _create_parser_with_parse_errors():
     return parse, usage, parse_errors
 
 
+def _create_parser_with_lifecycle_events():
+    lifecycle_events: list[tuple[str, str | None]] = []
+
+    def record_lifecycle_event(event_type: str, content_block_type: str | None) -> None:
+        lifecycle_events.append((event_type, content_block_type))
+
+    parse, usage = create_anthropic_messages_sse_usage_extractor(
+        on_lifecycle_event=record_lifecycle_event
+    )
+    return parse, usage, lifecycle_events
+
+
 class TestAnthropicSseUsageExtractor:
     """Tests for the incremental SSE usage parser."""
 
@@ -168,6 +180,85 @@ class TestAnthropicSseUsageExtractor:
         assert usage["tokens.input"] == 40
         assert usage["tokens.output"] == 250
 
+    def test_reports_content_free_lifecycle_fields_for_selected_events(self):
+        parse, usage, lifecycle_events = _create_parser_with_lifecycle_events()
+
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"content":[{"type":"text","text":"secret"}],'
+            b'"usage":{"input_tokens":40}}}\n\n'
+            b"event: content_block_start\n"
+            b'data: {"type":"content_block_start","index":0,'
+            b'"content_block":{"type":"thinking","thinking":"secret"}}\n\n'
+            b"event: content_block_start\n"
+            b'data: {"type":"content_block_start","index":1,'
+            b'"content_block":{"type":"tool_use","name":"secret"}}\n\n'
+            b"event: content_block_start\n"
+            b'data: {"type":"content_block_start","index":2,'
+            b'"content_block":{"type":"future_block","content":"secret"}}\n\n'
+        )
+
+        assert usage["tokens.input"] == 40
+        assert lifecycle_events == [
+            ("message_start", None),
+            ("content_block_start", "thinking"),
+            ("content_block_start", "tool_use"),
+            ("content_block_start", "future_block"),
+        ]
+
+    def test_reports_eventless_lifecycle_fields_from_data_type(self):
+        parse, usage, lifecycle_events = _create_parser_with_lifecycle_events()
+
+        parse(
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":41}}}\n\n'
+            b'data: {"type":"content_block_start","index":0,'
+            b'"content_block":{"type":"redacted_thinking","data":"secret"}}\n\n'
+            b'data: {"type":"content_block_start","index":1,'
+            b'"content_block":{"type":"text","text":"secret"}}\n\n'
+        )
+
+        assert usage["tokens.input"] == 41
+        assert lifecycle_events == [
+            ("message_start", None),
+            ("content_block_start", "redacted_thinking"),
+            ("content_block_start", "text"),
+        ]
+
+    def test_lifecycle_event_type_mismatch_is_ignored_and_parser_recovers(self):
+        parse, usage, lifecycle_events = _create_parser_with_lifecycle_events()
+
+        parse(
+            b"event: content_block_start\n"
+            b'data: {"type":"message_start","content_block":{"type":"text"}}\n\n'
+            b"event: content_block_start\n"
+            b'data: {"type":"content_block_start",'
+            b'"content_block":{"type":"text","text":"secret"}}\n\n'
+        )
+
+        assert usage == {}
+        assert lifecycle_events == [("content_block_start", "text")]
+
+    def test_malformed_or_oversized_lifecycle_events_do_not_report(self):
+        parse, usage, lifecycle_events = _create_parser_with_lifecycle_events()
+        oversized_type = b"x" * 1025
+
+        parse(b'event: message_start\ndata: {"type":"message_start"\n\n')
+        parse(
+            b"event: content_block_start\n"
+            b'data: {"type":"content_block_start","content_block":{"type":"'
+            + oversized_type
+            + b'"}}\n\n'
+        )
+        parse(
+            b"event: content_block_delta\n"
+            b'data: {"type":"content_block_delta","delta":{"text":"secret"}}\n\n'
+        )
+
+        assert usage == {}
+        assert lifecycle_events == []
+
     @pytest.mark.parametrize("event_type", ["message_start", "message_delta"])
     def test_data_only_malformed_usage_event_reports_parse_error(self, event_type):
         parse, usage, parse_errors = _create_parser_with_parse_errors()
@@ -288,15 +379,15 @@ class TestAnthropicSseUsageExtractor:
         """Entering skip mode leaves unprocessed line_buf data; next chunk should handle it."""
         parse, usage = create_anthropic_messages_sse_usage_extractor()
         # One chunk has event line + start of data (no newline yet) + another event
-        # The while loop processes "event: content_block_start", sets skip, returns.
+        # The while loop processes "event: content_block_stop", sets skip, returns.
         # line_buf still has the partial "data: ..." from this chunk.
         parse(
-            b"event: content_block_start\n"
-            b'data: {"type":"content_block_start"}\n\n'
+            b"event: content_block_stop\n"
+            b'data: {"type":"content_block_stop"}\n\n'
             b"event: message_delta\n"
             b'data: {"usage":{"output_tokens":77}}\n\n'
         )
-        # content_block_start triggers skip, but \n\n boundary is in same chunk.
+        # content_block_stop triggers skip, but \n\n boundary is in same chunk.
         # Skip mode should find it and then process message_delta.
         assert usage["tokens.output"] == 77
 
@@ -310,8 +401,8 @@ class TestAnthropicSseUsageExtractor:
         )
         # Two consecutive skip events
         parse(
-            b"event: content_block_start\n"
-            b'data: {"type":"content_block_start"}\n\n'
+            b"event: ping\n"
+            b'data: {"type":"ping"}\n\n'
             b"event: content_block_delta\n"
             b'data: {"delta":{"text":"hello world"}}\n\n'
             b"event: content_block_stop\n"

--- a/crates/runner/mitm-addon/tests/test_claude_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_claude_output_timing.py
@@ -1,0 +1,384 @@
+"""Tests for Claude Code provider-output timing observations."""
+
+import gzip
+import json
+from datetime import UTC, datetime
+from itertools import pairwise
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from mitmproxy import http
+from mitmproxy.flow import Error
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import usage
+from tests.flow_helpers import response_stream
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
+from tests.model_provider_flow_helpers import make_model_provider_sse_flow
+from tests.usage_helpers import CapturedWebhookRequest, UsageWebhookServer
+from tests.webhook_test_helpers import QueuedUsageExecutor
+
+_TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
+_FIRST_MESSAGE_START = "claude_proxy_first_message_start"
+_FIRST_THINKING_OR_TEXT_BLOCK_START = "claude_proxy_first_thinking_or_text_block_start"
+_FIRST_TEXT_BLOCK_START = "claude_proxy_first_text_block_start"
+
+
+def _claude_sse_flow(
+    real_flow,
+    tmp_path: Path,
+    *,
+    cli_agent_type: str | None = "claude-code",
+    model_usage_provider: str | None = "claude-sonnet-4-6",
+) -> http.HTTPFlow:
+    return make_model_provider_sse_flow(
+        real_flow,
+        tmp_path,
+        host="api.anthropic.com",
+        original_url="https://api.anthropic.com/v1/messages",
+        firewall_name="model-provider:anthropic-api-key",
+        cli_agent_type=cli_agent_type,
+        model_usage_provider=model_usage_provider,
+    )
+
+
+def _message_start(*, secret: str | None = None) -> bytes:
+    content: list[dict[str, str]] = []
+    if secret is not None:
+        content.append({"type": "text", "text": secret})
+    return _sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+                "content": content,
+                "usage": {"input_tokens": 50, "output_tokens": 1},
+            },
+        },
+    )
+
+
+def _content_block_start(block_type: str, *, secret: str | None = None) -> bytes:
+    content_block: dict[str, str] = {"type": block_type}
+    if secret is not None:
+        content_block["content"] = secret
+        content_block["text"] = secret
+        content_block["thinking"] = secret
+    return _sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": content_block,
+        },
+    )
+
+
+def _sse_event(event_type: str, payload: dict[str, object]) -> bytes:
+    return (
+        f"event: {event_type}\n".encode()
+        + b"data: "
+        + json.dumps(payload, separators=(",", ":")).encode()
+        + b"\n\n"
+    )
+
+
+def _timing_requests(webhook: UsageWebhookServer) -> list[CapturedWebhookRequest]:
+    return [request for request in webhook.requests if request.path == _TELEMETRY_PATH]
+
+
+def _operations(requests: list[CapturedWebhookRequest]) -> list[dict[str, object]]:
+    operations: list[dict[str, object]] = []
+    for request in requests:
+        body = request.json_body()
+        request_operations = body.get("sandboxOperations")
+        assert isinstance(request_operations, list)
+        for operation in request_operations:
+            assert isinstance(operation, dict)
+            operations.append(operation)
+    return operations
+
+
+def _feed(flow: http.HTTPFlow, *events: bytes) -> None:
+    callback = response_stream(flow)
+    for event in events:
+        assert callback(event) == event
+
+
+@pytest.mark.parametrize("thinking_type", ["thinking", "redacted_thinking"])
+def test_reports_content_free_lifecycle_milestones_and_preserves_usage(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    thinking_type: str,
+) -> None:
+    flow = _claude_sse_flow(real_flow, tmp_path)
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    secret = "provider-secret-that-must-not-be-reported"
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed(
+            flow,
+            _message_start(secret=secret),
+            _content_block_start(thinking_type, secret=secret),
+            _content_block_start("text", secret=secret),
+        )
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    requests = _timing_requests(usage_webhook_server)
+    assert [len(request.json_body()["sandboxOperations"]) for request in requests] == [
+        1,
+        1,
+        1,
+    ]
+    assert all(request.header("authorization") == "Bearer tok-xyz" for request in requests)
+
+    operations = _operations(requests)
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_MESSAGE_START,
+        _FIRST_THINKING_OR_TEXT_BLOCK_START,
+        _FIRST_TEXT_BLOCK_START,
+    ]
+    assert all(operation["duration_ms"] == 0 for operation in operations)
+    assert all(operation["success"] is True for operation in operations)
+    timestamps = [datetime.fromisoformat(str(operation["ts"])) for operation in operations]
+    assert timestamps == sorted(timestamps)
+    assert all(timestamp.tzinfo == UTC for timestamp in timestamps)
+    assert all(request.json_body()["runId"] == "run-abc-123" for request in requests)
+
+    usage_events = usage_webhook_server.usage_events()
+    assert {event["category"]: event["quantity"] for event in usage_events} == {
+        "tokens.input": 50,
+        "tokens.output": 1,
+    }
+    serialized_requests = b"".join(request.body for request in requests)
+    assert secret.encode() not in serialized_requests
+    assert secret not in read_jsonl_text_after_flush(proxy_log)
+
+
+def test_text_first_uses_one_observation_time_for_broad_and_text_milestones(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    flow = _claude_sse_flow(real_flow, tmp_path)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed(flow, _message_start(), _content_block_start("text"))
+        mitm_addon.response(flow)
+
+    requests = _timing_requests(usage_webhook_server)
+    assert [len(request.json_body()["sandboxOperations"]) for request in requests] == [1, 2]
+    operations = _operations(requests)
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_MESSAGE_START,
+        _FIRST_THINKING_OR_TEXT_BLOCK_START,
+        _FIRST_TEXT_BLOCK_START,
+    ]
+    assert operations[1]["ts"] == operations[2]["ts"]
+
+
+def test_tool_turns_reconnects_and_reused_sandboxes_preserve_run_boundaries(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        tool_only = _claude_sse_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(tool_only)
+        _feed(tool_only, _message_start(), _content_block_start("tool_use"))
+        mitm_addon.response(tool_only)
+
+        later_turn = _claude_sse_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(later_turn)
+        _feed(
+            later_turn,
+            _message_start(),
+            _content_block_start("thinking"),
+            _content_block_start("text"),
+        )
+        mitm_addon.response(later_turn)
+
+        reconnect = _claude_sse_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(reconnect)
+        _feed(
+            reconnect,
+            _message_start(),
+            _content_block_start("redacted_thinking"),
+            _content_block_start("text"),
+        )
+        mitm_addon.response(reconnect)
+
+        reused_sandbox_run = _claude_sse_flow(real_flow, tmp_path)
+        reused_sandbox_run.metadata[metadata_keys.VM_RUN_ID] = "run-reused-sandbox"
+        mitm_addon.responseheaders(reused_sandbox_run)
+        _feed(
+            reused_sandbox_run,
+            _message_start(),
+            _content_block_start("thinking"),
+            _content_block_start("text"),
+        )
+        mitm_addon.response(reused_sandbox_run)
+
+    operations_by_run: dict[str, list[dict[str, object]]] = {}
+    for request in _timing_requests(usage_webhook_server):
+        body = request.json_body()
+        run_id = body["runId"]
+        assert isinstance(run_id, str)
+        operations_by_run.setdefault(run_id, []).extend(_operations([request]))
+
+    expected_actions = [
+        _FIRST_MESSAGE_START,
+        _FIRST_THINKING_OR_TEXT_BLOCK_START,
+        _FIRST_TEXT_BLOCK_START,
+    ]
+    assert {
+        run_id: [operation["action_type"] for operation in operations]
+        for run_id, operations in operations_by_run.items()
+    } == {
+        "run-abc-123": expected_actions,
+        "run-reused-sandbox": expected_actions,
+    }
+
+
+def test_irrelevant_flows_and_events_do_not_report_timings(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        for flow in (
+            _claude_sse_flow(real_flow, tmp_path, cli_agent_type="codex"),
+            _claude_sse_flow(real_flow, tmp_path, cli_agent_type=None),
+            _claude_sse_flow(real_flow, tmp_path, model_usage_provider=None),
+        ):
+            mitm_addon.responseheaders(flow)
+            _feed(flow, _message_start(), _content_block_start("text"))
+
+        non_sse = _claude_sse_flow(real_flow, tmp_path)
+        assert non_sse.response is not None
+        non_sse.response.headers["content-type"] = "application/json"
+        mitm_addon.responseheaders(non_sse)
+        _feed(non_sse, _message_start(), _content_block_start("text"))
+
+        mismatched = _claude_sse_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(mismatched)
+        _feed(
+            mismatched,
+            _sse_event(
+                "content_block_start",
+                {
+                    "type": "message_start",
+                    "content_block": {"type": "text"},
+                },
+            ),
+            _sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "secret"},
+                },
+            ),
+        )
+
+    assert _timing_requests(usage_webhook_server) == []
+
+
+def test_gzip_chunks_are_observed_without_changing_forwarded_bytes(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+) -> None:
+    flow = _claude_sse_flow(real_flow, tmp_path)
+    assert flow.response is not None
+    flow.response.headers["content-encoding"] = "gzip"
+    plaintext = _message_start() + _content_block_start("text")
+    compressed = gzip.compress(plaintext)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        offsets = (0, 1, 7, len(compressed) // 2, len(compressed))
+        for start, end in pairwise(offsets):
+            chunk = compressed[start:end]
+            assert callback(chunk) == chunk
+        mitm_addon.response(flow)
+
+    assert [
+        operation["action_type"]
+        for operation in _operations(_timing_requests(usage_webhook_server))
+    ] == [
+        _FIRST_MESSAGE_START,
+        _FIRST_THINKING_OR_TEXT_BLOCK_START,
+        _FIRST_TEXT_BLOCK_START,
+    ]
+
+
+@pytest.mark.parametrize("terminal_hook", ["response", "error"])
+def test_saturated_delivery_retries_at_terminal_with_original_observation_time(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    terminal_hook: str,
+) -> None:
+    flow = _claude_sse_flow(real_flow, tmp_path)
+    executor = QueuedUsageExecutor()
+
+    with (
+        mitm_ctx(api_url=usage_webhook_server.api_url),
+        patch.object(usage.webhook, "usage_executor", executor),
+    ):
+        mitm_addon.responseheaders(flow)
+        for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
+            assert usage.webhook.enqueue_webhook_delivery(
+                usage_webhook_server.url("/filler"),
+                "tok-xyz",
+                {"runId": f"filler-{index}", "events": []},
+                str(tmp_path / "filler.jsonl"),
+                "usage_event",
+            )
+
+        _feed(flow, _message_start())
+        assert _timing_requests(usage_webhook_server) == []
+
+        first_delivery, first_args, first_kwargs = executor.submissions.pop(0)
+        assert callable(first_delivery)
+        first_delivery(*first_args, **first_kwargs)
+        retry_started_at = datetime.now(UTC)
+        if terminal_hook == "error":
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+        else:
+            mitm_addon.response(flow)
+
+        submissions = list(executor.submissions)
+        executor.submissions.clear()
+        for delivery, args, kwargs in submissions:
+            assert callable(delivery)
+            delivery(*args, **kwargs)
+
+    [request] = _timing_requests(usage_webhook_server)
+    [operation] = _operations([request])
+    assert operation["action_type"] == _FIRST_MESSAGE_START
+    assert datetime.fromisoformat(str(operation["ts"])) <= retry_started_at
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    assert flow.response is not None
+    assert flow.response.stream is False

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -180,6 +180,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_model_provider_websocket_usage.py`                | Model provider WebSocket usage reporting and source reconciliation                                                   |
 | `test_model_provider_websocket_lifecycle.py`            | Model provider WebSocket HTTP upgrade and terminal usage lifecycle                                                   |
 | `test_codex_output_timing.py`                           | Default Codex provider-output timing observations over WebSocket                                                     |
+| `test_claude_output_timing.py`                          | Claude Code provider-output lifecycle timing over Anthropic SSE                                                      |
 | `test_websocket_retention.py`                           | Registered WebSocket message retention and cleanup                                                                   |
 | `test_model_provider_websocket_metadata.py`             | Model provider WebSocket usage metadata parsing                                                                      |
 | `test_model_provider_usage.py`                          | Model provider usage reporter                                                                                        |


### PR DESCRIPTION
## Summary

- emit run-scoped timestamps for Claude's first `message_start`, first thinking-or-text block, and first text block through the existing sandbox operation telemetry path
- extend the existing Anthropic SSE scanner to expose only lifecycle event and block types, while preserving usage extraction and excluding provider content
- preserve first-observation semantics across tool turns and reconnects, with bounded state and terminal retry when webhook delivery is saturated

## Scope

- applies only to observable Anthropic SSE flows classified as `claude-code`
- does not change API contracts, database schema, queue payloads, persisted state, Codex timing behavior, or UI/browser timing
- does not add a feature switch or follow-up cleanup path

## Validation

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4255 passed

Closes #23038

Parent delivery issue: #22917
