### PR TITLE
chore(api): add provenance-aware local sql composition analysis

### DIFF
--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -597,6 +597,82 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          AND \${users.name} = \${"name"}
+        \`;
+        db.select().from(users).where(sql\`NOT \${fragment}\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 24,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          OR \${users.name} = \${"name"}
+        \`;
+        db.select()
+          .from(users)
+          .where(
+            sql\`(\${fragment}) AND \${users.deletedAt} IS NOT NULL\`,
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 27,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          OR \${users.name} = \${"name"}
+        \`;
+        db.select()
+          .from(users)
+          .where(
+            sql\`\${fragment} AND \${users.deletedAt} IS NOT NULL\`,
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "or" },
+          line: 27,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          AND \${users.name} = \${"name"}
+        \`;
+        db.select().from(users).where(sql\` \${fragment} \`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 20,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
         const predicate = sql\`\${users.id} = \${1}\`;
         db.select().from(users).where(predicate).having(predicate);
       `,
@@ -623,7 +699,13 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .from(users)
           .where(sql.join(predicates, sql\` AND \`));
       `,
-      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 26,
+        },
+      ],
     },
     {
       code: `${drizzlePreamble}
@@ -640,7 +722,13 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             ),
           );
       `,
-      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 23,
+        },
+      ],
     },
     {
       code: `${drizzlePreamble}
@@ -657,6 +745,42 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        function conjunction(left: SQL, right: SQL): SQL {
+          return sql\`\${left} AND \${right}\`;
+        }
+        db.select()
+          .from(users)
+          .where(
+            conjunction(
+              sql\`\${users.id} = \${1}\`,
+              sql\`\${users.name} = \${"one"}\`,
+            ),
+          );
+        db.select()
+          .from(users)
+          .having(
+            conjunction(
+              sql\`\${users.id} = \${2}\`,
+              sql\`\${users.name} = \${"two"}\`,
+            ),
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 26,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 34,
+        },
       ],
     },
     {
@@ -695,6 +819,23 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        db.select()
+          .from(users)
+          .where(
+            flag
+              ? sql\`\${users.id} = \${1} AND \${users.name} = \${"one"}\`
+              : sql\`\${users.id} = \${2} AND \${users.name} = \${"two"}\`,
+          );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "and" } },
       ],
     },
     {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -364,6 +364,8 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           WHERE \${eq(users.id, 1)}
           LIMIT 1
         \`;
+        declare function expose(value: SQL): void;
+        expose(composed);
         await decodeRows(db, composed, rowSchema);
         await decodeRows(
           db,
@@ -429,8 +431,272 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         builder.innerJoin(users, sql\`true\`);
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        db.select()
+          .from(users)
+          .where(
+            flag
+              ? sql\`\${users.id} = \${1}\`
+              : sql\`\${users.id} > \${1}\`,
+          );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        export const exportedQuery: SQL = sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+          LIMIT 1
+        \`;
+        await executeRawRows(db, exportedQuery, rowSchema);
+
+        const mutatedQuery: SQL = sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+          LIMIT 1
+        \`;
+        mutatedQuery.append(sql.raw(""));
+        await executeRawRows(db, mutatedQuery, rowSchema);
+
+        const nestedSource: SQL = sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+          LIMIT 1
+        \`;
+        const escapedWrapper = sql\`\${nestedSource}\`;
+        declare function expose(value: SQL): void;
+        expose(escapedWrapper);
+        await executeRawRows(db, nestedSource, rowSchema);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const fake = {
+          empty(): SQL {
+            return sql\`true\`;
+          },
+          join(items: SQL[]): SQL {
+            return items[0] ?? sql\`true\`;
+          },
+        };
+        db.select().from(users).innerJoin(users, fake.empty());
+        db.select()
+          .from(users)
+          .innerJoin(users, fake.join([sql\`true\`]));
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        function recursive(): SQL {
+          return recursive();
+        }
+        db.select().from(users).innerJoin(users, recursive());
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        const condition =
+          ${Array.from({ length: 17 }, () => "flag ? sql`true` : ").join("")}
+          sql\`true\`;
+        db.select().from(users).innerJoin(users, condition);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const predicate0: SQL = sql\`true\`;
+        ${Array.from({ length: 130 }, (_, index) => {
+          return `const predicate${index + 1}: SQL = sql\`\${predicate${index}}\`;`;
+        }).join("\n")}
+        db.select().from(users).innerJoin(users, predicate130);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        function queryFor(table: typeof users): SQL {
+          return sql\`
+            SELECT \${table.id}
+            FROM \${table}
+            WHERE \${eq(table.id, 1)}
+            LIMIT 1
+          \`;
+        }
+        await executeRawRows(db, queryFor(users), rowSchema);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        const predicates = [sql\`true\`];
+        db.select()
+          .from(users)
+          .innerJoin(
+            users,
+            sql.join(
+              [...predicates],
+              sql\` AND \`,
+            ),
+          );
+        db.select()
+          .from(users)
+          .innerJoin(
+            users,
+            sql.join(
+              predicates.map((predicate) => predicate),
+              sql\` AND \`,
+            ),
+          );
+        db.select()
+          .from(users)
+          .innerJoin(users, flag ? sql.empty() : sql\`true\`);
+      `,
+    },
   ],
   invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        import { executeRawRows } from "./lib/db-raw-rows";
+        declare const rowSchema: never;
+        const query: SQL = sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${eq(users.id, 1)}
+          LIMIT 1
+        \`;
+        await executeRawRows(db, query, rowSchema);
+      `,
+      errors: [{ messageId: "queryBuilder" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`\${sql\`\${users.id} = \${1}\`}\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`\${users.id} = \${1}\`;
+        db.select().from(users).where(predicate).having(predicate);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`\${users.id} = \${1}\`;
+        db.select()
+          .from(users)
+          .where(sql\`\${sql.empty()}\${predicate}\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicates = [
+          sql\`\${users.id} = \${1}\`,
+          sql\`\${users.name} = \${"name"}\`,
+        ];
+        db.select()
+          .from(users)
+          .where(sql.join(predicates, sql\` AND \`));
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(
+            drizzle.sql.join(
+              [
+                drizzle.sql\`\${users.id} = \${1}\`,
+                drizzle.sql\`\${users.name} = \${"name"}\`,
+              ],
+              drizzle.sql\` AND \`,
+            ),
+          );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        function comparison(
+          column: typeof users.id,
+          value: number,
+        ): SQL {
+          return sql\`\${column} = \${value}\`;
+        }
+        db.select().from(users).where(comparison(users.id, 1));
+        db.select().from(users).having(comparison(users.id, 2));
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const flag: boolean;
+        function choose(left: SQL, right: SQL): SQL {
+          return flag ? left : right;
+        }
+        db.select()
+          .from(users)
+          .where(
+            choose(
+              sql\`\${users.id} = \${1}\`,
+              sql\`\${users.name} = \${"name"}\`,
+            ),
+          );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        db.select()
+          .from(users)
+          .where(
+            flag
+              ? sql\`\${users.id} = \${1}\`
+              : sql\`\${users.name} = \${"name"}\`,
+          );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
     {
       code: `${drizzlePreamble}
         import { eq, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -629,7 +629,28 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "eq" },
-          line: 20,
+          line: 23,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`\${users.id} = \${1}\`;
+        db.select()
+          .from(users)
+          .where(sql\`unsupported(\${predicate}, \${predicate})\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 23,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 23,
         },
       ],
     },
@@ -692,6 +713,74 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           messageId: "typedApi",
           data: { helper: "not" },
           line: 26,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const predicate = sql.join(
+          [eq(users.id, 1), eq(users.name, "name")],
+          sql\` AND \`,
+        );
+        db.select().from(users).where(sql\`unsupported(\${predicate})\`);
+        db.select().from(users).having(sql\`NOT \${predicate}\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 24,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 25,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const fragment = sql\`\${users.deletedAt} IS NOT NULL\`;
+        db.select()
+          .from(users)
+          .where(sql\`\${fragment} AND \${eq(users.id, 1)}\`);
+        db.select()
+          .from(users)
+          .having(sql\`COALESCE(\${fragment}, FALSE)\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "isNotNull" },
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          AND \${users.name} = \${"name"}
+        \`;
+        db.select().from(users).where(sql\`unsupported(\${fragment})\`);
+        db.select().from(users).having(sql\`NOT \${fragment}\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 24,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 25,
         },
       ],
     },
@@ -767,7 +856,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 20,
+          line: 24,
         },
       ],
     },
@@ -777,7 +866,18 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const predicate = sql\`\${users.id} = \${1}\`;
         db.select().from(users).where(predicate).having(predicate);
       `,
-      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 21,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 21,
+        },
+      ],
     },
     {
       code: `${drizzlePreamble}
@@ -901,8 +1001,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           );
       `,
       errors: [
-        { messageId: "typedApi", data: { helper: "eq" } },
-        { messageId: "typedApi", data: { helper: "eq" } },
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 27,
+        },
       ],
     },
     {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -568,6 +568,15 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .innerJoin(users, flag ? sql.empty() : sql\`true\`);
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const column = sql\`\${users.id}\`;
+        db.select()
+          .from(users)
+          .where(sql\`COALESCE(\${column} = \${1}, FALSE)\`);
+      `,
+    },
   ],
   invalid: [
     {
@@ -593,6 +602,98 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .where(sql\`\${sql\`\${users.id} = \${1}\`}\`);
       `,
       errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const column = sql\`\${users.id}\`;
+        db.select().from(users).where(sql\`\${column} = \${1}\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 21,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`\${users.id} = \${1}\`;
+        db.select()
+          .from(users)
+          .where(sql\`unsupported('α', \${predicate})\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+          line: 20,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(
+            sql\`COALESCE(\${sql.join(
+              [eq(users.id, 1), eq(users.name, "name")],
+              sql\` AND \`,
+            )}, FALSE)\`,
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 23,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        function conjunction(left: SQL, right: SQL): SQL {
+          return sql\`\${left} AND \${right}\`;
+        }
+        db.select()
+          .from(users)
+          .where(
+            sql\`COALESCE(\${conjunction(
+              eq(users.id, 1),
+              eq(users.name, "name"),
+            )}, FALSE)\`,
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 26,
+        },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fragment = sql\`
+          \${users.id} = \${1}
+          AND \${users.name} = \${"name"}
+        \`;
+        db.select()
+          .from(users)
+          .where(sql\`EXISTS (SELECT 1 WHERE NOT \${fragment})\`);
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "not" },
+          line: 26,
+        },
+      ],
     },
     {
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-query-builder.test.ts
@@ -443,6 +443,8 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           ) AS consumption(window_id, units_applied)
           WHERE \${allowanceWindows.id} = consumption.window_id
         \`;
+        declare function expose(value: unknown): void;
+        expose(query);
         await db.execute(query);
       `,
     },
@@ -558,6 +560,8 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
           DELETE FROM cleanup_rows
           WHERE expires_at <= \${cutoff}
         \`;
+        declare function expose(value: unknown): void;
+        expose(query);
         await db.execute(query);
       `,
     },
@@ -674,6 +678,8 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
             credits = org_metadata.credits + \${amount},
             updated_at = now()
         \`;
+        declare function expose(value: unknown): void;
+        expose(query);
         await db.execute(query);
       `,
     },
@@ -1265,6 +1271,22 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
+        const source = sql\`runs\`;
+        await executeRawRows(
+          db,
+          sql\`
+            SELECT \${runs.id}
+            FROM \${source}
+            WHERE \${eq(runs.id, threadId)}
+            FOR UPDATE
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql } from "drizzle-orm";
         await executeRawRows(
           db,
           sql\`SELECT 1 FROM \${runs} WHERE \${eq(runs.id, 1)} LIMIT 1\`,
@@ -1407,6 +1429,8 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         const lockingQuery = ${runnerLockingQuery};
+        declare function expose(value: unknown): void;
+        expose(lockingQuery);
         await executeRawRows(db, lockingQuery, rowSchema);
       `,
     },
@@ -1733,8 +1757,121 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
         db.insert(users).select(${scalarQuery});
       `,
     },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        declare const chooseDelete: boolean;
+        const query = chooseDelete
+          ? sql\`
+              DELETE FROM \${cleanupRows}
+              WHERE \${cleanupRows.expiresAt} <= \${cutoff}
+            \`
+          : sql\`SELECT 1\`;
+        await db.execute(query);
+      `,
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        const parts = [
+          sql\`DELETE FROM \${cleanupRows}\`,
+          sql\` WHERE \${cleanupRows.expiresAt} <= \${cutoff}\`,
+        ];
+        parts.push(sql\` RETURNING \${cleanupRows.id}\`);
+        await db.execute(sql.join(parts));
+      `,
+    },
   ],
   invalid: [
+    {
+      code: `${deletePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const query: SQL = sql\`
+          DELETE FROM \${cleanupRows}
+          WHERE \${cleanupRows.expiresAt} <= \${cutoff}
+        \`;
+        await db.execute(query);
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        await db.execute(
+          sql.join([
+            sql\`DELETE FROM cleanup_rows\`,
+            sql\` WHERE expires_at <= \${cutoff}\`,
+          ]),
+        );
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        declare const firstPredicate: boolean;
+        const query = firstPredicate
+          ? sql\`
+              DELETE FROM \${cleanupRows}
+              WHERE \${cleanupRows.expiresAt} <= \${cutoff}
+            \`
+          : sql\`
+              DELETE FROM \${cleanupRows}
+              WHERE \${cleanupRows.id} > \${0}
+            \`;
+        await db.execute(query);
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        function deleteBefore(
+          table: typeof cleanupRows,
+          column: typeof cleanupRows.expiresAt,
+          value: Date,
+        ): SQL {
+          return sql\`
+            DELETE FROM \${table}
+            WHERE \${column} <= \${value}
+          \`;
+        }
+        await db.execute(
+          deleteBefore(cleanupRows, cleanupRows.expiresAt, cutoff),
+        );
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        const parts = [
+          sql\`DELETE FROM \${cleanupRows}\`,
+          sql\` WHERE \${cleanupRows.expiresAt} <= \${cutoff}\`,
+        ];
+        await db.execute(sql.join(parts));
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${deletePreamble}
+        import { sql } from "drizzle-orm";
+        const table = sql\`\${cleanupRows}\`;
+        await db.execute(sql\`
+          \${sql.empty()}DELETE FROM \${table}
+          WHERE \${cleanupRows.expiresAt} <= \${cutoff}
+        \`);
+      `,
+      errors: [{ messageId: "deleteQueryBuilder" }],
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        const query: SQL = ${runnerLockingQuery};
+        await executeRawRows(db, query, rowSchema);
+      `,
+      errors: [{ messageId: "lockingQueryBuilder" }],
+    },
     {
       code: `${lockingCteUpdatePreamble}
         import { inArray, lte, sql } from "drizzle-orm";
@@ -2338,6 +2475,24 @@ ruleTester.run("prefer-drizzle-query-builder", preferDrizzleQueryBuilder, {
       `,
       errors: [
         { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+      ],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        const selectedValue = flag ? ${mappedScalarQuery} : users.id;
+        function selectedFields() {
+          return flag
+            ? { value: users.id }
+            : { value: ${mappedScalarQuery} };
+        }
+        db.select({ value: selectedValue });
+        db.select(selectedFields());
+      `,
+      errors: [
         { messageId: "structuredScalarQuery" },
         { messageId: "structuredScalarQuery" },
       ],

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -173,6 +173,19 @@ export function isDrizzleTableType(
   });
 }
 
+export function isDrizzleSqlType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  return everyConcreteType(checker, type, (member) => {
+    return (
+      isDrizzleWrapperType(checker, member) &&
+      drizzleBrand(checker, member, location) === "SQL"
+    );
+  });
+}
+
 export function isDrizzlePatternOperandType(
   checker: TypeChecker,
   type: Type,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -44,10 +44,8 @@ import {
   SQL_TEMPLATE_EXPRESSION_BOUNDARY,
   sqlCodeMask,
 } from "../sql-lexing.ts";
-import {
-  analyzeDirectSql,
-  type DirectSqlAnalysis,
-} from "../sql-analysis/direct-sql-analysis.ts";
+import { analyzeSql, type SqlAnalysis } from "../sql-analysis/sql-analysis.ts";
+import { createSqlSourceComposer } from "../sql-analysis/sql-source.ts";
 import { createRule } from "../utils.ts";
 
 type BinaryLeftOperand = "array" | "pattern" | "wrapper";
@@ -793,10 +791,26 @@ export const preferDrizzleApis = createRule({
       new WeakSet<TSESTree.TaggedTemplateExpression>();
     const structurallyWholeTemplates =
       new WeakSet<TSESTree.TaggedTemplateExpression>();
+    const structuralCallInspections: Array<() => void> = [];
+    const legacyTemplateInspections: Array<() => void> = [];
+    const reportedStructuralFindings = new WeakMap<
+      TSESTree.Node,
+      Set<string>
+    >();
     const expressionTypeCache = new WeakMap<
       TSESTree.Expression,
       { readonly location: Node; readonly type: Type }
     >();
+    const drizzleMethodCache = new WeakMap<
+      TSESTree.MemberExpression,
+      boolean
+    >();
+    const sqlSourceComposer = createSqlSourceComposer(
+      context.sourceCode,
+      checker,
+      services,
+      isSafeSqlTerminalUse,
+    );
 
     function expressionType(node: TSESTree.Expression): {
       readonly location: Node;
@@ -823,8 +837,21 @@ export const preferDrizzleApis = createRule({
       });
     }
 
-    function reportStructuralAnalysis(analysis: DirectSqlAnalysis): void {
+    function reportStructuralAnalysis(analysis: SqlAnalysis): void {
       for (const finding of analysis.findings) {
+        const key =
+          finding.kind === "query-builder"
+            ? finding.kind
+            : `${finding.kind}:${finding.helper}`;
+        const reported = reportedStructuralFindings.get(finding.node);
+        if (reported?.has(key) === true) {
+          continue;
+        }
+        if (reported === undefined) {
+          reportedStructuralFindings.set(finding.node, new Set([key]));
+        } else {
+          reported.add(key);
+        }
         if (finding.kind === "query-builder") {
           context.report({
             node: finding.node,
@@ -874,19 +901,67 @@ export const preferDrizzleApis = createRule({
       if (memberName(node) !== name) {
         return false;
       }
+      const cached = drizzleMethodCache.get(node);
+      if (cached !== undefined) {
+        return cached;
+      }
       const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
-      return isDrizzleSymbol(checker, checker.getSymbolAtLocation(tsProperty));
+      const result = isDrizzleSymbol(
+        checker,
+        checker.getSymbolAtLocation(tsProperty),
+      );
+      drizzleMethodCache.set(node, result);
+      return result;
     }
 
-    function taggedArgument(
+    function predicateArgumentIndex(
       node: TSESTree.CallExpression,
-      index: number,
-    ): TSESTree.TaggedTemplateExpression | undefined {
-      const argument = node.arguments[index];
-      return argument?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
-        isDrizzleSqlTag(checker, services, argument.tag)
-        ? argument
+    ): number | undefined {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return undefined;
+      }
+      const method = memberName(node.callee);
+      if (method === "where" || method === "having") {
+        return 0;
+      }
+      return method === "innerJoin" ||
+        method === "leftJoin" ||
+        method === "rightJoin" ||
+        method === "fullJoin" ||
+        method === "innerJoinLateral" ||
+        method === "leftJoinLateral"
+        ? 1
         : undefined;
+    }
+
+    function isSafeSqlTerminalUse(node: TSESTree.Expression): boolean {
+      const parent = node.parent;
+      if (
+        parent.type !== AST_NODE_TYPES.CallExpression ||
+        parent.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        })
+      ) {
+        return false;
+      }
+      if (
+        parent.arguments.length === 3 &&
+        parent.arguments[1] === node &&
+        isExecuteRawRowsCallee(parent.callee)
+      ) {
+        return true;
+      }
+      const predicateIndex = predicateArgumentIndex(parent);
+      if (parent.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return false;
+      }
+      const method = memberName(parent.callee);
+      return (
+        predicateIndex !== undefined &&
+        method !== undefined &&
+        parent.arguments[predicateIndex] === node &&
+        isDrizzleMethod(parent.callee, method)
+      );
     }
 
     function inspectRawQueryCall(node: TSESTree.CallExpression): void {
@@ -900,18 +975,31 @@ export const preferDrizzleApis = createRule({
       }
       const query = node.arguments[1];
       if (
-        query?.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        query === undefined ||
+        query.type === AST_NODE_TYPES.SpreadElement ||
         !isExecuteRawRowsCallee(node.callee) ||
-        !isDrizzleSqlTag(checker, services, query.tag)
+        !sqlSourceComposer.couldCompose(query)
       ) {
         return;
       }
-      structurallyOwnedTemplates.add(query);
-      const analysis = analyzeDirectSql(query, "statement", checker, services);
-      if (analysis.isSimpleSelect) {
-        structurallyWholeTemplates.add(query);
-      }
-      reportStructuralAnalysis(analysis);
+      structuralCallInspections.push(() => {
+        const analysis = analyzeSql(
+          query,
+          "statement",
+          checker,
+          services,
+          sqlSourceComposer,
+        );
+        for (const template of analysis.expandedTemplates) {
+          structurallyOwnedTemplates.add(template);
+        }
+        if (analysis.isSimpleSelect) {
+          for (const template of analysis.expandedTemplates) {
+            structurallyWholeTemplates.add(template);
+          }
+        }
+        reportStructuralAnalysis(analysis);
+      });
     }
 
     function inspectPredicateCall(node: TSESTree.CallExpression): void {
@@ -919,35 +1007,38 @@ export const preferDrizzleApis = createRule({
         return;
       }
       const method = memberName(node.callee);
-      const predicateIndex =
-        method === "where" || method === "having"
-          ? 0
-          : method === "innerJoin" ||
-              method === "leftJoin" ||
-              method === "rightJoin" ||
-              method === "fullJoin" ||
-              method === "innerJoinLateral" ||
-              method === "leftJoinLateral"
-            ? 1
-            : undefined;
+      const predicateIndex = predicateArgumentIndex(node);
       if (method === undefined || predicateIndex === undefined) {
         return;
       }
-      const predicate = taggedArgument(node, predicateIndex);
-      if (predicate === undefined || !isDrizzleMethod(node.callee, method)) {
+      const predicate = node.arguments[predicateIndex];
+      if (
+        predicate === undefined ||
+        predicate.type === AST_NODE_TYPES.SpreadElement ||
+        !sqlSourceComposer.couldCompose(predicate)
+      ) {
         return;
       }
-      structurallyOwnedTemplates.add(predicate);
-      const analysis = analyzeDirectSql(
-        predicate,
-        "predicate",
-        checker,
-        services,
-      );
-      reportStructuralAnalysis(analysis);
-      if (method === "innerJoin" && analysis.isTruePredicate) {
-        context.report({ node, messageId: "crossJoin" });
-      }
+      const predicateMember = node.callee;
+      structuralCallInspections.push(() => {
+        if (!isDrizzleMethod(predicateMember, method)) {
+          return;
+        }
+        const analysis = analyzeSql(
+          predicate,
+          "predicate",
+          checker,
+          services,
+          sqlSourceComposer,
+        );
+        for (const template of analysis.expandedTemplates) {
+          structurallyOwnedTemplates.add(template);
+        }
+        reportStructuralAnalysis(analysis);
+        if (method === "innerJoin" && analysis.isTruePredicate) {
+          context.report({ node, messageId: "crossJoin" });
+        }
+      });
     }
 
     function isTrueSqlTag(node: TSESTree.Expression): boolean {
@@ -1383,245 +1474,258 @@ export const preferDrizzleApis = createRule({
         context.report({ node, messageId: "crossJoinLateral" });
       },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
-        if (!isDrizzleSqlTag(checker, services, node.tag)) {
-          return;
-        }
-        if (structurallyWholeTemplates.has(node)) {
-          return;
-        }
+        legacyTemplateInspections.push(() => {
+          if (!isDrizzleSqlTag(checker, services, node.tag)) {
+            return;
+          }
+          if (structurallyWholeTemplates.has(node)) {
+            return;
+          }
 
-        const quasis = node.quasi.quasis.map(quasiText);
-        const syntaxSource = sqlCodeMask(
-          quasis.join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
-        );
-        const syntaxQuasis = syntaxSource.split(
-          SQL_TEMPLATE_EXPRESSION_BOUNDARY,
-        );
-        const expressions = node.quasi.expressions;
-        if (
-          expressions.length === 0 &&
-          quasis.length === 1 &&
-          quasis[0] === ""
-        ) {
-          context.report({ node, messageId: "emptyFragment" });
-          return;
-        }
-        const countStars = countStarMatches(syntaxSource);
-        for (const match of countStars) {
-          const isWholeAggregate =
+          const quasis = node.quasi.quasis.map(quasiText);
+          const syntaxSource = sqlCodeMask(
+            quasis.join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
+          );
+          const syntaxQuasis = syntaxSource.split(
+            SQL_TEMPLATE_EXPRESSION_BOUNDARY,
+          );
+          const expressions = node.quasi.expressions;
+          if (
             expressions.length === 0 &&
-            syntaxSource.slice(0, match.start).trim() === "" &&
-            syntaxSource.slice(match.end).trim() === "";
-          if (!isWholeAggregate || hasDirectMapWith(node)) {
-            reportLegacy(node, node, "count");
+            quasis.length === 1 &&
+            quasis[0] === ""
+          ) {
+            context.report({ node, messageId: "emptyFragment" });
+            return;
           }
-        }
-        const existence = existenceTemplateMatch(syntaxQuasis);
-        if (
-          existence !== undefined &&
-          existence.tableExpressionIndexes.every((index) => {
-            const expressionNode = expressions[index];
-            if (expressionNode === undefined) {
-              return false;
+          const countStars = countStarMatches(syntaxSource);
+          for (const match of countStars) {
+            const isWholeAggregate =
+              expressions.length === 0 &&
+              syntaxSource.slice(0, match.start).trim() === "" &&
+              syntaxSource.slice(match.end).trim() === "";
+            if (!isWholeAggregate || hasDirectMapWith(node)) {
+              reportLegacy(node, node, "count");
             }
-            const expression = expressionType(expressionNode);
-            return isDrizzleTableType(
-              checker,
-              expression.type,
-              expression.location,
-            );
-          }) &&
-          existence.predicateExpressionIndexes.every((index) => {
-            const expressionNode = expressions[index];
-            return (
-              expressionNode !== undefined &&
-              isDrizzleWrapperType(checker, expressionType(expressionNode).type)
-            );
-          })
-        ) {
-          context.report({
-            node,
-            messageId: "existencePredicate",
-            data: { helper: existence.helper },
-          });
-          return;
-        }
-        for (let index = 0; index < expressions.length - 1; index += 1) {
-          const columnNode = expressions[index];
-          const valuesNode = expressions[index + 1];
-          if (columnNode === undefined || valuesNode === undefined) {
-            continue;
           }
-          const prefix = syntaxQuasis[index] ?? "";
-          const lowerStart = lowerCallStart(prefix);
+          const existence = existenceTemplateMatch(syntaxQuasis);
           if (
-            lowerStart !== undefined &&
-            hasPredicateLeftBoundary(prefix.slice(0, lowerStart)) &&
-            /^\s*\)\s+IN\s*\(\s*$/i.test(syntaxQuasis[index + 1] ?? "") &&
-            membershipRightBoundary(syntaxQuasis[index + 2] ?? "") &&
-            isDrizzleColumnType(
-              checker,
-              expressionType(columnNode).type,
-              expressionType(columnNode).location,
-            ) &&
-            isInlineParameterListSqlJoin(valuesNode)
-          ) {
-            reportLegacy(node, columnNode, "inArray");
-          }
-        }
-        for (let index = 0; index < expressions.length - 1; index += 1) {
-          const leftNode = expressions[index];
-          const rightNode = expressions[index + 1];
-          if (leftNode === undefined || rightNode === undefined) {
-            continue;
-          }
-          const left = expressionType(leftNode);
-          const right = expressionType(rightNode);
-          const middle = syntaxQuasis[index + 1] ?? "";
-          const rawSuffix = quasis[index + 2] ?? "";
-          const binary = BINARY_HELPERS.get(middle.trim().toUpperCase());
-          if (
-            binary !== undefined &&
-            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-            (binary.rightBoundary === "pattern"
-              ? hasPatternRightBoundary(rawSuffix)
-              : hasPredicateRightBoundary(rawSuffix)) &&
-            binaryLeftMatches(binary.left, left) &&
-            binaryRightMatches(binary.right, right.type)
-          ) {
-            reportLegacy(node, leftNode, binary.helper);
-          }
-          const membership = /^\s+(NOT\s+)?IN\s*\(\s*$/i.exec(middle);
-          if (
-            membership !== null &&
-            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-            membershipRightBoundary(rawSuffix) &&
-            isDrizzleColumnType(checker, left.type, left.location) &&
-            hasParameterListOrigin(rightNode)
-          ) {
-            reportLegacy(
-              node,
-              leftNode,
-              membership[1] === undefined ? "inArray" : "notInArray",
-            );
-          }
-        }
-
-        for (let index = 0; index < expressions.length - 2; index += 1) {
-          const leftNode = expressions[index];
-          const minimumNode = expressions[index + 1];
-          const maximumNode = expressions[index + 2];
-          if (
-            leftNode === undefined ||
-            minimumNode === undefined ||
-            maximumNode === undefined
-          ) {
-            continue;
-          }
-          const range = rangeMatch(
-            syntaxQuasis[index + 1] ?? "",
-            quasis[index + 2] ?? "",
-          );
-          if (
-            range !== undefined &&
-            hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-            hasPredicateRightBoundary(quasis[index + 3] ?? "") &&
-            isDrizzleWrapperType(checker, expressionType(leftNode).type)
-          ) {
-            reportLegacy(node, leftNode, range.helper);
-          }
-        }
-
-        for (let index = 0; index < expressions.length; index += 1) {
-          const expressionNode = expressions[index];
-          if (expressionNode === undefined) {
-            continue;
-          }
-          const expression = expressionType(expressionNode);
-          const prefix = syntaxQuasis[index] ?? "";
-          const suffix = syntaxQuasis[index + 1] ?? "";
-          const rawSuffix = quasis[index + 1] ?? "";
-
-          const unary = unaryPredicateMatch(prefix);
-          if (
-            unary !== undefined &&
-            hasPredicateLeftBoundary(prefix.slice(0, unary.start)) &&
-            hasPredicateRightBoundary(rawSuffix) &&
-            isDrizzleWrapperType(checker, expression.type)
-          ) {
-            reportLegacy(node, expressionNode, unary.helper);
-          }
-
-          const nullMatch = nullPredicateMatch(suffix);
-          if (
-            nullMatch !== undefined &&
-            hasPredicateLeftBoundary(prefix) &&
-            hasPredicateRightBoundary(rawSuffix.slice(nullMatch.length)) &&
-            isDrizzleWrapperType(checker, expression.type)
-          ) {
-            reportLegacy(node, expressionNode, nullMatch.helper);
-          }
-
-          const order = orderingMatch(suffix);
-          if (
-            order !== undefined &&
-            hasOrderingLeftBoundary(prefix) &&
-            isDrizzleWrapperType(checker, expression.type)
-          ) {
-            reportLegacy(node, expressionNode, order.helper);
-          }
-
-          const aggregate = aggregateMatch(prefix);
-          const aggregateSuffix = aggregateRemainder(
-            syntaxQuasis
-              .slice(index + 1)
-              .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
-          );
-          if (
-            aggregate === undefined ||
-            aggregateSuffix === undefined ||
-            (index > 0 && prefix.slice(0, aggregate.start).trim() === "") ||
-            hasAggregateWindowSuffix(aggregateSuffix, 0) ||
-            !isDrizzleWrapperType(checker, expression.type)
-          ) {
-            continue;
-          }
-          const isWholeAggregate =
-            expressions.length === 1 &&
-            prefix.slice(0, aggregate.start).trim() === "" &&
-            aggregateSuffix.trim() === "";
-          if (!isWholeAggregate) {
-            reportLegacy(node, expressionNode, aggregate.helper);
-          } else if (
-            hasDirectMapWith(node) ||
-            ((aggregate.helper === "max" || aggregate.helper === "min") &&
-              isDrizzleColumnType(
+            existence !== undefined &&
+            existence.tableExpressionIndexes.every((index) => {
+              const expressionNode = expressions[index];
+              if (expressionNode === undefined) {
+                return false;
+              }
+              const expression = expressionType(expressionNode);
+              return isDrizzleTableType(
                 checker,
                 expression.type,
                 expression.location,
-              ))
+              );
+            }) &&
+            existence.predicateExpressionIndexes.every((index) => {
+              const expressionNode = expressions[index];
+              return (
+                expressionNode !== undefined &&
+                isDrizzleWrapperType(
+                  checker,
+                  expressionType(expressionNode).type,
+                )
+              );
+            })
           ) {
-            reportLegacy(node, node, aggregate.helper);
+            context.report({
+              node,
+              messageId: "existencePredicate",
+              data: { helper: existence.helper },
+            });
+            return;
           }
-        }
+          for (let index = 0; index < expressions.length - 1; index += 1) {
+            const columnNode = expressions[index];
+            const valuesNode = expressions[index + 1];
+            if (columnNode === undefined || valuesNode === undefined) {
+              continue;
+            }
+            const prefix = syntaxQuasis[index] ?? "";
+            const lowerStart = lowerCallStart(prefix);
+            if (
+              lowerStart !== undefined &&
+              hasPredicateLeftBoundary(prefix.slice(0, lowerStart)) &&
+              /^\s*\)\s+IN\s*\(\s*$/i.test(syntaxQuasis[index + 1] ?? "") &&
+              membershipRightBoundary(syntaxQuasis[index + 2] ?? "") &&
+              isDrizzleColumnType(
+                checker,
+                expressionType(columnNode).type,
+                expressionType(columnNode).location,
+              ) &&
+              isInlineParameterListSqlJoin(valuesNode)
+            ) {
+              reportLegacy(node, columnNode, "inArray");
+            }
+          }
+          for (let index = 0; index < expressions.length - 1; index += 1) {
+            const leftNode = expressions[index];
+            const rightNode = expressions[index + 1];
+            if (leftNode === undefined || rightNode === undefined) {
+              continue;
+            }
+            const left = expressionType(leftNode);
+            const right = expressionType(rightNode);
+            const middle = syntaxQuasis[index + 1] ?? "";
+            const rawSuffix = quasis[index + 2] ?? "";
+            const binary = BINARY_HELPERS.get(middle.trim().toUpperCase());
+            if (
+              binary !== undefined &&
+              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+              (binary.rightBoundary === "pattern"
+                ? hasPatternRightBoundary(rawSuffix)
+                : hasPredicateRightBoundary(rawSuffix)) &&
+              binaryLeftMatches(binary.left, left) &&
+              binaryRightMatches(binary.right, right.type)
+            ) {
+              reportLegacy(node, leftNode, binary.helper);
+            }
+            const membership = /^\s+(NOT\s+)?IN\s*\(\s*$/i.exec(middle);
+            if (
+              membership !== null &&
+              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+              membershipRightBoundary(rawSuffix) &&
+              isDrizzleColumnType(checker, left.type, left.location) &&
+              hasParameterListOrigin(rightNode)
+            ) {
+              reportLegacy(
+                node,
+                leftNode,
+                membership[1] === undefined ? "inArray" : "notInArray",
+              );
+            }
+          }
 
-        const boolean = booleanHelper(syntaxQuasis);
-        if (boolean === undefined) {
-          return;
-        }
-        if (
-          !expressions.every((expressionNode) => {
-            return isDrizzleWrapperType(
-              checker,
-              expressionType(expressionNode).type,
+          for (let index = 0; index < expressions.length - 2; index += 1) {
+            const leftNode = expressions[index];
+            const minimumNode = expressions[index + 1];
+            const maximumNode = expressions[index + 2];
+            if (
+              leftNode === undefined ||
+              minimumNode === undefined ||
+              maximumNode === undefined
+            ) {
+              continue;
+            }
+            const range = rangeMatch(
+              syntaxQuasis[index + 1] ?? "",
+              quasis[index + 2] ?? "",
             );
-          })
-        ) {
-          return;
+            if (
+              range !== undefined &&
+              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
+              hasPredicateRightBoundary(quasis[index + 3] ?? "") &&
+              isDrizzleWrapperType(checker, expressionType(leftNode).type)
+            ) {
+              reportLegacy(node, leftNode, range.helper);
+            }
+          }
+
+          for (let index = 0; index < expressions.length; index += 1) {
+            const expressionNode = expressions[index];
+            if (expressionNode === undefined) {
+              continue;
+            }
+            const expression = expressionType(expressionNode);
+            const prefix = syntaxQuasis[index] ?? "";
+            const suffix = syntaxQuasis[index + 1] ?? "";
+            const rawSuffix = quasis[index + 1] ?? "";
+
+            const unary = unaryPredicateMatch(prefix);
+            if (
+              unary !== undefined &&
+              hasPredicateLeftBoundary(prefix.slice(0, unary.start)) &&
+              hasPredicateRightBoundary(rawSuffix) &&
+              isDrizzleWrapperType(checker, expression.type)
+            ) {
+              reportLegacy(node, expressionNode, unary.helper);
+            }
+
+            const nullMatch = nullPredicateMatch(suffix);
+            if (
+              nullMatch !== undefined &&
+              hasPredicateLeftBoundary(prefix) &&
+              hasPredicateRightBoundary(rawSuffix.slice(nullMatch.length)) &&
+              isDrizzleWrapperType(checker, expression.type)
+            ) {
+              reportLegacy(node, expressionNode, nullMatch.helper);
+            }
+
+            const order = orderingMatch(suffix);
+            if (
+              order !== undefined &&
+              hasOrderingLeftBoundary(prefix) &&
+              isDrizzleWrapperType(checker, expression.type)
+            ) {
+              reportLegacy(node, expressionNode, order.helper);
+            }
+
+            const aggregate = aggregateMatch(prefix);
+            const aggregateSuffix = aggregateRemainder(
+              syntaxQuasis
+                .slice(index + 1)
+                .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
+            );
+            if (
+              aggregate === undefined ||
+              aggregateSuffix === undefined ||
+              (index > 0 && prefix.slice(0, aggregate.start).trim() === "") ||
+              hasAggregateWindowSuffix(aggregateSuffix, 0) ||
+              !isDrizzleWrapperType(checker, expression.type)
+            ) {
+              continue;
+            }
+            const isWholeAggregate =
+              expressions.length === 1 &&
+              prefix.slice(0, aggregate.start).trim() === "" &&
+              aggregateSuffix.trim() === "";
+            if (!isWholeAggregate) {
+              reportLegacy(node, expressionNode, aggregate.helper);
+            } else if (
+              hasDirectMapWith(node) ||
+              ((aggregate.helper === "max" || aggregate.helper === "min") &&
+                isDrizzleColumnType(
+                  checker,
+                  expression.type,
+                  expression.location,
+                ))
+            ) {
+              reportLegacy(node, node, aggregate.helper);
+            }
+          }
+
+          const boolean = booleanHelper(syntaxQuasis);
+          if (boolean === undefined) {
+            return;
+          }
+          if (
+            !expressions.every((expressionNode) => {
+              return isDrizzleWrapperType(
+                checker,
+                expressionType(expressionNode).type,
+              );
+            })
+          ) {
+            return;
+          }
+          const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+          if (isOptionalDrizzleContext(checker.getContextualType(tsNode))) {
+            reportLegacy(node, node, boolean);
+          }
+        });
+      },
+      "Program:exit"(): void {
+        for (const inspect of structuralCallInspections) {
+          inspect();
         }
-        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-        if (isOptionalDrizzleContext(checker.getContextualType(tsNode))) {
-          reportLegacy(node, node, boolean);
+        for (const inspect of legacyTemplateInspections) {
+          inspect();
         }
       },
     };

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -866,7 +866,20 @@ export const preferDrizzleApis = createRule({
     function registerStructuralOwnership(analysis: SqlAnalysis): void {
       for (const template of analysis.expandedTemplates) {
         structurallyOwnedTemplates.add(template);
-        if (analysis.ownsExpandedTemplates) {
+        // Expansion can cross into a shared alias or factory definition. A
+        // use-site finding replaces only templates in its own syntax subtree.
+        if (
+          analysis.findings.some((finding) => {
+            let current: TSESTree.Node | null | undefined = template;
+            while (current !== undefined && current !== null) {
+              if (current === finding.node) {
+                return true;
+              }
+              current = current.parent;
+            }
+            return false;
+          })
+        ) {
           structurallyWholeTemplates.add(template);
         }
       }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -863,6 +863,15 @@ export const preferDrizzleApis = createRule({
       }
     }
 
+    function registerStructuralOwnership(analysis: SqlAnalysis): void {
+      for (const template of analysis.expandedTemplates) {
+        structurallyOwnedTemplates.add(template);
+        if (analysis.ownsExpandedTemplates) {
+          structurallyWholeTemplates.add(template);
+        }
+      }
+    }
+
     function reportLegacy(
       template: TSESTree.TaggedTemplateExpression,
       node: TSESTree.Node,
@@ -990,14 +999,7 @@ export const preferDrizzleApis = createRule({
           services,
           sqlSourceComposer,
         );
-        for (const template of analysis.expandedTemplates) {
-          structurallyOwnedTemplates.add(template);
-        }
-        if (analysis.isSimpleSelect) {
-          for (const template of analysis.expandedTemplates) {
-            structurallyWholeTemplates.add(template);
-          }
-        }
+        registerStructuralOwnership(analysis);
         reportStructuralAnalysis(analysis);
       });
     }
@@ -1031,9 +1033,7 @@ export const preferDrizzleApis = createRule({
           services,
           sqlSourceComposer,
         );
-        for (const template of analysis.expandedTemplates) {
-          structurallyOwnedTemplates.add(template);
-        }
+        registerStructuralOwnership(analysis);
         reportStructuralAnalysis(analysis);
         if (method === "innerJoin" && analysis.isTruePredicate) {
           context.report({ node, messageId: "crossJoin" });

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-query-builder.ts
@@ -34,7 +34,13 @@ import {
   SQL_TEMPLATE_EXPRESSION_BOUNDARY,
   sqlCodeMask,
 } from "../sql-lexing.ts";
-import { analyzeDirectSql } from "../sql-analysis/direct-sql-analysis.ts";
+import { analyzeSql } from "../sql-analysis/sql-analysis.ts";
+import {
+  createSqlSourceComposer,
+  type LegacySqlSource,
+  renderLegacySqlSource,
+  type SqlSource,
+} from "../sql-analysis/sql-source.ts";
 import { createRule } from "../utils.ts";
 
 interface SqlTokenBase {
@@ -74,7 +80,9 @@ interface PaginatedJoinedSelectMatch {
 
 interface SimpleLockingSelectMatch {
   readonly lockTableExpressionIndex: number | undefined;
+  readonly sourceTableEnd: number;
   readonly sourceTableExpressionIndex: number | undefined;
+  readonly sourceTableStart: number;
 }
 
 interface SimpleLockingCteUpdateMatch {
@@ -86,7 +94,9 @@ interface SimpleLockingCteUpdateMatch {
 }
 
 interface SimpleDeleteMatch {
+  readonly targetTableEnd: number;
   readonly targetTableExpressionIndex: number | undefined;
+  readonly targetTableStart: number;
 }
 
 interface SimpleUnnestUpdateMatch {
@@ -94,7 +104,9 @@ interface SimpleUnnestUpdateMatch {
 }
 
 interface SimpleUpsertMatch {
+  readonly targetTableEnd: number;
   readonly targetTableExpressionIndex: number | undefined;
+  readonly targetTableStart: number;
 }
 
 interface ScalarCteBodyMatch {
@@ -110,12 +122,6 @@ interface CompleteSqlStatement {
   readonly end: number;
   readonly hasTrailingSemicolon: boolean;
   readonly tokens: readonly SqlToken[];
-}
-
-interface ComposedSqlTemplate {
-  readonly expandedFactory: boolean;
-  readonly expressions: readonly TSESTree.Expression[];
-  readonly source: string;
 }
 
 interface RelationMatch {
@@ -1306,10 +1312,12 @@ function simpleDeleteMatch(
   }
 
   return {
+    targetTableEnd: targetTable.end,
     targetTableExpressionIndex:
       targetTable.kind === "expression"
         ? targetTable.expressionIndex
         : undefined,
+    targetTableStart: targetTable.start,
   };
 }
 
@@ -1523,10 +1531,12 @@ function simpleUpsertMatch(
   }
 
   return {
+    targetTableEnd: targetTable.end,
     targetTableExpressionIndex:
       targetTable.kind === "expression"
         ? targetTable.expressionIndex
         : undefined,
+    targetTableStart: targetTable.start,
   };
 }
 
@@ -1730,10 +1740,12 @@ function simpleLockingSelectMatch(
 
   return {
     lockTableExpressionIndex,
+    sourceTableEnd: sourceTable.end,
     sourceTableExpressionIndex:
       sourceTable.kind === "expression"
         ? sourceTable.expressionIndex
         : undefined,
+    sourceTableStart: sourceTable.start,
   };
 }
 
@@ -2314,6 +2326,7 @@ export const preferDrizzleQueryBuilder = createRule({
     // syntax. The API baseline has hundreds of result calls but zero targets.
     const scalarQueryCandidates = new Set<TSESTree.TaggedTemplateExpression>();
     const structuredSelectionCalls: TSESTree.CallExpression[] = [];
+    const completeSqlInspections: Array<() => void> = [];
     const reportedScalarQueries = new Set<TSESTree.TaggedTemplateExpression>();
     const resultPropertyTypes: Record<
       "execute" | "from",
@@ -2322,17 +2335,57 @@ export const preferDrizzleQueryBuilder = createRule({
       execute: new Map<Type, boolean>(),
       from: new Map<Type, boolean>(),
     };
+    const drizzleExecuteMemberCache = new WeakMap<
+      TSESTree.MemberExpression,
+      boolean
+    >();
+    const sqlSourceComposer = createSqlSourceComposer(
+      context.sourceCode,
+      checker,
+      services,
+      isSafeSqlTerminalUse,
+    );
 
     function isDrizzleExecuteMember(node: TSESTree.MemberExpression): boolean {
       if (memberName(node) !== "execute") {
         return false;
       }
+      const cached = drizzleExecuteMemberCache.get(node);
+      if (cached !== undefined) {
+        return cached;
+      }
       const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
-      return (
+      const result =
         checker
           .getSymbolAtLocation(tsProperty)
-          ?.declarations?.some(isDrizzleDeclaration) === true
-      );
+          ?.declarations?.some(isDrizzleDeclaration) === true;
+      drizzleExecuteMemberCache.set(node, result);
+      return result;
+    }
+
+    function isSafeSqlTerminalUse(node: TSESTree.Expression): boolean {
+      const parent = node.parent;
+      if (
+        parent.type === AST_NODE_TYPES.CallExpression &&
+        parent.arguments.length === 3 &&
+        parent.arguments[1] === node &&
+        !parent.arguments.some((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement;
+        }) &&
+        isExecuteRawRowsCallee(parent.callee)
+      ) {
+        return true;
+      }
+      if (
+        parent.type === AST_NODE_TYPES.CallExpression &&
+        parent.arguments.length === 1 &&
+        parent.arguments[0] === node &&
+        parent.callee.type === AST_NODE_TYPES.MemberExpression &&
+        isDrizzleExecuteMember(parent.callee)
+      ) {
+        return true;
+      }
+      return isStructuredResultArgument(node);
     }
 
     function expressionType(node: TSESTree.Expression) {
@@ -2391,10 +2444,9 @@ export const preferDrizzleQueryBuilder = createRule({
     }
 
     function isSchemaBackedPaginatedJoin(
-      query: TSESTree.TaggedTemplateExpression,
+      expressions: readonly TSESTree.Expression[],
       match: PaginatedJoinedSelectMatch,
     ): boolean {
-      const expressions = query.quasi.expressions;
       const limitExpression =
         match.limitExpressionIndex === undefined
           ? undefined
@@ -2698,157 +2750,20 @@ export const preferDrizzleQueryBuilder = createRule({
       return services.tsNodeToESTreeNodeMap.get(statement.expression);
     }
 
-    function hasOnlyDirectCallReferences(node: TSESTree.Identifier): boolean {
-      const variable = variableInScope(node);
+    function isComposedBuilderCteQuery(source: SqlSource): boolean {
       return (
-        variable !== null &&
-        variable.references.every((reference) => {
-          if (reference.init === true) {
-            return true;
-          }
-          const identifier = reference.identifier;
-          if (identifier.type !== AST_NODE_TYPES.Identifier) {
-            return false;
-          }
-          const callee = outerTransparentExpression(identifier);
+        source.hasLocalExpansion &&
+        source.variants.every((variant) => {
+          const rendered = renderLegacySqlSource(variant);
           return (
-            callee.parent?.type === AST_NODE_TYPES.CallExpression &&
-            callee.parent.callee === callee
-          );
-        })
-      );
-    }
-
-    function localSqlFactoryTemplate(node: TSESTree.Expression): {
-      readonly declaration: Node;
-      readonly template: TSESTree.TaggedTemplateExpression;
-    } | null {
-      let call: TSESTree.Node = node;
-      let transparentCall = transparentExpression(call);
-      while (transparentCall !== null) {
-        call = transparentCall;
-        transparentCall = transparentExpression(call);
-      }
-      if (
-        call.type !== AST_NODE_TYPES.CallExpression ||
-        call.callee.type !== AST_NODE_TYPES.Identifier ||
-        call.arguments.some((argument) => {
-          return argument.type === AST_NODE_TYPES.SpreadElement;
-        }) ||
-        !hasOnlyDirectCallReferences(call.callee) ||
-        !isDrizzleWrapperType(checker, expressionType(call).type)
-      ) {
-        return null;
-      }
-
-      const tsCallee = services.esTreeNodeToTSNodeMap.get(call.callee);
-      const declaration = resolvedSymbol(
-        checker,
-        checker.getSymbolAtLocation(tsCallee),
-      )?.valueDeclaration;
-      if (
-        declaration === undefined ||
-        !isFunctionDeclaration(declaration) ||
-        declaration.getSourceFile() !== tsCallee.getSourceFile() ||
-        declaration.body === undefined ||
-        declaration.body.statements.length !== 1 ||
-        hasExportModifier(declaration)
-      ) {
-        return null;
-      }
-      const statement = declaration.body.statements[0];
-      if (
-        statement === undefined ||
-        !isReturnStatement(statement) ||
-        statement.expression === undefined
-      ) {
-        return null;
-      }
-
-      let returned = services.tsNodeToESTreeNodeMap.get(statement.expression);
-      let transparent = transparentExpression(returned);
-      while (transparent !== null) {
-        returned = transparent;
-        transparent = transparentExpression(returned);
-      }
-      return returned.type === AST_NODE_TYPES.TaggedTemplateExpression
-        ? { declaration, template: returned }
-        : null;
-    }
-
-    function composeSqlTemplate(
-      template: TSESTree.TaggedTemplateExpression,
-      activeFactories: Set<Node>,
-    ): ComposedSqlTemplate | null {
-      if (!isDrizzleSqlTag(checker, services, template.tag)) {
-        return null;
-      }
-      const firstQuasi = template.quasi.quasis[0];
-      if (firstQuasi === undefined) {
-        return null;
-      }
-
-      let source = quasiText(firstQuasi);
-      let expandedFactory = false;
-      const expressions: TSESTree.Expression[] = [];
-      for (
-        let index = 0;
-        index < template.quasi.expressions.length;
-        index += 1
-      ) {
-        const expression = template.quasi.expressions[index];
-        const followingQuasi = template.quasi.quasis[index + 1];
-        if (expression === undefined || followingQuasi === undefined) {
-          return null;
-        }
-
-        const factory = localSqlFactoryTemplate(expression);
-        if (factory !== null && !activeFactories.has(factory.declaration)) {
-          activeFactories.add(factory.declaration);
-          const nested = composeSqlTemplate(factory.template, activeFactories);
-          activeFactories.delete(factory.declaration);
-          if (nested !== null) {
-            source += nested.source;
-            expressions.push(...nested.expressions);
-            expandedFactory = true;
-          } else {
-            source += SQL_TEMPLATE_EXPRESSION_BOUNDARY;
-            expressions.push(expression);
-          }
-        } else {
-          source += SQL_TEMPLATE_EXPRESSION_BOUNDARY;
-          expressions.push(expression);
-        }
-        source += quasiText(followingQuasi);
-      }
-
-      return { expandedFactory, expressions, source };
-    }
-
-    function isComposedBuilderCteQuery(
-      query: TSESTree.TaggedTemplateExpression,
-    ): boolean {
-      const firstQuasi = query.quasi.quasis[0];
-      const firstExpression = query.quasi.expressions[0];
-      if (
-        firstQuasi === undefined ||
-        firstExpression === undefined ||
-        sqlCodeMask(quasiText(firstQuasi)).trim() !== "" ||
-        localSqlFactoryTemplate(firstExpression) === null
-      ) {
-        return false;
-      }
-
-      const composition = composeSqlTemplate(query, new Set<Node>());
-      return (
-        composition !== null &&
-        composition.expandedFactory &&
-        completeBuilderCteSelectMatch(sqlCodeMask(composition.source)) &&
-        composition.expressions.every((expression) => {
-          const type = expressionType(expression).type;
-          return (
-            isBoundScalarParameterType(type) ||
-            isDrizzleWrapperType(checker, type)
+            completeBuilderCteSelectMatch(sqlCodeMask(rendered.source)) &&
+            rendered.expressions.every((expression) => {
+              const type = expressionType(expression).type;
+              return (
+                isBoundScalarParameterType(type) ||
+                isDrizzleWrapperType(checker, type)
+              );
+            })
           );
         })
       );
@@ -2903,6 +2818,11 @@ export const preferDrizzleQueryBuilder = createRule({
         inspectSelectedValue(transparent, visited);
         return;
       }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        inspectSelectedValue(node.consequent, visited);
+        inspectSelectedValue(node.alternate, visited);
+        return;
+      }
       const initializer = localConstInitializer(node);
       if (initializer !== null) {
         inspectSelectedValue(initializer, visited);
@@ -2933,6 +2853,11 @@ export const preferDrizzleQueryBuilder = createRule({
       const transparent = transparentExpression(node);
       if (transparent !== null) {
         inspectSelectionContainer(transparent, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        inspectSelectionContainer(node.consequent, visited);
+        inspectSelectionContainer(node.alternate, visited);
         return;
       }
       const initializer = localConstInitializer(node);
@@ -2977,63 +2902,72 @@ export const preferDrizzleQueryBuilder = createRule({
       inspectSelectionContainer(fields, new Set<TSESTree.Node>());
     }
 
-    function inspectCompleteWrite(node: TSESTree.CallExpression): void {
-      if (
-        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-        memberName(node.callee) !== "execute" ||
-        node.arguments.length !== 1
-      ) {
-        return;
-      }
-      const query = node.arguments[0];
-      if (
-        query === undefined ||
-        query.type !== AST_NODE_TYPES.TaggedTemplateExpression
-      ) {
-        return;
-      }
-
-      const source = query.quasi.quasis
-        .map(quasiText)
-        .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
-      const syntaxSource = sqlCodeMask(source);
+    function writeVariantMessage(
+      rendered: LegacySqlSource,
+    ):
+      | "deleteQueryBuilder"
+      | "lockingCteUpdateQueryBuilder"
+      | "unnestUpdateQueryBuilder"
+      | "upsertQueryBuilder"
+      | null {
+      const syntaxSource = sqlCodeMask(rendered.source);
       const statement = completeSqlStatement(syntaxSource);
       if (statement === undefined) {
-        return;
+        return null;
       }
       const deleteMatch = simpleDeleteMatch(syntaxSource, statement);
       const unnestUpdateMatch =
         deleteMatch === undefined
-          ? simpleUnnestUpdateMatch(source, syntaxSource, statement)
+          ? simpleUnnestUpdateMatch(rendered.source, syntaxSource, statement)
           : undefined;
       const lockingCteUpdateMatch =
         deleteMatch === undefined && unnestUpdateMatch === undefined
-          ? simpleLockingCteUpdateMatch(source, syntaxSource, statement)
+          ? simpleLockingCteUpdateMatch(
+              rendered.source,
+              syntaxSource,
+              statement,
+            )
           : undefined;
       const upsertMatch =
         deleteMatch === undefined &&
         unnestUpdateMatch === undefined &&
         lockingCteUpdateMatch === undefined
-          ? simpleUpsertMatch(source, syntaxSource, statement)
+          ? simpleUpsertMatch(rendered.source, syntaxSource, statement)
           : undefined;
       const match =
         deleteMatch ??
         unnestUpdateMatch ??
         lockingCteUpdateMatch ??
         upsertMatch;
-      if (
-        match === undefined ||
-        !isDrizzleSqlTag(checker, services, query.tag) ||
-        !isDrizzleExecuteMember(node.callee)
-      ) {
-        return;
+      if (match === undefined) {
+        return null;
       }
 
       const targetTableExpressionIndex = match.targetTableExpressionIndex;
+      const literalTarget =
+        deleteMatch !== undefined &&
+        deleteMatch.targetTableExpressionIndex === undefined
+          ? deleteMatch
+          : upsertMatch !== undefined &&
+              upsertMatch.targetTableExpressionIndex === undefined
+            ? upsertMatch
+            : undefined;
+      if (
+        literalTarget !== undefined &&
+        rendered.literalRanges.some((range) => {
+          return (
+            range.depth > 0 &&
+            range.start < literalTarget.targetTableEnd &&
+            range.end > literalTarget.targetTableStart
+          );
+        })
+      ) {
+        return null;
+      }
       if (targetTableExpressionIndex !== undefined) {
-        const targetTable = query.quasi.expressions[targetTableExpressionIndex];
+        const targetTable = rendered.expressions[targetTableExpressionIndex];
         if (targetTable === undefined) {
-          return;
+          return null;
         }
         const targetTableType = expressionType(targetTable);
         if (
@@ -3043,12 +2977,12 @@ export const preferDrizzleQueryBuilder = createRule({
             targetTableType.location,
           )
         ) {
-          return;
+          return null;
         }
       }
 
       if (lockingCteUpdateMatch !== undefined) {
-        const expressions = query.quasi.expressions;
+        const expressions = rendered.expressions;
         const sourceTable =
           expressions[lockingCteUpdateMatch.sourceTableExpressionIndex];
         const lockTable =
@@ -3066,7 +3000,7 @@ export const preferDrizzleQueryBuilder = createRule({
           orderColumn === undefined ||
           targetTable === undefined
         ) {
-          return;
+          return null;
         }
         const selectedColumnType = expressionType(selectedColumn);
         const orderColumnType = expressionType(orderColumn);
@@ -3090,26 +3024,185 @@ export const preferDrizzleQueryBuilder = createRule({
           context.sourceCode.getText(selectedColumn) !==
             context.sourceCode.getText(orderColumn)
         ) {
-          return;
+          return null;
         }
       }
 
-      context.report({
-        node: query,
-        messageId:
-          deleteMatch !== undefined
-            ? "deleteQueryBuilder"
-            : unnestUpdateMatch !== undefined
-              ? "unnestUpdateQueryBuilder"
-              : lockingCteUpdateMatch !== undefined
-                ? "lockingCteUpdateQueryBuilder"
-                : "upsertQueryBuilder",
+      return deleteMatch !== undefined
+        ? "deleteQueryBuilder"
+        : unnestUpdateMatch !== undefined
+          ? "unnestUpdateQueryBuilder"
+          : lockingCteUpdateMatch !== undefined
+            ? "lockingCteUpdateQueryBuilder"
+            : "upsertQueryBuilder";
+    }
+
+    function scheduleCompleteWriteInspection(
+      node: TSESTree.CallExpression,
+    ): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "execute" ||
+        node.arguments.length !== 1
+      ) {
+        return;
+      }
+      const query = node.arguments[0];
+      if (
+        query === undefined ||
+        query.type === AST_NODE_TYPES.SpreadElement ||
+        !sqlSourceComposer.couldCompose(query)
+      ) {
+        return;
+      }
+      const executeMember = node.callee;
+      completeSqlInspections.push(() => {
+        if (!isDrizzleExecuteMember(executeMember)) {
+          return;
+        }
+        const source = sqlSourceComposer.compose(query);
+        if (source === null) {
+          return;
+        }
+        const messages = source.variants.map((variant) => {
+          return writeVariantMessage(renderLegacySqlSource(variant));
+        });
+        const messageId = messages[0];
+        if (
+          messageId === undefined ||
+          messageId === null ||
+          messages.some((message) => {
+            return message !== messageId;
+          })
+        ) {
+          return;
+        }
+        context.report({ node: query, messageId });
       });
+    }
+
+    function rawVariantMessage(
+      rendered: LegacySqlSource,
+    ):
+      | "existsQueryBuilder"
+      | "lockingQueryBuilder"
+      | "queryBuilder"
+      | "scalarCteQueryBuilder"
+      | null {
+      const syntaxSource = sqlCodeMask(rendered.source);
+      if (
+        completeScalarCteProjectionMatch(syntaxSource) &&
+        rendered.expressions.every((expression) => {
+          return isBoundScalarParameterType(expressionType(expression).type);
+        })
+      ) {
+        return "scalarCteQueryBuilder";
+      }
+
+      const lockingMatch = simpleLockingSelectMatch(syntaxSource);
+      if (lockingMatch !== undefined) {
+        const sourceTableExpressionIndex =
+          lockingMatch.sourceTableExpressionIndex;
+        if (
+          sourceTableExpressionIndex === undefined &&
+          rendered.literalRanges.some((range) => {
+            return (
+              range.depth > 0 &&
+              range.start < lockingMatch.sourceTableEnd &&
+              range.end > lockingMatch.sourceTableStart
+            );
+          })
+        ) {
+          return null;
+        }
+        if (sourceTableExpressionIndex !== undefined) {
+          const sourceTable = rendered.expressions[sourceTableExpressionIndex];
+          if (sourceTable === undefined) {
+            return null;
+          }
+          const sourceTableType = expressionType(sourceTable);
+          if (
+            !isDrizzleTableType(
+              checker,
+              sourceTableType.type,
+              sourceTableType.location,
+            )
+          ) {
+            return null;
+          }
+        }
+        const lockTableExpressionIndex = lockingMatch.lockTableExpressionIndex;
+        if (
+          lockTableExpressionIndex !== undefined &&
+          !isDrizzleTableExpression(
+            rendered.expressions[lockTableExpressionIndex],
+          )
+        ) {
+          return null;
+        }
+        return "lockingQueryBuilder";
+      }
+
+      const joinedMatch = paginatedJoinedSelectMatch(
+        syntaxSource,
+        "schema-expression",
+      );
+      const existsMatch =
+        joinedMatch === undefined
+          ? completePaginatedExistsSelectMatch(syntaxSource)
+          : undefined;
+      const structuredMatch = joinedMatch ?? existsMatch;
+      if (
+        structuredMatch === undefined ||
+        !isSchemaBackedPaginatedJoin(rendered.expressions, structuredMatch)
+      ) {
+        return null;
+      }
+      return existsMatch === undefined ? "queryBuilder" : "existsQueryBuilder";
+    }
+
+    function inspectRawRowsQuery(query: TSESTree.Expression): void {
+      const source = sqlSourceComposer.compose(query);
+      if (source === null) {
+        return;
+      }
+      let messageId:
+        | "composedCteQueryBuilder"
+        | "existsQueryBuilder"
+        | "lockingQueryBuilder"
+        | "queryBuilder"
+        | "scalarCteQueryBuilder"
+        | undefined;
+      if (isComposedBuilderCteQuery(source)) {
+        messageId = "composedCteQueryBuilder";
+      } else {
+        const messages = source.variants.map((variant) => {
+          return rawVariantMessage(renderLegacySqlSource(variant));
+        });
+        const firstMessage = messages[0];
+        if (
+          firstMessage !== undefined &&
+          firstMessage !== null &&
+          messages.every((message) => {
+            return message === firstMessage;
+          })
+        ) {
+          messageId = firstMessage;
+        }
+      }
+      if (
+        messageId === undefined ||
+        analyzeSql(query, "statement", checker, services, sqlSourceComposer)
+          .isSimpleSelect
+      ) {
+        return;
+      }
+      context.report({ node: query, messageId });
     }
 
     return {
       CallExpression(node: TSESTree.CallExpression): void {
-        inspectCompleteWrite(node);
+        scheduleCompleteWriteInspection(node);
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           RESULT_FIELD_ARGUMENT.has(memberName(node.callee) ?? "")
@@ -3117,7 +3210,6 @@ export const preferDrizzleQueryBuilder = createRule({
           structuredSelectionCalls.push(node);
         }
         if (
-          !isExecuteRawRowsCallee(node.callee) ||
           node.arguments.length !== 3 ||
           node.arguments.some((argument) => {
             return argument.type === AST_NODE_TYPES.SpreadElement;
@@ -3128,94 +3220,14 @@ export const preferDrizzleQueryBuilder = createRule({
         const query = node.arguments[1];
         if (
           query === undefined ||
-          query.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
-          !isDrizzleSqlTag(checker, services, query.tag)
+          query.type === AST_NODE_TYPES.SpreadElement ||
+          !isExecuteRawRowsCallee(node.callee) ||
+          !sqlSourceComposer.couldCompose(query)
         ) {
           return;
         }
-        if (
-          analyzeDirectSql(query, "statement", checker, services).isSimpleSelect
-        ) {
-          return;
-        }
-
-        const source = query.quasi.quasis
-          .map(quasiText)
-          .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY);
-        const syntaxSource = sqlCodeMask(source);
-        if (isComposedBuilderCteQuery(query)) {
-          context.report({
-            node: query,
-            messageId: "composedCteQueryBuilder",
-          });
-          return;
-        }
-        if (
-          completeScalarCteProjectionMatch(syntaxSource) &&
-          query.quasi.expressions.every((expression) => {
-            return isBoundScalarParameterType(expressionType(expression).type);
-          })
-        ) {
-          context.report({ node: query, messageId: "scalarCteQueryBuilder" });
-          return;
-        }
-        const lockingMatch = simpleLockingSelectMatch(syntaxSource);
-        if (lockingMatch !== undefined) {
-          const sourceTableExpressionIndex =
-            lockingMatch.sourceTableExpressionIndex;
-          if (sourceTableExpressionIndex !== undefined) {
-            const sourceTable =
-              query.quasi.expressions[sourceTableExpressionIndex];
-            if (sourceTable === undefined) {
-              return;
-            }
-            const sourceTableType = expressionType(sourceTable);
-            if (
-              !isDrizzleTableType(
-                checker,
-                sourceTableType.type,
-                sourceTableType.location,
-              )
-            ) {
-              return;
-            }
-          }
-          const lockTableExpressionIndex =
-            lockingMatch.lockTableExpressionIndex;
-          if (lockTableExpressionIndex !== undefined) {
-            const lockTable = query.quasi.expressions[lockTableExpressionIndex];
-            if (!isDrizzleTableExpression(lockTable)) {
-              return;
-            }
-          }
-          context.report({ node: query, messageId: "lockingQueryBuilder" });
-          return;
-        }
-
-        const joinedMatch = paginatedJoinedSelectMatch(
-          syntaxSource,
-          "schema-expression",
-        );
-        const existsMatch =
-          joinedMatch === undefined
-            ? completePaginatedExistsSelectMatch(syntaxSource)
-            : undefined;
-        if (joinedMatch === undefined && existsMatch === undefined) {
-          return;
-        }
-
-        const structuredMatch = joinedMatch ?? existsMatch;
-        if (
-          structuredMatch === undefined ||
-          !isSchemaBackedPaginatedJoin(query, structuredMatch)
-        ) {
-          return;
-        }
-
-        context.report({
-          node: query,
-          messageId:
-            existsMatch === undefined ? "queryBuilder" : "existsQueryBuilder",
+        completeSqlInspections.push(() => {
+          inspectRawRowsQuery(query);
         });
       },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
@@ -3227,6 +3239,9 @@ export const preferDrizzleQueryBuilder = createRule({
         }
       },
       "Program:exit"(): void {
+        for (const inspect of completeSqlInspections) {
+          inspect();
+        }
         if (scalarQueryCandidates.size === 0) {
           return;
         }

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+
 import {
   AST_NODE_TYPES,
   type ParserServicesWithTypeInformation,
@@ -11,7 +13,11 @@ import {
   isDrizzleWrapperType,
 } from "../drizzle.ts";
 import { parsePostgres } from "./postgres-parser.ts";
-import { type SqlSourceComposer, type SqlSourceVariant } from "./sql-source.ts";
+import {
+  type SqlSourceChunk,
+  type SqlSourceComposer,
+  type SqlSourceVariant,
+} from "./sql-source.ts";
 
 type SqlAnalysisContext = "predicate" | "statement";
 
@@ -35,6 +41,7 @@ export interface SqlAnalysis {
 }
 
 interface SqlMarker {
+  readonly chunk: SqlSourceChunk;
   readonly isColumn: boolean;
   readonly isTable: boolean;
   readonly isWrapper: boolean;
@@ -43,10 +50,17 @@ interface SqlMarker {
 
 interface ParsedSql {
   readonly markers: ReadonlyMap<string, SqlMarker>;
+  readonly sourceRanges: readonly SqlSourceRange[];
   readonly statement: unknown;
 }
 
-type StructuralExpression =
+interface SqlSourceRange {
+  readonly chunk: SqlSourceChunk;
+  readonly end: number;
+  readonly start: number;
+}
+
+type StructuralExpression = (
   | {
       readonly children: readonly StructuralExpression[];
       readonly kind: "opaque";
@@ -68,11 +82,21 @@ type StructuralExpression =
       readonly items: readonly StructuralExpression[];
       readonly kind: "boolean";
       readonly operator: "and" | "or";
-    };
+    }
+) & {
+  readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
+};
+
+type ClassifiedHelperFinding = Extract<
+  SqlAnalysisFinding,
+  { readonly kind: "helper" }
+> & {
+  readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
+};
 
 interface ExpressionClassification {
   readonly anchor: TSESTree.Node | undefined;
-  readonly findings: readonly SqlAnalysisFinding[];
+  readonly findings: readonly ClassifiedHelperFinding[];
   readonly isWholeReplacement: boolean;
 }
 
@@ -185,6 +209,7 @@ function markerPrefix(quasis: readonly string[]): string {
 function parseSqlVariant(
   variant: SqlSourceVariant,
   context: SqlAnalysisContext,
+  trackSourceRanges: boolean,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
 ): ParsedSql | null {
@@ -193,20 +218,34 @@ function parseSqlVariant(
   });
   const prefix = markerPrefix(literals);
   const markers = new Map<string, SqlMarker>();
-  let source = "";
+  const sourceRanges: SqlSourceRange[] = [];
+  const contextPrefix = context === "statement" ? "" : "SELECT 1 WHERE ";
+  let source = contextPrefix;
+  // libpg_query locations are UTF-8 byte offsets, not JavaScript string
+  // indexes.
+  let sourceByteLength = trackSourceRanges
+    ? Buffer.byteLength(contextPrefix)
+    : 0;
   let markerIndex = 0;
   for (const chunk of variant.chunks) {
+    const start = sourceByteLength;
     if (chunk.kind === "literal") {
       source += chunk.text;
+      if (trackSourceRanges) {
+        sourceByteLength += Buffer.byteLength(chunk.text);
+        sourceRanges.push({ chunk, end: sourceByteLength, start });
+      }
       continue;
     }
     const expression = chunk.expression;
     const name = `${prefix}${markerIndex}`;
+    const markerSource = `"${name}"`;
     markerIndex += 1;
     let cachedColumn: boolean | undefined;
     let cachedTable: boolean | undefined;
     let cachedWrapper: boolean | undefined;
     const marker: SqlMarker = {
+      chunk,
       get isColumn(): boolean {
         cachedColumn ??= markerIsColumn(expression, checker, services);
         return cachedColumn;
@@ -222,17 +261,19 @@ function parseSqlVariant(
       node: expression,
     };
     markers.set(name, marker);
-    source += `"${name}"`;
+    source += markerSource;
+    if (trackSourceRanges) {
+      sourceByteLength += Buffer.byteLength(markerSource);
+      sourceRanges.push({ chunk, end: sourceByteLength, start });
+    }
   }
 
-  const parseResult = parsePostgres(
-    context === "statement" ? source : `SELECT 1 WHERE ${source}`,
-  );
+  const parseResult = parsePostgres(source);
   if (parseResult === null || parseResult.statements.length !== 1) {
     return null;
   }
   const statement = parseResult.statements[0];
-  return statement === undefined ? null : { markers, statement };
+  return statement === undefined ? null : { markers, sourceRanges, statement };
 }
 
 function stringNodeValue(value: unknown): string | undefined {
@@ -285,9 +326,48 @@ function isExpressionNode(value: unknown): boolean {
   );
 }
 
+function syntaxLocation(value: unknown): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  for (const payload of Object.values(value)) {
+    if (isRecord(payload) && typeof payload.location === "number") {
+      return payload.location;
+    }
+  }
+  return undefined;
+}
+
+function ownSourceChunks(
+  value: unknown,
+  sourceRanges: readonly SqlSourceRange[],
+): ReadonlySet<SqlSourceChunk> {
+  const location = syntaxLocation(value);
+  if (location === undefined || location < 0) {
+    return new Set();
+  }
+  const range = sourceRanges.find((candidate) => {
+    return candidate.start <= location && location < candidate.end;
+  });
+  return range === undefined ? new Set() : new Set([range.chunk]);
+}
+
+function mergeSourceChunks(
+  own: ReadonlySet<SqlSourceChunk>,
+  expressions: readonly StructuralExpression[],
+): ReadonlySet<SqlSourceChunk> {
+  return new Set([
+    ...own,
+    ...expressions.flatMap((expression) => {
+      return [...expression.sourceChunks];
+    }),
+  ]);
+}
+
 function collectStructuralExpressions(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  sourceRanges: readonly SqlSourceRange[],
 ): StructuralExpression[] {
   const expressions: StructuralExpression[] = [];
 
@@ -302,7 +382,7 @@ function collectStructuralExpressions(
       return;
     }
     if (isExpressionNode(current)) {
-      expressions.push(structuralExpression(current, markers));
+      expressions.push(structuralExpression(current, markers, sourceRanges));
       return;
     }
     for (const child of Object.values(current)) {
@@ -317,13 +397,21 @@ function collectStructuralExpressions(
 function structuralExpression(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
+  sourceRanges: readonly SqlSourceRange[],
 ): StructuralExpression {
   const marker = columnMarker(value, markers);
   if (marker !== undefined) {
-    return { kind: "marker", marker };
+    return {
+      kind: "marker",
+      marker,
+      sourceChunks: new Set([marker.chunk]),
+    };
   }
   if (recordProperty(value, "A_Const") !== undefined) {
-    return { kind: "constant" };
+    return {
+      kind: "constant",
+      sourceChunks: ownSourceChunks(value, sourceRanges),
+    };
   }
 
   const binary = recordProperty(value, "A_Expr");
@@ -334,11 +422,17 @@ function structuralExpression(
     binary.lexpr !== undefined &&
     binary.rexpr !== undefined
   ) {
+    const left = structuralExpression(binary.lexpr, markers, sourceRanges);
+    const right = structuralExpression(binary.rexpr, markers, sourceRanges);
     return {
       kind: "comparison",
-      left: structuralExpression(binary.lexpr, markers),
+      left,
       operator: binaryOperator,
-      right: structuralExpression(binary.rexpr, markers),
+      right,
+      sourceChunks: mergeSourceChunks(ownSourceChunks(value, sourceRanges), [
+        left,
+        right,
+      ]),
     };
   }
 
@@ -348,26 +442,36 @@ function structuralExpression(
     Array.isArray(boolean.args) &&
     boolean.args.length >= 2
   ) {
+    const items = boolean.args.map((item) => {
+      return structuralExpression(item, markers, sourceRanges);
+    });
     return {
-      items: boolean.args.map((item) => {
-        return structuralExpression(item, markers);
-      }),
+      items,
       kind: "boolean",
       operator: boolean.boolop === "AND_EXPR" ? "and" : "or",
+      sourceChunks: mergeSourceChunks(
+        ownSourceChunks(value, sourceRanges),
+        items,
+      ),
     };
   }
 
   const payload = isRecord(value) ? Object.values(value)[0] : undefined;
+  const children = collectStructuralExpressions(payload, markers, sourceRanges);
   return {
-    children: collectStructuralExpressions(payload, markers),
+    children,
     kind: "opaque",
+    sourceChunks: mergeSourceChunks(
+      ownSourceChunks(value, sourceRanges),
+      children,
+    ),
   };
 }
 
-function deduplicateFindings(
-  findings: readonly SqlAnalysisFinding[],
-): SqlAnalysisFinding[] {
-  const result: SqlAnalysisFinding[] = [];
+function deduplicateFindings<T extends SqlAnalysisFinding>(
+  findings: readonly T[],
+): T[] {
+  const result: T[] = [];
   const seen = new Map<TSESTree.Node, Set<string>>();
   for (const finding of findings) {
     const key =
@@ -422,6 +526,7 @@ function classifyExpression(
             helper,
             kind: "helper",
             node: expression.left.marker.node,
+            sourceChunks: expression.sourceChunks,
           },
         ],
         isWholeReplacement: true,
@@ -451,6 +556,7 @@ function classifyExpression(
               helper: expression.operator,
               kind: "helper",
               node: reportNode,
+              sourceChunks: expression.sourceChunks,
             },
           ],
           isWholeReplacement: true,
@@ -620,36 +726,101 @@ function isCompositionBoundary(
   );
 }
 
-function commonCompositionBoundary(
-  variant: SqlSourceVariant,
-  root: TSESTree.Expression,
-): TSESTree.Expression {
-  const contributingChunks = variant.chunks.filter((chunk) => {
+function commonCompositionBoundaries(
+  chunks: readonly SqlSourceChunk[],
+  preferCallBoundary: boolean,
+): TSESTree.Expression[] {
+  const contributingChunks = chunks.filter((chunk) => {
     return chunk.kind === "expression" || chunk.text.trim() !== "";
   });
   const firstChunk = contributingChunks[0];
   if (firstChunk === undefined) {
-    return root;
+    return [];
   }
-  const commonBoundaries = firstChunk.origins.filter(
-    (origin): origin is TSESTree.Expression => {
-      return (
-        isCompositionBoundary(origin) &&
-        contributingChunks.every((chunk) => {
-          return chunk.origins.includes(origin);
-        })
-      );
-    },
+  const commonBoundaries = [
+    ...new Set(
+      firstChunk.origins.filter((origin): origin is TSESTree.Expression => {
+        return (
+          isCompositionBoundary(origin) &&
+          contributingChunks.every((chunk) => {
+            return chunk.origins.includes(origin);
+          })
+        );
+      }),
+    ),
+  ];
+  const callBoundaries: TSESTree.Expression[] = preferCallBoundary
+    ? commonBoundaries.filter((boundary) => {
+        return boundary.type === AST_NODE_TYPES.CallExpression;
+      })
+    : [];
+  return [
+    ...callBoundaries,
+    ...[...commonBoundaries].reverse().filter((boundary) => {
+      return !callBoundaries.includes(boundary);
+    }),
+  ];
+}
+
+function commonCompositionBoundary(
+  variant: SqlSourceVariant,
+  preferCallBoundary: boolean,
+): TSESTree.Expression | undefined {
+  return commonCompositionBoundaries(variant.chunks, preferCallBoundary)[0];
+}
+
+function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
+  return {
+    helper: finding.helper,
+    kind: finding.kind,
+    node: finding.node,
+  };
+}
+
+function replacementBoundaryForFinding(
+  finding: ClassifiedHelperFinding,
+  variant: SqlSourceVariant,
+  variantCount: number,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): TSESTree.Expression | undefined {
+  // A parsed descendant can cross template boundaries because Drizzle inserts
+  // nested SQL without parentheses. Reparse each editable boundary in
+  // isolation before claiming that the helper can replace it.
+  const candidates = commonCompositionBoundaries(
+    [...finding.sourceChunks],
+    variantCount === 1,
   );
-  // A factory or sql.join call owns the concrete replacement even when every
-  // chunk also comes from one shared returned or separator template.
-  return (
-    commonBoundaries.find((boundary) => {
-      return boundary.type === AST_NODE_TYPES.CallExpression;
-    }) ??
-    commonBoundaries[commonBoundaries.length - 1] ??
-    root
-  );
+  for (const candidate of candidates) {
+    const candidateVariant = {
+      chunks: variant.chunks.filter((chunk) => {
+        return chunk.origins.includes(candidate);
+      }),
+    };
+    const parsed = parseSqlVariant(
+      candidateVariant,
+      "predicate",
+      false,
+      checker,
+      services,
+    );
+    const expression =
+      parsed === null ? undefined : predicateExpression(parsed.statement);
+    if (parsed === null || expression === undefined) {
+      continue;
+    }
+    const classification = classifyExpression(
+      structuralExpression(expression, parsed.markers, parsed.sourceRanges),
+    );
+    if (
+      classification.isWholeReplacement &&
+      classification.findings.length === 1 &&
+      classification.findings[0]?.helper === finding.helper
+    ) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 function analyzeParsed(
@@ -658,6 +829,9 @@ function analyzeParsed(
   hasLocalExpansion: boolean,
   parsed: ParsedSql,
   variant: SqlSourceVariant,
+  variantCount: number,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
 ): SqlAnalysis {
   const simpleSelect =
     context === "statement" && isSimpleSelect(parsed.statement, parsed.markers);
@@ -677,30 +851,54 @@ function analyzeParsed(
       : parsed.statement;
   const structuralExpressions =
     context === "predicate" && expression !== undefined
-      ? [structuralExpression(expression, parsed.markers)]
-      : collectStructuralExpressions(expression, parsed.markers);
+      ? [structuralExpression(expression, parsed.markers, parsed.sourceRanges)]
+      : collectStructuralExpressions(
+          expression,
+          parsed.markers,
+          parsed.sourceRanges,
+        );
   const classifications = structuralExpressions.map((item) => {
     return classifyExpression(item);
   });
   const predicateClassification =
     context === "predicate" ? classifications[0] : undefined;
   const predicateFinding = predicateClassification?.findings[0];
-  const ownsExpandedTemplates =
+  const rootNeedsCompositionBoundary =
+    hasLocalExpansion && predicateFinding !== undefined;
+  const canReplaceRoot =
     predicateClassification?.isWholeReplacement === true &&
     predicateClassification.findings.length === 1 &&
     predicateFinding?.kind === "helper" &&
-    (predicateFinding.helper === "and" || predicateFinding.helper === "or") &&
-    hasLocalExpansion;
-  const replacementBoundary = ownsExpandedTemplates
-    ? commonCompositionBoundary(variant, node)
+    rootNeedsCompositionBoundary;
+  const replacementBoundary = canReplaceRoot
+    ? commonCompositionBoundary(variant, variantCount === 1)
     : undefined;
+  const ownsExpandedTemplates = replacementBoundary !== undefined;
   const findings = deduplicateFindings(
     classifications.flatMap((classification) => {
-      return ownsExpandedTemplates
-        ? classification.findings.map((finding) => {
-            return { ...finding, node: replacementBoundary ?? node };
-          })
-        : classification.findings;
+      if (ownsExpandedTemplates) {
+        return classification.findings.map((finding) => {
+          return publicFinding({
+            ...finding,
+            node: replacementBoundary ?? node,
+          });
+        });
+      }
+      return classification.findings.flatMap((finding) => {
+        if (!hasLocalExpansion) {
+          return [publicFinding(finding)];
+        }
+        const boundary = replacementBoundaryForFinding(
+          finding,
+          variant,
+          variantCount,
+          checker,
+          services,
+        );
+        return boundary === undefined
+          ? []
+          : [publicFinding({ ...finding, node: boundary })];
+      });
     }),
   );
   return {
@@ -770,13 +968,28 @@ export function analyzeSql(
   } else {
     const variants: SqlAnalysis[] = [];
     for (const variant of source.variants) {
-      const parsed = parseSqlVariant(variant, context, checker, services);
+      const parsed = parseSqlVariant(
+        variant,
+        context,
+        source.hasLocalExpansion,
+        checker,
+        services,
+      );
       if (parsed === null) {
         variants.length = 0;
         break;
       }
       variants.push(
-        analyzeParsed(node, context, source.hasLocalExpansion, parsed, variant),
+        analyzeParsed(
+          node,
+          context,
+          source.hasLocalExpansion,
+          parsed,
+          variant,
+          source.variants.length,
+          checker,
+          services,
+        ),
       );
     }
     const first = variants[0];

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -35,9 +35,9 @@ export type SqlAnalysisFinding =
 export interface SqlAnalysis {
   readonly expandedTemplates: ReadonlySet<TSESTree.TaggedTemplateExpression>;
   readonly findings: readonly SqlAnalysisFinding[];
+  readonly hasWholeReplacementBoundary: boolean;
   readonly isSimpleSelect: boolean;
   readonly isTruePredicate: boolean;
-  readonly ownsExpandedTemplates: boolean;
 }
 
 interface SqlMarker {
@@ -540,7 +540,7 @@ function classifyExpression(
         left.findings[0]?.node ??
         right.anchor ??
         right.findings[0]?.node,
-      findings: deduplicateFindings([...left.findings, ...right.findings]),
+      findings: [...left.findings, ...right.findings],
       isWholeReplacement: false,
     };
   }
@@ -581,11 +581,9 @@ function classifyExpression(
       children.find((child) => {
         return child.findings[0] !== undefined;
       })?.findings[0]?.node,
-    findings: deduplicateFindings(
-      children.flatMap((child) => {
-        return child.findings;
-      }),
-    ),
+    findings: children.flatMap((child) => {
+      return child.findings;
+    }),
     isWholeReplacement: false,
   };
 }
@@ -726,9 +724,23 @@ function isCompositionBoundary(
   );
 }
 
+function isWithinCompositionRoot(
+  node: TSESTree.Node,
+  root: TSESTree.Expression,
+): boolean {
+  let current: TSESTree.Node | null | undefined = node;
+  while (current !== undefined && current !== null) {
+    if (current === root) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
 function commonCompositionBoundaries(
   chunks: readonly SqlSourceChunk[],
-  preferCallBoundary: boolean,
+  root: TSESTree.Expression,
 ): TSESTree.Expression[] {
   const contributingChunks = chunks.filter((chunk) => {
     return chunk.kind === "expression" || chunk.text.trim() !== "";
@@ -737,11 +749,15 @@ function commonCompositionBoundaries(
   if (firstChunk === undefined) {
     return [];
   }
+  // A definition can feed multiple SQL contexts with different precedence.
+  // Keep replacement ownership at the current use site instead of changing the
+  // shared initializer or factory body.
   const commonBoundaries = [
     ...new Set(
       firstChunk.origins.filter((origin): origin is TSESTree.Expression => {
         return (
           isCompositionBoundary(origin) &&
+          isWithinCompositionRoot(origin, root) &&
           contributingChunks.every((chunk) => {
             return chunk.origins.includes(origin);
           })
@@ -749,24 +765,30 @@ function commonCompositionBoundaries(
       }),
     ),
   ];
-  const callBoundaries: TSESTree.Expression[] = preferCallBoundary
-    ? commonBoundaries.filter((boundary) => {
-        return boundary.type === AST_NODE_TYPES.CallExpression;
-      })
-    : [];
+  const callBoundaries = commonBoundaries.filter((boundary) => {
+    return boundary.type === AST_NODE_TYPES.CallExpression;
+  });
+  const identifierBoundaries = commonBoundaries.filter((boundary) => {
+    return boundary.type === AST_NODE_TYPES.Identifier;
+  });
+  const prioritizedBoundaries = new Set<TSESTree.Expression>([
+    ...callBoundaries,
+    ...identifierBoundaries,
+  ]);
   return [
     ...callBoundaries,
+    ...identifierBoundaries,
     ...[...commonBoundaries].reverse().filter((boundary) => {
-      return !callBoundaries.includes(boundary);
+      return !prioritizedBoundaries.has(boundary);
     }),
   ];
 }
 
 function commonCompositionBoundary(
   variant: SqlSourceVariant,
-  preferCallBoundary: boolean,
+  root: TSESTree.Expression,
 ): TSESTree.Expression | undefined {
-  return commonCompositionBoundaries(variant.chunks, preferCallBoundary)[0];
+  return commonCompositionBoundaries(variant.chunks, root)[0];
 }
 
 function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
@@ -780,7 +802,7 @@ function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
 function replacementBoundaryForFinding(
   finding: ClassifiedHelperFinding,
   variant: SqlSourceVariant,
-  variantCount: number,
+  root: TSESTree.Expression,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
 ): TSESTree.Expression | undefined {
@@ -789,7 +811,7 @@ function replacementBoundaryForFinding(
   // isolation before claiming that the helper can replace it.
   const candidates = commonCompositionBoundaries(
     [...finding.sourceChunks],
-    variantCount === 1,
+    root,
   );
   for (const candidate of candidates) {
     const candidateVariant = {
@@ -829,7 +851,6 @@ function analyzeParsed(
   hasLocalExpansion: boolean,
   parsed: ParsedSql,
   variant: SqlSourceVariant,
-  variantCount: number,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
 ): SqlAnalysis {
@@ -839,9 +860,9 @@ function analyzeParsed(
     return {
       expandedTemplates: new Set(),
       findings: [{ kind: "query-builder", node }],
+      hasWholeReplacementBoundary: true,
       isSimpleSelect: true,
       isTruePredicate: false,
-      ownsExpandedTemplates: true,
     };
   }
 
@@ -871,12 +892,12 @@ function analyzeParsed(
     predicateFinding?.kind === "helper" &&
     rootNeedsCompositionBoundary;
   const replacementBoundary = canReplaceRoot
-    ? commonCompositionBoundary(variant, variantCount === 1)
+    ? commonCompositionBoundary(variant, node)
     : undefined;
-  const ownsExpandedTemplates = replacementBoundary !== undefined;
+  const hasWholeReplacementBoundary = replacementBoundary !== undefined;
   const findings = deduplicateFindings(
     classifications.flatMap((classification) => {
-      if (ownsExpandedTemplates) {
+      if (hasWholeReplacementBoundary) {
         return classification.findings.map((finding) => {
           return publicFinding({
             ...finding,
@@ -891,7 +912,7 @@ function analyzeParsed(
         const boundary = replacementBoundaryForFinding(
           finding,
           variant,
-          variantCount,
+          node,
           checker,
           services,
         );
@@ -904,12 +925,12 @@ function analyzeParsed(
   return {
     expandedTemplates: new Set(),
     findings,
+    hasWholeReplacementBoundary,
     isSimpleSelect: false,
     isTruePredicate:
       context === "predicate" &&
       expression !== undefined &&
       isTrueConstant(expression),
-    ownsExpandedTemplates,
   };
 }
 
@@ -917,7 +938,7 @@ function sameAnalysisSignature(left: SqlAnalysis, right: SqlAnalysis): boolean {
   if (
     left.isSimpleSelect !== right.isSimpleSelect ||
     left.isTruePredicate !== right.isTruePredicate ||
-    left.ownsExpandedTemplates !== right.ownsExpandedTemplates ||
+    left.hasWholeReplacementBoundary !== right.hasWholeReplacementBoundary ||
     left.findings.length !== right.findings.length
   ) {
     return false;
@@ -939,9 +960,9 @@ function emptyAnalysis(
   return {
     expandedTemplates,
     findings: [],
+    hasWholeReplacementBoundary: false,
     isSimpleSelect: false,
     isTruePredicate: false,
-    ownsExpandedTemplates: false,
   };
 }
 
@@ -986,7 +1007,6 @@ export function analyzeSql(
           source.hasLocalExpansion,
           parsed,
           variant,
-          source.variants.length,
           checker,
           services,
         ),
@@ -1008,9 +1028,9 @@ export function analyzeSql(
             return variant.findings;
           }),
         ),
+        hasWholeReplacementBoundary: first.hasWholeReplacementBoundary,
         isSimpleSelect: first.isSimpleSelect,
         isTruePredicate: first.isTruePredicate,
-        ownsExpandedTemplates: first.ownsExpandedTemplates,
       };
     }
   }

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -1,4 +1,5 @@
 import {
+  AST_NODE_TYPES,
   type ParserServicesWithTypeInformation,
   type TSESTree,
 } from "@typescript-eslint/utils";
@@ -30,6 +31,7 @@ export interface SqlAnalysis {
   readonly findings: readonly SqlAnalysisFinding[];
   readonly isSimpleSelect: boolean;
   readonly isTruePredicate: boolean;
+  readonly ownsExpandedTemplates: boolean;
 }
 
 interface SqlMarker {
@@ -71,6 +73,7 @@ type StructuralExpression =
 interface ExpressionClassification {
   readonly anchor: TSESTree.Node | undefined;
   readonly findings: readonly SqlAnalysisFinding[];
+  readonly isWholeReplacement: boolean;
 }
 
 interface RelationMatch {
@@ -395,12 +398,14 @@ function classifyExpression(
           ? expression.marker.node
           : undefined,
       findings: [],
+      isWholeReplacement: false,
     };
   }
   if (expression.kind === "constant") {
     return {
       anchor: undefined,
       findings: [],
+      isWholeReplacement: false,
     };
   }
   if (expression.kind === "comparison") {
@@ -419,6 +424,7 @@ function classifyExpression(
             node: expression.left.marker.node,
           },
         ],
+        isWholeReplacement: true,
       };
     }
     const left = classifyExpression(expression.left);
@@ -430,6 +436,7 @@ function classifyExpression(
         right.anchor ??
         right.findings[0]?.node,
       findings: deduplicateFindings([...left.findings, ...right.findings]),
+      isWholeReplacement: false,
     };
   }
   if (expression.kind === "boolean") {
@@ -446,12 +453,14 @@ function classifyExpression(
               node: reportNode,
             },
           ],
+          isWholeReplacement: true,
         };
       }
     }
     return {
       anchor: undefined,
       findings: [],
+      isWholeReplacement: false,
     };
   }
 
@@ -471,6 +480,7 @@ function classifyExpression(
         return child.findings;
       }),
     ),
+    isWholeReplacement: false,
   };
 }
 
@@ -594,10 +604,60 @@ function isTrueConstant(expression: unknown): boolean {
   return boolean?.boolval === true;
 }
 
+function isCompositionBoundary(
+  node: TSESTree.Node,
+): node is TSESTree.Expression {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression ||
+    node.type === AST_NODE_TYPES.ChainExpression ||
+    node.type === AST_NODE_TYPES.ConditionalExpression ||
+    node.type === AST_NODE_TYPES.Identifier ||
+    node.type === AST_NODE_TYPES.TaggedTemplateExpression ||
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion
+  );
+}
+
+function commonCompositionBoundary(
+  variant: SqlSourceVariant,
+  root: TSESTree.Expression,
+): TSESTree.Expression {
+  const contributingChunks = variant.chunks.filter((chunk) => {
+    return chunk.kind === "expression" || chunk.text.trim() !== "";
+  });
+  const firstChunk = contributingChunks[0];
+  if (firstChunk === undefined) {
+    return root;
+  }
+  const commonBoundaries = firstChunk.origins.filter(
+    (origin): origin is TSESTree.Expression => {
+      return (
+        isCompositionBoundary(origin) &&
+        contributingChunks.every((chunk) => {
+          return chunk.origins.includes(origin);
+        })
+      );
+    },
+  );
+  // A factory or sql.join call owns the concrete replacement even when every
+  // chunk also comes from one shared returned or separator template.
+  return (
+    commonBoundaries.find((boundary) => {
+      return boundary.type === AST_NODE_TYPES.CallExpression;
+    }) ??
+    commonBoundaries[commonBoundaries.length - 1] ??
+    root
+  );
+}
+
 function analyzeParsed(
   node: TSESTree.Expression,
   context: SqlAnalysisContext,
+  hasLocalExpansion: boolean,
   parsed: ParsedSql,
+  variant: SqlSourceVariant,
 ): SqlAnalysis {
   const simpleSelect =
     context === "statement" && isSimpleSelect(parsed.statement, parsed.markers);
@@ -607,6 +667,7 @@ function analyzeParsed(
       findings: [{ kind: "query-builder", node }],
       isSimpleSelect: true,
       isTruePredicate: false,
+      ownsExpandedTemplates: true,
     };
   }
 
@@ -618,9 +679,28 @@ function analyzeParsed(
     context === "predicate" && expression !== undefined
       ? [structuralExpression(expression, parsed.markers)]
       : collectStructuralExpressions(expression, parsed.markers);
+  const classifications = structuralExpressions.map((item) => {
+    return classifyExpression(item);
+  });
+  const predicateClassification =
+    context === "predicate" ? classifications[0] : undefined;
+  const predicateFinding = predicateClassification?.findings[0];
+  const ownsExpandedTemplates =
+    predicateClassification?.isWholeReplacement === true &&
+    predicateClassification.findings.length === 1 &&
+    predicateFinding?.kind === "helper" &&
+    (predicateFinding.helper === "and" || predicateFinding.helper === "or") &&
+    hasLocalExpansion;
+  const replacementBoundary = ownsExpandedTemplates
+    ? commonCompositionBoundary(variant, node)
+    : undefined;
   const findings = deduplicateFindings(
-    structuralExpressions.flatMap((item) => {
-      return classifyExpression(item).findings;
+    classifications.flatMap((classification) => {
+      return ownsExpandedTemplates
+        ? classification.findings.map((finding) => {
+            return { ...finding, node: replacementBoundary ?? node };
+          })
+        : classification.findings;
     }),
   );
   return {
@@ -631,6 +711,7 @@ function analyzeParsed(
       context === "predicate" &&
       expression !== undefined &&
       isTrueConstant(expression),
+    ownsExpandedTemplates,
   };
 }
 
@@ -638,6 +719,7 @@ function sameAnalysisSignature(left: SqlAnalysis, right: SqlAnalysis): boolean {
   if (
     left.isSimpleSelect !== right.isSimpleSelect ||
     left.isTruePredicate !== right.isTruePredicate ||
+    left.ownsExpandedTemplates !== right.ownsExpandedTemplates ||
     left.findings.length !== right.findings.length
   ) {
     return false;
@@ -661,6 +743,7 @@ function emptyAnalysis(
     findings: [],
     isSimpleSelect: false,
     isTruePredicate: false,
+    ownsExpandedTemplates: false,
   };
 }
 
@@ -692,7 +775,9 @@ export function analyzeSql(
         variants.length = 0;
         break;
       }
-      variants.push(analyzeParsed(node, context, parsed));
+      variants.push(
+        analyzeParsed(node, context, source.hasLocalExpansion, parsed, variant),
+      );
     }
     const first = variants[0];
     if (
@@ -712,6 +797,7 @@ export function analyzeSql(
         ),
         isSimpleSelect: first.isSimpleSelect,
         isTruePredicate: first.isTruePredicate,
+        ownsExpandedTemplates: first.ownsExpandedTemplates,
       };
     }
   }

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -6,15 +6,15 @@ import { type TypeChecker } from "typescript";
 
 import {
   isDrizzleColumnType,
-  isDrizzleSqlTag,
   isDrizzleTableType,
   isDrizzleWrapperType,
 } from "../drizzle.ts";
 import { parsePostgres } from "./postgres-parser.ts";
+import { type SqlSourceComposer, type SqlSourceVariant } from "./sql-source.ts";
 
-type DirectSqlContext = "predicate" | "statement";
+type SqlAnalysisContext = "predicate" | "statement";
 
-export type DirectSqlFinding =
+export type SqlAnalysisFinding =
   | {
       readonly helper: "and" | "eq" | "gt" | "gte" | "lt" | "lte" | "ne" | "or";
       readonly kind: "helper";
@@ -22,11 +22,12 @@ export type DirectSqlFinding =
     }
   | {
       readonly kind: "query-builder";
-      readonly node: TSESTree.TaggedTemplateExpression;
+      readonly node: TSESTree.Expression;
     };
 
-export interface DirectSqlAnalysis {
-  readonly findings: readonly DirectSqlFinding[];
+export interface SqlAnalysis {
+  readonly expandedTemplates: ReadonlySet<TSESTree.TaggedTemplateExpression>;
+  readonly findings: readonly SqlAnalysisFinding[];
   readonly isSimpleSelect: boolean;
   readonly isTruePredicate: boolean;
 }
@@ -38,7 +39,7 @@ interface SqlMarker {
   readonly node: TSESTree.Expression;
 }
 
-interface ParsedDirectSql {
+interface ParsedSql {
   readonly markers: ReadonlyMap<string, SqlMarker>;
   readonly statement: unknown;
 }
@@ -69,7 +70,7 @@ type StructuralExpression =
 
 interface ExpressionClassification {
   readonly anchor: TSESTree.Node | undefined;
-  readonly findings: readonly DirectSqlFinding[];
+  readonly findings: readonly SqlAnalysisFinding[];
 }
 
 interface RelationMatch {
@@ -78,15 +79,9 @@ interface RelationMatch {
   readonly sourceTable: SqlMarker;
 }
 
-const EMPTY_ANALYSIS: DirectSqlAnalysis = {
-  findings: [],
-  isSimpleSelect: false,
-  isTruePredicate: false,
-};
-
 const ANALYSIS_CACHE = new WeakMap<
-  TSESTree.TaggedTemplateExpression,
-  Map<DirectSqlContext, DirectSqlAnalysis>
+  SqlSourceComposer,
+  WeakMap<TSESTree.Expression, Map<SqlAnalysisContext, SqlAnalysis>>
 >();
 
 const COMPARISON_HELPERS = new Map<
@@ -140,10 +135,6 @@ function recordProperty(
   return isRecord(result) ? result : undefined;
 }
 
-function quasiText(node: TSESTree.TemplateElement): string {
-  return node.value.cooked ?? node.value.raw;
-}
-
 function markerIsColumn(
   node: TSESTree.Expression,
   checker: TypeChecker,
@@ -188,26 +179,27 @@ function markerPrefix(quasis: readonly string[]): string {
   }
 }
 
-function parseDirectSql(
-  node: TSESTree.TaggedTemplateExpression,
-  context: DirectSqlContext,
+function parseSqlVariant(
+  variant: SqlSourceVariant,
+  context: SqlAnalysisContext,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
-): ParsedDirectSql | null {
-  if (!isDrizzleSqlTag(checker, services, node.tag)) {
-    return null;
-  }
-  const quasis = node.quasi.quasis.map(quasiText);
-  const prefix = markerPrefix(quasis);
+): ParsedSql | null {
+  const literals = variant.chunks.flatMap((chunk) => {
+    return chunk.kind === "literal" ? [chunk.text] : [];
+  });
+  const prefix = markerPrefix(literals);
   const markers = new Map<string, SqlMarker>();
-  let source = quasis[0] ?? "";
-  for (let index = 0; index < node.quasi.expressions.length; index += 1) {
-    const expression = node.quasi.expressions[index];
-    const followingQuasi = quasis[index + 1];
-    if (expression === undefined || followingQuasi === undefined) {
-      return null;
+  let source = "";
+  let markerIndex = 0;
+  for (const chunk of variant.chunks) {
+    if (chunk.kind === "literal") {
+      source += chunk.text;
+      continue;
     }
-    const name = `${prefix}${index}`;
+    const expression = chunk.expression;
+    const name = `${prefix}${markerIndex}`;
+    markerIndex += 1;
     let cachedColumn: boolean | undefined;
     let cachedTable: boolean | undefined;
     let cachedWrapper: boolean | undefined;
@@ -227,7 +219,7 @@ function parseDirectSql(
       node: expression,
     };
     markers.set(name, marker);
-    source += `"${name}"${followingQuasi}`;
+    source += `"${name}"`;
   }
 
   const parseResult = parsePostgres(
@@ -370,9 +362,9 @@ function structuralExpression(
 }
 
 function deduplicateFindings(
-  findings: readonly DirectSqlFinding[],
-): DirectSqlFinding[] {
-  const result: DirectSqlFinding[] = [];
+  findings: readonly SqlAnalysisFinding[],
+): SqlAnalysisFinding[] {
+  const result: SqlAnalysisFinding[] = [];
   const seen = new Map<TSESTree.Node, Set<string>>();
   for (const finding of findings) {
     const key =
@@ -603,14 +595,15 @@ function isTrueConstant(expression: unknown): boolean {
 }
 
 function analyzeParsed(
-  node: TSESTree.TaggedTemplateExpression,
-  context: DirectSqlContext,
-  parsed: ParsedDirectSql,
-): DirectSqlAnalysis {
+  node: TSESTree.Expression,
+  context: SqlAnalysisContext,
+  parsed: ParsedSql,
+): SqlAnalysis {
   const simpleSelect =
     context === "statement" && isSimpleSelect(parsed.statement, parsed.markers);
   if (simpleSelect) {
     return {
+      expandedTemplates: new Set(),
       findings: [{ kind: "query-builder", node }],
       isSimpleSelect: true,
       isTruePredicate: false,
@@ -631,6 +624,7 @@ function analyzeParsed(
     }),
   );
   return {
+    expandedTemplates: new Set(),
     findings,
     isSimpleSelect: false,
     isTruePredicate:
@@ -640,22 +634,90 @@ function analyzeParsed(
   };
 }
 
-export function analyzeDirectSql(
-  node: TSESTree.TaggedTemplateExpression,
-  context: DirectSqlContext,
+function sameAnalysisSignature(left: SqlAnalysis, right: SqlAnalysis): boolean {
+  if (
+    left.isSimpleSelect !== right.isSimpleSelect ||
+    left.isTruePredicate !== right.isTruePredicate ||
+    left.findings.length !== right.findings.length
+  ) {
+    return false;
+  }
+  return left.findings.every((finding, index) => {
+    const other = right.findings[index];
+    return (
+      other !== undefined &&
+      finding.kind === other.kind &&
+      (finding.kind === "query-builder" ||
+        (other.kind === "helper" && finding.helper === other.helper))
+    );
+  });
+}
+
+function emptyAnalysis(
+  expandedTemplates: ReadonlySet<TSESTree.TaggedTemplateExpression>,
+): SqlAnalysis {
+  return {
+    expandedTemplates,
+    findings: [],
+    isSimpleSelect: false,
+    isTruePredicate: false,
+  };
+}
+
+export function analyzeSql(
+  node: TSESTree.Expression,
+  context: SqlAnalysisContext,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
-): DirectSqlAnalysis {
-  const cached = ANALYSIS_CACHE.get(node)?.get(context);
+  composer: SqlSourceComposer,
+): SqlAnalysis {
+  let composerCache = ANALYSIS_CACHE.get(composer);
+  if (composerCache === undefined) {
+    composerCache = new WeakMap();
+    ANALYSIS_CACHE.set(composer, composerCache);
+  }
+  const cached = composerCache.get(node)?.get(context);
   if (cached !== undefined) {
     return cached;
   }
-  const parsed = parseDirectSql(node, context, checker, services);
-  const analysis =
-    parsed === null ? EMPTY_ANALYSIS : analyzeParsed(node, context, parsed);
-  const nodeCache = ANALYSIS_CACHE.get(node);
+  const source = composer.compose(node);
+  let analysis: SqlAnalysis;
+  if (source === null) {
+    analysis = emptyAnalysis(new Set());
+  } else {
+    const variants: SqlAnalysis[] = [];
+    for (const variant of source.variants) {
+      const parsed = parseSqlVariant(variant, context, checker, services);
+      if (parsed === null) {
+        variants.length = 0;
+        break;
+      }
+      variants.push(analyzeParsed(node, context, parsed));
+    }
+    const first = variants[0];
+    if (
+      first === undefined ||
+      variants.some((variant) => {
+        return !sameAnalysisSignature(variant, first);
+      })
+    ) {
+      analysis = emptyAnalysis(source.expandedTemplates);
+    } else {
+      analysis = {
+        expandedTemplates: source.expandedTemplates,
+        findings: deduplicateFindings(
+          variants.flatMap((variant) => {
+            return variant.findings;
+          }),
+        ),
+        isSimpleSelect: first.isSimpleSelect,
+        isTruePredicate: first.isTruePredicate,
+      };
+    }
+  }
+  const nodeCache = composerCache.get(node);
   if (nodeCache === undefined) {
-    ANALYSIS_CACHE.set(node, new Map([[context, analysis]]));
+    composerCache.set(node, new Map([[context, analysis]]));
   } else {
     nodeCache.set(context, analysis);
   }

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
@@ -920,13 +920,16 @@ export function createSqlSourceComposer(
         });
       }
     }
-    return {
-      expandedTemplates,
-      hasLocalExpansion,
-      variants: variantChunks.map((chunks) => {
-        return { chunks };
-      }),
-    };
+    return prependOrigin(
+      {
+        expandedTemplates,
+        hasLocalExpansion,
+        variants: variantChunks.map((chunks) => {
+          return { chunks };
+        }),
+      },
+      node,
+    );
   }
 
   function staticArray(node: TSESTree.Expression): {

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
@@ -1,0 +1,1178 @@
+import {
+  AST_NODE_TYPES,
+  type ParserServicesWithTypeInformation,
+  type TSESLint,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  canHaveModifiers,
+  forEachChild,
+  getModifiers,
+  isArrayLiteralExpression,
+  isAsExpression,
+  isCallExpression,
+  isConditionalExpression,
+  isFunctionDeclaration,
+  isIdentifier,
+  isNonNullExpression,
+  isParenthesizedExpression,
+  isReturnStatement,
+  isSatisfiesExpression,
+  isTemplateSpan,
+  isTypeAssertionExpression,
+  isVariableDeclaration,
+  isVariableDeclarationList,
+  NodeFlags,
+  SyntaxKind,
+  type Node,
+  type Symbol as TypeScriptSymbol,
+  type TypeChecker,
+  type VariableDeclaration,
+} from "typescript";
+
+import {
+  isDrizzleSqlType,
+  isDrizzleSqlTag,
+  isDrizzleSymbol,
+  resolvedSymbol,
+} from "../drizzle.ts";
+import { SQL_TEMPLATE_EXPRESSION_BOUNDARY } from "../sql-lexing.ts";
+
+const MAX_SOURCE_VARIANTS = 16;
+const MAX_COMPOSITION_STEPS = 256;
+
+interface SqlLiteralSourceChunk {
+  readonly depth: number;
+  readonly kind: "literal";
+  readonly origins: readonly TSESTree.Node[];
+  readonly text: string;
+}
+
+interface SqlExpressionSourceChunk {
+  readonly depth: number;
+  readonly expression: TSESTree.Expression;
+  readonly kind: "expression";
+  readonly origins: readonly TSESTree.Node[];
+}
+
+export type SqlSourceChunk = SqlExpressionSourceChunk | SqlLiteralSourceChunk;
+
+export interface SqlSourceVariant {
+  readonly chunks: readonly SqlSourceChunk[];
+}
+
+export interface SqlSource {
+  readonly expandedTemplates: ReadonlySet<TSESTree.TaggedTemplateExpression>;
+  readonly hasLocalExpansion: boolean;
+  readonly variants: readonly SqlSourceVariant[];
+}
+
+export interface LegacySqlSource {
+  readonly expressions: readonly TSESTree.Expression[];
+  readonly literalRanges: readonly SqlLiteralRange[];
+  readonly source: string;
+}
+
+export interface SqlLiteralRange {
+  readonly depth: number;
+  readonly end: number;
+  readonly start: number;
+}
+
+export interface SqlSourceComposer {
+  couldCompose(node: TSESTree.Expression): boolean;
+  compose(node: TSESTree.Expression): SqlSource | null;
+}
+
+interface MutableCompositionState {
+  readonly activeDeclarations: Set<Node>;
+  steps: number;
+  substitutions: ReadonlyMap<TypeScriptSymbol, BoundExpression>;
+}
+
+interface MutableCompositionCandidateState {
+  readonly activeDeclarations: Set<TSESTree.Node>;
+  budgetExceeded: boolean;
+  steps: number;
+}
+
+interface BoundExpression {
+  readonly expression: TSESTree.Expression;
+  readonly origins: readonly TSESTree.Node[];
+}
+
+interface LocalFunction {
+  readonly declaration: Node;
+  readonly parameters: readonly TypeScriptSymbol[];
+  readonly returned: TSESTree.Expression;
+}
+
+type SafeTerminalUse = (node: TSESTree.Expression) => boolean;
+
+function quasiText(node: TSESTree.TemplateElement): string {
+  return node.value.cooked ?? node.value.raw;
+}
+
+function transparentExpression(
+  node: TSESTree.Node,
+): TSESTree.Expression | null {
+  if (
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion ||
+    node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.ChainExpression
+  ) {
+    return node.expression;
+  }
+  return null;
+}
+
+function transparentParent(
+  node: TSESTree.Expression,
+): TSESTree.Expression | null {
+  const parent = node.parent;
+  if (
+    (parent.type === AST_NODE_TYPES.TSAsExpression ||
+      parent.type === AST_NODE_TYPES.TSTypeAssertion ||
+      parent.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+      parent.type === AST_NODE_TYPES.TSNonNullExpression ||
+      parent.type === AST_NODE_TYPES.ChainExpression) &&
+    parent.expression === node
+  ) {
+    return parent;
+  }
+  return null;
+}
+
+function isComposableExpression(
+  node: TSESTree.Node,
+): node is TSESTree.Expression {
+  return (
+    node.type === AST_NODE_TYPES.ArrayExpression ||
+    node.type === AST_NODE_TYPES.CallExpression ||
+    node.type === AST_NODE_TYPES.ChainExpression ||
+    node.type === AST_NODE_TYPES.ConditionalExpression ||
+    node.type === AST_NODE_TYPES.Identifier ||
+    node.type === AST_NODE_TYPES.TaggedTemplateExpression ||
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion
+  );
+}
+
+function outerTransparentExpression(
+  node: TSESTree.Expression,
+): TSESTree.Expression {
+  let current = node;
+  let parent = transparentParent(current);
+  while (parent !== null) {
+    current = parent;
+    parent = transparentParent(current);
+  }
+  return current;
+}
+
+function hasExportModifier(node: Node): boolean {
+  return (
+    canHaveModifiers(node) &&
+    getModifiers(node)?.some((modifier) => {
+      return modifier.kind === SyntaxKind.ExportKeyword;
+    }) === true
+  );
+}
+
+function isConstVariable(declaration: VariableDeclaration): boolean {
+  return (
+    isVariableDeclarationList(declaration.parent) &&
+    (declaration.parent.flags & NodeFlags.Const) !== 0
+  );
+}
+
+function variableIsExported(declaration: VariableDeclaration): boolean {
+  return hasExportModifier(declaration.parent.parent);
+}
+
+function mergeTemplates(
+  left: ReadonlySet<TSESTree.TaggedTemplateExpression>,
+  right: ReadonlySet<TSESTree.TaggedTemplateExpression>,
+): ReadonlySet<TSESTree.TaggedTemplateExpression> {
+  return new Set([...left, ...right]);
+}
+
+function emptySource(): SqlSource {
+  return {
+    expandedTemplates: new Set(),
+    hasLocalExpansion: false,
+    variants: [{ chunks: [] }],
+  };
+}
+
+function concatenateSources(
+  left: SqlSource,
+  right: SqlSource,
+): SqlSource | null {
+  if (left.variants.length * right.variants.length > MAX_SOURCE_VARIANTS) {
+    return null;
+  }
+  return {
+    expandedTemplates: mergeTemplates(
+      left.expandedTemplates,
+      right.expandedTemplates,
+    ),
+    hasLocalExpansion: left.hasLocalExpansion || right.hasLocalExpansion,
+    variants: left.variants.flatMap((leftVariant) => {
+      return right.variants.map((rightVariant) => {
+        return {
+          chunks: [...leftVariant.chunks, ...rightVariant.chunks],
+        };
+      });
+    }),
+  };
+}
+
+function combineChoices(left: SqlSource, right: SqlSource): SqlSource | null {
+  if (left.variants.length + right.variants.length > MAX_SOURCE_VARIANTS) {
+    return null;
+  }
+  return {
+    expandedTemplates: mergeTemplates(
+      left.expandedTemplates,
+      right.expandedTemplates,
+    ),
+    hasLocalExpansion: true,
+    variants: [...left.variants, ...right.variants],
+  };
+}
+
+function withLocalExpansion(source: SqlSource): SqlSource {
+  return source.hasLocalExpansion
+    ? source
+    : { ...source, hasLocalExpansion: true };
+}
+
+function prependOrigin(source: SqlSource, origin: TSESTree.Node): SqlSource {
+  return {
+    ...source,
+    variants: source.variants.map((variant) => {
+      return {
+        chunks: variant.chunks.map((chunk) => {
+          return { ...chunk, origins: [origin, ...chunk.origins] };
+        }),
+      };
+    }),
+  };
+}
+
+function incrementDepth(source: SqlSource): SqlSource {
+  return {
+    ...source,
+    variants: source.variants.map((variant) => {
+      return {
+        chunks: variant.chunks.map((chunk) => {
+          return { ...chunk, depth: chunk.depth + 1 };
+        }),
+      };
+    }),
+  };
+}
+
+function literalChunk(node: TSESTree.TemplateElement): SqlLiteralSourceChunk {
+  return {
+    depth: 0,
+    kind: "literal",
+    origins: [node],
+    text: quasiText(node),
+  };
+}
+
+function expressionSource(
+  expression: TSESTree.Expression,
+  origins: readonly TSESTree.Node[],
+): SqlSource {
+  return {
+    expandedTemplates: new Set(),
+    hasLocalExpansion: false,
+    variants: [
+      {
+        chunks: [{ depth: 0, expression, kind: "expression", origins }],
+      },
+    ],
+  };
+}
+
+export function renderLegacySqlSource(
+  variant: SqlSourceVariant,
+): LegacySqlSource {
+  const expressions: TSESTree.Expression[] = [];
+  const literalRanges: SqlLiteralRange[] = [];
+  let source = "";
+  for (const chunk of variant.chunks) {
+    if (chunk.kind === "literal") {
+      const start = source.length;
+      source += chunk.text;
+      literalRanges.push({ depth: chunk.depth, end: source.length, start });
+    } else {
+      source += SQL_TEMPLATE_EXPRESSION_BOUNDARY;
+      expressions.push(chunk.expression);
+    }
+  }
+  return { expressions, literalRanges, source };
+}
+
+export function createSqlSourceComposer(
+  sourceCode: TSESLint.SourceCode,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  isSafeTerminalUse: SafeTerminalUse,
+): SqlSourceComposer {
+  const cache = new WeakMap<TSESTree.Expression, SqlSource | null>();
+  const compositionCandidateCache = new WeakMap<TSESTree.Expression, boolean>();
+
+  function symbolAt(node: TSESTree.Node): TypeScriptSymbol | undefined {
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    return resolvedSymbol(checker, checker.getSymbolAtLocation(tsNode));
+  }
+
+  function expressionIsDrizzleSql(node: TSESTree.Expression): boolean {
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    return isDrizzleSqlType(checker, checker.getTypeAtLocation(tsNode), tsNode);
+  }
+
+  function couldComposeExpression(
+    node: TSESTree.Expression,
+    state: MutableCompositionCandidateState,
+  ): boolean {
+    const cached = compositionCandidateCache.get(node);
+    if (cached !== undefined) {
+      return cached;
+    }
+    state.steps += 1;
+    if (state.steps > MAX_COMPOSITION_STEPS) {
+      state.budgetExceeded = true;
+      return false;
+    }
+    const transparent = transparentExpression(node);
+    if (transparent !== null) {
+      const result = couldComposeExpression(transparent, state);
+      if (!state.budgetExceeded) {
+        compositionCandidateCache.set(node, result);
+      }
+      return result;
+    }
+    if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+      compositionCandidateCache.set(node, true);
+      return true;
+    }
+    if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+      const result =
+        couldComposeExpression(node.consequent, state) ||
+        couldComposeExpression(node.alternate, state);
+      if (!state.budgetExceeded) {
+        compositionCandidateCache.set(node, result);
+      }
+      return result;
+    }
+    if (node.type === AST_NODE_TYPES.CallExpression) {
+      const localFunctionVariable =
+        node.callee.type === AST_NODE_TYPES.Identifier
+          ? variableInScope(node.callee)
+          : null;
+      const result =
+        (node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          !node.callee.computed &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          (node.callee.property.name === "empty" ||
+            node.callee.property.name === "join")) ||
+        localFunctionVariable?.defs.some((definition) => {
+          return definition.node.type === AST_NODE_TYPES.FunctionDeclaration;
+        }) === true;
+      if (!state.budgetExceeded) {
+        compositionCandidateCache.set(node, result);
+      }
+      return result;
+    }
+    if (node.type !== AST_NODE_TYPES.Identifier) {
+      compositionCandidateCache.set(node, false);
+      return false;
+    }
+    const variable = variableInScope(node);
+    const declaration = variable?.defs.find((definition) => {
+      return definition.node.type === AST_NODE_TYPES.VariableDeclarator;
+    })?.node;
+    if (
+      declaration?.type !== AST_NODE_TYPES.VariableDeclarator ||
+      declaration.init === null ||
+      state.activeDeclarations.has(declaration)
+    ) {
+      compositionCandidateCache.set(node, false);
+      return false;
+    }
+    const initializer = declaration.init;
+    if (!isComposableExpression(initializer)) {
+      compositionCandidateCache.set(node, false);
+      return false;
+    }
+    state.activeDeclarations.add(declaration);
+    const result = couldComposeExpression(initializer, state);
+    state.activeDeclarations.delete(declaration);
+    if (!state.budgetExceeded) {
+      compositionCandidateCache.set(node, result);
+    }
+    return result;
+  }
+
+  function isCompositionCandidate(node: TSESTree.Expression): boolean {
+    const state: MutableCompositionCandidateState = {
+      activeDeclarations: new Set(),
+      budgetExceeded: false,
+      steps: 0,
+    };
+    return couldComposeExpression(node, state) && !state.budgetExceeded;
+  }
+
+  function variableInScope(
+    node: TSESTree.Identifier,
+  ): TSESLint.Scope.Variable | null {
+    let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(node);
+    while (scope !== null) {
+      const variable = scope.variables.find((candidate) => {
+        return candidate.name === node.name;
+      });
+      if (variable !== undefined) {
+        return variable;
+      }
+      scope = scope.upper;
+    }
+    return null;
+  }
+
+  function drizzleSqlMember(
+    node: TSESTree.CallExpression,
+    name: "empty" | "join",
+  ): boolean {
+    if (
+      node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+      node.callee.computed ||
+      node.callee.property.type !== AST_NODE_TYPES.Identifier ||
+      node.callee.property.name !== name ||
+      !isDrizzleSqlTag(checker, services, node.callee.object)
+    ) {
+      return false;
+    }
+    const tsProperty = services.esTreeNodeToTSNodeMap.get(node.callee.property);
+    return isDrizzleSymbol(checker, checker.getSymbolAtLocation(tsProperty));
+  }
+
+  function directCallUse(node: TSESTree.Identifier): boolean {
+    const use = outerTransparentExpression(node);
+    return (
+      use.parent?.type === AST_NODE_TYPES.CallExpression &&
+      use.parent.callee === use
+    );
+  }
+
+  function hasOnlyDirectCallReferences(node: TSESTree.Identifier): boolean {
+    const variable = variableInScope(node);
+    return (
+      variable !== null &&
+      variable.references.every((reference) => {
+        return (
+          reference.init === true ||
+          (reference.identifier.type === AST_NODE_TYPES.Identifier &&
+            !reference.isWrite() &&
+            directCallUse(reference.identifier))
+        );
+      })
+    );
+  }
+
+  function hasOnlySubstitutableParameterReferences(
+    root: Node,
+    parameters: ReadonlySet<TypeScriptSymbol>,
+  ): boolean {
+    let safe = true;
+
+    function referenceIsSubstitutable(node: Node): boolean {
+      let current = node;
+      while (
+        (isParenthesizedExpression(current.parent) ||
+          isAsExpression(current.parent) ||
+          isSatisfiesExpression(current.parent) ||
+          isTypeAssertionExpression(current.parent) ||
+          isNonNullExpression(current.parent)) &&
+        current.parent.expression === current
+      ) {
+        current = current.parent;
+      }
+      const parent = current.parent;
+      return (
+        current === root ||
+        (isTemplateSpan(parent) && parent.expression === current) ||
+        (isCallExpression(parent) &&
+          parent.arguments.some((argument) => {
+            return argument === current;
+          })) ||
+        (isArrayLiteralExpression(parent) &&
+          parent.elements.some((element) => {
+            return element === current;
+          })) ||
+        (isConditionalExpression(parent) &&
+          (parent.whenTrue === current || parent.whenFalse === current))
+      );
+    }
+
+    function visit(node: Node): void {
+      if (!safe) {
+        return;
+      }
+      if (isIdentifier(node)) {
+        const symbol = resolvedSymbol(
+          checker,
+          checker.getSymbolAtLocation(node),
+        );
+        if (
+          symbol !== undefined &&
+          parameters.has(symbol) &&
+          !referenceIsSubstitutable(node)
+        ) {
+          safe = false;
+          return;
+        }
+      }
+      forEachChild(node, visit);
+    }
+
+    visit(root);
+    return safe;
+  }
+
+  function localFunction(node: TSESTree.CallExpression): LocalFunction | null {
+    if (
+      node.callee.type !== AST_NODE_TYPES.Identifier ||
+      node.arguments.some((argument) => {
+        return argument.type === AST_NODE_TYPES.SpreadElement;
+      })
+    ) {
+      return null;
+    }
+    const tsCallee = services.esTreeNodeToTSNodeMap.get(node.callee);
+    const declaration = symbolAt(node.callee)?.valueDeclaration;
+    if (
+      declaration === undefined ||
+      !isFunctionDeclaration(declaration) ||
+      declaration.getSourceFile() !== tsCallee.getSourceFile() ||
+      declaration.body === undefined ||
+      declaration.body.statements.length !== 1 ||
+      hasExportModifier(declaration) ||
+      declaration.parameters.length !== node.arguments.length
+    ) {
+      return null;
+    }
+    if (!hasOnlyDirectCallReferences(node.callee)) {
+      return null;
+    }
+    const parameters: TypeScriptSymbol[] = [];
+    for (const parameter of declaration.parameters) {
+      if (
+        parameter.dotDotDotToken !== undefined ||
+        parameter.initializer !== undefined ||
+        !isIdentifier(parameter.name)
+      ) {
+        return null;
+      }
+      const symbol = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(parameter.name),
+      );
+      if (symbol === undefined) {
+        return null;
+      }
+      parameters.push(symbol);
+    }
+    const statement = declaration.body.statements[0];
+    if (
+      statement === undefined ||
+      !isReturnStatement(statement) ||
+      statement.expression === undefined
+    ) {
+      return null;
+    }
+    if (
+      !hasOnlySubstitutableParameterReferences(
+        statement.expression,
+        new Set(parameters),
+      )
+    ) {
+      return null;
+    }
+    const returned = services.tsNodeToESTreeNodeMap.get(statement.expression);
+    if (!isComposableExpression(returned) || !expressionIsDrizzleSql(node)) {
+      return null;
+    }
+    return {
+      declaration,
+      parameters,
+      returned,
+    };
+  }
+
+  function joinCallUsing(
+    node: TSESTree.Expression,
+  ): TSESTree.CallExpression | null {
+    const use = outerTransparentExpression(node);
+    const parent = use.parent;
+    return parent.type === AST_NODE_TYPES.CallExpression &&
+      parent.arguments[0] === use &&
+      drizzleSqlMember(parent, "join")
+      ? parent
+      : null;
+  }
+
+  function arrayHasOnlySafeJoinUses(
+    node: TSESTree.ArrayExpression,
+    activeVariables: Set<TypeScriptSymbol>,
+    activeExpressions: Set<TSESTree.Expression>,
+  ): boolean {
+    const directJoin = joinCallUsing(node);
+    if (directJoin !== null) {
+      return isSafeComposedValueUse(
+        directJoin,
+        activeVariables,
+        activeExpressions,
+      );
+    }
+    const use = outerTransparentExpression(node);
+    if (
+      use.parent.type !== AST_NODE_TYPES.VariableDeclarator ||
+      use.parent.init !== use ||
+      use.parent.id.type !== AST_NODE_TYPES.Identifier
+    ) {
+      return false;
+    }
+    const declaration = symbolAt(use.parent.id)?.valueDeclaration;
+    if (
+      declaration === undefined ||
+      !isVariableDeclaration(declaration) ||
+      !isConstVariable(declaration) ||
+      variableIsExported(declaration)
+    ) {
+      return false;
+    }
+    const variable = variableInScope(use.parent.id);
+    return (
+      variable !== null &&
+      variable.references.every((reference) => {
+        if (reference.init === true) {
+          return true;
+        }
+        const identifier = reference.identifier;
+        if (
+          identifier.type !== AST_NODE_TYPES.Identifier ||
+          reference.isWrite()
+        ) {
+          return false;
+        }
+        const join = joinCallUsing(identifier);
+        return (
+          join !== null &&
+          isSafeComposedValueUse(join, activeVariables, activeExpressions)
+        );
+      })
+    );
+  }
+
+  function isSafeComposedValueUse(
+    node: TSESTree.Expression,
+    activeVariables: Set<TypeScriptSymbol>,
+    activeExpressions: Set<TSESTree.Expression>,
+  ): boolean {
+    const use = outerTransparentExpression(node);
+    if (activeExpressions.has(use)) {
+      return false;
+    }
+    activeExpressions.add(use);
+    let safe = false;
+    if (isSafeTerminalUse(use)) {
+      safe = true;
+    } else {
+      const parent = use.parent;
+      if (
+        parent.type === AST_NODE_TYPES.TemplateLiteral &&
+        parent.expressions.includes(use) &&
+        parent.parent.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        isDrizzleSqlTag(checker, services, parent.parent.tag)
+      ) {
+        safe = isSafeComposedValueUse(
+          parent.parent,
+          activeVariables,
+          activeExpressions,
+        );
+      } else if (
+        parent.type === AST_NODE_TYPES.ConditionalExpression &&
+        (parent.consequent === use || parent.alternate === use)
+      ) {
+        safe = isSafeComposedValueUse(
+          parent,
+          activeVariables,
+          activeExpressions,
+        );
+      } else if (
+        parent.type === AST_NODE_TYPES.ArrayExpression &&
+        parent.elements.includes(use)
+      ) {
+        safe = arrayHasOnlySafeJoinUses(
+          parent,
+          activeVariables,
+          activeExpressions,
+        );
+      } else if (
+        parent.type === AST_NODE_TYPES.CallExpression &&
+        parent.arguments.includes(use) &&
+        (drizzleSqlMember(parent, "join") || localFunction(parent) !== null)
+      ) {
+        safe = isSafeComposedValueUse(
+          parent,
+          activeVariables,
+          activeExpressions,
+        );
+      } else if (
+        parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        parent.init === use &&
+        parent.id.type === AST_NODE_TYPES.Identifier
+      ) {
+        const declaration = symbolAt(parent.id)?.valueDeclaration;
+        safe =
+          declaration !== undefined &&
+          isVariableDeclaration(declaration) &&
+          isConstVariable(declaration) &&
+          !variableIsExported(declaration) &&
+          hasOnlySafeConstReferences(parent.id, activeVariables);
+      }
+    }
+    activeExpressions.delete(use);
+    return safe;
+  }
+
+  function isSafeCompositionReference(
+    node: TSESTree.Identifier,
+    activeVariables: Set<TypeScriptSymbol>,
+  ): boolean {
+    return isSafeComposedValueUse(node, activeVariables, new Set());
+  }
+
+  function hasOnlySafeConstReferences(
+    node: TSESTree.Identifier,
+    activeVariables: Set<TypeScriptSymbol> = new Set(),
+  ): boolean {
+    const symbol = symbolAt(node);
+    if (symbol === undefined || activeVariables.has(symbol)) {
+      return false;
+    }
+    const variable = variableInScope(node);
+    activeVariables.add(symbol);
+    const safe =
+      variable !== null &&
+      variable.references.every((reference) => {
+        return (
+          reference.init === true ||
+          (reference.identifier.type === AST_NODE_TYPES.Identifier &&
+            !reference.isWrite() &&
+            (reference.identifier === node ||
+              isSafeCompositionReference(
+                reference.identifier,
+                activeVariables,
+              )))
+        );
+      });
+    activeVariables.delete(symbol);
+    return safe;
+  }
+
+  function localConstInitializer(node: TSESTree.Identifier): {
+    readonly declaration: Node;
+    readonly initializer: TSESTree.Expression;
+  } | null {
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    const declaration = symbolAt(node)?.valueDeclaration;
+    if (
+      declaration === undefined ||
+      !isVariableDeclaration(declaration) ||
+      declaration.getSourceFile() !== tsNode.getSourceFile() ||
+      !isConstVariable(declaration) ||
+      variableIsExported(declaration) ||
+      declaration.initializer === undefined ||
+      !hasOnlySafeConstReferences(node)
+    ) {
+      return null;
+    }
+    const initializer = services.tsNodeToESTreeNodeMap.get(
+      declaration.initializer,
+    );
+    return isComposableExpression(initializer)
+      ? { declaration, initializer }
+      : null;
+  }
+
+  function consumeStep(state: MutableCompositionState): boolean {
+    state.steps += 1;
+    return state.steps <= MAX_COMPOSITION_STEPS;
+  }
+
+  function resolvedExpression(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+  ): BoundExpression {
+    let expression = node;
+    const origins: TSESTree.Node[] = [node];
+    const visited = new Set<TypeScriptSymbol>();
+    while (expression.type === AST_NODE_TYPES.Identifier) {
+      const symbol = symbolAt(expression);
+      if (symbol === undefined || visited.has(symbol)) {
+        break;
+      }
+      const substitution = state.substitutions.get(symbol);
+      if (substitution === undefined) {
+        break;
+      }
+      visited.add(symbol);
+      origins.push(...substitution.origins);
+      expression = substitution.expression;
+    }
+    return { expression, origins };
+  }
+
+  function composeInterpolation(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    const resolved = resolvedExpression(node, state);
+    const nested = composeExpression(resolved.expression, state);
+    if (nested !== null) {
+      return withLocalExpansion(prependOrigin(incrementDepth(nested), node));
+    }
+    return expressionSource(resolved.expression, resolved.origins);
+  }
+
+  function composeJoinedChunk(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    const resolved = resolvedExpression(node, state);
+    const nested = composeExpression(resolved.expression, state);
+    return nested === null
+      ? expressionSource(resolved.expression, resolved.origins)
+      : withLocalExpansion(prependOrigin(nested, node));
+  }
+
+  function composeTemplate(
+    node: TSESTree.TaggedTemplateExpression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    if (!isDrizzleSqlTag(checker, services, node.tag)) {
+      return null;
+    }
+    const first = node.quasi.quasis[0];
+    if (first === undefined) {
+      return null;
+    }
+    const expandedTemplates = new Set<TSESTree.TaggedTemplateExpression>([
+      node,
+    ]);
+    let hasLocalExpansion = false;
+    let variantChunks: SqlSourceChunk[][] = [[literalChunk(first)]];
+    for (let index = 0; index < node.quasi.expressions.length; index += 1) {
+      const expression = node.quasi.expressions[index];
+      const following = node.quasi.quasis[index + 1];
+      if (expression === undefined || following === undefined) {
+        return null;
+      }
+      const interpolation = composeInterpolation(expression, state);
+      if (interpolation === null) {
+        return null;
+      }
+      if (
+        variantChunks.length * interpolation.variants.length >
+        MAX_SOURCE_VARIANTS
+      ) {
+        return null;
+      }
+      for (const template of interpolation.expandedTemplates) {
+        expandedTemplates.add(template);
+      }
+      hasLocalExpansion ||= interpolation.hasLocalExpansion;
+      const followingChunk = literalChunk(following);
+      const onlyChunks = variantChunks[0];
+      const onlyInterpolation = interpolation.variants[0];
+      if (
+        variantChunks.length === 1 &&
+        interpolation.variants.length === 1 &&
+        onlyChunks !== undefined &&
+        onlyInterpolation !== undefined
+      ) {
+        onlyChunks.push(...onlyInterpolation.chunks, followingChunk);
+      } else {
+        variantChunks = variantChunks.flatMap((chunks) => {
+          return interpolation.variants.map((variant) => {
+            return [...chunks, ...variant.chunks, followingChunk];
+          });
+        });
+      }
+    }
+    return {
+      expandedTemplates,
+      hasLocalExpansion,
+      variants: variantChunks.map((chunks) => {
+        return { chunks };
+      }),
+    };
+  }
+
+  function staticArray(node: TSESTree.Expression): {
+    readonly declaration: Node | undefined;
+    readonly node: TSESTree.ArrayExpression;
+  } | null {
+    let current = node;
+    let transparent = transparentExpression(current);
+    while (transparent !== null) {
+      current = transparent;
+      transparent = transparentExpression(current);
+    }
+    if (current.type === AST_NODE_TYPES.ArrayExpression) {
+      return { declaration: undefined, node: current };
+    }
+    if (current.type !== AST_NODE_TYPES.Identifier) {
+      return null;
+    }
+    const initializer = localConstInitializer(current);
+    if (initializer === null) {
+      return null;
+    }
+    let value = initializer.initializer;
+    let wrapper = transparentExpression(value);
+    while (wrapper !== null) {
+      value = wrapper;
+      wrapper = transparentExpression(value);
+    }
+    return value.type === AST_NODE_TYPES.ArrayExpression
+      ? { declaration: initializer.declaration, node: value }
+      : null;
+  }
+
+  function composeJoin(
+    node: TSESTree.CallExpression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    if (
+      !drizzleSqlMember(node, "join") ||
+      (node.arguments.length !== 1 && node.arguments.length !== 2) ||
+      node.arguments.some((argument) => {
+        return argument.type === AST_NODE_TYPES.SpreadElement;
+      })
+    ) {
+      return null;
+    }
+    const itemsArgument = node.arguments[0];
+    if (
+      itemsArgument === undefined ||
+      itemsArgument.type === AST_NODE_TYPES.SpreadElement
+    ) {
+      return null;
+    }
+    const array = staticArray(itemsArgument);
+    if (
+      array === null ||
+      array.node.elements.some((element) => {
+        return (
+          element === null || element.type === AST_NODE_TYPES.SpreadElement
+        );
+      }) ||
+      (array.declaration !== undefined &&
+        state.activeDeclarations.has(array.declaration))
+    ) {
+      return null;
+    }
+
+    if (array.declaration !== undefined) {
+      state.activeDeclarations.add(array.declaration);
+    }
+    const separatorArgument = node.arguments[1];
+    if (separatorArgument?.type === AST_NODE_TYPES.SpreadElement) {
+      if (array.declaration !== undefined) {
+        state.activeDeclarations.delete(array.declaration);
+      }
+      return null;
+    }
+    const separator =
+      separatorArgument === undefined
+        ? emptySource()
+        : composeJoinedChunk(separatorArgument, state);
+    if (separator === null) {
+      if (array.declaration !== undefined) {
+        state.activeDeclarations.delete(array.declaration);
+      }
+      return null;
+    }
+
+    let result = emptySource();
+    for (let index = 0; index < array.node.elements.length; index += 1) {
+      const element = array.node.elements[index];
+      if (element === null || element.type === AST_NODE_TYPES.SpreadElement) {
+        if (array.declaration !== undefined) {
+          state.activeDeclarations.delete(array.declaration);
+        }
+        return null;
+      }
+      if (index > 0) {
+        const withSeparator = concatenateSources(result, separator);
+        if (withSeparator === null) {
+          if (array.declaration !== undefined) {
+            state.activeDeclarations.delete(array.declaration);
+          }
+          return null;
+        }
+        result = withSeparator;
+      }
+      const item = composeJoinedChunk(element, state);
+      if (item === null) {
+        if (array.declaration !== undefined) {
+          state.activeDeclarations.delete(array.declaration);
+        }
+        return null;
+      }
+      const withItem = concatenateSources(result, item);
+      if (withItem === null) {
+        if (array.declaration !== undefined) {
+          state.activeDeclarations.delete(array.declaration);
+        }
+        return null;
+      }
+      result = withItem;
+    }
+    if (array.declaration !== undefined) {
+      state.activeDeclarations.delete(array.declaration);
+    }
+    return withLocalExpansion(prependOrigin(result, node));
+  }
+
+  function composeFactory(
+    node: TSESTree.CallExpression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    const factory = localFunction(node);
+    if (factory === null || state.activeDeclarations.has(factory.declaration)) {
+      return null;
+    }
+    const substitutions = new Map(state.substitutions);
+    for (let index = 0; index < factory.parameters.length; index += 1) {
+      const parameter = factory.parameters[index];
+      const argument = node.arguments[index];
+      if (
+        parameter === undefined ||
+        argument === undefined ||
+        argument.type === AST_NODE_TYPES.SpreadElement
+      ) {
+        return null;
+      }
+      substitutions.set(parameter, {
+        expression: argument,
+        origins: [node, argument],
+      });
+    }
+    state.activeDeclarations.add(factory.declaration);
+    const previousSubstitutions = state.substitutions;
+    state.substitutions = substitutions;
+    const result = composeExpression(factory.returned, state);
+    state.substitutions = previousSubstitutions;
+    state.activeDeclarations.delete(factory.declaration);
+    return result === null
+      ? null
+      : withLocalExpansion(prependOrigin(result, node));
+  }
+
+  function composeAlias(
+    node: TSESTree.Identifier,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    if (!expressionIsDrizzleSql(node)) {
+      return null;
+    }
+    const local = localConstInitializer(node);
+    if (local === null || state.activeDeclarations.has(local.declaration)) {
+      return null;
+    }
+    state.activeDeclarations.add(local.declaration);
+    const result = composeExpression(local.initializer, state);
+    state.activeDeclarations.delete(local.declaration);
+    return result === null
+      ? null
+      : withLocalExpansion(prependOrigin(result, node));
+  }
+
+  function composeExpression(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+  ): SqlSource | null {
+    if (!consumeStep(state)) {
+      return null;
+    }
+    const resolved = resolvedExpression(node, state);
+    if (resolved.expression !== node) {
+      const substituted = composeExpression(resolved.expression, state);
+      return substituted === null ? null : prependOrigin(substituted, node);
+    }
+    const transparent = transparentExpression(node);
+    if (transparent !== null) {
+      const result = composeExpression(transparent, state);
+      return result === null ? null : prependOrigin(result, node);
+    }
+    if (state.substitutions.size === 0 && !isCompositionCandidate(node)) {
+      return null;
+    }
+    if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+      return composeTemplate(node, state);
+    }
+    if (node.type === AST_NODE_TYPES.Identifier) {
+      return composeAlias(node, state);
+    }
+    if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+      const consequent = composeExpression(node.consequent, state);
+      const alternate = composeExpression(node.alternate, state);
+      if (consequent === null || alternate === null) {
+        return null;
+      }
+      const choices = combineChoices(
+        prependOrigin(consequent, node.consequent),
+        prependOrigin(alternate, node.alternate),
+      );
+      return choices === null ? null : prependOrigin(choices, node);
+    }
+    if (node.type !== AST_NODE_TYPES.CallExpression) {
+      return null;
+    }
+    if (drizzleSqlMember(node, "empty") && node.arguments.length === 0) {
+      return withLocalExpansion(prependOrigin(emptySource(), node));
+    }
+    return composeJoin(node, state) ?? composeFactory(node, state);
+  }
+
+  return {
+    couldCompose(node: TSESTree.Expression): boolean {
+      return isCompositionCandidate(node);
+    },
+    compose(node: TSESTree.Expression): SqlSource | null {
+      if (cache.has(node)) {
+        return cache.get(node) ?? null;
+      }
+      const state: MutableCompositionState = {
+        activeDeclarations: new Set(),
+        steps: 0,
+        substitutions: new Map(),
+      };
+      const source = composeExpression(node, state);
+      cache.set(node, source);
+      return source;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add one provenance-aware, bounded SQL source composer shared by parser-backed analysis and legacy query-builder classifiers
- support safe nested templates, local immutable aliases, conditionals, `sql.empty()`, static `sql.join()` lists, and same-file single-return factories with argument substitution
- keep uncertain composition opaque, require all concrete variants to agree, preserve diagnostic ownership, and remove the replaced query-builder-specific flattener
- map PostgreSQL UTF-8 byte locations back to composed source chunks and reparse candidate replacement boundaries before reporting helper findings
- preserve PostgreSQL precedence across nested `NOT`, `AND`, `OR`, comparisons, explicit parentheses, joins, factories, and branches while retaining independently replaceable descendants
- keep replacement diagnostics and whole-template ownership inside the current use-site syntax tree so shared aliases and factory definitions remain safe in other SQL contexts
- defer collected type-aware inspections to `Program:exit` so API lint reuses TypeScript analysis caches

## Scope

This changes build-time static analysis only. It does not change production SQL,
database schema or persisted data, runtime APIs or protocols, deployment
compatibility, feature switches, autofixes, suppressions, or the parser-backed
SQL capability catalog.

## Validation

- `corepack pnpm -F @vm0/eslint-rules lint`
- `corepack pnpm -F @vm0/eslint-rules check-types`
- `corepack pnpm -F @vm0/eslint-rules test` — 47 files, 857 tests
- `corepack pnpm -F api lint`
- `corepack pnpm -F api check-types`
- `corepack pnpm knip`
- `git diff --check`
- pre-commit formatting, Knip, and full Turbo type checking — 13 type-check tasks passed
- five same-mount interleaved `origin/main` (`d59963fe90`) / candidate (`17bd4dd00d`) API ESLint samples:
  - elapsed median: 24,756.16 ms → 25,616.60 ms (`+3.48%`, gate `<= +5%`)
  - peak RSS median: 3,468,080 KiB → 3,438,384 KiB (`-0.86%`, gate `<= +10%`)

Closes #23082

Parent context: #23047
