### PR TITLE
perf: disable unused codex plugin and apps startup work

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -25,7 +25,7 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    CODEX_ANALYTICS_DISABLED_CONFIG, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
+    CODEX_FIXED_STARTUP_CONFIGS, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
     HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
@@ -364,7 +364,7 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
     let codex_home = PathBuf::from(runtime.codex_home());
     let child_user_env = runtime.child_user_env();
     let mut config_overrides = runtime.codex_startup_config_overrides();
-    config_overrides.push(CODEX_ANALYTICS_DISABLED_CONFIG.to_string());
+    config_overrides.extend(CODEX_FIXED_STARTUP_CONFIGS.map(str::to_string));
     let mut config = CodexAppServerConfig::new(binary, codex_home)
         .with_child_env(
             runtime.home_dir.as_ref(),

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -168,13 +168,13 @@ fn build_codex_openai_base_url_config(openai_base_url: &str) -> String {
 
 fn push_codex_config_overrides(args: &mut Vec<String>, overrides: &[String]) {
     for override_value in overrides {
-        push_codex_config_override(args, override_value);
+        push_codex_config_override(args, override_value.clone());
     }
 }
 
-fn push_codex_config_override(args: &mut Vec<String>, override_value: &str) {
+fn push_codex_config_override(args: &mut Vec<String>, override_value: impl Into<String>) {
     args.push("-c".to_string());
-    args.push(override_value.to_string());
+    args.push(override_value.into());
 }
 
 fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
@@ -223,12 +223,12 @@ fn build_codex_args(
         paths::CANONICAL_WORKING_DIR.to_string(),
     ];
 
-    push_codex_config_override(&mut args, &build_codex_memories_config());
+    push_codex_config_override(&mut args, build_codex_memories_config());
 
     if startup_config_overrides.is_empty() && !openai_base_url.is_empty() {
         push_codex_config_override(
             &mut args,
-            &build_codex_openai_base_url_config(openai_base_url),
+            build_codex_openai_base_url_config(openai_base_url),
         );
     }
     push_codex_config_overrides(&mut args, startup_config_overrides);

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::{env, paths};
 use guest_common::log_info;
 
-use super::{CODEX_ANALYTICS_DISABLED_CONFIG, CliRuntimeConfig, LOG_TAG, codex_runtime_config};
+use super::{CODEX_FIXED_STARTUP_CONFIGS, CliRuntimeConfig, LOG_TAG, codex_runtime_config};
 
 pub(super) fn build_cli_command_for_runtime(
     runtime: &CliRuntimeConfig<'_>,
@@ -168,9 +168,13 @@ fn build_codex_openai_base_url_config(openai_base_url: &str) -> String {
 
 fn push_codex_config_overrides(args: &mut Vec<String>, overrides: &[String]) {
     for override_value in overrides {
-        args.push("-c".to_string());
-        args.push(override_value.clone());
+        push_codex_config_override(args, override_value);
     }
+}
+
+fn push_codex_config_override(args: &mut Vec<String>, override_value: &str) {
+    args.push("-c".to_string());
+    args.push(override_value.to_string());
 }
 
 fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
@@ -219,16 +223,18 @@ fn build_codex_args(
         paths::CANONICAL_WORKING_DIR.to_string(),
     ];
 
-    args.push("-c".to_string());
-    args.push(build_codex_memories_config());
-    args.push("-c".to_string());
-    args.push(CODEX_ANALYTICS_DISABLED_CONFIG.to_string());
+    push_codex_config_override(&mut args, &build_codex_memories_config());
 
     if startup_config_overrides.is_empty() && !openai_base_url.is_empty() {
-        args.push("-c".to_string());
-        args.push(build_codex_openai_base_url_config(openai_base_url));
+        push_codex_config_override(
+            &mut args,
+            &build_codex_openai_base_url_config(openai_base_url),
+        );
     }
     push_codex_config_overrides(&mut args, startup_config_overrides);
+    for override_value in CODEX_FIXED_STARTUP_CONFIGS {
+        push_codex_config_override(&mut args, override_value);
+    }
 
     if fast_mode {
         push_codex_fast_mode_configs(&mut args);

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -72,7 +72,11 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
-const CODEX_ANALYTICS_DISABLED_CONFIG: &str = "analytics.enabled=false";
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+    "analytics.enabled=false",
+    "features.plugins=false",
+    "features.apps=false",
+];
 const CODEX_WEB_SEARCH_DISABLED_CONFIG: &str = r#"web_search="disabled""#;
 /// Maximum retained bytes for one ordinary CLI stdout record before parsing.
 ///

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -12,6 +12,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+    "analytics.enabled=false",
+    "features.plugins=false",
+    "features.apps=false",
+];
+
 #[tokio::test]
 async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_started()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -82,7 +88,7 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert!(cli_result.failure_diagnostic.is_none());
     assert!(cli_result.last_event_sequence.is_none());
-    assert_app_server_analytics_disabled(&argv_path)?;
+    assert_app_server_fixed_startup_policy(&argv_path)?;
 
     let events = read_agent_log_events(&runtime.paths)?;
     assert_event_type_sequence(
@@ -266,25 +272,27 @@ fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> Result<PathBuf
     Ok(path)
 }
 
-fn assert_app_server_analytics_disabled(argv_path: &Path) -> Result<(), std::io::Error> {
+fn assert_app_server_fixed_startup_policy(argv_path: &Path) -> Result<(), std::io::Error> {
     let args = std::fs::read_to_string(argv_path)?
         .lines()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let analytics_index = args
-        .windows(2)
-        .position(
-            |window| matches!(window, [flag, value] if flag == "-c" && value == "analytics.enabled=false"),
-        )
-        .ok_or_else(|| {
-            std::io::Error::other(format!(
-                "Codex app-server argv should disable upstream analytics: {args:?}"
-            ))
-        })?;
     let app_server_index = args
         .iter()
         .position(|arg| arg == "app-server")
         .ok_or_else(|| std::io::Error::other("Codex argv omitted app-server subcommand"))?;
-    assert!(analytics_index < app_server_index);
+    for expected in CODEX_FIXED_STARTUP_CONFIGS {
+        let config_index = args
+            .windows(2)
+            .position(|window| {
+                matches!(window, [flag, value] if flag == "-c" && value == expected)
+            })
+            .ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "Codex app-server argv should include fixed startup config {expected:?}: {args:?}"
+                ))
+            })?;
+        assert!(config_index < app_server_index);
+    }
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_prompt_stdin.rs
+++ b/crates/guest-agent/tests/codex_prompt_stdin.rs
@@ -11,6 +11,11 @@ use std::time::Duration;
 
 const PRODUCTION_PROMPT_BYTES: usize = 140_421;
 const RESUME_THREAD_ID: &str = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+    "analytics.enabled=false",
+    "features.plugins=false",
+    "features.apps=false",
+];
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
@@ -67,7 +72,7 @@ async fn fresh_and_resumed_codex_stdin_preserve_prompt_text_exactly() -> TestRes
 }
 
 #[tokio::test]
-async fn fresh_and_resumed_codex_disable_upstream_analytics() -> TestResult {
+async fn fresh_and_resumed_codex_apply_fixed_startup_policy() -> TestResult {
     let mock = common::build_and_locate_mock_codex()?;
     let root = tempfile::tempdir()?;
     let argv_path = root.path().join("codex-argv");
@@ -76,7 +81,7 @@ async fn fresh_and_resumed_codex_disable_upstream_analytics() -> TestResult {
 
     for resume in [false, true] {
         let run_id = format!(
-            "codex-analytics-{}",
+            "codex-startup-policy-{}",
             if resume { "resume" } else { "fresh" }
         );
         let runtime = build_runtime(root.path(), &recording_mock, &run_id, "hello", resume)?;
@@ -84,7 +89,7 @@ async fn fresh_and_resumed_codex_disable_upstream_analytics() -> TestResult {
         let result = execute_with_timeout(&runtime).await?;
 
         assert_eq!(result.exit_code, common::CLEAN_EXIT);
-        assert_analytics_disabled(&argv_path)?;
+        assert_fixed_startup_policy(&argv_path)?;
     }
 
     Ok(())
@@ -239,15 +244,17 @@ fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> TestResult<Pat
     )
 }
 
-fn assert_analytics_disabled(argv_path: &Path) -> TestResult {
+fn assert_fixed_startup_policy(argv_path: &Path) -> TestResult {
     let args = std::fs::read_to_string(argv_path)?
         .lines()
         .map(str::to_string)
         .collect::<Vec<_>>();
-    assert!(
-        args.windows(2)
-            .any(|window| matches!(window, [flag, value] if flag == "-c" && value == "analytics.enabled=false")),
-        "Codex argv should disable upstream analytics: {args:?}"
-    );
+    for expected in CODEX_FIXED_STARTUP_CONFIGS {
+        assert!(
+            args.windows(2)
+                .any(|window| matches!(window, [flag, value] if flag == "-c" && value == expected)),
+            "Codex argv should include fixed startup config {expected:?}: {args:?}"
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- disable the unused upstream Codex plugin and built-in Apps subsystems for both ordinary exec and direct app-server launches
- keep the fixed guest-agent startup policy shared across both launch paths and authoritative over runtime-provided overrides
- verify the final fresh, resumed, and app-server process arguments at the child-process boundary

## Why

Codex 0.145.0 enables plugin and Apps startup work by default. Production and
controlled-runner evidence showed unused plugin and Apps requests, including an
approximately 21.5 MB curated plugin download on affected runs. The requests
overlap other startup work, so this PR claims deterministic work elimination,
not a specific end-to-end latency reduction.

VM0-managed skills are mounted independently under
`/home/user/.codex/skills`; this PR does not change skill delivery or the
general skill loader.

## Validation

- `cargo test -p guest-agent --test codex_prompt_stdin`
- `cargo test -p guest-agent --test codex_app_server_backend`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo fmt --all --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- deployed the branch image to `local-liangyou-vm7` and inspected live
  processes for both execution paths:
  - ordinary exec included `features.plugins=false` and
    `features.apps=false`
  - direct app-server included both overrides before `app-server`
  - each network log contained only model API traffic and no curated,
    featured, remote plugin, or built-in Apps requests

The real-agent smoke runs reached the model API and then received the expected
`401` because the local queue carries no model credentials; startup argv and
network behavior were observable before that failure.

## Compatibility and risk

- no API, schema, persisted-state, runner protocol, or frontend changes
- old and new guest-agent versions can overlap safely
- upstream Codex plugins and Apps connectors become unavailable; current
  production evidence found no successful Apps or remote-plugin use
- rollback is a guest-agent revert

After production promotion, plugin/Apps request counts and a
promotion-separated `api_to_first_assistant_message` cohort should be checked
before attributing a user-visible latency change.

Closes #23122
Relates to #22892
