### PR TITLE
fix(api): make artifact previews write-once and immutable

### DIFF
--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -584,6 +584,51 @@ function putS3ObjectWithClient(
   });
 }
 
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+function isS3PreconditionFailedError(error: unknown): boolean {
+  const candidate = error as {
+    readonly name?: string;
+    readonly $metadata?: { readonly httpStatusCode?: number };
+  };
+  return (
+    candidate.name === "PreconditionFailed" ||
+    candidate.$metadata?.httpStatusCode === 412
+  );
+}
+
+/**
+ * Upload an object exactly once. An existing key is an idempotent success, so
+ * callers can safely retry without changing bytes behind an immutable URL.
+ */
+export function putImmutableS3Object(
+  bucket: string,
+  key: string,
+  body: string | Buffer,
+  contentType: string,
+  signal?: AbortSignal,
+): Computed<Promise<void>> {
+  return computed(async (get): Promise<void> => {
+    const client = get(s3ClientForBucket(bucket));
+    const uploaded = await settle(
+      client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          ContentType: contentType,
+          CacheControl: IMMUTABLE_CACHE_CONTROL,
+          IfNoneMatch: "*",
+        }),
+        signal ? { abortSignal: signal } : undefined,
+      ),
+    );
+    if (!uploaded.ok && !isS3PreconditionFailedError(uploaded.error)) {
+      throw uploaded.error;
+    }
+  });
+}
+
 export function putHostedSitesS3Object(
   bucket: string,
   key: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -328,7 +328,7 @@ describe("video Artifact previews", () => {
     expect(frameRequests).toHaveLength(0);
     expect(
       owner.objectStore.puts.some((put) => {
-        return put.key.endsWith("/poster.jpg");
+        return put.key.endsWith("/poster-v2.jpg");
       }),
     ).toBeFalsy();
     const response = await chat.listArtifacts(owner.actor);
@@ -357,19 +357,44 @@ describe("video Artifact previews", () => {
       `https://cdn.vm7.io/cdn-cgi/media/mode=frame,time=1s,width=640,format=jpg/${videoArtifact.url}`,
     );
     const posterPuts = owner.objectStore.puts.filter((put) => {
-      return put.key.endsWith("/poster.jpg");
+      return put.key.endsWith("/poster-v2.jpg");
     });
     expect(posterPuts).toHaveLength(1);
     expect(posterPuts[0]).toMatchObject({
       bucket: "test-user-artifacts",
+      cacheControl: "public, max-age=31536000, immutable",
       contentType: "image/jpeg",
+      ifNoneMatch: "*",
     });
 
     const response = await chat.listArtifacts(owner.actor);
     const previewedArtifact = response.artifacts.find((item) => {
       return item.fileId === videoArtifact.fileId;
     });
-    expect(previewedArtifact?.previewImageUrl).toMatch(/\/poster\.jpg$/);
+    expect(previewedArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
+  }, 180_000);
+
+  it("reuses an existing write-once poster after a concurrent upload", async () => {
+    const owner = await artifactActor(
+      "Artifacts API concurrent video preview agent",
+    );
+    await setVideoArtifactPosters(owner.actor, true);
+    mockCloudflareVideoFrame(owner.actor.userId);
+    owner.objectStore.rejectNextImmutablePutAsExisting();
+
+    const videoArtifact = await createRunUploadedFile({
+      owner,
+      prompt: "upload video with concurrent poster generation",
+      filename: "concurrent-poster.mp4",
+      contentType: "video/mp4",
+    });
+    await flushWaitUntilForTest();
+
+    const response = await chat.listArtifacts(owner.actor);
+    const previewedArtifact = response.artifacts.find((item) => {
+      return item.fileId === videoArtifact.fileId;
+    });
+    expect(previewedArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
   }, 180_000);
 
   it("leaves video preview empty when media frame extraction fails", async () => {
@@ -388,7 +413,7 @@ describe("video Artifact previews", () => {
     expect(frameRequests).toHaveLength(1);
     expect(
       owner.objectStore.puts.some((put) => {
-        return put.key.endsWith("/poster.jpg");
+        return put.key.endsWith("/poster-v2.jpg");
       }),
     ).toBeFalsy();
 
@@ -622,7 +647,7 @@ describe("GET /api/zero/artifacts", () => {
       return item.fileId === artifact.fileId;
     });
     expect(firstArtifact?.previewImageUrl).toContain(
-      `/preview-v2-${artifact.deploymentId}.webp`,
+      `/preview-v3-${artifact.deploymentId}.webp`,
     );
     expect(snapshotRequests).toHaveLength(1);
     expect(snapshotRequests[0]).toMatchObject({
@@ -650,17 +675,30 @@ describe("GET /api/zero/artifacts", () => {
       },
     });
     expect(
-      owner.objectStore.puts.some((put) => {
-        return (
-          put.bucket === "test-user-artifacts" &&
-          put.key.endsWith(`/preview-v2-${artifact.deploymentId}.webp`) &&
-          put.contentType === "image/webp"
-        );
+      owner.objectStore.puts.find((put) => {
+        return put.key.endsWith(`/preview-v3-${artifact.deploymentId}.webp`);
       }),
-    ).toBeTruthy();
+    ).toMatchObject({
+      bucket: "test-user-artifacts",
+      cacheControl: "public, max-age=31536000, immutable",
+      contentType: "image/webp",
+      ifNoneMatch: "*",
+    });
     if (!firstResponse.syncUntil) {
       throw new Error("Expected artifact sync timestamp");
     }
+
+    await chat.completeHostedSite(owner.actor, artifact.deploymentId);
+    await flushWaitUntilForTest();
+
+    const retriedResponse = await chat.listArtifacts(owner.actor);
+    const retriedArtifact = retriedResponse.artifacts.find((item) => {
+      return item.fileId === artifact.fileId;
+    });
+    expect(retriedArtifact?.previewImageUrl).toBe(
+      firstArtifact?.previewImageUrl,
+    );
+    expect(snapshotRequests).toHaveLength(1);
 
     host.captureHostedSitesS3();
     const redeployed = await host.redeployHtml(owner.actor, {
@@ -676,7 +714,7 @@ describe("GET /api/zero/artifacts", () => {
       return item.fileId === artifact.fileId;
     });
     expect(refreshedArtifact?.previewImageUrl).toContain(
-      `/preview-v2-${redeployed.deploymentId}.webp`,
+      `/preview-v3-${redeployed.deploymentId}.webp`,
     );
     expect(refreshedArtifact?.previewImageUrl).not.toBe(
       firstArtifact?.previewImageUrl,
@@ -729,7 +767,7 @@ describe("GET /api/zero/artifacts", () => {
       expect(rejectedArtifact).not.toHaveProperty("previewImageUrl");
       expect(
         owner.objectStore.puts.some((put) => {
-          return put.key.endsWith(`/preview-v2-${artifact.deploymentId}.webp`);
+          return put.key.endsWith(`/preview-v3-${artifact.deploymentId}.webp`);
         }),
       ).toBeFalsy();
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -39,6 +39,8 @@ interface StoredS3Object {
 
 interface CapturedS3Put {
   readonly bucket: string;
+  readonly cacheControl: string | null;
+  readonly ifNoneMatch: string | null;
   readonly key: string;
   readonly contentType: string | null;
 }
@@ -292,10 +294,12 @@ export function createChatCallbacksApi(context: TestContext) {
       addObject(object: StoredS3Object): void;
       readonly deletedKeys: readonly string[];
       readonly puts: readonly CapturedS3Put[];
+      rejectNextImmutablePutAsExisting(): void;
     } {
       const objects: StoredS3Object[] = [];
       const deletedKeys: string[] = [];
       const puts: CapturedS3Put[] = [];
+      let rejectNextImmutablePut = false;
       context.mocks.s3.send.mockImplementation((...args: unknown[]) => {
         const input = commandInput(args[0]);
         const key = typeof input.Key === "string" ? input.Key : "";
@@ -317,10 +321,25 @@ export function createChatCallbacksApi(context: TestContext) {
         if (name === "PutObjectCommand") {
           puts.push({
             bucket,
+            cacheControl:
+              typeof input.CacheControl === "string"
+                ? input.CacheControl
+                : null,
+            ifNoneMatch:
+              typeof input.IfNoneMatch === "string" ? input.IfNoneMatch : null,
             key,
             contentType:
               typeof input.ContentType === "string" ? input.ContentType : null,
           });
+          if (rejectNextImmutablePut && input.IfNoneMatch === "*") {
+            rejectNextImmutablePut = false;
+            return Promise.reject(
+              Object.assign(new Error("immutable object already exists"), {
+                name: "PreconditionFailed",
+                $metadata: { httpStatusCode: 412 },
+              }),
+            );
+          }
         }
         if (name === "HeadObjectCommand") {
           return Promise.resolve(storedS3ObjectResponse(objects, bucket, key));
@@ -354,6 +373,9 @@ export function createChatCallbacksApi(context: TestContext) {
         },
         deletedKeys,
         puts,
+        rejectNextImmutablePutAsExisting(): void {
+          rejectNextImmutablePut = true;
+        },
       };
     },
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -1002,7 +1002,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const videoArtifact = artifacts.artifacts.find((artifact) => {
       return artifact.fileId === fileId;
     });
-    expect(videoArtifact?.previewImageUrl).toMatch(/\/poster\.jpg$/);
+    expect(videoArtifact?.previewImageUrl).toMatch(/\/poster-v2\.jpg$/);
   });
 
   it("does not record a run association for ordinary clerk session auth", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -993,7 +993,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
       objectStore.puts.some((put) => {
         return (
           put.bucket === "test-user-artifacts" &&
-          put.key.endsWith("/poster.jpg") &&
+          put.key.endsWith("/poster-v2.jpg") &&
           put.contentType === "image/jpeg"
         );
       }),

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -11,7 +11,7 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$ } from "../external/db";
-import { putS3Object } from "../external/s3";
+import { putImmutableS3Object } from "../external/s3";
 import { tapError } from "../utils";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
@@ -29,7 +29,7 @@ const PREVIEW_VIEWPORT = {
 } as const;
 const PREVIEW_IMAGE_CONTENT_TYPE = "image/webp";
 const PREVIEW_IMAGE_EXTENSION = "webp";
-const PREVIEW_IMAGE_BASENAME = "preview-v2";
+const PREVIEW_IMAGE_BASENAME = "preview-v3";
 const PREVIEW_WAF_COOKIE_NAME = "vm0_artifact_preview";
 
 const browserSnapshotSchema = z.object({
@@ -44,9 +44,10 @@ const browserSnapshotSchema = z.object({
   }),
 });
 
-// Videos are immutable, so a fixed poster key (no versioning) is fine. The
-// Cloudflare Media Transformations frame endpoint only outputs jpg/png.
-const VIDEO_POSTER_FILENAME = "poster.jpg";
+// Poster versions are write-once. Renderer changes must use a new filename
+// instead of replacing bytes behind an immutable CDN URL. The Cloudflare Media
+// Transformations frame endpoint only outputs jpg/png.
+const VIDEO_POSTER_FILENAME = "poster-v2.jpg";
 const VIDEO_POSTER_CONTENT_TYPE = "image/jpeg";
 
 export interface RenderArtifactPreviewArgs {
@@ -224,11 +225,12 @@ const renderAndStoreArtifactPreview$ = command(
 
     const key = buildArtifactKey(args.userId, args.id, filename);
     await get(
-      putS3Object(
+      putImmutableS3Object(
         env("R2_USER_ARTIFACTS_BUCKET_NAME"),
         key,
         image,
         contentType,
+        signal,
       ),
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -121,7 +121,7 @@ export const recordHostedSiteArtifact$ = command(
     { set },
     args: RecordHostedSiteArtifactArgs,
     signal: AbortSignal,
-  ): Promise<string | null> => {
+  ): Promise<RecordedUploadedFile | null> => {
     if (!args.runId) {
       return null;
     }
@@ -184,19 +184,31 @@ export const recordHostedSiteArtifact$ = command(
             entrypoint: args.entrypoint,
             spaFallback: args.spaFallback,
           },
-          // Legacy redeploys reuse a mutable alias row, so their preview must
-          // be regenerated. Versioned rows are immutable and keep their own
-          // preview when completion is retried.
-          ...(args.deploymentVersion === null ? { previewImageUrl: null } : {}),
+          // Legacy redeploys reuse a mutable alias row. Preserve the preview
+          // when the same deployment is completed again, but clear it when a
+          // new deployment takes over that row. Versioned rows are immutable
+          // and keep their own preview.
+          ...(args.deploymentVersion === null
+            ? {
+                previewImageUrl: sql`case
+                  when ${runUploadedFiles.metadata}->>'deploymentId' = ${args.deploymentId}
+                  then ${runUploadedFiles.previewImageUrl}
+                  else null
+                end`,
+              }
+            : {}),
           updatedAt: sql`now()`,
         },
       })
-      .returning({ id: runUploadedFiles.id });
+      .returning({
+        id: runUploadedFiles.id,
+        previewImageUrl: runUploadedFiles.previewImageUrl,
+      });
     signal.throwIfAborted();
 
     await set(syncArtifactCatalogForFile$, row?.id, signal);
     await publishArtifactsChangedForRun(writeDb, args.runId, signal);
-    return row?.id ?? null;
+    return row ?? null;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -2053,13 +2053,16 @@ function buildManifest(args: {
 
 function artifactPreviewArgs(
   deployment: HostedDeploymentRow,
-  artifactRowId: string | null,
+  artifactRow: {
+    readonly id: string;
+    readonly previewImageUrl: string | null;
+  } | null,
 ): RenderArtifactPreviewArgs | null {
-  if (!artifactRowId || !deployment.runId) {
+  if (!artifactRow || artifactRow.previewImageUrl || !deployment.runId) {
     return null;
   }
   return {
-    id: artifactRowId,
+    id: artifactRow.id,
     runId: deployment.runId,
     userId: deployment.userId,
     url: deployment.artifactUrl ?? deployment.url,
@@ -2657,7 +2660,7 @@ export const completeHostedSiteDeployment$ = command(
     );
     signal.throwIfAborted();
 
-    const artifactRowId = await set(
+    const artifactRow = await set(
       recordHostedSiteArtifact$,
       hostedSiteArtifactArgs(deployment),
       signal,
@@ -2669,7 +2672,7 @@ export const completeHostedSiteDeployment$ = command(
     // empty without blocking the deployment.
     set(
       scheduleArtifactPreviewRender$,
-      artifactPreviewArgs(deployment, artifactRowId),
+      artifactPreviewArgs(deployment, artifactRow),
     );
 
     return {


### PR DESCRIPTION
## Summary

- Store newly generated website and presentation previews under `preview-v3-<deploymentId>.webp`, and video posters under `poster-v2.jpg`.
- Upload those preview objects with `Cache-Control: public, max-age=31536000, immutable` and `If-None-Match: *`; treat an existing object as an idempotent success.
- Preserve the first successful preview when the same hosted deployment is completed again, while still generating a new URL when a legacy alias moves to a different deployment.
- Leave all existing `preview-v2` and `poster.jpg` objects and URLs untouched.

## User impact

New website, presentation, and video thumbnails can be cached immutably without allowing retries or concurrent renders to replace bytes behind an existing URL. Existing thumbnails keep their current cache behavior and require no migration.

## Verification

- `pnpm exec prettier --write` on all changed TypeScript files
- `pnpm -F api lint`
- `node --max-old-space-size=4096 ../../node_modules/typescript/bin/tsc --noEmit`
- `pnpm knip`
- Attempted `pnpm -F api exec vitest run src/signals/routes/__tests__/artifacts.bdd.test.ts`; the local environment has no Postgres service, so setup failed with `ECONNREFUSED` before the changed behavior ran. The PR pipeline provides the required pgvector Postgres service.
