### PR TITLE
docs(python): describe firewall allow auth handling

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1023,7 +1023,12 @@ def _ensure_compiled_network_policies(
 
 
 class FirewallAllow(NamedTuple):
-    """Base URL matched and auth headers should be injected.
+    """Matched-firewall allow decision for connector auth handling.
+
+    Depending on the auth configuration, handling may inject headers or query
+    parameters, rewrite and forward through ``auth.base``, apply AWS SigV4
+    signing, or make no credential changes. Asterisk-form allows that proceed
+    without auth are represented by ``FirewallPolicyAllow`` instead.
 
     ``permission`` and ``rule`` are present for a matched permission. They are
     ``None`` for unknown-endpoint allow, where the firewall base matched but no


### PR DESCRIPTION
## Summary

- describe `FirewallAllow` as a matched-firewall allow decision for connector auth handling
- document header and query injection, `auth.base` forwarding, AWS SigV4 signing, and empty auth
- preserve the explicit no-auth distinction for `FirewallPolicyAllow`

## Scope

Documentation only. This PR does not change runtime behavior, types, APIs, protocols, persisted
state, dependencies, or tests.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,255 passed)
- `git diff --check`

Closes #23094
