### PR TITLE
test(api): assert stale sweep inaction from queue state, not lock waiters

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -325,6 +325,44 @@ async function cleanupSandboxes(): Promise<void> {
   expect(response.status).toBe(200);
 }
 
+/**
+ * Product-visible proof that the stale sweep admitted nothing on this thread
+ * while a request is still blocked on the org admission lock.
+ *
+ * The sweep runs inline in the cron request, so `cleanupSandboxes()` returning
+ * at all already shows it never reached that lock — any attempt would block on
+ * the hold this test owns. This asserts the outcome half through the queue API:
+ * the pending events are exactly the ones queued before the sweep, nothing is
+ * running, and no queued item was drained into a run.
+ *
+ * Deliberately not asserted through `admissionLock.waiterCount()`: that counter
+ * is a cluster-wide `pg_locks` observation of one `hashtext(orgId)` key shared
+ * by several admission paths, and it never decreases while the lock is held, so
+ * any unrelated arrival is permanent. It is a sound lower-bound barrier and an
+ * unsound equality contract.
+ */
+async function expectSweepLeftQueueUntouched(
+  threadId: string,
+  pendingEventIds: readonly string[],
+): Promise<void> {
+  const swept = await accept(
+    queueClient().get({ headers: authHeaders(), params: { threadId } }),
+    [200],
+  );
+  expect(swept.body.running).toBeNull();
+  expect(
+    swept.body.pending.map((event) => {
+      return event.id;
+    }),
+  ).toStrictEqual(pendingEventIds);
+  const messages = await wf.readThreadMessages(threadId);
+  expect(
+    messages.filter((message) => {
+      return typeof message.runId === "string";
+    }),
+  ).toStrictEqual([]);
+}
+
 describe("workflow queue", () => {
   it("does not let the stale sweep race a newly admitted workflow event", async () => {
     mockNow(Date.UTC(2020, 0, 1));
@@ -340,10 +378,23 @@ describe("workflow queue", () => {
     });
 
     const workflowRequest = postWorkflowWebhook(automation, "fresh event");
-    await expect.poll(admissionLock.waiterCount).toBe(1);
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    const queued = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    const event = queued.body.pending[0];
+    if (!event) {
+      throw new Error("Expected a pending workflow event");
+    }
 
+    // The business assertion: the stale sweep must not race the freshly
+    // admitted event that is still blocked on org admission.
     await cleanupSandboxes();
-    await expect(admissionLock.waiterCount()).resolves.toBe(1);
+    await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
 
     admissionLock.release();
     const result = await workflowRequest;
@@ -406,13 +457,12 @@ describe("workflow queue", () => {
       })
       .toBe(true);
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(2);
-    const admittedWaiters = await admissionLock.waiterCount();
 
-    // The business assertion: the stale sweep must not add an admission
-    // attempt of its own for this org, so the waiter count stays exactly where
-    // both blocked requests left it.
+    // The business assertion: the stale sweep must leave the fresh user message
+    // queued and must not drain it ahead of the stale workflow event that is
+    // still blocked on org admission.
     await cleanupSandboxes();
-    await expect(admissionLock.waiterCount()).resolves.toBe(admittedWaiters);
+    await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
 
     admissionLock.release();
     const [workflowResult, userResult] = await Promise.all([


### PR DESCRIPTION
## Why

Turbo run https://github.com/vm0-ai/vm0/actions/runs/30186607986 (`merge_group`, SHA `04af5d7074e3e7c5f4851bf0aa358530dc6bd080`, shard `test-api (5)`) failed with:

```
FAIL src/signals/routes/__tests__/zero-workflow-queue.test.ts > workflow queue
     > does not let the stale sweep drain a fresh user message ahead of a stale workflow event
AssertionError: expected 3 to be 2 // Object.is equality
 ❯ src/signals/routes/__tests__/zero-workflow-queue.test.ts:415:45
```

Not owned by the queued change: PR #23078 (`fix: avoid stale knip pre-commit results`) touches only `lefthook.yml`. Every other failed job in the run was a fail-fast cancellation or the aggregate `ci-gate-turbo` gate.

This is a **recurrence**. #23065 fixed the same test for the same signature two hours before this run (it is an ancestor of the failing SHA). That fix relaxed the two entry barriers to lower bounds but kept the final assertion as exact equality against a snapshot of the same counter, which only narrowed the race window instead of removing it.

## Root cause

Classification: **test isolation / observation of global cluster-wide state.**

`holdOrgAdmissionLockFixture().waiterCount()` counts ungranted rows in `pg_locks` — a cluster-wide view — on the advisory key `hashtext(orgId)`. Several product paths legitimately take that key: `checkRunConcurrencyPreflight` and `commitPreparedLaunch` (`agent-run-create.service.ts`), and `loadDrainCandidates` / `promoteQueuedCandidate` (`zero-run-queue.service.ts`). During the fixture's hold window the count is **monotonically non-decreasing** — every waiter stays blocked until `admissionLock.release()`, which happens after the assertion.

First causal event: a third backend arrives on the org admission key between the `admittedWaiters` snapshot (line 409) and the post-sweep read (line 415). It is intermittent because that arrival is scheduling-dependent — under CI contention it lands inside the window, and on an idle run it does not.

The sweep itself is **not** the third waiter. `drainStaleChatThreadQueues$` runs inline in the cron request, so any org admission attempt would block on the held lock and `cleanupSandboxes()` could never have returned 200 — but it did, and the failure is an assertion at line 415, not a timeout.

The trailing `AbortError: Aborted due to finished test` and the `Unknown response status 500 for POST /api/zero/chat/messages` unhandled rejection are downstream: the in-flight `userRequest` is abandoned when the assertion throws. Neither is causal.

## Fix

Stop proving a negative with a shared global counter; assert the same claim from product state.

After `cleanupSandboxes()`, both stale-sweep tests now read the thread through the workflow queue API and require that nothing is running, the pending events are exactly the ones queued before the sweep, and no queued item was drained into a run. `cleanupSandboxes()` returning at all remains the other half of the proof, since the sweep runs inline in the cron request and any org admission attempt would block on the hold the test owns.

`waiterCount()` is kept only where it is sound — as a monotonic lower-bound barrier (`toBeGreaterThanOrEqual`). The exact-equality poll in the sibling test (`.toBe(1)`) is relaxed for the same reason: it is the identical latent flake four lines away, same fixture, same sweep, same root cause.

The business assertion is strengthened, not weakened: it now names the behaviour in the test title (the sweep must not drain the fresh user message ahead of the stale workflow event) and additionally catches a sweep that *consumes* a queue item without admission — a regression the waiter count cannot see.

No retries, sleeps, raised timeouts, skips, or weakened assertions. Test-only change; no product code touched.

## Validation

Local Postgres 18 (`TZ=UTC`, UTC cluster), against this branch:

- **CI signature reproduced on pre-fix code.** Injecting one extra backend blocked on `pg_advisory_xact_lock(hashtext(orgId))` makes the *original* assertion fail with the exact CI output: `AssertionError: expected 3 to be 2 // Object.is equality`.
- **Fix survives that same injection** — both stale-sweep tests pass with the third waiter present.
- **Regression protection retained (mutation test).** Removing `queueItemCreatedBefore: staleBefore` from `drainStaleChatThreadQueues$` (the guard added by #23051) is still caught: the sweep tries to drain the fresh user message, blocks on the held admission lock, and the test fails. Restored afterwards.
- **No coverage regression.** A second mutation (sweep selecting fresh threads) is missed by the new *and* the old assertions equally.
- `zero-workflow-queue.test.ts` (14 tests) — 5/5 consecutive clean runs.
- `pnpm vitest run --project=api --shard=5/8` (the exact failing shard, 21 files / 244 tests) — 4 clean runs on a freshly migrated schema.
- `pnpm -F api lint` — 0 warnings, 0 errors. `prettier --check` — clean. `git diff --check` — clean.

### Evidence limitations

- `pnpm -F api check-types` could not run locally: `tsc --noEmit` is OOM-killed in this 3.9 GB sandbox. Left to the PR pipeline. The change uses only APIs already used in this same file (`accept(queueClient().get(...))`, `body.running`, `body.pending`, `wf.readThreadMessages`, `message.runId`); oxlint's type-aware pass over `__tests__` is clean.
- The flake did not reproduce spontaneously in ~10 local shard runs on this 2-core sandbox, so the specific product path that supplied the third waiter in CI is still not pinned down. The fix does not depend on its identity — it removes the dependency on the counter entirely.
- One shard run had an unrelated timeout in `cron-delete-cleanups.test.ts` ("caps connector cleanup at ten batches…", 15s limit). Untouched by this change, and it scans rows across all orgs, so it is sensitive to accumulated local database state. Flagging as a separate latent risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
