### PR TITLE
fix(mitm-addon): preserve usage when diagnostic type overflows

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -23,6 +23,7 @@ from typing import Literal, cast
 Path = tuple[str, ...]
 WildcardPath = tuple[str, ...]
 ScalarKind = Literal["string", "int"]
+ScalarOverflowPolicy = Literal["error", "discard"]
 _JsonStringScanner = Callable[[str, int, bool], tuple[str, int]]
 # `scanstring` is the stdlib JSON string scanner, but typeshed does not expose it.
 _SCAN_JSON_STRING = cast(_JsonStringScanner, vars(json.decoder)["scanstring"])
@@ -90,17 +91,25 @@ class ScalarField:
     """Selected scalar field configuration.
 
     ``kind`` must be ``"string"`` or ``"int"``. ``max_bytes`` is the capture
-    limit for the selected scalar token; exceeding it fails extraction with
-    ``"string limit exceeded"`` or ``"number limit exceeded"``.
+    limit for the selected scalar token. ``overflow_policy`` defaults to
+    ``"error"``, which fails extraction with ``"string limit exceeded"`` or
+    ``"number limit exceeded"``. Selected strings may use ``"discard"`` to
+    stop retaining an oversized optional observation while continuing to
+    validate the document.
     """
 
     kind: ScalarKind
     max_bytes: int = 4096
+    overflow_policy: ScalarOverflowPolicy = "error"
 
     def __post_init__(self) -> None:
         if self.kind not in ("string", "int"):
             raise ValueError("scalar field kind must be 'string' or 'int'")
         _validate_positive_int("scalar field max_bytes", self.max_bytes)
+        if self.overflow_policy not in ("error", "discard"):
+            raise ValueError("scalar field overflow_policy must be 'error' or 'discard'")
+        if self.kind != "string" and self.overflow_policy == "discard":
+            raise ValueError("scalar field overflow_policy 'discard' requires a string field")
 
 
 @dataclass
@@ -141,6 +150,7 @@ class _StringState:
     path: Path | None
     max_bytes: int
     raw: bytearray | None
+    overflow_policy: ScalarOverflowPolicy = "error"
     escape: bool = False
     has_escape: bool = False
     unicode_remaining: int = 0
@@ -176,9 +186,11 @@ class JsonSelectiveExtractor:
       ``"*"`` segment, recording counts by the concrete wildcard key.
     - ``object_presence_paths`` records exact paths where JSON objects appear.
 
-    Oversized selected scalars fail extraction. Oversized object keys are treated
-    as unknown keys instead, so selected descendants below that key cannot match.
-    Objects that are array elements do not match normal object-path observations.
+    Oversized selected scalars fail extraction by default. Selected strings with
+    ``overflow_policy="discard"`` instead drop that observation and continue
+    validation. Oversized object keys are treated as unknown keys, so selected
+    descendants below that key cannot match. Objects that are array elements do
+    not match normal object-path observations.
     """
 
     def __init__(
@@ -279,8 +291,8 @@ class JsonSelectiveExtractor:
         """Finalize the current document and return the extraction result.
 
         Call once after all chunks have been fed. If parsing is incomplete,
-        invalid, or a configured bound was exceeded, the returned result has
-        ``complete=False`` and empty observation containers.
+        invalid, or a strict configured bound was exceeded, the returned result
+        has ``complete=False`` and empty observation containers.
         """
         if not self._error and self._number is not None:
             self._finish_number()
@@ -418,6 +430,7 @@ class JsonSelectiveExtractor:
                     path=path,
                     max_bytes=field.max_bytes,
                     raw=bytearray(),
+                    overflow_policy=field.overflow_policy,
                 )
             else:
                 self._string = _StringState(
@@ -679,7 +692,7 @@ class JsonSelectiveExtractor:
             return
         state.raw.append(b)
         if len(state.raw) > state.max_bytes:
-            if state.role == "key":
+            if state.role == "key" or state.overflow_policy == "discard":
                 state.raw = None
                 return
             self._error = "string limit exceeded"

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -142,7 +142,7 @@ _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS = {
     **{("response", *path): field for path, field in _RESPONSES_RESPONSE_SCALAR_FIELDS.items()},
 }
 _RESPONSES_SSE_SCALAR_FIELDS = {
-    ("type",): ScalarField("string", max_bytes=1024),
+    ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
     **_RESPONSES_SSE_RESPONSE_SCALAR_FIELDS,
 }
 

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -100,6 +100,16 @@ def test_rejects_bool_scalar_field_max_bytes():
         ScalarField("string", max_bytes=True)
 
 
+def test_rejects_invalid_scalar_field_overflow_policy():
+    with pytest.raises(ValueError, match="overflow_policy"):
+        ScalarField("string", overflow_policy=json.loads('"ignore"'))
+
+
+def test_rejects_discard_overflow_policy_for_integer_field():
+    with pytest.raises(ValueError, match="requires a string field"):
+        ScalarField("int", overflow_policy="discard")
+
+
 def test_rejects_invalid_scalar_field_config_value():
     with pytest.raises(TypeError, match="ScalarField"):
         JsonSelectiveExtractor(scalar_fields=json.loads('{"model": "string"}'))
@@ -564,6 +574,64 @@ def test_rejects_oversized_selected_string():
     assert result.complete is False
     assert result.error == "string limit exceeded"
     assert result.values == {}
+
+
+def test_discards_oversized_optional_selected_string_across_chunks():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={
+            ("type",): ScalarField("string", max_bytes=3, overflow_policy="discard"),
+            ("usage", "output_tokens"): ScalarField("int"),
+        }
+    )
+
+    extractor.feed(b'{"type":"abc')
+    extractor.feed(b'def","usage":{"output_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "output_tokens"): 7}
+    assert extractor.observed_scalar_for_diagnostics(("type",)) is None
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (rb'{"type":"abcd\x"}', "invalid string escape"),
+        (b'{"type":"abcd\xff"}', "invalid string"),
+    ],
+)
+def test_discarded_oversized_selected_string_still_validates_json(payload, error):
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("type",): ScalarField("string", max_bytes=3, overflow_policy="discard")}
+    )
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == error
+    assert result.values == {}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_type"),
+    [
+        (b'{"type":"ok","type":"long"}', None),
+        (b'{"type":"long","type":"ok"}', "ok"),
+    ],
+)
+def test_discarded_oversized_duplicate_selected_string_uses_last_value(payload, expected_type):
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("type",): ScalarField("string", max_bytes=3, overflow_policy="discard")}
+    )
+
+    extractor.feed(payload)
+    result = _finish(extractor)
+
+    assert result.complete is True
+    expected_values = {} if expected_type is None else {("type",): expected_type}
+    assert result.values == expected_values
+    assert extractor.observed_scalar_for_diagnostics(("type",)) == expected_type
 
 
 def test_selected_string_limit_counts_escape_bytes():

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -130,6 +130,25 @@ class TestModelProviderSseUsage:
             "tokens.cache_creation": 15,
         }
 
+    def test_full_pipeline_openai_sse_reports_usage_with_oversized_type(self, tmp_path, real_flow):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"event: response.completed\n"
+            b'data: {"type":"' + b"x" * 2048 + b'","response":{"model":"gpt-5.5",'
+            b'"usage":{"input_tokens":50,"output_tokens":20}}}\n\n'
+        )
+
+        webhook = self._run_response(flow)
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 50,
+            "tokens.output": 20,
+        }
+        assert _model_sse_parse_warnings(flow) == []
+
     @pytest.mark.parametrize("capture_body", [False, True])
     def test_brotli_sse_does_not_use_model_json_fallback(self, tmp_path, real_flow, capture_body):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -183,11 +183,28 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
-    def test_named_terminal_event_with_oversized_type_extracts_usage(self):
-        parse, usage = create_openai_responses_sse_usage_extractor()
+    @pytest.mark.parametrize(
+        "event_prefix",
+        [
+            pytest.param(b"", id="eventless"),
+            pytest.param(b"event: response.completed\n", id="named"),
+        ],
+    )
+    @pytest.mark.parametrize("with_parse_error_callback", [False, True])
+    def test_oversized_type_does_not_change_usage_with_parse_error_callback(
+        self, event_prefix, with_parse_error_callback
+    ):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error if with_parse_error_callback else None
+        )
         parse(
-            b"event: response.completed\n"
-            b'data: {"type":"'
+            event_prefix
+            + b'data: {"type":"'
             + b"x" * 2048
             + b'","response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
         )
@@ -197,6 +214,7 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.input": 9,
             "tokens.output": 4,
         }
+        assert parse_errors == []
 
     def test_eventless_duplicate_unknown_type_keeps_first_type_boundary(self):
         parse, usage = create_openai_responses_sse_usage_extractor()


### PR DESCRIPTION
## Summary

- add an opt-in discard policy for oversized optional string observations while keeping selected scalars strict by default
- apply the policy to the bounded OpenAI Responses event `type` diagnostic so parse-error callbacks cannot suppress valid usage
- cover named and eventless callback behavior, JSON validation after overflow, duplicate fields, and the production usage webhook path

## Scope

- preserves eventless terminal parse diagnostics and known non-usage filtering
- does not change SSE framing, reporting APIs, schemas, persisted state, or runner protocols

## Verification

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_json_selective.py tests/test_openai_responses_sse.py tests/test_model_provider_sse_usage.py` — 217 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4266 passed
- `lefthook run pre-commit`

Closes #23096
