### PR TITLE
ci: decouple app release from api promotion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1332,16 +1332,16 @@ jobs:
 
           echo "Published runtime API schema for $RELEASE_SHA"
 
-  # Publish the immutable app artifact to Cloudflare Pages. If the same release
-  # run also promotes API, wait for API traffic to be live first.
+  # Publish the immutable app artifact to Cloudflare Pages after any required
+  # production migration succeeds, without waiting for API promotion.
   promote-app-production:
-    needs: [release-please, builds-complete, promote-api-production]
+    needs: [release-please, builds-complete, migrate-production]
     if: >-
       always() &&
       needs.release-please.outputs.app_release_created == 'true' &&
       needs.builds-complete.result == 'success' &&
-      (needs.release-please.outputs.api_deploy_required != 'true' ||
-       needs.promote-api-production.result == 'success')
+      (needs.release-please.outputs.api_release_created != 'true' ||
+       needs.migrate-production.result == 'success')
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -40,12 +40,14 @@ active, or introduce a versioned/new endpoint and migrate the frontend first.
 ### Backend
 
 The backend is the compatibility boundary for both frontend and runner traffic.
-In the production release workflow, app and runner promotion wait for API
-promotion when the same release also changes the API. That ordering reduces the
-chance of a new frontend or runner talking to an old backend, but it does not
-remove cross-version windows: old browser pages can still call the new backend,
-old runners keep draining against the new backend, and traffic promotion is not
-an atomic process visible to every client at the same instant.
+In the production release workflow, app promotion starts after any required
+production migration and does not wait for API promotion. A new frontend can
+therefore talk to the old backend during a normal production rollout or remain
+paired with it if API promotion fails. Runner promotion still waits for API
+promotion when the same release also changes the API. Old browser pages can
+also call the new backend, old runners keep draining against the new backend,
+and traffic promotion is not an atomic process visible to every client at the
+same instant.
 
 Production database migrations are part of the API release lifecycle and run
 before the new API deployment is promoted. Old backend code can therefore
@@ -57,14 +59,14 @@ This is a traffic-promotion guarantee, not a guarantee that no deployment
 preparation has happened yet. Staged Vercel builds, runner rootfs/snapshot
 builds, host provisioning, and other non-serving preparation jobs may complete
 before migrations run. API traffic promotion must wait until the required
-migrations have completed; app and runner promotion also wait for API promotion
-when the same release changes the API.
+migrations have completed. App promotion waits for required migrations but is
+independent of API promotion. Runner promotion waits for API promotion when the
+same release changes the API.
 
 Backend changes must be safe with:
 
 - old frontend -> new backend
-- new frontend -> old backend, if traffic propagation or non-production
-  deployment order can expose that pairing
+- new frontend -> old backend
 - old runner -> new backend
 - new runner -> old backend, if traffic propagation or non-production
   deployment order can expose that pairing

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -106,4 +106,20 @@ describe("release-please API deployment graph", () => {
     expect(promoteApiProductionJob).not.toContain("api_deploy_required");
     expect(promoteApiProductionJob).not.toContain("api_release_created");
   });
+
+  it("promotes App after migrations without waiting for API promotion", () => {
+    const workflow = readText(".github/workflows/release-please.yml");
+    const promoteAppProductionJob = workflowJobBlock(
+      workflow,
+      "promote-app-production",
+    );
+
+    expect(promoteAppProductionJob).toContain(
+      "needs: [release-please, builds-complete, migrate-production]",
+    );
+    expect(promoteAppProductionJob).toContain(
+      "needs.migrate-production.result == 'success'",
+    );
+    expect(promoteAppProductionJob).not.toContain("promote-api-production");
+  });
 });


### PR DESCRIPTION
## Summary

- gate App production deployment on the shared build barrier and any required production migration
- remove the App dependency on API promotion, so API promotion or deployment-record failures cannot block Cloudflare Pages
- preserve App-only releases when no API migration is required
- add regression coverage for the release job graph

## User impact

App releases can reach production immediately after required database migrations complete, independently of API promotion status.

## Verification

- `pnpm exec prettier --check ../.github/workflows/release-please.yml apps/api/src/__tests__/release-please-config.test.ts`
- `pnpm -F api exec vitest run src/__tests__/release-please-config.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec oxlint src/__tests__/release-please-config.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `pnpm -F api exec eslint src/__tests__/release-please-config.test.ts --max-warnings 0`