### PR TITLE
chore(api): add parser-backed sql lint analysis

### DIFF
--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -895,7 +895,7 @@ async function transitionClaimedJobToRunning(
           locked_job AS MATERIALIZED (
             SELECT
               ${runnerJobQueue.runId} AS "runId",
-              ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
+              ${lte(runnerJobQueue.expiresAt, sql`now()`)} AS "isExpired"
             FROM ${runnerJobQueue}
             INNER JOIN locked_run
               ON locked_run."id" = ${runnerJobQueue.runId}
@@ -924,9 +924,10 @@ async function transitionClaimedJobToRunning(
             INNER JOIN locked_job
               ON locked_job."runId" = locked_run."id"
             CROSS JOIN claim_clock
-            WHERE
-              ${agentRuns.id} = locked_run."id"
-              AND ${agentRuns.status} = 'pending'
+            WHERE ${and(
+              eq(agentRuns.id, sql`locked_run."id"`),
+              eq(agentRuns.status, sql`'pending'`),
+            )}
             RETURNING
               ${agentRuns.id} AS "id",
               ${agentRuns.startedAt} AS "claimedAt"
@@ -934,17 +935,18 @@ async function transitionClaimedJobToRunning(
           deleted_job AS (
             DELETE FROM ${runnerJobQueue}
             USING locked_run, locked_job
-            WHERE
-              ${runnerJobQueue.runId} = locked_job."runId"
-              AND locked_job."runId" = locked_run."id"
-              AND (
+            WHERE ${and(
+              eq(runnerJobQueue.runId, sql`locked_job."runId"`),
+              sql`locked_job."runId" = locked_run."id"`,
+              sql`(
                 locked_run."status" <> 'pending'
                 OR EXISTS (
                   SELECT 1
                   FROM updated_run
                   WHERE updated_run."id" = locked_run."id"
                 )
-              )
+              )`,
+            )}
             RETURNING ${runnerJobQueue.runId} AS "runId"
           )
           SELECT

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -18,7 +18,7 @@ import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { command } from "ccstate";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, notExists } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -207,13 +207,19 @@ async function deleteRunForAction(
   if (runThreadIds.length > 0) {
     await db.delete(chatMessages).where(eq(chatMessages.runId, runId));
     signal.throwIfAborted();
-    await db.delete(chatThreads).where(
-      sql`${inArray(chatThreads.id, runThreadIds)} AND NOT EXISTS (
-        SELECT 1
-        FROM ${chatMessages}
-        WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
-      )`,
-    );
+    await db
+      .delete(chatThreads)
+      .where(
+        and(
+          inArray(chatThreads.id, runThreadIds),
+          notExists(
+            db
+              .select({ id: chatMessages.id })
+              .from(chatMessages)
+              .where(eq(chatMessages.chatThreadId, chatThreads.id)),
+          ),
+        ),
+      );
     signal.throwIfAborted();
   }
   await db.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, exists, sql, type SQL } from "drizzle-orm";
+import { and, eq, exists, or, sql, type SQL } from "drizzle-orm";
 import { artifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatMessages } from "@vm0/db/schema/chat-message";
@@ -115,10 +115,10 @@ async function userCanAccessArtifactUrl(
   const rows = await executeRawRows(
     db,
     sql`
-      SELECT (
-        ${uploadedArtifactAccessCondition(db, args)}
-        OR ${attachedArtifactAccessCondition(db, args)}
-      ) AS "canAccess"
+      SELECT ${or(
+        uploadedArtifactAccessCondition(db, args),
+        attachedArtifactAccessCondition(db, args),
+      )} AS "canAccess"
     `,
     artifactAccessRowSchema,
   );

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1107,9 +1107,11 @@ async function loadStorageIndex(
         ${sql.param(userIds)}::text[],
         ${sql.param(names)}::varchar(256)[]
       ) AS requested(org_id, user_id, name)`,
-      sql`${storages.orgId} = requested.org_id
-        AND ${storages.userId} = requested.user_id
-        AND ${storages.name} = requested.name`,
+      and(
+        eq(storages.orgId, sql`requested.org_id`),
+        eq(storages.userId, sql`requested.user_id`),
+        eq(storages.name, sql`requested.name`),
+      ),
     )
     .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id));
 

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -275,9 +275,11 @@ async function selectModelRankings(
         COALESCE(${sum(modelStat.outputTokens)}, 0)::bigint AS output_tokens,
         COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS total_tokens
       FROM ${modelStat}
-      WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
-        AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
-        AND ${inArray(modelStat.model, modelStatsModelIds)}
+      WHERE ${and(
+        gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`),
+        lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
+        inArray(modelStat.model, modelStatsModelIds),
+      )}
       GROUP BY 1
     ),
     previous_period AS (
@@ -285,9 +287,11 @@ async function selectModelRankings(
         ${modelExpr} AS model,
         COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS previous_total_tokens
       FROM ${modelStat}
-      WHERE ${gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`)}
-        AND ${lt(modelStat.hourStart, sql`${previousEndParam}::timestamp`)}
-        AND ${inArray(modelStat.model, modelStatsModelIds)}
+      WHERE ${and(
+        gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
+        lt(modelStat.hourStart, sql`${previousEndParam}::timestamp`),
+        inArray(modelStat.model, modelStatsModelIds),
+      )}
       GROUP BY 1
     )
     SELECT

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -337,10 +337,17 @@ async function pruneInactiveExpiredCacheRows(
       WITH candidates AS (
       SELECT ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
       FROM ${systemStoragePresignedUrlCache}
-      WHERE
-        ${eq(systemStoragePresignedUrlCache.scope, scope)}
-        AND ${lte(systemStoragePresignedUrlCache.expiresAt, sql`${issuedAtTimestamp}::timestamp`)}
-        AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${inactiveCutoffTimestamp}::timestamp`)}
+      WHERE ${and(
+        eq(systemStoragePresignedUrlCache.scope, scope),
+        lte(
+          systemStoragePresignedUrlCache.expiresAt,
+          sql`${issuedAtTimestamp}::timestamp`,
+        ),
+        lte(
+          systemStoragePresignedUrlCache.lastRequestedAt,
+          sql`${inactiveCutoffTimestamp}::timestamp`,
+        ),
+      )}
       ORDER BY
         ${systemStoragePresignedUrlCache.lastRequestedAt},
         ${systemStoragePresignedUrlCache.expiresAt},
@@ -351,17 +358,27 @@ async function pruneInactiveExpiredCacheRows(
       SELECT ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
       FROM ${systemStoragePresignedUrlCache}
       INNER JOIN candidates
-        ON ${systemStoragePresignedUrlCache.cacheKey} = candidates."cacheKey"
-      WHERE
-        ${eq(systemStoragePresignedUrlCache.scope, scope)}
-        AND ${lte(systemStoragePresignedUrlCache.expiresAt, sql`${issuedAtTimestamp}::timestamp`)}
-        AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${inactiveCutoffTimestamp}::timestamp`)}
+        ON ${eq(
+          systemStoragePresignedUrlCache.cacheKey,
+          sql`candidates."cacheKey"`,
+        )}
+      WHERE ${and(
+        eq(systemStoragePresignedUrlCache.scope, scope),
+        lte(
+          systemStoragePresignedUrlCache.expiresAt,
+          sql`${issuedAtTimestamp}::timestamp`,
+        ),
+        lte(
+          systemStoragePresignedUrlCache.lastRequestedAt,
+          sql`${inactiveCutoffTimestamp}::timestamp`,
+        ),
+      )}
       ORDER BY ${systemStoragePresignedUrlCache.cacheKey}
       FOR UPDATE OF ${systemStoragePresignedUrlCache}
     )
     DELETE FROM ${systemStoragePresignedUrlCache}
     USING locked
-    WHERE ${systemStoragePresignedUrlCache.cacheKey} = locked."cacheKey"
+    WHERE ${eq(systemStoragePresignedUrlCache.cacheKey, sql`locked."cacheKey"`)}
       RETURNING ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
     `,
     deletedCacheRowSchema,

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
-import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -83,19 +83,21 @@ async function selectIncompleteRoundFrontier(
         FROM ${chatMessages}
         INNER JOIN ${agentRuns}
           ON ${eq(agentRuns.id, chatMessages.runId)}
-        WHERE ${eq(chatMessages.chatThreadId, threadId)}
-          AND ${isNotNull(chatMessages.runId)}
-          AND NOT (
+        WHERE ${and(
+          eq(chatMessages.chatThreadId, threadId),
+          isNotNull(chatMessages.runId),
+          sql`NOT (
             ${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)
-          )
-          AND ${visibleChatMessageCondition(db)}
-          AND (
-            (${isSuccessfulRun})
-            OR (
-              ${agentRuns.status} IN ('cancelled', 'failed', 'timeout')
-              AND ${chatMessages.role} IN ('user', 'assistant')
-            )
-          )
+          )`,
+          visibleChatMessageCondition(db),
+          or(
+            isSuccessfulRun,
+            and(
+              sql`${agentRuns.status} IN ('cancelled', 'failed', 'timeout')`,
+              sql`${chatMessages.role} IN ('user', 'assistant')`,
+            ),
+          ),
+        )}
         ORDER BY
           ${desc(chatMessages.seqId)}
         LIMIT 1

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -74,6 +74,7 @@ import {
   notExists,
   or,
   type SQL,
+  type SQLWrapper,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -1248,11 +1249,11 @@ function artifactVisibilityConditions(
   ];
 }
 
-function artifactChatThreadId(db: Pick<Db, "select">): SQL {
+function artifactChatThreadId(db: Pick<Db, "select">, runId: SQLWrapper): SQL {
   const earliestThread = db
     .select({ threadId: chatMessages.chatThreadId })
     .from(chatMessages)
-    .where(eq(chatMessages.runId, runUploadedFiles.runId))
+    .where(eq(chatMessages.runId, runId))
     .orderBy(asc(chatMessages.seqId))
     .limit(1);
 
@@ -1445,16 +1446,7 @@ async function listChangedArtifacts(args: {
         INNER JOIN ${zeroRuns}
           ON ${eq(zeroRuns.id, agentRuns.id)}
         INNER JOIN ${chatThreads}
-          ON ${chatThreads.id} = COALESCE(
-            ${zeroRuns.chatThreadId},
-            (
-              SELECT ${chatMessages.chatThreadId}
-              FROM ${chatMessages}
-              WHERE ${eq(chatMessages.runId, zeroRuns.id)}
-              ORDER BY ${asc(chatMessages.seqId)}
-              LIMIT 1
-            )
-          )
+          ON ${eq(chatThreads.id, artifactChatThreadId(args.db, zeroRuns.id))}
         INNER JOIN ${agentComposes}
           ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
         INNER JOIN ${zeroAgents}
@@ -1467,10 +1459,15 @@ async function listChangedArtifacts(args: {
           ${effectiveUpdatedAt} AS effective_updated_at
         FROM visible_runs
         INNER JOIN ${runUploadedFiles}
-          ON ${runUploadedFiles.runId} = visible_runs.run_id
-        WHERE ${sql.join(fileConditions, sql` AND `)}
-          AND ${lowerBoundClause}
-          AND ${lt(effectiveUpdatedAt, sql`${args.syncUntil}::timestamptz AT TIME ZONE 'UTC'`)}
+          ON ${eq(runUploadedFiles.runId, sql`visible_runs.run_id`)}
+        WHERE ${and(
+          ...fileConditions,
+          lowerBoundClause,
+          lt(
+            effectiveUpdatedAt,
+            sql`${args.syncUntil}::timestamptz AT TIME ZONE 'UTC'`,
+          ),
+        )}
         ORDER BY ${asc(effectiveUpdatedAt)}, ${asc(runUploadedFiles.id)}
         LIMIT ${args.limit + 1}
       )
@@ -1507,22 +1504,16 @@ async function listChangedArtifacts(args: {
         ${zeroAgents.avatarUrl} AS agent_avatar_url
       FROM changed_artifact_ids
       INNER JOIN ${runUploadedFiles}
-        ON ${runUploadedFiles.id} = changed_artifact_ids.row_id
+        ON ${eq(runUploadedFiles.id, sql`changed_artifact_ids.row_id`)}
       INNER JOIN ${agentRuns}
         ON ${eq(agentRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${zeroRuns}
         ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${chatThreads}
-        ON ${chatThreads.id} = COALESCE(
-          ${zeroRuns.chatThreadId},
-          (
-            SELECT ${chatMessages.chatThreadId}
-            FROM ${chatMessages}
-            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${asc(chatMessages.seqId)}
-            LIMIT 1
-          )
-        )
+        ON ${eq(
+          chatThreads.id,
+          artifactChatThreadId(args.db, runUploadedFiles.runId),
+        )}
       INNER JOIN ${agentComposes}
         ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
       INNER JOIN ${zeroAgents}
@@ -1599,7 +1590,10 @@ async function listArtifactHistory(args: {
     .from(runUploadedFiles)
     .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
     .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
-    .innerJoin(chatThreads, eq(chatThreads.id, artifactChatThreadId(args.db)))
+    .innerJoin(
+      chatThreads,
+      eq(chatThreads.id, artifactChatThreadId(args.db, runUploadedFiles.runId)),
+    )
     .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
     .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
     .where(and(...conditions, keysetCondition))
@@ -1711,7 +1705,10 @@ async function artifactUrlIsVisible(
     .from(runUploadedFiles)
     .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
     .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
-    .innerJoin(chatThreads, eq(chatThreads.id, artifactChatThreadId(db)))
+    .innerJoin(
+      chatThreads,
+      eq(chatThreads.id, artifactChatThreadId(db, runUploadedFiles.runId)),
+    )
     .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
     .where(and(...conditions))
     .limit(1);
@@ -1890,7 +1887,7 @@ async function loadChatSearchContexts(
     )
     .innerJoin(
       matchedChatMessage,
-      sql`${matchedChatMessage.id} = chat_search_matches.message_id`,
+      eq(matchedChatMessage.id, sql`chat_search_matches.message_id`),
     )
     .crossJoinLateral(context)
     .orderBy(resultOrdinality, asc(context.seqId));

--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -149,7 +149,7 @@ export async function checkCreditAmountForLockedOrg(
       reservedCredits: reserved.total,
     })
     .from(expired)
-    .innerJoin(reserved, sql`true`)
+    .crossJoin(reserved)
     .leftJoin(orgMetadata, eq(orgMetadata.orgId, args.orgId));
   signal.throwIfAborted();
 
@@ -271,7 +271,7 @@ export const checkManagedCredits$ = command(
         ),
       })
       .from(expired)
-      .innerJoin(reserved, sql`true`)
+      .crossJoin(reserved)
       .leftJoin(orgMetadata, eq(orgMetadata.orgId, args.orgId))
       .leftJoin(
         usagePricing,

--- a/turbo/packages/eslint-rules/package.json
+++ b/turbo/packages/eslint-rules/package.json
@@ -24,7 +24,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.64.0"
+    "@typescript-eslint/utils": "^8.64.0",
+    "libpg-query": "17.7.4"
   },
   "devDependencies": {
     "@typescript-eslint/rule-tester": "^8.64.0",

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
@@ -90,6 +90,17 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
       `,
     },
     {
+      code: `${drizzlePreamble}
+        import { and, eq, or, sql, type SQL } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        declare const optionalCondition: SQL | undefined;
+        declare const optionalConditions: readonly (SQL | undefined)[];
+        sql\`\${and(eq(users.id, 1), optionalCondition)}\`;
+        sql\`\${or(eq(users.id, 1), ...optionalConditions)}\`;
+        sql\`\${drizzle.and(drizzle.eq(users.id, 1), undefined)}\`;
+      `,
+    },
+    {
       code: `
         function sql(strings: TemplateStringsArray, ...values: unknown[]) {
           return { strings, values };
@@ -160,6 +171,28 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         sql\`\${mixed}\`;
       `,
       errors: [{ messageId: "mixedInterpolation" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { and, sql, type SQL } from "drizzle-orm";
+        declare const optionalCondition: SQL | undefined;
+        declare const optionalConditions: readonly (SQL | undefined)[];
+        declare const unsafeCondition: unknown;
+        declare const unsafeConditions: readonly unknown[];
+        declare function localAnd(condition: SQL): SQL | undefined;
+        sql\`\${and(optionalCondition)}\`;
+        sql\`\${and(...optionalConditions)}\`;
+        sql\`\${and(sql\`true\`, unsafeCondition)}\`;
+        sql\`\${and(sql\`true\`, ...unsafeConditions)}\`;
+        sql\`\${localAnd(sql\`true\`)}\`;
+      `,
+      errors: [
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+      ],
     },
     {
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -78,6 +78,13 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       `,
     },
     {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select().from(users).where(sql\`\${users.id} =\`);
+        db.select().from(users).crossJoin(users);
+      `,
+    },
+    {
       code: `
         function sql(strings: TemplateStringsArray, ...values: unknown[]) {
           return { strings, values };
@@ -345,8 +352,294 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`discount(*)\`;
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+
+        const composed: SQL = sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+          LIMIT 1
+        \`;
+        await decodeRows(db, composed, rowSchema);
+        await decodeRows(
+          db,
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${eq(users.id, 1)}
+            LIMIT 1;
+            SELECT 1
+          \`,
+          rowSchema,
+        );
+        db.select().from(users).where(sql\`'\${users.id}' = 'literal'\`);
+        db.select().from(users).where(sql\`\${1} = \${2}\`);
+        db.select()
+          .from(users)
+          .where(
+            sql\`__VM0_SQL_MARKER_0_0 = 1 AND '\${users.id}' = 'literal'\`,
+          );
+
+        function local(
+          decodeRows: (...arguments_: unknown[]) => unknown,
+        ): unknown {
+          return decodeRows(
+            db,
+            sql\`
+              SELECT \${users.id}
+              FROM \${users}
+              WHERE \${eq(users.id, 1)}
+              LIMIT 1
+            \`,
+            rowSchema,
+          );
+        }
+        void local;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "@fake/lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${eq(users.id, 1)}
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const builder = {
+          innerJoin(relation: unknown, condition: unknown) {
+            return { relation, condition };
+          },
+        };
+        builder.innerJoin(users, sql\`true\`);
+      `,
+    },
   ],
   invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${users.id} AS "id"
+            FROM \${users}
+            WHERE \${eq(users.id, 1)}
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${users.deletedAt} IS NULL
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql as query } from "drizzle-orm";
+        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await decodeRows(
+          db,
+          query\`select \${users.id} from \${users} where \${eq(users.id, 1)} limit 1;\`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        import * as rawRows from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await rawRows.executeRawRows(
+          db,
+          drizzle.sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${drizzle.eq(users.id, 1)}
+              AND $$ORDER BY ignored$$ = $$ORDER BY ignored$$
+              /* GROUP BY ignored /* nested ORDER BY */ */
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            /* __vm0_sql_marker_0_ and Unicode α */
+            SELECT \${users.id} AS "识别符"
+            FROM \${users}
+            WHERE \${eq(users.id, 1)}
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${users.id} = \${1}
+            ORDER BY \${users.id}
+            LIMIT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`\${users.deletedAt} IS NULL\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "isNull" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${users.deletedAt} IS NULL
+            ORDER BY \${users.id}
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "isNull" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`\${users.deletedAt} > now()\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const condition = eq(users.id, 1);
+        db.select()
+          .from(users)
+          .where(sql\`\${condition} AND unsupported(\${users.name})\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(
+            sql\`(\${users.id} = \${1} OR unsupported(\${users.name}))
+              AND \${users.id} > \${2}\`,
+          );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`unsupported(\${users.id} = \${1})\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        await executeRawRows(
+          db,
+          sql\`
+            WITH first_group AS (
+              SELECT 1
+              WHERE \${eq(users.id, 1)} AND \${eq(users.name, "one")}
+            ),
+            second_group AS (
+              SELECT 1
+              WHERE \${eq(users.id, 2)} AND \${eq(users.name, "two")}
+            )
+            SELECT 1
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .innerJoin(users, sql\`/* structural */ TRUE\`);
+      `,
+      errors: [{ messageId: "crossJoin" }],
+    },
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -317,6 +317,12 @@ const composedReadCtePreamble = `
 ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
   valid: [
     {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
       code: `${lockingCteUpdatePreamble}
         import { inArray, lte, sql } from "drizzle-orm";
         await db.execute(sql\`
@@ -846,6 +852,13 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         import { executeRawRows } from "./other/db-raw-rows";
+        await executeRawRows(db, ${directQuery}, rowSchema);
+      `,
+    },
+    {
+      code: `${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { executeRawRows } from "@fake/lib/db-raw-rows";
         await executeRawRows(db, ${directQuery}, rowSchema);
       `,
     },
@@ -2190,47 +2203,6 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         );
       `,
       errors: [{ messageId: "lockingQueryBuilder" }],
-    },
-    {
-      code: `${rawRowsImport}${schemaPreamble}
-        import { eq, sql } from "drizzle-orm";
-        await executeRawRows(db, ${directQuery}, rowSchema);
-      `,
-      errors: [{ messageId: "queryBuilder" }],
-    },
-    {
-      code: `${schemaPreamble}
-        import { eq, sql as query } from "drizzle-orm";
-        import { executeRawRows as decodeRows } from "./lib/db-raw-rows";
-        await decodeRows(
-          db,
-          query\`select \${runs.id} from \${runs} inner join \${runStates} on \${eq(runStates.id, runs.id)} where \${eq(runs.threadId, threadId)} and \${eq(runs.id, excludedRunId)} limit 1;\`,
-          rowSchema,
-        );
-      `,
-      errors: [{ messageId: "queryBuilder" }],
-    },
-    {
-      code: `${schemaPreamble}
-        import * as drizzle from "drizzle-orm";
-        import * as rawRows from "./lib/db-raw-rows";
-        await rawRows.executeRawRows(
-          db,
-          drizzle.sql\`
-            SELECT \${runs.id}
-            FROM \${runs}
-            INNER JOIN \${runStates}
-              ON \${drizzle.eq(runStates.id, runs.id)}
-            WHERE \${drizzle.eq(runs.threadId, threadId)}
-              AND $$ORDER BY ignored$$ = $$ORDER BY ignored$$
-              /* GROUP BY ignored /* nested ORDER BY */ */
-              AND (SELECT 1 FROM ignored ORDER BY ignored LIMIT 1) = 1
-            LIMIT 1
-          \`,
-          rowSchema,
-        );
-      `,
-      errors: [{ messageId: "queryBuilder" }],
     },
     {
       code: `${structuredSelectionPreamble}

--- a/turbo/packages/eslint-rules/src/api/execute-raw-rows.ts
+++ b/turbo/packages/eslint-rules/src/api/execute-raw-rows.ts
@@ -1,0 +1,117 @@
+import {
+  AST_NODE_TYPES,
+  type ParserServicesWithTypeInformation,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  isImportDeclaration,
+  isImportSpecifier,
+  isNamespaceImport,
+  isStringLiteral,
+  type Node,
+  type TypeChecker,
+} from "typescript";
+
+function importSource(node: Node): string | undefined {
+  let current: Node | undefined = node;
+  while (current !== undefined && !isImportDeclaration(current)) {
+    current = current.parent;
+  }
+  return current !== undefined && isStringLiteral(current.moduleSpecifier)
+    ? current.moduleSpecifier.text.replaceAll("\\", "/")
+    : undefined;
+}
+
+function isRawRowsModule(source: string | undefined): boolean {
+  return (
+    source !== undefined &&
+    /^(?:\.\.?\/)+lib\/db-raw-rows(?:\.[cm]?[jt]s)?$/.test(source)
+  );
+}
+
+function memberName(node: TSESTree.MemberExpression): string | undefined {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (
+    node.computed &&
+    node.property.type === AST_NODE_TYPES.Literal &&
+    typeof node.property.value === "string"
+  ) {
+    return node.property.value;
+  }
+  return undefined;
+}
+
+export function createExecuteRawRowsMatcher(
+  program: TSESTree.Program,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): (node: TSESTree.Expression) => boolean {
+  const directBindings = new Set<string>();
+  const namespaces = new Set<string>();
+
+  for (const statement of program.body) {
+    if (
+      statement.type !== AST_NODE_TYPES.ImportDeclaration ||
+      typeof statement.source.value !== "string" ||
+      !isRawRowsModule(statement.source.value)
+    ) {
+      continue;
+    }
+    for (const specifier of statement.specifiers) {
+      if (
+        specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+        ((specifier.imported.type === AST_NODE_TYPES.Identifier &&
+          specifier.imported.name === "executeRawRows") ||
+          (specifier.imported.type === AST_NODE_TYPES.Literal &&
+            specifier.imported.value === "executeRawRows"))
+      ) {
+        directBindings.add(specifier.local.name);
+      } else if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+        namespaces.add(specifier.local.name);
+      }
+    }
+  }
+
+  return (node: TSESTree.Expression): boolean => {
+    if (node.type === AST_NODE_TYPES.Identifier) {
+      if (!directBindings.has(node.name)) {
+        return false;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return (
+        checker
+          .getSymbolAtLocation(tsNode)
+          ?.declarations?.some((declaration) => {
+            return (
+              isImportSpecifier(declaration) &&
+              (declaration.propertyName?.text ?? declaration.name.text) ===
+                "executeRawRows" &&
+              isRawRowsModule(importSource(declaration))
+            );
+          }) === true
+      );
+    }
+
+    if (
+      node.type !== AST_NODE_TYPES.MemberExpression ||
+      memberName(node) !== "executeRawRows" ||
+      node.object.type !== AST_NODE_TYPES.Identifier ||
+      !namespaces.has(node.object.name)
+    ) {
+      return false;
+    }
+    const tsObject = services.esTreeNodeToTSNodeMap.get(node.object);
+    return (
+      checker
+        .getSymbolAtLocation(tsObject)
+        ?.declarations?.some((declaration) => {
+          return (
+            isNamespaceImport(declaration) &&
+            isRawRowsModule(importSource(declaration))
+          );
+        }) === true
+    );
+  };
+}

--- a/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
@@ -1,7 +1,21 @@
-import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
-import { TypeFlags, type Type, type TypeChecker } from "typescript";
+import {
+  ESLintUtils,
+  type ParserServicesWithTypeInformation,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  IndexKind,
+  isCallExpression,
+  TypeFlags,
+  type Type,
+  type TypeChecker,
+} from "typescript";
 
-import { isDrizzleSqlTag, isDrizzleWrapperType } from "../drizzle.ts";
+import {
+  isDrizzleSqlTag,
+  isDrizzleWrapperType,
+  isNamedDrizzleSignature,
+} from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
 type MessageId =
@@ -95,6 +109,70 @@ function interpolationProblem(
   return null;
 }
 
+function isDefinitelyPresentBooleanHelper(
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  expression: TSESTree.Expression,
+): boolean {
+  if (expression.type !== "CallExpression") {
+    return false;
+  }
+  const tsExpression = services.esTreeNodeToTSNodeMap.get(expression);
+  if (!isCallExpression(tsExpression)) {
+    return false;
+  }
+  const signature = checker.getResolvedSignature(tsExpression);
+  if (
+    signature === undefined ||
+    (!isNamedDrizzleSignature(signature, "and") &&
+      !isNamedDrizzleSignature(signature, "or"))
+  ) {
+    return false;
+  }
+  let hasPresentCondition = false;
+  for (const argument of expression.arguments) {
+    if (argument.type === "SpreadElement") {
+      const tsArgument = services.esTreeNodeToTSNodeMap.get(argument.argument);
+      const elementType = checker.getIndexTypeOfType(
+        checker.getTypeAtLocation(tsArgument),
+        IndexKind.Number,
+      );
+      if (
+        elementType === undefined ||
+        !isOptionalDrizzleWrapperType(checker, elementType)
+      ) {
+        return false;
+      }
+      continue;
+    }
+    const tsArgument = services.esTreeNodeToTSNodeMap.get(argument);
+    const type = checker.getTypeAtLocation(tsArgument);
+    if (!isOptionalDrizzleWrapperType(checker, type)) {
+      return false;
+    }
+    if (isDrizzleWrapperType(checker, type)) {
+      hasPresentCondition = true;
+    }
+  }
+  return hasPresentCondition;
+}
+
+function isOptionalDrizzleWrapperType(
+  checker: TypeChecker,
+  type: Type,
+): boolean {
+  const members = constrainedTypeMembers(checker, type, new Set<Type>());
+  return (
+    members !== null &&
+    members.every((member) => {
+      return (
+        (member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0 ||
+        isDrizzleWrapperType(checker, member)
+      );
+    })
+  );
+}
+
 export const noUnsafeSqlInterpolation = createRule({
   name: "no-unsafe-sql-interpolation",
   defaultOptions: [],
@@ -134,7 +212,11 @@ export const noUnsafeSqlInterpolation = createRule({
             checker,
             checker.getTypeAtLocation(tsExpression),
           );
-          if (messageId !== null) {
+          if (
+            messageId !== null &&
+            (messageId !== "undefinedInterpolation" ||
+              !isDefinitelyPresentBooleanHelper(checker, services, expression))
+          ) {
             context.report({ node: expression, messageId });
           }
         }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -39,10 +39,15 @@ import {
   isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
+import { createExecuteRawRowsMatcher } from "../execute-raw-rows.ts";
 import {
   SQL_TEMPLATE_EXPRESSION_BOUNDARY,
   sqlCodeMask,
 } from "../sql-lexing.ts";
+import {
+  analyzeDirectSql,
+  type DirectSqlAnalysis,
+} from "../sql-analysis/direct-sql-analysis.ts";
 import { createRule } from "../utils.ts";
 
 type BinaryLeftOperand = "array" | "pattern" | "wrapper";
@@ -154,6 +159,17 @@ const BINARY_HELPERS = new Map<string, BinaryHelper>([
       rightBoundary: "predicate",
     },
   ],
+]);
+
+const STRUCTURAL_HELPERS = new Set([
+  "and",
+  "eq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "ne",
+  "or",
 ]);
 
 type BooleanToken = "operand" | "and" | "or" | "(" | ")";
@@ -752,10 +768,14 @@ export const preferDrizzleApis = createRule({
     },
     schema: [],
     messages: {
+      crossJoin:
+        "Use Drizzle crossJoin(...) for this equivalent inner join on true.",
       crossJoinLateral:
         "Use Drizzle crossJoinLateral(...) for this equivalent lateral join.",
       emptyFragment:
         "Use Drizzle sql.empty() for this intentionally empty SQL fragment.",
+      queryBuilder:
+        "Use a Drizzle select builder for this complete schema-backed query.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
       existencePredicate:
         "Use Drizzle {{helper}}(...) with a select builder for this equivalent existence predicate.",
@@ -764,6 +784,15 @@ export const preferDrizzleApis = createRule({
   create(context) {
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
+    const isExecuteRawRowsCallee = createExecuteRawRowsMatcher(
+      context.sourceCode.ast,
+      checker,
+      services,
+    );
+    const structurallyOwnedTemplates =
+      new WeakSet<TSESTree.TaggedTemplateExpression>();
+    const structurallyWholeTemplates =
+      new WeakSet<TSESTree.TaggedTemplateExpression>();
     const expressionTypeCache = new WeakMap<
       TSESTree.Expression,
       { readonly location: Node; readonly type: Type }
@@ -786,12 +815,39 @@ export const preferDrizzleApis = createRule({
       return result;
     }
 
-    function report(node: TSESTree.Node, helper: string): void {
+    function reportTypedApi(node: TSESTree.Node, helper: string): void {
       context.report({
         node,
         messageId: "typedApi",
         data: { helper },
       });
+    }
+
+    function reportStructuralAnalysis(analysis: DirectSqlAnalysis): void {
+      for (const finding of analysis.findings) {
+        if (finding.kind === "query-builder") {
+          context.report({
+            node: finding.node,
+            messageId: "queryBuilder",
+          });
+        } else {
+          reportTypedApi(finding.node, finding.helper);
+        }
+      }
+    }
+
+    function reportLegacy(
+      template: TSESTree.TaggedTemplateExpression,
+      node: TSESTree.Node,
+      helper: string,
+    ): void {
+      if (
+        structurallyOwnedTemplates.has(template) &&
+        STRUCTURAL_HELPERS.has(helper)
+      ) {
+        return;
+      }
+      reportTypedApi(node, helper);
     }
 
     function memberName(node: TSESTree.MemberExpression): string | undefined {
@@ -820,6 +876,78 @@ export const preferDrizzleApis = createRule({
       }
       const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
       return isDrizzleSymbol(checker, checker.getSymbolAtLocation(tsProperty));
+    }
+
+    function taggedArgument(
+      node: TSESTree.CallExpression,
+      index: number,
+    ): TSESTree.TaggedTemplateExpression | undefined {
+      const argument = node.arguments[index];
+      return argument?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        isDrizzleSqlTag(checker, services, argument.tag)
+        ? argument
+        : undefined;
+    }
+
+    function inspectRawQueryCall(node: TSESTree.CallExpression): void {
+      if (
+        node.arguments.length !== 3 ||
+        node.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        })
+      ) {
+        return;
+      }
+      const query = node.arguments[1];
+      if (
+        query?.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        !isExecuteRawRowsCallee(node.callee) ||
+        !isDrizzleSqlTag(checker, services, query.tag)
+      ) {
+        return;
+      }
+      structurallyOwnedTemplates.add(query);
+      const analysis = analyzeDirectSql(query, "statement", checker, services);
+      if (analysis.isSimpleSelect) {
+        structurallyWholeTemplates.add(query);
+      }
+      reportStructuralAnalysis(analysis);
+    }
+
+    function inspectPredicateCall(node: TSESTree.CallExpression): void {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return;
+      }
+      const method = memberName(node.callee);
+      const predicateIndex =
+        method === "where" || method === "having"
+          ? 0
+          : method === "innerJoin" ||
+              method === "leftJoin" ||
+              method === "rightJoin" ||
+              method === "fullJoin" ||
+              method === "innerJoinLateral" ||
+              method === "leftJoinLateral"
+            ? 1
+            : undefined;
+      if (method === undefined || predicateIndex === undefined) {
+        return;
+      }
+      const predicate = taggedArgument(node, predicateIndex);
+      if (predicate === undefined || !isDrizzleMethod(node.callee, method)) {
+        return;
+      }
+      structurallyOwnedTemplates.add(predicate);
+      const analysis = analyzeDirectSql(
+        predicate,
+        "predicate",
+        checker,
+        services,
+      );
+      reportStructuralAnalysis(analysis);
+      if (method === "innerJoin" && analysis.isTruePredicate) {
+        context.report({ node, messageId: "crossJoin" });
+      }
     }
 
     function isTrueSqlTag(node: TSESTree.Expression): boolean {
@@ -1220,6 +1348,8 @@ export const preferDrizzleApis = createRule({
 
     return {
       CallExpression(node: TSESTree.CallExpression): void {
+        inspectRawQueryCall(node);
+        inspectPredicateCall(node);
         if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
           return;
         }
@@ -1256,6 +1386,9 @@ export const preferDrizzleApis = createRule({
         if (!isDrizzleSqlTag(checker, services, node.tag)) {
           return;
         }
+        if (structurallyWholeTemplates.has(node)) {
+          return;
+        }
 
         const quasis = node.quasi.quasis.map(quasiText);
         const syntaxSource = sqlCodeMask(
@@ -1280,7 +1413,7 @@ export const preferDrizzleApis = createRule({
             syntaxSource.slice(0, match.start).trim() === "" &&
             syntaxSource.slice(match.end).trim() === "";
           if (!isWholeAggregate || hasDirectMapWith(node)) {
-            report(node, "count");
+            reportLegacy(node, node, "count");
           }
         }
         const existence = existenceTemplateMatch(syntaxQuasis);
@@ -1333,7 +1466,7 @@ export const preferDrizzleApis = createRule({
             ) &&
             isInlineParameterListSqlJoin(valuesNode)
           ) {
-            report(columnNode, "inArray");
+            reportLegacy(node, columnNode, "inArray");
           }
         }
         for (let index = 0; index < expressions.length - 1; index += 1) {
@@ -1356,7 +1489,7 @@ export const preferDrizzleApis = createRule({
             binaryLeftMatches(binary.left, left) &&
             binaryRightMatches(binary.right, right.type)
           ) {
-            report(leftNode, binary.helper);
+            reportLegacy(node, leftNode, binary.helper);
           }
           const membership = /^\s+(NOT\s+)?IN\s*\(\s*$/i.exec(middle);
           if (
@@ -1366,7 +1499,8 @@ export const preferDrizzleApis = createRule({
             isDrizzleColumnType(checker, left.type, left.location) &&
             hasParameterListOrigin(rightNode)
           ) {
-            report(
+            reportLegacy(
+              node,
               leftNode,
               membership[1] === undefined ? "inArray" : "notInArray",
             );
@@ -1394,7 +1528,7 @@ export const preferDrizzleApis = createRule({
             hasPredicateRightBoundary(quasis[index + 3] ?? "") &&
             isDrizzleWrapperType(checker, expressionType(leftNode).type)
           ) {
-            report(leftNode, range.helper);
+            reportLegacy(node, leftNode, range.helper);
           }
         }
 
@@ -1415,7 +1549,7 @@ export const preferDrizzleApis = createRule({
             hasPredicateRightBoundary(rawSuffix) &&
             isDrizzleWrapperType(checker, expression.type)
           ) {
-            report(expressionNode, unary.helper);
+            reportLegacy(node, expressionNode, unary.helper);
           }
 
           const nullMatch = nullPredicateMatch(suffix);
@@ -1425,7 +1559,7 @@ export const preferDrizzleApis = createRule({
             hasPredicateRightBoundary(rawSuffix.slice(nullMatch.length)) &&
             isDrizzleWrapperType(checker, expression.type)
           ) {
-            report(expressionNode, nullMatch.helper);
+            reportLegacy(node, expressionNode, nullMatch.helper);
           }
 
           const order = orderingMatch(suffix);
@@ -1434,7 +1568,7 @@ export const preferDrizzleApis = createRule({
             hasOrderingLeftBoundary(prefix) &&
             isDrizzleWrapperType(checker, expression.type)
           ) {
-            report(expressionNode, order.helper);
+            reportLegacy(node, expressionNode, order.helper);
           }
 
           const aggregate = aggregateMatch(prefix);
@@ -1457,7 +1591,7 @@ export const preferDrizzleApis = createRule({
             prefix.slice(0, aggregate.start).trim() === "" &&
             aggregateSuffix.trim() === "";
           if (!isWholeAggregate) {
-            report(expressionNode, aggregate.helper);
+            reportLegacy(node, expressionNode, aggregate.helper);
           } else if (
             hasDirectMapWith(node) ||
             ((aggregate.helper === "max" || aggregate.helper === "min") &&
@@ -1467,7 +1601,7 @@ export const preferDrizzleApis = createRule({
                 expression.location,
               ))
           ) {
-            report(node, aggregate.helper);
+            reportLegacy(node, node, aggregate.helper);
           }
         }
 
@@ -1487,7 +1621,7 @@ export const preferDrizzleApis = createRule({
         }
         const tsNode = services.esTreeNodeToTSNodeMap.get(node);
         if (isOptionalDrizzleContext(checker.getContextualType(tsNode))) {
-          report(node, boolean);
+          reportLegacy(node, node, boolean);
         }
       },
     };

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -8,11 +8,7 @@ import {
   canHaveModifiers,
   getModifiers,
   isFunctionDeclaration,
-  isImportDeclaration,
-  isImportSpecifier,
-  isNamespaceImport,
   isReturnStatement,
-  isStringLiteral,
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
@@ -33,10 +29,12 @@ import {
   isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
+import { createExecuteRawRowsMatcher } from "../execute-raw-rows.ts";
 import {
   SQL_TEMPLATE_EXPRESSION_BOUNDARY,
   sqlCodeMask,
 } from "../sql-lexing.ts";
+import { analyzeDirectSql } from "../sql-analysis/direct-sql-analysis.ts";
 import { createRule } from "../utils.ts";
 
 interface SqlTokenBase {
@@ -65,13 +63,6 @@ interface WordToken extends SqlTokenBase {
 }
 
 type SqlToken = ExpressionToken | NumberToken | PunctuationToken | WordToken;
-
-interface SimpleSelectMatch {
-  readonly joinConditionExpressionIndexes: readonly number[];
-  readonly joinTableExpressionIndexes: readonly number[];
-  readonly selectedColumnExpressionIndex: number;
-  readonly sourceTableExpressionIndex: number;
-}
 
 interface PaginatedJoinedSelectMatch {
   readonly clauseExpressionIndexes: readonly number[];
@@ -298,23 +289,6 @@ function memberName(node: TSESTree.MemberExpression): string | null {
     return typeof node.property.value === "string" ? node.property.value : null;
   }
   return null;
-}
-
-function importSource(node: Node): string | undefined {
-  let current: Node | undefined = node;
-  while (current !== undefined && !isImportDeclaration(current)) {
-    current = current.parent;
-  }
-  return current !== undefined && isStringLiteral(current.moduleSpecifier)
-    ? current.moduleSpecifier.text.replaceAll("\\", "/")
-    : undefined;
-}
-
-function isRawRowsModule(source: string | undefined): boolean {
-  return (
-    source !== undefined &&
-    /(?:^|\/)lib\/db-raw-rows(?:\.[cm]?[jt]s)?$/.test(source)
-  );
 }
 
 function topLevelTokens(source: string): readonly SqlToken[] | undefined {
@@ -1910,122 +1884,6 @@ function simpleLockingCteUpdateMatch(
   };
 }
 
-function simpleSelectMatch(
-  source: string,
-  syntaxSource: string,
-): SimpleSelectMatch | undefined {
-  const tokens = topLevelTokens(syntaxSource);
-  if (tokens === undefined) {
-    return undefined;
-  }
-
-  let cursor = 0;
-  if (!isWord(tokens[cursor], "SELECT")) {
-    return undefined;
-  }
-  cursor += 1;
-  const selectedColumnExpressionIndex = expressionIndex(tokens[cursor]);
-  if (selectedColumnExpressionIndex === undefined) {
-    return undefined;
-  }
-  cursor += 1;
-
-  if (isWord(tokens[cursor], "AS")) {
-    const aliasKeyword = tokens[cursor];
-    cursor += 1;
-    if (tokens[cursor]?.kind === "word" && !isWord(tokens[cursor], "FROM")) {
-      cursor += 1;
-    } else {
-      const from = tokens[cursor];
-      if (
-        aliasKeyword === undefined ||
-        from === undefined ||
-        !isWord(from, "FROM") ||
-        !/^"(?:[^"]|"")+"$/s.test(
-          source.slice(aliasKeyword.end, from.start).trim(),
-        )
-      ) {
-        return undefined;
-      }
-    }
-  }
-
-  if (!isWord(tokens[cursor], "FROM")) {
-    return undefined;
-  }
-  cursor += 1;
-  const sourceTableExpressionIndex = expressionIndex(tokens[cursor]);
-  if (sourceTableExpressionIndex === undefined) {
-    return undefined;
-  }
-  cursor += 1;
-
-  const joinTableExpressionIndexes: number[] = [];
-  const joinConditionExpressionIndexes: number[] = [];
-  while (isWord(tokens[cursor], "INNER")) {
-    cursor += 1;
-    if (!isWord(tokens[cursor], "JOIN")) {
-      return undefined;
-    }
-    cursor += 1;
-    const joinTableIndex = expressionIndex(tokens[cursor]);
-    if (joinTableIndex === undefined) {
-      return undefined;
-    }
-    joinTableExpressionIndexes.push(joinTableIndex);
-    cursor += 1;
-    if (!isWord(tokens[cursor], "ON")) {
-      return undefined;
-    }
-    cursor += 1;
-    const joinConditionIndex = expressionIndex(tokens[cursor]);
-    if (joinConditionIndex === undefined) {
-      return undefined;
-    }
-    joinConditionExpressionIndexes.push(joinConditionIndex);
-    cursor += 1;
-  }
-
-  if (!isWord(tokens[cursor], "WHERE")) {
-    return undefined;
-  }
-  cursor += 1;
-
-  let end = tokens.length;
-  const trailingToken = tokens[end - 1];
-  if (trailingToken?.kind === "punctuation" && trailingToken.value === ";") {
-    end -= 1;
-  }
-  const limitKeywordIndex = end - 2;
-  const limitValue = tokens[limitKeywordIndex + 1];
-  if (
-    cursor >= limitKeywordIndex ||
-    !isWord(tokens[limitKeywordIndex], "LIMIT") ||
-    limitValue?.kind !== "number" ||
-    limitValue.value !== "1"
-  ) {
-    return undefined;
-  }
-  for (let index = cursor; index < limitKeywordIndex; index += 1) {
-    const token = tokens[index];
-    if (
-      token === undefined ||
-      (token.kind === "word" &&
-        UNSUPPORTED_TOP_LEVEL_WHERE_KEYWORDS.has(token.value)) ||
-      (token.kind === "punctuation" && token.value === ";")
-    ) {
-      return undefined;
-    }
-  }
-
-  return {
-    joinConditionExpressionIndexes,
-    joinTableExpressionIndexes,
-    selectedColumnExpressionIndex,
-    sourceTableExpressionIndex,
-  };
-}
-
 function isPaginatedJoinedSelectClauseBoundary(
   token: SqlToken | undefined,
 ): boolean {
@@ -2447,8 +2305,11 @@ export const preferDrizzleQueryBuilder = createRule({
   create(context) {
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
-    const directRawRowsBindings = new Set<string>();
-    const rawRowsNamespaces = new Set<string>();
+    const isExecuteRawRowsCallee = createExecuteRawRowsMatcher(
+      context.sourceCode.ast,
+      checker,
+      services,
+    );
     // Keep the type-aware consumer traversal out of files with no matching
     // syntax. The API baseline has hundreds of result calls but zero targets.
     const scalarQueryCandidates = new Set<TSESTree.TaggedTemplateExpression>();
@@ -2461,67 +2322,6 @@ export const preferDrizzleQueryBuilder = createRule({
       execute: new Map<Type, boolean>(),
       from: new Map<Type, boolean>(),
     };
-
-    for (const statement of context.sourceCode.ast.body) {
-      if (
-        statement.type !== AST_NODE_TYPES.ImportDeclaration ||
-        typeof statement.source.value !== "string" ||
-        !isRawRowsModule(statement.source.value)
-      ) {
-        continue;
-      }
-      for (const specifier of statement.specifiers) {
-        if (
-          specifier.type === AST_NODE_TYPES.ImportSpecifier &&
-          ((specifier.imported.type === AST_NODE_TYPES.Identifier &&
-            specifier.imported.name === "executeRawRows") ||
-            (specifier.imported.type === AST_NODE_TYPES.Literal &&
-              specifier.imported.value === "executeRawRows"))
-        ) {
-          directRawRowsBindings.add(specifier.local.name);
-        } else if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
-          rawRowsNamespaces.add(specifier.local.name);
-        }
-      }
-    }
-
-    function isExecuteRawRowsCallee(node: TSESTree.Expression): boolean {
-      if (node.type === AST_NODE_TYPES.Identifier) {
-        if (!directRawRowsBindings.has(node.name)) {
-          return false;
-        }
-        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-        const symbol = checker.getSymbolAtLocation(tsNode);
-        return (
-          symbol?.declarations?.some((declaration) => {
-            return (
-              isImportSpecifier(declaration) &&
-              (declaration.propertyName?.text ?? declaration.name.text) ===
-                "executeRawRows" &&
-              isRawRowsModule(importSource(declaration))
-            );
-          }) === true
-        );
-      }
-      if (
-        node.type !== AST_NODE_TYPES.MemberExpression ||
-        memberName(node) !== "executeRawRows" ||
-        node.object.type !== AST_NODE_TYPES.Identifier ||
-        !rawRowsNamespaces.has(node.object.name)
-      ) {
-        return false;
-      }
-      const tsObject = services.esTreeNodeToTSNodeMap.get(node.object);
-      const symbol = checker.getSymbolAtLocation(tsObject);
-      return (
-        symbol?.declarations?.some((declaration) => {
-          return (
-            isNamespaceImport(declaration) &&
-            isRawRowsModule(importSource(declaration))
-          );
-        }) === true
-      );
-    }
 
     function isDrizzleExecuteMember(node: TSESTree.MemberExpression): boolean {
       if (memberName(node) !== "execute") {
@@ -3333,6 +3133,11 @@ export const preferDrizzleQueryBuilder = createRule({
         ) {
           return;
         }
+        if (
+          analyzeDirectSql(query, "statement", checker, services).isSimpleSelect
+        ) {
+          return;
+        }
 
         const source = query.quasi.quasis
           .map(quasiText)
@@ -3387,61 +3192,24 @@ export const preferDrizzleQueryBuilder = createRule({
           return;
         }
 
-        const simpleMatch = simpleSelectMatch(source, syntaxSource);
-        const joinedMatch =
-          simpleMatch === undefined
-            ? paginatedJoinedSelectMatch(syntaxSource, "schema-expression")
-            : undefined;
+        const joinedMatch = paginatedJoinedSelectMatch(
+          syntaxSource,
+          "schema-expression",
+        );
         const existsMatch =
-          simpleMatch === undefined && joinedMatch === undefined
+          joinedMatch === undefined
             ? completePaginatedExistsSelectMatch(syntaxSource)
             : undefined;
-        if (
-          simpleMatch === undefined &&
-          joinedMatch === undefined &&
-          existsMatch === undefined
-        ) {
+        if (joinedMatch === undefined && existsMatch === undefined) {
           return;
         }
 
-        if (simpleMatch !== undefined) {
-          const selectedColumn =
-            query.quasi.expressions[simpleMatch.selectedColumnExpressionIndex];
-          const sourceTable =
-            query.quasi.expressions[simpleMatch.sourceTableExpressionIndex];
-          if (selectedColumn === undefined || sourceTable === undefined) {
-            return;
-          }
-          const selectedColumnType = expressionType(selectedColumn);
-          const sourceTableType = expressionType(sourceTable);
-          if (
-            !isDrizzleColumnType(
-              checker,
-              selectedColumnType.type,
-              selectedColumnType.location,
-            ) ||
-            !isDrizzleTableType(
-              checker,
-              sourceTableType.type,
-              sourceTableType.location,
-            ) ||
-            !simpleMatch.joinTableExpressionIndexes.every((index) => {
-              return isDrizzleTableExpression(query.quasi.expressions[index]);
-            }) ||
-            !simpleMatch.joinConditionExpressionIndexes.every((index) => {
-              return isDrizzleWrapperExpression(query.quasi.expressions[index]);
-            })
-          ) {
-            return;
-          }
-        } else {
-          const structuredMatch = joinedMatch ?? existsMatch;
-          if (
-            structuredMatch === undefined ||
-            !isSchemaBackedPaginatedJoin(query, structuredMatch)
-          ) {
-            return;
-          }
+        const structuredMatch = joinedMatch ?? existsMatch;
+        if (
+          structuredMatch === undefined ||
+          !isSchemaBackedPaginatedJoin(query, structuredMatch)
+        ) {
+          return;
         }
 
         context.report({

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/direct-sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/direct-sql-analysis.ts
@@ -412,8 +412,6 @@ function classifyExpression(
     };
   }
   if (expression.kind === "comparison") {
-    const left = classifyExpression(expression.left);
-    const right = classifyExpression(expression.right);
     const helper = COMPARISON_HELPERS.get(expression.operator);
     if (
       helper !== undefined &&
@@ -431,6 +429,8 @@ function classifyExpression(
         ],
       };
     }
+    const left = classifyExpression(expression.left);
+    const right = classifyExpression(expression.right);
     return {
       anchor:
         left.anchor ??
@@ -441,41 +441,25 @@ function classifyExpression(
     };
   }
   if (expression.kind === "boolean") {
-    const children = expression.items.map((item) => {
-      return classifyExpression(item);
-    });
-    const anchor = children.find((child) => {
-      return child.anchor !== undefined || child.findings.length > 0;
-    });
-    if (
-      anchor !== undefined &&
-      (anchor.anchor !== undefined || anchor.findings[0] !== undefined)
-    ) {
-      const reportNode = anchor.anchor ?? anchor.findings[0]?.node;
-      if (reportNode === undefined) {
+    for (const item of expression.items) {
+      const child = classifyExpression(item);
+      const reportNode = child.anchor ?? child.findings[0]?.node;
+      if (reportNode !== undefined) {
         return {
-          anchor: undefined,
-          findings: [],
+          anchor: reportNode,
+          findings: [
+            {
+              helper: expression.operator,
+              kind: "helper",
+              node: reportNode,
+            },
+          ],
         };
       }
-      return {
-        anchor: reportNode,
-        findings: [
-          {
-            helper: expression.operator,
-            kind: "helper",
-            node: reportNode,
-          },
-        ],
-      };
     }
     return {
       anchor: undefined,
-      findings: deduplicateFindings(
-        children.flatMap((child) => {
-          return child.findings;
-        }),
-      ),
+      findings: [],
     };
   }
 

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/direct-sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/direct-sql-analysis.ts
@@ -1,0 +1,679 @@
+import {
+  type ParserServicesWithTypeInformation,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import { type TypeChecker } from "typescript";
+
+import {
+  isDrizzleColumnType,
+  isDrizzleSqlTag,
+  isDrizzleTableType,
+  isDrizzleWrapperType,
+} from "../drizzle.ts";
+import { parsePostgres } from "./postgres-parser.ts";
+
+type DirectSqlContext = "predicate" | "statement";
+
+export type DirectSqlFinding =
+  | {
+      readonly helper: "and" | "eq" | "gt" | "gte" | "lt" | "lte" | "ne" | "or";
+      readonly kind: "helper";
+      readonly node: TSESTree.Node;
+    }
+  | {
+      readonly kind: "query-builder";
+      readonly node: TSESTree.TaggedTemplateExpression;
+    };
+
+export interface DirectSqlAnalysis {
+  readonly findings: readonly DirectSqlFinding[];
+  readonly isSimpleSelect: boolean;
+  readonly isTruePredicate: boolean;
+}
+
+interface SqlMarker {
+  readonly isColumn: boolean;
+  readonly isTable: boolean;
+  readonly isWrapper: boolean;
+  readonly node: TSESTree.Expression;
+}
+
+interface ParsedDirectSql {
+  readonly markers: ReadonlyMap<string, SqlMarker>;
+  readonly statement: unknown;
+}
+
+type StructuralExpression =
+  | {
+      readonly children: readonly StructuralExpression[];
+      readonly kind: "opaque";
+    }
+  | {
+      readonly kind: "constant";
+    }
+  | {
+      readonly kind: "marker";
+      readonly marker: SqlMarker;
+    }
+  | {
+      readonly kind: "comparison";
+      readonly left: StructuralExpression;
+      readonly operator: string;
+      readonly right: StructuralExpression;
+    }
+  | {
+      readonly items: readonly StructuralExpression[];
+      readonly kind: "boolean";
+      readonly operator: "and" | "or";
+    };
+
+interface ExpressionClassification {
+  readonly anchor: TSESTree.Node | undefined;
+  readonly findings: readonly DirectSqlFinding[];
+}
+
+interface RelationMatch {
+  readonly joinedConditions: readonly SqlMarker[];
+  readonly joinedTables: readonly SqlMarker[];
+  readonly sourceTable: SqlMarker;
+}
+
+const EMPTY_ANALYSIS: DirectSqlAnalysis = {
+  findings: [],
+  isSimpleSelect: false,
+  isTruePredicate: false,
+};
+
+const ANALYSIS_CACHE = new WeakMap<
+  TSESTree.TaggedTemplateExpression,
+  Map<DirectSqlContext, DirectSqlAnalysis>
+>();
+
+const COMPARISON_HELPERS = new Map<
+  string,
+  "eq" | "gt" | "gte" | "lt" | "lte" | "ne"
+>([
+  ["=", "eq"],
+  ["<>", "ne"],
+  [">", "gt"],
+  [">=", "gte"],
+  ["<", "lt"],
+  ["<=", "lte"],
+]);
+
+const EXPRESSION_NODE_KEYS = new Set([
+  "A_ArrayExpr",
+  "A_Const",
+  "A_Expr",
+  "A_Indirection",
+  "BoolExpr",
+  "BooleanTest",
+  "CaseExpr",
+  "CaseWhen",
+  "CoalesceExpr",
+  "CollateClause",
+  "ColumnRef",
+  "FuncCall",
+  "MinMaxExpr",
+  "NamedArgExpr",
+  "NullTest",
+  "ParamRef",
+  "RowExpr",
+  "SQLValueFunction",
+  "SetToDefault",
+  "SubLink",
+  "TypeCast",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordProperty(
+  value: unknown,
+  property: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const result = value[property];
+  return isRecord(result) ? result : undefined;
+}
+
+function quasiText(node: TSESTree.TemplateElement): string {
+  return node.value.cooked ?? node.value.raw;
+}
+
+function markerIsColumn(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  const type = checker.getTypeAtLocation(tsNode);
+  return isDrizzleColumnType(checker, type, tsNode);
+}
+
+function markerIsTable(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  const type = checker.getTypeAtLocation(tsNode);
+  return isDrizzleTableType(checker, type, tsNode);
+}
+
+function markerIsWrapper(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isDrizzleWrapperType(checker, checker.getTypeAtLocation(tsNode));
+}
+
+function markerPrefix(quasis: readonly string[]): string {
+  let suffix = 0;
+  while (true) {
+    const prefix = `__vm0_sql_marker_${suffix}_`;
+    if (
+      quasis.every((quasi) => {
+        return !quasi.toLowerCase().includes(prefix);
+      })
+    ) {
+      return prefix;
+    }
+    suffix += 1;
+  }
+}
+
+function parseDirectSql(
+  node: TSESTree.TaggedTemplateExpression,
+  context: DirectSqlContext,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): ParsedDirectSql | null {
+  if (!isDrizzleSqlTag(checker, services, node.tag)) {
+    return null;
+  }
+  const quasis = node.quasi.quasis.map(quasiText);
+  const prefix = markerPrefix(quasis);
+  const markers = new Map<string, SqlMarker>();
+  let source = quasis[0] ?? "";
+  for (let index = 0; index < node.quasi.expressions.length; index += 1) {
+    const expression = node.quasi.expressions[index];
+    const followingQuasi = quasis[index + 1];
+    if (expression === undefined || followingQuasi === undefined) {
+      return null;
+    }
+    const name = `${prefix}${index}`;
+    let cachedColumn: boolean | undefined;
+    let cachedTable: boolean | undefined;
+    let cachedWrapper: boolean | undefined;
+    const marker: SqlMarker = {
+      get isColumn(): boolean {
+        cachedColumn ??= markerIsColumn(expression, checker, services);
+        return cachedColumn;
+      },
+      get isTable(): boolean {
+        cachedTable ??= markerIsTable(expression, checker, services);
+        return cachedTable;
+      },
+      get isWrapper(): boolean {
+        cachedWrapper ??= markerIsWrapper(expression, checker, services);
+        return cachedWrapper;
+      },
+      node: expression,
+    };
+    markers.set(name, marker);
+    source += `"${name}"${followingQuasi}`;
+  }
+
+  const parseResult = parsePostgres(
+    context === "statement" ? source : `SELECT 1 WHERE ${source}`,
+  );
+  if (parseResult === null || parseResult.statements.length !== 1) {
+    return null;
+  }
+  const statement = parseResult.statements[0];
+  return statement === undefined ? null : { markers, statement };
+}
+
+function stringNodeValue(value: unknown): string | undefined {
+  const stringNode = recordProperty(value, "String");
+  return typeof stringNode?.sval === "string" ? stringNode.sval : undefined;
+}
+
+function columnMarker(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): SqlMarker | undefined {
+  const columnRef = recordProperty(value, "ColumnRef");
+  if (!Array.isArray(columnRef?.fields) || columnRef.fields.length !== 1) {
+    return undefined;
+  }
+  const name = stringNodeValue(columnRef.fields[0]);
+  return name === undefined ? undefined : markers.get(name);
+}
+
+function relationMarker(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): SqlMarker | undefined {
+  const rangeVar = recordProperty(value, "RangeVar");
+  if (
+    rangeVar === undefined ||
+    typeof rangeVar.relname !== "string" ||
+    Object.keys(rangeVar).some((key) => {
+      return !["inh", "location", "relname", "relpersistence"].includes(key);
+    })
+  ) {
+    return undefined;
+  }
+  return markers.get(rangeVar.relname);
+}
+
+function operatorName(value: unknown): string | undefined {
+  if (!Array.isArray(value) || value.length !== 1) {
+    return undefined;
+  }
+  return stringNodeValue(value[0]);
+}
+
+function isExpressionNode(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.keys(value).some((key) => {
+      return EXPRESSION_NODE_KEYS.has(key);
+    })
+  );
+}
+
+function collectStructuralExpressions(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): StructuralExpression[] {
+  const expressions: StructuralExpression[] = [];
+
+  function visit(current: unknown): void {
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        visit(item);
+      }
+      return;
+    }
+    if (!isRecord(current)) {
+      return;
+    }
+    if (isExpressionNode(current)) {
+      expressions.push(structuralExpression(current, markers));
+      return;
+    }
+    for (const child of Object.values(current)) {
+      visit(child);
+    }
+  }
+
+  visit(value);
+  return expressions;
+}
+
+function structuralExpression(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): StructuralExpression {
+  const marker = columnMarker(value, markers);
+  if (marker !== undefined) {
+    return { kind: "marker", marker };
+  }
+  if (recordProperty(value, "A_Const") !== undefined) {
+    return { kind: "constant" };
+  }
+
+  const binary = recordProperty(value, "A_Expr");
+  const binaryOperator = operatorName(binary?.name);
+  if (
+    binary?.kind === "AEXPR_OP" &&
+    binaryOperator !== undefined &&
+    binary.lexpr !== undefined &&
+    binary.rexpr !== undefined
+  ) {
+    return {
+      kind: "comparison",
+      left: structuralExpression(binary.lexpr, markers),
+      operator: binaryOperator,
+      right: structuralExpression(binary.rexpr, markers),
+    };
+  }
+
+  const boolean = recordProperty(value, "BoolExpr");
+  if (
+    (boolean?.boolop === "AND_EXPR" || boolean?.boolop === "OR_EXPR") &&
+    Array.isArray(boolean.args) &&
+    boolean.args.length >= 2
+  ) {
+    return {
+      items: boolean.args.map((item) => {
+        return structuralExpression(item, markers);
+      }),
+      kind: "boolean",
+      operator: boolean.boolop === "AND_EXPR" ? "and" : "or",
+    };
+  }
+
+  const payload = isRecord(value) ? Object.values(value)[0] : undefined;
+  return {
+    children: collectStructuralExpressions(payload, markers),
+    kind: "opaque",
+  };
+}
+
+function deduplicateFindings(
+  findings: readonly DirectSqlFinding[],
+): DirectSqlFinding[] {
+  const result: DirectSqlFinding[] = [];
+  const seen = new Map<TSESTree.Node, Set<string>>();
+  for (const finding of findings) {
+    const key =
+      finding.kind === "query-builder"
+        ? finding.kind
+        : `${finding.kind}:${finding.helper}`;
+    const nodeKeys = seen.get(finding.node);
+    if (nodeKeys?.has(key) === true) {
+      continue;
+    }
+    if (nodeKeys === undefined) {
+      seen.set(finding.node, new Set([key]));
+    } else {
+      nodeKeys.add(key);
+    }
+    result.push(finding);
+  }
+  return result;
+}
+
+function classifyExpression(
+  expression: StructuralExpression,
+): ExpressionClassification {
+  if (expression.kind === "marker") {
+    return {
+      anchor:
+        expression.marker.isColumn || expression.marker.isWrapper
+          ? expression.marker.node
+          : undefined,
+      findings: [],
+    };
+  }
+  if (expression.kind === "constant") {
+    return {
+      anchor: undefined,
+      findings: [],
+    };
+  }
+  if (expression.kind === "comparison") {
+    const left = classifyExpression(expression.left);
+    const right = classifyExpression(expression.right);
+    const helper = COMPARISON_HELPERS.get(expression.operator);
+    if (
+      helper !== undefined &&
+      expression.left.kind === "marker" &&
+      (expression.left.marker.isColumn || expression.left.marker.isWrapper)
+    ) {
+      return {
+        anchor: expression.left.marker.node,
+        findings: [
+          {
+            helper,
+            kind: "helper",
+            node: expression.left.marker.node,
+          },
+        ],
+      };
+    }
+    return {
+      anchor:
+        left.anchor ??
+        left.findings[0]?.node ??
+        right.anchor ??
+        right.findings[0]?.node,
+      findings: deduplicateFindings([...left.findings, ...right.findings]),
+    };
+  }
+  if (expression.kind === "boolean") {
+    const children = expression.items.map((item) => {
+      return classifyExpression(item);
+    });
+    const anchor = children.find((child) => {
+      return child.anchor !== undefined || child.findings.length > 0;
+    });
+    if (
+      anchor !== undefined &&
+      (anchor.anchor !== undefined || anchor.findings[0] !== undefined)
+    ) {
+      const reportNode = anchor.anchor ?? anchor.findings[0]?.node;
+      if (reportNode === undefined) {
+        return {
+          anchor: undefined,
+          findings: [],
+        };
+      }
+      return {
+        anchor: reportNode,
+        findings: [
+          {
+            helper: expression.operator,
+            kind: "helper",
+            node: reportNode,
+          },
+        ],
+      };
+    }
+    return {
+      anchor: undefined,
+      findings: deduplicateFindings(
+        children.flatMap((child) => {
+          return child.findings;
+        }),
+      ),
+    };
+  }
+
+  const children = expression.children.map((child) => {
+    return classifyExpression(child);
+  });
+  return {
+    anchor:
+      children.find((child) => {
+        return child.anchor !== undefined || child.findings.length > 0;
+      })?.anchor ??
+      children.find((child) => {
+        return child.findings[0] !== undefined;
+      })?.findings[0]?.node,
+    findings: deduplicateFindings(
+      children.flatMap((child) => {
+        return child.findings;
+      }),
+    ),
+  };
+}
+
+function selectStatement(value: unknown): Record<string, unknown> | undefined {
+  const statement = recordProperty(value, "stmt");
+  return recordProperty(statement, "SelectStmt");
+}
+
+function selectedColumn(
+  select: Record<string, unknown>,
+  markers: ReadonlyMap<string, SqlMarker>,
+): SqlMarker | undefined {
+  if (!Array.isArray(select.targetList) || select.targetList.length !== 1) {
+    return undefined;
+  }
+  const target = recordProperty(select.targetList[0], "ResTarget");
+  if (
+    target === undefined ||
+    (target.name !== undefined && typeof target.name !== "string") ||
+    Object.keys(target).some((key) => {
+      return !["location", "name", "val"].includes(key);
+    })
+  ) {
+    return undefined;
+  }
+  return columnMarker(target.val, markers);
+}
+
+function relationMatch(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): RelationMatch | undefined {
+  const direct = relationMarker(value, markers);
+  if (direct !== undefined) {
+    return {
+      joinedConditions: [],
+      joinedTables: [],
+      sourceTable: direct,
+    };
+  }
+
+  const join = recordProperty(value, "JoinExpr");
+  if (
+    join?.jointype !== "JOIN_INNER" ||
+    join.larg === undefined ||
+    join.rarg === undefined ||
+    join.quals === undefined ||
+    Object.keys(join).some((key) => {
+      return !["jointype", "larg", "quals", "rarg"].includes(key);
+    })
+  ) {
+    return undefined;
+  }
+  const left = relationMatch(join.larg, markers);
+  const right = relationMarker(join.rarg, markers);
+  const condition = columnMarker(join.quals, markers);
+  if (left === undefined || right === undefined || condition === undefined) {
+    return undefined;
+  }
+  return {
+    joinedConditions: [...left.joinedConditions, condition],
+    joinedTables: [...left.joinedTables, right],
+    sourceTable: left.sourceTable,
+  };
+}
+
+function isLimitOne(value: unknown): boolean {
+  const constant = recordProperty(value, "A_Const");
+  const integer = recordProperty(constant, "ival");
+  return integer?.ival === 1;
+}
+
+function isSimpleSelect(
+  statement: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): boolean {
+  const select = selectStatement(statement);
+  if (
+    select === undefined ||
+    Object.keys(select).some((key) => {
+      return ![
+        "fromClause",
+        "limitCount",
+        "limitOption",
+        "op",
+        "targetList",
+        "whereClause",
+      ].includes(key);
+    }) ||
+    select.limitOption !== "LIMIT_OPTION_COUNT" ||
+    select.op !== "SETOP_NONE" ||
+    select.whereClause === undefined ||
+    !isLimitOne(select.limitCount) ||
+    !Array.isArray(select.fromClause) ||
+    select.fromClause.length !== 1
+  ) {
+    return false;
+  }
+
+  const selected = selectedColumn(select, markers);
+  const relation = relationMatch(select.fromClause[0], markers);
+  return (
+    selected?.isColumn === true &&
+    relation?.sourceTable.isTable === true &&
+    relation.joinedTables.every((marker) => {
+      return marker.isTable;
+    }) &&
+    relation.joinedConditions.every((marker) => {
+      return marker.isColumn || marker.isWrapper;
+    })
+  );
+}
+
+function predicateExpression(statement: unknown): unknown {
+  return selectStatement(statement)?.whereClause;
+}
+
+function isTrueConstant(expression: unknown): boolean {
+  const constant = recordProperty(expression, "A_Const");
+  const boolean = recordProperty(constant, "boolval");
+  return boolean?.boolval === true;
+}
+
+function analyzeParsed(
+  node: TSESTree.TaggedTemplateExpression,
+  context: DirectSqlContext,
+  parsed: ParsedDirectSql,
+): DirectSqlAnalysis {
+  const simpleSelect =
+    context === "statement" && isSimpleSelect(parsed.statement, parsed.markers);
+  if (simpleSelect) {
+    return {
+      findings: [{ kind: "query-builder", node }],
+      isSimpleSelect: true,
+      isTruePredicate: false,
+    };
+  }
+
+  const expression =
+    context === "predicate"
+      ? predicateExpression(parsed.statement)
+      : parsed.statement;
+  const structuralExpressions =
+    context === "predicate" && expression !== undefined
+      ? [structuralExpression(expression, parsed.markers)]
+      : collectStructuralExpressions(expression, parsed.markers);
+  const findings = deduplicateFindings(
+    structuralExpressions.flatMap((item) => {
+      return classifyExpression(item).findings;
+    }),
+  );
+  return {
+    findings,
+    isSimpleSelect: false,
+    isTruePredicate:
+      context === "predicate" &&
+      expression !== undefined &&
+      isTrueConstant(expression),
+  };
+}
+
+export function analyzeDirectSql(
+  node: TSESTree.TaggedTemplateExpression,
+  context: DirectSqlContext,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): DirectSqlAnalysis {
+  const cached = ANALYSIS_CACHE.get(node)?.get(context);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const parsed = parseDirectSql(node, context, checker, services);
+  const analysis =
+    parsed === null ? EMPTY_ANALYSIS : analyzeParsed(node, context, parsed);
+  const nodeCache = ANALYSIS_CACHE.get(node);
+  if (nodeCache === undefined) {
+    ANALYSIS_CACHE.set(node, new Map([[context, analysis]]));
+  } else {
+    nodeCache.set(context, analysis);
+  }
+  return analysis;
+}

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/postgres-parser.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/postgres-parser.ts
@@ -1,0 +1,64 @@
+import { createRequire } from "node:module";
+
+const POSTGRES_MAJOR_VERSION = 17;
+
+type UnknownFunction = (...args: unknown[]) => unknown;
+type ErrorConstructor = abstract new (...args: never[]) => Error;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isUnknownFunction(value: unknown): value is UnknownFunction {
+  return typeof value === "function";
+}
+
+function isErrorConstructor(value: unknown): value is ErrorConstructor {
+  if (typeof value !== "function") {
+    return false;
+  }
+  const prototype: unknown = value.prototype;
+  return prototype instanceof Error;
+}
+
+const require = createRequire(import.meta.url);
+const parserModule: unknown = require("libpg-query");
+if (
+  !isRecord(parserModule) ||
+  !isUnknownFunction(parserModule.loadModule) ||
+  !isUnknownFunction(parserModule.parseSync) ||
+  !isErrorConstructor(parserModule.SqlError)
+) {
+  throw new Error("libpg-query returned an unexpected module shape");
+}
+const loadModule = parserModule.loadModule;
+const parseSync = parserModule.parseSync;
+const SqlError = parserModule.SqlError;
+
+await loadModule();
+
+interface PostgresParseResult {
+  readonly statements: readonly unknown[];
+}
+
+export function parsePostgres(source: string): PostgresParseResult | null {
+  try {
+    const parsed: unknown = parseSync(source);
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.version !== "number" ||
+      Math.floor(parsed.version / 10_000) !== POSTGRES_MAJOR_VERSION ||
+      !Array.isArray(parsed.stmts)
+    ) {
+      throw new Error("libpg-query returned an unexpected PostgreSQL AST");
+    }
+    return {
+      statements: parsed.stmts,
+    };
+  } catch (error) {
+    if (error instanceof SqlError) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -923,6 +923,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.64.0
         version: 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      libpg-query:
+        specifier: 17.7.4
+        version: 17.7.4
     devDependencies:
       '@types/node':
         specifier: 24.3.0
@@ -3001,6 +3004,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pgsql/types@17.6.2':
+    resolution: {integrity: sha512-1UtbELdbqNdyOShhrVfSz3a1gDi0s9XXiQemx+6QqtsrXe62a6zOGU+vjb2GRfG5jeEokI1zBBcfD42enRv0Rw==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -7080,6 +7086,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libpg-query@17.7.4:
+    resolution: {integrity: sha512-hTV3LvacQgJhc6GHpu5GYZMQBOAEpJ/LF1JjkixZ8YLh2TtbuN8y0JlNiPTe8PBTV9ChFkKcZMWSYKyhJfkYaQ==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -11891,6 +11900,8 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.57.0':
     optional: true
 
+  '@pgsql/types@17.6.2': {}
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -16264,6 +16275,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libpg-query@17.7.4:
+    dependencies:
+      '@pgsql/types': 17.6.2
 
   lie@3.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

- add a shared PostgreSQL 17 parser-backed analyzer for direct Drizzle SQL templates, with collision-free interpolation provenance, explicit statement/predicate contexts, lazy Drizzle role checks, and weak caching
- make `prefer-drizzle-apis` the diagnostic owner for simple schema-backed selects, comparisons, boolean composition, and ordinary inner joins on `true`, while retaining the neighboring query-builder and legacy fragment families
- replace the migrated handwritten simple-select grammar and convert currently exposed API SQL leaves and true joins to equivalent Drizzle APIs

## Scope

- malformed, ambiguous, composed, or unsupported SQL remains valid
- no autofix or suggestion rewrites SQL
- no schema, persisted data, API/runtime protocol, feature switch, or deployment compatibility change
- local composition, remaining SQL helper families, broader read/write query migration, and final rule retirement remain follow-up work under #23047

## Performance

The development container shares CPU and memory, so the acceptance gate uses five same-mount, interleaved main/branch samples rather than absolute timing:

- median API ESLint wall time: `+4.34%` (limit `+5%`)
- median process-tree peak RSS: `+2.19%` (limit `+10%`)
- changed-rule `TIMING`: approximately `829 ms` on main and `766 ms` on this branch

Full measurements and the retained GC outlier are recorded in #23053.

## Validation

- `corepack pnpm format`
- `corepack pnpm -F @vm0/eslint-rules lint`
- `corepack pnpm -F @vm0/eslint-rules check-types`
- `corepack pnpm -F @vm0/eslint-rules test` (47 files, 813 tests)
- `corepack pnpm -F api lint`
- `corepack pnpm -F api check-types`
- `corepack pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts src/signals/routes/__tests__/zero-artifacts-image-edit-snapshot.test.ts src/signals/routes/__tests__/storages.bdd.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts src/signals/routes/__tests__/storage-presigned-url-cache.test.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/artifacts.bdd.test.ts src/signals/routes/__tests__/zero-browser.test.ts src/signals/routes/__tests__/zero-finance.test.ts --maxWorkers=1 --silent=passed-only -t 'allows exactly one concurrent runner claim|cleans up pending runs after the pending timeout|saves, reads, and overwrites a snapshot for a visible image artifact|chains the cli storage lifecycle with version history and upload-failure recovery|aggregates sandbox model observations into public rankings and applies retention|prunes inactive expired cache rows from cron|injects incomplete rounds and truncates old content chronologically|searches own messages with filters, context, and like-escaping|returns updated thread metadata in incremental mode|rejects browser admission past the credit and concurrency limits|maps all operations to APIDojo and charges one credit each'` (11 passed, 260 skipped)
- `corepack pnpm knip`
- `git diff --check`
- pre-commit `corepack pnpm check-types` (13 workspaces)

Closes #23053

Parent delivery issue: #23047
