### PR TITLE
test(api): isolate teams pre-dispatch failure scenario

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -2087,6 +2087,13 @@ describe("POST /api/zero/teams/bot", () => {
     expect(switchBody).not.toHaveProperty("dispatch");
 
     outboundRequests.splice(0, outboundRequests.length);
+    teamsGraphHistoryHandlers({
+      tenantId: fixture.teamsTenantId,
+      chatMessages: [],
+      channelMessages: [],
+      threadRoots: {},
+      threadReplies: {},
+    });
     const failedResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,


### PR DESCRIPTION
## Summary

- register the existing Microsoft Graph history handlers for the Teams
  pre-dispatch failure scenario
- model a successful personal app lookup with empty chat history
- preserve the existing typing, failure reply, audit link, selected-agent
  footer, and reaction assertions unchanged

## Scope

This is a test-only isolation fix. It does not change production Teams
behavior, API contracts, schema, migrations, persisted data, timeouts, retries,
or test selection.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts -t "sends typing and adds audit/footer text for Teams run pre-dispatch failures" --reporter=verbose` — 1 passed; no unmatched MSW request or direct-message context fallback warning
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts --reporter=dot --silent=passed-only` — 25 passed
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hook — file-size guard, generated-firewall guard, Prettier,
  repository Knip, repository type checking, and commitlint passed

Closes #23052
