### PR TITLE
test(runner): cover protected model provider env keys

### DIFF
--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -113,7 +113,9 @@ fn model_provider_env_placeholder_validation_rejects_non_placeholder_values() {
     for (key, value) in protected_values {
         let ctx = context_with_env(HashMap::from([(key.to_owned(), value.to_owned())]));
 
-        let error = validate_context_for_test(&ctx).unwrap_err();
+        let Err(error) = validate_context_for_test(&ctx) else {
+            panic!("validation unexpectedly accepted {key}");
+        };
 
         assert!(
             error.contains(key),

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -95,14 +95,35 @@ fn model_provider_env_placeholder_validation_accepts_anthropic_api_key_placehold
 }
 
 #[test]
-fn model_provider_env_placeholder_validation_rejects_real_anthropic_api_key() {
-    let secret = "sk-ant-api03-real-secret-value";
-    let ctx = context_with_env(HashMap::from([("ANTHROPIC_API_KEY".into(), secret.into())]));
+fn model_provider_env_placeholder_validation_rejects_non_placeholder_values() {
+    let protected_values = [
+        ("ANTHROPIC_API_KEY", "sk-ant-api03-rejected-test-value"),
+        ("ANTHROPIC_AUTH_TOKEN", "sk-rejected-anthropic-auth-token"),
+        (
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "sk-ant-oat01-rejected-test-value",
+        ),
+        ("OPENAI_API_KEY", "sk-proj-rejected-test-value"),
+        ("CHATGPT_ACCESS_TOKEN", "chatgpt-token-rejected-test-value"),
+        ("CHATGPT_ACCOUNT_ID", "ws_rejected_test_account"),
+        ("CHATGPT_REFRESH_TOKEN", "rt_rejected_test_refresh_token"),
+        ("CHATGPT_ID_TOKEN", "hdr.rejected-test-id-token.sig"),
+    ];
 
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+    for (key, value) in protected_values {
+        let ctx = context_with_env(HashMap::from([(key.to_owned(), value.to_owned())]));
 
-    assert!(error.contains("ANTHROPIC_API_KEY"));
-    assert!(!error.contains(secret));
+        let error = validate_context_for_test(&ctx).unwrap_err();
+
+        assert!(
+            error.contains(key),
+            "validation error did not identify {key}"
+        );
+        assert!(
+            !error.contains(value),
+            "validation error for {key} echoed its rejected value"
+        );
+    }
 }
 
 #[test]
@@ -304,20 +325,6 @@ fn model_provider_env_placeholder_validation_accepts_empty_anthropic_api_key_wit
 }
 
 #[test]
-fn model_provider_env_placeholder_validation_rejects_real_anthropic_auth_token() {
-    let secret = "sk-real-openrouter-token";
-    let ctx = context_with_env(HashMap::from([(
-        "ANTHROPIC_AUTH_TOKEN".into(),
-        secret.into(),
-    )]));
-
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
-
-    assert!(error.contains("ANTHROPIC_AUTH_TOKEN"));
-    assert!(!error.contains(secret));
-}
-
-#[test]
 fn model_provider_env_placeholder_validation_accepts_claude_oauth_placeholder() {
     let ctx = context_with_env(HashMap::from([(
         "CLAUDE_CODE_OAUTH_TOKEN".into(),
@@ -338,17 +345,6 @@ fn model_provider_env_placeholder_validation_accepts_openai_api_key_placeholder(
 }
 
 #[test]
-fn model_provider_env_placeholder_validation_rejects_real_openai_api_key() {
-    let secret = "sk-proj-real-openai-secret";
-    let ctx = context_with_env(HashMap::from([("OPENAI_API_KEY".into(), secret.into())]));
-
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
-
-    assert!(error.contains("OPENAI_API_KEY"));
-    assert!(!error.contains(secret));
-}
-
-#[test]
 fn model_provider_env_placeholder_validation_accepts_codex_oauth_placeholders() {
     let ctx = context_with_env(HashMap::from([
         (
@@ -366,45 +362,6 @@ fn model_provider_env_placeholder_validation_accepts_codex_oauth_placeholders() 
     ]));
 
     assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
-}
-
-#[test]
-fn model_provider_env_placeholder_validation_rejects_real_chatgpt_access_token() {
-    let secret = "ey-real-chatgpt-access-token";
-    let ctx = context_with_env(HashMap::from([(
-        "CHATGPT_ACCESS_TOKEN".into(),
-        secret.into(),
-    )]));
-
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
-
-    assert!(error.contains("CHATGPT_ACCESS_TOKEN"));
-    assert!(!error.contains(secret));
-}
-
-#[test]
-fn model_provider_env_placeholder_validation_rejects_real_chatgpt_refresh_token() {
-    let secret = "rt_real_chatgpt_refresh_token";
-    let ctx = context_with_env(HashMap::from([(
-        "CHATGPT_REFRESH_TOKEN".into(),
-        secret.into(),
-    )]));
-
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
-
-    assert!(error.contains("CHATGPT_REFRESH_TOKEN"));
-    assert!(!error.contains(secret));
-}
-
-#[test]
-fn model_provider_env_placeholder_validation_rejects_chatgpt_id_token() {
-    let secret = "hdr.real-chatgpt-id-token.sig";
-    let ctx = context_with_env(HashMap::from([("CHATGPT_ID_TOKEN".into(), secret.into())]));
-
-    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
-
-    assert!(error.contains("CHATGPT_ID_TOKEN"));
-    assert!(!error.contains(secret));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- consolidate raw-value rejection coverage into one table-driven runner test
- cover all eight protected model-provider environment keys, including `CLAUDE_CODE_OAUTH_TOKEN` and `CHATGPT_ACCOUNT_ID`
- exercise each case through the full pre-sandbox execution-context validation boundary
- verify errors identify rejected keys without echoing rejected values

## Scope

Tests only. This PR does not change runtime behavior, APIs, protocols, persisted data, generated contracts, or deployment behavior.

## Validation

- `cargo test -p runner --bin runner model_provider_env_placeholder_validation_rejects_non_placeholder_values`
- `cargo test -p runner --bin runner`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- temporarily removed each missing registry entry independently and confirmed the focused regression test failed; restored both entries and confirmed the test passed

Closes #23087
