### PR TITLE
fix(api): exclude fresh events from stale queue sweep

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -32,6 +32,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
   holdOrgAdmissionLockFixture,
   rewriteWorkflowQueueEventAsPreviousVersionFixture,
+  setWorkflowQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/chat-messages";
 
 const context = testContext();
@@ -329,6 +330,60 @@ describe("workflow queue", () => {
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       runId,
     ]);
+  });
+
+  it("does not let the stale sweep drain a fresh user message ahead of a stale workflow event", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowRequest = postWorkflowWebhook(automation, "stale event");
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    const queued = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    const event = queued.body.pending[0];
+    if (!event) {
+      throw new Error("Expected a pending workflow event");
+    }
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: event.id,
+      createdAt: new Date("2019-12-31T23:54:00.000Z"),
+    });
+
+    const userRequest = chatMessagesClient().send({
+      headers: authHeaders(),
+      body: {
+        agentId: scenario.agentId,
+        threadId: automation.threadId,
+        prompt: "fresh user message",
+      },
+    });
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+
+    await cleanupSandboxes();
+    await expect(admissionLock.waiterCount()).resolves.toBe(2);
+
+    admissionLock.release();
+    const [workflowResult, userResult] = await Promise.all([
+      workflowRequest,
+      accept(userRequest, [201]),
+    ]);
+    await admissionLock.done;
+    expect(workflowResult.status).toBe(200);
+    expect(userResult.status).toBe(201);
   });
 
   it("queues webhook events behind the active run and drains one per completion", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   DecryptCommand,
@@ -33,6 +33,7 @@ import {
   completeRunWithoutCallbacksFixture,
   holdOrgAdmissionLockFixture,
   rewriteWorkflowQueueEventAsPreviousVersionFixture,
+  setQueuedUserMessageCreatedAtFixture,
   setWorkflowQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/chat-messages";
 
@@ -429,6 +430,48 @@ describe("workflow queue", () => {
     expect(recovered.body.pending).toHaveLength(0);
     expect(recovered.body.running?.runId).toStrictEqual(expect.any(String));
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
+  });
+
+  it("recovers a stale user message after its terminal callback is missed", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+    );
+    const messageId = randomUUID();
+    const queued = await accept(
+      chatMessagesClient().send({
+        headers: authHeaders(),
+        body: {
+          agentId: scenario.agentId,
+          threadId: automation.threadId,
+          prompt: "stale user message",
+          clientMessageId: messageId,
+        },
+      }),
+      [201],
+    );
+    expect(queued.body.runId).toBeNull();
+    await setQueuedUserMessageCreatedAtFixture({
+      messageId,
+      createdAt: new Date("2019-12-31T23:54:00.000Z"),
+    });
+
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    await runsApi.claimRunnerJob(firstRunId);
+    await completeRunWithoutCallbacksFixture({ runId: firstRunId });
+
+    await cleanupSandboxes();
+
+    const messages = await wf.readThreadMessages(automation.threadId);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        content: "stale user message",
+        revokesMessageId: messageId,
+        runId: expect.any(String),
+      }),
+    );
   });
 
   it("queues webhook events behind the active run and drains one per completion", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -30,6 +30,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
+  completeRunWithoutCallbacksFixture,
   holdOrgAdmissionLockFixture,
   rewriteWorkflowQueueEventAsPreviousVersionFixture,
   setWorkflowQueueEventCreatedAtFixture,
@@ -384,6 +385,50 @@ describe("workflow queue", () => {
     await admissionLock.done;
     expect(workflowResult.status).toBe(200);
     expect(userResult.status).toBe(201);
+  });
+
+  it("recovers a stale workflow event after its terminal callback is missed", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+    );
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "stale pending event"),
+    );
+    const queued = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    const event = queued.body.pending[0];
+    if (!event) {
+      throw new Error("Expected a pending workflow event");
+    }
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: event.id,
+      createdAt: new Date("2019-12-31T23:54:00.000Z"),
+    });
+
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    await runsApi.claimRunnerJob(firstRunId);
+    await completeRunWithoutCallbacksFixture({ runId: firstRunId });
+
+    await cleanupSandboxes();
+
+    const recovered = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(recovered.body.pending).toHaveLength(0);
+    expect(recovered.body.running?.runId).toStrictEqual(expect.any(String));
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
   });
 
   it("queues webhook events behind the active run and drains one per completion", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -42,6 +42,7 @@ const webhooksApi = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
+const CRON_CLEANUP_SANDBOXES_ROUTE = "/api/cron/cleanup-sandboxes";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
   "/api/cron/execute-workflow-automations";
 const CRON_SECRET = "test-cron-secret";
@@ -293,7 +294,43 @@ async function executeDueWorkflowAutomations(): Promise<void> {
   expect(response.status).toBe(200);
 }
 
+async function cleanupSandboxes(): Promise<void> {
+  const response = await createApp({ signal: context.signal }).request(
+    CRON_CLEANUP_SANDBOXES_ROUTE,
+    { headers: { authorization: `Bearer ${CRON_SECRET}` } },
+  );
+  expect(response.status).toBe(200);
+}
+
 describe("workflow queue", () => {
+  it("does not let the stale sweep race a newly admitted workflow event", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowRequest = postWorkflowWebhook(automation, "fresh event");
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+
+    await cleanupSandboxes();
+    await expect(admissionLock.waiterCount()).resolves.toBe(1);
+
+    admissionLock.release();
+    const result = await workflowRequest;
+    await admissionLock.done;
+    const runId = expectAcceptedRunId(result);
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      runId,
+    ]);
+  });
+
   it("queues webhook events behind the active run and drains one per completion", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -7,7 +7,7 @@ import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
 } from "@vm0/db/schema/zero-workflow";
-import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import type { Db, ReadonlyDb } from "../external/db";
@@ -438,13 +438,16 @@ export async function pauseWorkflowQueueEventAfterRunFailure(
 }
 
 /**
- * Chat threads with pending work — the safety-net sweep re-drains these in
- * case admission or a terminal-run callback missed its immediate drain.
+ * Chat threads with stale pending work — the safety-net sweep re-drains these
+ * after the immediate admission or terminal-run callback had time to finish.
  * User messages remain drainable while workflow automation intake is paused.
  */
-export async function pendingChatThreadQueueThreadIds(
+export async function staleChatThreadQueueThreadIds(
   db: Db,
-  limit: number,
+  args: {
+    readonly staleBefore: Date;
+    readonly limit: number;
+  },
 ): Promise<readonly string[]> {
   const rows = await db
     .selectDistinct({ chatThreadId: chatMessageQueue.chatThreadId })
@@ -452,6 +455,7 @@ export async function pendingChatThreadQueueThreadIds(
     .innerJoin(chatThreads, eq(chatThreads.id, chatMessageQueue.chatThreadId))
     .where(
       and(
+        lt(chatMessageQueue.createdAt, args.staleBefore),
         or(
           inArray(chatMessageQueue.itemType, [
             "user_message",
@@ -465,7 +469,7 @@ export async function pendingChatThreadQueueThreadIds(
         ),
       ),
     )
-    .limit(limit);
+    .limit(args.limit);
   return rows.map((row) => {
     return row.chatThreadId;
   });

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -272,6 +272,7 @@ export interface PendingWorkflowQueueEvent {
 export async function loadNextWorkflowQueueEvent(
   db: Db,
   chatThreadId: string,
+  queueItemCreatedBefore?: Date,
 ): Promise<PendingWorkflowQueueEvent | null> {
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(chatThreadId));
@@ -303,6 +304,9 @@ export async function loadNextWorkflowQueueEvent(
         and(
           eq(chatMessageQueue.chatThreadId, chatThreadId),
           eq(chatMessageQueue.itemType, "workflow_event"),
+          queueItemCreatedBefore
+            ? lt(chatMessageQueue.createdAt, queueItemCreatedBefore)
+            : undefined,
         ),
       )
       .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -3,8 +3,9 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
+import { nowDate } from "../external/time";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
-import { pendingChatThreadQueueThreadIds } from "./chat-message-queue.service";
+import { staleChatThreadQueueThreadIds } from "./chat-message-queue.service";
 import {
   drainQueuedUserMessagesForThread$,
   type ChatCallbackPreCreateTimingCollector,
@@ -16,6 +17,7 @@ import {
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
+const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
 
 interface DrainChatThreadQueueInput {
   readonly chatThreadId: string;
@@ -104,10 +106,10 @@ export const drainStaleChatThreadQueues$ = command(
     signal: AbortSignal,
   ): Promise<number> => {
     const db = set(writeDb$);
-    const threadIds = await pendingChatThreadQueueThreadIds(
-      db,
-      DRAIN_SWEEP_LIMIT,
-    );
+    const threadIds = await staleChatThreadQueueThreadIds(db, {
+      staleBefore: new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS),
+      limit: DRAIN_SWEEP_LIMIT,
+    });
     signal.throwIfAborted();
     for (const chatThreadId of threadIds) {
       await set(

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -22,6 +22,7 @@ const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
 interface DrainChatThreadQueueInput {
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly queueItemCreatedBefore?: Date;
   readonly timing?: ChatCallbackPreCreateTimingCollector;
   readonly workflowEventLaunch?: {
     readonly eventId: string;
@@ -49,7 +50,11 @@ export const drainChatThreadQueueForThread$ = command(
   ): Promise<WorkflowQueueDrainResult | null> => {
     await set(
       drainQueuedUserMessagesForThread$,
-      { chatThreadId: input.chatThreadId, timing: input.timing },
+      {
+        chatThreadId: input.chatThreadId,
+        queueItemCreatedBefore: input.queueItemCreatedBefore,
+        timing: input.timing,
+      },
       signal,
     );
     signal.throwIfAborted();
@@ -58,6 +63,7 @@ export const drainChatThreadQueueForThread$ = command(
       {
         chatThreadId: input.chatThreadId,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        queueItemCreatedBefore: input.queueItemCreatedBefore,
         ...(input.workflowEventLaunch
           ? { workflowEventLaunch: input.workflowEventLaunch }
           : {}),
@@ -106,8 +112,9 @@ export const drainStaleChatThreadQueues$ = command(
     signal: AbortSignal,
   ): Promise<number> => {
     const db = set(writeDb$);
+    const staleBefore = new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS);
     const threadIds = await staleChatThreadQueueThreadIds(db, {
-      staleBefore: new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS),
+      staleBefore,
       limit: DRAIN_SWEEP_LIMIT,
     });
     signal.throwIfAborted();
@@ -117,6 +124,7 @@ export const drainStaleChatThreadQueues$ = command(
         {
           chatThreadId,
           dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+          queueItemCreatedBefore: staleBefore,
         },
         signal,
       );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2299,6 +2299,7 @@ async function autoSendQueuedMessageForThread(args: {
   readonly chatThreadId: string;
   readonly userId: string;
   readonly agentId: string;
+  readonly queueItemCreatedBefore?: Date;
   readonly timing: ChatCallbackPreCreateTimingCollector;
 }): Promise<void> {
   const { chatThreadId: threadId, userId } = args;
@@ -2308,7 +2309,11 @@ async function autoSendQueuedMessageForThread(args: {
     "api_dispatch_pre_create_zero_chat_callback_auto_send_lookup_queued_message",
     "nested",
     () => {
-      return loadNextUnclaimedQueuedUserMessage(args.db, threadId);
+      return loadNextUnclaimedQueuedUserMessage(
+        args.db,
+        threadId,
+        args.queueItemCreatedBefore,
+      );
     },
   );
   if (!queuedMessage) {
@@ -3216,6 +3221,7 @@ export const drainQueuedUserMessagesForThread$ = command(
     { set },
     args: {
       readonly chatThreadId: string;
+      readonly queueItemCreatedBefore?: Date;
       readonly timing?: ChatCallbackPreCreateTimingCollector;
     },
     signal: AbortSignal,
@@ -3251,6 +3257,7 @@ export const drainQueuedUserMessagesForThread$ = command(
       chatThreadId: args.chatThreadId,
       userId: thread.userId,
       agentId: thread.agentId,
+      queueItemCreatedBefore: args.queueItemCreatedBefore,
       timing: args.timing ?? new ChatCallbackPreCreateTimingCollector(),
       getResolvedAttachFiles: dependencies.getResolvedAttachFiles,
       createRun: (input) => {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -7,7 +7,7 @@ import {
   type ChatMessageStructuredPrompt,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { and, asc, eq, exists, inArray, sql, type SQL } from "drizzle-orm";
+import { and, asc, eq, exists, inArray, lt, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -184,6 +184,7 @@ export function queuedUserMessageExists(db: Pick<Db, "select">): SQL {
 export async function loadNextUnclaimedQueuedUserMessage(
   db: Db,
   threadId: string,
+  queueItemCreatedBefore?: Date,
 ): Promise<QueuedUserMessage | null> {
   const [message] = await db
     .select({
@@ -210,7 +211,14 @@ export async function loadNextUnclaimedQueuedUserMessage(
       eq(chatMessages.id, chatMessageQueue.chatMessageId),
     )
     .innerJoin(chatThreads, eq(chatThreads.id, chatMessages.chatThreadId))
-    .where(unclaimedQueuedUserMessageCondition(threadId))
+    .where(
+      and(
+        unclaimedQueuedUserMessageCondition(threadId),
+        queueItemCreatedBefore
+          ? lt(chatMessageQueue.createdAt, queueItemCreatedBefore)
+          : undefined,
+      ),
+    )
     .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))
     .limit(1);
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -83,6 +83,7 @@ interface WorkflowEventLaunch {
 interface DrainWorkflowQueueArgs {
   readonly chatThreadId: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly queueItemCreatedBefore?: Date;
   readonly workflowEventLaunch?: WorkflowEventLaunch;
 }
 
@@ -210,7 +211,11 @@ export const drainWorkflowQueueForThread$ = command(
     const db = set(writeDb$);
 
     for (let attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
-      const event = await loadNextWorkflowQueueEvent(db, args.chatThreadId);
+      const event = await loadNextWorkflowQueueEvent(
+        db,
+        args.chatThreadId,
+        args.queueItemCreatedBefore,
+      );
       signal.throwIfAborted();
       if (!event) {
         return null;

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -61,6 +61,29 @@ export async function setWorkflowQueueEventCreatedAtFixture(args: {
 }
 
 /**
+ * Move one exact queued web message into historical state without waiting for
+ * real time to pass. Product APIs cannot construct an already-stale queue item.
+ */
+export async function setQueuedUserMessageCreatedAtFixture(args: {
+  readonly messageId: string;
+  readonly createdAt: Date;
+}): Promise<void> {
+  const updated = await db()
+    .update(chatMessageQueue)
+    .set({ createdAt: args.createdAt })
+    .where(
+      and(
+        eq(chatMessageQueue.chatMessageId, args.messageId),
+        eq(chatMessageQueue.itemType, "user_message"),
+      ),
+    )
+    .returning({ id: chatMessageQueue.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one queued user message to become historical");
+  }
+}
+
+/**
  * Complete one claimed run without dispatching its terminal callbacks. This
  * reproduces the missed-callback state that the stale queue sweep recovers.
  */

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,4 +1,5 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
@@ -7,6 +8,7 @@ import { z } from "zod";
 
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
+import { nowDate } from "../lib/time";
 import {
   decryptPersistentSecretsMap,
   encryptPersistentSecretsMap,
@@ -55,6 +57,24 @@ export async function setWorkflowQueueEventCreatedAtFixture(args: {
     .returning({ id: chatMessageQueue.id });
   if (updated.length !== 1) {
     throw new Error("Expected one workflow queue event to become historical");
+  }
+}
+
+/**
+ * Complete one claimed run without dispatching its terminal callbacks. This
+ * reproduces the missed-callback state that the stale queue sweep recovers.
+ */
+export async function completeRunWithoutCallbacksFixture(args: {
+  readonly runId: string;
+}): Promise<void> {
+  const completedAt = nowDate();
+  const updated = await db()
+    .update(agentRuns)
+    .set({ status: "completed", completedAt })
+    .where(and(eq(agentRuns.id, args.runId), eq(agentRuns.status, "running")))
+    .returning({ id: agentRuns.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one running run to complete without callbacks");
   }
 }
 

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -36,6 +36,29 @@ const previousWorkflowQueueEventParamsSchema = z.object({
 });
 
 /**
+ * Move one exact workflow event into historical state without waiting for real
+ * time to pass. Product APIs cannot construct an already-stale queue item.
+ */
+export async function setWorkflowQueueEventCreatedAtFixture(args: {
+  readonly eventId: string;
+  readonly createdAt: Date;
+}): Promise<void> {
+  const updated = await db()
+    .update(chatMessageQueue)
+    .set({ createdAt: args.createdAt })
+    .where(
+      and(
+        eq(chatMessageQueue.id, args.eventId),
+        eq(chatMessageQueue.itemType, "workflow_event"),
+      ),
+    )
+    .returning({ id: chatMessageQueue.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one workflow queue event to become historical");
+  }
+}
+
+/**
  * Rewrites one current workflow event to the persisted shape and automation
  * state produced by the previous API version.
  *


### PR DESCRIPTION
## Summary

- exclude chat queue items younger than five minutes from the global stale-queue sweep
- enforce the same cutoff when the scheduler loads the actual user-message or workflow-event queue head
- keep immediate workflow and user-message admission as the sole owner of fresh items
- add API concurrency coverage for isolated fresh events, mixed-priority queues, and stale workflow/user recovery

## Background

Workflow events are persisted before run preparation so the final run transaction can claim them atomically. The stale-queue sweep previously selected every pending item regardless of age, allowing a concurrent cron invocation to race the request that had just inserted an event. In parallel API tests, the cron worker could consume another worker's event into a failed run before the original request completed.

The five-minute grace period preserves crash recovery while keeping normal request processing out of the safety-net path. With the minutely cron schedule, an abandoned item is recovered after approximately five to six minutes.

The cutoff is applied both while selecting candidate threads and while loading the queue head. This prevents an old lower-priority workflow event from selecting a thread and then causing the scheduler to claim a newly inserted, higher-priority user message.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts apps/api/src/signals/services/chat-message-queue.service.ts apps/api/src/signals/services/chat-thread-queue-drain.service.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/services/zero-chat-queued-message.service.ts apps/api/src/signals/services/zero-workflow-queue-drain.service.ts apps/api/src/test-fixtures/chat-messages.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts --reporter=dot --silent=passed-only` (14 passed)
- `pnpm vitest run --project=api --shard=4/8 --coverage.enabled --coverage.reporter=json --reporter=dot --silent=passed-only` (312 passed; the original head also passed five consecutive stress runs)
- pre-commit hook (repository Knip and TypeScript checks passed)

The full API suite additionally ran 2,394 tests: 2,393 passed and the unrelated `zero-teams-bot` pre-dispatch test failed because its Microsoft Graph token request had no MSW handler. That failure reproduces when the Teams test file is run by itself, does not execute the chat queue sweep, and is tracked in #23052.
