### PR TITLE
perf: disable upstream codex analytics during startup

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -25,8 +25,8 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
-    LOG_TAG, ParsedEventAction, command,
+    CODEX_ANALYTICS_DISABLED_CONFIG, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
+    HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
@@ -363,13 +363,15 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
     };
     let codex_home = PathBuf::from(runtime.codex_home());
     let child_user_env = runtime.child_user_env();
+    let mut config_overrides = runtime.codex_startup_config_overrides();
+    config_overrides.push(CODEX_ANALYTICS_DISABLED_CONFIG.to_string());
     let mut config = CodexAppServerConfig::new(binary, codex_home)
         .with_child_env(
             runtime.home_dir.as_ref(),
             child_user_env.as_ref(),
             runtime.api_url.as_ref(),
         )
-        .with_config_overrides(runtime.codex_startup_config_overrides())
+        .with_config_overrides(config_overrides)
         .with_current_dir(paths::CANONICAL_WORKING_DIR)
         .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
     if runtime.use_mock_codex

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::{env, paths};
 use guest_common::log_info;
 
-use super::{CliRuntimeConfig, LOG_TAG, codex_runtime_config};
+use super::{CODEX_ANALYTICS_DISABLED_CONFIG, CliRuntimeConfig, LOG_TAG, codex_runtime_config};
 
 pub(super) fn build_cli_command_for_runtime(
     runtime: &CliRuntimeConfig<'_>,
@@ -221,6 +221,8 @@ fn build_codex_args(
 
     args.push("-c".to_string());
     args.push(build_codex_memories_config());
+    args.push("-c".to_string());
+    args.push(CODEX_ANALYTICS_DISABLED_CONFIG.to_string());
 
     if startup_config_overrides.is_empty() && !openai_base_url.is_empty() {
         args.push("-c".to_string());

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -72,6 +72,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
+const CODEX_ANALYTICS_DISABLED_CONFIG: &str = "analytics.enabled=false";
 const CODEX_WEB_SEARCH_DISABLED_CONFIG: &str = r#"web_search="disabled""#;
 /// Maximum retained bytes for one ordinary CLI stdout record before parsing.
 ///

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -7,7 +7,9 @@ mod common;
 
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
+use shell_quote::quote_shell_arg;
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
@@ -15,12 +17,14 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
+    let argv_path = tmp.path().join("codex-argv");
+    let recording_mock = recording_codex(tmp.path(), &mock, &argv_path)?;
     let run_id = "codex-app-server-backend-test";
     let prompt = "drive the app-server backend";
 
     unsafe {
         common::setup_codex_app_server_env(
-            &mock,
+            &recording_mock,
             tmp.path(),
             common::CodexAppServerEnvConfig {
                 run_id,
@@ -78,6 +82,7 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert!(cli_result.failure_diagnostic.is_none());
     assert!(cli_result.last_event_sequence.is_none());
+    assert_app_server_analytics_disabled(&argv_path)?;
 
     let events = read_agent_log_events(&runtime.paths)?;
     assert_event_type_sequence(
@@ -241,4 +246,45 @@ fn assert_event_type_sequence(events: &[Value], expected: &[&str]) {
         .map(|value| Some(*value))
         .collect::<Vec<_>>();
     assert_eq!(actual, expected);
+}
+
+fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> Result<PathBuf, std::io::Error> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let path = root.join("recording-codex");
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexec {} \"$@\"\n",
+            quote_shell_arg(&argv_path.to_string_lossy()),
+            quote_shell_arg(&mock.to_string_lossy()),
+        ),
+    )?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}
+
+fn assert_app_server_analytics_disabled(argv_path: &Path) -> Result<(), std::io::Error> {
+    let args = std::fs::read_to_string(argv_path)?
+        .lines()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let analytics_index = args
+        .windows(2)
+        .position(
+            |window| matches!(window, [flag, value] if flag == "-c" && value == "analytics.enabled=false"),
+        )
+        .ok_or_else(|| {
+            std::io::Error::other(format!(
+                "Codex app-server argv should disable upstream analytics: {args:?}"
+            ))
+        })?;
+    let app_server_index = args
+        .iter()
+        .position(|arg| arg == "app-server")
+        .ok_or_else(|| std::io::Error::other("Codex argv omitted app-server subcommand"))?;
+    assert!(analytics_index < app_server_index);
+    Ok(())
 }

--- a/crates/guest-agent/tests/codex_prompt_stdin.rs
+++ b/crates/guest-agent/tests/codex_prompt_stdin.rs
@@ -5,6 +5,7 @@ mod common;
 use guest_agent::active_input::ActiveInputRuntime;
 use guest_agent::masker::SecretMasker;
 use guest_agent::run_context::GuestRuntime;
+use shell_quote::quote_shell_arg;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -60,6 +61,30 @@ async fn fresh_and_resumed_codex_stdin_preserve_prompt_text_exactly() -> TestRes
         let events = execute_and_read_session(&runtime).await?;
 
         assert_eq!(events[1]["item"]["text"], prompt);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fresh_and_resumed_codex_disable_upstream_analytics() -> TestResult {
+    let mock = common::build_and_locate_mock_codex()?;
+    let root = tempfile::tempdir()?;
+    let argv_path = root.path().join("codex-argv");
+    let recording_mock = recording_codex(root.path(), &mock, &argv_path)?;
+    common::ensure_canonical_workspace_for_test()?;
+
+    for resume in [false, true] {
+        let run_id = format!(
+            "codex-analytics-{}",
+            if resume { "resume" } else { "fresh" }
+        );
+        let runtime = build_runtime(root.path(), &recording_mock, &run_id, "hello", resume)?;
+
+        let result = execute_with_timeout(&runtime).await?;
+
+        assert_eq!(result.exit_code, common::CLEAN_EXIT);
+        assert_analytics_disabled(&argv_path)?;
     }
 
     Ok(())
@@ -200,4 +225,29 @@ fn executable_script(root: &Path, name: &str, contents: &str) -> TestResult<Path
     permissions.set_mode(0o700);
     std::fs::set_permissions(&path, permissions)?;
     Ok(path)
+}
+
+fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> TestResult<PathBuf> {
+    executable_script(
+        root,
+        "recording-codex",
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexec {} \"$@\"\n",
+            quote_shell_arg(&argv_path.to_string_lossy()),
+            quote_shell_arg(&mock.to_string_lossy()),
+        ),
+    )
+}
+
+fn assert_analytics_disabled(argv_path: &Path) -> TestResult {
+    let args = std::fs::read_to_string(argv_path)?
+        .lines()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    assert!(
+        args.windows(2)
+            .any(|window| matches!(window, [flag, value] if flag == "-c" && value == "analytics.enabled=false")),
+        "Codex argv should disable upstream analytics: {args:?}"
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- pass `analytics.enabled=false` at both VM0 Codex process boundaries
- keep the fixed opt-out separate from provider startup overrides so legacy `OPENAI_BASE_URL` routing remains unchanged
- verify final argv for fresh and resumed `codex exec` runs and the active-input `codex app-server` path

## Why

Controlled Codex 0.145.0 benchmarks in #23092 found that disabling upstream analytics reduces startup-to-first-output latency by about 126 ms for API-key runs and 171 ms for healthy OAuth runs. VM0 telemetry is independent and remains enabled.

## Validation

- `cargo test -p guest-agent --test codex_prompt_stdin`
- `cargo test -p guest-agent --test codex_app_server_backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent`
- repository pre-commit Rust checks

## Compatibility

This changes only child-process startup arguments. It does not change schemas, persisted state, queue or runner protocols, environment contracts, or deployment ordering.

Closes #23092

Parent: #22892
