### PR TITLE
perf: resize artifact catalog thumbnails with cloudflare

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -32,6 +32,7 @@ import { z } from "zod";
 
 import { executeRawRows } from "../../../lib/db-raw-rows";
 import { mockEnv } from "../../../lib/env";
+import { mockExternalConnectorCatalogEnabled } from "../../../lib/connector-catalog-source-selection";
 import { setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
@@ -575,6 +576,9 @@ const ensureSeeded: () => Promise<BenchChatThreadFixture> = (() => {
   let cached: Promise<BenchChatThreadFixture> | undefined;
   return () => {
     cached ??= (async () => {
+      // Vitest bench mode skips the normal API test beforeEach hooks, so
+      // preserve the general-test static catalog baseline in the lazy setup.
+      mockExternalConnectorCatalogEnabled(false);
       installR2ListMock();
       const seeded = await seedBenchChatThread();
       await seedBackgroundLoad();

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -65,7 +65,7 @@ async function findCard(title: string): Promise<HTMLElement> {
 }
 
 describe("artifact catalog page", () => {
-  it("renders the first page of artifacts with their kind", async () => {
+  it("renders artifacts with their kind and resized thumbnails", async () => {
     context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
       return respond(200, {
         artifacts: [
@@ -74,7 +74,9 @@ describe("artifact catalog page", () => {
             id: "a0000000-0000-4000-a000-000000000002",
             kind: "hosted-site",
             title: "launch-site",
-            thumbnail: { url: "https://cdn.example.com/preview.webp" },
+            thumbnail: {
+              url: "https://cdn.vm0.io/artifacts/test/preview.webp",
+            },
           }),
         ],
         nextCursor: null,
@@ -90,7 +92,7 @@ describe("artifact catalog page", () => {
     ).toBeInTheDocument();
     expect(site.querySelector("img")).toHaveAttribute(
       "src",
-      "https://cdn.example.com/preview.webp",
+      "https://cdn.vm0.io/cdn-cgi/image/width=640,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/test/preview.webp",
     );
   });
 

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -11,6 +11,7 @@ import {
   IconVideo,
   IconWorld,
 } from "@tabler/icons-react";
+import { r2ImageTransformUrl } from "@vm0/core";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
 
@@ -31,6 +32,7 @@ import { emptyArtifactImg } from "../zero-page/platform-assets.ts";
 // requested. The signal layer deduplicates repeated requests for one cursor.
 const ARTIFACT_AUTO_LOAD_THRESHOLD_PX = 800;
 const ARTIFACT_GRID_MIN_CARD_WIDTH_PX = 292;
+const ARTIFACT_CARD_THUMBNAIL_WIDTH_PX = 640;
 
 const ARTIFACT_KIND_OPTIONS: readonly {
   readonly ariaLabel: string;
@@ -108,7 +110,10 @@ function ArtifactCatalogCard({
       >
         {artifact.thumbnail ? (
           <img
-            src={artifact.thumbnail.url}
+            src={r2ImageTransformUrl(artifact.thumbnail.url, {
+              width: ARTIFACT_CARD_THUMBNAIL_WIDTH_PX,
+              fit: "scale-down",
+            })}
             alt=""
             loading="lazy"
             className="h-full w-full object-cover"


### PR DESCRIPTION
## Summary

- serve artifact catalog card thumbnails through the existing Cloudflare image transformation URL at 640px wide
- preserve each thumbnail's aspect ratio at the CDN and keep the existing browser-side `object-cover` crop
- cover the production CDN URL generated by the catalog page in its page-level test

## User impact

Artifact cards no longer download full-resolution source images when a 640px thumbnail is sufficient. Cloudflare can negotiate an efficient output format while the catalog layout and crop behavior remain unchanged.

## Verification

- `pnpm exec prettier --write apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx --maxWorkers=4 --silent=passed-only` (10 tests passed)

Browser verification was not run because vm0 PRs rely on the preview pipeline for UI verification unless local serving is explicitly requested.
