### PR TITLE
refactor: reduce fallback slop in workflow schedules

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -335,6 +335,19 @@ function summarizeSchedule(schedule: ZeroWorkflowSchedule): string {
   return `Once at ${schedule.atTime}`;
 }
 
+function requiredScheduleColumn<T>(
+  row: AutomationRow,
+  field: "cronExpression" | "intervalSeconds" | "atTime",
+  value: T | null,
+): T {
+  if (value === null) {
+    throw new Error(
+      `Workflow automation ${row.id} has a ${row.scheduleType} schedule without ${field}`,
+    );
+  }
+  return value;
+}
+
 function rowToSchedule(row: AutomationRow): ZeroWorkflowSchedule {
   if (row.kind !== "schedule" || row.scheduleType === null) {
     throw new Error(
@@ -344,16 +357,27 @@ function rowToSchedule(row: AutomationRow): ZeroWorkflowSchedule {
   if (row.scheduleType === "cron") {
     return {
       type: "cron",
-      cronExpression: row.cronExpression ?? "",
+      cronExpression: requiredScheduleColumn(
+        row,
+        "cronExpression",
+        row.cronExpression,
+      ),
       timezone: row.timezone,
     };
   }
   if (row.scheduleType === "loop") {
-    return { type: "loop", intervalSeconds: row.intervalSeconds ?? 0 };
+    return {
+      type: "loop",
+      intervalSeconds: requiredScheduleColumn(
+        row,
+        "intervalSeconds",
+        row.intervalSeconds,
+      ),
+    };
   }
   return {
     type: "once",
-    atTime: (row.atTime ?? new Date(0)).toISOString(),
+    atTime: requiredScheduleColumn(row, "atTime", row.atTime).toISOString(),
     timezone: row.timezone,
   };
 }


### PR DESCRIPTION
## Summary

Workflow schedule reads now enforce the database schedule-shape invariant instead of manufacturing an empty cron expression, a zero-second loop, or a Unix-epoch one-time run. Corrupted automation rows fail with the automation ID, schedule type, and missing field, while valid schedules are unchanged.

## Scan

- Scan timestamp: `2026-07-25T20:02:56.009Z`
- Base commit: `5dd31a58e19c4b691a6a19bc6b1223cb615d63fc`
- Tracked source files scanned: `4,391`
- Total matches: `20,099`
- Scanner initial high-confidence production actionable total: `240`
- Scanner initial suggested 5% budget: `12`
- Manually confirmed `actionable_total`: `1`
- Final `edit_budget`: `1` (`max(1, ceil(1 * 0.05))`), reduced after surrounding-code review excluded overlapping category hits, comments and test fixtures, external payload variation without a proven vm0 requirement, UI display fallbacks, and intentional precedence chains
- Candidates changed: `1` semantic internal-state candidate across `3` fallback occurrences

Total matches by category:

```json
{
  "nullish": 6218,
  "nullish-chain": 139,
  "field-fallback-chain": 111,
  "optional-prop": 6058,
  "zod-optional": 2528,
  "zod-loose-optional": 2,
  "loose-record": 1102,
  "loose-index-signature": 3,
  "as-any": 0,
  "as-unknown-as": 30,
  "empty-fallback": 722,
  "string-fallback": 770,
  "null-undefined-fallback": 1608,
  "empty-catch": 3,
  "promise-catch-swallow": 16,
  "rust-unwrap-or": 647,
  "rust-ok-discard": 142
}
```

## Files changed

- `turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts`: require `cronExpression`, `intervalSeconds`, or `atTime` according to the persisted schedule type before constructing the public schedule. This is safe because the `zero_workflow_automations_schedule_config_check` database constraint already requires exactly that non-null field for each schedule type and requires the other schedule fields to be null. A missing value therefore represents corrupted internal state rather than an optional input.

## Verification

- `git diff --check`: passed
- Follow-up full repository scan: `nullish` decreased from `6,218` to `6,215`; `string-fallback` decreased from `770` to `769`
- Existing workflow automation coverage exercises valid cron, loop, and once schedule paths
- Package lint, typecheck, and targeted Vitest were not run because the fresh checkout has no installed workspace dependencies; the PR pipeline will run the full required checks

This workflow intentionally leaves the remaining candidates for later daily runs.