### PR TITLE
fix(preview): propagate bypass through sandbox cli requests

### DIFF
--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -21,6 +21,12 @@ import { matchedRoutes } from "hono/route";
 import { corsMiddleware } from "./lib/cors";
 import { env } from "./lib/env";
 import { flushLogs, logger } from "./lib/log";
+import {
+  cookieHeaderValue,
+  previewAutomationBypassSecret,
+  requestHasPreviewAutomationBypassHeaderOrCookie,
+  VERCEL_PROTECTION_BYPASS_HEADER,
+} from "./lib/preview-automation-bypass";
 import { now } from "./lib/time";
 import { isSupportedWebClientVersion } from "./lib/web-client-compatibility";
 import { waitUntil } from "./signals/context/wait-until";
@@ -41,8 +47,6 @@ import {
 const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
-const VERCEL_PROTECTION_BYPASS_HEADER = "x-vercel-protection-bypass";
-const VERCEL_PROTECTION_BYPASS_COOKIE = VERCEL_PROTECTION_BYPASS_HEADER;
 const PREVIEW_AUTOMATION_BYPASS_ERROR = "Preview automation bypass required";
 const BYPASS_FINGERPRINT_LENGTH = 12;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
@@ -302,67 +306,17 @@ function requestHeader(context: Context, name: string): string | undefined {
   return presentHeaderValue(context.req.raw.headers.get(name));
 }
 
-function previewAutomationBypassSecret(): string | undefined {
-  if (env("ENV") !== "preview") {
-    return undefined;
-  }
-  return env("VERCEL_AUTOMATION_BYPASS_SECRET");
-}
-
-function unquoteCookieValue(value: string): string {
-  return value.startsWith('"') && value.endsWith('"')
-    ? value.slice(1, -1)
-    : value;
-}
-
-function safeDecodeURIComponent(value: string): string {
-  const result = safeSync(() => {
-    return decodeURIComponent(value);
-  });
-  return "ok" in result ? result.ok : value;
-}
-
-function cookieHeaderValue(
-  cookieHeader: string | undefined,
-  name: string,
-): string | undefined {
-  for (const cookie of cookieHeader?.split(";") ?? []) {
-    const separatorIndex = cookie.indexOf("=");
-    if (separatorIndex === -1) {
-      continue;
-    }
-    const key = cookie.slice(0, separatorIndex).trim();
-    if (key !== name) {
-      continue;
-    }
-    return unquoteCookieValue(cookie.slice(separatorIndex + 1).trim());
-  }
-  return undefined;
-}
-
-function cookieHeaderHasBypassSecret(
-  cookieHeader: string | undefined,
-  secret: string,
-): boolean {
-  const value = cookieHeaderValue(
-    cookieHeader,
-    VERCEL_PROTECTION_BYPASS_COOKIE,
-  );
-  return value === secret || safeDecodeURIComponent(value ?? "") === secret;
-}
-
 function requestHasPreviewAutomationBypass(
   context: Context,
   secret: string,
 ): boolean {
-  if (requestHeader(context, VERCEL_PROTECTION_BYPASS_HEADER) === secret) {
+  if (
+    requestHasPreviewAutomationBypassHeaderOrCookie(context.req.raw, secret)
+  ) {
     return true;
   }
   const url = safeUrlParse(context.req.url);
-  if (url?.searchParams.get(VERCEL_PROTECTION_BYPASS_HEADER) === secret) {
-    return true;
-  }
-  return cookieHeaderHasBypassSecret(requestHeader(context, "cookie"), secret);
+  return url?.searchParams.get(VERCEL_PROTECTION_BYPASS_HEADER) === secret;
 }
 
 function isCorsPreflightRequest(context: Context): boolean {
@@ -408,7 +362,7 @@ function previewAutomationBypassDebug(context: Context, secret: string) {
     cookie: bypassFingerprint(
       cookieHeaderValue(
         requestHeader(context, "cookie"),
-        VERCEL_PROTECTION_BYPASS_COOKIE,
+        VERCEL_PROTECTION_BYPASS_HEADER,
       ),
     ),
     cookieHeaderPresent: Boolean(requestHeader(context, "cookie")),

--- a/turbo/apps/api/src/lib/preview-automation-bypass.ts
+++ b/turbo/apps/api/src/lib/preview-automation-bypass.ts
@@ -1,0 +1,53 @@
+import { env } from "./env";
+import { safeUriComponentDecode } from "../signals/utils";
+
+export const VERCEL_AUTOMATION_BYPASS_ENV = "VERCEL_AUTOMATION_BYPASS_SECRET";
+export const VERCEL_PROTECTION_BYPASS_HEADER = "x-vercel-protection-bypass";
+
+export function previewAutomationBypassSecret(): string | undefined {
+  if (env("ENV") !== "preview") {
+    return undefined;
+  }
+  return env("VERCEL_AUTOMATION_BYPASS_SECRET");
+}
+
+function unquoteCookieValue(value: string): string {
+  return value.startsWith('"') && value.endsWith('"')
+    ? value.slice(1, -1)
+    : value;
+}
+
+export function cookieHeaderValue(
+  cookieHeader: string | undefined,
+  name: string,
+): string | undefined {
+  for (const cookie of cookieHeader?.split(";") ?? []) {
+    const separatorIndex = cookie.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const key = cookie.slice(0, separatorIndex).trim();
+    if (key !== name) {
+      continue;
+    }
+    return unquoteCookieValue(cookie.slice(separatorIndex + 1).trim());
+  }
+  return undefined;
+}
+
+export function requestHasPreviewAutomationBypassHeaderOrCookie(
+  request: Request,
+  secret: string,
+): boolean {
+  if (request.headers.get(VERCEL_PROTECTION_BYPASS_HEADER)?.trim() === secret) {
+    return true;
+  }
+  const cookieValue = cookieHeaderValue(
+    request.headers.get("cookie") ?? undefined,
+    VERCEL_PROTECTION_BYPASS_HEADER,
+  );
+  return (
+    cookieValue === secret ||
+    safeUriComponentDecode(cookieValue ?? "") === secret
+  );
+}

--- a/turbo/apps/api/src/signals/context/hono.ts
+++ b/turbo/apps/api/src/signals/context/hono.ts
@@ -3,6 +3,11 @@ import { command, computed, state } from "ccstate";
 import type { Context } from "hono";
 import { RedirectStatusCode } from "hono/utils/http-status";
 
+import {
+  previewAutomationBypassSecret,
+  requestHasPreviewAutomationBypassHeaderOrCookie,
+} from "../../lib/preview-automation-bypass";
+
 const innerHonoContext$ = state<Context>({} as Context);
 const innerRoute$ = state<AppRoute | null>(null);
 
@@ -23,6 +28,14 @@ function header(name: string) {
 export const userAgent$ = header("User-Agent");
 export const authorization$ = header("authorization");
 export const cookie$ = header("cookie");
+export const previewAutomationBypass$ = computed((get) => {
+  const context = get(innerHonoContext$);
+  const secret = previewAutomationBypassSecret();
+  return secret &&
+    requestHasPreviewAutomationBypassHeaderOrCookie(context.req.raw, secret)
+    ? secret
+    : undefined;
+});
 
 function resHeader(name: string) {
   return computed((get) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -819,10 +819,14 @@ export function createRunsApi(context: TestContext) {
       actor: ApiTestUser | null,
       body: ZeroRunRequest,
       statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 429 | 503)[],
+      extraHeaders?: Readonly<Record<string, string>>,
     ) {
       return await accept(
         runApp(context)(zeroRunsMainContract).create({
-          headers: authenticate(context, actor),
+          headers: {
+            ...authenticate(context, actor),
+            ...extraHeaders,
+          },
           body,
         }),
         statuses,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8398,6 +8398,50 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 });
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
+  it("passes a valid preview bypass header or cookie into the run environment", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const previewBypass = "bdd-preview-bypass";
+    const requests = [
+      {
+        prompt: "preview bypass from header",
+        headers: { "x-vercel-protection-bypass": previewBypass },
+      },
+      {
+        prompt: "preview bypass from cookie",
+        headers: {
+          cookie: `other=value; x-vercel-protection-bypass=${previewBypass}`,
+        },
+      },
+    ] as const;
+
+    for (const request of requests) {
+      mockEnv("ENV", "preview");
+      mockEnv("VERCEL_AUTOMATION_BYPASS_SECRET", previewBypass);
+      const created = await api.requestCreateRun(
+        actor,
+        {
+          agentId,
+          prompt: request.prompt,
+          modelProvider: "anthropic-api-key",
+        },
+        [201],
+        request.headers,
+      );
+      mockEnv("ENV", "development");
+
+      expect(created.status).toBe(201);
+      if (created.status !== 201) {
+        throw new Error("Expected preview run creation to succeed");
+      }
+      const claim = await api.claimRunnerJob(created.body.runId);
+      expect(claim.environment).toMatchObject({
+        VERCEL_AUTOMATION_BYPASS_SECRET: previewBypass,
+      });
+      await api.requestCancelRun(actor, created.body.runId, [200]);
+    }
+  });
+
   it("accepts previous runner telemetry", async () => {
     const api = createRunsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -115,6 +115,8 @@ import {
   notFound,
   providerUnavailable,
 } from "../../lib/error";
+import { VERCEL_AUTOMATION_BYPASS_ENV } from "../../lib/preview-automation-bypass";
+import { previewAutomationBypass$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import {
@@ -6912,7 +6914,19 @@ export const prepareAgentRun$ = command(
     input: PrepareAgentRunArgs,
     signal: AbortSignal,
   ): Promise<PreparedAgentRun | CreateRunErrorResult> => {
-    const { args, timing } = input;
+    // A preview request that passed the protection guard gives its sandbox CLI
+    // the same bypass through the existing user-environment channel.
+    const previewAutomationBypass = get(previewAutomationBypass$);
+    const args = previewAutomationBypass
+      ? {
+          ...input.args,
+          extraEnvironment: {
+            ...input.args.extraEnvironment,
+            [VERCEL_AUTOMATION_BYPASS_ENV]: previewAutomationBypass,
+          },
+        }
+      : input.args;
+    const { timing } = input;
     const db = set(writeDb$);
     if (input.checkOrgPlanStatusBeforeContext) {
       const tierGate = await timing.measure(

--- a/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
   CLIENT_REQUEST_ID_HEADER,
@@ -65,6 +65,7 @@ describe("CLI client headers", () => {
   });
 
   it("overrides spoofed headers after contract-client header merging", async () => {
+    vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-bypass");
     const contract = initContract();
     const testContract = contract.router({
       get: {
@@ -114,6 +115,12 @@ describe("CLI client headers", () => {
     }
 
     expect(firstHeaders.get("authorization")).toBe("Bearer test-token");
+    expect(firstHeaders.get("x-vercel-protection-bypass")).toBe(
+      "preview-bypass",
+    );
+    expect(secondHeaders.get("x-vercel-protection-bypass")).toBe(
+      "preview-bypass",
+    );
     expect(firstHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
     expect(firstHeaders.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
     expect(secondHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");

--- a/turbo/apps/cli/src/lib/api/client-headers.ts
+++ b/turbo/apps/cli/src/lib/api/client-headers.ts
@@ -13,6 +13,8 @@ import {
 
 declare const __CLI_VERSION__: string;
 
+const VERCEL_PROTECTION_BYPASS_HEADER = "x-vercel-protection-bypass";
+
 type CliClientHeaderInjector = (headers: Headers) => void;
 
 export function createCliClientHeaderInjector(options: {
@@ -36,6 +38,10 @@ const addDefaultCliClientHeaders = createCliClientHeaderInjector({
 
 function addCliClientHeaders(headers: Headers): void {
   addDefaultCliClientHeaders(headers);
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers.set(VERCEL_PROTECTION_BYPASS_HEADER, bypassSecret);
+  }
 }
 
 export function headersWithCliClientHeaders(

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -25,13 +25,6 @@ function buildHeaders(token: string): Record<string, string> {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-
-  // Add Vercel bypass secret if available (for CI/preview deployments)
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
-
   return headers;
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/integrations-feishu.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-feishu.ts
@@ -90,10 +90,6 @@ export async function downloadFeishuFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),
   });

--- a/turbo/apps/cli/src/lib/api/domains/integrations-github.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-github.ts
@@ -75,10 +75,6 @@ export async function downloadGithubFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),

--- a/turbo/apps/cli/src/lib/api/domains/integrations-phone.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-phone.ts
@@ -92,10 +92,6 @@ export async function downloadPhoneFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),

--- a/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
@@ -113,10 +113,6 @@ export async function downloadSlackFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),

--- a/turbo/apps/cli/src/lib/api/domains/integrations-teams.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-teams.ts
@@ -89,10 +89,6 @@ export async function downloadTeamsFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),

--- a/turbo/apps/cli/src/lib/api/domains/integrations-telegram.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-telegram.ts
@@ -110,10 +110,6 @@ export async function downloadTelegramFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -146,10 +146,6 @@ export async function downloadWebFile(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(url, {
     headers: headersWithCliClientHeaders(headers),
@@ -387,10 +383,6 @@ function authenticatedJsonHeaders(token: string): Headers {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headersWithCliClientHeaders(headers);
 }
 
@@ -726,10 +718,6 @@ export async function uploadWebFile(
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    prepareHeaders["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const prepareUrl = new URL("/api/zero/uploads/prepare", baseUrl);
   const prepareRes = await fetch(prepareUrl, {
@@ -810,10 +798,6 @@ export async function generateWebVoice(
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(new URL("/api/zero/voice-io/speech", baseUrl), {
     method: "POST",
@@ -854,10 +838,6 @@ export async function generateWebImage(
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(
     new URL("/api/zero/image-io/generate", baseUrl),
@@ -930,10 +910,6 @@ export async function generateWebVideo(
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const response = await fetch(
     new URL("/api/zero/video-io/generate", baseUrl),
@@ -984,10 +960,6 @@ export async function transcribeAudio(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
 
   const url = new URL("/api/zero/voice-io/stt", baseUrl);
   if (options.verbose) {

--- a/turbo/apps/cli/src/lib/api/domains/zero-banking.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-banking.ts
@@ -18,10 +18,6 @@ function authenticatedJsonHeaders(token: string): Record<string, string> {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headers;
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -48,10 +48,6 @@ function buildHeaders(token?: string): Record<string, string> {
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headers;
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-host.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-host.ts
@@ -19,10 +19,6 @@ function authHeaders(
   if (options.json) {
     headers["Content-Type"] = "application/json";
   }
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headers;
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-maps.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-maps.ts
@@ -25,10 +25,6 @@ function authenticatedJsonHeaders(token: string): Record<string, string> {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headers;
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-weather.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-weather.ts
@@ -24,10 +24,6 @@ function authenticatedJsonHeaders(token: string): Record<string, string> {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
   };
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
   return headers;
 }
 

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   vi.stubEnv("VM0_APP_URL", undefined);
   vi.stubEnv("ZERO_TOKEN", "");
   vi.stubEnv("ZERO_AGENT_ID", "");
+  vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", undefined);
 
   vi.stubEnv("SENTRY_DSN", "");
 });


### PR DESCRIPTION
## Summary

- Carry a valid `x-vercel-protection-bypass` request header or cookie into the run's existing `extraEnvironment` payload as `VERCEL_AUTOMATION_BYPASS_SECRET`.
- Reuse the current API → runner execution context → guest user environment path, so no runner protocol or Rust changes are required.
- Centralize Zero CLI bypass-header injection in the shared API request-header layer and remove the duplicated per-domain implementations.

## Behavior and compatibility

- The API only propagates the value in preview when the incoming header or cookie matches its configured bypass secret. Query-string bypasses still satisfy the existing preview guard but are not copied into the run environment.
- The environment field is additive, so draining old runners continue to accept the same claim shape and forward the user environment as before.
- Zero API requests receive the bypass automatically when the CLI environment contains it. Presigned storage uploads, artifact downloads, and third-party requests do not receive the header.
- Production behavior is unchanged.

## Verification

- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts -t 'preview automation bypass'` — 6 passed
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/lib/api/__tests__/client-headers.test.ts` — 2 passed
- Added an API BDD assertion covering both header and cookie propagation through runner claim; it is left to the PR pipeline because the local test database is not running.
- API package typecheck produced no diagnostics before the local 4 GB environment approached its memory limit; the PR pipeline remains authoritative for that check.

Fixes #23043
