### PR TITLE
fix(platform): preserve chat views across thread and agent switches

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -37,6 +37,14 @@ const currentChatThreadAgentId$ = computed((get): string | null => {
   return get(chatThreadMetaMap$).get(threadId)?.agentId ?? null;
 });
 
+export const currentChatAgentScope$ = computed((get): string | null => {
+  return (
+    get(currentChatThreadAgentId$) ??
+    get(internalChatAgentId$) ??
+    get(currentAgentId$)
+  );
+});
+
 export const currentChatAgentId$ = computed(
   async (get): Promise<string | null> => {
     return (

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -340,9 +340,10 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps existing thread history without replacing the thread container after returning with an optimistic follow-up", async () => {
+  it("keeps the thread container without carrying resolved history or submission state across threads", async () => {
     const user = userEvent.setup({ delay: null });
     const sendGate = context.mocks.deferred<void>();
+    const otherThreadMessagesGate = context.mocks.deferred<void>();
     const threadId = "b0000000-0000-4000-a000-000000000901";
     const otherThreadId = "b0000000-0000-4000-a000-000000000902";
     const lifecycle = mockChatLifecycle(context, {
@@ -382,6 +383,59 @@ describe("chat lifecycle", () => {
         updatedAt: "2026-03-10T00:00:00Z",
       },
     ]);
+    context.mocks.api(
+      chatThreadMessagesContract.list,
+      async ({ params, query, respond }) => {
+        if (query.sinceSeqId || query.beforeSeqId) {
+          return respond(200, { messages: [] });
+        }
+        if (params.threadId === otherThreadId) {
+          await otherThreadMessagesGate.promise;
+          return respond(200, {
+            messages: [
+              {
+                id: "msg-other-user",
+                seqId: 1,
+                role: "user",
+                runId: "run-other",
+                content: "Other thread context",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+              {
+                id: "msg-other-assistant",
+                seqId: 2,
+                role: "assistant",
+                runId: "run-other",
+                content: "Other thread answer",
+                createdAt: "2026-03-10T00:00:01Z",
+              },
+            ],
+            hasHistoryBefore: false,
+          });
+        }
+        return respond(200, {
+          messages: [
+            {
+              id: "msg-existing-user",
+              seqId: 1,
+              role: "user",
+              runId: "run-existing",
+              content: "Existing context before follow-up",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+            {
+              id: "msg-existing-assistant",
+              seqId: 2,
+              role: "assistant",
+              runId: "run-existing",
+              content: "Existing assistant answer",
+              createdAt: "2026-03-10T00:00:01Z",
+            },
+          ],
+          hasHistoryBefore: false,
+        });
+      },
+    );
 
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
@@ -418,12 +472,29 @@ describe("chat lifecycle", () => {
           `[data-chat-thread-container-id="${otherThreadId}"]`,
         ),
       ).toBe(threadContainer);
+      expect(
+        screen.queryByText("Existing context before follow-up"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Pending follow-up")).not.toBeInTheDocument();
     });
+
+    otherThreadMessagesGate.resolve(undefined);
+    await waitFor(() => {
+      expect(screen.getByText("Other thread context")).toBeInTheDocument();
+    });
+    const otherTextarea = screen.getByPlaceholderText(
+      PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await user.type(otherTextarea, "Fresh draft for other thread");
+    expect(screen.getByLabelText("Send")).toBeEnabled();
 
     await user.click(linkByText("Long thread"));
     await waitFor(() => {
       expect(document.title).toBe("Long thread | VM0");
       expect(screen.getByText("Pending follow-up")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Other thread context"),
+      ).not.toBeInTheDocument();
       expect(
         screen.getByText("Existing context before follow-up"),
       ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -340,7 +340,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps existing thread history visible after returning with an optimistic follow-up", async () => {
+  it("keeps existing thread history without replacing the thread container after returning with an optimistic follow-up", async () => {
     const user = userEvent.setup({ delay: null });
     const sendGate = context.mocks.deferred<void>();
     const threadId = "b0000000-0000-4000-a000-000000000901";
@@ -388,6 +388,12 @@ describe("chat lifecycle", () => {
     await expect(
       screen.findByText("Existing context before follow-up"),
     ).resolves.toBeInTheDocument();
+    const threadContainer = document.querySelector(
+      `[data-chat-thread-container-id="${threadId}"]`,
+    );
+    if (!(threadContainer instanceof HTMLElement)) {
+      throw new Error("Chat thread container not found");
+    }
 
     const textarea = await waitFor(() => {
       return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
@@ -407,6 +413,11 @@ describe("chat lifecycle", () => {
     await user.click(linkByText("Other thread"));
     await waitFor(() => {
       expect(document.title).toBe("Other thread | VM0");
+      expect(
+        document.querySelector(
+          `[data-chat-thread-container-id="${otherThreadId}"]`,
+        ),
+      ).toBe(threadContainer);
     });
 
     await user.click(linkByText("Long thread"));
@@ -416,6 +427,9 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Existing context before follow-up"),
       ).toBeInTheDocument();
+      expect(
+        document.querySelector(`[data-chat-thread-container-id="${threadId}"]`),
+      ).toBe(threadContainer);
     });
     expectTextBefore(
       document.body,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1851,7 +1851,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("moves to the first chat thread for the next pinned agent from a chat thread", async () => {
+  it("moves to the next pinned agent thread without replacing the chat list", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({
       pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID],
@@ -1886,6 +1886,7 @@ describe("zero sidebar", () => {
         within(sidebar()).getByText("Research kickoff"),
       ).toBeInTheDocument();
     });
+    const chatList = within(sidebar()).getByLabelText("Chat threads");
 
     fireEvent.keyDown(document.body, {
       key: "}",
@@ -1895,6 +1896,10 @@ describe("zero sidebar", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${INCIDENT_THREAD_ID}`);
+      expect(
+        within(sidebar()).getByText("Support escalation"),
+      ).toBeInTheDocument();
+      expect(within(sidebar()).getByLabelText("Chat threads")).toBe(chatList);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1851,8 +1851,9 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("moves to the next pinned agent thread without replacing the chat list", async () => {
+  it("keeps the chat list owner without carrying rows across agent scopes", async () => {
     prepareAgentTeam();
+    const supportUnreadGate = context.mocks.deferred<void>();
     context.mocks.data.userPreferences({
       pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID],
     });
@@ -1878,9 +1879,40 @@ describe("zero sidebar", () => {
       },
     );
     mockSidebarThreadStory([researchThread, supportThread, olderSupportThread]);
+    context.mocks.api(
+      chatThreadsContract.unreads,
+      async ({ query, respond }) => {
+        if (query.agentId === SUPPORT_AGENT_ID) {
+          await supportUnreadGate.promise;
+        }
+        const threadId =
+          query.agentId === SUPPORT_AGENT_ID
+            ? INCIDENT_THREAD_ID
+            : RESEARCH_THREAD_ID;
+        return respond(200, {
+          unreads: [
+            {
+              threadId,
+              unreadAt: "2026-03-10T00:05:00Z",
+            },
+          ],
+        });
+      },
+    );
 
-    setupSidebarPage({ context, path: `/chats/${RESEARCH_THREAD_ID}` });
+    setupSidebarPage({
+      context,
+      path: `/chats/${RESEARCH_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: true },
+    });
 
+    await waitFor(() => {
+      expect(
+        within(sidebar()).getByText("Research kickoff"),
+      ).toBeInTheDocument();
+    });
+    openChatListMenu();
+    click(menuItemByText("Unread only"));
     await waitFor(() => {
       expect(
         within(sidebar()).getByText("Research kickoff"),
@@ -1896,6 +1928,14 @@ describe("zero sidebar", () => {
 
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${INCIDENT_THREAD_ID}`);
+      expect(
+        within(sidebar()).queryByText("Research kickoff"),
+      ).not.toBeInTheDocument();
+      expect(within(sidebar()).getByLabelText("Chat threads")).toBe(chatList);
+    });
+
+    supportUnreadGate.resolve(undefined);
+    await waitFor(() => {
       expect(
         within(sidebar()).getByText("Support escalation"),
       ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -75,6 +75,7 @@ import {
   type SidebarChatThreadWindow,
 } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 import {
+  currentChatAgentScope$,
   currentChatAgentId$,
   currentChatThreadId$,
 } from "../../signals/agent-chat.ts";
@@ -997,7 +998,11 @@ function ChatThreadsContent() {
   return <ExpandedChatThreadsContent />;
 }
 
-function ExpandedChatThreadsContent() {
+function AgentChatThreadsContent({
+  currentMainThreadId,
+}: {
+  currentMainThreadId: string | null;
+}) {
   // The primitive count preserves the previous resolved value while the
   // underlying event projection recomputes. Visible rows subscribe separately
   // in VirtualizedChatThreads.
@@ -1005,13 +1010,35 @@ function ExpandedChatThreadsContent() {
   const threadCount =
     threadCountLoadable.state === "hasData" ? threadCountLoadable.data : 0;
   const chatThreadsLoading = threadCountLoadable.state === "loading";
+  const currentMainThreadListed =
+    useLastResolved(currentChatThreadListed$) ?? false;
+  const scrollCurrentChatThreadOnRef = useSet(scrollCurrentChatThreadOnRef$);
+
+  return (
+    <div className="flex flex-col gap-1">
+      {currentMainThreadId && currentMainThreadListed ? (
+        <span
+          key={currentMainThreadId}
+          ref={scrollCurrentChatThreadOnRef}
+          data-chat-thread-id={currentMainThreadId}
+          hidden
+        />
+      ) : null}
+      {chatThreadsLoading ? (
+        <ChatThreadsSkeleton />
+      ) : (
+        <ChatThreads threadCount={threadCount} />
+      )}
+    </div>
+  );
+}
+
+function ExpandedChatThreadsContent() {
+  const agentScope = useGet(currentChatAgentScope$);
   const isScrolled = useGet(isScrolled$);
   const setIsScrolledFn = useSet(setIsScrolled$);
   const currentMainThreadId = useGet(currentChatThreadId$);
-  const currentMainThreadListed =
-    useLastResolved(currentChatThreadListed$) ?? false;
   const scrollToThread = useSet(scrollToThread$);
-  const scrollCurrentChatThreadOnRef = useSet(scrollCurrentChatThreadOnRef$);
   const pageSignal = useGet(pageSignal$);
   const focusThreadLink = (
     viewport: HTMLElement,
@@ -1064,24 +1091,6 @@ function ExpandedChatThreadsContent() {
     detach(scrollAndFocusCurrentThread(), Reason.DomCallback);
   };
 
-  const content = (
-    <div className="flex flex-col gap-1">
-      {currentMainThreadId && currentMainThreadListed ? (
-        <span
-          key={currentMainThreadId}
-          ref={scrollCurrentChatThreadOnRef}
-          data-chat-thread-id={currentMainThreadId}
-          hidden
-        />
-      ) : null}
-      {chatThreadsLoading ? (
-        <ChatThreadsSkeleton />
-      ) : (
-        <ChatThreads threadCount={threadCount} />
-      )}
-    </div>
-  );
-
   return (
     <OverlayScrollArea
       className="mt-1 min-h-0 flex-1"
@@ -1107,14 +1116,19 @@ function ExpandedChatThreadsContent() {
         boxShadow: isScrolled ? "0 -1px 0 0 hsl(var(--border) / 0.4)" : "none",
       }}
     >
-      {content}
+      <AgentChatThreadsContent
+        key={agentScope ?? "no-agent"}
+        currentMainThreadId={currentMainThreadId}
+      />
     </OverlayScrollArea>
   );
 }
 export function ChatThreadsSection() {
+  const agentScope = useGet(currentChatAgentScope$);
+
   return (
     <div className="mt-4 flex flex-col min-h-0 flex-1">
-      <ChatThreadsTitle />
+      <ChatThreadsTitle key={agentScope ?? "no-agent"} />
       <ChatThreadsContent />
       <ChatThreadRenameDialog />
       <DeleteChatThreadDialog />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -467,7 +467,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
-        <AutomationMenuButton thread={thread} />
+        <AutomationMenuButton key={thread.threadId} thread={thread} />
         <ArtifactsButton thread={thread} />
       </div>
     </header>
@@ -1650,7 +1650,7 @@ function ChatArtifactInboxSlot({
     return null;
   }
 
-  return <ChatArtifactInboxList thread={thread} />;
+  return <ChatArtifactInboxList key={thread.threadId} thread={thread} />;
 }
 
 function formatHeaderWorkflowAutomationRun(value: string | null): string {
@@ -2663,7 +2663,10 @@ export function ZeroChatThreadPage() {
           ) : selectedMailDraftSignals ? (
             <MailDraftSidebar signals={selectedMailDraftSignals} />
           ) : automationPanelThread ? (
-            <HeaderAutomationSidebar thread={automationPanelThread} />
+            <HeaderAutomationSidebar
+              key={automationPanelThread.threadId}
+              thread={automationPanelThread}
+            />
           ) : artifactPanelOpen ? (
             <ChatArtifactInboxSlot
               artifactRef={artifactRef}
@@ -3593,10 +3596,19 @@ function ChatThreadMessagesPane({ thread }: { thread: ChatThreadSignals }) {
         onScroll={handleScroll}
         className="absolute inset-0 overflow-y-auto focus:outline-none [overflow-anchor:none] [scrollbar-gutter:stable]"
       >
-        <ChatThreadMessagesMain thread={thread} />
+        <ChatThreadMessagesMain
+          key={`messages:${thread.threadId}`}
+          thread={thread}
+        />
       </div>
-      <ChatThreadSkeletonOverlay thread={thread} />
-      <ScrollToBottomButton thread={thread} />
+      <ChatThreadSkeletonOverlay
+        key={`skeleton:${thread.threadId}`}
+        thread={thread}
+      />
+      <ScrollToBottomButton
+        key={`scroll-button:${thread.threadId}`}
+        thread={thread}
+      />
     </div>
   );
 }
@@ -3636,12 +3648,14 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   return (
     <>
       <ChatThreadHeader thread={thread} />
-      <ChatHistoryBackfillProgress thread={thread} />
+      <ChatHistoryBackfillProgress key={thread.threadId} thread={thread} />
 
       <div className="relative min-h-0 flex-1">
         <div className="flex h-full min-w-0 flex-col">
           <ChatThreadMessagesPane thread={thread} />
-          <ChatThreadComposer thread={thread} />
+          {/* Command loadables are hook-owned, so keep their identity boundary
+              narrower than the persistent thread and message owners. */}
+          <ChatThreadComposer key={thread.threadId} thread={thread} />
         </div>
       </div>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2507,7 +2507,6 @@ function ChatThreadArea({
         <>
           {leftThread && (
             <ChatThread
-              key={leftThread.threadId}
               thread={leftThread}
               onFocusFallbackRef={setMainThreadKeyboardFocusRef}
             />
@@ -2515,7 +2514,7 @@ function ChatThreadArea({
           {rightThread && (
             <>
               <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-              <ChatThread key={rightThread.threadId} thread={rightThread} />
+              <ChatThread thread={rightThread} />
             </>
           )}
         </>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -35,7 +35,6 @@ import {
 import { activeRoute$ } from "../../signals/active-route.ts";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { defaultAgentName$ } from "../../signals/agent.ts";
-import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import {
   manageSectionCollapsed$,
   setManageSectionCollapsed$,
@@ -134,14 +133,6 @@ const FOOTER_NAV = [
     iconImg: slackIcon,
   },
 ] as const satisfies readonly FooterNavItem[];
-
-// Leaf component: subscribes to currentChatAgentId$ so ZeroSidebar doesn't re-render on agent changes.
-// useLastResolved keeps the previously-resolved agent ID during re-loads, preventing unnecessary
-// remounts of ChatThreadsSection that would cause the chat list to flash.
-function ChatThreadsSectionWithKey() {
-  const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  return <ChatThreadsSection key={currentChatAgentId} />;
-}
 
 // Shared subscription hooks. Each sibling component pulls its own state from
 // signals via these instead of receiving anything from a parent through props.
@@ -485,7 +476,7 @@ function ExpandedSidebarSections() {
   return (
     <div className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2 flex flex-col overflow-hidden">
       <PinnedAgentListSection />
-      <ChatThreadsSectionWithKey />
+      <ChatThreadsSection />
     </div>
   );
 }
@@ -827,7 +818,7 @@ function ChatListColumn() {
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-2 pt-1">
         <PinnedAgentListSection layout="horizontal" />
-        <ChatThreadsSectionWithKey />
+        <ChatThreadsSection />
       </div>
       <div className="px-2 pb-2">
         <SidebarUpgradeCard />


### PR DESCRIPTION
## Summary

- preserve the existing left/right `ChatThread` render owners when thread signals change
- keep `ChatThreadsSection` mounted when the active agent changes; its children already subscribe to agent-scoped signals
- cover thread and agent switches with page-level DOM continuity regressions

## User impact

Switching between cached chat threads or agents no longer forces React to tear down and rebuild the full chat or thread-list subtree. This reduces avoidable commit work and the visible flash captured in the supplied trace.

## Scope

This focused PR intentionally does not change:

- thread signal publication or initialization order
- message, skeleton, or composer loading gates

## Verification

- `pnpm exec prettier --write ...` using Prettier 3.8.1 from the lockfile
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec knip --workspace @vm0/app --no-progress`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --maxWorkers=1` — 70 passed