### PR TITLE
fix: trigger api and platform releases

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed 2026-07-12 to trigger a release)
+// (no-op API release marker refreshed 2026-07-26 to trigger a release)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -11,7 +11,7 @@ import { setLogErrorHandler } from "./signals/log.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
-// (no-op Platform release marker refreshed 2026-07-12 to trigger a release)
+// (no-op Platform release marker refreshed 2026-07-26 to trigger a release)
 
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();


### PR DESCRIPTION
## Summary

- refresh the no-op API release marker
- refresh the no-op Platform release marker

## Scope

- no runtime behavior changes

## Validation

- `pnpm exec prettier --check apps/api/src/index.ts apps/platform/src/main.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- pre-commit hooks

Tests were not run because the changes only update comments.
