### PR TITLE
feat(api): enable external connector catalog

### DIFF
--- a/turbo/apps/api/src/__tests__/setup.ts
+++ b/turbo/apps/api/src/__tests__/setup.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/client-kms";
 import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
 
+import { mockExternalConnectorCatalogEnabled } from "../lib/connector-catalog-source-selection";
 import { clearMockedEnv, mockEnv } from "../lib/env";
 import {
   resetSecretKmsClientForTests,
@@ -51,6 +52,9 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  // Static catalog fixtures remain the rollback baseline for general API tests.
+  // External catalog integration tests opt into the accepted snapshot explicitly.
+  mockExternalConnectorCatalogEnabled(false);
   mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
   setSecretKmsClientForTests(createApiTestKmsClient());
 });
@@ -60,6 +64,7 @@ afterEach(async () => {
   clearMockNow();
   resetSecretKmsClientForTests();
   clearMockedEnv();
+  mockExternalConnectorCatalogEnabled(false);
   resetApiTestMocks();
   server.resetHandlers();
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1446,7 +1446,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setApiVersion(DEFAULT_API_VERSION);
-  clearMockedExternalConnectorCatalogEnabled();
+  mockExternalConnectorCatalogEnabled(false);
   clearMockNow();
 });
 
@@ -1595,7 +1595,7 @@ describe("connector catalog valid lifecycle", () => {
     );
   });
 
-  it("does not let a user select the external catalog source", async () => {
+  it("does not let a user override the global external catalog source", async () => {
     configureSource();
     const release = buildRelease({
       version: "2026-07-15.user-source-override",
@@ -1603,6 +1603,7 @@ describe("connector catalog valid lifecycle", () => {
     serveObjects(catalogObjects([release], release));
     await syncCatalog();
 
+    clearMockedExternalConnectorCatalogEnabled();
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const headers = { authorization: "Bearer clerk-session" };
     const featureClient = setupApp({ context })(zeroFeatureSwitchesContract);
@@ -1611,7 +1612,7 @@ describe("connector catalog valid lifecycle", () => {
         headers,
         body: {
           switches: {
-            [FeatureSwitchKey.ExternalConnectorCatalog]: true,
+            [FeatureSwitchKey.ExternalConnectorCatalog]: false,
           },
         },
       }),
@@ -1622,7 +1623,7 @@ describe("connector catalog valid lifecycle", () => {
     ).toBeUndefined();
     expect(
       update.body.effectiveSwitches[FeatureSwitchKey.ExternalConnectorCatalog],
-    ).toBeFalsy();
+    ).toBeTruthy();
 
     const callsBeforePublicCatalog = context.mocks.s3.send.mock.calls.length;
     const publicCatalog = await accept(
@@ -1633,7 +1634,7 @@ describe("connector catalog valid lifecycle", () => {
       publicCatalog.body.connectors.some((connector) => {
         return connector.connectorRef === release.connectorRef;
       }),
-    ).toBeFalsy();
+    ).toBeTruthy();
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(
       callsBeforePublicCatalog,
     );

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -20,10 +20,13 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
-  it("should return false for disabled switch without context", () => {
+  it("should enable the external connector catalog globally", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.ExternalConnectorCatalog, {}),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.GoogleContactsConnector, {})).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -50,7 +50,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description:
       "Use the accepted external catalog as the global source for official connectors",
-    enabled: false,
+    enabled: true,
     userOverridable: false,
   },
   [FeatureSwitchKey.AhrefsConnector]: {


### PR DESCRIPTION
## Summary

- enable the global, non-user-overridable external connector catalog source
- keep general API fixtures explicitly on the retained static rollback source
- verify the real production default and prove users cannot turn the global
  source off
- preserve the existing single source-selection boundary for public catalog,
  private runtime, and runner-firewall consumers

## Compatibility and rollout

This changes no API, persisted schema, queue payload, runner contract, or
publisher contract. During deployment overlap, old revisions continue to use
the complete static source and new revisions use the complete accepted external
snapshot; no request combines sources.

Merge and deployment remain gated by the production readiness checks in #21658.
That parent stays open for deployment verification, rollback evidence,
monitoring, and the observation window. Static-source removal remains in
#21060.

## Verification

- `pnpm format`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` —
  24 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --silent=passed-only`
  — 95 passed
- `pnpm -F @vm0/core exec vitest run --silent=passed-only` — 214 passed
- `pnpm knip`
- pre-commit repository-wide TypeScript checks — 13 workspaces passed
- full API suite after `pnpm -F @vm0/db db:migrate` — 168/169 files and
  2395/2396 tests passed; the remaining Teams pre-dispatch test fails identically
  on unmodified `origin/main` at `7d198dded1` and is unrelated to this diff
- `git diff --check`

Closes #23063

Parent: #21658
