### PR TITLE
feat: prune oversized codex session history

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1071,6 +1071,7 @@ echo "--- Test: Codex compact-generation compatibility ---"
 CODEX_COMPACT_SMOKE=$(cat <<'PY'
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -1251,11 +1252,18 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         server_thread.start()
         root = Path(temp_root)
         port = server.server_port
+        current_codex = shutil.which("codex")
+        assert current_codex is not None, "bundled Codex is not on PATH"
+        current_version = subprocess.check_output(
+            [current_codex, "--version"],
+            text=True,
+        )
+        assert "0.145.0" in current_version
 
         seed_home = root / "seed" / ".codex"
         write_config(seed_home, port)
         run_codex(
-            "/usr/local/bin/codex",
+            current_codex,
             seed_home,
             seed_token,
         )
@@ -1347,7 +1355,7 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
 
         probe_reader(
             "current",
-            Path("/usr/local/bin/codex"),
+            Path(current_codex),
             root / "current",
             candidate_relative_path,
             candidate_bytes,

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1079,6 +1079,7 @@ from pathlib import Path
 
 summary_token = "CODEX-COMPACT-SUMMARY-TOKEN"
 seed_token = "CODEX-COMPACT-SEED-TOKEN"
+compacting_turn_token = "CODEX-COMPACTING-TURN-TOKEN"
 candidate_turn_token = "CODEX-COMPACT-CANDIDATE-TURN-TOKEN"
 append_token = "CODEX-COMPACT-APPEND-TOKEN"
 requests = []
@@ -1163,10 +1164,23 @@ def event_type(record):
     return record.get("payload", {}).get("type")
 
 
-def probe_current_codex(
+def normalize_probe_root(value, root):
+    if isinstance(value, str):
+        return value.replace(str(root), "$PROBE_ROOT")
+    if isinstance(value, list):
+        return [normalize_probe_root(item, root) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: normalize_probe_root(item, root)
+            for key, item in value.items()
+        }
+    return value
+
+
+def resume_history(
     root,
     candidate_relative_path,
-    candidate_bytes,
+    history_bytes,
     session_id,
     port,
 ):
@@ -1174,7 +1188,7 @@ def probe_current_codex(
     write_config(codex_home, port)
     history_file = codex_home / "sessions" / candidate_relative_path
     history_file.parent.mkdir(parents=True)
-    history_file.write_bytes(candidate_bytes)
+    history_file.write_bytes(history_bytes)
     assert not list(codex_home.glob("*.sqlite")), (
         "probe must begin without Codex SQLite state"
     )
@@ -1194,7 +1208,42 @@ def probe_current_codex(
     assert requests and requests[-1][0] == "/v1/responses", (
         f"Codex did not reach the loopback Responses endpoint\n{output}"
     )
-    request_json = json.dumps(requests[-1][1])
+    return resumed, history_file, original_size, requests[-1][1]
+
+
+def probe_current_codex(
+    root,
+    candidate_relative_path,
+    full_bytes,
+    candidate_bytes,
+    session_id,
+    port,
+):
+    full_root = root / "full"
+    _, _, _, full_request = resume_history(
+        full_root,
+        candidate_relative_path,
+        full_bytes,
+        session_id,
+        port,
+    )
+    candidate_root = root / "candidate"
+    resumed, history_file, original_size, candidate_request = resume_history(
+        candidate_root,
+        candidate_relative_path,
+        candidate_bytes,
+        session_id,
+        port,
+    )
+    full_input = normalize_probe_root(full_request["input"], full_root)
+    candidate_input = normalize_probe_root(
+        candidate_request["input"],
+        candidate_root,
+    )
+    assert full_input == candidate_input, (
+        "Codex reconstructed different model input from the compact generation"
+    )
+    request_json = json.dumps(candidate_request)
     assert summary_token in request_json, (
         "Codex did not reconstruct compact replacement history"
     )
@@ -1213,7 +1262,8 @@ def probe_current_codex(
         "Codex changed the resumed thread ID"
     )
 
-    histories = list((codex_home / "sessions").rglob("*.jsonl"))
+    candidate_home = candidate_root / ".codex"
+    histories = list((candidate_home / "sessions").rglob("*.jsonl"))
     assert histories == [history_file], (
         f"Codex created a different rollout path: {histories}"
     )
@@ -1267,7 +1317,22 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         candidate_relative_path = source.relative_to(
             seed_home / "sessions"
         )
-        complete_index = next(
+        compacting_turn = run_codex(
+            seed_home,
+            "resume",
+            session_id,
+            compacting_turn_token,
+        )
+        compacting_output = compacting_turn.stdout + compacting_turn.stderr
+        assert (
+            f"no rollout found for thread id {session_id}"
+            not in compacting_output.lower()
+        ), compacting_output
+        records = [
+            json.loads(line)
+            for line in source.read_text().splitlines()
+        ]
+        complete_index = max(
             index
             for index, record in enumerate(records)
             if event_type(record) in {"task_complete", "turn_complete"}
@@ -1348,15 +1413,34 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             if event_type(record) in {"task_complete", "turn_complete"}
         ]
         assert (
-            len(candidate_starts) >= 2
-            and len(candidate_completions) == 1
+            len(candidate_starts) >= 3
+            and len(candidate_completions) == 2
             and candidate_starts[-1] == candidate_completions[-1]
         ), "failed to build a compacting turn delimited by the next turn"
-        candidate_bytes = source.read_bytes()
+        full_lines = source.read_bytes().splitlines(keepends=True)
+        full_records = [json.loads(line) for line in full_lines]
+        compact_index = max(
+            index
+            for index, record in enumerate(full_records)
+            if record.get("type") == "compacted"
+        )
+        candidate_start_index = max(
+            index
+            for index, record in enumerate(full_records[:compact_index])
+            if event_type(record) in {"task_started", "turn_started"}
+        )
+        full_bytes = b"".join(full_lines)
+        candidate_bytes = b"".join(
+            [full_lines[0], *full_lines[candidate_start_index:]]
+        )
+        assert len(candidate_bytes) < len(full_bytes), (
+            "probe candidate must discard history superseded by compaction"
+        )
 
         probe_current_codex(
             root / "current",
             candidate_relative_path,
+            full_bytes,
             candidate_bytes,
             session_id,
             port,

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1064,9 +1064,8 @@ sudo "$BIN_DIR/runner" exec --timeout 75 \
   || fail "Claude compact-generation compatibility"
 echo "PASS: Claude compact-generation compatibility"
 
-# Test 9: verify both supported Codex readers resume and append a native
-# compact generation under the same thread ID. Model requests terminate on
-# loopback; the rollback CLI is installed only into this ephemeral test root.
+# Test 9: verify the bundled Codex resumes and appends a native compact
+# generation under the same thread ID. Model requests terminate on loopback.
 echo "--- Test: Codex compact-generation compatibility ---"
 CODEX_COMPACT_SMOKE=$(cat <<'PY'
 import json
@@ -1082,6 +1081,8 @@ summary_token = "CODEX-COMPACT-SUMMARY-TOKEN"
 seed_token = "CODEX-COMPACT-SEED-TOKEN"
 append_token = "CODEX-COMPACT-APPEND-TOKEN"
 requests = []
+current_codex = shutil.which("codex")
+assert current_codex is not None, "bundled Codex is not on PATH"
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -1127,7 +1128,7 @@ stream_max_retries = 0
     )
 
 
-def run_codex(binary, codex_home, *args):
+def run_codex(codex_home, *args):
     env = os.environ.copy()
     env.update(
         {
@@ -1140,7 +1141,7 @@ def run_codex(binary, codex_home, *args):
     )
     return subprocess.run(
         [
-            str(binary),
+            current_codex,
             "exec",
             *args,
             "--skip-git-repo-check",
@@ -1161,9 +1162,7 @@ def event_type(record):
     return record.get("payload", {}).get("type")
 
 
-def probe_reader(
-    label,
-    binary,
+def probe_current_codex(
     root,
     candidate_relative_path,
     candidate_bytes,
@@ -1182,7 +1181,6 @@ def probe_reader(
 
     requests.clear()
     resumed = run_codex(
-        binary,
         codex_home,
         "resume",
         session_id,
@@ -1193,11 +1191,11 @@ def probe_reader(
         f"no rollout found for thread id {session_id}" not in output.lower()
     ), output
     assert requests and requests[-1][0] == "/v1/responses", (
-        f"{label}: Codex did not reach the loopback Responses endpoint\n{output}"
+        f"Codex did not reach the loopback Responses endpoint\n{output}"
     )
     request_json = json.dumps(requests[-1][1])
     assert summary_token in request_json, (
-        f"{label}: Codex did not reconstruct compact replacement history"
+        "Codex did not reconstruct compact replacement history"
     )
 
     started = [
@@ -1211,15 +1209,15 @@ def probe_reader(
         if event.get("type") == "thread.started"
     ]
     assert thread_started and thread_started[0].get("thread_id") == session_id, (
-        f"{label}: Codex changed the resumed thread ID"
+        "Codex changed the resumed thread ID"
     )
 
     histories = list((codex_home / "sessions").rglob("*.jsonl"))
     assert histories == [history_file], (
-        f"{label}: Codex created a different rollout path: {histories}"
+        f"Codex created a different rollout path: {histories}"
     )
     assert history_file.stat().st_size > original_size, (
-        f"{label}: Codex did not append to the compact generation"
+        "Codex did not append to the compact generation"
     )
 
     records = [
@@ -1240,7 +1238,7 @@ def probe_reader(
     assert (
         len(turn_completions) >= 2
         and turn_starts[-1] == turn_completions[-1]
-    ), f"{label}: Codex did not append a complete turn"
+    ), "Codex did not append a complete turn"
 
 
 with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
@@ -1252,18 +1250,10 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         server_thread.start()
         root = Path(temp_root)
         port = server.server_port
-        current_codex = shutil.which("codex")
-        assert current_codex is not None, "bundled Codex is not on PATH"
-        current_version = subprocess.check_output(
-            [current_codex, "--version"],
-            text=True,
-        )
-        assert "0.145.0" in current_version
 
         seed_home = root / "seed" / ".codex"
         write_config(seed_home, port)
         run_codex(
-            current_codex,
             seed_home,
             seed_token,
         )
@@ -1328,44 +1318,8 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             seed_home / "sessions"
         )
 
-        rollback_install = root / "rollback-install"
-        subprocess.run(
-            [
-                "npm",
-                "install",
-                "--prefix",
-                str(rollback_install),
-                "--ignore-scripts",
-                "--no-audit",
-                "--no-fund",
-                "--package-lock=false",
-                "@openai/codex@0.144.6",
-            ],
-            timeout=90,
-            check=True,
-        )
-        rollback_codex = (
-            rollback_install / "node_modules/.bin/codex"
-        )
-        rollback_version = subprocess.check_output(
-            [rollback_codex, "--version"],
-            text=True,
-        )
-        assert "0.144.6" in rollback_version
-
-        probe_reader(
-            "current",
-            Path(current_codex),
+        probe_current_codex(
             root / "current",
-            candidate_relative_path,
-            candidate_bytes,
-            session_id,
-            port,
-        )
-        probe_reader(
-            "rollback",
-            rollback_codex,
-            root / "rollback",
             candidate_relative_path,
             candidate_bytes,
             session_id,
@@ -1376,7 +1330,7 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         server_thread.join()
 PY
 )
-sudo "$BIN_DIR/runner" exec --timeout 150 \
+sudo "$BIN_DIR/runner" exec --timeout 75 \
   --sandbox "$SANDBOX_ID" -- python3 -c "$CODEX_COMPACT_SMOKE" \
   || fail "Codex compact-generation compatibility"
 echo "PASS: Codex compact-generation compatibility"

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1175,7 +1175,7 @@ def probe_current_codex(
     history_file.parent.mkdir(parents=True)
     history_file.write_bytes(candidate_bytes)
     assert not list(codex_home.glob("*.sqlite")), (
-        f"{label}: probe must begin without Codex SQLite state"
+        "probe must begin without Codex SQLite state"
     )
     original_size = history_file.stat().st_size
 

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1064,7 +1064,317 @@ sudo "$BIN_DIR/runner" exec --timeout 75 \
   || fail "Claude compact-generation compatibility"
 echo "PASS: Claude compact-generation compatibility"
 
-# Test 9: verify /etc/environment is loaded for both user and root
+# Test 9: verify both supported Codex readers resume and append a native
+# compact generation under the same thread ID. Model requests terminate on
+# loopback; the rollback CLI is installed only into this ephemeral test root.
+echo "--- Test: Codex compact-generation compatibility ---"
+CODEX_COMPACT_SMOKE=$(cat <<'PY'
+import json
+import os
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+summary_token = "CODEX-COMPACT-SUMMARY-TOKEN"
+seed_token = "CODEX-COMPACT-SEED-TOKEN"
+append_token = "CODEX-COMPACT-APPEND-TOKEN"
+requests = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        requests.append((self.path, payload))
+        body = json.dumps(
+            {
+                "error": {
+                    "message": "loopback compatibility probe",
+                    "type": "invalid_request_error",
+                }
+            }
+        ).encode()
+        self.send_response(400)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def write_config(codex_home, port):
+    codex_home.mkdir(parents=True)
+    (codex_home / "config.toml").write_text(
+        f"""
+model = "gpt-5.1-codex-mini"
+model_provider = "mock"
+approval_policy = "never"
+sandbox_mode = "read-only"
+
+[model_providers.mock]
+name = "mock"
+base_url = "http://127.0.0.1:{port}/v1"
+env_key = "PATH"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+""".lstrip()
+    )
+
+
+def run_codex(binary, codex_home, *args):
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(codex_home.parent),
+            "CODEX_HOME": str(codex_home),
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+        }
+    )
+    return subprocess.run(
+        [
+            str(binary),
+            "exec",
+            *args,
+            "--skip-git-repo-check",
+            "--json",
+        ],
+        cwd="/home/user/workspace",
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def event_type(record):
+    if record.get("type") != "event_msg":
+        return None
+    return record.get("payload", {}).get("type")
+
+
+def probe_reader(
+    label,
+    binary,
+    root,
+    candidate_relative_path,
+    candidate_bytes,
+    session_id,
+    port,
+):
+    codex_home = root / ".codex"
+    write_config(codex_home, port)
+    history_file = codex_home / "sessions" / candidate_relative_path
+    history_file.parent.mkdir(parents=True)
+    history_file.write_bytes(candidate_bytes)
+    assert not list(codex_home.glob("*.sqlite")), (
+        f"{label}: probe must begin without Codex SQLite state"
+    )
+    original_size = history_file.stat().st_size
+
+    requests.clear()
+    resumed = run_codex(
+        binary,
+        codex_home,
+        "resume",
+        session_id,
+        append_token,
+    )
+    output = resumed.stdout + resumed.stderr
+    assert (
+        f"no rollout found for thread id {session_id}" not in output.lower()
+    ), output
+    assert requests and requests[-1][0] == "/v1/responses", (
+        f"{label}: Codex did not reach the loopback Responses endpoint\n{output}"
+    )
+    request_json = json.dumps(requests[-1][1])
+    assert summary_token in request_json, (
+        f"{label}: Codex did not reconstruct compact replacement history"
+    )
+
+    started = [
+        json.loads(line)
+        for line in resumed.stdout.splitlines()
+        if line.startswith("{")
+    ]
+    thread_started = [
+        event
+        for event in started
+        if event.get("type") == "thread.started"
+    ]
+    assert thread_started and thread_started[0].get("thread_id") == session_id, (
+        f"{label}: Codex changed the resumed thread ID"
+    )
+
+    histories = list((codex_home / "sessions").rglob("*.jsonl"))
+    assert histories == [history_file], (
+        f"{label}: Codex created a different rollout path: {histories}"
+    )
+    assert history_file.stat().st_size > original_size, (
+        f"{label}: Codex did not append to the compact generation"
+    )
+
+    records = [
+        json.loads(line)
+        for line in history_file.read_text().splitlines()
+    ]
+    assert records[0]["payload"]["id"] == session_id
+    turn_starts = [
+        record["payload"]["turn_id"]
+        for record in records
+        if event_type(record) in {"task_started", "turn_started"}
+    ]
+    turn_completions = [
+        record["payload"]["turn_id"]
+        for record in records
+        if event_type(record) in {"task_complete", "turn_complete"}
+    ]
+    assert (
+        len(turn_completions) >= 2
+        and turn_starts[-1] == turn_completions[-1]
+    ), f"{label}: Codex did not append a complete turn"
+
+
+with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
+    with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+        server_thread = threading.Thread(
+            target=server.serve_forever,
+            daemon=True,
+        )
+        server_thread.start()
+        root = Path(temp_root)
+        port = server.server_port
+
+        seed_home = root / "seed" / ".codex"
+        write_config(seed_home, port)
+        run_codex(
+            "/usr/local/bin/codex",
+            seed_home,
+            seed_token,
+        )
+        source = next((seed_home / "sessions").rglob("*.jsonl"))
+        records = [
+            json.loads(line)
+            for line in source.read_text().splitlines()
+        ]
+        session_id = records[0]["payload"]["id"]
+        complete_index = next(
+            index
+            for index, record in enumerate(records)
+            if event_type(record) in {"task_complete", "turn_complete"}
+        )
+        records.insert(
+            complete_index,
+            {
+                "timestamp": "2026-01-01T00:00:00.000Z",
+                "type": "compacted",
+                "payload": {
+                    "message": summary_token,
+                    "replacement_history": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": seed_token,
+                                }
+                            ],
+                        },
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": summary_token,
+                                }
+                            ],
+                        },
+                    ],
+                    "window_number": 2,
+                    "first_window_id": (
+                        "019c0000-0000-7000-8000-000000000001"
+                    ),
+                    "previous_window_id": (
+                        "019c0000-0000-7000-8000-000000000002"
+                    ),
+                    "window_id": (
+                        "019c0000-0000-7000-8000-000000000003"
+                    ),
+                },
+            },
+        )
+        candidate_bytes = "".join(
+            json.dumps(record, separators=(",", ":")) + "\n"
+            for record in records
+        ).encode()
+        candidate_relative_path = source.relative_to(
+            seed_home / "sessions"
+        )
+
+        rollback_install = root / "rollback-install"
+        subprocess.run(
+            [
+                "npm",
+                "install",
+                "--prefix",
+                str(rollback_install),
+                "--ignore-scripts",
+                "--no-audit",
+                "--no-fund",
+                "--package-lock=false",
+                "@openai/codex@0.144.6",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=True,
+        )
+        rollback_codex = (
+            rollback_install / "node_modules/.bin/codex"
+        )
+        rollback_version = subprocess.check_output(
+            [rollback_codex, "--version"],
+            text=True,
+        )
+        assert "0.144.6" in rollback_version
+
+        probe_reader(
+            "current",
+            Path("/usr/local/bin/codex"),
+            root / "current",
+            candidate_relative_path,
+            candidate_bytes,
+            session_id,
+            port,
+        )
+        probe_reader(
+            "rollback",
+            rollback_codex,
+            root / "rollback",
+            candidate_relative_path,
+            candidate_bytes,
+            session_id,
+            port,
+        )
+
+        server.shutdown()
+        server_thread.join()
+PY
+)
+sudo "$BIN_DIR/runner" exec --timeout 150 \
+  --sandbox "$SANDBOX_ID" -- python3 -c "$CODEX_COMPACT_SMOKE" \
+  || fail "Codex compact-generation compatibility"
+echo "PASS: Codex compact-generation compatibility"
+
+# Test 10: verify /etc/environment is loaded for both user and root
 # [sync:etc-environment] Keep in sync with: crates/runner/scripts/customize-rootfs.sh
 echo "--- Test: environment variables ---"
 EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -1095,7 +1405,7 @@ check_env "user" ""
 check_env "root" "--sudo"
 echo "PASS: environment variables"
 
-# Test 10: verify HTTPS works through proxy for each runtime
+# Test 11: verify HTTPS works through proxy for each runtime
 # All traffic goes through mitmproxy, so TLS must trust the proxy CA.
 echo "--- Test: HTTPS through proxy ---"
 TLS_URL="https://www.google.com"
@@ -1133,7 +1443,7 @@ sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "cd /tmp && printf 
 echo "  HTTPS go: ok"
 echo "PASS: HTTPS through proxy"
 
-# Test 11: verify DNS resolution works inside sandbox
+# Test 12: verify DNS resolution works inside sandbox
 # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
 echo "--- Test: DNS resolution ---"
 OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- getent hosts localhost 2>&1) \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1118,7 +1118,7 @@ sandbox_mode = "read-only"
 [model_providers.mock]
 name = "mock"
 base_url = "http://127.0.0.1:{port}/v1"
-env_key = "PATH"
+env_key = "CODEX_COMPACT_PROBE_TOKEN"
 wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
@@ -1132,6 +1132,7 @@ def run_codex(binary, codex_home, *args):
         {
             "HOME": str(codex_home.parent),
             "CODEX_HOME": str(codex_home),
+            "CODEX_COMPACT_PROBE_TOKEN": "test-token",
             "NO_PROXY": "127.0.0.1,localhost",
             "no_proxy": "127.0.0.1,localhost",
         }
@@ -1332,8 +1333,6 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
                 "--package-lock=false",
                 "@openai/codex@0.144.6",
             ],
-            capture_output=True,
-            text=True,
             timeout=90,
             check=True,
         )

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1079,6 +1079,7 @@ from pathlib import Path
 
 summary_token = "CODEX-COMPACT-SUMMARY-TOKEN"
 seed_token = "CODEX-COMPACT-SEED-TOKEN"
+candidate_turn_token = "CODEX-COMPACT-CANDIDATE-TURN-TOKEN"
 append_token = "CODEX-COMPACT-APPEND-TOKEN"
 requests = []
 current_codex = shutil.which("codex")
@@ -1263,11 +1264,15 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             for line in source.read_text().splitlines()
         ]
         session_id = records[0]["payload"]["id"]
+        candidate_relative_path = source.relative_to(
+            seed_home / "sessions"
+        )
         complete_index = next(
             index
             for index, record in enumerate(records)
             if event_type(record) in {"task_complete", "turn_complete"}
         )
+        records.pop(complete_index)
         records.insert(
             complete_index,
             {
@@ -1310,13 +1315,44 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
                 },
             },
         )
-        candidate_bytes = "".join(
-            json.dumps(record, separators=(",", ":")) + "\n"
-            for record in records
-        ).encode()
-        candidate_relative_path = source.relative_to(
-            seed_home / "sessions"
+        source.write_bytes(
+            "".join(
+                json.dumps(record, separators=(",", ":")) + "\n"
+                for record in records
+            ).encode()
         )
+
+        candidate_turn = run_codex(
+            seed_home,
+            "resume",
+            session_id,
+            candidate_turn_token,
+        )
+        candidate_output = candidate_turn.stdout + candidate_turn.stderr
+        assert (
+            f"no rollout found for thread id {session_id}"
+            not in candidate_output.lower()
+        ), candidate_output
+        candidate_records = [
+            json.loads(line)
+            for line in source.read_text().splitlines()
+        ]
+        candidate_starts = [
+            record["payload"]["turn_id"]
+            for record in candidate_records
+            if event_type(record) in {"task_started", "turn_started"}
+        ]
+        candidate_completions = [
+            record["payload"]["turn_id"]
+            for record in candidate_records
+            if event_type(record) in {"task_complete", "turn_complete"}
+        ]
+        assert (
+            len(candidate_starts) >= 2
+            and len(candidate_completions) == 1
+            and candidate_starts[-1] == candidate_completions[-1]
+        ), "failed to build a compacting turn delimited by the next turn"
+        candidate_bytes = source.read_bytes()
 
         probe_current_codex(
             root / "current",

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -24,7 +24,10 @@ use flate2::{Compression, write::GzEncoder};
 use futures_util::stream::{self, FuturesUnordered, StreamExt};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
-use guest_session_prune::{ClaudeHistorySelection, select_claude_compact_generation};
+use guest_session_prune::{
+    ClaudeHistorySelection, CodexHistorySelection, select_claude_compact_generation,
+    select_codex_compact_generation,
+};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
@@ -37,6 +40,7 @@ const ARTIFACT_CHECKPOINT_CONCURRENCY: usize = 2;
 const SESSION_HISTORY_ZSTD_LEVEL: i32 = 3;
 const SESSION_HISTORY_COMPRESSION_MIN_BYTES: usize = SESSION_HISTORY_GZIP_MIN_BYTES as usize;
 const CLAUDE_SESSION_PRUNING_FEATURE_FLAG: &str = "claudeSessionPruning";
+const CODEX_SESSION_PRUNING_FEATURE_FLAG: &str = "codexSessionPruning";
 
 #[derive(Clone, Copy)]
 enum CheckpointMode {
@@ -64,20 +68,38 @@ struct PreparedSessionHistory {
 
 enum PreparedLiveHistory {
     MatchesCheckpoint,
-    ClaudeCandidate(Option<PendingClaudeHistoryReplacement>),
+    NativeCandidate {
+        kind: NativeHistoryKind,
+        replacement: Option<PendingNativeHistoryReplacement>,
+    },
 }
 
-struct PendingClaudeHistoryReplacement {
+#[derive(Clone, Copy)]
+enum NativeHistoryKind {
+    ClaudeCode,
+    Codex,
+}
+
+impl NativeHistoryKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "Claude",
+            Self::Codex => "Codex",
+        }
+    }
+}
+
+struct PendingNativeHistoryReplacement {
     staged: tempfile::NamedTempFile,
     target: PathBuf,
 }
 
-impl PendingClaudeHistoryReplacement {
+impl PendingNativeHistoryReplacement {
     fn stage(target: &Path, candidate: &[u8]) -> std::io::Result<Self> {
         let parent = target.parent().ok_or_else(|| {
             std::io::Error::new(
                 ErrorKind::InvalidInput,
-                "Claude session history path has no parent",
+                "session history path has no parent",
             )
         })?;
         let mut staged = tempfile::NamedTempFile::new_in(parent)?;
@@ -331,7 +353,7 @@ impl CheckpointMode {
         matches!(self, Self::Recovery)
     }
 
-    fn can_prune_claude_history(self) -> bool {
+    fn can_prune_history(self) -> bool {
         matches!(self, Self::Success)
     }
 }
@@ -517,6 +539,7 @@ struct CheckpointInputs<'a> {
     run_id: &'a str,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
+    codex_session_pruning_enabled: bool,
     home_dir: &'a str,
     artifact_entries: &'a [env::ArtifactEnv],
     session_id_file: Cow<'a, str>,
@@ -533,6 +556,12 @@ impl<'a> CheckpointInputs<'a> {
                 .config
                 .feature_flags
                 .get(CLAUDE_SESSION_PRUNING_FEATURE_FLAG)
+                .copied()
+                .unwrap_or(false),
+            codex_session_pruning_enabled: runtime
+                .config
+                .feature_flags
+                .get(CODEX_SESSION_PRUNING_FEATURE_FLAG)
                 .copied()
                 .unwrap_or(false),
             home_dir: &runtime.config.home_dir,
@@ -826,12 +855,13 @@ fn prepare_session_history(
     mode: CheckpointMode,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
+    codex_session_pruning_enabled: bool,
     cli_agent_session_id: &str,
     history_marker_payload: &str,
     history_read_start: std::time::Instant,
 ) -> Result<PreparedSessionHistory, AgentError> {
     if claude_session_pruning_enabled
-        && mode.can_prune_claude_history()
+        && mode.can_prune_history()
         && framework == env::Framework::ClaudeCode
         && !session_history::is_codex_marker(history_marker_payload)
     {
@@ -841,7 +871,7 @@ fn prepare_session_history(
                 let source_size = candidate.source_size();
                 let candidate_size = candidate.candidate_size();
                 let candidate = candidate.into_bytes();
-                let replacement = PendingClaudeHistoryReplacement::stage(
+                let replacement = PendingNativeHistoryReplacement::stage(
                     Path::new(history_marker_payload),
                     &candidate,
                 )
@@ -854,7 +884,10 @@ fn prepare_session_history(
                 record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
                 let mut prepared =
                     prepare_raw_session_history(mode, history_read_start, candidate)?;
-                prepared.live_history = PreparedLiveHistory::ClaudeCandidate(replacement);
+                prepared.live_history = PreparedLiveHistory::NativeCandidate {
+                    kind: NativeHistoryKind::ClaudeCode,
+                    replacement,
+                };
                 return Ok(prepared);
             }
             Ok(ClaudeHistorySelection::Ineligible(reason)) => {
@@ -869,6 +902,93 @@ fn prepare_session_history(
                 log_warn!(
                     LOG_TAG,
                     "Claude session history selector failed; using ordinary checkpoint path: {error}"
+                );
+                record_sandbox_op(
+                    "session_history_prune",
+                    prune_start.elapsed(),
+                    false,
+                    Some("selector_io"),
+                );
+            }
+        }
+    }
+
+    if codex_session_pruning_enabled
+        && mode.can_prune_history()
+        && framework == env::Framework::Codex
+        && session_history::is_codex_marker(history_marker_payload)
+    {
+        let prune_start = std::time::Instant::now();
+        match session_history::resolve_plain_codex_session_history_from_payload(
+            history_marker_payload,
+        ) {
+            Ok(Some(mut source)) => {
+                match select_codex_compact_generation(&mut source.file, cli_agent_session_id) {
+                    Ok(CodexHistorySelection::Candidate(candidate)) => {
+                        let source_size = candidate.source_size();
+                        let candidate_size = candidate.candidate_size();
+                        let candidate = candidate.into_bytes();
+                        let replacement =
+                            PendingNativeHistoryReplacement::stage(&source.path, &candidate).ok();
+                        log_info!(
+                            LOG_TAG,
+                            "Selected Codex compact generation for checkpoint \
+                             (source_size={source_size}, candidate_size={candidate_size})"
+                        );
+                        record_sandbox_op(
+                            "session_history_prune",
+                            prune_start.elapsed(),
+                            true,
+                            None,
+                        );
+                        let mut prepared =
+                            prepare_raw_session_history(mode, history_read_start, candidate)?;
+                        prepared.live_history = PreparedLiveHistory::NativeCandidate {
+                            kind: NativeHistoryKind::Codex,
+                            replacement,
+                        };
+                        return Ok(prepared);
+                    }
+                    Ok(CodexHistorySelection::Ineligible(reason)) => {
+                        log_info!(
+                            LOG_TAG,
+                            "Codex session history not eligible for pruning: {}",
+                            reason.as_str()
+                        );
+                        record_sandbox_op(
+                            "session_history_prune",
+                            prune_start.elapsed(),
+                            true,
+                            None,
+                        );
+                    }
+                    Err(error) => {
+                        log_warn!(
+                            LOG_TAG,
+                            "Codex session history selector failed; using ordinary checkpoint \
+                             path: {error}"
+                        );
+                        record_sandbox_op(
+                            "session_history_prune",
+                            prune_start.elapsed(),
+                            false,
+                            Some("selector_io"),
+                        );
+                    }
+                }
+            }
+            Ok(None) => {
+                log_info!(
+                    LOG_TAG,
+                    "Codex session history not eligible for pruning: compressed_source"
+                );
+                record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
+            }
+            Err(error) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Codex session history selector failed; using ordinary checkpoint path: \
+                     {error}"
                 );
                 record_sandbox_op(
                     "session_history_prune",
@@ -1202,6 +1322,7 @@ async fn create_checkpoint_impl(
         mode,
         inputs.framework,
         inputs.claude_session_pruning_enabled,
+        inputs.codex_session_pruning_enabled,
         &cli_agent_session_id,
         &history_marker_payload,
         history_read_start,
@@ -1289,7 +1410,10 @@ fn reconcile_live_history_after_checkpoint(live_history: PreparedLiveHistory) ->
     let started_at = std::time::Instant::now();
     match live_history {
         PreparedLiveHistory::MatchesCheckpoint => true,
-        PreparedLiveHistory::ClaudeCandidate(Some(replacement)) => {
+        PreparedLiveHistory::NativeCandidate {
+            kind,
+            replacement: Some(replacement),
+        } => {
             if replacement.persist().is_ok() {
                 record_sandbox_op(
                     "session_history_prune_reconcile",
@@ -1299,7 +1423,8 @@ fn reconcile_live_history_after_checkpoint(live_history: PreparedLiveHistory) ->
                 );
                 log_info!(
                     LOG_TAG,
-                    "Replaced live Claude session history with committed compact generation"
+                    "Replaced live {} session history with committed compact generation",
+                    kind.label()
                 );
                 true
             } else {
@@ -1311,13 +1436,17 @@ fn reconcile_live_history_after_checkpoint(live_history: PreparedLiveHistory) ->
                 );
                 log_warn!(
                     LOG_TAG,
-                    "Failed to reconcile committed Claude compact generation into live session \
-                     history; next resume will restore checkpoint history"
+                    "Failed to reconcile committed {} compact generation into live session \
+                     history; next resume will restore checkpoint history",
+                    kind.label()
                 );
                 false
             }
         }
-        PreparedLiveHistory::ClaudeCandidate(None) => {
+        PreparedLiveHistory::NativeCandidate {
+            kind,
+            replacement: None,
+        } => {
             record_sandbox_op(
                 "session_history_prune_reconcile",
                 started_at.elapsed(),
@@ -1326,8 +1455,9 @@ fn reconcile_live_history_after_checkpoint(live_history: PreparedLiveHistory) ->
             );
             log_warn!(
                 LOG_TAG,
-                "Failed to reconcile committed Claude compact generation into live session \
-                 history; next resume will restore checkpoint history"
+                "Failed to reconcile committed {} compact generation into live session \
+                 history; next resume will restore checkpoint history",
+                kind.label()
             );
             false
         }
@@ -2007,6 +2137,7 @@ mod tests {
             run_id: "checkpoint-missing-mount",
             framework: env::Framework::ClaudeCode,
             claude_session_pruning_enabled: false,
+            codex_session_pruning_enabled: false,
             home_dir: &home_dir,
             artifact_entries: &entries,
             session_id_file: guest_paths.session_id_file().into(),
@@ -2101,6 +2232,7 @@ mod tests {
             run_id: "checkpoint-codex-zstd-reuse",
             framework: env::Framework::Codex,
             claude_session_pruning_enabled: false,
+            codex_session_pruning_enabled: false,
             home_dir: &home_dir,
             artifact_entries: &[],
             session_id_file: guest_paths.session_id_file().into(),
@@ -2204,6 +2336,7 @@ mod tests {
             run_id: "checkpoint-codex-zstd-legacy-fallback",
             framework: env::Framework::Codex,
             claude_session_pruning_enabled: false,
+            codex_session_pruning_enabled: false,
             home_dir: &home_dir,
             artifact_entries: &[],
             session_id_file: guest_paths.session_id_file().into(),

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -913,76 +913,78 @@ fn prepare_session_history(
         }
     }
 
+    let mut resolved_codex_history = None;
     if codex_session_pruning_enabled
         && mode.can_prune_history()
         && framework == env::Framework::Codex
         && session_history::is_codex_marker(history_marker_payload)
     {
         let prune_start = std::time::Instant::now();
-        match session_history::resolve_plain_codex_session_history_from_payload(
-            history_marker_payload,
-        ) {
-            Ok(Some(mut source)) => {
-                match select_codex_compact_generation(&mut source.file, cli_agent_session_id) {
-                    Ok(CodexHistorySelection::Candidate(candidate)) => {
-                        let source_size = candidate.source_size();
-                        let candidate_size = candidate.candidate_size();
-                        let candidate = candidate.into_bytes();
-                        let replacement =
-                            PendingNativeHistoryReplacement::stage(&source.path, &candidate).ok();
-                        log_info!(
-                            LOG_TAG,
-                            "Selected Codex compact generation for checkpoint \
+        match session_history::resolve_codex_session_history_from_payload(history_marker_payload) {
+            Ok(mut source) => {
+                if let Some(file) = source.plain_file_mut() {
+                    match select_codex_compact_generation(file, cli_agent_session_id) {
+                        Ok(CodexHistorySelection::Candidate(candidate)) => {
+                            let source_size = candidate.source_size();
+                            let candidate_size = candidate.candidate_size();
+                            let candidate = candidate.into_bytes();
+                            let replacement =
+                                PendingNativeHistoryReplacement::stage(source.path(), &candidate)
+                                    .ok();
+                            log_info!(
+                                LOG_TAG,
+                                "Selected Codex compact generation for checkpoint \
                              (source_size={source_size}, candidate_size={candidate_size})"
-                        );
-                        record_sandbox_op(
-                            "session_history_prune",
-                            prune_start.elapsed(),
-                            true,
-                            None,
-                        );
-                        let mut prepared =
-                            prepare_raw_session_history(mode, history_read_start, candidate)?;
-                        prepared.live_history = PreparedLiveHistory::NativeCandidate {
-                            kind: NativeHistoryKind::Codex,
-                            replacement,
-                        };
-                        return Ok(prepared);
-                    }
-                    Ok(CodexHistorySelection::Ineligible(reason)) => {
-                        log_info!(
-                            LOG_TAG,
-                            "Codex session history not eligible for pruning: {}",
-                            reason.as_str()
-                        );
-                        record_sandbox_op(
-                            "session_history_prune",
-                            prune_start.elapsed(),
-                            true,
-                            None,
-                        );
-                    }
-                    Err(error) => {
-                        log_warn!(
-                            LOG_TAG,
-                            "Codex session history selector failed; using ordinary checkpoint \
+                            );
+                            record_sandbox_op(
+                                "session_history_prune",
+                                prune_start.elapsed(),
+                                true,
+                                None,
+                            );
+                            let mut prepared =
+                                prepare_raw_session_history(mode, history_read_start, candidate)?;
+                            prepared.live_history = PreparedLiveHistory::NativeCandidate {
+                                kind: NativeHistoryKind::Codex,
+                                replacement,
+                            };
+                            return Ok(prepared);
+                        }
+                        Ok(CodexHistorySelection::Ineligible(reason)) => {
+                            log_info!(
+                                LOG_TAG,
+                                "Codex session history not eligible for pruning: {}",
+                                reason.as_str()
+                            );
+                            record_sandbox_op(
+                                "session_history_prune",
+                                prune_start.elapsed(),
+                                true,
+                                None,
+                            );
+                        }
+                        Err(error) => {
+                            log_warn!(
+                                LOG_TAG,
+                                "Codex session history selector failed; using ordinary checkpoint \
                              path: {error}"
-                        );
-                        record_sandbox_op(
-                            "session_history_prune",
-                            prune_start.elapsed(),
-                            false,
-                            Some("selector_io"),
-                        );
+                            );
+                            record_sandbox_op(
+                                "session_history_prune",
+                                prune_start.elapsed(),
+                                false,
+                                Some("selector_io"),
+                            );
+                        }
                     }
+                } else {
+                    log_info!(
+                        LOG_TAG,
+                        "Codex session history not eligible for pruning: compressed_source"
+                    );
+                    record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
                 }
-            }
-            Ok(None) => {
-                log_info!(
-                    LOG_TAG,
-                    "Codex session history not eligible for pruning: compressed_source"
-                );
-                record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
+                resolved_codex_history = Some(source);
             }
             Err(error) => {
                 log_warn!(
@@ -1000,10 +1002,16 @@ fn prepare_session_history(
         }
     }
 
-    let source = match session_history::read_session_history_checkpoint_source_from_payload_bounded(
-        history_marker_payload,
-        RESUME_SESSION_HISTORY_MAX_BYTES,
-    ) {
+    let source_result = resolved_codex_history.map_or_else(
+        || {
+            session_history::read_session_history_checkpoint_source_from_payload_bounded(
+                history_marker_payload,
+                RESUME_SESSION_HISTORY_MAX_BYTES,
+            )
+        },
+        |source| source.into_checkpoint_source_bounded(RESUME_SESSION_HISTORY_MAX_BYTES),
+    );
+    let source = match source_result {
         Ok(source) => source,
         Err(e) => {
             return Err(fail_preserving_error(
@@ -2161,7 +2169,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkpoint_reuses_codex_zstd_session_history_upload_body() {
+    async fn checkpoint_reuses_codex_zstd_session_history_when_pruning_enabled() {
         let server = MockServer::start();
         let dir = tempfile::tempdir().unwrap();
         let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
@@ -2232,7 +2240,7 @@ mod tests {
             run_id: "checkpoint-codex-zstd-reuse",
             framework: env::Framework::Codex,
             claude_session_pruning_enabled: false,
-            codex_session_pruning_enabled: false,
+            codex_session_pruning_enabled: true,
             home_dir: &home_dir,
             artifact_entries: &[],
             session_id_file: guest_paths.session_id_file().into(),

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -144,27 +144,10 @@ impl ResolvedCodexSessionHistory {
     }
 
     pub(crate) fn into_checkpoint_source_bounded(
-        mut self,
+        self,
         max_bytes: u64,
     ) -> Result<SessionHistoryCheckpointSource, AgentError> {
-        self.file
-            .rewind()
-            .map_err(|error| read_history_error(&self.path, error))?;
-        if self.is_zstd {
-            let encoded_len = self
-                .file
-                .metadata()
-                .map_err(|error| read_history_error(&self.path, error))?
-                .len();
-            if encoded_len <= max_bytes {
-                let encoded = read_zstd_encoded_session_history(self.file, &self.path, max_bytes)?;
-                return Ok(SessionHistoryCheckpointSource::CodexZstd { encoded });
-            }
-        }
-
-        DecodedSessionHistoryReader::open(self.path, self.file)?
-            .read(Some(max_bytes))
-            .map(SessionHistoryCheckpointSource::Decoded)
+        read_open_codex_checkpoint_source_bounded(self.path, self.file, self.is_zstd, max_bytes)
     }
 }
 
@@ -199,20 +182,39 @@ pub(crate) fn read_session_history_checkpoint_source_from_payload_bounded(
     max_bytes: u64,
 ) -> Result<SessionHistoryCheckpointSource, AgentError> {
     match resolve_session_history_source(payload)? {
-        ResolvedSessionHistorySource::Codex(session) if session.is_zstd() => {
-            if session.encoded_len()? <= max_bytes {
-                let encoded = session.into_zstd_bytes(max_bytes)?;
-                Ok(SessionHistoryCheckpointSource::CodexZstd { encoded })
-            } else {
-                ResolvedSessionHistorySource::Codex(session)
-                    .read(Some(max_bytes))
-                    .map(SessionHistoryCheckpointSource::Decoded)
-            }
+        ResolvedSessionHistorySource::Codex(session) => {
+            let is_zstd = session.is_zstd();
+            let (path, file) = session.into_file()?;
+            read_open_codex_checkpoint_source_bounded(path, file, is_zstd, max_bytes)
         }
         source => source
             .read(Some(max_bytes))
             .map(SessionHistoryCheckpointSource::Decoded),
     }
+}
+
+fn read_open_codex_checkpoint_source_bounded(
+    path: PathBuf,
+    mut file: File,
+    is_zstd: bool,
+    max_bytes: u64,
+) -> Result<SessionHistoryCheckpointSource, AgentError> {
+    file.rewind()
+        .map_err(|error| read_history_error(&path, error))?;
+    if is_zstd {
+        let encoded_len = file
+            .metadata()
+            .map_err(|error| read_history_error(&path, error))?
+            .len();
+        if encoded_len <= max_bytes {
+            let encoded = read_zstd_encoded_session_history(file, &path, max_bytes)?;
+            return Ok(SessionHistoryCheckpointSource::CodexZstd { encoded });
+        }
+    }
+
+    DecodedSessionHistoryReader::open(path, file)?
+        .read(Some(max_bytes))
+        .map(SessionHistoryCheckpointSource::Decoded)
 }
 
 pub(crate) fn prepare_session_history_sidecar_from_payload_bounded(

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -35,7 +35,7 @@ use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io::{self, BufReader, Read, Seek};
 use std::path::{Path, PathBuf};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
@@ -128,9 +128,44 @@ pub(crate) struct PreparedSessionHistorySidecar {
     source: SessionHistoryCheckpointSource,
 }
 
-pub(crate) struct PlainCodexSessionHistory {
-    pub(crate) path: PathBuf,
-    pub(crate) file: File,
+pub(crate) struct ResolvedCodexSessionHistory {
+    path: PathBuf,
+    file: File,
+    is_zstd: bool,
+}
+
+impl ResolvedCodexSessionHistory {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn plain_file_mut(&mut self) -> Option<&mut File> {
+        (!self.is_zstd).then_some(&mut self.file)
+    }
+
+    pub(crate) fn into_checkpoint_source_bounded(
+        mut self,
+        max_bytes: u64,
+    ) -> Result<SessionHistoryCheckpointSource, AgentError> {
+        self.file
+            .rewind()
+            .map_err(|error| read_history_error(&self.path, error))?;
+        if self.is_zstd {
+            let encoded_len = self
+                .file
+                .metadata()
+                .map_err(|error| read_history_error(&self.path, error))?
+                .len();
+            if encoded_len <= max_bytes {
+                let encoded = read_zstd_encoded_session_history(self.file, &self.path, max_bytes)?;
+                return Ok(SessionHistoryCheckpointSource::CodexZstd { encoded });
+            }
+        }
+
+        DecodedSessionHistoryReader::open(self.path, self.file)?
+            .read(Some(max_bytes))
+            .map(SessionHistoryCheckpointSource::Decoded)
+    }
 }
 
 impl PreparedSessionHistorySidecar {
@@ -206,11 +241,13 @@ pub(crate) fn prepare_session_history_sidecar_from_payload_bounded(
     }
 }
 
-pub(crate) fn resolve_plain_codex_session_history_from_payload(
+pub(crate) fn resolve_codex_session_history_from_payload(
     payload: &str,
-) -> Result<Option<PlainCodexSessionHistory>, AgentError> {
+) -> Result<ResolvedCodexSessionHistory, AgentError> {
     if !is_codex_marker(payload) {
-        return Ok(None);
+        return Err(AgentError::Checkpoint(
+            "Invalid Codex session history marker".to_string(),
+        ));
     }
     let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
         return Err(AgentError::Checkpoint(
@@ -220,11 +257,13 @@ pub(crate) fn resolve_plain_codex_session_history_from_payload(
     let Some(session) = resolve_codex_session_history(&sessions_dir, thread_id)? else {
         return Err(codex_session_not_found_error(&sessions_dir));
     };
-    if session.is_zstd() {
-        return Ok(None);
-    }
+    let is_zstd = session.is_zstd();
     let (path, file) = session.into_file()?;
-    Ok(Some(PlainCodexSessionHistory { path, file }))
+    Ok(ResolvedCodexSessionHistory {
+        path,
+        file,
+        is_zstd,
+    })
 }
 
 fn read_session_history_from_payload_impl(

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -128,6 +128,11 @@ pub(crate) struct PreparedSessionHistorySidecar {
     source: SessionHistoryCheckpointSource,
 }
 
+pub(crate) struct PlainCodexSessionHistory {
+    pub(crate) path: PathBuf,
+    pub(crate) file: File,
+}
+
 impl PreparedSessionHistorySidecar {
     pub(crate) fn into_source(self) -> SessionHistoryCheckpointSource {
         self.source
@@ -199,6 +204,27 @@ pub(crate) fn prepare_session_history_sidecar_from_payload_bounded(
             .open_decoded_reader()?
             .prepare_sidecar(max_decoded_bytes),
     }
+}
+
+pub(crate) fn resolve_plain_codex_session_history_from_payload(
+    payload: &str,
+) -> Result<Option<PlainCodexSessionHistory>, AgentError> {
+    if !is_codex_marker(payload) {
+        return Ok(None);
+    }
+    let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
+        return Err(AgentError::Checkpoint(
+            "Invalid Codex session history marker".to_string(),
+        ));
+    };
+    let Some(session) = resolve_codex_session_history(&sessions_dir, thread_id)? else {
+        return Err(codex_session_not_found_error(&sessions_dir));
+    };
+    if session.is_zstd() {
+        return Ok(None);
+    }
+    let (path, file) = session.into_file()?;
+    Ok(Some(PlainCodexSessionHistory { path, file }))
 }
 
 fn read_session_history_from_payload_impl(

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -451,6 +451,51 @@ async fn success_checkpoint_preserves_oversized_codex_history_when_pruning_disab
 }
 
 #[tokio::test]
+async fn success_checkpoint_preserves_small_codex_history_when_pruning_enabled() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    set_codex_session_pruning(&mut runtime, true);
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
+    std::fs::write(&history_path, &history).unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"identity"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"existing": true}));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-unpruned-codex"}));
+    });
+
+    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
+        .await
+        .unwrap();
+
+    prepare_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert_eq!(std::fs::read(&history_path).unwrap(), history);
+}
+
+#[tokio::test]
 async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() {
     let api = SharedApiMock::new().await;
     let server = api.server();

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -23,6 +23,14 @@ fn set_claude_session_pruning(runtime: &mut guest_agent::run_context::GuestRunti
         .insert("claudeSessionPruning".to_string(), enabled);
 }
 
+fn set_codex_session_pruning(runtime: &mut guest_agent::run_context::GuestRuntime, enabled: bool) {
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    runtime
+        .config
+        .feature_flags
+        .insert("codexSessionPruning".to_string(), enabled);
+}
+
 fn session_file_paths() -> (String, String) {
     let paths = shared_guest_paths();
     (
@@ -161,6 +169,139 @@ fn write_prunable_claude_history(session_id: &str) -> Result<(tempfile::TempDir,
     Ok((history_dir, candidate))
 }
 
+fn write_prunable_codex_history(
+    session_id: &str,
+) -> Result<(tempfile::TempDir, std::path::PathBuf, Vec<u8>), String> {
+    let history_dir =
+        tempfile::tempdir().map_err(|error| format!("create Codex history dir: {error}"))?;
+    let day_dir = history_dir
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026")
+        .join("07")
+        .join("26");
+    std::fs::create_dir_all(&day_dir)
+        .map_err(|error| format!("create Codex session directory: {error}"))?;
+    let history_path = day_dir.join(format!("rollout-{session_id}.jsonl"));
+
+    let line = |record_type: &str, payload: serde_json::Value| -> Result<Vec<u8>, String> {
+        let mut bytes = serde_json::to_vec(&json!({
+            "timestamp": "2026-07-26T00:00:00Z",
+            "type": record_type,
+            "payload": payload,
+        }))
+        .map_err(|error| format!("encode Codex history: {error}"))?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    };
+    let canonical = line(
+        "session_meta",
+        json!({
+            "id": session_id,
+            "session_id": session_id,
+            "timestamp": "2026-07-26T00:00:00Z",
+            "cwd": guest_agent::paths::CANONICAL_WORKING_DIR,
+            "originator": "codex",
+            "cli_version": "0.144.6",
+            "source": "cli",
+            "history_mode": "legacy",
+        }),
+    )?;
+    let turn_id = "compact-turn";
+    let retained_records = [
+        line(
+            "event_msg",
+            json!({
+                "type": "task_started",
+                "turn_id": turn_id,
+                "model_context_window": 258400,
+                "collaboration_mode_kind": "default",
+            }),
+        )?,
+        line(
+            "event_msg",
+            json!({
+                "type": "user_message",
+                "message": "compact this thread",
+                "images": [],
+                "local_images": [],
+                "audio": [],
+                "local_audio": [],
+                "text_elements": [],
+            }),
+        )?,
+        line(
+            "turn_context",
+            json!({
+                "turn_id": turn_id,
+                "cwd": guest_agent::paths::CANONICAL_WORKING_DIR,
+                "approval_policy": {"granular": {"sandbox_approval": true}},
+                "sandbox_policy": {"type": "read_only"},
+                "model": "gpt-test",
+                "summary": "auto",
+            }),
+        )?,
+        line(
+            "compacted",
+            json!({
+                "message": "retained summary",
+                "replacement_history": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "retained summary",
+                    }],
+                }],
+                "window_number": 1,
+                "first_window_id": "019c0000-0000-7000-8000-000000000001",
+                "window_id": "019c0000-0000-7000-8000-000000000002",
+            }),
+        )?,
+        line(
+            "world_state",
+            json!({"full": true, "state": {"working_directory": "/workspace"}}),
+        )?,
+        line(
+            "event_msg",
+            json!({
+                "type": "task_complete",
+                "turn_id": turn_id,
+                "last_agent_message": "retained summary",
+            }),
+        )?,
+    ];
+    let candidate = std::iter::once(canonical.clone())
+        .chain(retained_records.iter().cloned())
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let mut history_file = std::fs::File::create(&history_path)
+        .map_err(|error| format!("create Codex history: {error}"))?;
+    history_file
+        .write_all(&canonical)
+        .map_err(|error| format!("write canonical Codex history: {error}"))?;
+    history_file
+        .set_len(api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES + 1)
+        .map_err(|error| format!("size Codex history: {error}"))?;
+    history_file
+        .seek(SeekFrom::End(0))
+        .and_then(|_| history_file.write_all(b"\n"))
+        .and_then(|()| {
+            for record in retained_records {
+                history_file.write_all(&record)?;
+            }
+            history_file.flush()
+        })
+        .map_err(|error| format!("write retained Codex history: {error}"))?;
+
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, session_id)
+        .map_err(|error| format!("write Codex session id: {error}"))?;
+    Ok((history_dir, history_path, candidate))
+}
+
 fn zstd_session_history_for_test(history: &[u8]) -> std::io::Result<Vec<u8>> {
     zstd::stream::encode_all(history, 3)
 }
@@ -271,6 +412,45 @@ async fn success_checkpoint_preserves_oversized_claude_history_when_pruning_disa
 }
 
 #[tokio::test]
+async fn success_checkpoint_preserves_oversized_codex_history_when_pruning_disabled() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    set_codex_session_pruning(&mut runtime, false);
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let (history_dir, history_path, _) = write_prunable_codex_history(session_id).unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+    let source_size = std::fs::metadata(&history_path).unwrap().len();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Session history exceeds maximum size"),
+        "disabled Codex pruning must retain the original hard-limit behavior: {error}"
+    );
+    assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
 async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() {
     let api = SharedApiMock::new().await;
     let server = api.server();
@@ -355,6 +535,97 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
     assert_eq!(
         std::path::Path::new(&identity.history_marker_payload),
         history_path
+    );
+}
+
+#[tokio::test]
+async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    set_codex_session_pruning(&mut runtime, true);
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let (history_dir, history_path, candidate) = write_prunable_codex_history(session_id).unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+    let source_size = std::fs::metadata(&history_path).unwrap().len();
+
+    let history_hash = hex::encode(Sha256::digest(&candidate));
+    let history_size = candidate.len();
+    let upload_url = server.url("/test/pruned-codex-history-upload");
+    let prepare_history_path = history_path.clone();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"identity"}"#);
+        then.respond_with(move |_| {
+            if std::fs::metadata(&prepare_history_path)
+                .is_ok_and(|metadata| metadata.len() == source_size)
+            {
+                json_http_response(
+                    200,
+                    json!({
+                        "presignedUrl": upload_url.clone(),
+                        "existing": false,
+                    }),
+                )
+            } else {
+                http_status(500)
+            }
+        });
+    });
+    let upload_len = history_size.to_string();
+    let upload_body = candidate.clone();
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/pruned-codex-history-upload")
+            .header("Content-Type", "application/octet-stream");
+        then.respond_with(move |request| {
+            upload_validation_response(request, &upload_body, &upload_len)
+        });
+    });
+    let checkpoint_history_path = history_path.clone();
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#))
+            .json_body_includes(r#"{"cliAgentType":"codex"}"#)
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.respond_with(move |_| {
+            if std::fs::metadata(&checkpoint_history_path)
+                .is_ok_and(|metadata| metadata.len() == source_size)
+            {
+                json_http_response(200, json!({"checkpointId": "checkpoint-pruned-codex"}))
+            } else {
+                http_status(500)
+            }
+        });
+    });
+
+    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
+        .await
+        .unwrap();
+
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert_eq!(std::fs::read(&history_path).unwrap(), candidate);
+
+    let identity_bytes =
+        std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
+    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    assert_eq!(identity.framework, FinalSessionHistoryFramework::Codex);
+    assert_eq!(identity.history_size_bytes, history_size as u64);
+    assert_eq!(identity.history_hash, history_hash);
+    assert!(
+        identity.history_marker_payload.contains(session_id),
+        "Codex identity must retain the marker for the original thread"
     );
 }
 
@@ -1368,6 +1639,45 @@ async fn recovery_checkpoint_does_not_prune_eligible_claude_history() {
             .to_string()
             .contains("Session history line 1 is not valid JSON"),
         "recovery checkpoint should validate the original history: {error}"
+    );
+    assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    set_codex_session_pruning(&mut runtime, true);
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let (history_dir, history_path, _) = write_prunable_codex_history(session_id).unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+    let source_size = std::fs::metadata(&history_path).unwrap().len();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let error = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Session history exceeds maximum size"),
+        "recovery checkpoint must retain the original Codex hard-limit behavior: {error}"
     );
     assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
     assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());

--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -75,7 +75,7 @@ pub enum CodexHistoryIneligibleReason {
     RecordTooLarge,
     /// The newest compacted record did not contain usable replacement history.
     InvalidCompactBoundary,
-    /// The selected compacting or later turn was incomplete or inconsistent.
+    /// The selected compacting or later turn was unbounded or inconsistent.
     InvalidTurn,
     /// The selected compacting or later turn did not retain compatible context.
     MissingTurnContext,
@@ -170,7 +170,7 @@ impl TurnState {
         }
     }
 
-    fn validate_completion(&self) -> Result<(), CodexHistoryIneligibleReason> {
+    fn validate_segment(&self) -> Result<(), CodexHistoryIneligibleReason> {
         if let Some(reason) = self.invalid {
             return Err(reason);
         }
@@ -187,7 +187,7 @@ impl TurnState {
 struct CandidateState {
     bytes: Vec<u8>,
     selected_turn_id: String,
-    selected_turn_complete: bool,
+    selected_turn_delimited: bool,
     invalid: Option<CodexHistoryIneligibleReason>,
 }
 
@@ -200,7 +200,7 @@ impl CandidateState {
         Self {
             bytes: turn.bytes.clone(),
             selected_turn_id: turn.id.clone(),
-            selected_turn_complete: false,
+            selected_turn_delimited: false,
             invalid,
         }
     }
@@ -370,7 +370,7 @@ fn select_with_limits_and_hook(
     if current_turn.is_some() {
         candidate.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
     }
-    if !candidate.selected_turn_complete {
+    if !candidate.selected_turn_delimited {
         candidate.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
     }
     if let Some(reason) = candidate.invalid {
@@ -427,11 +427,7 @@ fn process_record(
 
     match record {
         RolloutRecord::Event(EventRecord::TurnStarted(turn_id)) => {
-            if current_turn.is_some()
-                && let Some(existing) = candidate.as_mut()
-            {
-                existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
-            }
+            finish_current_turn(current_turn, candidate);
             if let Some(existing) = candidate.as_mut() {
                 existing.push(raw_record, body_max_bytes);
             }
@@ -448,7 +444,7 @@ fn process_record(
                             Some(CandidateState {
                                 bytes: Vec::new(),
                                 selected_turn_id: String::new(),
-                                selected_turn_complete: false,
+                                selected_turn_delimited: false,
                                 invalid: Some(CodexHistoryIneligibleReason::InvalidTurn),
                             })
                         });
@@ -539,10 +535,24 @@ fn complete_turn(
         }
         return;
     }
-    let validation = turn.validate_completion();
+    finish_turn(turn, candidate);
+}
+
+fn finish_current_turn(
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+) {
+    let Some(turn) = current_turn.take() else {
+        return;
+    };
+    finish_turn(turn, candidate);
+}
+
+fn finish_turn(turn: TurnState, candidate: &mut Option<CandidateState>) {
+    let validation = turn.validate_segment();
     if let Some(existing) = candidate.as_mut() {
-        if existing.selected_turn_id == turn_id {
-            existing.selected_turn_complete = true;
+        if existing.selected_turn_id == turn.id {
+            existing.selected_turn_delimited = true;
         }
         if let Err(reason) = validation {
             existing.invalidate(reason);
@@ -1113,6 +1123,37 @@ mod tests {
         let selected = candidate_bytes(select(&file).unwrap());
 
         assert!(selected.ends_with(&later.concat()));
+    }
+
+    #[test]
+    fn accepts_compacting_turn_delimited_by_the_next_turn_start() {
+        let records = [
+            turn_started(TURN_ID),
+            user_message(),
+            turn_context(TURN_ID),
+            compacted("summary"),
+            turn_started("turn-2"),
+            turn_context("turn-2"),
+            user_message(),
+            line(
+                "response_item",
+                json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "done"}],
+                }),
+            ),
+            turn_complete("turn-2"),
+        ];
+        let file = source(&records);
+
+        let selected = candidate_bytes(select(&file).unwrap());
+        let expected = std::iter::once(canonical(Some("legacy")))
+            .chain(records)
+            .flatten()
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected, expected);
     }
 
     #[test]

--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -1,0 +1,1300 @@
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+use super::{
+    BoundedRecord, READ_BUFFER_BYTES, SelectionLimits, read_bounded_record, strip_jsonl_line_ending,
+};
+
+/// Maximum decoded size of an accepted Codex compact generation.
+pub const CODEX_COMPACT_GENERATION_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Maximum size of one Codex JSONL record inspected by the selector.
+pub const CODEX_JSONL_RECORD_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+const PRODUCTION_LIMITS: SelectionLimits = SelectionLimits {
+    candidate_max_bytes: CODEX_COMPACT_GENERATION_MAX_BYTES,
+    record_max_bytes: CODEX_JSONL_RECORD_MAX_BYTES,
+};
+
+/// Result of attempting to select a bounded Codex compact generation.
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub enum CodexHistorySelection {
+    /// A structurally valid raw compact generation was selected.
+    Candidate(CodexHistoryCandidate),
+    /// The source did not have an eligible compact generation.
+    Ineligible(CodexHistoryIneligibleReason),
+}
+
+/// Raw Codex compact-generation bytes selected for checkpointing.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CodexHistoryCandidate {
+    bytes: Vec<u8>,
+    source_size: u64,
+}
+
+impl CodexHistoryCandidate {
+    /// Return the complete decoded source size observed during selection.
+    #[must_use]
+    pub const fn source_size(&self) -> u64 {
+        self.source_size
+    }
+
+    /// Return the selected raw generation size.
+    #[must_use]
+    pub fn candidate_size(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    /// Consume the candidate and return its exact raw JSONL bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+/// Content-free reason that a Codex history was not eligible for pruning.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CodexHistoryIneligibleReason {
+    /// The complete source is already within the retained-generation guard.
+    SourceWithinGuard,
+    /// The canonical first record was missing or malformed.
+    InvalidCanonicalMetadata,
+    /// The canonical thread identity did not match the checkpoint identity.
+    ThreadIdMismatch,
+    /// The canonical history mode was not legacy.
+    UnsupportedHistoryMode,
+    /// No compacted record was found in the only retained window that can fit.
+    NoCompactBoundary,
+    /// A retained JSONL record was malformed, incomplete, or unsupported.
+    InvalidRecord,
+    /// A retained JSONL record exceeded the individual-record limit.
+    RecordTooLarge,
+    /// The newest compacted record did not contain usable replacement history.
+    InvalidCompactBoundary,
+    /// The selected compacting or later turn was incomplete or inconsistent.
+    InvalidTurn,
+    /// The selected compacting or later turn did not retain compatible context.
+    MissingTurnContext,
+    /// A rollback followed the selected compacted record.
+    RollbackAfterCompact,
+    /// The selected candidate exceeded its decoded-size limit.
+    CandidateTooLarge,
+    /// The source EOF changed while the candidate was selected.
+    SourceChanged,
+}
+
+impl CodexHistoryIneligibleReason {
+    /// Return a stable content-free diagnostic label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceWithinGuard => "source_within_guard",
+            Self::InvalidCanonicalMetadata => "invalid_canonical_metadata",
+            Self::ThreadIdMismatch => "thread_id_mismatch",
+            Self::UnsupportedHistoryMode => "unsupported_history_mode",
+            Self::NoCompactBoundary => "no_compact_boundary",
+            Self::InvalidRecord => "invalid_record",
+            Self::RecordTooLarge => "record_too_large",
+            Self::InvalidCompactBoundary => "invalid_compact_boundary",
+            Self::InvalidTurn => "invalid_turn",
+            Self::MissingTurnContext => "missing_turn_context",
+            Self::RollbackAfterCompact => "rollback_after_compact",
+            Self::CandidateTooLarge => "candidate_too_large",
+            Self::SourceChanged => "source_changed",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum EventRecord<'a> {
+    TurnStarted(&'a str),
+    UserMessage,
+    TurnComplete(&'a str),
+    TurnAborted,
+    ThreadRolledBack,
+    Other,
+}
+
+#[derive(Debug)]
+enum RolloutRecord<'a> {
+    Compacted(Result<(), CodexHistoryIneligibleReason>),
+    Event(EventRecord<'a>),
+    TurnContext(Option<&'a str>),
+    Other,
+}
+
+struct TurnState {
+    id: String,
+    bytes: Vec<u8>,
+    saw_user_message: bool,
+    saw_compatible_context: bool,
+    invalid: Option<CodexHistoryIneligibleReason>,
+}
+
+impl TurnState {
+    fn new(id: &str, raw_record: &[u8], body_max_bytes: usize) -> Self {
+        let mut state = Self {
+            id: id.to_string(),
+            bytes: Vec::new(),
+            saw_user_message: false,
+            saw_compatible_context: false,
+            invalid: None,
+        };
+        state.push(raw_record, body_max_bytes);
+        state
+    }
+
+    fn push(&mut self, raw_record: &[u8], body_max_bytes: usize) {
+        if self.invalid.is_some() {
+            return;
+        }
+        let Some(next_size) = self.bytes.len().checked_add(raw_record.len()) else {
+            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
+            return;
+        };
+        if next_size > body_max_bytes {
+            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
+            return;
+        }
+        self.bytes.extend_from_slice(raw_record);
+    }
+
+    fn invalidate(&mut self, reason: CodexHistoryIneligibleReason) {
+        if self.invalid.is_none() {
+            self.invalid = Some(reason);
+            self.bytes.clear();
+        }
+    }
+
+    fn validate_completion(&self) -> Result<(), CodexHistoryIneligibleReason> {
+        if let Some(reason) = self.invalid {
+            return Err(reason);
+        }
+        if !self.saw_user_message {
+            return Err(CodexHistoryIneligibleReason::InvalidTurn);
+        }
+        if !self.saw_compatible_context {
+            return Err(CodexHistoryIneligibleReason::MissingTurnContext);
+        }
+        Ok(())
+    }
+}
+
+struct CandidateState {
+    bytes: Vec<u8>,
+    selected_turn_id: String,
+    selected_turn_complete: bool,
+    invalid: Option<CodexHistoryIneligibleReason>,
+}
+
+impl CandidateState {
+    fn from_compacting_turn(
+        turn: &TurnState,
+        compact_validation: Result<(), CodexHistoryIneligibleReason>,
+    ) -> Self {
+        let invalid = turn.invalid.or_else(|| compact_validation.err());
+        Self {
+            bytes: turn.bytes.clone(),
+            selected_turn_id: turn.id.clone(),
+            selected_turn_complete: false,
+            invalid,
+        }
+    }
+
+    fn push(&mut self, raw_record: &[u8], body_max_bytes: usize) {
+        if self.invalid.is_some() {
+            return;
+        }
+        let Some(next_size) = self.bytes.len().checked_add(raw_record.len()) else {
+            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
+            return;
+        };
+        if next_size > body_max_bytes {
+            self.invalidate(CodexHistoryIneligibleReason::CandidateTooLarge);
+            return;
+        }
+        self.bytes.extend_from_slice(raw_record);
+    }
+
+    fn invalidate(&mut self, reason: CodexHistoryIneligibleReason) {
+        if self.invalid.is_none() {
+            self.invalid = Some(reason);
+            self.bytes.clear();
+        }
+    }
+}
+
+/// Select Codex's latest self-contained raw native compact generation.
+///
+/// The source handle must refer to the canonical plain legacy rollout. The
+/// source is never modified. Files at or below 64 MiB are left unchanged. For
+/// larger files, selection reads only the canonical first record and the final
+/// bounded window that can still produce an accepted candidate.
+pub fn select_codex_compact_generation(
+    source: &mut File,
+    expected_thread_id: &str,
+) -> io::Result<CodexHistorySelection> {
+    select_with_limits_and_hook(source, expected_thread_id, PRODUCTION_LIMITS, || {})
+}
+
+fn select_with_limits_and_hook(
+    source: &mut File,
+    expected_thread_id: &str,
+    limits: SelectionLimits,
+    before_final_check: impl FnOnce(),
+) -> io::Result<CodexHistorySelection> {
+    let source_size = source.metadata()?.len();
+    if source_size <= limits.candidate_max_bytes {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::SourceWithinGuard,
+        ));
+    }
+
+    source.seek(SeekFrom::Start(0))?;
+    let canonical_record = {
+        let mut reader = BufReader::with_capacity(READ_BUFFER_BYTES, &mut *source);
+        match read_bounded_record(&mut reader, limits.record_max_bytes)? {
+            BoundedRecord::Record(record) if record.ends_with(b"\n") => record,
+            BoundedRecord::Oversized => {
+                return Ok(CodexHistorySelection::Ineligible(
+                    CodexHistoryIneligibleReason::RecordTooLarge,
+                ));
+            }
+            BoundedRecord::Eof | BoundedRecord::Record(_) => {
+                return Ok(CodexHistorySelection::Ineligible(
+                    CodexHistoryIneligibleReason::InvalidCanonicalMetadata,
+                ));
+            }
+        }
+    };
+
+    let canonical_value =
+        match serde_json::from_slice::<Value>(strip_jsonl_line_ending(&canonical_record)) {
+            Ok(value) => value,
+            Err(_) => {
+                return Ok(CodexHistorySelection::Ineligible(
+                    CodexHistoryIneligibleReason::InvalidCanonicalMetadata,
+                ));
+            }
+        };
+    if let Err(reason) = validate_canonical_metadata(&canonical_value, expected_thread_id) {
+        return Ok(CodexHistorySelection::Ineligible(reason));
+    }
+
+    let Some(body_max_bytes) = usize::try_from(limits.candidate_max_bytes)
+        .ok()
+        .and_then(|max| max.checked_sub(canonical_record.len()))
+    else {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::CandidateTooLarge,
+        ));
+    };
+    if body_max_bytes == 0 {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::CandidateTooLarge,
+        ));
+    }
+
+    let body_window = body_max_bytes as u64;
+    let tail_start = source_size.saturating_sub(body_window);
+    if tail_start == 0 {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::NoCompactBoundary,
+        ));
+    }
+    source.seek(SeekFrom::Start(tail_start - 1))?;
+    let mut preceding_byte = [0_u8; 1];
+    source.read_exact(&mut preceding_byte)?;
+    source.seek(SeekFrom::Start(tail_start))?;
+
+    let mut reader = BufReader::with_capacity(READ_BUFFER_BYTES, &mut *source);
+    if preceding_byte != *b"\n" {
+        match read_bounded_record(&mut reader, limits.record_max_bytes)? {
+            BoundedRecord::Eof => {
+                return Ok(CodexHistorySelection::Ineligible(
+                    CodexHistoryIneligibleReason::NoCompactBoundary,
+                ));
+            }
+            BoundedRecord::Record(_) | BoundedRecord::Oversized => {}
+        }
+    }
+
+    let mut current_turn: Option<TurnState> = None;
+    let mut candidate: Option<CandidateState> = None;
+    loop {
+        match read_bounded_record(&mut reader, limits.record_max_bytes)? {
+            BoundedRecord::Eof => break,
+            BoundedRecord::Oversized => {
+                invalidate_retained_state(
+                    &mut current_turn,
+                    &mut candidate,
+                    CodexHistoryIneligibleReason::RecordTooLarge,
+                );
+            }
+            BoundedRecord::Record(raw_record) if !raw_record.ends_with(b"\n") => {
+                invalidate_retained_state(
+                    &mut current_turn,
+                    &mut candidate,
+                    CodexHistoryIneligibleReason::InvalidRecord,
+                );
+            }
+            BoundedRecord::Record(raw_record) => {
+                process_record(
+                    &raw_record,
+                    body_max_bytes,
+                    &mut current_turn,
+                    &mut candidate,
+                );
+            }
+        }
+    }
+
+    let observed_eof = reader.stream_position()?;
+    before_final_check();
+    let final_size = reader.get_ref().metadata()?.len();
+    if observed_eof != source_size || final_size != source_size {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::SourceChanged,
+        ));
+    }
+
+    let Some(mut candidate) = candidate else {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::NoCompactBoundary,
+        ));
+    };
+    if current_turn.is_some() {
+        candidate.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+    }
+    if !candidate.selected_turn_complete {
+        candidate.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+    }
+    if let Some(reason) = candidate.invalid {
+        return Ok(CodexHistorySelection::Ineligible(reason));
+    }
+
+    let mut bytes = canonical_record;
+    bytes.extend_from_slice(&candidate.bytes);
+    if bytes.len() as u64 > limits.candidate_max_bytes {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::CandidateTooLarge,
+        ));
+    }
+    if bytes.len() as u64 >= source_size {
+        return Ok(CodexHistorySelection::Ineligible(
+            CodexHistoryIneligibleReason::NoCompactBoundary,
+        ));
+    }
+
+    Ok(CodexHistorySelection::Candidate(CodexHistoryCandidate {
+        bytes,
+        source_size,
+    }))
+}
+
+fn process_record(
+    raw_record: &[u8],
+    body_max_bytes: usize,
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+) {
+    let parsed = serde_json::from_slice::<Value>(strip_jsonl_line_ending(raw_record))
+        .map_err(|_| CodexHistoryIneligibleReason::InvalidRecord)
+        .and_then(|value| {
+            validate_rollout_record(&value)?;
+            Ok(value)
+        });
+    let value = match parsed {
+        Ok(value) => value,
+        Err(reason) => {
+            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            invalidate_retained_state(current_turn, candidate, reason);
+            return;
+        }
+    };
+    let record = match classify_rollout_record(&value) {
+        Ok(record) => record,
+        Err(reason) => {
+            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            invalidate_retained_state(current_turn, candidate, reason);
+            return;
+        }
+    };
+
+    match record {
+        RolloutRecord::Event(EventRecord::TurnStarted(turn_id)) => {
+            if current_turn.is_some()
+                && let Some(existing) = candidate.as_mut()
+            {
+                existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+            }
+            if let Some(existing) = candidate.as_mut() {
+                existing.push(raw_record, body_max_bytes);
+            }
+            *current_turn = Some(TurnState::new(turn_id, raw_record, body_max_bytes));
+        }
+        record => {
+            append_to_retained_state(raw_record, body_max_bytes, current_turn, candidate);
+            match record {
+                RolloutRecord::Compacted(validation) => {
+                    *candidate = current_turn
+                        .as_ref()
+                        .map(|turn| CandidateState::from_compacting_turn(turn, validation))
+                        .or_else(|| {
+                            Some(CandidateState {
+                                bytes: Vec::new(),
+                                selected_turn_id: String::new(),
+                                selected_turn_complete: false,
+                                invalid: Some(CodexHistoryIneligibleReason::InvalidTurn),
+                            })
+                        });
+                }
+                RolloutRecord::Event(EventRecord::UserMessage) => {
+                    if let Some(turn) = current_turn.as_mut() {
+                        turn.saw_user_message = true;
+                    } else if let Some(existing) = candidate.as_mut() {
+                        existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+                    }
+                }
+                RolloutRecord::TurnContext(turn_id) => {
+                    if let Some(turn) = current_turn.as_mut() {
+                        if turn_id.is_none_or(|turn_id| turn_id == turn.id) {
+                            turn.saw_compatible_context = true;
+                        } else {
+                            turn.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+                        }
+                    } else if let Some(existing) = candidate.as_mut() {
+                        existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+                    }
+                }
+                RolloutRecord::Event(EventRecord::TurnComplete(turn_id)) => {
+                    complete_turn(turn_id, current_turn, candidate);
+                }
+                RolloutRecord::Event(EventRecord::TurnAborted) => {
+                    if let Some(existing) = candidate.as_mut() {
+                        existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+                    }
+                    *current_turn = None;
+                }
+                RolloutRecord::Event(EventRecord::ThreadRolledBack) => {
+                    if let Some(existing) = candidate.as_mut() {
+                        existing.invalidate(CodexHistoryIneligibleReason::RollbackAfterCompact);
+                    }
+                    if let Some(turn) = current_turn.as_mut() {
+                        turn.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+                    }
+                }
+                RolloutRecord::Event(EventRecord::TurnStarted(_)) => {}
+                RolloutRecord::Event(EventRecord::Other) | RolloutRecord::Other => {}
+            }
+        }
+    }
+}
+
+fn append_to_retained_state(
+    raw_record: &[u8],
+    body_max_bytes: usize,
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+) {
+    if let Some(turn) = current_turn.as_mut() {
+        turn.push(raw_record, body_max_bytes);
+    }
+    if let Some(existing) = candidate.as_mut() {
+        existing.push(raw_record, body_max_bytes);
+    }
+}
+
+fn invalidate_retained_state(
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+    reason: CodexHistoryIneligibleReason,
+) {
+    if let Some(turn) = current_turn.as_mut() {
+        turn.invalidate(reason);
+    }
+    if let Some(existing) = candidate.as_mut() {
+        existing.invalidate(reason);
+    }
+}
+
+fn complete_turn(
+    turn_id: &str,
+    current_turn: &mut Option<TurnState>,
+    candidate: &mut Option<CandidateState>,
+) {
+    let Some(turn) = current_turn.take() else {
+        if let Some(existing) = candidate.as_mut() {
+            existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+        }
+        return;
+    };
+    if turn.id != turn_id {
+        if let Some(existing) = candidate.as_mut() {
+            existing.invalidate(CodexHistoryIneligibleReason::InvalidTurn);
+        }
+        return;
+    }
+    let validation = turn.validate_completion();
+    if let Some(existing) = candidate.as_mut() {
+        if existing.selected_turn_id == turn_id {
+            existing.selected_turn_complete = true;
+        }
+        if let Err(reason) = validation {
+            existing.invalidate(reason);
+        }
+    }
+}
+
+fn validate_canonical_metadata(
+    value: &Value,
+    expected_thread_id: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    let object = rollout_object(value)?;
+    if object.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return Err(CodexHistoryIneligibleReason::InvalidCanonicalMetadata);
+    }
+    let payload = object
+        .get("payload")
+        .and_then(Value::as_object)
+        .ok_or(CodexHistoryIneligibleReason::InvalidCanonicalMetadata)?;
+    for field in ["timestamp", "cwd", "originator", "cli_version"] {
+        require_string(payload, field)
+            .map_err(|_| CodexHistoryIneligibleReason::InvalidCanonicalMetadata)?;
+    }
+    let expected = Uuid::parse_str(expected_thread_id)
+        .map_err(|_| CodexHistoryIneligibleReason::ThreadIdMismatch)?;
+    let id = uuid_field(payload, "id")
+        .map_err(|_| CodexHistoryIneligibleReason::InvalidCanonicalMetadata)?;
+    if id != expected {
+        return Err(CodexHistoryIneligibleReason::ThreadIdMismatch);
+    }
+    if let Some(session_id) = payload.get("session_id") {
+        let session_id = session_id
+            .as_str()
+            .and_then(|value| Uuid::parse_str(value).ok())
+            .ok_or(CodexHistoryIneligibleReason::InvalidCanonicalMetadata)?;
+        if session_id != expected {
+            return Err(CodexHistoryIneligibleReason::ThreadIdMismatch);
+        }
+    }
+    match payload.get("history_mode") {
+        None => Ok(()),
+        Some(Value::String(mode)) if mode == "legacy" => Ok(()),
+        Some(Value::String(_)) => Err(CodexHistoryIneligibleReason::UnsupportedHistoryMode),
+        Some(_) => Err(CodexHistoryIneligibleReason::InvalidCanonicalMetadata),
+    }
+}
+
+fn validate_rollout_record(value: &Value) -> Result<(), CodexHistoryIneligibleReason> {
+    let object = rollout_object(value)?;
+    let record_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+    let payload = object
+        .get("payload")
+        .and_then(Value::as_object)
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+
+    match record_type {
+        // A legacy rollout has exactly one canonical metadata record. Seeing
+        // another one in the retained suffix makes the thread identity
+        // ambiguous, so only the separately validated first record is allowed.
+        "session_meta" => Err(CodexHistoryIneligibleReason::InvalidRecord),
+        "response_item" => validate_response_item_value(
+            object
+                .get("payload")
+                .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?,
+        ),
+        "inter_agent_communication" => validate_inter_agent_communication(payload),
+        "inter_agent_communication_metadata" => require_bool(payload, "trigger_turn"),
+        "compacted" => Ok(()),
+        "turn_context" => validate_turn_context_payload(payload),
+        "world_state" => validate_world_state_payload(payload),
+        "event_msg" => require_nonempty_string(payload, "type").map(|_| ()),
+        _ => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn classify_rollout_record(
+    value: &Value,
+) -> Result<RolloutRecord<'_>, CodexHistoryIneligibleReason> {
+    let object = rollout_object(value)?;
+    let record_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+    let payload = object
+        .get("payload")
+        .and_then(Value::as_object)
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+    match record_type {
+        "compacted" => Ok(RolloutRecord::Compacted(validate_compacted(payload))),
+        "turn_context" => Ok(RolloutRecord::TurnContext(optional_nonempty_string(
+            payload, "turn_id",
+        )?)),
+        "event_msg" => classify_event(payload).map(RolloutRecord::Event),
+        _ => Ok(RolloutRecord::Other),
+    }
+}
+
+fn classify_event(
+    payload: &Map<String, Value>,
+) -> Result<EventRecord<'_>, CodexHistoryIneligibleReason> {
+    match require_nonempty_string(payload, "type")? {
+        "task_started" | "turn_started" => {
+            require_nonempty_string(payload, "turn_id").map(EventRecord::TurnStarted)
+        }
+        "user_message" => Ok(EventRecord::UserMessage),
+        "task_complete" | "turn_complete" => {
+            require_nonempty_string(payload, "turn_id").map(EventRecord::TurnComplete)
+        }
+        "turn_aborted" => Ok(EventRecord::TurnAborted),
+        "thread_rolled_back" => Ok(EventRecord::ThreadRolledBack),
+        _ => Ok(EventRecord::Other),
+    }
+}
+
+fn validate_compacted(payload: &Map<String, Value>) -> Result<(), CodexHistoryIneligibleReason> {
+    require_string(payload, "message")
+        .map_err(|_| CodexHistoryIneligibleReason::InvalidCompactBoundary)?;
+    let replacement_history = payload
+        .get("replacement_history")
+        .and_then(Value::as_array)
+        .filter(|items| !items.is_empty())
+        .ok_or(CodexHistoryIneligibleReason::InvalidCompactBoundary)?;
+    for item in replacement_history {
+        validate_response_item_value(item)
+            .map_err(|_| CodexHistoryIneligibleReason::InvalidCompactBoundary)?;
+    }
+    if payload
+        .get("window_number")
+        .is_some_and(|value| value.as_u64().is_none())
+    {
+        return Err(CodexHistoryIneligibleReason::InvalidCompactBoundary);
+    }
+    for field in ["first_window_id", "previous_window_id", "window_id"] {
+        if let Some(value) = payload.get(field)
+            && !value.is_null()
+            && value
+                .as_str()
+                .and_then(|value| Uuid::parse_str(value).ok())
+                .is_none()
+        {
+            return Err(CodexHistoryIneligibleReason::InvalidCompactBoundary);
+        }
+    }
+    Ok(())
+}
+
+fn validate_response_item_value(value: &Value) -> Result<(), CodexHistoryIneligibleReason> {
+    let object = value
+        .as_object()
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+    let item_type = require_nonempty_string(object, "type")?;
+    match item_type {
+        "additional_tools" => {
+            require_nonempty_string(object, "role")?;
+            require_array(object, "tools")
+        }
+        "message" => {
+            require_nonempty_string(object, "role")?;
+            require_array(object, "content")
+        }
+        "agent_message" => {
+            require_nonempty_string(object, "author")?;
+            require_nonempty_string(object, "recipient")?;
+            require_array(object, "content")
+        }
+        "reasoning" => {
+            require_array(object, "summary")?;
+            require_optional_string(object, "encrypted_content")
+        }
+        "local_shell_call" => {
+            require_optional_string(object, "call_id")?;
+            require_nonempty_string(object, "status")?;
+            require_object(object, "action")
+        }
+        "function_call" => {
+            require_nonempty_string(object, "name")?;
+            require_string(object, "arguments")?;
+            require_nonempty_string(object, "call_id").map(|_| ())
+        }
+        "tool_search_call" => {
+            require_optional_string(object, "call_id")?;
+            require_nonempty_string(object, "execution")?;
+            object
+                .contains_key("arguments")
+                .then_some(())
+                .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+        }
+        "function_call_output" | "custom_tool_call_output" => {
+            require_nonempty_string(object, "call_id")?;
+            validate_output(object.get("output"))
+        }
+        "custom_tool_call" => {
+            require_nonempty_string(object, "call_id")?;
+            require_nonempty_string(object, "name")?;
+            require_string(object, "input").map(|_| ())
+        }
+        "tool_search_output" => {
+            require_optional_string(object, "call_id")?;
+            require_nonempty_string(object, "status")?;
+            require_nonempty_string(object, "execution")?;
+            require_array(object, "tools")
+        }
+        "web_search_call" => Ok(()),
+        "image_generation_call" => {
+            require_nonempty_string(object, "status")?;
+            require_string(object, "result").map(|_| ())
+        }
+        "compaction" | "compaction_summary" => {
+            require_nonempty_string(object, "encrypted_content").map(|_| ())
+        }
+        "compaction_trigger" => Ok(()),
+        "context_compaction" => require_optional_string(object, "encrypted_content"),
+        _ => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn validate_output(value: Option<&Value>) -> Result<(), CodexHistoryIneligibleReason> {
+    match value {
+        Some(Value::String(_)) | Some(Value::Array(_)) => Ok(()),
+        Some(_) | None => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn validate_inter_agent_communication(
+    payload: &Map<String, Value>,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    require_nonempty_string(payload, "author")?;
+    require_nonempty_string(payload, "recipient")?;
+    require_string(payload, "content")?;
+    require_bool(payload, "trigger_turn")
+}
+
+fn validate_turn_context_payload(
+    payload: &Map<String, Value>,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    optional_nonempty_string(payload, "turn_id")?;
+    require_nonempty_string(payload, "cwd")?;
+    require_nonempty_string(payload, "model")?;
+    require_nonempty_string_or_object(payload, "approval_policy")?;
+    require_object(payload, "sandbox_policy")?;
+    require_nonempty_string(payload, "summary").map(|_| ())
+}
+
+fn validate_world_state_payload(
+    payload: &Map<String, Value>,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    require_bool(payload, "full")?;
+    payload
+        .contains_key("state")
+        .then_some(())
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+fn rollout_object(value: &Value) -> Result<&Map<String, Value>, CodexHistoryIneligibleReason> {
+    let object = value
+        .as_object()
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)?;
+    require_nonempty_string(object, "timestamp")?;
+    if object
+        .get("ordinal")
+        .is_some_and(|value| !value.is_null() && value.as_u64().is_none())
+    {
+        return Err(CodexHistoryIneligibleReason::InvalidRecord);
+    }
+    Ok(object)
+}
+
+fn uuid_field(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<Uuid, CodexHistoryIneligibleReason> {
+    require_nonempty_string(object, field)?
+        .parse()
+        .map_err(|_| CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+fn require_nonempty_string<'a>(
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<&'a str, CodexHistoryIneligibleReason> {
+    let value = require_string(object, field)?;
+    if value.is_empty() {
+        return Err(CodexHistoryIneligibleReason::InvalidRecord);
+    }
+    Ok(value)
+}
+
+fn require_string<'a>(
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<&'a str, CodexHistoryIneligibleReason> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+fn optional_nonempty_string<'a>(
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<Option<&'a str>, CodexHistoryIneligibleReason> {
+    match object.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.is_empty() => Ok(Some(value)),
+        Some(_) => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn require_optional_string(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    match object.get(field) {
+        None | Some(Value::Null | Value::String(_)) => Ok(()),
+        Some(_) => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn require_array(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    object
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|_| ())
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+fn require_object(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    object
+        .get(field)
+        .and_then(Value::as_object)
+        .map(|_| ())
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+fn require_nonempty_string_or_object(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    match object.get(field) {
+        Some(Value::String(value)) if !value.is_empty() => Ok(()),
+        Some(Value::Object(value)) if !value.is_empty() => Ok(()),
+        Some(_) | None => Err(CodexHistoryIneligibleReason::InvalidRecord),
+    }
+}
+
+fn require_bool(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CodexHistoryIneligibleReason> {
+    object
+        .get(field)
+        .and_then(Value::as_bool)
+        .map(|_| ())
+        .ok_or(CodexHistoryIneligibleReason::InvalidRecord)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, Write};
+
+    use serde_json::json;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    const THREAD_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const TURN_ID: &str = "turn-1";
+    const TEST_LIMITS: SelectionLimits = SelectionLimits {
+        candidate_max_bytes: 8 * 1024,
+        record_max_bytes: 2 * 1024,
+    };
+
+    fn line(record_type: &str, payload: Value) -> Vec<u8> {
+        let mut bytes = serde_json::to_vec(&json!({
+            "timestamp": "2026-07-26T00:00:00Z",
+            "type": record_type,
+            "payload": payload,
+        }))
+        .unwrap();
+        bytes.push(b'\n');
+        bytes
+    }
+
+    fn canonical(history_mode: Option<&str>) -> Vec<u8> {
+        let mut payload = json!({
+            "id": THREAD_ID,
+            "session_id": THREAD_ID,
+            "timestamp": "2026-07-26T00:00:00Z",
+            "cwd": "/workspace",
+            "originator": "codex",
+            "cli_version": "0.144.6",
+            "source": "cli",
+        });
+        if let Some(history_mode) = history_mode {
+            payload["history_mode"] = json!(history_mode);
+        }
+        line("session_meta", payload)
+    }
+
+    fn event(event_type: &str, extra: Value) -> Vec<u8> {
+        let mut payload = json!({"type": event_type});
+        payload.as_object_mut().unwrap().extend(
+            extra
+                .as_object()
+                .expect("event extra must be an object")
+                .clone(),
+        );
+        line("event_msg", payload)
+    }
+
+    fn turn_started(turn_id: &str) -> Vec<u8> {
+        event("task_started", json!({"turn_id": turn_id}))
+    }
+
+    fn user_message() -> Vec<u8> {
+        event("user_message", json!({"message": "hello"}))
+    }
+
+    fn turn_context(turn_id: &str) -> Vec<u8> {
+        line(
+            "turn_context",
+            json!({
+                "turn_id": turn_id,
+                "cwd": "/workspace",
+                "approval_policy": "never",
+                "sandbox_policy": {"type": "read_only", "network_access": false},
+                "model": "gpt-test",
+                "summary": "auto",
+            }),
+        )
+    }
+
+    fn compacted(message: &str) -> Vec<u8> {
+        line(
+            "compacted",
+            json!({
+                "message": message,
+                "replacement_history": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": message}],
+                }],
+                "window_number": 2,
+                "first_window_id": "019c0000-0000-7000-8000-000000000001",
+                "previous_window_id": "019c0000-0000-7000-8000-000000000002",
+                "window_id": "019c0000-0000-7000-8000-000000000003",
+            }),
+        )
+    }
+
+    fn turn_complete(turn_id: &str) -> Vec<u8> {
+        event("task_complete", json!({"turn_id": turn_id}))
+    }
+
+    fn source(records: &[Vec<u8>]) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&canonical(Some("legacy"))).unwrap();
+        let retained_len: usize = records.iter().map(Vec::len).sum();
+        let filler_len = TEST_LIMITS
+            .candidate_max_bytes
+            .saturating_sub(retained_len as u64)
+            .saturating_add(512) as usize;
+        file.write_all(&line(
+            "response_item",
+            json!({
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "x".repeat(filler_len)}],
+            }),
+        ))
+        .unwrap();
+        for record in records {
+            file.write_all(record).unwrap();
+        }
+        file.flush().unwrap();
+        file
+    }
+
+    fn complete_generation(summary: &str) -> Vec<Vec<u8>> {
+        vec![
+            turn_started(TURN_ID),
+            user_message(),
+            turn_context(TURN_ID),
+            compacted(summary),
+            turn_complete(TURN_ID),
+        ]
+    }
+
+    fn select(file: &NamedTempFile) -> io::Result<CodexHistorySelection> {
+        let mut source = file.reopen()?;
+        select_with_limits_and_hook(&mut source, THREAD_ID, TEST_LIMITS, || {})
+    }
+
+    fn candidate_bytes(selection: CodexHistorySelection) -> Vec<u8> {
+        match selection {
+            CodexHistorySelection::Candidate(candidate) => candidate.into_bytes(),
+            CodexHistorySelection::Ineligible(reason) => {
+                panic!("expected candidate, got {reason:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_canonical_metadata_and_complete_compacting_turn_exactly() {
+        let generation = complete_generation("latest summary");
+        let file = source(&generation);
+
+        let selected = candidate_bytes(select(&file).unwrap());
+        let expected = std::iter::once(canonical(Some("legacy")))
+            .chain(generation)
+            .flatten()
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected, expected);
+    }
+
+    #[test]
+    fn latest_invalid_compaction_supersedes_an_older_generation() {
+        let mut records = complete_generation("older");
+        records.extend([
+            turn_started("turn-2"),
+            user_message(),
+            turn_context("turn-2"),
+            line(
+                "compacted",
+                json!({"message": "latest", "replacement_history": []}),
+            ),
+            turn_complete("turn-2"),
+        ]);
+        let file = source(&records);
+
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::InvalidCompactBoundary)
+        );
+    }
+
+    #[test]
+    fn retains_complete_later_turns_after_the_selected_compaction() {
+        let mut records = complete_generation("summary");
+        let later = [
+            turn_started("turn-2"),
+            user_message(),
+            turn_context("turn-2"),
+            line(
+                "response_item",
+                json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "done"}],
+                }),
+            ),
+            turn_complete("turn-2"),
+        ];
+        records.extend(later.clone());
+        let file = source(&records);
+
+        let selected = candidate_bytes(select(&file).unwrap());
+
+        assert!(selected.ends_with(&later.concat()));
+    }
+
+    #[test]
+    fn rejects_missing_context_incomplete_turn_and_rollback() {
+        let missing_context = [
+            turn_started(TURN_ID),
+            user_message(),
+            compacted("summary"),
+            turn_complete(TURN_ID),
+        ];
+        let file = source(&missing_context);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::MissingTurnContext)
+        );
+
+        let incomplete = [
+            turn_started(TURN_ID),
+            user_message(),
+            turn_context(TURN_ID),
+            compacted("summary"),
+        ];
+        let file = source(&incomplete);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::InvalidTurn)
+        );
+
+        let mut rolled_back = complete_generation("summary");
+        rolled_back.push(event("thread_rolled_back", json!({"num_turns": 1})));
+        let file = source(&rolled_back);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::RollbackAfterCompact)
+        );
+
+        let mut incomplete_later = complete_generation("summary");
+        incomplete_later.extend([
+            turn_started("turn-2"),
+            user_message(),
+            turn_context("turn-2"),
+        ]);
+        let file = source(&incomplete_later);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::InvalidTurn)
+        );
+    }
+
+    #[test]
+    fn accepts_omitted_mode_and_rejects_unsupported_modes_and_wrong_thread_id() {
+        let generation = complete_generation("summary");
+        let mut file = source(&generation);
+        file.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+        file.as_file_mut().write_all(&canonical(None)).unwrap();
+        file.as_file_mut().flush().unwrap();
+        let selected = candidate_bytes(select(&file).unwrap());
+        let expected = std::iter::once(canonical(None))
+            .chain(generation)
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(selected, expected);
+
+        for mode in ["paginated", "future"] {
+            let mut file = source(&complete_generation("summary"));
+            file.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+            file.as_file_mut()
+                .write_all(&canonical(Some(mode)))
+                .unwrap();
+            file.as_file_mut().flush().unwrap();
+            assert_eq!(
+                select(&file).unwrap(),
+                CodexHistorySelection::Ineligible(
+                    CodexHistoryIneligibleReason::UnsupportedHistoryMode
+                )
+            );
+        }
+
+        let file = source(&complete_generation("summary"));
+        let mut source_file = file.reopen().unwrap();
+        assert_eq!(
+            select_with_limits_and_hook(
+                &mut source_file,
+                "99999999-9999-4999-8999-999999999999",
+                TEST_LIMITS,
+                || {},
+            )
+            .unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::ThreadIdMismatch)
+        );
+
+        let mut file = source(&complete_generation("summary"));
+        file.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+        file.as_file_mut()
+            .write_all(&line(
+                "session_meta",
+                json!({"id": THREAD_ID, "session_id": THREAD_ID}),
+            ))
+            .unwrap();
+        file.as_file_mut().flush().unwrap();
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(
+                CodexHistoryIneligibleReason::InvalidCanonicalMetadata
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_oversized_and_unknown_retained_records() {
+        for bad_record in [
+            b"{not-json}\n".to_vec(),
+            vec![0xff, b'\n'],
+            line("future_record", json!({})),
+            canonical(Some("legacy")),
+            line(
+                "response_item",
+                json!({"type": "future_response_item", "value": "unknown"}),
+            ),
+            line("world_state", json!({"full": "yes", "state": {}})),
+        ] {
+            let mut records = complete_generation("summary");
+            records.insert(records.len() - 1, bad_record);
+            let file = source(&records);
+            assert_eq!(
+                select(&file).unwrap(),
+                CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::InvalidRecord)
+            );
+        }
+
+        let mut records = complete_generation("summary");
+        records.insert(
+            records.len() - 1,
+            line(
+                "event_msg",
+                json!({"type": "warning", "message": "x".repeat(4096)}),
+            ),
+        );
+        let file = source(&records);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::RecordTooLarge)
+        );
+
+        let mut records = complete_generation("summary");
+        records.push(b"{\"timestamp\":\"partial\"}".to_vec());
+        let file = source(&records);
+        assert_eq!(
+            select(&file).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::InvalidRecord)
+        );
+    }
+
+    #[test]
+    fn detects_source_growth_before_acceptance() {
+        let mut file = source(&complete_generation("summary"));
+        let path = file.path().to_owned();
+        let mut source = file.reopen().unwrap();
+
+        let selection = select_with_limits_and_hook(&mut source, THREAD_ID, TEST_LIMITS, || {
+            file.as_file_mut().seek(SeekFrom::End(0)).unwrap();
+            file.as_file_mut().write_all(b"changed\n").unwrap();
+            file.as_file_mut().flush().unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(
+            selection,
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::SourceChanged)
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn source_within_guard_is_not_scanned() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"not json").unwrap();
+        let mut source = file.reopen().unwrap();
+
+        assert_eq!(
+            select_with_limits_and_hook(&mut source, THREAD_ID, TEST_LIMITS, || {}).unwrap(),
+            CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::SourceWithinGuard)
+        );
+    }
+}

--- a/crates/guest-session-prune/src/lib.rs
+++ b/crates/guest-session-prune/src/lib.rs
@@ -1,8 +1,10 @@
 //! Bounded native session-history selection for guest checkpoints.
 //!
-//! The crate currently supports one operation: retain Claude Code's latest
-//! structurally valid native compact generation without changing its session
-//! ID or modifying the live JSONL file.
+//! The crate retains structurally valid native compact generations for Claude
+//! Code and legacy Codex rollouts without changing their native session IDs or
+//! modifying live JSONL files.
+
+mod codex;
 
 use std::collections::HashSet;
 use std::fs::File;
@@ -11,6 +13,11 @@ use std::path::Path;
 
 use serde_json::Value;
 use uuid::Uuid;
+
+pub use codex::{
+    CODEX_COMPACT_GENERATION_MAX_BYTES, CODEX_JSONL_RECORD_MAX_BYTES, CodexHistoryCandidate,
+    CodexHistoryIneligibleReason, CodexHistorySelection, select_codex_compact_generation,
+};
 
 /// Maximum decoded size of an accepted Claude compact generation.
 pub const CLAUDE_COMPACT_GENERATION_MAX_BYTES: u64 = 64 * 1024 * 1024;

--- a/crates/guest-session-prune/tests/codex.rs
+++ b/crates/guest-session-prune/tests/codex.rs
@@ -1,0 +1,139 @@
+use std::io::{Seek, SeekFrom, Write};
+
+use guest_session_prune::{
+    CODEX_COMPACT_GENERATION_MAX_BYTES, CodexHistoryIneligibleReason, CodexHistorySelection,
+    select_codex_compact_generation,
+};
+use serde_json::{Value, json};
+
+const THREAD_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TURN_ID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+fn line(record_type: &str, payload: Value) -> serde_json::Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec(&json!({
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "type": record_type,
+        "payload": payload,
+    }))?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+#[test]
+fn selects_a_small_generation_from_a_source_above_the_public_guard()
+-> Result<(), Box<dyn std::error::Error>> {
+    let canonical = line(
+        "session_meta",
+        json!({
+            "session_id": THREAD_ID,
+            "id": THREAD_ID,
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "cwd": "/workspace",
+            "originator": "codex_exec",
+            "cli_version": "0.145.0",
+            "source": "exec",
+            "model_provider": "mock",
+            "history_mode": "legacy",
+        }),
+    )?;
+    let retained = [
+        line(
+            "event_msg",
+            json!({
+                "type": "task_started",
+                "turn_id": TURN_ID,
+                "model_context_window": 258400,
+                "collaboration_mode_kind": "default",
+            }),
+        )?,
+        line(
+            "event_msg",
+            json!({
+                "type": "user_message",
+                "message": "continue",
+                "images": [],
+                "local_images": [],
+                "audio": [],
+                "local_audio": [],
+                "text_elements": [],
+            }),
+        )?,
+        line(
+            "turn_context",
+            json!({
+                "turn_id": TURN_ID,
+                "cwd": "/workspace",
+                "approval_policy": {"granular": {"sandbox_approval": true}},
+                "sandbox_policy": {"type": "read_only"},
+                "model": "gpt-test",
+                "summary": "auto",
+            }),
+        )?,
+        line(
+            "compacted",
+            json!({
+                "message": "retained summary",
+                "replacement_history": [{
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "retained summary",
+                    }],
+                }],
+            }),
+        )?,
+        line(
+            "world_state",
+            json!({
+                "full": true,
+                "state": {"resources": []},
+            }),
+        )?,
+        line(
+            "event_msg",
+            json!({
+                "type": "task_complete",
+                "turn_id": TURN_ID,
+                "last_agent_message": "retained summary",
+            }),
+        )?,
+    ];
+
+    let mut file = tempfile::NamedTempFile::new()?;
+    file.write_all(&canonical)?;
+    file.as_file_mut()
+        .set_len(CODEX_COMPACT_GENERATION_MAX_BYTES + 1)?;
+    file.as_file_mut().seek(SeekFrom::End(0))?;
+    file.write_all(b"\n")?;
+    for record in &retained {
+        file.write_all(record)?;
+    }
+    file.flush()?;
+
+    let mut source = file.reopen()?;
+    let candidate = match select_codex_compact_generation(&mut source, THREAD_ID)? {
+        CodexHistorySelection::Candidate(candidate) => candidate,
+        CodexHistorySelection::Ineligible(reason) => {
+            return Err(format!("expected candidate, got {reason:?}").into());
+        }
+    };
+    let expected = std::iter::once(canonical)
+        .chain(retained)
+        .flatten()
+        .collect::<Vec<_>>();
+
+    assert!(candidate.source_size() > CODEX_COMPACT_GENERATION_MAX_BYTES);
+    assert_eq!(candidate.candidate_size(), expected.len() as u64);
+    let selected = candidate.into_bytes();
+    assert_eq!(selected, expected);
+
+    let mut repeated = tempfile::tempfile()?;
+    repeated.write_all(&selected)?;
+    repeated.seek(SeekFrom::Start(0))?;
+    assert_eq!(
+        select_codex_compact_generation(&mut repeated, THREAD_ID)?,
+        CodexHistorySelection::Ineligible(CodexHistoryIneligibleReason::SourceWithinGuard)
+    );
+    Ok(())
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8019,6 +8019,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(claim.featureFlags).toMatchObject({
       [FeatureSwitchKey.PlanUpgradeGuidance]: true,
       [FeatureSwitchKey.ZeroFinance]: true,
+      [FeatureSwitchKey.CodexSessionPruning]: false,
       [FeatureSwitchKey.ClaudeSessionPruning]: false,
     });
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "codexFastMode",
+  CodexSessionPruning = "codexSessionPruning",
   ClaudeSessionPruning = "claudeSessionPruning",
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -115,6 +115,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ZeroMail]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroPeopleSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.CodexSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerChatThreadSuggestions]).toBe(
@@ -143,6 +144,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ZeroMail]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroPeopleSearch]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.CodexSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -335,6 +335,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.CodexSessionPruning]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Prune oversized Codex checkpoint histories to the latest native compact generation.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ClaudeSessionPruning]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- select a bounded, exact native generation from oversized plain Codex legacy JSONL by retaining canonical session metadata, the native user-turn segment containing the newest usable compaction, and every exact later record
- follow Codex's native replay boundary semantics: a matching completion or the next turn start can delimit a retained segment, while an unterminated final segment still fails closed
- feed eligible candidates through the existing checkpoint transaction, atomically reconcile the canonical live rollout only after commit, and publish reusable identity only after local and remote history match
- gate Codex pruning independently for staff organizations and verify the bundled Codex reconstructs identical model input from the full and pruned rollouts before appending under the same UUID and rollout path

## Compatibility

- attempts selection only for successful Codex checkpoints above the 64 MiB candidate guard; recovery checkpoints are unchanged
- rejects paginated, malformed, unsupported, ambiguous, unterminated, rolled-back, wrong-ID, or over-limit candidates and preserves the existing ordinary checkpoint path
- does not rewrite native payloads, change thread IDs or filenames, mutate Codex SQLite state, add an API/database schema, or change runner reuse lifecycle
- old guests ignore the additive feature-map key; the new switch is globally disabled and independently enabled for staff organizations
- rollback builds rerun the same behavior test against the Codex version bundled by that build; this PR does not install a second CLI in CI

## Validation

- `cargo test -p guest-session-prune`
- `cargo test -p guest-agent --all-features`
- `cargo clippy -p guest-session-prune -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-session-prune -p guest-agent --all-features --no-deps`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'injects agent identity, tool hints, and user info into the runner context'`
- `pnpm turbo run lint check-types --filter=api --filter=@vm0/core --filter=@vm0/connectors`
- `pnpm knip`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- embedded Python syntax and loopback compatibility probe against bundled Codex 0.145.0
- production-like 212 MB rollout selection to a 492 KB exact candidate; full and pruned resumes produced identical normalized 560-item model input
- repository pre-commit hooks, including workspace Rust Clippy/docs and full Turbo type checking

Closes #23062

Parent: #23035
