### PR TITLE
refactor(api): use settlement time for finalized usage reports

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -9,10 +9,10 @@ import {
   zeroUsageInsightContract,
 } from "@vm0/api-contracts/contracts/zero-usage-insight";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { nowDate } from "../../../lib/time";
+import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   ensureUsagePricingRow,
@@ -26,16 +26,15 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 /*
- * Usage rows are bucketed by their database insertion time, which cannot be
- * backdated through any product path. All seeded activity therefore lands in
- * the current hour; window-boundary behavior for past days (yesterday
- * buckets, 7d/day-window edges, timezone date shifts, and the
- * activity-vs-billing-time distinction) is no longer covered here.
+ * Finalized usage is filtered and bucketed by settlement time. Database
+ * insertion time remains independent from the application clock used by
+ * inline managed settlement and the pending-usage processing endpoint.
  */
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
 const GOOGLE_GEOCODING_URL =
   "https://maps.googleapis.com/maps/api/geocode/json";
+const HOUR_MS = 3_600_000;
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
@@ -212,6 +211,10 @@ function authenticateInsightActor(actor: ApiTestUser): void {
 }
 
 describe("GET /api/zero/usage/insight", () => {
+  afterEach(() => {
+    clearMockNow();
+  });
+
   it("returns 401 when not authenticated", async () => {
     const response = await accept(
       apiClient().get({
@@ -451,6 +454,50 @@ describe("GET /api/zero/usage/insight", () => {
     expect(bucket).toBeDefined();
     expect(bucket?.ts).toContain(selectedDate);
     expect(bucket?.ts).toMatch(/:00:00/);
+  });
+
+  it("uses settlement time for range membership and hourly buckets", async () => {
+    const actor = await entitledInsightActor();
+    const settledAt = new Date(nowDate().getTime() + 25 * HOUR_MS);
+    mockNow(settledAt);
+    const credits = await recordRunlessUsage(actor);
+    clearMockNow();
+    authenticateInsightActor(actor);
+
+    const currentRange = await accept(
+      apiClient().get({
+        query: { range: "7d", groupBy: "source", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(currentRange.body.grandTotalCredits).toBe(0);
+    expect(currentRange.body.buckets).toStrictEqual([]);
+
+    const processedDate = settledAt.toISOString().slice(0, 10);
+    const processedRange = await accept(
+      apiClient().get({
+        query: {
+          range: "day",
+          date: processedDate,
+          groupBy: "source",
+          tz: "UTC",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    const processedHour = new Date(settledAt);
+    processedHour.setUTCMinutes(0, 0, 0);
+
+    expect(processedRange.body.grandTotalCredits).toBe(credits);
+    expect(processedRange.body.buckets).toStrictEqual([
+      {
+        ts: processedHour.toISOString(),
+        series: { others: credits },
+        tokens: { others: 0 },
+      },
+    ]);
   });
 
   it("scope isolation — other user's activity in same org is invisible", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from "node:crypto";
 
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import { zeroMapsContract } from "@vm0/api-contracts/contracts/zero-maps";
 import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { HttpResponse, http } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
+import { server } from "../../../mocks/server";
 import { seedUsagePricingRows } from "../../../test-fixtures/system-config-seeds";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
@@ -25,11 +28,14 @@ const chatCallbacks = createChatCallbacksApi(context);
 const mocks = createZeroRouteMocks(context);
 
 /*
- * Timezone/DST period-boundary reads ("today"/"yesterday" row membership) are
- * not covered here: usage_event.created_at is a database default, so sandbox
- * webhooks cannot backdate ledger rows into a past period.
+ * Finalized period membership follows settlement time. Database insertion time
+ * remains independent from the application clock used by inline managed
+ * settlement and the pending-usage processing endpoint.
  */
 
+const DAY_MS = 86_400_000;
+const GOOGLE_GEOCODING_URL =
+  "https://maps.googleapis.com/maps/api/geocode/json";
 const MODEL_TOKEN_CATEGORIES = {
   input: "tokens.input",
   output: "tokens.output",
@@ -728,6 +734,82 @@ describe("GET /api/zero/usage/record", () => {
         kind: "connector",
         credits: 20,
         providers: [{ provider: connectorProvider, credits: 20 }],
+      },
+    ]);
+  });
+
+  it("uses settlement time consistently for rows, totals, and breakdowns", async () => {
+    const fixture = await entitledRecordActor();
+    billing.configureMapsProvider();
+    await seedUsagePricingRows([
+      {
+        kind: "maps",
+        provider: "google-maps",
+        category: "geocoding",
+        unitPrice: 6,
+        unitSize: 1,
+      },
+    ]);
+    server.use(
+      http.get(GOOGLE_GEOCODING_URL, () => {
+        return HttpResponse.json({
+          status: "OK",
+          results: [
+            {
+              formatted_address: "1 Infinite Loop, Cupertino, CA",
+              geometry: { location: { lat: 37.3317, lng: -122.0301 } },
+            },
+          ],
+        });
+      }),
+    );
+
+    const run = await createUnthreadedRun(fixture.actor, {
+      prompt: "Settlement boundary usage",
+      triggerSource: "cli",
+    });
+    const settledAt = new Date(nowDate().getTime() + 8 * DAY_MS);
+    mockNow(settledAt);
+    const mapsToken = api.zeroTokenForRunWithCapabilities(
+      fixture.actor,
+      run.runId,
+      ["maps:read"],
+    );
+    const maps = setupApp({ context })(zeroMapsContract);
+    const geocode = await accept(
+      maps.geocode({
+        headers: { authorization: `Bearer ${mapsToken}` },
+        body: { address: "1 Infinite Loop, Cupertino" },
+      }),
+      [200],
+    );
+    expect(geocode.body.creditsCharged).toBe(6);
+
+    mockNow(new Date(settledAt.getTime() + 60_000));
+    mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.rows).toHaveLength(1);
+    expect(response.body.pagination.total).toBe(1);
+    expect(response.body.totalCredits).toBe(6);
+    expect(response.body.rows[0]).toMatchObject({
+      source: "cli",
+      runId: run.runId,
+      credits: 6,
+      tokens: 0,
+    });
+    expect(response.body.rows[0]?.breakdown).toStrictEqual([
+      {
+        kind: "other",
+        credits: 6,
+        providers: [{ provider: "google-maps", credits: 6 }],
       },
     ]);
   });

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -71,8 +71,8 @@ interface TimeParts {
 interface UsageInsightSqlParams {
   readonly userId: string;
   readonly orgId: string;
-  readonly startTs: string;
-  readonly endTs: string;
+  readonly startTs: Date;
+  readonly endTs: Date;
   readonly trunc: "hour" | "day";
   readonly tz: string;
 }
@@ -314,15 +314,15 @@ function rangeToWindow(
 
 function usageBucketExpr(activityTime: SQLWrapper, p: UsageInsightSqlParams) {
   return sql`date_trunc(${p.trunc}, ${activityTime} AT TIME ZONE 'UTC' AT TIME ZONE ${p.tz})`.mapWith(
-    usageEvent.createdAt,
+    usageEvent.processedAt,
   );
 }
 
 function activityTimeWindowPredicate(p: UsageInsightSqlParams) {
-  const activityTime = sql`${usageEvent.createdAt} AT TIME ZONE 'UTC'`;
   return and(
-    gte(activityTime, sql`${p.startTs}::timestamptz`),
-    lt(activityTime, sql`${p.endTs}::timestamptz`),
+    isNotNull(usageEvent.processedAt),
+    gte(usageEvent.processedAt, p.startTs),
+    lt(usageEvent.processedAt, p.endTs),
   );
 }
 
@@ -345,7 +345,8 @@ function usageRowsCte(db: Db, p: UsageInsightSqlParams) {
   return db.$with("usage_rows").as(
     db
       .select({
-        activityTime: usageEvent.createdAt,
+        // Finalized reports assign usage to the time settlement completed.
+        activityTime: usageEvent.processedAt,
         runId: usageEvent.runId,
         userId: usageEvent.userId,
         orgId: usageEvent.orgId,
@@ -713,8 +714,8 @@ export const zeroUsageInsight$ = command(
     const params: UsageInsightSqlParams = {
       userId: args.userId,
       orgId: args.orgId,
-      startTs: startTs.toISOString(),
-      endTs: endTs.toISOString(),
+      startTs,
+      endTs,
       trunc,
       tz: args.options.tz,
     };

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -16,6 +16,7 @@ import {
   pgInt8ToSafeIntegerSchema,
   pgTimestampWithoutTimezoneToDateSchema,
 } from "../../lib/db-raw-rows";
+import { timestampWithoutTimeZone } from "../../lib/time";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
@@ -167,10 +168,11 @@ function recordWith(
   );
   const userPredicate =
     userId === null ? sql.empty() : sql`AND ue.user_id = ${userId}`;
+  // Finalized reports assign usage to the time settlement completed.
   const periodPredicate = period
     ? sql`
-        AND ue.created_at AT TIME ZONE 'UTC' >= ${period.start.toISOString()}::timestamptz
-        AND ue.created_at AT TIME ZONE 'UTC' < ${period.end.toISOString()}::timestamptz`
+        AND ue.processed_at >= ${timestampWithoutTimeZone(period.start)}::timestamp
+        AND ue.processed_at < ${timestampWithoutTimeZone(period.end)}::timestamp`
     : sql.empty();
   return sql`
     WITH usage_rows AS (
@@ -184,6 +186,7 @@ function recordWith(
       WHERE ue.org_id = ${orgId}
         ${userPredicate}
         AND ue.status = 'processed'
+        AND ue.processed_at IS NOT NULL
         ${periodPredicate}
     ),
     runs AS (
@@ -337,10 +340,11 @@ async function queryUsageRecordBreakdown(
 
   const userPredicate =
     userId === null ? sql.empty() : sql`AND ue.user_id = ${userId}`;
+  // Keep breakdown membership on the same settlement clock as record totals.
   const periodPredicate = period
     ? sql`
-          AND ue.created_at AT TIME ZONE 'UTC' >= ${period.start.toISOString()}::timestamptz
-          AND ue.created_at AT TIME ZONE 'UTC' < ${period.end.toISOString()}::timestamptz`
+          AND ue.processed_at >= ${timestampWithoutTimeZone(period.start)}::timestamp
+          AND ue.processed_at < ${timestampWithoutTimeZone(period.end)}::timestamp`
     : sql.empty();
   const rowKeyList = sql.join(
     rowKeys.map((rowKey) => {
@@ -369,6 +373,7 @@ async function queryUsageRecordBreakdown(
         WHERE ue.org_id = ${orgId}
           ${userPredicate}
           AND ue.status = 'processed'
+          AND ue.processed_at IS NOT NULL
           ${periodPredicate}
       ),
       keyed AS (


### PR DESCRIPTION
## Summary

- use `usage_event.processed_at` as the range clock for finalized Usage Insight
  and Usage Record data
- derive Usage Insight hourly and daily buckets from settlement time
- keep Usage Record rows, totals, and provider breakdowns on the same
  index-friendly processed-time predicate
- preserve run-derived activity timestamps, response contracts, and settlement
  behavior

## Tests

- add API integration coverage for created-inside/processed-outside and
  created-outside/processed-inside range membership
- verify Usage Insight uses the processed hourly bucket
- verify Usage Record row totals and provider breakdowns use the same processed
  range
- use org-scoped inline managed settlement so controlled clocks cannot process
  pending events owned by parallel tests

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts src/signals/routes/__tests__/zero-usage-record.test.ts`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- staged-path pre-commit hooks, including Prettier, full Knip, and Turbo type
  checking

No schema, migration, API contract, runner protocol, pricing, credit settlement,
or Run Usage behavior changes.

Closes #23135

Parent context: #23034
