### PR TITLE
perf(mitm-addon): avoid duplicate public destination validation

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -841,11 +841,10 @@ async def request(flow: http.HTTPFlow) -> None:
     """Dispatch a request-phase classification and apply its outcome.
 
     `request_classification.classification_for_request()` reuses an intentionally
-    cached header-phase classification when present; otherwise it delegates to
+    cached header-phase classification when present and revalidates cached
+    firewall allows against the current destination. Otherwise it delegates to
     `request_classification.classify_request()`, which owns the canonical decision
-    order. This hook dispatches the result. For firewall allows, it revalidates any
-    `publicDestination` constraint against the current runtime destination before
-    allowing traffic or injecting credentials.
+    order. This hook dispatches the current-state result.
     """
     connector_intent.capture_and_strip(flow)
 
@@ -911,16 +910,11 @@ async def request(flow: http.HTTPFlow) -> None:
             _set_firewall_block_response(flow, classification.firewall_block)
             return
         if classification.kind == "public_destination_denied":
+            auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+            terminal_usage.release_tracked_flow(flow)
             _block_public_destination_denied(flow, classification.public_destination_denial)
             return
         if classification.kind == "firewall_policy_allow":
-            public_destination_denial = request_classification.current_public_destination_denial(
-                flow,
-                classification.firewall_allow,
-            )
-            if public_destination_denial is not None:
-                _block_public_destination_denied(flow, public_destination_denial)
-                return
             prepare_firewall_metadata(
                 flow,
                 classification.firewall_allow,
@@ -933,15 +927,6 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "firewall_allow":
             allow = classification.firewall_allow
             vm_info = classification.vm_info
-            public_destination_denial = request_classification.current_public_destination_denial(
-                flow,
-                allow,
-            )
-            if public_destination_denial is not None:
-                auth_base_forwarder.release_forward_request_admission_from_flow(flow)
-                terminal_usage.release_tracked_flow(flow)
-                _block_public_destination_denied(flow, public_destination_denial)
-                return
             if connector_diagnostics.maybe_make_firewall_allow_local_response(
                 flow,
                 classification,

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -242,22 +242,33 @@ def classification_for_request(
     api_url: str,
     tls_admission: TlsAdmissionView | None,
 ) -> RequestClassification:
-    """Return the classification the request hook should use.
+    """Return a classification valid for the current request state.
 
     The request hook reuses a header-phase cached classification when one was
-    intentionally carried forward. Otherwise, it classifies the request using
-    the current flow state.
+    intentionally carried forward. Cached firewall allows are revalidated
+    against the current runtime destination because the endpoint may have
+    changed between hooks. Otherwise, this classifies the current flow.
     """
 
     classification = cached_classification(flow)
-    if classification is not None:
-        return classification
-    return classify_request(
-        flow,
-        registry_path=registry_path,
-        api_url=api_url,
-        tls_admission=tls_admission,
-    )
+    if classification is None:
+        return classify_request(
+            flow,
+            registry_path=registry_path,
+            api_url=api_url,
+            tls_admission=tls_admission,
+        )
+    if isinstance(classification, FirewallAllow | FirewallPolicyAllow):
+        public_destination_denial = current_public_destination_denial(
+            flow,
+            classification.firewall_allow,
+        )
+        if public_destination_denial is not None:
+            return PublicDestinationDenied(
+                vm_info=classification.vm_info,
+                public_destination_denial=public_destination_denial,
+            )
+    return classification
 
 
 def classify_request(
@@ -459,11 +470,10 @@ def current_public_destination_denial(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
 ) -> PublicDestinationDenial | None:
-    """Revalidate a firewall allow against the current runtime destination.
+    """Revalidate a cached firewall allow against the current runtime destination.
 
-    This is required even when `requestheaders()` cached a `firewall_allow`,
-    because header-phase publicDestination checks may defer unresolved runtime
-    hostnames until the request phase can observe the final destination.
+    Header-phase publicDestination checks may defer unresolved runtime hostnames
+    until the request phase can observe the final destination.
     """
 
     trusted_authority_host = flow_metadata.trusted_authority_host(flow.metadata)

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -1212,8 +1212,7 @@ async def test_public_destination_revalidates_cached_policy_allow_classification
 
     auth_fetch.assert_not_awaited()
     request_phase_validated_hosts = validated_hosts[1:]
-    assert request_phase_validated_hosts
-    assert request_phase_validated_hosts[-1] == "10.0.0.1"
+    assert "10.0.0.1" in request_phase_validated_hosts
     _assert_public_destination_denied(
         flow,
         destination_host="10.0.0.1",

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -9,6 +9,7 @@ import auth_base_forwarder
 import builtin_host_policy
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import public_destination
 import request_classification
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
@@ -22,6 +23,7 @@ def _write_public_destination_firewall_registry(
     tmp_path,
     *,
     auth_config: dict[str, object] | None = None,
+    unknown_policy: str = "deny",
     vm_fields: dict[str, object] | None = None,
 ):
     return _write_registry(
@@ -40,7 +42,7 @@ def _write_public_destination_firewall_registry(
                 "allow": ["call"],
                 "deny": [],
                 "ask": [],
-                "unknownPolicy": "deny",
+                "unknownPolicy": unknown_policy,
             },
             vm_fields=vm_fields,
         ),
@@ -53,6 +55,7 @@ def _public_destination_flow(
     *,
     destination_host: str,
     method: str = "GET",
+    path: str = "/v1/items",
     extra_headers: tuple[tuple[str, str], ...] = (),
 ):
     return real_flow(
@@ -60,10 +63,22 @@ def _public_destination_flow(
         client_ip="10.200.0.5",
         host=destination_host,
         sni="service.example.com",
-        path="/v1/items",
+        path=path,
         method=method,
         request_headers=headers(("Host", "service.example.com"), *extra_headers),
     )
+
+
+def _track_public_destination_validations(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    validated_hosts: list[object] = []
+    validate_runtime_destination_host = public_destination.validate_runtime_destination_host
+
+    def track(runtime_host: object) -> public_destination.RuntimeDestinationCheck:
+        validated_hosts.append(runtime_host)
+        return validate_runtime_destination_host(runtime_host)
+
+    monkeypatch.setattr(public_destination, "validate_runtime_destination_host", track)
+    return validated_hosts
 
 
 def _assert_public_destination_denied(flow, *, destination_host: str, reason: str) -> None:
@@ -149,10 +164,17 @@ async def test_public_destination_blocks_unsafe_runtime_destination_before_auth(
     ],
 )
 async def test_public_destination_allows_public_runtime_destination(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, destination_host
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    monkeypatch,
+    destination_host,
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host=destination_host)
+    validated_hosts = _track_public_destination_validations(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -161,12 +183,47 @@ async def test_public_destination_allows_public_runtime_destination(
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
+    assert validated_hosts == [destination_host]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://service.example.com"
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "call"
     assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+async def test_public_destination_policy_allow_validates_public_runtime_destination_once(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    monkeypatch,
+):
+    reg_path = _write_public_destination_firewall_registry(
+        tmp_path,
+        unknown_policy="allow",
+    )
+    flow = _public_destination_flow(
+        real_flow,
+        headers,
+        destination_host="93.184.216.34",
+        method="OPTIONS",
+        path="*",
+    )
+    validated_hosts = _track_public_destination_validations(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_awaited()
+    assert validated_hosts == ["93.184.216.34"]
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert "Authorization" not in flow.request.headers
 
 
 async def test_public_destination_blocks_prebound_private_original_destination(
@@ -1111,6 +1168,58 @@ async def test_public_destination_revalidates_cached_auth_base_hostname_classifi
         reason="non_public_destination",
     )
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_public_destination_revalidates_cached_policy_allow_classification(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    monkeypatch,
+):
+    reg_path = _write_public_destination_firewall_registry(
+        tmp_path,
+        unknown_policy="allow",
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = _public_destination_flow(
+        real_flow,
+        headers,
+        destination_host="93.184.216.34",
+        method="OPTIONS",
+        path="*",
+        extra_headers=(("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),),
+    )
+    validated_hosts = _track_public_destination_validations(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        assert validated_hosts == ["93.184.216.34"]
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
+
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("10.0.0.1", 443),
+        )
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_awaited()
+    request_phase_validated_hosts = validated_hosts[1:]
+    assert request_phase_validated_hosts
+    assert request_phase_validated_hosts[-1] == "10.0.0.1"
+    _assert_public_destination_denied(
+        flow,
+        destination_host="10.0.0.1",
+        reason="non_public_destination",
+    )
+    assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
 
 
 async def test_firewall_allow_header_auth_requestheaders_blocks_public_destination_private_host(


### PR DESCRIPTION
## Summary

- make request-phase classification revalidate only firewall allows cached by `requestheaders()`
- remove duplicate `publicDestination` validation from fresh ordinary and policy allow dispatch
- preserve shared denial cleanup for auth-base admission and terminal usage
- add deterministic fresh and cached regressions for ordinary and policy allow flows

## Behavior

Fresh `FirewallAllow` and `FirewallPolicyAllow` classifications now validate the current runtime destination once. Classifications carried across the header/request hook boundary still revalidate against the current endpoint and remain fail-closed if a connected peer changes to a private address.

## Exclusions

- no change to public/private address policy or runtime-host candidate extraction
- no API, database, configuration, protocol, persisted-state, or deployment compatibility change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_public_destination.py` — 63 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4257 passed

Closes #23097
