### PR TITLE
fix: stabilize workflow queue stale-sweep admission barrier against extra org lock waiters

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -368,7 +368,7 @@ describe("workflow queue", () => {
     });
 
     const workflowRequest = postWorkflowWebhook(automation, "stale event");
-    await expect.poll(admissionLock.waiterCount).toBe(1);
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
     const queued = await accept(
       queueClient().get({
         headers: authHeaders(),
@@ -393,10 +393,26 @@ describe("workflow queue", () => {
         prompt: "fresh user message",
       },
     });
-    await expect.poll(admissionLock.waiterCount).toBe(2);
+    // The persisted queued message is the product milestone proving the send
+    // reached the queue; the waiter count is a cluster-wide `pg_locks`
+    // observation of one org key that several admission attempts share, so it
+    // is only used as a lower-bound barrier here.
+    await expect
+      .poll(async () => {
+        const messages = await wf.readThreadMessages(automation.threadId);
+        return messages.some((message) => {
+          return message.content === "fresh user message";
+        });
+      })
+      .toBe(true);
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(2);
+    const admittedWaiters = await admissionLock.waiterCount();
 
+    // The business assertion: the stale sweep must not add an admission
+    // attempt of its own for this org, so the waiter count stays exactly where
+    // both blocked requests left it.
     await cleanupSandboxes();
-    await expect(admissionLock.waiterCount()).resolves.toBe(2);
+    await expect(admissionLock.waiterCount()).resolves.toBe(admittedWaiters);
 
     admissionLock.release();
     const [workflowResult, userResult] = await Promise.all([


### PR DESCRIPTION
## Why

Turbo run https://github.com/vm0-ai/vm0/actions/runs/30168189394 (`merge_group`, SHA `a8832e75a559f928e124f74add13a22958c4d434`, shard `test-api (5)`) failed with:

```
FAIL src/signals/routes/__tests__/zero-workflow-queue.test.ts > workflow queue
     > does not let the stale sweep drain a fresh user message ahead of a stale workflow event
AssertionError: expected 3 to be 2 // Object.is equality
Caused by: Error: Matcher did not succeed in time.
```

The same SHA passed on the re-run (https://github.com/vm0-ai/vm0/actions/runs/30168478984), so this is not a deterministic failure owned by the queued PR. The queued PR (#23030) does not touch this assertion or add any `pg_advisory_xact_lock(hashtext(orgId))` call site.

## Root cause

Classification: **test observation of global, cluster-wide state** (secondary: the synchronization barrier was expressed as an exact count instead of a product milestone).

`holdOrgAdmissionLockFixture().waiterCount()` counts rows in `pg_locks` — a **cluster-wide** view — that are ungranted on the advisory key held by the fixture. That key is `hashtext(orgId)`, the shared org admission key. Several product paths legitimately acquire it: `checkRunConcurrencyPreflight`, `commitPreparedLaunch` (`agent-run-create.service.ts`), and `loadDrainCandidates` / `promoteQueuedCandidate` via `drainOrgQueue$` (`zero-run-queue.service.ts`). The per-thread scheduler `drainChatThreadQueueForThread$` also runs two independent halves (`drainQueuedUserMessagesForThread$`, then `drainWorkflowQueueForThread$`), each able to enter a launch that takes that same key.

The number of backends momentarily blocked on the org key is therefore an implementation detail, not a stable contract. Crucially, during the fixture's hold window the count is **monotonically non-decreasing** — every waiter stays blocked until `admissionLock.release()`, which only happens *after* the assertion. So once the count overshoots 2, `expect.poll(...).toBe(2)` can never recover, and the poll burns its full timeout reporting the overshoot value. That is exactly the observed `expected 3 to be 2` + `Matcher did not succeed in time`.

The first causal event is the arrival of a third backend on the org admission key before any poll tick observed exactly 2. It is intermittent because that third acquisition is scheduling-dependent: under CI contention it lands inside the hold window, and on a fast/idle run it does not.

The trailing `AbortError: Aborted due to finished test` and the `Unknown response status 500 for POST /api/zero/chat/messages` unhandled rejection are downstream of the failed assertion — the in-flight `userRequest` is abandoned when the assertion throws and rejects at teardown. Neither is causal.

## Fix

Scoped to the one failing test:

- Both `expect.poll(admissionLock.waiterCount)` calls become **lower bounds** (`toBeGreaterThanOrEqual`). A barrier's meaning is "the requests have reached admission", which is `>= n`, not `== n`.
- The user-request barrier is additionally anchored to a **product milestone** — the queued user message becoming visible on the thread — mirroring the sibling test in the same file ("lets a fresh user message win final admission ahead of a stale workflow event").
- The business assertion is preserved exactly, just made relative: capture the count once both blocked requests have arrived, run the stale sweep, then assert the count is **unchanged**. The claim under test — *the stale sweep adds no admission attempt of its own for this org* — is unchanged in strength.

The repo already treats exact waiter counts as unstable in this way: `chat-messages.bdd.test.ts` uses `toBeGreaterThanOrEqual` for the same fixture.

No retries, sleeps, raised timeouts, skips, or weakened business assertions.

## Validation

Local Postgres 17-equivalent (pgvector, `TZ=UTC`), reproduced against the failing SHA `a8832e75a`:

- **Failure mode reproduced exactly.** Injecting one extra backend blocked on the same org key (a bare `pg_advisory_xact_lock(hashtext(orgId))` transaction) makes the *original* assertion fail with the identical CI signature: `AssertionError: expected 3 to be 2 // Object.is equality` / `Caused by: Error: Matcher did not succeed in time.`
- **Fix survives that same injection**: with the third waiter present, the updated test passes.
- `zero-workflow-queue.test.ts` (14 tests) — 5/5 consecutive clean runs.
- `pnpm vitest run --project=api --shard=5/8` (the exact failing CI shard composition, 21 files / 244 tests) — passes; ran 4× at the failing SHA before the fix and 1× after.
- `pnpm -F api lint` — 0 errors, 0 warnings. `prettier` — unchanged. `git diff --check` — clean.

### Evidence limitations

- I could not make the third acquirer appear spontaneously in ~25 local runs (2-core sandbox), so the specific product path that supplied it in CI is not pinned down. The fix does not depend on its identity: it depends on the verified facts that the count is cluster-wide, that several product paths share the key, and that exact equality cannot recover from an overshoot.
- `pnpm -F api check-types` could not run locally — `tsc --noEmit` is OOM-killed in this 3.9 GB sandbox. Left to the PR pipeline. The change uses only APIs already used elsewhere in this file and in `chat-messages.bdd.test.ts`.
- While validating, two neighbouring tests (`recovers a stale workflow event…`, `recovers a stale user message…`) failed on my local database after ~40 accumulated runs and passed again after a full schema reset. They are untouched by this change and are sensitive to accumulated global rows (`drainStaleQueues$` scans `agent_run_queue` across **all** orgs). Flagging it as a separate latent isolation risk; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
