### PR TITLE
fix: avoid stale knip pre-commit results

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,7 +23,7 @@ pre-commit:
               Platform static assets should be managed in vm0-ai/static-files.
               Use append-only, versioned or content-hashed paths under static.vm0.io/platform and reference them with platformStaticAssetUrl().
           - name: knip
-            run: pnpm knip --cache
+            run: pnpm knip
             root: turbo/
             glob: "turbo/**/*.{js,ts,tsx,jsx,json}"
             skip:


### PR DESCRIPTION
## Summary

- run Knip without its persistent cache in the pre-commit hook
- avoid stale unused-code results after branch switches, pulls, and rebases

## Scope

- no product runtime or CI behavior changes

## Validation

- `pnpm exec prettier --check ../lefthook.yml`
- `lefthook validate`
- `pnpm knip`
- pre-commit hooks

Tests were not run because this only changes the local pre-commit command.
