### PR TITLE
test(e2e): bypass clerk bot protection in playwright feature tests

### DIFF
--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -1,9 +1,18 @@
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test as base } from "@playwright/test";
 
 export { expect };
 
 export const test = base.extend({
   context: async ({ context }, use) => {
+    // Every page load runs `clerk.load()`, which handshakes with the Clerk
+    // Frontend API — including tests that only restore a saved storage
+    // state. Without the testing token that handshake is subject to bot
+    // protection and rate limiting, and a throttled `/v1/client` leaves the
+    // app parked on its bootstrap skeleton forever. Registering here also
+    // buys the retry on 429/502/503/504 that the token helper performs.
+    await setupClerkTestingToken({ context });
+
     const apiUrl = process.env.VM0_API_BACKEND_URL;
     const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
     if (apiUrl && bypassSecret) {

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -1,3 +1,4 @@
+import { clerkSetup } from "@clerk/testing/playwright";
 import {
   createOrganization,
   createUser,
@@ -6,6 +7,12 @@ import {
 } from "./lib/clerk-api";
 
 export default async function globalSetup(): Promise<void> {
+  // Publishes CLERK_FAPI and CLERK_TESTING_TOKEN into the environment that
+  // every Playwright worker inherits, so `setupClerkTestingToken` works in
+  // each worker process. Clerk requires this during global setup: a token
+  // fetched inside one test body never reaches the other workers.
+  await clerkSetup();
+
   const email = generateTestEmail();
   console.log("[globalSetup] email:", email);
 

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -1,4 +1,3 @@
-import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test } from "../fixtures";
 import { signInThroughHostedAuth } from "../lib/auth";
 import {
@@ -27,8 +26,6 @@ test("paid onboarding completes through the video workflow", async ({
     const userId = await createUser(email);
     const orgId = await createOrganization("E2E Paid Onboarding Org", userId);
 
-    await clerkSetup();
-    await setupClerkTestingToken({ page });
     await signInThroughHostedAuth(page, email, appUrl, {
       followRedirect: false,
       activeOrganizationId: orgId,

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test } from "../fixtures";
 import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
 import { completeExploreOnboarding } from "../lib/onboarding";
@@ -11,9 +11,6 @@ test("complete app onboarding to chat page", async ({ browser, page }) => {
   const orgId = process.env.E2E_CLERK_ORG_ID!;
   const apiUrl = process.env.VM0_API_BACKEND_URL!;
   const appUrl = deriveAppUrl(apiUrl);
-
-  await clerkSetup();
-  await setupClerkTestingToken({ page });
 
   await signInThroughHostedAuth(page, email, appUrl, {
     followRedirect: false,


### PR DESCRIPTION
## Trigger

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30187914881
- Event: `push` to `main`, SHA `41b3c2c0533f49d9f68b4f13af23292d2a595d3b`, run started 2026-07-26 04:31 UTC
- Failing job: `cli-e2e-02-playwright` — `[features] › playwright/tests/agents.spec.ts:6:5 › navigate to agents page and verify heading` (1 failed, 7 passed, no retry configured)

## Root-cause classification

Missing test synchronization at an external boundary — an unprotected, non-retried Clerk Frontend API handshake in the `features` Playwright project.

## First causal event

The uploaded `error-context.md` artifact captured the page at timeout. It contained no app shell at all:

```yaml
- paragraph: Spinning up the team...
- region "Notifications alt+T"
```

That is the platform bootstrap skeleton (`turbo/apps/platform/src/signals/app-skeleton.ts`), not the Agents page. The skeleton is only torn down when a route setup calls `hideAppSkeleton$`. For `/agents` that runs inside `setupAuthPageWrapper` (`turbo/apps/platform/src/signals/route.ts:295`), whose very first statement is `await get(clerk$)`. `clerk$` (`turbo/apps/platform/src/signals/auth.ts:297`) awaits `clerkInstance.load()`, which has no timeout. If the Clerk FAPI `/v1/client` handshake stalls or errors, `setupAgentsPage$` is never reached, `hideAppSkeleton$` never fires, and the `Agents` heading never mounts — exactly the captured state.

The `features` project is the only one that ran that handshake unprotected:

| Spec | Registers Clerk testing token |
| --- | --- |
| `smoke.spec.ts`, `paid-onboarding.spec.ts` | yes |
| `agents`, `chat`, `create-agent`, `billing-payment`, `webchat`, `workflows` | **no** |

Restoring a storage state does not skip the handshake — `clerk.load()` still calls `/v1/client` on every page load to hydrate the session cookie. Without the token, those requests are subject to Clerk bot protection and rate limiting and get no retry. `setupClerkTestingToken` both appends `__clerk_testing_token` and retries `429/502/503/504`.

Notably #21882 added a `/agents` heading check at the end of `smoke.spec.ts` that is byte-for-byte the assertion `agents.spec.ts` makes, and deliberately wrapped it in `setupClerkTestingToken({ context: verificationContext })`. The feature specs never got that same protection.

## Why the outcome was intermittent

It depends on Clerk-side bot scoring and rate-limit state, not on repository code. The six `features` specs run concurrently, each independently loading Clerk against the same instance. This run landed at 04:31 UTC, inside the window where scheduled Clerk cleanup work saturates the same API; the surrounding `main` runs failed in the same band with unrelated symptoms (`bench-api` ×3, `deploy-api` ×2) and `main` was green again from 05:06 UTC.

## Fix

- `e2e/playwright/global-setup.ts` — call `clerkSetup()` once. It publishes `CLERK_FAPI` and `CLERK_TESTING_TOKEN` into the environment Playwright workers inherit. This is required: a token fetched inside one test body never reaches the other worker processes, which is why the feature specs could not simply call the helper themselves.
- `e2e/playwright/fixtures.ts` — register `setupClerkTestingToken({ context })` on the shared context fixture, so every spec gets the bypass and the FAPI retry. `fixtures.ts` already centralises the analogous Vercel bypass concern, and the failing gap is identical across all six feature specs, so fixing only `agents.spec.ts` would leave five siblings exposed.
- `smoke.spec.ts` / `paid-onboarding.spec.ts` — drop the now-redundant per-test `clerkSetup()`. Each was a separate Clerk backend token fetch, adding load to the very API whose saturation causes this failure. The helper de-duplicates route registration per context, and `smoke.spec.ts` keeps its explicit call for the verification context it builds via `browser.newContext()` outside the fixture.

The business assertion is untouched: `agents.spec.ts` still asserts the real `Agents` heading with the same 20s budget. No retry, sleep, timeout increase, skip, or weakened assertion.

## Validation

Run locally from `e2e/`:

- `pnpm check-types` — pass
- `pnpm test` (Clerk API fixture integration tests) — 6/6 pass
- `prettier@3.6.2 --check` on all four changed files — clean
- `git diff --check` — clean

Behavioural verification against a stub Clerk FAPI over HTTPS, driving the **actual** `fixtures.ts` exported `test`:

- Ordering requirement proven: `setupClerkTestingToken` throws `The Clerk Frontend API URL is required... Make sure the clerkSetup function is called during your global setup` when `clerkSetup()` has not run — confirming the global-setup half is load-bearing, not cosmetic.
- `clerkSetup()` publishes `CLERK_FAPI` + `CLERK_TESTING_TOKEN` and retries through a `429` during the token fetch.
- Through the shipped fixture, a stub FAPI that emits `429, 429, 200` yields **status 200** to the page across **3 requests, every one carrying `__clerk_testing_token`**. Repeated 5×, 5/5 pass.
- Negative control on a plain `@playwright/test` context (the pre-fix state of the feature specs): **1 request, no token, page receives 429** — the unprotected handshake failure this PR removes.

## Evidence limitations

- The real Playwright suite needs a deployed API/app preview plus Clerk secrets, so it was not run locally; the PR pipeline covers it.
- The run used `retries: 0` and `trace: "on-first-retry"`, so no trace or browser console log was captured. The artifact proves the app was stuck in the bootstrap skeleton, but cannot distinguish a stalled `/v1/client` from a rejected one. Both fail identically at `await get(clerk$)` and both are addressed by the token plus the helper's retry.
- Clerk-side throttling cannot be reproduced locally, so the stub above models it rather than reproducing the incident itself.
