### PR TITLE
fix(runner): recheck stale mitmproxy by port

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -93,8 +93,8 @@ enum Warning {
         port: u16,
         ppid: Option<u32>,
     },
-    /// Runner is stopped but mitmproxy process is still running (leaked).
-    StaleMitmproxy { pid: u32, port: u16 },
+    /// Runner is stopped but a mitmproxy process is still using its port.
+    StaleMitmproxy { port: u16 },
     /// status.json lists a dns_port but no dnsmasq process found on it.
     NoDnsmasq { port: u16, base_dir: PathBuf },
     /// A network namespace whose pool lock is not held by any process.
@@ -154,11 +154,8 @@ impl fmt::Display for Warning {
                     "orphan mitmdump PID {pid} (port {port}, ppid={ppid_str})"
                 )
             }
-            Self::StaleMitmproxy { pid, port } => {
-                write!(
-                    f,
-                    "stale mitmproxy PID {pid} on port {port} (runner stopped)"
-                )
+            Self::StaleMitmproxy { port } => {
+                write!(f, "stale mitmproxy process on port {port} (runner stopped)")
             }
             Self::OrphanNamespace { ns_name, .. } => {
                 write!(f, "orphan namespace {ns_name} (pool lock not held)")
@@ -275,10 +272,7 @@ impl Warning {
                     None => true,
                 }
             }
-            Self::StaleMitmproxy { pid, .. } => {
-                // Resolved if the stale mitmproxy process has exited.
-                pid_exists(*pid)
-            }
+            Self::StaleMitmproxy { port } => fresh.mitmdumps.iter().any(|mitm| mitm.port == *port),
             Self::OrphanFirecracker { pid, .. } | Self::OrphanMitmdump { pid, .. } => {
                 // Resolved if the process exited or a runner registry entry
                 // appeared after the initial scan and now owns the process.
@@ -636,11 +630,8 @@ async fn build_runner_report(
                     base_dir: base_dir.clone(),
                 });
             }
-            ("stopped", Some(mitm_pid)) => {
-                warnings.push(Warning::StaleMitmproxy {
-                    pid: mitm_pid,
-                    port,
-                });
+            ("stopped", Some(_)) => {
+                warnings.push(Warning::StaleMitmproxy { port });
             }
             _ => {}
         }
@@ -2313,13 +2304,10 @@ mod tests {
             "orphan firecracker PID 42 (sandbox xyz, ppid=?)"
         );
 
-        let w = Warning::StaleMitmproxy {
-            pid: 555,
-            port: 32821,
-        };
+        let w = Warning::StaleMitmproxy { port: 32821 };
         assert_eq!(
             w.to_string(),
-            "stale mitmproxy PID 555 on port 32821 (runner stopped)"
+            "stale mitmproxy process on port 32821 (runner stopped)"
         );
 
         let w = Warning::OrphanNbdDevice {
@@ -3021,13 +3009,49 @@ mod tests {
             vec![],
         )
         .await;
-        assert!(report.warnings.iter().any(|w| matches!(
-            w,
-            Warning::StaleMitmproxy {
-                pid: 999,
-                port: 32821,
-            }
-        )));
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| matches!(w, Warning::StaleMitmproxy { port: 32821 }))
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_proxy_recheck_tracks_the_recorded_port_across_pid_exit() {
+        let report = build_test_runner_report(
+            "stopped",
+            Some(32821),
+            None,
+            vec![mitm_proc(111, 32821), mitm_proc(222, 32821)],
+            vec![],
+        )
+        .await;
+        assert_eq!(report.proxy_pid, Some(111));
+        let mut reports = [report];
+        let replacement_only = process::DiscoveredProcesses {
+            firecrackers: vec![],
+            mitmdumps: vec![mitm_proc(222, 32821)],
+            dnsmasqs: vec![],
+        };
+
+        recheck_current_runner_warnings(None, &replacement_only, &mut reports).await;
+
+        assert!(
+            reports[0]
+                .warnings
+                .iter()
+                .any(|warning| matches!(warning, Warning::StaleMitmproxy { port: 32821 }))
+        );
+
+        let unrelated_only = process::DiscoveredProcesses {
+            firecrackers: vec![],
+            mitmdumps: vec![mitm_proc(333, 32822)],
+            dnsmasqs: vec![],
+        };
+        recheck_current_runner_warnings(None, &unrelated_only, &mut reports).await;
+
+        assert!(!has_proxy_warning(&reports[0]));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- model stopped-runner stale mitmproxy warnings by their claimed proxy port instead of one initially observed PID
- confirm stale proxy warnings against the shared fresh process inventory so a surviving same-port worker keeps the warning active
- avoid rendering an exited initial PID as the persistent anomaly
- cover initial PID exit, same-port worker survival, and exact-port clearing through the doctor report and recheck flow

## Scope

This changes only the read-only `runner doctor` diagnostic. It does not change proxy lifecycle or cleanup, persisted status, APIs, schemas, runner/guest protocols, or deployment behavior.

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #23089
