### PR TITLE
fix(e2e): stabilize slack dm dispatch by making fixture event ids unique

### DIFF
--- a/e2e/fixtures/slack/app-mention-payload.json
+++ b/e2e/fixtures/slack/app-mention-payload.json
@@ -3,7 +3,7 @@
   "team_id": "{{TEAM_ID}}",
   "api_app_id": "A_E2E_APP",
   "type": "event_callback",
-  "event_id": "Ev_E2E_MENTION",
+  "event_id": "{{EVENT_ID}}",
   "event_time": 1700000000,
   "event": {
     "type": "app_mention",

--- a/e2e/fixtures/slack/dm-message-payload.json
+++ b/e2e/fixtures/slack/dm-message-payload.json
@@ -3,7 +3,7 @@
   "team_id": "{{TEAM_ID}}",
   "api_app_id": "A_E2E_APP",
   "type": "event_callback",
-  "event_id": "Ev_E2E_DM",
+  "event_id": "{{EVENT_ID}}",
   "event_time": 1700000000,
   "event": {
     "type": "message",

--- a/e2e/helpers/slack.bash
+++ b/e2e/helpers/slack.bash
@@ -290,14 +290,31 @@ wait_for_slack_mock_post_message() {
 }
 
 # Substitute common placeholders in a JSON fixture file.
-# Usage: slack_render_fixture <path> <team_id> <channel_id> <user_id> [extra_ts]
+# Usage: slack_render_fixture <path> <team_id> <channel_id> <user_id> [extra_ts] [event_id]
+#
+# event_id must be unique per logical Slack event. Slack event IDs are
+# globally unique in production, and slack_chat_ingress enforces that with
+# a unique index on event_id — admission dedupes against the whole table,
+# not per workspace. A fixture-wide constant therefore makes two concurrent
+# CI jobs collide: cli-e2e-01-serial (ser-t07-slack.bats) and
+# cli-e2e-03-runner (t40-slack-roundtrip.bats) render this same DM fixture
+# against the same preview deployment, so whichever posts second dedupes
+# onto the first job's already-"processed" row, the webhook skips
+# processCanonicalSlackIngress$, and no run is ever dispatched.
+#
+# Deriving the default from the fixture name plus the already-unique
+# team/timestamp keeps independent events independent across jobs and runs,
+# while staying stable when the same event is re-rendered within one test.
+# Pass an explicit event_id to replay one event (Slack retry semantics).
 slack_render_fixture() {
     local path="$1" team_id="$2" channel_id="$3" user_id="$4"
     local ts="${5:-$(date +%s).000100}"
+    local event_id="${6:-Ev_$(basename "$path" .json)_${team_id}_${ts}}"
     sed \
         -e "s/{{TEAM_ID}}/$team_id/g" \
         -e "s/{{CHANNEL_ID}}/$channel_id/g" \
         -e "s/{{USER_ID}}/$user_id/g" \
         -e "s/{{TS}}/$ts/g" \
+        -e "s/{{EVENT_ID}}/$event_id/g" \
         "$path"
 }


### PR DESCRIPTION
## Summary

`cli-e2e-01-serial` failed on the `Turbo` merge-group run for PR #23075 with `slack: DM dispatches an agent run` timing out after 60s. This is a genuine flaky test caused by a **colliding Slack `event_id` between two concurrently running CI jobs**, not by the queued change.

- Triggering run: https://github.com/vm0-ai/vm0/actions/runs/30187033027
- Event: `merge_group` (`gh-readonly-queue/main/pr-23075-...`), failing SHA `ad0083a1e057e10e6102304a04e30970dae91940`
- Failing job: [`cli-e2e-01-serial`](https://github.com/vm0-ai/vm0/actions/runs/30187033027/job/89753732765), `e2e/tests/01-serial/ser-t07-slack.bats:191`

## Root cause

Classification: **test isolation / shared-state pollution across concurrent CI jobs.**

`e2e/fixtures/slack/dm-message-payload.json` hardcoded `"event_id": "Ev_E2E_DM"`, and `slack_render_fixture` substituted `TEAM_ID`, `CHANNEL_ID`, `USER_ID` and `TS` but **not** `event_id`. Every job rendering that fixture therefore posted the identical Slack event id.

`slack_chat_ingress` declares `uniqueIndex("idx_slack_chat_ingress_event_id").on(table.eventId)` — the dedup boundary is the **whole table**, not per workspace. `admitCanonicalSlackChatEvent` inserts with `.onConflictDoNothing({ target: slackChatIngress.eventId })` and returns the pre-existing row on conflict. The webhook then does:

```ts
if (ingress.status !== "processed" && ingress.status !== "ignored") {
  waitUntil(... processCanonicalSlackIngress$ ...)
}
```

Two jobs in the *same* workflow run render this same DM fixture against the *same* preview deployment and database:

| Job | Test | Team | Channel |
|---|---|---|---|
| `cli-e2e-01-serial` | `ser-t07-slack.bats` | `T_E2E_<run_id>` | `D_E2E_DM` |
| `cli-e2e-03-runner` | `t40-slack-roundtrip.bats` | `T_E2E_RT_<run_id>` | `D_E2E_RT_<run_id>` |

Both suites correctly scope team, channel and user per run — `event_id` was the one identifier left global.

### First causal event

Whichever job posts `Ev_E2E_DM` first inserts the ingress row and dispatches its run. The second job's POST conflicts on the unique index, gets back the first job's row with `status: "processed"`, so the processor is **never scheduled**. The webhook still returns `OK` (so `slack_post_event` / `assert_success` passes) and the route row is still created — but no ingress row, no queue entry, and no run for that workspace. `wait_for_slack_run` then polls for the full 60s and fails.

This matches the failure state dump exactly: `chat_thread_routes` has the DM route, while `chat_ingress`, `chat_message_queue` and `recent_runs` are all empty.

### Why the outcome was intermittent

`slack_chat_ingress.route_id` is `onDelete: "cascade"`, so each job's own `slack_reset_state` removes its own ingress rows. The failure only occurs when the two jobs' DM posts interleave such that the other job's `Ev_E2E_DM` row is live and already `processed` at the moment this job posts. Job start times drift run to run, so the outcome is timing-dependent.

Direct timestamped evidence from this run:
- `cli-e2e-01-serial` ran 04:02:44 → 04:04:22; all `cli-e2e-03-runner` shards ran 04:02:41 → 04:04:04 — fully overlapping.
- The serial DM's route was created at **04:03:14.101Z**.
- The roundtrip job's agent reply was posted to `D_E2E_RT_30187033027` at **04:03:14.497Z** — 0.4s later, i.e. both jobs were mid-DM-dispatch simultaneously.

### Why this is not the queued PR, a gate failure, or infrastructure

- PR #23075 is an SQL-lint chore and touches no Slack ingress, webhook or dispatch code.
- The same PR passed on merge-group run [30187224311](https://github.com/vm0-ai/vm0/actions/runs/30187224311) and merged.
- `cli-e2e-01-serial` failed in only this run out of the 12 most recent failed `Turbo` runs; the others failed on unrelated jobs.
- `ci-gate-turbo` is the aggregate gate summarising the `cli-e2e-01-serial` failure, not an independent cause.

## Fix

Template `event_id` in both Slack fixtures and default it in `slack_render_fixture` to a per-fixture, per-workspace, per-timestamp value.

This fixes the test's assumption rather than the product: Slack event ids **are** globally unique in production, so global dedup on `event_id` is correct, intended behaviour (the schema documents it as "the canonical path's deduplication boundary"). The fixture was violating a real-world invariant by reusing one event id for two genuinely different messages in two different workspaces.

The default is stable when the same event is re-rendered within a test, and an explicit 6th argument still lets a caller replay a fixed event id to exercise Slack retry semantics. Both fixtures are templated because they feed the same dedup key; `Ev_E2E_MENTION` had the identical latent collision.

No business assertion changed — the DM test still asserts a real run is dispatched with the correct `triggerSource`, `userId` and `promptPreview`.

## Validation

- Rendered all three real call sites (serial mention, serial DM, runner roundtrip DM) **5 times**: 45/45 assertions pass — valid JSON, no unsubstituted placeholders, all three `event_id`s mutually distinct, stable across re-render, explicit override honoured, and every other rendered field unchanged.
- Generated ids are 60 chars, well within `varchar(255)`.
- `bash -n e2e/helpers/slack.bash` passes; `git diff --check` clean.
- `shellcheck -x` on the changed region is clean at `style` severity; the only file finding is a pre-existing SC2178 nameref warning that is present on `main` unchanged.

### Evidence limitations

The e2e suite itself cannot run locally — it requires a Vercel preview deployment plus `SLACK_SIGNING_SECRET` and `VERCEL_AUTOMATION_BYPASS_SECRET`. End-to-end confirmation relies on the PR pipeline running `cli-e2e-01-serial` and `cli-e2e-03-runner` concurrently, which is exactly the interleaving this change addresses.
