### PR TITLE
fix: refresh website template v2 archives to upstream ccff774

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -150,7 +150,9 @@ describe("registry resource download", () => {
     for (const archive of v2Archives) {
       // The pinned digest must be the one the registry ships, otherwise the
       // version ids below would be resolved for an archive nobody pulls.
-      expect(findWebsiteTemplateResource(archive.id)?.source.archive).toEqual({
+      expect(
+        findWebsiteTemplateResource(archive.id)?.source.archive,
+      ).toStrictEqual({
         type: "tar.gz",
         sha256: archive.sha256,
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -70,79 +70,79 @@ describe("registry resource download", () => {
       {
         id: "template:black-slabs-v2",
         versionId:
-          "bfdd76866483fc78cf49f1e05a55732c3001dc6edd0899433367773eb3ec2435",
+          "3a7ccdd16e0c710cf20a0deddbd02d3a58a8125d2b3542648bc261bbaf9c5c91",
         sha256:
-          "0f12d8408536ce4e0178129db5ceecc3b7d77605eaff76bff8fab04fd6193c22",
+          "de6f78c5a524cf3959ca56af7a93ec5bca113555bbd1a5983eebf1bc353971d4",
       },
       {
         id: "template:blueprint-grid-v2",
         versionId:
-          "d7b65f9e32a9dc691ba9f96dfc45945d034ee7e841d53ff904a41038574572a3",
+          "c86f579ecca5f29d45eab19ae19157bdc9a9bc14c99cdbf8611b86aaae3aea70",
         sha256:
-          "38737948531b22ab5ae03c537464b948b48e139ca0362ea68e9dd3daaf6760b6",
+          "dec02c4fe156566272a92b7386cb032cec7e3a1250dd42429ca3e7f42374dc28",
       },
       {
         id: "template:coastal-hotel-v2",
         versionId:
-          "9851c21802d2c96cb0d6a4b799f73249287b1ed8b46ab94cb719ce4d9f38c3e8",
+          "7c13e39abcabf4cb31bdecdac80e096d6e039367e23c55ca0c3e6647d8fb3583",
         sha256:
-          "5c8650684d247143e010859d957c58c3c77d2b4e3a5540dbb4c4961cc2d70d54",
+          "09d239d7a0e1c27334f2c3c8da9e408174cece6bcc8a34342438598db739aa4e",
       },
       {
         id: "template:dot-matrix-v2",
         versionId:
-          "c3dc44d2445926f7bdc65e017028155aff73d7d59bc0deb783faf6ba689dcf5b",
+          "9a8977088b02b43d15654674571a88c0128b29076bb8e837d47ddd3a6ea4fd6a",
         sha256:
-          "20931f59434fea45e2772dd4a2a7790572f65b3514b84bfbb245968618f0ad44",
+          "0beb9b1bcb12ace6d3541df269a629af8e3b41c8f9d7e3c3fcfe069655cd9074",
       },
       {
         id: "template:frame-stack-v2",
         versionId:
-          "4b29a3ccedbd2259f2663e9bae60bafe0ca03ab98c415c0d2624f2dbd5379972",
+          "cb8cf528ebfce90e6f78081fbaee0029f2790ff5398ffa0642a6c30c8c1e0c1b",
         sha256:
-          "628139021e196f12e06723d899d299a89dc16696870fede38fc9864b6ffff9c1",
+          "7c4c13eaa22b4185607c6ac6a726dd931fe896b279b38a6267c0105f81214f8b",
       },
       {
         id: "template:frosted-scatter-v2",
         versionId:
-          "5076edab7ea87ad666e04ce74e8781f19eda8c660c697834d97a4e0d161f3035",
+          "7cab5008dbe877dd5ac43e3511d06109d101dda389bbdcc4589396ff495d9d41",
         sha256:
-          "3b0fab9f9f52434f37686377793dae2e467e818e48b85b6696f862d9e8e23232",
+          "c67a7baf924ae4b57241e61527dd875d084e38040653a9bbcc659c13d2382cf9",
       },
       {
         id: "template:gallery-wall-v2",
         versionId:
-          "26e2033b18e1a1c2efed697b3b29b0f8e589c4556de34bd2caff1dc801b377e5",
+          "c208b3119387422c4487d1a9a6f3c8f1618d0ee77dcfd51cbe26e6b4092cb002",
         sha256:
-          "df998b7ca480d24665b49e6c07f4e29eb8f26f3916ed3b8051f41e47535588ab",
+          "f6e41fb711b8c9317a425b463a9812e99f2aecb630d1acbfb77ef0965c2ba55f",
       },
       {
         id: "template:glass-bloom-v2",
         versionId:
-          "3fc6629067c9581ccccd11b679e99e26dbbd45b9d15cce182ce4edb224216d1e",
+          "fe6ac8450b6f822707c3e38c2705b2b88828c9226befa090086dc53635d9f9b6",
         sha256:
-          "b66ec9fda392e13a8f0c71c842cc0b2e655695cf60d7dd28e8db3b322ba35596",
+          "713fbac57cf37a0ddd6d7e7d79a0b9f29f8fff7a0aa55bc741bc5dcd0e498d25",
       },
       {
         id: "template:serif-stack-v2",
         versionId:
-          "00b1f6cbce5f93d1df53adc3519b7f32ebc9c1417c78a88b7f2e98fa7aff231e",
+          "e61f178818ccf31a0676ca0183fccbaef3019972adab592d8a5ba17287f54f65",
         sha256:
-          "0641c65b035abab0b53d3b345178688f1b4091083d1b7c574b640537b49ef3e5",
+          "6d5d65fb21d6c5ec5627fe32fbfc55e80841a2343f2d91bf3ee3a0f62547766a",
       },
       {
         id: "template:sticker-pop-v2",
         versionId:
-          "438eea8bf5a75642d2d645c035314416e1a0a44c9462d33b3fd6b36c6f21f673",
+          "d358cbcd29fc725fc282f4675ebba533fd60af564038d8efa0d4a057a29aee5b",
         sha256:
-          "4b076e69118268108e550322cdfe9befd91378bee5d28bf73627df54ccbaacbd",
+          "61954f4652e2cc86cd1016a537078ea050fe95735a7477e6bd56c91a0c0aec3b",
       },
       {
         id: "template:warm-cards-v2",
         versionId:
-          "736c14987395cb828dfa3626ace6ea947ca9852509b64d2867c6be105bdb8a12",
+          "f587c890c6db593a4cd102cb863f2484868277200d5630b40712ee8b2ded3153",
         sha256:
-          "20f0a7fa09bf2653b55fb0323b050accaa565817587d105b98ada03243b75bf3",
+          "213197ef200b16738b51b5d6c4a90b6e6c12c86c63207ef6afc31456cdd0d2e1",
       },
     ] as const;
 

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/registry-resources";
+import { findWebsiteTemplateResource } from "@vm0/core/resource-registry";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -147,6 +148,13 @@ describe("registry resource download", () => {
     ] as const;
 
     for (const archive of v2Archives) {
+      // The pinned digest must be the one the registry ships, otherwise the
+      // version ids below would be resolved for an archive nobody pulls.
+      expect(findWebsiteTemplateResource(archive.id)?.source.archive).toEqual({
+        type: "tar.gz",
+        sha256: archive.sha256,
+      });
+
       expect(
         resolvePrivateRegistryResourceArchive(
           archive.id,

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -136,47 +136,47 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "template:black-slabs":
     "eaca342df50857477c64a1ca73faffb4a1819879948fc8610ff095fae9fe3f22",
   "template:black-slabs-v2":
-    "bfdd76866483fc78cf49f1e05a55732c3001dc6edd0899433367773eb3ec2435",
+    "3a7ccdd16e0c710cf20a0deddbd02d3a58a8125d2b3542648bc261bbaf9c5c91",
   "template:blueprint-grid":
     "78988a658604a25feb259d54e4543bfe6d57f85efe7ad67737e02c794d25e491",
   "template:blueprint-grid-v2":
-    "d7b65f9e32a9dc691ba9f96dfc45945d034ee7e841d53ff904a41038574572a3",
+    "c86f579ecca5f29d45eab19ae19157bdc9a9bc14c99cdbf8611b86aaae3aea70",
   "template:coastal-hotel":
     "3907cdbed6078702a058ed9c66c1cdeb76f83f1062efcf3b046cce0bd5c8ed06",
   "template:coastal-hotel-v2":
-    "9851c21802d2c96cb0d6a4b799f73249287b1ed8b46ab94cb719ce4d9f38c3e8",
+    "7c13e39abcabf4cb31bdecdac80e096d6e039367e23c55ca0c3e6647d8fb3583",
   "template:dot-matrix":
     "293a2bc33150ca1f39132a8235c5cf355944e8d3e213b5f7703237314a2ac449",
   "template:dot-matrix-v2":
-    "c3dc44d2445926f7bdc65e017028155aff73d7d59bc0deb783faf6ba689dcf5b",
+    "9a8977088b02b43d15654674571a88c0128b29076bb8e837d47ddd3a6ea4fd6a",
   "template:frame-stack":
     "efbf1788c8b084aa12b7cd48f7a3bf5fc9964d1e6115edbd9124f8cacfbfb3ca",
   "template:frame-stack-v2":
-    "4b29a3ccedbd2259f2663e9bae60bafe0ca03ab98c415c0d2624f2dbd5379972",
+    "cb8cf528ebfce90e6f78081fbaee0029f2790ff5398ffa0642a6c30c8c1e0c1b",
   "template:frosted-scatter":
     "c4507fd54d252dc905df36d99f23ab65a4d41185b78e62515ff3eb3d87a381a4",
   "template:frosted-scatter-v2":
-    "5076edab7ea87ad666e04ce74e8781f19eda8c660c697834d97a4e0d161f3035",
+    "7cab5008dbe877dd5ac43e3511d06109d101dda389bbdcc4589396ff495d9d41",
   "template:gallery-wall":
     "9e81cd8b35f9f6374440cd3a4a8fc214db4a137962797df69bde46248c4e75f3",
   "template:gallery-wall-v2":
-    "26e2033b18e1a1c2efed697b3b29b0f8e589c4556de34bd2caff1dc801b377e5",
+    "c208b3119387422c4487d1a9a6f3c8f1618d0ee77dcfd51cbe26e6b4092cb002",
   "template:glass-bloom":
     "52d38ebc1e62b974f7ab2f6dba8823b0a2f7c43d5c11d8079f32e3ff85df1e50",
   "template:glass-bloom-v2":
-    "3fc6629067c9581ccccd11b679e99e26dbbd45b9d15cce182ce4edb224216d1e",
+    "fe6ac8450b6f822707c3e38c2705b2b88828c9226befa090086dc53635d9f9b6",
   "template:serif-stack":
     "adee3b87f670c52a3cc4971e5dd8795f8ca05690087caff4b0d8b32b9029bead",
   "template:serif-stack-v2":
-    "00b1f6cbce5f93d1df53adc3519b7f32ebc9c1417c78a88b7f2e98fa7aff231e",
+    "e61f178818ccf31a0676ca0183fccbaef3019972adab592d8a5ba17287f54f65",
   "template:sticker-pop":
     "ddae2ff9236b0a4663dc19ad23b374488c0d4d9eddf9b5a4e8cad36011b0b420",
   "template:sticker-pop-v2":
-    "438eea8bf5a75642d2d645c035314416e1a0a44c9462d33b3fd6b36c6f21f673",
+    "d358cbcd29fc725fc282f4675ebba533fd60af564038d8efa0d4a057a29aee5b",
   "template:warm-cards":
     "0a87c99afe9cf24424aa1a1740a57cc3698e43f3c571b8ef1fd4560192f38746",
   "template:warm-cards-v2":
-    "736c14987395cb828dfa3626ace6ea947ca9852509b64d2867c6be105bdb8a12",
+    "f587c890c6db593a4cd102cb863f2484868277200d5630b40712ee8b2ded3153",
 } as const satisfies Record<string, string>;
 
 // Presentation runbook versions keyed by the digest in the current registry.

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -5,27 +5,27 @@ import { findRegistryResourceForPull } from "../index";
 
 const EXPECTED_WEBSITE_TEMPLATE_V2_SHA256: Record<string, string> = {
   "black-slabs":
-    "840a02ad6e9caac5abfa6abea991f7a0c71fdee16700011d64ad3af7013164cc",
+    "de6f78c5a524cf3959ca56af7a93ec5bca113555bbd1a5983eebf1bc353971d4",
   "blueprint-grid":
-    "8d02b52dfe72d8d0e59ba69e6ee9ffe3ae527c68e6cc89afe04264801c5c8d53",
+    "dec02c4fe156566272a92b7386cb032cec7e3a1250dd42429ca3e7f42374dc28",
   "coastal-hotel":
-    "b9e2ac6e12ee525ce8896b704071eebf439590700d95060c6db76c90d167a08e",
+    "09d239d7a0e1c27334f2c3c8da9e408174cece6bcc8a34342438598db739aa4e",
   "dot-matrix":
-    "823b02b5ac17d4899de867b99a9332912f6ace671cce8a72a91cff9426a661b3",
+    "0beb9b1bcb12ace6d3541df269a629af8e3b41c8f9d7e3c3fcfe069655cd9074",
   "frame-stack":
-    "c2a9d32dadbc0e00c3e29fe78eebe6525757b81e21d39eb25cbf34adb98e2322",
+    "7c4c13eaa22b4185607c6ac6a726dd931fe896b279b38a6267c0105f81214f8b",
   "frosted-scatter":
-    "a2a191134d56a33b90bfc0540c97a022f8f4b028d942ddcd482380ad5e9589ca",
+    "c67a7baf924ae4b57241e61527dd875d084e38040653a9bbcc659c13d2382cf9",
   "gallery-wall":
-    "0295121b12c8ded9a93efd3781e308020ffcb5b71b1f9fc682cac96cf4d5c14a",
+    "f6e41fb711b8c9317a425b463a9812e99f2aecb630d1acbfb77ef0965c2ba55f",
   "glass-bloom":
-    "48374e9ded67087f481b82d260a70438aa2fd9abc33367e4190fa5fb606214e4",
+    "713fbac57cf37a0ddd6d7e7d79a0b9f29f8fff7a0aa55bc741bc5dcd0e498d25",
   "serif-stack":
-    "9cb399465cb5c66ae7fb857986450ef154e7dc7c6e7c59a89281011933c55ab3",
+    "6d5d65fb21d6c5ec5627fe32fbfc55e80841a2343f2d91bf3ee3a0f62547766a",
   "sticker-pop":
-    "5802135c5f922d6ae3748d13468e6bc24549f70c946fdf109b34ff02de471b09",
+    "61954f4652e2cc86cd1016a537078ea050fe95735a7477e6bd56c91a0c0aec3b",
   "warm-cards":
-    "0973164b9b4e3811ab565430043f74a6fa0546ca6f215db64a1eb79bd14542e6",
+    "213197ef200b16738b51b5d6c4a90b6e6c12c86c63207ef6afc31456cdd0d2e1",
 };
 
 describe("zero resource pull registry resolver", () => {

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -51,27 +51,27 @@ const EXPECTED_WEBSITE_TEMPLATE_SHA256: Record<string, string> = {
 
 const EXPECTED_WEBSITE_TEMPLATE_V2_SHA256: Record<string, string> = {
   "black-slabs":
-    "840a02ad6e9caac5abfa6abea991f7a0c71fdee16700011d64ad3af7013164cc",
+    "de6f78c5a524cf3959ca56af7a93ec5bca113555bbd1a5983eebf1bc353971d4",
   "blueprint-grid":
-    "8d02b52dfe72d8d0e59ba69e6ee9ffe3ae527c68e6cc89afe04264801c5c8d53",
+    "dec02c4fe156566272a92b7386cb032cec7e3a1250dd42429ca3e7f42374dc28",
   "coastal-hotel":
-    "b9e2ac6e12ee525ce8896b704071eebf439590700d95060c6db76c90d167a08e",
+    "09d239d7a0e1c27334f2c3c8da9e408174cece6bcc8a34342438598db739aa4e",
   "dot-matrix":
-    "823b02b5ac17d4899de867b99a9332912f6ace671cce8a72a91cff9426a661b3",
+    "0beb9b1bcb12ace6d3541df269a629af8e3b41c8f9d7e3c3fcfe069655cd9074",
   "frame-stack":
-    "c2a9d32dadbc0e00c3e29fe78eebe6525757b81e21d39eb25cbf34adb98e2322",
+    "7c4c13eaa22b4185607c6ac6a726dd931fe896b279b38a6267c0105f81214f8b",
   "frosted-scatter":
-    "a2a191134d56a33b90bfc0540c97a022f8f4b028d942ddcd482380ad5e9589ca",
+    "c67a7baf924ae4b57241e61527dd875d084e38040653a9bbcc659c13d2382cf9",
   "gallery-wall":
-    "0295121b12c8ded9a93efd3781e308020ffcb5b71b1f9fc682cac96cf4d5c14a",
+    "f6e41fb711b8c9317a425b463a9812e99f2aecb630d1acbfb77ef0965c2ba55f",
   "glass-bloom":
-    "48374e9ded67087f481b82d260a70438aa2fd9abc33367e4190fa5fb606214e4",
+    "713fbac57cf37a0ddd6d7e7d79a0b9f29f8fff7a0aa55bc741bc5dcd0e498d25",
   "serif-stack":
-    "9cb399465cb5c66ae7fb857986450ef154e7dc7c6e7c59a89281011933c55ab3",
+    "6d5d65fb21d6c5ec5627fe32fbfc55e80841a2343f2d91bf3ee3a0f62547766a",
   "sticker-pop":
-    "5802135c5f922d6ae3748d13468e6bc24549f70c946fdf109b34ff02de471b09",
+    "61954f4652e2cc86cd1016a537078ea050fe95735a7477e6bd56c91a0c0aec3b",
   "warm-cards":
-    "0973164b9b4e3811ab565430043f74a6fa0546ca6f215db64a1eb79bd14542e6",
+    "213197ef200b16738b51b5d6c4a90b6e6c12c86c63207ef6afc31456cdd0d2e1",
 };
 
 describe("website template items", () => {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -3573,27 +3573,27 @@ const WEBSITE_TEMPLATE_PACKAGES: readonly WebsiteTemplatePackage[] =
 
 const WEBSITE_TEMPLATE_V2_ARCHIVE_SHA256: Record<string, string> = {
   "black-slabs":
-    "840a02ad6e9caac5abfa6abea991f7a0c71fdee16700011d64ad3af7013164cc",
+    "de6f78c5a524cf3959ca56af7a93ec5bca113555bbd1a5983eebf1bc353971d4",
   "blueprint-grid":
-    "8d02b52dfe72d8d0e59ba69e6ee9ffe3ae527c68e6cc89afe04264801c5c8d53",
+    "dec02c4fe156566272a92b7386cb032cec7e3a1250dd42429ca3e7f42374dc28",
   "coastal-hotel":
-    "b9e2ac6e12ee525ce8896b704071eebf439590700d95060c6db76c90d167a08e",
+    "09d239d7a0e1c27334f2c3c8da9e408174cece6bcc8a34342438598db739aa4e",
   "dot-matrix":
-    "823b02b5ac17d4899de867b99a9332912f6ace671cce8a72a91cff9426a661b3",
+    "0beb9b1bcb12ace6d3541df269a629af8e3b41c8f9d7e3c3fcfe069655cd9074",
   "frame-stack":
-    "c2a9d32dadbc0e00c3e29fe78eebe6525757b81e21d39eb25cbf34adb98e2322",
+    "7c4c13eaa22b4185607c6ac6a726dd931fe896b279b38a6267c0105f81214f8b",
   "frosted-scatter":
-    "a2a191134d56a33b90bfc0540c97a022f8f4b028d942ddcd482380ad5e9589ca",
+    "c67a7baf924ae4b57241e61527dd875d084e38040653a9bbcc659c13d2382cf9",
   "gallery-wall":
-    "0295121b12c8ded9a93efd3781e308020ffcb5b71b1f9fc682cac96cf4d5c14a",
+    "f6e41fb711b8c9317a425b463a9812e99f2aecb630d1acbfb77ef0965c2ba55f",
   "glass-bloom":
-    "48374e9ded67087f481b82d260a70438aa2fd9abc33367e4190fa5fb606214e4",
+    "713fbac57cf37a0ddd6d7e7d79a0b9f29f8fff7a0aa55bc741bc5dcd0e498d25",
   "serif-stack":
-    "9cb399465cb5c66ae7fb857986450ef154e7dc7c6e7c59a89281011933c55ab3",
+    "6d5d65fb21d6c5ec5627fe32fbfc55e80841a2343f2d91bf3ee3a0f62547766a",
   "sticker-pop":
-    "5802135c5f922d6ae3748d13468e6bc24549f70c946fdf109b34ff02de471b09",
+    "61954f4652e2cc86cd1016a537078ea050fe95735a7477e6bd56c91a0c0aec3b",
   "warm-cards":
-    "0973164b9b4e3811ab565430043f74a6fa0546ca6f215db64a1eb79bd14542e6",
+    "213197ef200b16738b51b5d6c4a90b6e6c12c86c63207ef6afc31456cdd0d2e1",
 };
 
 function websiteTemplateV2ArchiveSha256(slug: string): string {


### PR DESCRIPTION
## Summary

The 11 feature-gated `template:*-v2` website packages were still serving archives built from `vm0-ai/Template-artifact@d11b988`. Upstream `main` has since moved to `ccff774`, which changed **every one of the 11 templates** (35 files, +300/-75) across two commits:

- `d5f29ad` — image and style fixes: `resolve-images.mjs` request/attribution handling, `engine/sections.mjs`, `SKILL.md`, `skin-frame-stack.mjs`
- `0f8fd39` — example adjustments: `engine/sections.mjs` in 10 bundles, plus new `example.html` / `sample-plan.json` content for `coastal-hotel` and `serif-stack`

This PR rebuilds all 11 archives from `ccff774`, uploads them to private R2, and repoints the pinned ids and digests.

## User-visible impact

Users inside the `WebsiteTemplateV2` rollout (currently staff orgs only — `enabled: false`) generate websites from the current upstream templates instead of a four-day-old snapshot, picking up the image-resolution and section fixes. Every picker-backed v1 website resource is untouched, so released clients and users outside the rollout keep pulling the exact package they pull today.

## Implementation

- `WEBSITE_TEMPLATE_V2_ARCHIVE_SHA256` in `@vm0/core` — new archive digests for all 11 slugs
- `PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS` in the API download route — new private R2 version ids for the 11 `template:*-v2` ids
- Coverage in API, Core, and CLI repinned to the same values

The API test's `v2Archives` fixture also had **stale `sha256` values** — they were never updated by #22497 and could not fail, because the test passes the same digest as both `expectedSha256` and `defaultSha256`. Those entries now carry the real shipped digests, so the fixture documents reality again.

## Storage notes

- Archives contain only `archive/<slug>` from `Template-artifact@ccff774`; nothing was added, rewritten, or excluded
- Built deterministically (`portable`, `noMtime`), so `sha256` is reproducible from the upstream tree
- Uploaded through the standard `/api/storages/prepare` → S3 PUT → `/api/storages/commit` flow into the existing `registry-resource@template:<slug>-v2` volumes; prior versions stay intact and addressable

| slug | version id | sha256 | files |
|---|---|---|---|
| black-slabs | `3a7ccdd1…` | `de6f78c5…` | 16 |
| blueprint-grid | `c86f579e…` | `dec02c4f…` | 16 |
| coastal-hotel | `7c13e39a…` | `09d239d7…` | 17 |
| dot-matrix | `9a897708…` | `0beb9b1b…` | 15 |
| frame-stack | `cb8cf528…` | `7c4c13ea…` | 18 |
| frosted-scatter | `7cab5008…` | `c67a7baf…` | 16 |
| gallery-wall | `c208b311…` | `f6e41fb7…` | 16 |
| glass-bloom | `fe6ac845…` | `713fbac5…` | 16 |
| serif-stack | `e61f1788…` | `6d5d65fb…` | 18 |
| sticker-pop | `d358cbcd…` | `61954f46…` | 16 |
| warm-cards | `f587c890…` | `213197ef…` | 16 |

## Verification

- Reproduced the **currently shipped** `black-slabs-v2` version id from its file manifest and confirmed the live archive is byte-identical to `Template-artifact@d11b988`, which validates the packaging and upload path used here
- Round-tripped all 11 uploads: downloaded each archive back from R2, matched the recorded SHA-256, and re-hashed every file against its manifest entry (0 mismatches)
- Smoke-rendered all 11 bundles (`node render.mjs sample-plan.json`) — all exit 0 and emit HTML
- Prettier 3.8.1 and `git diff --check`
- Lint, type-check, and unit tests left to the PR pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)