### PR TITLE
fix(api): seed connector catalog for local development

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -145,7 +145,7 @@ ZERO_WEB_SEARCH_PERPLEXITY_TOKEN=op://Development/Perplexity/PERPLEXITY_API_TOKE
 ZERO_FINANCE_APIDOJO_TOKEN=op://Development/APIDojo/RAPIDAPI_KEY
 
 # Optional: Zero Browser provider (Browser Use)
-ZERO_BROWSER_USE_API_KEY=op://Development/browser-use/ZERO_BROWSER_USE_API_KEY
+# ZERO_BROWSER_USE_API_KEY=
 
 # Optional: Steam Web API
 STEAM_WEB_API_KEY=op://Development/steam/STEAM_WEB_API_KEY

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -145,7 +145,7 @@ ZERO_WEB_SEARCH_PERPLEXITY_TOKEN=op://Development/Perplexity/PERPLEXITY_API_TOKE
 ZERO_FINANCE_APIDOJO_TOKEN=op://Development/APIDojo/RAPIDAPI_KEY
 
 # Optional: Zero Browser provider (Browser Use)
-# ZERO_BROWSER_USE_API_KEY=
+ZERO_BROWSER_USE_API_KEY=op://Development/browser-use/ZERO_BROWSER_USE_API_KEY
 
 # Optional: Steam Web API
 STEAM_WEB_API_KEY=op://Development/steam/STEAM_WEB_API_KEY

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -20,10 +20,13 @@ import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { skills } from "@vm0/db/schema/skill";
 import { storages } from "@vm0/db/schema/storage";
+import { createStore } from "ccstate";
 
 import { closeDbPool, db } from "../lib/db";
 import { optionalEnv } from "../lib/env";
 import { nowDate } from "../lib/time";
+import { reconcileConnectorCatalogCompatibility$ } from "../signals/services/connector-catalog-compatibility.service";
+import { syncConnectorCatalog$ } from "../signals/services/connector-catalog-sync.service";
 import { onRejection } from "../signals/utils";
 import rawDevSeedSkillVolumes from "./dev-seed-skill-volumes.json";
 
@@ -748,6 +751,21 @@ async function devSeed() {
       `Seeded ${insertedCount} metadata-only skills and cleared stale volumes`,
     );
   }
+
+  // --- connector catalog (validated R2 snapshot + compatibility state) ---
+  writeLine("Syncing connector catalog");
+  const store = createStore();
+  const signal = new AbortController().signal;
+  const connectorCatalog = await store.set(syncConnectorCatalog$, signal);
+  await store.set(reconcileConnectorCatalogCompatibility$, signal);
+  if (!connectorCatalog.active) {
+    throw new Error(
+      "Connector catalog seed did not produce an active snapshot",
+    );
+  }
+  writeLine(
+    `Seeded connector catalog ${connectorCatalog.active.catalogVersion} (${connectorCatalog.outcome})`,
+  );
 }
 
 function isMainModule(): boolean {


### PR DESCRIPTION
## Summary

- sync and validate the external connector catalog during local development seeding
- reconcile executable compatibility and require an active snapshot before setup succeeds

## Scope

- affects local `db:dev-seed` only
- reuses the production catalog sync, validation, compatibility, and skill-registration path
- does not change environment injection, production cron scheduling, catalog artifacts, or runtime fallback behavior

## Validation

- `pnpm -F api db:dev-seed` (accepted from an empty catalog state and unchanged on repeat)
- `pnpm -F api exec vitest run src/scripts/__tests__/dev-seed.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace apps/api`
- `pnpm knip`
- local runner firewall resolution for GitHub and Slack returned 200 from the seeded snapshot
