### PR TITLE
fix: expose thread session bindings in production telemetry

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -811,6 +811,20 @@ describe("CHAT-02: web chat send and client ids", () => {
     expect(pendingBinding.agent_session_run_id).toBe(runId);
     expect(pendingBinding.agent_session_id).toMatch(/[0-9a-f-]{36}/);
     expect(pendingBinding.run_session_id).toBe(pendingBinding.agent_session_id);
+    expect(sandboxOperationEventsForRun(runId)).toContainEqual({
+      _time: expect.any(String),
+      source: "api",
+      op_type: "chat_thread_session_binding_persisted",
+      sandbox_type: "chat",
+      duration_ms: 0,
+      success: true,
+      run_id: runId,
+      chat_thread_id: clientThreadId,
+      agent_session_id: pendingBinding.agent_session_id,
+      agent_session_run_id: runId,
+      binding_action: "initialized",
+      run_status: "pending",
+    });
 
     const timingEvents = apiDispatchTimingEventsForRun(runId);
     expectApiDispatchActions(
@@ -1392,6 +1406,20 @@ describe("CHAT-02: org queue markers", () => {
     expect(queuedBinding.agent_session_run_id).toBe(queuedRun.body.runId);
     expect(queuedBinding.agent_session_id).toMatch(/[0-9a-f-]{36}/);
     expect(queuedBinding.run_session_id).toBe(queuedBinding.agent_session_id);
+    expect(sandboxOperationEventsForRun(queuedRun.body.runId)).toContainEqual({
+      _time: expect.any(String),
+      source: "api",
+      op_type: "chat_thread_session_binding_persisted",
+      sandbox_type: "chat",
+      duration_ms: 0,
+      success: true,
+      run_id: queuedRun.body.runId,
+      chat_thread_id: queuedRun.body.threadId,
+      agent_session_id: queuedBinding.agent_session_id,
+      agent_session_run_id: queuedRun.body.runId,
+      binding_action: "initialized",
+      run_status: "queued",
+    });
 
     const queuedThread = queuedRun.body.threadId;
     const beforeDequeue = await waitForThreadMessages(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4922,6 +4922,34 @@ function recordQueuedRunEnqueueTelemetry(args: {
   }
 }
 
+function recordThreadSessionBindingTelemetry(args: {
+  readonly binding: ThreadSessionBindingWrite;
+  readonly runStatus: "pending" | "queued";
+}): void {
+  const result = safeSync(() => {
+    recordSandboxOperation({
+      sandboxType: "chat",
+      actionType: "chat_thread_session_binding_persisted",
+      durationMs: 0,
+      success: true,
+      runId: args.binding.agentSessionRunId,
+      dimensions: {
+        chat_thread_id: args.binding.chatThreadId,
+        agent_session_id: args.binding.agentSessionId,
+        agent_session_run_id: args.binding.agentSessionRunId,
+        binding_action: args.binding.action,
+        run_status: args.runStatus,
+      },
+    });
+  });
+  if ("error" in result) {
+    L.warn("Failed to record chat thread session binding telemetry", {
+      runId: args.binding.agentSessionRunId,
+      error: result.error,
+    });
+  }
+}
+
 async function publishQueueChangedSafely(args: {
   readonly orgId: string;
   readonly runId: string;
@@ -6651,11 +6679,8 @@ async function committedAtomicLaunchResponse(args: {
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
   if (args.committed.threadSessionBinding) {
-    L.debug("Chat thread session binding persisted", {
-      chatThreadId: args.committed.threadSessionBinding.chatThreadId,
-      agentSessionId: args.committed.threadSessionBinding.agentSessionId,
-      agentSessionRunId: args.committed.threadSessionBinding.agentSessionRunId,
-      bindingAction: args.committed.threadSessionBinding.action,
+    recordThreadSessionBindingTelemetry({
+      binding: args.committed.threadSessionBinding,
       runStatus: args.committed.kind,
     });
   }


### PR DESCRIPTION
## Summary

- replace the filtered debug-only binding event with the existing sandbox operation telemetry path after final admission
- expose `chat_thread_id`, `agent_session_id`, `agent_session_run_id`, `binding_action`, and `run_status` for pending and queued chat-thread runs
- keep the event free of prompts and secrets while leaving schema, readers, and queue behavior unchanged

## Context

Stage 1 production acceptance for #23102 found that `Chat thread session binding persisted` was emitted at debug level and filtered by the production Axiom transport. This PR repairs only that observability gap from #23105; it does not begin Stage 2 canonical reads.

## Verification

- `pnpm prettier --write --ignore-unknown apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "creates a web chat run with client-provided ids|marks queued chat runs and revokes the marker on dequeue" --maxWorkers=1 --silent=passed-only` — 2 passed
- pre-commit file-size and generated-firewall checks
- `pnpm -F api check-types` was attempted twice locally; the TypeScript process reached the container V8 heap limit at 2.0 GB and 2.5 GB without producing a type diagnostic. The PR pipeline must complete the full type check on its larger runner.

Refs #23102