### PR TITLE
docs(mitm-addon): clarify decompress_body test contract

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -377,10 +377,11 @@ class TestStreamDecodeFeed:
 
 
 class TestDecompressBody:
-    """Direct tests for ``decompress_body`` — the non-streaming one-shot
-    path used by ``extract_anthropic_messages_usage_from_json`` and ``log_connector_usage``
-    to decompress full response bodies (up to
-    ``LARGE_RESPONSE_DECOMPRESS_LIMIT``) for JSON parsing.
+    """Direct tests for the bounded, best-effort, one-shot ``decompress_body`` policy.
+
+    Response-body capture and silent usage extraction share this policy. Diagnostic
+    JSON usage extraction instead uses ``decompress_json_usage_body`` so invalid or
+    incomplete compressed bodies remain observable.
 
     Focus: verify the documented ``max_output`` cap is enforced during
     decompression (not only via after-the-fact slicing). Brotli uses a soft


### PR DESCRIPTION
## Summary

- replace the stale `TestDecompressBody` caller list with the durable bounded best-effort contract
- clarify that response capture and silent usage extraction share this policy
- distinguish diagnostic JSON usage decompression without changing runtime behavior

## Exclusions

- no production code, test assertions, dependencies, schemas, migrations, or persisted data change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4255 passed)

Closes #23093
