### PR TITLE
chore(api): migrate sql fragments to structural analysis

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -31,6 +31,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  or,
   sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -882,7 +883,10 @@ async function getLatestRunsByThreadId(
     .where(
       and(
         eq(zeroRuns.chatThreadId, threadId),
-        sql`(${agentRuns.status} IS DISTINCT FROM ${"cancelled"} OR ${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR})`,
+        or(
+          sql`${agentRuns.status} IS DISTINCT FROM ${"cancelled"}`,
+          sql`${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR}`,
+        ),
       ),
     )
     .orderBy(desc(agentRuns.createdAt))

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { count, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { and, count, gte, isNotNull, lt, sql } from "drizzle-orm";
 
 import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
@@ -32,9 +32,11 @@ export const aggregateUsageDaily$ = command(
         ${count()}::int,
         COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint
       FROM ${agentRuns}
-      WHERE ${gte(agentRuns.createdAt, yesterday)}
-        AND ${lt(agentRuns.createdAt, today)}
-        AND ${isNotNull(agentRuns.completedAt)}
+      WHERE ${and(
+        gte(agentRuns.createdAt, yesterday),
+        lt(agentRuns.createdAt, today),
+        isNotNull(agentRuns.completedAt),
+      )}
       GROUP BY ${agentRuns.userId}, ${agentRuns.orgId}
       ON CONFLICT (user_id, org_id, date) DO UPDATE SET
         run_count = EXCLUDED.run_count,

--- a/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, inArray, lt, sql } from "drizzle-orm";
+import { and, inArray, lt, or, sql } from "drizzle-orm";
 
 import { isStoredScreenshotPointer } from "@vm0/api-contracts/contracts/zero-computer-use";
 import { computerUseCommands } from "@vm0/db/schema/computer-use-host";
@@ -36,7 +36,10 @@ export const cleanupComputerUseScreenshots$ = command(
           and(
             lt(computerUseCommands.createdAt, cutoff),
             sql`jsonb_exists(${computerUseCommands.result}, 'screenshot')`,
-            sql`(${computerUseCommands.result}->'screenshot'->>'type' = 's3' OR jsonb_typeof(${computerUseCommands.result}->'screenshot') = 'string')`,
+            or(
+              sql`${computerUseCommands.result}->'screenshot'->>'type' = 's3'`,
+              sql`jsonb_typeof(${computerUseCommands.result}->'screenshot') = 'string'`,
+            ),
           ),
         )
         .limit(SCREENSHOT_CLEANUP_BATCH_SIZE);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -28,6 +28,8 @@ import {
   isNotNull,
   lte,
   max,
+  not,
+  or,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -800,7 +802,7 @@ async function latestEventBackedAssistantMessage(
         eq(chatMessages.role, "assistant"),
         isNotNull(chatMessages.sequenceNumber),
         isNotNull(chatMessages.content),
-        sql`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
+        not(sql`${chatMessages.content} ~ '^[[:space:]]*$'`),
         ...(options.maxSequenceNumber === undefined
           ? []
           : [lte(chatMessages.sequenceNumber, options.maxSequenceNumber)]),
@@ -1787,7 +1789,10 @@ async function getLatestRunsByThreadId(
       and(
         eq(zeroRuns.chatThreadId, threadId),
         eq(zeroRuns.triggerSource, triggerSource),
-        sql`(${agentRuns.status} IS DISTINCT FROM ${"cancelled"} OR ${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR})`,
+        or(
+          sql`${agentRuns.status} IS DISTINCT FROM ${"cancelled"}`,
+          sql`${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR}`,
+        ),
       ),
     )
     .orderBy(desc(agentRuns.createdAt))

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, gte, inArray, lt, sql, sum } from "drizzle-orm";
+import { and, eq, gt, gte, inArray, lt, or, sql, sum } from "drizzle-orm";
 import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -180,15 +180,23 @@ async function replaceModelStats(
           ${modelUsageObservation.cacheReadInputTokens}::bigint AS cache_read_input_tokens,
           ${modelUsageObservation.cacheCreationInputTokens}::bigint AS cache_creation_input_tokens
         FROM ${modelUsageObservation}
-        WHERE ${gte(modelUsageObservation.observedAt, sql`${windowStartParam}::timestamp`)}
-          AND ${lt(modelUsageObservation.observedAt, sql`${windowEndParam}::timestamp`)}
-          AND ${inArray(modelUsageObservation.model, modelStatsModelIds)}
-          AND (
-            ${modelUsageObservation.inputTokens} > 0
-            OR ${modelUsageObservation.outputTokens} > 0
-            OR ${modelUsageObservation.cacheReadInputTokens} > 0
-            OR ${modelUsageObservation.cacheCreationInputTokens} > 0
-          )
+        WHERE ${and(
+          gte(
+            modelUsageObservation.observedAt,
+            sql`${windowStartParam}::timestamp`,
+          ),
+          lt(
+            modelUsageObservation.observedAt,
+            sql`${windowEndParam}::timestamp`,
+          ),
+          inArray(modelUsageObservation.model, modelStatsModelIds),
+          or(
+            gt(modelUsageObservation.inputTokens, sql`0`),
+            gt(modelUsageObservation.outputTokens, sql`0`),
+            gt(modelUsageObservation.cacheReadInputTokens, sql`0`),
+            gt(modelUsageObservation.cacheCreationInputTokens, sql`0`),
+          ),
+        )}
       ),
       aggregated AS (
         SELECT

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -686,7 +686,10 @@ function deleteUserS3Data(db: Db, userId: string): Computed<Promise<void>> {
       .where(
         and(
           eq(storages.userId, userId),
-          sql`${storages.s3Prefix} = ${storages.orgId} || '/' || ${storages.id}::text`,
+          eq(
+            storages.s3Prefix,
+            sql`${storages.orgId} || '/' || ${storages.id}::text`,
+          ),
         ),
       );
 

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,7 +1,17 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
-import { and, asc, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  not,
+  or,
+  sql,
+} from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -87,9 +97,9 @@ async function selectIncompleteRoundFrontier(
         WHERE ${and(
           eq(chatMessages.chatThreadId, threadId),
           isNotNull(chatMessages.runId),
-          sql`NOT (
-            ${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)
-          )`,
+          not(
+            sql`${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)`,
+          ),
           visibleChatMessageCondition(db),
           or(
             isSuccessfulRun,

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -203,8 +203,8 @@ export async function loadNextUnclaimedQueuedUserMessage(
       modelProviderCredentialScope: sql`NULL`.mapWith(pgNullDecoder),
       selectedModel: chatThreads.selectedModel,
       triggerSource: sql`CASE
-        WHEN ${chatMessageQueue.triggerSource} = 'slack' THEN 'slack'
-        WHEN ${chatMessageQueue.triggerSource} = 'feishu' THEN 'feishu'
+        WHEN ${eq(chatMessageQueue.triggerSource, sql`'slack'`)} THEN 'slack'
+        WHEN ${eq(chatMessageQueue.triggerSource, sql`'feishu'`)} THEN 'feishu'
         ELSE 'web'
       END`.mapWith(queuedUserMessageTriggerSourceDecoder),
       encryptedParams: chatMessageQueue.encryptedParams,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1036,15 +1036,15 @@ export function zeroChatThreadDraftIds(args: {
       .where(
         and(
           eq(chatThreads.userId, args.userId),
-          sql`(
-            COALESCE(${chatThreads.draftContent}, '') <> ''
-            OR ${isNotNull(chatThreads.draftStructuredPrompt)}
-            OR ${isNotNull(chatThreads.draftStructuredPromptWithFeedback)}
-            OR (
-              ${isNotNull(chatThreads.draftAttachments)}
-              AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
-            )
-          )`,
+          or(
+            sql`COALESCE(${chatThreads.draftContent}, '') <> ''`,
+            isNotNull(chatThreads.draftStructuredPrompt),
+            isNotNull(chatThreads.draftStructuredPromptWithFeedback),
+            and(
+              isNotNull(chatThreads.draftAttachments),
+              sql`jsonb_array_length(${chatThreads.draftAttachments}) > 0`,
+            ),
+          ),
         ),
       );
     return rows.map((row) => {

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -328,8 +328,10 @@ function activityTimeWindowPredicate(p: UsageInsightSqlParams) {
 
 function usageRowTokenExpr() {
   return sql`CASE
-    WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)}
-      AND ${inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES)}
+    WHEN ${and(
+      eq(usageEvent.kind, MODEL_USAGE_KIND),
+      inArray(usageEvent.category, MODEL_TOKEN_CATEGORIES),
+    )}
     THEN ${usageEvent.quantity}
     ELSE 0
   END::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -196,7 +196,10 @@ export function mergedRunModel(events: UsageEventRunUsageTotalsSubquery) {
 }
 
 function usageEventTokenSum(categories: readonly string[], alias: string) {
-  return sql`COALESCE(SUM(CASE WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)} AND ${inArray(usageEvent.category, categories)} THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
+  return sql`COALESCE(SUM(CASE WHEN ${and(
+    eq(usageEvent.kind, MODEL_USAGE_KIND),
+    inArray(usageEvent.category, categories),
+  )} THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -225,7 +225,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .select({ id: users.id })
           .from(users)
           .as("selected_users");
-        const dynamicCondition = sql\`true\`;
         sql\` \`;
         sql\`true::boolean\`;
         db.select()
@@ -248,9 +247,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select()
           .from(users)
           .innerJoinLateral(selected, eq(selected.id, users.id));
-        db.select()
-          .from(users)
-          .innerJoinLateral(selected, dynamicCondition);
       `,
     },
     {
@@ -706,12 +702,12 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         \`;
         db.select()
           .from(users)
-          .where(sql\`EXISTS (SELECT 1 WHERE NOT \${fragment})\`);
+          .where(sql\`EXISTS (SELECT 1 WHERE \${fragment})\`);
       `,
       errors: [
         {
           messageId: "typedApi",
-          data: { helper: "not" },
+          data: { helper: "and" },
           line: 26,
         },
       ],
@@ -753,11 +749,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [
         {
           messageId: "typedApi",
-          data: { helper: "isNotNull" },
+          data: { helper: "and" },
         },
         {
           messageId: "typedApi",
-          data: { helper: "and" },
+          data: { helper: "isNotNull" },
         },
       ],
     },
@@ -1277,12 +1273,16 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const names = ["one", "two"];
-        sql\`lower(\${users.name}) IN (\${sql.join(
-          names.map((name) => {
-            return sql\`\${name}\`;
-          }),
-          sql\`, \`,
-        )})\`;
+        db.select()
+          .from(users)
+          .where(
+            sql\`lower(\${users.name}) IN (\${sql.join(
+              names.map((name) => {
+                return sql\`\${name}\`;
+              }),
+              sql\`, \`,
+            )})\`,
+          );
       `,
       errors: [{ messageId: "typedApi", data: { helper: "inArray" } }],
     },
@@ -1295,22 +1295,46 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const aliasedNameSql = nameSql.as("aliased_name");
         const selected = db.select({ id: users.id }).from(users);
         const tag = drizzle.sql;
-        query\`NOT \${condition}\`;
-        drizzle.sql\`WHERE NOT \${condition} AND \${condition}\`;
-        tag\`\${users.name} NOT LIKE \${"prefix%"} ESCAPE '\\\\'\`;
-        query\`\${users.name} ILIKE \${"prefix%"}\`;
-        drizzle.sql\`\${users.name} NOT ILIKE \${query\`LOWER(\${"prefix%"})\`}\`;
-        tag\`\${nameSql} ILIKE \${"prefix%"}\`;
-        query\`\${aliasedNameSql} NOT LIKE \${"prefix%"}\`;
-        tag\`\${users.id} BETWEEN \${1} AND \${2}\`;
-        tag\`\${users.deletedAt} BETWEEN \${"2026-01-01"}::timestamp AND \${"2026-01-02"}::timestamp\`;
-        query\`WHERE \${users.id} NOT BETWEEN \${1} AND \${2} ORDER BY 1\`;
-        drizzle.sql\`EXISTS \${selected}\`;
-        tag\`NOT EXISTS \${selected}\`;
+        db.select().from(users).where(query\`NOT \${condition}\`);
+        db.select()
+          .from(users)
+          .where(drizzle.sql\`unsupported(NOT \${condition})\`);
+        db.select()
+          .from(users)
+          .where(tag\`\${users.name} NOT LIKE \${"prefix%"} ESCAPE '\\\\'\`);
+        db.select()
+          .from(users)
+          .where(query\`\${users.name} ILIKE \${"prefix%"}\`);
+        db.select()
+          .from(users)
+          .where(
+            drizzle.sql\`\${users.name} NOT ILIKE \${query\`LOWER(\${"prefix%"})\`}\`,
+          );
+        db.select()
+          .from(users)
+          .where(tag\`\${nameSql} ILIKE \${"prefix%"}\`);
+        db.select()
+          .from(users)
+          .where(query\`\${aliasedNameSql} NOT LIKE \${"prefix%"}\`);
+        db.select()
+          .from(users)
+          .where(tag\`\${users.id} BETWEEN \${1} AND \${2}\`);
+        db.select()
+          .from(users)
+          .where(
+            tag\`\${users.deletedAt} BETWEEN \${"2026-01-01"}::timestamp AND \${"2026-01-02"}::timestamp\`,
+          );
+        db.select()
+          .from(users)
+          .where(query\`\${users.id} NOT BETWEEN \${1} AND \${2}\`);
+        db.select()
+          .from(users)
+          .where(drizzle.sql\`EXISTS \${selected}\`);
+        db.select().from(users).where(tag\`NOT EXISTS \${selected}\`);
         function pattern<T extends typeof users.name>(left: T) {
-          query\`\${left} NOT ILIKE \${"prefix%"}\`;
+          return query\`\${left} NOT ILIKE \${"prefix%"}\`;
         }
-        void pattern;
+        db.select().from(users).where(pattern(users.name));
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "not" } },
@@ -1334,18 +1358,26 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const tagsSql = sql\`\${users.tags}\`;
         const typedTagsSql = sql\`\${users.tags}\`.mapWith(users.tags);
         const aliasedTagsSql = typedTagsSql.as("aliased_tags");
-        sql\`\${users.tags} <@ \${tagsSql}\`;
-        sql\`\${users.tags} && \${tagsSql}\`;
-        sql\`\${typedTagsSql} @> \${tagsSql}\`;
-        sql\`\${aliasedTagsSql} <@ \${tagsSql}\`;
+        db.select()
+          .from(users)
+          .where(sql\`\${users.tags} <@ \${tagsSql}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.tags} && \${tagsSql}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${typedTagsSql} @> \${tagsSql}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${aliasedTagsSql} <@ \${tagsSql}\`);
         function overlaps<T extends typeof users.tags>(left: T, right: SQLWrapper) {
-          sql\`\${left} && \${right}\`;
+          return sql\`\${left} && \${right}\`;
         }
         function overlapsSql<T extends SQL<string[]>>(left: T, right: SQLWrapper) {
-          sql\`\${left} && \${right}\`;
+          return sql\`\${left} && \${right}\`;
         }
-        void overlaps;
-        void overlapsSql;
+        db.select().from(users).where(overlaps(users.tags, tagsSql));
+        db.select().from(users).where(overlapsSql(typedTagsSql, tagsSql));
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "arrayContained" } },
@@ -1360,14 +1392,22 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       code: `${drizzlePreamble}
         import { eq, sql } from "drizzle-orm";
         const condition = eq(users.id, 1);
-        sql\`SELECT COUNT(*)::int, COUNT(*) FILTER (WHERE \${condition}) FROM \${users}\`;
-        sql\`SELECT SUM(\${users.id}) FROM \${users}\`;
-        sql\`SELECT COUNT(\${users.id}) FROM \${users}\`;
-        sql\`SELECT COUNT(DISTINCT \${users.id}) FROM \${users}\`;
-        sql\`SELECT AVG(\${users.id}) FROM \${users}\`;
-        sql\`SELECT AVG(DISTINCT \${users.id}) FROM \${users}\`;
-        sql\`SELECT SUM(DISTINCT \${users.id}) FROM \${users}\`;
-        sql\`SELECT MIN(\${users.id}) FROM \${users}\`;
+        await db.execute(
+          sql\`SELECT COUNT(*)::int, COUNT(*) FILTER (WHERE \${condition}) FROM \${users}\`,
+        );
+        await db.execute(sql\`SELECT SUM(\${users.id}) FROM \${users}\`);
+        await db.execute(sql\`SELECT COUNT(\${users.id}) FROM \${users}\`);
+        await db.execute(
+          sql\`SELECT COUNT(DISTINCT \${users.id}) FROM \${users}\`,
+        );
+        await db.execute(sql\`SELECT AVG(\${users.id}) FROM \${users}\`);
+        await db.execute(
+          sql\`SELECT AVG(DISTINCT \${users.id}) FROM \${users}\`,
+        );
+        await db.execute(
+          sql\`SELECT SUM(DISTINCT \${users.id}) FROM \${users}\`,
+        );
+        await db.execute(sql\`SELECT MIN(\${users.id}) FROM \${users}\`);
         const fragment = sql\`\${users.id} + 1\`;
         sql\`COUNT(*)\`.mapWith(Number);
         sql\`SUM(\${fragment})\`.mapWith(users.id);
@@ -1391,12 +1431,16 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     {
       code: `${drizzlePreamble}
         import { and, eq, isNotNull, sql } from "drizzle-orm";
-        sql\`EXISTS (
-          SELECT 1
-          FROM \${users}
-          WHERE \${eq(users.id, 1)}
-            AND \${isNotNull(users.name)}
-        )\`;
+        db.select()
+          .from(users)
+          .where(
+            sql\`EXISTS (
+              SELECT 1
+              FROM \${users}
+              WHERE \${eq(users.id, 1)}
+                AND \${isNotNull(users.name)}
+            )\`,
+          );
       `,
       errors: [
         {
@@ -1412,14 +1456,26 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         import { alias } from "drizzle-orm/pg-core";
         const otherUsers = alias(users, "other_users");
         const tag = drizzle.sql;
-        query\` not   exists(
-          select 1 from \${users}
-          inner join \${otherUsers} on \${eq(otherUsers.id, users.id)}
-          where \${eq(users.id, 1)} and \${isNotNull(otherUsers.name)}
-          limit 1
-        ) \`;
-        drizzle.sql\`EXISTS (SELECT 1 FROM \${otherUsers} WHERE \${eq(otherUsers.id, 1)})\`;
-        tag\`NOT EXISTS (SELECT 1 FROM \${users} WHERE \${eq(users.id, 1)})\`;
+        db.select()
+          .from(users)
+          .where(
+            query\` not   exists(
+              select 1 from \${users}
+              inner join \${otherUsers} on \${eq(otherUsers.id, users.id)}
+              where \${eq(users.id, 1)} and \${isNotNull(otherUsers.name)}
+              limit 1
+            ) \`,
+          );
+        db.select()
+          .from(users)
+          .where(
+            drizzle.sql\`EXISTS (SELECT 1 FROM \${otherUsers} WHERE \${eq(otherUsers.id, 1)})\`,
+          );
+        db.select()
+          .from(users)
+          .where(
+            tag\`NOT EXISTS (SELECT 1 FROM \${users} WHERE \${eq(users.id, 1)})\`,
+          );
       `,
       errors: [
         {
@@ -1439,7 +1495,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
-        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${users.id} = \${1})\`;
+        db.select()
+          .from(users)
+          .where(
+            sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${users.id} = \${1})\`,
+          );
       `,
       errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
     },
@@ -1471,14 +1531,19 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .select({ id: users.id })
           .from(users)
           .as("selected_users");
+        const trueCondition = query\`true\`;
         db.select()
           .from(users)
           .innerJoinLateral(selected, query\` true \`);
         db.select()
           .from(users)
           .innerJoinLateral(selected, drizzle.sql\`TRUE\`);
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, trueCondition);
       `,
       errors: [
+        { messageId: "crossJoinLateral" },
         { messageId: "crossJoinLateral" },
         { messageId: "crossJoinLateral" },
       ],
@@ -1514,12 +1579,12 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const value = 1;
-        sql\`\${users.id} = \${value}\`;
-        sql\`\${users.id} <> \${value}\`;
-        sql\`\${users.id} > \${value}\`;
-        sql\`\${users.id} >= \${value}\`;
-        sql\`\${users.id} < \${value}\`;
-        sql\`\${users.id} <= \${value}\`;
+        db.select().from(users).where(sql\`\${users.id} = \${value}\`);
+        db.select().from(users).where(sql\`\${users.id} <> \${value}\`);
+        db.select().from(users).where(sql\`\${users.id} > \${value}\`);
+        db.select().from(users).where(sql\`\${users.id} >= \${value}\`);
+        db.select().from(users).where(sql\`\${users.id} < \${value}\`);
+        db.select().from(users).where(sql\`\${users.id} <= \${value}\`);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },
@@ -1533,8 +1598,12 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     {
       code: `${drizzlePreamble}
         import { sql as query } from "drizzle-orm";
-        query\` \${users.deletedAt}  is   null \`;
-        query\`\${users.deletedAt}\nIS NOT NULL\`;
+        db.select()
+          .from(users)
+          .where(query\` \${users.deletedAt}  is   null \`);
+        db.select()
+          .from(users)
+          .where(query\`\${users.deletedAt}\nIS NOT NULL\`);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "isNull" } },
@@ -1544,9 +1613,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     {
       code: `${drizzlePreamble}
         import * as drizzle from "drizzle-orm";
-        drizzle.sql\`MAX ( \${users.id} )\`;
+        db.select({ value: drizzle.sql\`MAX ( \${users.id} )\` }).from(users);
         const query = drizzle.sql;
-        query\`min(\${users.id})\`;
+        db.select({ value: query\`min(\${users.id})\` }).from(users);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "max" } },
@@ -1560,7 +1629,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .select({ id: users.id })
           .from(users)
           .as("selected_users");
-        sql\`\${selected.id} > \${users.id}\`;
+        db.select()
+          .from(users)
+          .where(sql\`\${selected.id} > \${users.id}\`);
       `,
       errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
     },
@@ -1568,29 +1639,38 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const value = 1;
-        sql\`(\${users.id} = \${value})\`;
-        sql\`\${users.deletedAt} >= \${"2026-01-01"}::timestamp\`;
-        sql\`\${users.deletedAt} < \${"2026-01-02"}::timestamptz AT TIME ZONE 'UTC' ORDER BY 1\`;
-        sql\`
-          SELECT \${users.id}
-          FROM \${users}
-          WHERE \${users.id} >= \${value}
-            AND \${users.deletedAt} IS NOT NULL
-        \`;
-        sql\`CASE
-          WHEN \${users.id} > \${value} AND \${users.id} <> \${value}
-          THEN \${users.name}
-          ELSE NULL
-        END\`;
+        db.select().from(users).where(sql\`(\${users.id} = \${value})\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.deletedAt} >= \${"2026-01-01"}::timestamp\`);
+        await db.execute(
+          sql\`SELECT 1
+            WHERE \${users.deletedAt} < \${"2026-01-02"}::timestamptz
+              AT TIME ZONE 'UTC'
+            ORDER BY 1\`,
+        );
+        await db.execute(
+          sql\`
+            SELECT \${users.id}
+            FROM \${users}
+            WHERE \${users.id} >= \${value}
+              AND \${users.deletedAt} IS NOT NULL
+          \`,
+        );
+        db.select({
+          value: sql\`CASE
+            WHEN \${users.id} > \${value} AND \${users.id} <> \${value}
+            THEN \${users.name}
+            ELSE NULL
+          END\`,
+        }).from(users);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "gte" } },
         { messageId: "typedApi", data: { helper: "lt" } },
-        { messageId: "typedApi", data: { helper: "gte" } },
-        { messageId: "typedApi", data: { helper: "isNotNull" } },
-        { messageId: "typedApi", data: { helper: "gt" } },
-        { messageId: "typedApi", data: { helper: "ne" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "and" } },
       ],
     },
     {
@@ -1600,23 +1680,23 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             operators.sql\`(\${fields.id} > \${0}) OR \${fields.deletedAt} IS NULL\`,
         });
       `,
-      errors: [
-        { messageId: "typedApi", data: { helper: "gt" } },
-        { messageId: "typedApi", data: { helper: "isNull" } },
-      ],
+      errors: [{ messageId: "typedApi", data: { helper: "or" } }],
     },
     {
       code: `${drizzlePreamble}
         import { sql, type SQLWrapper } from "drizzle-orm";
-        function predicates<T extends SQLWrapper>(left: T, right: string) {
-          sql\`\${left} = \${right}\`;
-          sql\`\${left} IS NOT NULL\`;
+        function comparison<T extends SQLWrapper>(left: T, right: string) {
+          return sql\`\${left} = \${right}\`;
+        }
+        function present<T extends SQLWrapper>(value: T) {
+          return sql\`\${value} IS NOT NULL\`;
         }
         function aggregate<T extends typeof users.id>(column: T) {
           return sql\`MAX(\${column})\`;
         }
-        void predicates;
-        void aggregate;
+        db.select().from(users).where(comparison(users.id, "1"));
+        db.select().from(users).where(present(users.id));
+        db.select({ value: aggregate(users.id) }).from(users);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },
@@ -1638,23 +1718,50 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             sql\`, \`,
           );
         }
-        function optional(value: SQL | undefined): SQL | undefined {
+        function optional(value: SQL): SQL {
           return value;
         }
         const condition = eq(users.id, 1);
         const jsonArray = sql\`jsonb_build_array(\${"tag"})\`;
-        sql\`\${users.name} LIKE \${"prefix%"} ESCAPE '\\\\'\`;
-        sql\`\${users.name} IN (\${nameList})\`;
-        sql\`\${users.name} IN (\${nameSqlList()})\`;
-        sql\`\${users.name} NOT IN (\${nameList})\`;
-        sql\`\${users.name} NOT IN (\${nameSqlList()})\`;
-        sql\`ORDER BY \${users.name} ASC, \${users.id} DESC NULLS FIRST\`;
-        sql\`COALESCE(SUM(\${users.id}), 0)\`;
-        sql\`COUNT(\${users.id}) FILTER (WHERE \${condition})::int\`;
-        sql\`MAX(\${users.deletedAt}) FILTER (WHERE \${condition})\`;
-        sql\`SELECT COUNT(\${users.id}), COUNT(DISTINCT \${users.name}), MAX(\${users.id}) FROM \${users}\`;
-        optional(sql\`(\${condition} AND \${condition}) OR \${condition}\`);
-        sql\`\${users.tags} @> \${jsonArray}\`;
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} LIKE \${"prefix%"} ESCAPE '\\\\'\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} IN (\${nameList})\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} IN (\${nameSqlList()})\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} NOT IN (\${nameList})\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} NOT IN (\${nameSqlList()})\`);
+        db.select()
+          .from(users)
+          .orderBy(
+            sql\`\${users.name} ASC\`,
+            sql\`\${users.id} DESC NULLS FIRST\`,
+          );
+        db.select({
+          value: sql\`COALESCE(SUM(\${users.id}), 0)\`,
+        }).from(users);
+        db.select({
+          value: sql\`COUNT(\${users.id}) FILTER (WHERE \${condition})::int\`,
+        }).from(users);
+        db.select({
+          value: sql\`MAX(\${users.deletedAt}) FILTER (WHERE \${condition})\`,
+        }).from(users);
+        await db.execute(
+          sql\`SELECT COUNT(\${users.id}), COUNT(DISTINCT \${users.name}), MAX(\${users.id}) FROM \${users}\`,
+        );
+        db.select()
+          .from(users)
+          .where(optional(sql\`(\${condition} AND \${condition}) OR \${condition}\`));
+        db.select()
+          .from(users)
+          .where(sql\`\${users.tags} @> \${jsonArray}\`);
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "like" } },
@@ -1681,23 +1788,35 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const names = ["one", "two"];
         const condition = eq(users.id, 1);
         const tag = drizzle.sql;
-        query\`lower(\${users.name}) IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )})\`;
-        drizzle.sql\`WHERE LOWER (\${users.name}) in (\${drizzle.sql.join(
-          names.map((name) => drizzle.sql\`\${name}\`),
-          drizzle.sql\`, \`,
-        )}) AND \${condition}\`;
-        tag\`NOT lower(\${users.name}) IN (\${tag.join(
-          names.map((name) => tag\`\${name}\`),
-          tag\`, \`,
-        )})\`;
+        db.select()
+          .from(users)
+          .where(
+            query\`lower(\${users.name}) IN (\${query.join(
+              names.map((name) => query\`\${name}\`),
+              query\`, \`,
+            )})\`,
+          );
+        db.select()
+          .from(users)
+          .where(
+            drizzle.sql\`LOWER (\${users.name}) in (\${drizzle.sql.join(
+              names.map((name) => drizzle.sql\`\${name}\`),
+              drizzle.sql\`, \`,
+            )}) AND \${condition}\`,
+          );
+        db.select()
+          .from(users)
+          .where(
+            tag\`NOT lower(\${users.name}) IN (\${tag.join(
+              names.map((name) => tag\`\${name}\`),
+              tag\`, \`,
+            )})\`,
+          );
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "inArray" } },
-        { messageId: "typedApi", data: { helper: "inArray" } },
-        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "not" } },
       ],
     },
     {
@@ -1709,13 +1828,26 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           names.map((name) => drizzle.sql\`\${name}\`),
           drizzle.sql\`, \`,
         );
-        query\`\${users.name} LIKE \${"prefix%"}\`;
-        drizzle.sql\`\${users.name} IN (\${nameList})\`;
-        drizzle.sql\`ORDER BY \${users.name} ASC, COALESCE(SUM(\${users.id}), 0)\`;
+        db.select()
+          .from(users)
+          .where(query\`\${users.name} LIKE \${"prefix%"}\`);
+        db.select()
+          .from(users)
+          .where(drizzle.sql\`\${users.name} IN (\${nameList})\`);
+        db.select()
+          .from(users)
+          .orderBy(
+            drizzle.sql\`\${users.name} ASC\`,
+            drizzle.sql\`COALESCE(SUM(\${users.id}), 0)\`,
+          );
         function contains<T extends typeof users.tags>(column: T, value: SQLWrapper) {
-          query\`\${column} @> \${value}\`;
+          return query\`\${column} @> \${value}\`;
         }
-        void contains;
+        db.select()
+          .from(users)
+          .where(
+            contains(users.tags, drizzle.sql\`\${users.tags}\`),
+          );
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "like" } },
@@ -1750,6 +1882,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "like" } },
+        { messageId: "typedApi", data: { helper: "and" } },
         { messageId: "typedApi", data: { helper: "not" } },
         { messageId: "typedApi", data: { helper: "ilike" } },
         { messageId: "typedApi", data: { helper: "between" } },

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -65,6 +65,14 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`MAX(\${users.id} + 1) FILTER (WHERE \${users.id} > 0)\`;
         sql\`MAX(\${users.id}) OVER (ORDER BY id)\`;
         sql\`COUNT(\${users.id}) FILTER (WHERE (\${condition})) OVER (ORDER BY id)\`;
+        db.select({
+          value: sql\`SUM(\${users.id} ORDER BY \${users.name})\`.mapWith(
+            Number,
+          ),
+        }).from(users);
+        db.select({
+          value: sql\`SUM(VARIADIC \${users.tags})\`.mapWith(Number),
+        }).from(users);
         sql\`MAX(\${fragment})\`;
         sql\`SUM(\${users.id})\`;
         sql\`COUNT(\${users.id})\`;
@@ -589,6 +597,60 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select()
           .from(users)
           .where(sql\`COALESCE(\${column} = \${1}, FALSE)\`);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const statement = sql\`
+          DELETE FROM \${users}
+          WHERE \${users.id} = \${1}
+        \`;
+        await db.execute(statement);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const otherUsers = alias(users, "other_users");
+        const relation = sql\`
+          \${users}
+          INNER JOIN \${otherUsers} ON \${users.id} = \${otherUsers.id}
+        \`;
+        db.select().from(relation);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const selection = sql\`\${users.id} = \${1} AS matched\`;
+        db.select({ matched: selection }).from(users);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`
+          \${users.id} = \${1}
+          ORDER BY \${users.id}
+        \`;
+        db.select().from(users).where(predicate);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const ordering = sql\`\${users.id} DESC LIMIT 1\`;
+        db.select().from(users).orderBy(ordering);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .innerJoin(users, sql\`true ORDER BY \${users.id}\`);
       `,
     },
   ],
@@ -1445,6 +1507,18 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "sum" } },
         { messageId: "typedApi", data: { helper: "max" } },
       ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`SUM(
+            \${users.id}
+            ORDER BY \${users.name} DESC
+          )\`.mapWith(Number),
+        }).from(users);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "desc" } }],
     },
     {
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -147,6 +147,24 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
+        import { eq, not, sql } from "drizzle-orm";
+        const first = eq(users.id, 1);
+        const second = eq(users.name, "name");
+        db.select()
+          .from(users)
+          .where(not(sql\`\${first} AND \${second}\`));
+        db.select({
+          value: sql\`\${first} AND \${second}\`,
+        }).from(users);
+        db.select()
+          .from(users)
+          .groupBy(sql\`\${first} AND \${second}\`)
+          .orderBy(sql\`\${first} AND \${second}\`);
+        sql\`\${first} AND \${second}\`.mapWith(Boolean);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
         import { eq, sql as query } from "drizzle-orm";
         const names = ["one", "two"];
         const nameList = query.join(
@@ -1879,6 +1897,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           where: (fields, operators) =>
             operators.sql\`\${fields.id} BETWEEN \${1} AND \${2}\`,
         });
+        db.query.users.findMany({
+          where: (fields, operators) => {
+            return operators.sql\`\${operators.eq(fields.id, 1)} AND \${operators.isNotNull(fields.name)}\`;
+          },
+        });
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "like" } },
@@ -1886,6 +1909,23 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "not" } },
         { messageId: "typedApi", data: { helper: "ilike" } },
         { messageId: "typedApi", data: { helper: "between" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { not, sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(
+            not(
+              sql\`\${users.id} = \${1} AND \${users.name} = \${"name"}\`,
+            ),
+          );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
       ],
     },
   ],

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -186,6 +186,39 @@ export function isDrizzleSqlType(
   });
 }
 
+export function isDrizzleSelectType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  return everyConcreteType(checker, type, (member) => {
+    if (!isDrizzleWrapperType(checker, member)) {
+      return false;
+    }
+    const metadataType = propertyType(checker, member, "_", location);
+    if (metadataType === undefined) {
+      return false;
+    }
+    const dialectType = propertyType(
+      checker,
+      metadataType,
+      "dialect",
+      location,
+    );
+    const selectModeType = propertyType(
+      checker,
+      metadataType,
+      "selectMode",
+      location,
+    );
+    return (
+      dialectType?.isStringLiteral() === true &&
+      dialectType.value === "pg" &&
+      selectModeType !== undefined
+    );
+  });
+}
+
 export function isDrizzlePatternOperandType(
   checker: TypeChecker,
   type: Type,

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -20,738 +20,80 @@ import {
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
-  TypeFlags,
   type Expression as TypeScriptExpression,
   type Node,
+  type Signature,
   type Symbol as TypeScriptSymbol,
-  type Type,
   type VariableDeclaration,
 } from "typescript";
 
 import {
-  isDrizzleArrayOperandType,
-  isDrizzleColumnType,
-  isDrizzlePatternOperandType,
+  isDrizzleDeclaration,
   isDrizzleSqlTag,
   isDrizzleSymbol,
-  isDrizzleTableType,
-  isDrizzleWrapperType,
   isNamedDrizzleSignature,
   resolvedSymbol,
 } from "../drizzle.ts";
 import { createExecuteRawRowsMatcher } from "../execute-raw-rows.ts";
 import {
-  SQL_TEMPLATE_EXPRESSION_BOUNDARY,
-  sqlCodeMask,
-} from "../sql-lexing.ts";
-import { analyzeSql, type SqlAnalysis } from "../sql-analysis/sql-analysis.ts";
+  analyzeSql,
+  type SqlAnalysis,
+  type SqlAnalysisContext,
+  type SqlCapabilityChecks,
+} from "../sql-analysis/sql-analysis.ts";
 import { createSqlSourceComposer } from "../sql-analysis/sql-source.ts";
 import { createRule } from "../utils.ts";
 
-type BinaryLeftOperand = "array" | "pattern" | "wrapper";
-type BinaryRightOperand = "any" | "string-or-wrapper" | "wrapper";
-type BinaryRightBoundary = "pattern" | "predicate";
-
-interface BinaryHelper {
-  readonly helper: string;
-  readonly left: BinaryLeftOperand;
-  readonly right: BinaryRightOperand;
-  readonly rightBoundary: BinaryRightBoundary;
-}
-
-const BINARY_HELPERS = new Map<string, BinaryHelper>([
-  [
-    "=",
-    { helper: "eq", left: "wrapper", right: "any", rightBoundary: "predicate" },
-  ],
-  [
-    "<>",
-    { helper: "ne", left: "wrapper", right: "any", rightBoundary: "predicate" },
-  ],
-  [
-    ">",
-    { helper: "gt", left: "wrapper", right: "any", rightBoundary: "predicate" },
-  ],
-  [
-    ">=",
-    {
-      helper: "gte",
-      left: "wrapper",
-      right: "any",
-      rightBoundary: "predicate",
-    },
-  ],
-  [
-    "<",
-    { helper: "lt", left: "wrapper", right: "any", rightBoundary: "predicate" },
-  ],
-  [
-    "<=",
-    {
-      helper: "lte",
-      left: "wrapper",
-      right: "any",
-      rightBoundary: "predicate",
-    },
-  ],
-  [
-    "LIKE",
-    {
-      helper: "like",
-      left: "pattern",
-      right: "string-or-wrapper",
-      rightBoundary: "pattern",
-    },
-  ],
-  [
-    "NOT LIKE",
-    {
-      helper: "notLike",
-      left: "pattern",
-      right: "string-or-wrapper",
-      rightBoundary: "pattern",
-    },
-  ],
-  [
-    "ILIKE",
-    {
-      helper: "ilike",
-      left: "pattern",
-      right: "string-or-wrapper",
-      rightBoundary: "pattern",
-    },
-  ],
-  [
-    "NOT ILIKE",
-    {
-      helper: "notIlike",
-      left: "pattern",
-      right: "string-or-wrapper",
-      rightBoundary: "pattern",
-    },
-  ],
-  [
-    "@>",
-    {
-      helper: "arrayContains",
-      left: "array",
-      right: "wrapper",
-      rightBoundary: "predicate",
-    },
-  ],
-  [
-    "<@",
-    {
-      helper: "arrayContained",
-      left: "array",
-      right: "wrapper",
-      rightBoundary: "predicate",
-    },
-  ],
-  [
-    "&&",
-    {
-      helper: "arrayOverlaps",
-      left: "array",
-      right: "wrapper",
-      rightBoundary: "predicate",
-    },
-  ],
-]);
-
-const STRUCTURAL_HELPERS = new Set([
+const PREDICATE_HELPERS = new Set([
   "and",
+  "arrayContained",
+  "arrayContains",
+  "arrayOverlaps",
+  "between",
   "eq",
+  "exists",
   "gt",
   "gte",
+  "ilike",
+  "inArray",
+  "isNotNull",
+  "isNull",
+  "like",
   "lt",
   "lte",
   "ne",
+  "not",
+  "notBetween",
+  "notExists",
+  "notIlike",
+  "notInArray",
+  "notLike",
   "or",
 ]);
 
-type BooleanToken = "operand" | "and" | "or" | "(" | ")";
-type BooleanExpressionKind = "operand" | "and" | "or";
-type ExistenceKeyword =
-  | "and"
-  | "exists"
-  | "from"
-  | "inner"
-  | "join"
-  | "limit"
-  | "not"
-  | "on"
-  | "select"
-  | "where"
-  | "one"
-  | "("
-  | ")";
+const SELECTION_HELPERS = new Set([
+  "asc",
+  "avg",
+  "avgDistinct",
+  "count",
+  "countDistinct",
+  "desc",
+  "max",
+  "min",
+  "sum",
+  "sumDistinct",
+]);
 
-interface ExistenceExpressionToken {
-  readonly kind: "expression";
-  readonly index: number;
-}
+const SELECTION_OBJECT_METHODS = new Set([
+  "returning",
+  "select",
+  "selectDistinct",
+  "selectDistinctOn",
+  "set",
+  "values",
+]);
 
-type ExistenceToken = ExistenceKeyword | ExistenceExpressionToken;
-
-interface ExistenceTemplateMatch {
-  readonly helper: "exists" | "notExists";
-  readonly tableExpressionIndexes: readonly number[];
-  readonly predicateExpressionIndexes: readonly number[];
-}
-
-function quasiText(node: TSESTree.TemplateElement): string {
-  return node.value.cooked ?? node.value.raw;
-}
-
-interface NullPredicateMatch {
-  helper: "isNull" | "isNotNull";
-  length: number;
-}
-
-function nullPredicateMatch(quasi: string): NullPredicateMatch | undefined {
-  const match = /^\s*IS\s+(NOT\s+)?NULL\b/i.exec(quasi);
-  if (match === null) {
-    return undefined;
-  }
-  return {
-    helper: match[1] === undefined ? "isNull" : "isNotNull",
-    length: match[0].length,
-  };
-}
-
-function hasPredicateLeftBoundary(quasi: string): boolean {
-  const prefix = quasi.trimEnd();
-  return (
-    prefix === "" ||
-    prefix.endsWith("(") ||
-    /\b(?:AND|HAVING|NOT|ON|OR|WHEN|WHERE)$/i.test(prefix)
-  );
-}
-
-function removeRightOperandPostfix(quasi: string): string | undefined {
-  let suffix = quasi;
-  while (/^\s*::/.test(suffix)) {
-    const cast =
-      /^\s*::\s*[a-z_][\w$]*(?:\s*\.\s*[a-z_][\w$]*)?(?:\s*\([^()]*\))?(?:\s*\[\s*\])*/i.exec(
-        suffix,
-      );
-    if (cast === null) {
-      return undefined;
-    }
-    suffix = suffix.slice(cast[0].length);
-  }
-
-  const timeZone = /^\s+AT\s+TIME\s+ZONE\s+'(?:''|[^'])*'/i.exec(suffix);
-  if (timeZone !== null) {
-    suffix = suffix.slice(timeZone[0].length);
-  }
-  return suffix;
-}
-
-function hasPredicateRightBoundary(quasi: string): boolean {
-  const withoutPostfix = removeRightOperandPostfix(quasi);
-  if (withoutPostfix === undefined) {
-    return false;
-  }
-  const suffix = withoutPostfix.trimStart();
-  return (
-    suffix === "" ||
-    /^[),;]/.test(suffix) ||
-    /^(?:AND|ELSE|END|EXCEPT|FETCH|FOR|FULL|GROUP|HAVING|INNER|INTERSECT|LEFT|LIMIT|OFFSET|ON|OR|ORDER|RETURNING|RIGHT|THEN|UNION|WHEN|WHERE)\b/i.test(
-      suffix,
-    )
-  );
-}
-
-function hasPatternRightBoundary(quasi: string): boolean {
-  const escape = /^\s+ESCAPE\s+'(?:''|[^'])*'/i.exec(quasi);
-  return hasPredicateRightBoundary(
-    escape === null ? quasi : quasi.slice(escape[0].length),
-  );
-}
-
-function membershipRightBoundary(quasi: string): boolean {
-  const close = /^\s*\)/.exec(quasi);
-  return (
-    close !== null && hasPredicateRightBoundary(quasi.slice(close[0].length))
-  );
-}
-
-function lowerCallStart(quasi: string): number | undefined {
-  const match = /\bLOWER\s*\(\s*$/i.exec(quasi);
-  if (match === null || hasSqlIdentifierPrefix(quasi, match.index)) {
-    return undefined;
-  }
-  return match.index;
-}
-
-function hasOrderingLeftBoundary(quasi: string): boolean {
-  const prefix = quasi.trimEnd();
-  return (
-    prefix === "" ||
-    prefix.endsWith(",") ||
-    prefix.endsWith("(") ||
-    /\bORDER\s+BY$/i.test(prefix)
-  );
-}
-
-interface OrderingMatch {
-  helper: "asc" | "desc";
-}
-
-function orderingMatch(quasi: string): OrderingMatch | undefined {
-  const direction = /^\s+(ASC|DESC)\b/i.exec(quasi);
-  if (direction === null) {
-    return undefined;
-  }
-  let length = direction[0].length;
-  const nulls = /^\s+NULLS\s+(?:FIRST|LAST)\b/i.exec(quasi.slice(length));
-  if (nulls !== null) {
-    length += nulls[0].length;
-  }
-  const suffix = quasi.slice(length).trimStart();
-  if (
-    suffix !== "" &&
-    !/^[,);]/.test(suffix) &&
-    !/^(?:FETCH|FOR|LIMIT|OFFSET)\b/i.test(suffix)
-  ) {
-    return undefined;
-  }
-  return {
-    helper: direction[1]?.toLowerCase() === "asc" ? "asc" : "desc",
-  };
-}
-
-interface AggregateMatch {
-  helper:
-    | "avg"
-    | "avgDistinct"
-    | "count"
-    | "countDistinct"
-    | "max"
-    | "min"
-    | "sum"
-    | "sumDistinct";
-  start: number;
-}
-
-function previousNonWhitespaceCharacter(
-  source: string,
-  start: number,
-): string | undefined {
-  let offset = start - 1;
-  while (offset >= 0 && /\s/.test(source[offset] ?? "")) {
-    offset -= 1;
-  }
-  return offset < 0 ? undefined : source[offset];
-}
-
-function isSqlIdentifierCharacter(character: string | undefined): boolean {
-  if (character === undefined) {
-    return false;
-  }
-  return /[\w$]/.test(character) || character.charCodeAt(0) > 0x7f;
-}
-
-function hasSqlIdentifierPrefix(source: string, start: number): boolean {
-  const previous = previousNonWhitespaceCharacter(source, start);
-  return (
-    isSqlIdentifierCharacter(source[start - 1]) ||
-    previous === "." ||
-    previous === SQL_TEMPLATE_EXPRESSION_BOUNDARY
-  );
-}
-
-function aggregateMatch(quasi: string): AggregateMatch | undefined {
-  const distinct = /\b(AVG|COUNT|SUM)\s*\(\s*DISTINCT\s*$/i.exec(quasi);
-  if (distinct !== null && !hasSqlIdentifierPrefix(quasi, distinct.index)) {
-    const aggregate = distinct[1]?.toLowerCase();
-    const helper =
-      aggregate === "avg"
-        ? "avgDistinct"
-        : aggregate === "count"
-          ? "countDistinct"
-          : "sumDistinct";
-    return { helper, start: distinct.index };
-  }
-  const aggregate = /\b(AVG|SUM|COUNT|MAX|MIN)\s*\(\s*$/i.exec(quasi);
-  if (aggregate === null) {
-    return undefined;
-  }
-  if (hasSqlIdentifierPrefix(quasi, aggregate.index)) {
-    return undefined;
-  }
-  const helper = aggregate[1]?.toLowerCase();
-  if (
-    helper !== "avg" &&
-    helper !== "sum" &&
-    helper !== "count" &&
-    helper !== "max" &&
-    helper !== "min"
-  ) {
-    return undefined;
-  }
-  return { helper, start: aggregate.index };
-}
-
-function aggregateRemainder(quasi: string): string | undefined {
-  const close = /^\s*\)/.exec(quasi);
-  return close === null ? undefined : quasi.slice(close[0].length);
-}
-
-interface UnaryPredicateMatch {
-  readonly helper: "exists" | "not" | "notExists";
-  readonly start: number;
-}
-
-function unaryPredicateMatch(quasi: string): UnaryPredicateMatch | undefined {
-  const match = /\b(?:(NOT)\s+)?(EXISTS)\s*$|\b(NOT)\s*$/i.exec(quasi);
-  if (match === null) {
-    return undefined;
-  }
-  if (match[2] !== undefined) {
-    return {
-      helper: match[1] === undefined ? "exists" : "notExists",
-      start: match.index,
-    };
-  }
-  return { helper: "not", start: match.index };
-}
-
-interface RangeMatch {
-  readonly helper: "between" | "notBetween";
-}
-
-function rangeMatch(
-  firstSeparator: string,
-  secondSeparator: string,
-): RangeMatch | undefined {
-  const secondRemainder = removeRightOperandPostfix(secondSeparator);
-  if (secondRemainder?.trim().toUpperCase() !== "AND") {
-    return undefined;
-  }
-  const operator = firstSeparator.trim().toUpperCase();
-  if (operator === "BETWEEN") {
-    return { helper: "between" };
-  }
-  return operator === "NOT BETWEEN" ? { helper: "notBetween" } : undefined;
-}
-
-function skipSqlWhitespace(source: string, start: number): number {
-  let offset = start;
-  while (/\s/.test(source[offset] ?? "")) {
-    offset += 1;
-  }
-  return offset;
-}
-
-function sqlKeywordAt(
-  source: string,
-  offset: number,
-  keyword: string,
-): boolean {
-  if (source.slice(offset, offset + keyword.length).toUpperCase() !== keyword) {
-    return false;
-  }
-  return !/[\w$]/.test(source[offset + keyword.length] ?? "");
-}
-
-function hasAggregateWindowSuffix(source: string, start: number): boolean {
-  let offset = skipSqlWhitespace(source, start);
-  if (sqlKeywordAt(source, offset, "OVER")) {
-    return true;
-  }
-  if (!sqlKeywordAt(source, offset, "FILTER")) {
-    return false;
-  }
-  offset = skipSqlWhitespace(source, offset + "FILTER".length);
-  if (source[offset] !== "(") {
-    return false;
-  }
-  let depth = 0;
-  while (offset < source.length) {
-    const character = source[offset];
-    if (character === "(") {
-      depth += 1;
-    } else if (character === ")") {
-      depth -= 1;
-      if (depth === 0) {
-        offset += 1;
-        break;
-      }
-    }
-    offset += 1;
-  }
-  return (
-    depth === 0 &&
-    sqlKeywordAt(source, skipSqlWhitespace(source, offset), "OVER")
-  );
-}
-
-interface SqlSourceMatch {
-  readonly end: number;
-  readonly start: number;
-}
-
-function countStarMatches(code: string): readonly SqlSourceMatch[] {
-  const count = /\bCOUNT\s*\(\s*\*\s*\)/gi;
-  const matches: SqlSourceMatch[] = [];
-  for (const match of code.matchAll(count)) {
-    const start = match.index;
-    if (hasSqlIdentifierPrefix(code, start)) {
-      continue;
-    }
-    if (hasAggregateWindowSuffix(code, start + match[0].length)) {
-      continue;
-    }
-    matches.push({ start, end: start + match[0].length });
-  }
-  return matches;
-}
-
-function tokenizeBooleanQuasi(quasi: string): BooleanToken[] | undefined {
-  const tokens: BooleanToken[] = [];
-  let offset = 0;
-  while (offset < quasi.length) {
-    const whitespace = /^\s+/.exec(quasi.slice(offset));
-    if (whitespace !== null) {
-      offset += whitespace[0].length;
-      continue;
-    }
-    const character = quasi[offset];
-    if (character === "(" || character === ")") {
-      tokens.push(character);
-      offset += 1;
-      continue;
-    }
-    const operator = /^(AND|OR)\b/i.exec(quasi.slice(offset));
-    if (operator === null) {
-      return undefined;
-    }
-    tokens.push(operator[1]?.toLowerCase() === "and" ? "and" : "or");
-    offset += operator[0].length;
-  }
-  return tokens;
-}
-
-function booleanTokens(quasis: readonly string[]): BooleanToken[] | undefined {
-  const tokens: BooleanToken[] = [];
-  for (let index = 0; index < quasis.length; index += 1) {
-    const quasiTokens = tokenizeBooleanQuasi(quasis[index] ?? "");
-    if (quasiTokens === undefined) {
-      return undefined;
-    }
-    tokens.push(...quasiTokens);
-    if (index < quasis.length - 1) {
-      tokens.push("operand");
-    }
-  }
-  return tokens;
-}
-
-function booleanHelper(quasis: readonly string[]): "and" | "or" | undefined {
-  const tokens = booleanTokens(quasis);
-  if (tokens === undefined) {
-    return undefined;
-  }
-  const parsedTokens = tokens;
-  let offset = 0;
-
-  function primary(): BooleanExpressionKind | undefined {
-    const token = parsedTokens[offset];
-    if (token === "operand") {
-      offset += 1;
-      return "operand";
-    }
-    if (token !== "(") {
-      return undefined;
-    }
-    offset += 1;
-    const expression = disjunction();
-    if (expression === undefined || parsedTokens[offset] !== ")") {
-      return undefined;
-    }
-    offset += 1;
-    return expression;
-  }
-
-  function conjunction(): BooleanExpressionKind | undefined {
-    let expression = primary();
-    if (expression === undefined) {
-      return undefined;
-    }
-    while (parsedTokens[offset] === "and") {
-      offset += 1;
-      if (primary() === undefined) {
-        return undefined;
-      }
-      expression = "and";
-    }
-    return expression;
-  }
-
-  function disjunction(): BooleanExpressionKind | undefined {
-    let expression = conjunction();
-    if (expression === undefined) {
-      return undefined;
-    }
-    while (parsedTokens[offset] === "or") {
-      offset += 1;
-      if (conjunction() === undefined) {
-        return undefined;
-      }
-      expression = "or";
-    }
-    return expression;
-  }
-
-  const expression = disjunction();
-  return offset === parsedTokens.length && expression !== "operand"
-    ? expression
-    : undefined;
-}
-
-function tokenizeExistenceQuasi(quasi: string): ExistenceKeyword[] | undefined {
-  const tokens: ExistenceKeyword[] = [];
-  let offset = 0;
-  while (offset < quasi.length) {
-    const whitespace = /^\s+/.exec(quasi.slice(offset));
-    if (whitespace !== null) {
-      offset += whitespace[0].length;
-      continue;
-    }
-    const character = quasi[offset];
-    if (character === "(" || character === ")") {
-      tokens.push(character);
-      offset += 1;
-      continue;
-    }
-    const one = /^1\b/.exec(quasi.slice(offset));
-    if (one !== null) {
-      tokens.push("one");
-      offset += one[0].length;
-      continue;
-    }
-    const keyword =
-      /^(AND|EXISTS|FROM|INNER|JOIN|LIMIT|NOT|ON|SELECT|WHERE)\b/i.exec(
-        quasi.slice(offset),
-      );
-    if (keyword === null) {
-      return undefined;
-    }
-    const value = keyword[1]?.toLowerCase();
-    if (
-      value !== "and" &&
-      value !== "exists" &&
-      value !== "from" &&
-      value !== "inner" &&
-      value !== "join" &&
-      value !== "limit" &&
-      value !== "not" &&
-      value !== "on" &&
-      value !== "select" &&
-      value !== "where"
-    ) {
-      return undefined;
-    }
-    tokens.push(value);
-    offset += keyword[0].length;
-  }
-  return tokens;
-}
-
-function existenceTokens(
-  quasis: readonly string[],
-): ExistenceToken[] | undefined {
-  const tokens: ExistenceToken[] = [];
-  for (let index = 0; index < quasis.length; index += 1) {
-    const quasiTokens = tokenizeExistenceQuasi(quasis[index] ?? "");
-    if (quasiTokens === undefined) {
-      return undefined;
-    }
-    tokens.push(...quasiTokens);
-    if (index < quasis.length - 1) {
-      tokens.push({ kind: "expression", index });
-    }
-  }
-  return tokens;
-}
-
-function existenceTemplateMatch(
-  quasis: readonly string[],
-): ExistenceTemplateMatch | undefined {
-  const tokens = existenceTokens(quasis);
-  if (tokens === undefined) {
-    return undefined;
-  }
-  const parsedTokens = tokens;
-  let offset = 0;
-  const tableExpressionIndexes: number[] = [];
-  const predicateExpressionIndexes: number[] = [];
-
-  function consume(keyword: ExistenceKeyword): boolean {
-    if (parsedTokens[offset] !== keyword) {
-      return false;
-    }
-    offset += 1;
-    return true;
-  }
-
-  function consumeExpression(target: number[]): boolean {
-    const token = parsedTokens[offset];
-    if (typeof token === "string" || token === undefined) {
-      return false;
-    }
-    target.push(token.index);
-    offset += 1;
-    return true;
-  }
-
-  const negated = consume("not");
-  if (
-    !consume("exists") ||
-    !consume("(") ||
-    !consume("select") ||
-    !consume("one") ||
-    !consume("from") ||
-    !consumeExpression(tableExpressionIndexes)
-  ) {
-    return undefined;
-  }
-
-  while (consume("inner")) {
-    if (
-      !consume("join") ||
-      !consumeExpression(tableExpressionIndexes) ||
-      !consume("on") ||
-      !consumeExpression(predicateExpressionIndexes)
-    ) {
-      return undefined;
-    }
-  }
-
-  if (!consume("where") || !consumeExpression(predicateExpressionIndexes)) {
-    return undefined;
-  }
-  while (consume("and")) {
-    if (!consumeExpression(predicateExpressionIndexes)) {
-      return undefined;
-    }
-  }
-  if (consume("limit") && !consume("one")) {
-    return undefined;
-  }
-  if (!consume(")") || offset !== parsedTokens.length) {
-    return undefined;
-  }
-
-  return {
-    helper: negated ? "notExists" : "exists",
-    tableExpressionIndexes,
-    predicateExpressionIndexes,
-  };
-}
+const RELATIONAL_QUERY_METHODS = new Set(["findFirst", "findMany"]);
 
 export const preferDrizzleApis = createRule({
   name: "prefer-drizzle-apis",
@@ -782,28 +124,19 @@ export const preferDrizzleApis = createRule({
   create(context) {
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
-    const isExecuteRawRowsCallee = createExecuteRawRowsMatcher(
+    const executeRawRowsMatcher = createExecuteRawRowsMatcher(
       context.sourceCode.ast,
       checker,
       services,
     );
-    const structurallyOwnedTemplates =
-      new WeakSet<TSESTree.TaggedTemplateExpression>();
-    const structurallyWholeTemplates =
-      new WeakSet<TSESTree.TaggedTemplateExpression>();
     const structuralCallInspections: Array<() => void> = [];
-    const legacyTemplateInspections: Array<() => void> = [];
     const reportedStructuralFindings = new WeakMap<
       TSESTree.Node,
       Set<string>
     >();
-    const expressionTypeCache = new WeakMap<
-      TSESTree.Expression,
-      { readonly location: Node; readonly type: Type }
-    >();
-    const drizzleMethodCache = new WeakMap<
-      TSESTree.MemberExpression,
-      boolean
+    const resolvedCallSignatureCache = new WeakMap<
+      TSESTree.CallExpression,
+      Signature | null
     >();
     const sqlSourceComposer = createSqlSourceComposer(
       context.sourceCode,
@@ -811,22 +144,14 @@ export const preferDrizzleApis = createRule({
       services,
       isSafeSqlTerminalUse,
     );
+    const sqlCapabilityChecks: SqlCapabilityChecks = {
+      hasDirectResultMapping: hasDirectMapWith,
+      hasParameterListOrigin,
+      isInlineParameterList: isInlineParameterListSqlJoin,
+    };
 
-    function expressionType(node: TSESTree.Expression): {
-      readonly location: Node;
-      readonly type: Type;
-    } {
-      const cached = expressionTypeCache.get(node);
-      if (cached !== undefined) {
-        return cached;
-      }
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      const result = {
-        location: tsNode,
-        type: checker.getTypeAtLocation(tsNode),
-      };
-      expressionTypeCache.set(node, result);
-      return result;
+    function isExecuteRawRowsCallee(node: TSESTree.Expression): boolean {
+      return executeRawRowsMatcher(node);
     }
 
     function reportTypedApi(node: TSESTree.Node, helper: string): void {
@@ -842,7 +167,9 @@ export const preferDrizzleApis = createRule({
         const key =
           finding.kind === "query-builder"
             ? finding.kind
-            : `${finding.kind}:${finding.helper}`;
+            : finding.kind === "empty-fragment"
+              ? finding.kind
+              : `${finding.kind}:${finding.helper}`;
         const reported = reportedStructuralFindings.get(finding.node);
         if (reported?.has(key) === true) {
           continue;
@@ -857,46 +184,21 @@ export const preferDrizzleApis = createRule({
             node: finding.node,
             messageId: "queryBuilder",
           });
+        } else if (finding.kind === "empty-fragment") {
+          context.report({
+            node: finding.node,
+            messageId: "emptyFragment",
+          });
+        } else if (finding.kind === "existence-predicate") {
+          context.report({
+            node: finding.node,
+            messageId: "existencePredicate",
+            data: { helper: finding.helper },
+          });
         } else {
           reportTypedApi(finding.node, finding.helper);
         }
       }
-    }
-
-    function registerStructuralOwnership(analysis: SqlAnalysis): void {
-      for (const template of analysis.expandedTemplates) {
-        structurallyOwnedTemplates.add(template);
-        // Expansion can cross into a shared alias or factory definition. A
-        // use-site finding replaces only templates in its own syntax subtree.
-        if (
-          analysis.findings.some((finding) => {
-            let current: TSESTree.Node | null | undefined = template;
-            while (current !== undefined && current !== null) {
-              if (current === finding.node) {
-                return true;
-              }
-              current = current.parent;
-            }
-            return false;
-          })
-        ) {
-          structurallyWholeTemplates.add(template);
-        }
-      }
-    }
-
-    function reportLegacy(
-      template: TSESTree.TaggedTemplateExpression,
-      node: TSESTree.Node,
-      helper: string,
-    ): void {
-      if (
-        structurallyOwnedTemplates.has(template) &&
-        STRUCTURAL_HELPERS.has(helper)
-      ) {
-        return;
-      }
-      reportTypedApi(node, helper);
     }
 
     function memberName(node: TSESTree.MemberExpression): string | undefined {
@@ -909,31 +211,37 @@ export const preferDrizzleApis = createRule({
       node: TSESTree.CallExpression,
       name: string,
     ): boolean {
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      const signature = checker.getResolvedSignature(tsNode);
+      const signature = resolvedCallSignature(node);
       return (
         signature !== undefined && isNamedDrizzleSignature(signature, name)
       );
     }
 
-    function isDrizzleMethod(
-      node: TSESTree.MemberExpression,
+    function resolvedCallSignature(
+      node: TSESTree.CallExpression,
+    ): Signature | undefined {
+      const cached = resolvedCallSignatureCache.get(node);
+      if (cached !== undefined) {
+        return cached ?? undefined;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const signature = checker.getResolvedSignature(tsNode);
+      resolvedCallSignatureCache.set(node, signature ?? null);
+      return signature;
+    }
+
+    function isDrizzleMethodCall(
+      node: TSESTree.CallExpression,
       name: string,
     ): boolean {
-      if (memberName(node) !== name) {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== name
+      ) {
         return false;
       }
-      const cached = drizzleMethodCache.get(node);
-      if (cached !== undefined) {
-        return cached;
-      }
-      const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
-      const result = isDrizzleSymbol(
-        checker,
-        checker.getSymbolAtLocation(tsProperty),
-      );
-      drizzleMethodCache.set(node, result);
-      return result;
+      const declaration = resolvedCallSignature(node)?.declaration;
+      return declaration !== undefined && isDrizzleDeclaration(declaration);
     }
 
     function predicateArgumentIndex(
@@ -956,8 +264,107 @@ export const preferDrizzleApis = createRule({
         : undefined;
     }
 
+    function isDrizzleHelperUse(
+      call: TSESTree.CallExpression,
+      node: TSESTree.Expression,
+    ): boolean {
+      const name =
+        call.callee.type === AST_NODE_TYPES.Identifier
+          ? call.callee.name
+          : call.callee.type === AST_NODE_TYPES.MemberExpression
+            ? memberName(call.callee)
+            : undefined;
+      return (
+        name !== undefined &&
+        (PREDICATE_HELPERS.has(name) || SELECTION_HELPERS.has(name)) &&
+        call.arguments.includes(node) &&
+        isNamedDrizzleCall(call, name)
+      );
+    }
+
+    function selectionObjectCall(
+      node: TSESTree.Expression,
+    ): TSESTree.CallExpression | undefined {
+      let current: TSESTree.Node = node;
+      while (true) {
+        const parent: TSESTree.Node = current.parent;
+        if (
+          parent.type === AST_NODE_TYPES.Property &&
+          parent.value === current &&
+          parent.parent.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          current = parent.parent;
+          continue;
+        }
+        if (
+          parent.type === AST_NODE_TYPES.ArrayExpression &&
+          parent.elements.includes(current)
+        ) {
+          current = parent;
+          continue;
+        }
+        if (
+          parent.type !== AST_NODE_TYPES.CallExpression ||
+          !parent.arguments.includes(current) ||
+          parent.callee.type !== AST_NODE_TYPES.MemberExpression
+        ) {
+          return undefined;
+        }
+        const method = memberName(parent.callee);
+        return method !== undefined &&
+          SELECTION_OBJECT_METHODS.has(method) &&
+          isDrizzleMethodCall(parent, method)
+          ? parent
+          : undefined;
+      }
+    }
+
+    function isDirectDrizzleMethodUse(
+      call: TSESTree.CallExpression,
+      node: TSESTree.Expression,
+    ): boolean {
+      if (
+        call.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        !call.arguments.includes(node)
+      ) {
+        return false;
+      }
+      const method = memberName(call.callee);
+      if (method === undefined || !isDrizzleMethodCall(call, method)) {
+        return false;
+      }
+      if (
+        method === "execute" ||
+        method === "from" ||
+        method === "groupBy" ||
+        method === "orderBy"
+      ) {
+        return true;
+      }
+      const predicateIndex = predicateArgumentIndex(call);
+      return (
+        predicateIndex !== undefined && call.arguments[predicateIndex] === node
+      );
+    }
+
     function isSafeSqlTerminalUse(node: TSESTree.Expression): boolean {
       const parent = node.parent;
+      if (parent.type === AST_NODE_TYPES.MemberExpression) {
+        const method = memberName(parent);
+        const call = parent.parent;
+        if (
+          parent.object === node &&
+          (method === "as" || method === "mapWith") &&
+          call.type === AST_NODE_TYPES.CallExpression &&
+          call.callee === parent &&
+          isDrizzleMethodCall(call, method)
+        ) {
+          return true;
+        }
+      }
+      if (selectionObjectCall(node) !== undefined) {
+        return true;
+      }
       if (
         parent.type !== AST_NODE_TYPES.CallExpression ||
         parent.arguments.some((argument) => {
@@ -966,23 +373,12 @@ export const preferDrizzleApis = createRule({
       ) {
         return false;
       }
-      if (
-        parent.arguments.length === 3 &&
-        parent.arguments[1] === node &&
-        isExecuteRawRowsCallee(parent.callee)
-      ) {
-        return true;
-      }
-      const predicateIndex = predicateArgumentIndex(parent);
-      if (parent.callee.type !== AST_NODE_TYPES.MemberExpression) {
-        return false;
-      }
-      const method = memberName(parent.callee);
       return (
-        predicateIndex !== undefined &&
-        method !== undefined &&
-        parent.arguments[predicateIndex] === node &&
-        isDrizzleMethod(parent.callee, method)
+        (parent.arguments.length === 3 &&
+          parent.arguments[1] === node &&
+          isExecuteRawRowsCallee(parent.callee)) ||
+        isDirectDrizzleMethodUse(parent, node) ||
+        isDrizzleHelperUse(parent, node)
       );
     }
 
@@ -1011,8 +407,8 @@ export const preferDrizzleApis = createRule({
           checker,
           services,
           sqlSourceComposer,
+          sqlCapabilityChecks,
         );
-        registerStructuralOwnership(analysis);
         reportStructuralAnalysis(analysis);
       });
     }
@@ -1034,19 +430,24 @@ export const preferDrizzleApis = createRule({
       ) {
         return;
       }
-      const predicateMember = node.callee;
       structuralCallInspections.push(() => {
-        if (!isDrizzleMethod(predicateMember, method)) {
-          return;
-        }
         const analysis = analyzeSql(
           predicate,
           "predicate",
           checker,
           services,
           sqlSourceComposer,
+          sqlCapabilityChecks,
         );
-        registerStructuralOwnership(analysis);
+        if (
+          analysis.findings.length === 0 &&
+          !(method === "innerJoin" && analysis.isTruePredicate)
+        ) {
+          return;
+        }
+        if (!isDrizzleMethodCall(node, method)) {
+          return;
+        }
         reportStructuralAnalysis(analysis);
         if (method === "innerJoin" && analysis.isTruePredicate) {
           context.report({ node, messageId: "crossJoin" });
@@ -1054,18 +455,371 @@ export const preferDrizzleApis = createRule({
       });
     }
 
-    function isTrueSqlTag(node: TSESTree.Expression): boolean {
-      if (node.type !== AST_NODE_TYPES.TaggedTemplateExpression) {
-        return false;
+    function contextRoots(node: TSESTree.Node): readonly TSESTree.Expression[] {
+      if (node.type === AST_NODE_TYPES.ObjectExpression) {
+        return node.properties.flatMap((property) => {
+          return property.type === AST_NODE_TYPES.Property &&
+            property.kind === "init" &&
+            !property.computed
+            ? contextRoots(property.value)
+            : [];
+        });
       }
-      const quasi = node.quasi.quasis[0];
-      return (
-        isDrizzleSqlTag(checker, services, node.tag) &&
-        node.quasi.expressions.length === 0 &&
-        node.quasi.quasis.length === 1 &&
-        quasi !== undefined &&
-        quasiText(quasi).trim().toLowerCase() === "true"
+      if (node.type === AST_NODE_TYPES.ArrayExpression) {
+        return node.elements.flatMap((element) => {
+          return element === null ||
+            element.type === AST_NODE_TYPES.SpreadElement
+            ? []
+            : contextRoots(element);
+        });
+      }
+      if (
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        node.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+          return contextRoots(node.body);
+        }
+        if (
+          node.body.body.length !== 1 ||
+          node.body.body[0]?.type !== AST_NODE_TYPES.ReturnStatement ||
+          node.body.body[0].argument === null
+        ) {
+          return [];
+        }
+        return contextRoots(node.body.body[0].argument);
+      }
+      if (
+        node.type === AST_NODE_TYPES.CallExpression ||
+        node.type === AST_NODE_TYPES.ChainExpression ||
+        node.type === AST_NODE_TYPES.ConditionalExpression ||
+        node.type === AST_NODE_TYPES.Identifier ||
+        node.type === AST_NODE_TYPES.TaggedTemplateExpression ||
+        node.type === AST_NODE_TYPES.TSAsExpression ||
+        node.type === AST_NODE_TYPES.TSNonNullExpression ||
+        node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        node.type === AST_NODE_TYPES.TSTypeAssertion
+      ) {
+        return sqlSourceComposer.couldCompose(node) ? [node] : [];
+      }
+      return [];
+    }
+
+    function reportAnalysis(
+      node: TSESTree.Expression,
+      analysisContext: SqlAnalysisContext,
+    ): SqlAnalysis {
+      const analysis = analyzeSql(
+        node,
+        analysisContext,
+        checker,
+        services,
+        sqlSourceComposer,
+        sqlCapabilityChecks,
       );
+      reportStructuralAnalysis(analysis);
+      return analysis;
+    }
+
+    function inspectAdditionalContextCall(node: TSESTree.CallExpression): void {
+      const helper =
+        node.callee.type === AST_NODE_TYPES.Identifier
+          ? node.callee.name
+          : node.callee.type === AST_NODE_TYPES.MemberExpression
+            ? memberName(node.callee)
+            : undefined;
+      const helperContext =
+        helper === undefined
+          ? undefined
+          : PREDICATE_HELPERS.has(helper)
+            ? "predicate"
+            : SELECTION_HELPERS.has(helper)
+              ? "selection"
+              : undefined;
+      if (helper !== undefined && helperContext !== undefined) {
+        const roots = node.arguments.flatMap((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement
+            ? []
+            : contextRoots(argument);
+        });
+        if (roots.length > 0) {
+          structuralCallInspections.push(() => {
+            const analyses = roots.map((root) => {
+              return analyzeSql(
+                root,
+                helperContext,
+                checker,
+                services,
+                sqlSourceComposer,
+                sqlCapabilityChecks,
+              );
+            });
+            if (
+              !analyses.some((analysis) => {
+                return analysis.findings.length > 0;
+              })
+            ) {
+              return;
+            }
+            if (!isNamedDrizzleCall(node, helper)) {
+              return;
+            }
+            for (const analysis of analyses) {
+              reportStructuralAnalysis(analysis);
+            }
+          });
+        }
+      }
+
+      if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
+        const member = node.callee;
+        const method = memberName(member);
+        if (method === undefined) {
+          return;
+        }
+        if (
+          (method === "as" || method === "mapWith") &&
+          sqlSourceComposer.couldCompose(member.object)
+        ) {
+          const root = member.object;
+          structuralCallInspections.push(() => {
+            const analysis = analyzeSql(
+              root,
+              "selection",
+              checker,
+              services,
+              sqlSourceComposer,
+              sqlCapabilityChecks,
+            );
+            if (analysis.findings.length === 0) {
+              return;
+            }
+            if (isDrizzleMethodCall(node, method)) {
+              reportStructuralAnalysis(analysis);
+            }
+          });
+        }
+
+        let analysisContext:
+          | "ordering"
+          | "relation"
+          | "selection"
+          | "statement"
+          | undefined;
+        let argumentsToInspect = node.arguments;
+        if (method === "execute") {
+          analysisContext = "statement";
+        } else if (method === "from") {
+          analysisContext = "relation";
+          argumentsToInspect = node.arguments.slice(0, 1);
+        } else if (method === "orderBy") {
+          analysisContext = "ordering";
+        } else if (method === "groupBy") {
+          analysisContext = "selection";
+        } else if (
+          method === "innerJoin" ||
+          method === "innerJoinLateral" ||
+          method === "leftJoin" ||
+          method === "leftJoinLateral" ||
+          method === "rightJoin" ||
+          method === "fullJoin"
+        ) {
+          analysisContext = "relation";
+          argumentsToInspect = node.arguments.slice(0, 1);
+        } else if (SELECTION_OBJECT_METHODS.has(method)) {
+          analysisContext = "selection";
+        }
+        if (analysisContext === undefined) {
+          return;
+        }
+        const roots = argumentsToInspect.flatMap((argument) => {
+          return argument.type === AST_NODE_TYPES.SpreadElement
+            ? []
+            : contextRoots(argument);
+        });
+        if (roots.length === 0) {
+          return;
+        }
+        structuralCallInspections.push(() => {
+          const analyses = roots.map((root) => {
+            return analyzeSql(
+              root,
+              analysisContext,
+              checker,
+              services,
+              sqlSourceComposer,
+              sqlCapabilityChecks,
+            );
+          });
+          if (
+            !analyses.some((analysis) => {
+              return analysis.findings.length > 0;
+            })
+          ) {
+            return;
+          }
+          if (!isDrizzleMethodCall(node, method)) {
+            return;
+          }
+          for (const analysis of analyses) {
+            reportStructuralAnalysis(analysis);
+          }
+        });
+        return;
+      }
+    }
+
+    function staticPropertyName(node: TSESTree.Property): string | undefined {
+      if (node.computed) {
+        return undefined;
+      }
+      if (node.key.type === AST_NODE_TYPES.Identifier) {
+        return node.key.name;
+      }
+      return node.key.type === AST_NODE_TYPES.Literal &&
+        typeof node.key.value === "string"
+        ? node.key.value
+        : undefined;
+    }
+
+    interface ContextualRoot {
+      readonly context: "ordering" | "predicate" | "selection";
+      readonly node: TSESTree.Expression;
+    }
+
+    function relationalConfigRoots(
+      node: TSESTree.ObjectExpression,
+    ): readonly ContextualRoot[] {
+      return node.properties.flatMap((property) => {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.kind !== "init"
+        ) {
+          return [];
+        }
+        const name = staticPropertyName(property);
+        if (
+          name === "with" &&
+          property.value.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          return property.value.properties.flatMap((relation) => {
+            return relation.type === AST_NODE_TYPES.Property &&
+              relation.kind === "init" &&
+              relation.value.type === AST_NODE_TYPES.ObjectExpression
+              ? relationalConfigRoots(relation.value)
+              : [];
+          });
+        }
+        const analysisContext =
+          name === "where"
+            ? "predicate"
+            : name === "orderBy"
+              ? "ordering"
+              : name === "extras"
+                ? "selection"
+                : undefined;
+        return analysisContext === undefined
+          ? []
+          : contextRoots(property.value).map((root) => {
+              return { context: analysisContext, node: root };
+            });
+      });
+    }
+
+    function inspectRelationalQueryCall(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        node.arguments.length === 0
+      ) {
+        return;
+      }
+      const method = memberName(node.callee);
+      const config = node.arguments[0];
+      if (
+        method === undefined ||
+        !RELATIONAL_QUERY_METHODS.has(method) ||
+        config?.type !== AST_NODE_TYPES.ObjectExpression
+      ) {
+        return;
+      }
+      const roots = relationalConfigRoots(config);
+      if (roots.length === 0) {
+        return;
+      }
+      structuralCallInspections.push(() => {
+        const analyses = roots.map((root) => {
+          return analyzeSql(
+            root.node,
+            root.context,
+            checker,
+            services,
+            sqlSourceComposer,
+            sqlCapabilityChecks,
+          );
+        });
+        if (
+          !analyses.some((analysis) => {
+            return analysis.findings.length > 0;
+          })
+        ) {
+          return;
+        }
+        if (!isDrizzleMethodCall(node, method)) {
+          return;
+        }
+        for (const analysis of analyses) {
+          reportStructuralAnalysis(analysis);
+        }
+      });
+    }
+
+    function inspectLateralJoin(node: TSESTree.CallExpression): void {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return;
+      }
+      const method = memberName(node.callee);
+      if (
+        (method !== "innerJoinLateral" && method !== "leftJoinLateral") ||
+        node.arguments.length !== 2
+      ) {
+        return;
+      }
+      const relation = node.arguments[0];
+      const condition = node.arguments[1];
+      if (
+        relation === undefined ||
+        relation.type === AST_NODE_TYPES.SpreadElement ||
+        condition === undefined ||
+        condition.type === AST_NODE_TYPES.SpreadElement ||
+        !sqlSourceComposer.couldCompose(condition)
+      ) {
+        return;
+      }
+      structuralCallInspections.push(() => {
+        const analysis = analyzeSql(
+          condition,
+          "predicate",
+          checker,
+          services,
+          sqlSourceComposer,
+          sqlCapabilityChecks,
+        );
+        if (analysis.findings.length === 0 && !analysis.isTruePredicate) {
+          return;
+        }
+        if (!isDrizzleMethodCall(node, method)) {
+          return;
+        }
+        reportStructuralAnalysis(analysis);
+        if (
+          !analysis.isTruePredicate ||
+          (method === "leftJoinLateral" &&
+            !leftLateralIsNullRejected(node, relation))
+        ) {
+          return;
+        }
+        context.report({ node, messageId: "crossJoinLateral" });
+      });
     }
 
     function expressionSymbol(
@@ -1149,64 +903,13 @@ export const preferDrizzleApis = createRule({
       );
     }
 
-    function isStringOrDrizzleWrapper(type: Type): boolean {
-      if (type.isUnion()) {
-        return type.types.every(isStringOrDrizzleWrapper);
-      }
-      if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
-        return false;
-      }
-      if ((type.flags & TypeFlags.TypeParameter) !== 0) {
-        const constraint = checker.getBaseConstraintOfType(type);
-        return constraint !== undefined && isStringOrDrizzleWrapper(constraint);
-      }
-      return (
-        (type.flags & TypeFlags.StringLike) !== 0 ||
-        isDrizzleWrapperType(checker, type)
-      );
-    }
-
-    function binaryLeftMatches(
-      expected: BinaryLeftOperand,
-      expression: { readonly location: Node; readonly type: Type },
-    ): boolean {
-      if (expected === "wrapper") {
-        return isDrizzleWrapperType(checker, expression.type);
-      }
-      if (expected === "pattern") {
-        return isDrizzlePatternOperandType(
-          checker,
-          expression.type,
-          expression.location,
-        );
-      }
-      return isDrizzleArrayOperandType(
-        checker,
-        expression.type,
-        expression.location,
-      );
-    }
-
-    function binaryRightMatches(
-      expected: BinaryRightOperand,
-      type: Type,
-    ): boolean {
-      if (expected === "any") {
-        return true;
-      }
-      return expected === "wrapper"
-        ? isDrizzleWrapperType(checker, type)
-        : isStringOrDrizzleWrapper(type);
-    }
-
     function hasDirectMapWith(
       node: TSESTree.TaggedTemplateExpression,
     ): boolean {
       const member = node.parent;
       if (
         member.type !== AST_NODE_TYPES.MemberExpression ||
-        member.object !== node ||
-        !isDrizzleMethod(member, "mapWith")
+        member.object !== node
       ) {
         return false;
       }
@@ -1214,30 +917,10 @@ export const preferDrizzleApis = createRule({
       return (
         call.type === AST_NODE_TYPES.CallExpression &&
         call.callee === member &&
+        isDrizzleMethodCall(call, "mapWith") &&
         call.arguments.length === 1 &&
         call.arguments[0]?.type !== AST_NODE_TYPES.SpreadElement
       );
-    }
-
-    function isOptionalDrizzleContext(type: Type | undefined): boolean {
-      if (type === undefined || !type.isUnion()) {
-        return false;
-      }
-      let hasUndefined = false;
-      let hasWrapper = false;
-      for (const member of type.types) {
-        if ((member.flags & TypeFlags.Undefined) !== 0) {
-          hasUndefined = true;
-        } else if (
-          (member.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0 ||
-          !isDrizzleWrapperType(checker, member)
-        ) {
-          return false;
-        } else {
-          hasWrapper = true;
-        }
-      }
-      return hasUndefined && hasWrapper;
     }
 
     function isConstVariable(declaration: VariableDeclaration): boolean {
@@ -1454,290 +1137,29 @@ export const preferDrizzleApis = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
-        if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
-          return;
-        }
-        const method = memberName(node.callee);
-        if (method !== "innerJoinLateral" && method !== "leftJoinLateral") {
-          return;
-        }
-        if (
-          !isDrizzleMethod(node.callee, method) ||
-          node.arguments.length !== 2
-        ) {
-          return;
-        }
-        const relation = node.arguments[0];
-        const condition = node.arguments[1];
-        if (
-          relation === undefined ||
-          relation.type === AST_NODE_TYPES.SpreadElement ||
-          condition === undefined ||
-          condition.type === AST_NODE_TYPES.SpreadElement ||
-          !isTrueSqlTag(condition)
-        ) {
-          return;
-        }
-        if (
-          method === "leftJoinLateral" &&
-          !leftLateralIsNullRejected(node, relation)
-        ) {
-          return;
-        }
-        context.report({ node, messageId: "crossJoinLateral" });
+        inspectAdditionalContextCall(node);
+        inspectLateralJoin(node);
+        inspectRelationalQueryCall(node);
       },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
-        legacyTemplateInspections.push(() => {
+        const firstQuasi = node.quasi.quasis[0];
+        const isExactEmpty =
+          node.quasi.expressions.length === 0 &&
+          node.quasi.quasis.length === 1 &&
+          firstQuasi !== undefined &&
+          (firstQuasi.value.cooked ?? firstQuasi.value.raw) === "";
+        if (!isExactEmpty) {
+          return;
+        }
+        structuralCallInspections.push(() => {
           if (!isDrizzleSqlTag(checker, services, node.tag)) {
             return;
           }
-          if (structurallyWholeTemplates.has(node)) {
-            return;
-          }
-
-          const quasis = node.quasi.quasis.map(quasiText);
-          const syntaxSource = sqlCodeMask(
-            quasis.join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
-          );
-          const syntaxQuasis = syntaxSource.split(
-            SQL_TEMPLATE_EXPRESSION_BOUNDARY,
-          );
-          const expressions = node.quasi.expressions;
-          if (
-            expressions.length === 0 &&
-            quasis.length === 1 &&
-            quasis[0] === ""
-          ) {
-            context.report({ node, messageId: "emptyFragment" });
-            return;
-          }
-          const countStars = countStarMatches(syntaxSource);
-          for (const match of countStars) {
-            const isWholeAggregate =
-              expressions.length === 0 &&
-              syntaxSource.slice(0, match.start).trim() === "" &&
-              syntaxSource.slice(match.end).trim() === "";
-            if (!isWholeAggregate || hasDirectMapWith(node)) {
-              reportLegacy(node, node, "count");
-            }
-          }
-          const existence = existenceTemplateMatch(syntaxQuasis);
-          if (
-            existence !== undefined &&
-            existence.tableExpressionIndexes.every((index) => {
-              const expressionNode = expressions[index];
-              if (expressionNode === undefined) {
-                return false;
-              }
-              const expression = expressionType(expressionNode);
-              return isDrizzleTableType(
-                checker,
-                expression.type,
-                expression.location,
-              );
-            }) &&
-            existence.predicateExpressionIndexes.every((index) => {
-              const expressionNode = expressions[index];
-              return (
-                expressionNode !== undefined &&
-                isDrizzleWrapperType(
-                  checker,
-                  expressionType(expressionNode).type,
-                )
-              );
-            })
-          ) {
-            context.report({
-              node,
-              messageId: "existencePredicate",
-              data: { helper: existence.helper },
-            });
-            return;
-          }
-          for (let index = 0; index < expressions.length - 1; index += 1) {
-            const columnNode = expressions[index];
-            const valuesNode = expressions[index + 1];
-            if (columnNode === undefined || valuesNode === undefined) {
-              continue;
-            }
-            const prefix = syntaxQuasis[index] ?? "";
-            const lowerStart = lowerCallStart(prefix);
-            if (
-              lowerStart !== undefined &&
-              hasPredicateLeftBoundary(prefix.slice(0, lowerStart)) &&
-              /^\s*\)\s+IN\s*\(\s*$/i.test(syntaxQuasis[index + 1] ?? "") &&
-              membershipRightBoundary(syntaxQuasis[index + 2] ?? "") &&
-              isDrizzleColumnType(
-                checker,
-                expressionType(columnNode).type,
-                expressionType(columnNode).location,
-              ) &&
-              isInlineParameterListSqlJoin(valuesNode)
-            ) {
-              reportLegacy(node, columnNode, "inArray");
-            }
-          }
-          for (let index = 0; index < expressions.length - 1; index += 1) {
-            const leftNode = expressions[index];
-            const rightNode = expressions[index + 1];
-            if (leftNode === undefined || rightNode === undefined) {
-              continue;
-            }
-            const left = expressionType(leftNode);
-            const right = expressionType(rightNode);
-            const middle = syntaxQuasis[index + 1] ?? "";
-            const rawSuffix = quasis[index + 2] ?? "";
-            const binary = BINARY_HELPERS.get(middle.trim().toUpperCase());
-            if (
-              binary !== undefined &&
-              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-              (binary.rightBoundary === "pattern"
-                ? hasPatternRightBoundary(rawSuffix)
-                : hasPredicateRightBoundary(rawSuffix)) &&
-              binaryLeftMatches(binary.left, left) &&
-              binaryRightMatches(binary.right, right.type)
-            ) {
-              reportLegacy(node, leftNode, binary.helper);
-            }
-            const membership = /^\s+(NOT\s+)?IN\s*\(\s*$/i.exec(middle);
-            if (
-              membership !== null &&
-              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-              membershipRightBoundary(rawSuffix) &&
-              isDrizzleColumnType(checker, left.type, left.location) &&
-              hasParameterListOrigin(rightNode)
-            ) {
-              reportLegacy(
-                node,
-                leftNode,
-                membership[1] === undefined ? "inArray" : "notInArray",
-              );
-            }
-          }
-
-          for (let index = 0; index < expressions.length - 2; index += 1) {
-            const leftNode = expressions[index];
-            const minimumNode = expressions[index + 1];
-            const maximumNode = expressions[index + 2];
-            if (
-              leftNode === undefined ||
-              minimumNode === undefined ||
-              maximumNode === undefined
-            ) {
-              continue;
-            }
-            const range = rangeMatch(
-              syntaxQuasis[index + 1] ?? "",
-              quasis[index + 2] ?? "",
-            );
-            if (
-              range !== undefined &&
-              hasPredicateLeftBoundary(syntaxQuasis[index] ?? "") &&
-              hasPredicateRightBoundary(quasis[index + 3] ?? "") &&
-              isDrizzleWrapperType(checker, expressionType(leftNode).type)
-            ) {
-              reportLegacy(node, leftNode, range.helper);
-            }
-          }
-
-          for (let index = 0; index < expressions.length; index += 1) {
-            const expressionNode = expressions[index];
-            if (expressionNode === undefined) {
-              continue;
-            }
-            const expression = expressionType(expressionNode);
-            const prefix = syntaxQuasis[index] ?? "";
-            const suffix = syntaxQuasis[index + 1] ?? "";
-            const rawSuffix = quasis[index + 1] ?? "";
-
-            const unary = unaryPredicateMatch(prefix);
-            if (
-              unary !== undefined &&
-              hasPredicateLeftBoundary(prefix.slice(0, unary.start)) &&
-              hasPredicateRightBoundary(rawSuffix) &&
-              isDrizzleWrapperType(checker, expression.type)
-            ) {
-              reportLegacy(node, expressionNode, unary.helper);
-            }
-
-            const nullMatch = nullPredicateMatch(suffix);
-            if (
-              nullMatch !== undefined &&
-              hasPredicateLeftBoundary(prefix) &&
-              hasPredicateRightBoundary(rawSuffix.slice(nullMatch.length)) &&
-              isDrizzleWrapperType(checker, expression.type)
-            ) {
-              reportLegacy(node, expressionNode, nullMatch.helper);
-            }
-
-            const order = orderingMatch(suffix);
-            if (
-              order !== undefined &&
-              hasOrderingLeftBoundary(prefix) &&
-              isDrizzleWrapperType(checker, expression.type)
-            ) {
-              reportLegacy(node, expressionNode, order.helper);
-            }
-
-            const aggregate = aggregateMatch(prefix);
-            const aggregateSuffix = aggregateRemainder(
-              syntaxQuasis
-                .slice(index + 1)
-                .join(SQL_TEMPLATE_EXPRESSION_BOUNDARY),
-            );
-            if (
-              aggregate === undefined ||
-              aggregateSuffix === undefined ||
-              (index > 0 && prefix.slice(0, aggregate.start).trim() === "") ||
-              hasAggregateWindowSuffix(aggregateSuffix, 0) ||
-              !isDrizzleWrapperType(checker, expression.type)
-            ) {
-              continue;
-            }
-            const isWholeAggregate =
-              expressions.length === 1 &&
-              prefix.slice(0, aggregate.start).trim() === "" &&
-              aggregateSuffix.trim() === "";
-            if (!isWholeAggregate) {
-              reportLegacy(node, expressionNode, aggregate.helper);
-            } else if (
-              hasDirectMapWith(node) ||
-              ((aggregate.helper === "max" || aggregate.helper === "min") &&
-                isDrizzleColumnType(
-                  checker,
-                  expression.type,
-                  expression.location,
-                ))
-            ) {
-              reportLegacy(node, node, aggregate.helper);
-            }
-          }
-
-          const boolean = booleanHelper(syntaxQuasis);
-          if (boolean === undefined) {
-            return;
-          }
-          if (
-            !expressions.every((expressionNode) => {
-              return isDrizzleWrapperType(
-                checker,
-                expressionType(expressionNode).type,
-              );
-            })
-          ) {
-            return;
-          }
-          const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-          if (isOptionalDrizzleContext(checker.getContextualType(tsNode))) {
-            reportLegacy(node, node, boolean);
-          }
+          reportAnalysis(node, "predicate");
         });
       },
       "Program:exit"(): void {
         for (const inspect of structuralCallInspections) {
-          inspect();
-        }
-        for (const inspect of legacyTemplateInspections) {
           inspect();
         }
       },

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -145,10 +145,80 @@ export const preferDrizzleApis = createRule({
       isSafeSqlTerminalUse,
     );
     const sqlCapabilityChecks: SqlCapabilityChecks = {
+      acceptsOptionalSql,
       hasDirectResultMapping: hasDirectMapWith,
       hasParameterListOrigin,
       isInlineParameterList: isInlineParameterListSqlJoin,
     };
+
+    function acceptsOptionalSql(node: TSESTree.Expression): boolean {
+      if (isRelationalWhereCallbackResult(node)) {
+        return true;
+      }
+      const parent = node.parent;
+      if (
+        parent.type === AST_NODE_TYPES.TemplateLiteral &&
+        parent.expressions.includes(node) &&
+        parent.parent.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        parent.parent.quasi === parent
+      ) {
+        return isDrizzleSqlTag(checker, services, parent.parent.tag);
+      }
+      if (
+        parent.type !== AST_NODE_TYPES.CallExpression ||
+        !parent.arguments.includes(node)
+      ) {
+        return false;
+      }
+      if (
+        isNamedDrizzleCall(parent, "and") ||
+        isNamedDrizzleCall(parent, "or")
+      ) {
+        return true;
+      }
+      const predicateIndex = predicateArgumentIndex(parent);
+      const method =
+        parent.callee.type === AST_NODE_TYPES.MemberExpression
+          ? memberName(parent.callee)
+          : undefined;
+      return (
+        method !== undefined &&
+        predicateIndex !== undefined &&
+        parent.arguments[predicateIndex] === node &&
+        isDrizzleMethodCall(parent, method)
+      );
+    }
+
+    function isRelationalWhereCallbackResult(
+      node: TSESTree.Expression,
+    ): boolean {
+      const parent = node.parent;
+      const callback =
+        (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          parent.type === AST_NODE_TYPES.FunctionExpression) &&
+        parent.body === node
+          ? parent
+          : parent.type === AST_NODE_TYPES.ReturnStatement &&
+              parent.argument === node &&
+              parent.parent.type === AST_NODE_TYPES.BlockStatement &&
+              parent.parent.body.length === 1 &&
+              (parent.parent.parent.type ===
+                AST_NODE_TYPES.ArrowFunctionExpression ||
+                parent.parent.parent.type ===
+                  AST_NODE_TYPES.FunctionExpression) &&
+              parent.parent.parent.body === parent.parent
+            ? parent.parent.parent
+            : undefined;
+      if (callback === undefined) {
+        return false;
+      }
+      const property = callback.parent;
+      return (
+        property.type === AST_NODE_TYPES.Property &&
+        property.value === callback &&
+        staticPropertyName(property) === "where"
+      );
+    }
 
     function isExecuteRawRowsCallee(node: TSESTree.Expression): boolean {
       return executeRawRowsMatcher(node);

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -50,12 +50,16 @@ export type SqlAnalysisFinding =
     };
 
 export interface SqlCapabilityChecks {
+  acceptsOptionalSql(node: TSESTree.Expression): boolean;
   hasDirectResultMapping(node: TSESTree.Expression): boolean;
   hasParameterListOrigin(node: TSESTree.Expression): boolean;
   isInlineParameterList(node: TSESTree.Expression): boolean;
 }
 
 const NO_CAPABILITY_CHECKS: SqlCapabilityChecks = {
+  acceptsOptionalSql(): boolean {
+    return false;
+  },
   hasDirectResultMapping(): boolean {
     return false;
   },
@@ -248,6 +252,7 @@ interface ExpressionClassification {
 }
 
 interface ClassificationContext {
+  readonly allowsOptionalSql: boolean;
   readonly capabilities: SqlCapabilityChecks;
   readonly checker: TypeChecker;
   readonly ownsResultMapping: boolean;
@@ -1139,8 +1144,8 @@ function operandNode(
 function nestedClassificationContext(
   context: ClassificationContext,
 ): ClassificationContext {
-  return context.ownsResultMapping
-    ? { ...context, ownsResultMapping: false }
+  return context.ownsResultMapping || !context.allowsOptionalSql
+    ? { ...context, allowsOptionalSql: true, ownsResultMapping: false }
     : context;
 }
 
@@ -1273,25 +1278,30 @@ function classifyExpression(
       return classifyExistence(expression.items[0], "notExists", context);
     }
     const helper = expression.operator;
-    for (const item of expression.items) {
-      const child = classifyExpression(
-        item,
-        nestedClassificationContext(context),
-      );
-      const reportNode = firstClassificationNode(child);
-      if (reportNode !== undefined) {
-        return {
-          anchor: reportNode,
-          findings: [
-            classifiedFinding(helper, reportNode, expression.sourceChunks),
-          ],
-          isWholeReplacement: true,
-        };
+    const children = expression.items.map((item) => {
+      return classifyExpression(item, nestedClassificationContext(context));
+    });
+    if ((helper !== "and" && helper !== "or") || context.allowsOptionalSql) {
+      for (const child of children) {
+        const reportNode = firstClassificationNode(child);
+        if (reportNode !== undefined) {
+          return {
+            anchor: reportNode,
+            findings: [
+              classifiedFinding(helper, reportNode, expression.sourceChunks),
+            ],
+            isWholeReplacement: true,
+          };
+        }
       }
     }
     return {
-      anchor: undefined,
-      findings: [],
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
       isWholeReplacement: false,
     };
   }
@@ -2161,11 +2171,11 @@ function classifyOrdering(
   ordering: StructuralOrdering,
   context: ClassificationContext,
 ): ExpressionClassification {
-  const node =
-    ordering.direction === undefined
-      ? undefined
-      : operandNode(ordering.expression, "wrapper", context);
-  if (node === undefined || ordering.direction === undefined) {
+  if (ordering.direction === undefined) {
+    return classifyExpression(ordering.expression, context);
+  }
+  const node = operandNode(ordering.expression, "wrapper", context);
+  if (node === undefined) {
     return classifyExpression(
       ordering.expression,
       nestedClassificationContext(context),
@@ -2235,6 +2245,7 @@ function replacementBoundaryForFinding(
       continue;
     }
     const classificationContext: ClassificationContext = {
+      allowsOptionalSql: true,
       capabilities,
       checker,
       ownsResultMapping: false,
@@ -2324,6 +2335,10 @@ function analyzeParsed(
   const ownsResultMapping =
     context === "selection" && structuralExpressions.length === 1;
   const classificationContext: ClassificationContext = {
+    allowsOptionalSql:
+      context === "statement" ||
+      context === "relation" ||
+      capabilities.acceptsOptionalSql(node),
     capabilities,
     checker,
     ownsResultMapping,

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -182,10 +182,13 @@ type StructuralExpression = (
       readonly argument: StructuralExpression | undefined;
       readonly filter: StructuralExpression | undefined;
       readonly helper: AggregateHelper | undefined;
+      readonly hasInternalOrdering: boolean;
       readonly isDistinct: boolean;
       readonly isStar: boolean;
+      readonly isVariadic: boolean;
       readonly isWindowed: boolean;
       readonly kind: "aggregate";
+      readonly orderings: readonly StructuralOrdering[];
     }
   | {
       readonly escape: StructuralExpression | undefined;
@@ -955,6 +958,11 @@ function structuralExpression(
         ? args.length === 0
         : !isStar && args.length === 1;
     if (helper !== undefined && validArity) {
+      const orderings = Array.isArray(call.agg_order)
+        ? call.agg_order.flatMap((item) => {
+            return structuralOrdering(item, markers, sourceRanges);
+          })
+        : [];
       const argument =
         args[0] === undefined
           ? undefined
@@ -967,13 +975,22 @@ function structuralExpression(
         argument,
         filter,
         helper,
+        hasInternalOrdering: orderings.length > 0,
         isDistinct: call.agg_distinct === true,
         isStar,
+        isVariadic: call.func_variadic === true,
         isWindowed: call.over !== undefined,
         kind: "aggregate",
+        orderings,
         sourceChunks: mergeSourceChunks(
           ownSourceChunks(value, sourceRanges),
-          [argument, filter].filter((item): item is StructuralExpression => {
+          [
+            argument,
+            filter,
+            ...orderings.map((ordering) => {
+              return ordering.expression;
+            }),
+          ].filter((item): item is StructuralExpression => {
             return item !== undefined;
           }),
         ),
@@ -1471,11 +1488,16 @@ function classifyExpression(
       expression.filter === undefined
         ? undefined
         : classifyExpression(expression.filter, childContext);
-    const children = [argumentClassification, filterClassification].filter(
-      (item): item is ExpressionClassification => {
-        return item !== undefined;
-      },
-    );
+    const orderingClassifications = expression.orderings.map((ordering) => {
+      return classifyOrdering(ordering, childContext);
+    });
+    const children = [
+      argumentClassification,
+      filterClassification,
+      ...orderingClassifications,
+    ].filter((item): item is ExpressionClassification => {
+      return item !== undefined;
+    });
     const argumentNode =
       expression.argument === undefined
         ? undefined
@@ -1495,6 +1517,8 @@ function classifyExpression(
     if (
       helper !== undefined &&
       validArgument &&
+      !expression.hasInternalOrdering &&
+      !expression.isVariadic &&
       !expression.isWindowed &&
       mappingAllowed
     ) {
@@ -1794,6 +1818,52 @@ function selectedExpressions(statement: unknown): readonly unknown[] {
   });
 }
 
+function contextOwnsWholeExpression(
+  context: "ordering" | "predicate" | "selection",
+  statement: unknown,
+): boolean {
+  const select = selectStatement(statement);
+  if (
+    select === undefined ||
+    select.limitOption !== "LIMIT_OPTION_DEFAULT" ||
+    select.op !== "SETOP_NONE" ||
+    !Array.isArray(select.targetList) ||
+    select.targetList.length !== 1
+  ) {
+    return false;
+  }
+  if (context === "selection") {
+    const target = recordProperty(select.targetList[0], "ResTarget");
+    return (
+      Object.keys(select).every((key) => {
+        return ["limitOption", "op", "targetList"].includes(key);
+      }) &&
+      target?.val !== undefined &&
+      Object.keys(target).every((key) => {
+        return ["location", "val"].includes(key);
+      })
+    );
+  }
+  if (!isSelectOneTarget(select.targetList[0])) {
+    return false;
+  }
+  if (context === "predicate") {
+    return (
+      select.whereClause !== undefined &&
+      Object.keys(select).every((key) => {
+        return ["limitOption", "op", "targetList", "whereClause"].includes(key);
+      })
+    );
+  }
+  return (
+    Array.isArray(select.sortClause) &&
+    select.sortClause.length === 1 &&
+    Object.keys(select).every((key) => {
+      return ["limitOption", "op", "sortClause", "targetList"].includes(key);
+    })
+  );
+}
+
 function orderingExpressions(
   statement: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
@@ -1932,6 +2002,24 @@ function sameStructuralExpressions(
   );
 }
 
+function sameStructuralOrderings(
+  left: readonly StructuralOrdering[],
+  right: readonly StructuralOrdering[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        item.direction === other.direction &&
+        item.hasExplicitNullOrdering === other.hasExplicitNullOrdering &&
+        sameStructuralExpression(item.expression, other.expression)
+      );
+    })
+  );
+}
+
 function sameStructuralExpression(
   left: StructuralExpression,
   right: StructuralExpression,
@@ -1997,11 +2085,14 @@ function sameStructuralExpression(
   if (left.kind === "aggregate" && right.kind === "aggregate") {
     return (
       left.helper === right.helper &&
+      left.hasInternalOrdering === right.hasInternalOrdering &&
       left.isDistinct === right.isDistinct &&
       left.isStar === right.isStar &&
+      left.isVariadic === right.isVariadic &&
       left.isWindowed === right.isWindowed &&
       sameOptionalExpression(left.argument, right.argument) &&
-      sameOptionalExpression(left.filter, right.filter)
+      sameOptionalExpression(left.filter, right.filter) &&
+      sameStructuralOrderings(left.orderings, right.orderings)
     );
   }
   if (left.kind === "existence" && right.kind === "existence") {
@@ -2151,6 +2242,9 @@ function exactExpressionBoundary(
     if (parsed === null) {
       continue;
     }
+    if (!contextOwnsWholeExpression("selection", parsed.statement)) {
+      continue;
+    }
     const selected = selectedExpressions(parsed.statement);
     if (selected.length !== 1 || selected[0] === undefined) {
       continue;
@@ -2242,6 +2336,11 @@ function replacementBoundaryForFinding(
       services,
     );
     if (parsed === null) {
+      continue;
+    }
+    if (
+      !contextOwnsWholeExpression(finding.isolationContext, parsed.statement)
+    ) {
       continue;
     }
     const classificationContext: ClassificationContext = {
@@ -2359,6 +2458,10 @@ function analyzeParsed(
   const rootFinding = rootClassification?.findings[0];
   const canReplaceRoot =
     hasLocalExpansion &&
+    (context === "ordering" ||
+      context === "predicate" ||
+      context === "selection") &&
+    contextOwnsWholeExpression(context, parsed.statement) &&
     rootClassification?.isWholeReplacement === true &&
     rootClassification.findings.length === 1 &&
     rootFinding !== undefined &&
@@ -2445,6 +2548,7 @@ function analyzeParsed(
     isSimpleSelect: false,
     isTruePredicate:
       context === "predicate" &&
+      contextOwnsWholeExpression(context, parsed.statement) &&
       predicateExpression(parsed.statement) !== undefined &&
       isTrueConstant(predicateExpression(parsed.statement)),
   };

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -5,10 +5,13 @@ import {
   type ParserServicesWithTypeInformation,
   type TSESTree,
 } from "@typescript-eslint/utils";
-import { type TypeChecker } from "typescript";
+import { TypeFlags, type Type, type TypeChecker } from "typescript";
 
 import {
   isDrizzleColumnType,
+  isDrizzleArrayOperandType,
+  isDrizzlePatternOperandType,
+  isDrizzleSelectType,
   isDrizzleTableType,
   isDrizzleWrapperType,
 } from "../drizzle.ts";
@@ -19,12 +22,26 @@ import {
   type SqlSourceVariant,
 } from "./sql-source.ts";
 
-type SqlAnalysisContext = "predicate" | "statement";
+export type SqlAnalysisContext =
+  | "ordering"
+  | "predicate"
+  | "relation"
+  | "selection"
+  | "statement";
 
 export type SqlAnalysisFinding =
   | {
-      readonly helper: "and" | "eq" | "gt" | "gte" | "lt" | "lte" | "ne" | "or";
+      readonly helper: SqlHelper;
       readonly kind: "helper";
+      readonly node: TSESTree.Node;
+    }
+  | {
+      readonly helper: "exists" | "notExists";
+      readonly kind: "existence-predicate";
+      readonly node: TSESTree.Node;
+    }
+  | {
+      readonly kind: "empty-fragment";
       readonly node: TSESTree.Node;
     }
   | {
@@ -32,17 +49,85 @@ export type SqlAnalysisFinding =
       readonly node: TSESTree.Expression;
     };
 
+export interface SqlCapabilityChecks {
+  hasDirectResultMapping(node: TSESTree.Expression): boolean;
+  hasParameterListOrigin(node: TSESTree.Expression): boolean;
+  isInlineParameterList(node: TSESTree.Expression): boolean;
+}
+
+const NO_CAPABILITY_CHECKS: SqlCapabilityChecks = {
+  hasDirectResultMapping(): boolean {
+    return false;
+  },
+  hasParameterListOrigin(): boolean {
+    return false;
+  },
+  isInlineParameterList(): boolean {
+    return false;
+  },
+};
+
 export interface SqlAnalysis {
   readonly expandedTemplates: ReadonlySet<TSESTree.TaggedTemplateExpression>;
+  readonly findingSignatures: readonly SqlFindingSignature[];
   readonly findings: readonly SqlAnalysisFinding[];
   readonly hasWholeReplacementBoundary: boolean;
   readonly isSimpleSelect: boolean;
   readonly isTruePredicate: boolean;
 }
 
+interface SqlFindingSignature {
+  readonly boundaryIsRoot: boolean;
+  readonly boundaryType: TSESTree.Node["type"];
+  readonly helper: SqlHelper | undefined;
+  readonly isPartial: boolean;
+  readonly kind: SqlAnalysisFinding["kind"];
+  readonly ownsResultMapping: boolean;
+}
+
+type SqlHelper =
+  | "and"
+  | "arrayContained"
+  | "arrayContains"
+  | "arrayOverlaps"
+  | "asc"
+  | "avg"
+  | "avgDistinct"
+  | "between"
+  | "count"
+  | "countDistinct"
+  | "desc"
+  | "eq"
+  | "exists"
+  | "gt"
+  | "gte"
+  | "ilike"
+  | "inArray"
+  | "isNotNull"
+  | "isNull"
+  | "like"
+  | "lt"
+  | "lte"
+  | "max"
+  | "min"
+  | "ne"
+  | "not"
+  | "notBetween"
+  | "notExists"
+  | "notIlike"
+  | "notInArray"
+  | "notLike"
+  | "or"
+  | "sum"
+  | "sumDistinct";
+
 interface SqlMarker {
   readonly chunk: SqlSourceChunk;
+  readonly isArrayOperand: boolean;
   readonly isColumn: boolean;
+  readonly isPatternOperand: boolean;
+  readonly isSelect: boolean;
+  readonly isStringOrWrapper: boolean;
   readonly isTable: boolean;
   readonly isWrapper: boolean;
   readonly node: TSESTree.Expression;
@@ -52,6 +137,11 @@ interface ParsedSql {
   readonly markers: ReadonlyMap<string, SqlMarker>;
   readonly sourceRanges: readonly SqlSourceRange[];
   readonly statement: unknown;
+}
+
+interface RenderedSql {
+  readonly source: string;
+  readonly sourceRanges: readonly SqlSourceRange[];
 }
 
 interface SqlSourceRange {
@@ -64,6 +154,7 @@ type StructuralExpression = (
   | {
       readonly children: readonly StructuralExpression[];
       readonly kind: "opaque";
+      readonly nodeKey: string;
     }
   | {
       readonly kind: "constant";
@@ -81,16 +172,72 @@ type StructuralExpression = (
   | {
       readonly items: readonly StructuralExpression[];
       readonly kind: "boolean";
-      readonly operator: "and" | "or";
+      readonly operator: "and" | "not" | "or";
+    }
+  | {
+      readonly argument: StructuralExpression | undefined;
+      readonly filter: StructuralExpression | undefined;
+      readonly helper: AggregateHelper | undefined;
+      readonly isDistinct: boolean;
+      readonly isStar: boolean;
+      readonly isWindowed: boolean;
+      readonly kind: "aggregate";
+    }
+  | {
+      readonly escape: StructuralExpression | undefined;
+      readonly helper: PatternHelper;
+      readonly kind: "pattern";
+      readonly left: StructuralExpression;
+      readonly right: StructuralExpression;
+    }
+  | {
+      readonly helper: ArrayHelper;
+      readonly kind: "array";
+      readonly left: StructuralExpression;
+      readonly right: StructuralExpression;
+    }
+  | {
+      readonly helper: "inArray" | "notInArray";
+      readonly kind: "membership";
+      readonly left: StructuralExpression;
+      readonly values: readonly StructuralExpression[];
+    }
+  | {
+      readonly helper: "between" | "notBetween";
+      readonly kind: "range";
+      readonly left: StructuralExpression;
+      readonly maximum: StructuralExpression;
+      readonly minimum: StructuralExpression;
+    }
+  | {
+      readonly helper: "isNotNull" | "isNull";
+      readonly kind: "null";
+      readonly operand: StructuralExpression;
+    }
+  | {
+      readonly children: readonly StructuralExpression[];
+      readonly isHandBuiltSelect: boolean;
+      readonly kind: "existence";
+      readonly selectMarker: SqlMarker | undefined;
+      readonly subselect: unknown;
     }
 ) & {
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 };
 
+interface StructuralOrdering {
+  readonly direction: "asc" | "desc" | undefined;
+  readonly expression: StructuralExpression;
+  readonly hasExplicitNullOrdering: boolean;
+  readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
+}
+
 type ClassifiedHelperFinding = Extract<
   SqlAnalysisFinding,
-  { readonly kind: "helper" }
+  { readonly kind: "existence-predicate" | "helper" }
 > & {
+  readonly isolationContext: "ordering" | "predicate" | "selection";
+  readonly isPartial: boolean;
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 };
 
@@ -98,6 +245,15 @@ interface ExpressionClassification {
   readonly anchor: TSESTree.Node | undefined;
   readonly findings: readonly ClassifiedHelperFinding[];
   readonly isWholeReplacement: boolean;
+}
+
+interface ClassificationContext {
+  readonly capabilities: SqlCapabilityChecks;
+  readonly checker: TypeChecker;
+  readonly ownsResultMapping: boolean;
+  readonly root: TSESTree.Expression;
+  readonly services: ParserServicesWithTypeInformation;
+  readonly variant: SqlSourceVariant;
 }
 
 interface RelationMatch {
@@ -121,6 +277,33 @@ const COMPARISON_HELPERS = new Map<
   [">=", "gte"],
   ["<", "lt"],
   ["<=", "lte"],
+]);
+
+type AggregateHelper =
+  | "avg"
+  | "avgDistinct"
+  | "count"
+  | "countDistinct"
+  | "max"
+  | "min"
+  | "sum"
+  | "sumDistinct";
+
+type ArrayHelper = "arrayContained" | "arrayContains" | "arrayOverlaps";
+
+type PatternHelper = "ilike" | "like" | "notIlike" | "notLike";
+
+const ARRAY_HELPERS = new Map<string, ArrayHelper>([
+  ["@>", "arrayContains"],
+  ["<@", "arrayContained"],
+  ["&&", "arrayOverlaps"],
+]);
+
+const PATTERN_HELPERS = new Map<string, PatternHelper>([
+  ["~~", "like"],
+  ["!~~", "notLike"],
+  ["~~*", "ilike"],
+  ["!~~*", "notIlike"],
 ]);
 
 const EXPRESSION_NODE_KEYS = new Set([
@@ -172,6 +355,45 @@ function markerIsColumn(
   return isDrizzleColumnType(checker, type, tsNode);
 }
 
+function markerIsArrayOperand(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isDrizzleArrayOperandType(
+    checker,
+    checker.getTypeAtLocation(tsNode),
+    tsNode,
+  );
+}
+
+function markerIsPatternOperand(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isDrizzlePatternOperandType(
+    checker,
+    checker.getTypeAtLocation(tsNode),
+    tsNode,
+  );
+}
+
+function markerIsSelect(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isDrizzleSelectType(
+    checker,
+    checker.getTypeAtLocation(tsNode),
+    tsNode,
+  );
+}
+
 function markerIsTable(
   node: TSESTree.Expression,
   checker: TypeChecker,
@@ -180,6 +402,36 @@ function markerIsTable(
   const tsNode = services.esTreeNodeToTSNodeMap.get(node);
   const type = checker.getTypeAtLocation(tsNode);
   return isDrizzleTableType(checker, type, tsNode);
+}
+
+function isStringOrDrizzleWrapper(type: Type, checker: TypeChecker): boolean {
+  if (type.isUnion()) {
+    return type.types.every((member) => {
+      return isStringOrDrizzleWrapper(member, checker);
+    });
+  }
+  if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
+    return false;
+  }
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return (
+      constraint !== undefined && isStringOrDrizzleWrapper(constraint, checker)
+    );
+  }
+  return (
+    (type.flags & TypeFlags.StringLike) !== 0 ||
+    isDrizzleWrapperType(checker, type)
+  );
+}
+
+function markerIsStringOrWrapper(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isStringOrDrizzleWrapper(checker.getTypeAtLocation(tsNode), checker);
 }
 
 function markerIsWrapper(
@@ -218,37 +470,73 @@ function parseSqlVariant(
   });
   const prefix = markerPrefix(literals);
   const markers = new Map<string, SqlMarker>();
-  const sourceRanges: SqlSourceRange[] = [];
-  const contextPrefix = context === "statement" ? "" : "SELECT 1 WHERE ";
-  let source = contextPrefix;
-  // libpg_query locations are UTF-8 byte offsets, not JavaScript string
-  // indexes.
-  let sourceByteLength = trackSourceRanges
-    ? Buffer.byteLength(contextPrefix)
-    : 0;
+  const markerNames: string[] = [];
+  const selectCandidateNames = new Set<string>();
+  const contextPrefix =
+    context === "statement"
+      ? ""
+      : context === "predicate"
+        ? "SELECT 1 WHERE "
+        : context === "selection"
+          ? "SELECT "
+          : context === "ordering"
+            ? "SELECT 1 ORDER BY "
+            : "SELECT 1 FROM ";
   let markerIndex = 0;
+  let precedingLiteral = "";
   for (const chunk of variant.chunks) {
-    const start = sourceByteLength;
     if (chunk.kind === "literal") {
-      source += chunk.text;
-      if (trackSourceRanges) {
-        sourceByteLength += Buffer.byteLength(chunk.text);
-        sourceRanges.push({ chunk, end: sourceByteLength, start });
-      }
+      precedingLiteral += chunk.text;
       continue;
     }
     const expression = chunk.expression;
     const name = `${prefix}${markerIndex}`;
-    const markerSource = `"${name}"`;
     markerIndex += 1;
+    markerNames.push(name);
+    if (/\bEXISTS\b/i.test(precedingLiteral)) {
+      selectCandidateNames.add(name);
+    }
+    precedingLiteral = "";
+    let cachedArrayOperand: boolean | undefined;
     let cachedColumn: boolean | undefined;
+    let cachedPatternOperand: boolean | undefined;
+    let cachedSelect: boolean | undefined;
+    let cachedStringOrWrapper: boolean | undefined;
     let cachedTable: boolean | undefined;
     let cachedWrapper: boolean | undefined;
     const marker: SqlMarker = {
       chunk,
+      get isArrayOperand(): boolean {
+        cachedArrayOperand ??= markerIsArrayOperand(
+          expression,
+          checker,
+          services,
+        );
+        return cachedArrayOperand;
+      },
       get isColumn(): boolean {
         cachedColumn ??= markerIsColumn(expression, checker, services);
         return cachedColumn;
+      },
+      get isPatternOperand(): boolean {
+        cachedPatternOperand ??= markerIsPatternOperand(
+          expression,
+          checker,
+          services,
+        );
+        return cachedPatternOperand;
+      },
+      get isSelect(): boolean {
+        cachedSelect ??= markerIsSelect(expression, checker, services);
+        return cachedSelect;
+      },
+      get isStringOrWrapper(): boolean {
+        cachedStringOrWrapper ??= markerIsStringOrWrapper(
+          expression,
+          checker,
+          services,
+        );
+        return cachedStringOrWrapper;
       },
       get isTable(): boolean {
         cachedTable ??= markerIsTable(expression, checker, services);
@@ -261,19 +549,58 @@ function parseSqlVariant(
       node: expression,
     };
     markers.set(name, marker);
-    source += markerSource;
-    if (trackSourceRanges) {
-      sourceByteLength += Buffer.byteLength(markerSource);
-      sourceRanges.push({ chunk, end: sourceByteLength, start });
-    }
   }
 
-  const parseResult = parsePostgres(source);
+  function render(useSelectMarkers: boolean): RenderedSql {
+    const sourceRanges: SqlSourceRange[] = [];
+    let source = contextPrefix;
+    // libpg_query locations are UTF-8 byte offsets, not JavaScript string
+    // indexes.
+    let sourceByteLength = trackSourceRanges
+      ? Buffer.byteLength(contextPrefix)
+      : 0;
+    let expressionIndex = 0;
+    for (const chunk of variant.chunks) {
+      const start = sourceByteLength;
+      let chunkSource: string;
+      if (chunk.kind === "literal") {
+        chunkSource = chunk.text;
+      } else {
+        const name = markerNames[expressionIndex];
+        expressionIndex += 1;
+        if (name === undefined) {
+          return { source: "", sourceRanges: [] };
+        }
+        const markerIdentifier = `"${name}"`;
+        chunkSource =
+          useSelectMarkers &&
+          selectCandidateNames.has(name) &&
+          markers.get(name)?.isSelect === true
+            ? `(SELECT ${markerIdentifier})`
+            : markerIdentifier;
+      }
+      source += chunkSource;
+      if (trackSourceRanges) {
+        sourceByteLength += Buffer.byteLength(chunkSource);
+        sourceRanges.push({ chunk, end: sourceByteLength, start });
+      }
+    }
+    return { source, sourceRanges };
+  }
+
+  let rendered = render(false);
+  let parseResult = parsePostgres(rendered.source);
+  if (parseResult === null && selectCandidateNames.size > 0) {
+    rendered = render(true);
+    parseResult = parsePostgres(rendered.source);
+  }
   if (parseResult === null || parseResult.statements.length !== 1) {
     return null;
   }
   const statement = parseResult.statements[0];
-  return statement === undefined ? null : { markers, sourceRanges, statement };
+  return statement === undefined
+    ? null
+    : { markers, sourceRanges: rendered.sourceRanges, statement };
 }
 
 function stringNodeValue(value: unknown): string | undefined {
@@ -394,6 +721,63 @@ function collectStructuralExpressions(
   return expressions;
 }
 
+function listItems(value: unknown): readonly unknown[] | undefined {
+  const list = recordProperty(value, "List");
+  return Array.isArray(list?.items) ? list.items : undefined;
+}
+
+function functionName(value: unknown): readonly string[] | undefined {
+  const call = recordProperty(value, "FuncCall");
+  if (!Array.isArray(call?.funcname)) {
+    return undefined;
+  }
+  const names = call.funcname.map(stringNodeValue);
+  return names.every((name): name is string => {
+    return name !== undefined;
+  })
+    ? names
+    : undefined;
+}
+
+function aggregateHelper(
+  call: Record<string, unknown>,
+): AggregateHelper | undefined {
+  const names = functionName({ FuncCall: call });
+  if (names?.length !== 1) {
+    return undefined;
+  }
+  const name = names[0]?.toLowerCase();
+  const isDistinct = call.agg_distinct === true;
+  if (name === "count") {
+    return isDistinct ? "countDistinct" : "count";
+  }
+  if (name === "avg") {
+    return isDistinct ? "avgDistinct" : "avg";
+  }
+  if (name === "sum") {
+    return isDistinct ? "sumDistinct" : "sum";
+  }
+  if (!isDistinct && (name === "max" || name === "min")) {
+    return name;
+  }
+  return undefined;
+}
+
+function opaqueNodeKey(value: unknown): string {
+  if (!isRecord(value)) {
+    return "unknown";
+  }
+  const key = Object.keys(value)[0] ?? "unknown";
+  const names = functionName(value);
+  return names === undefined
+    ? key
+    : `${key}:${names
+        .map((name) => {
+          return name.toLowerCase();
+        })
+        .join(".")}`;
+}
+
 function structuralExpression(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
@@ -417,30 +801,125 @@ function structuralExpression(
   const binary = recordProperty(value, "A_Expr");
   const binaryOperator = operatorName(binary?.name);
   if (
-    binary?.kind === "AEXPR_OP" &&
+    binary !== undefined &&
     binaryOperator !== undefined &&
     binary.lexpr !== undefined &&
     binary.rexpr !== undefined
   ) {
     const left = structuralExpression(binary.lexpr, markers, sourceRanges);
     const right = structuralExpression(binary.rexpr, markers, sourceRanges);
-    return {
-      kind: "comparison",
-      left,
-      operator: binaryOperator,
-      right,
-      sourceChunks: mergeSourceChunks(ownSourceChunks(value, sourceRanges), [
+    const own = ownSourceChunks(value, sourceRanges);
+    if (binary.kind === "AEXPR_LIKE" || binary.kind === "AEXPR_ILIKE") {
+      const helper = PATTERN_HELPERS.get(binaryOperator);
+      if (helper !== undefined) {
+        const rightCall = recordProperty(binary.rexpr, "FuncCall");
+        const rightNames = functionName(binary.rexpr);
+        const rightArguments = Array.isArray(rightCall?.args)
+          ? rightCall.args
+          : undefined;
+        const hasEscape =
+          rightNames?.length === 2 &&
+          rightNames[0] === "pg_catalog" &&
+          rightNames[1] === "like_escape" &&
+          rightArguments?.length === 2;
+        const pattern = hasEscape
+          ? structuralExpression(rightArguments?.[0], markers, sourceRanges)
+          : right;
+        const escape = hasEscape
+          ? structuralExpression(rightArguments?.[1], markers, sourceRanges)
+          : undefined;
+        return {
+          escape,
+          helper,
+          kind: "pattern",
+          left,
+          right: pattern,
+          sourceChunks: mergeSourceChunks(
+            own,
+            escape === undefined ? [left, pattern] : [left, pattern, escape],
+          ),
+        };
+      }
+    }
+    if (binary.kind === "AEXPR_OP") {
+      const arrayHelper = ARRAY_HELPERS.get(binaryOperator);
+      if (arrayHelper !== undefined) {
+        return {
+          helper: arrayHelper,
+          kind: "array",
+          left,
+          right,
+          sourceChunks: mergeSourceChunks(own, [left, right]),
+        };
+      }
+      return {
+        kind: "comparison",
         left,
+        operator: binaryOperator,
         right,
+        sourceChunks: mergeSourceChunks(own, [left, right]),
+      };
+    }
+    const items = listItems(binary.rexpr);
+    if (
+      binary.kind === "AEXPR_IN" &&
+      items !== undefined &&
+      (binaryOperator === "=" || binaryOperator === "<>")
+    ) {
+      const values = items.map((item) => {
+        return structuralExpression(item, markers, sourceRanges);
+      });
+      return {
+        helper: binaryOperator === "=" ? "inArray" : "notInArray",
+        kind: "membership",
+        left,
+        sourceChunks: mergeSourceChunks(own, [left, ...values]),
+        values,
+      };
+    }
+    if (
+      (binary.kind === "AEXPR_BETWEEN" ||
+        binary.kind === "AEXPR_NOT_BETWEEN") &&
+      items?.length === 2
+    ) {
+      const minimum = structuralExpression(items[0], markers, sourceRanges);
+      const maximum = structuralExpression(items[1], markers, sourceRanges);
+      return {
+        helper: binary.kind === "AEXPR_BETWEEN" ? "between" : "notBetween",
+        kind: "range",
+        left,
+        maximum,
+        minimum,
+        sourceChunks: mergeSourceChunks(own, [left, minimum, maximum]),
+      };
+    }
+  }
+
+  const nullTest = recordProperty(value, "NullTest");
+  if (
+    nullTest?.arg !== undefined &&
+    (nullTest.nulltesttype === "IS_NULL" ||
+      nullTest.nulltesttype === "IS_NOT_NULL")
+  ) {
+    const operand = structuralExpression(nullTest.arg, markers, sourceRanges);
+    return {
+      helper: nullTest.nulltesttype === "IS_NULL" ? "isNull" : "isNotNull",
+      kind: "null",
+      operand,
+      sourceChunks: mergeSourceChunks(ownSourceChunks(value, sourceRanges), [
+        operand,
       ]),
     };
   }
 
   const boolean = recordProperty(value, "BoolExpr");
   if (
-    (boolean?.boolop === "AND_EXPR" || boolean?.boolop === "OR_EXPR") &&
+    (boolean?.boolop === "AND_EXPR" ||
+      boolean?.boolop === "NOT_EXPR" ||
+      boolean?.boolop === "OR_EXPR") &&
     Array.isArray(boolean.args) &&
-    boolean.args.length >= 2
+    ((boolean.boolop === "NOT_EXPR" && boolean.args.length === 1) ||
+      (boolean.boolop !== "NOT_EXPR" && boolean.args.length >= 2))
   ) {
     const items = boolean.args.map((item) => {
       return structuralExpression(item, markers, sourceRanges);
@@ -448,11 +927,75 @@ function structuralExpression(
     return {
       items,
       kind: "boolean",
-      operator: boolean.boolop === "AND_EXPR" ? "and" : "or",
+      operator:
+        boolean.boolop === "AND_EXPR"
+          ? "and"
+          : boolean.boolop === "OR_EXPR"
+            ? "or"
+            : "not",
       sourceChunks: mergeSourceChunks(
         ownSourceChunks(value, sourceRanges),
         items,
       ),
+    };
+  }
+
+  const call = recordProperty(value, "FuncCall");
+  if (call !== undefined) {
+    const helper = aggregateHelper(call);
+    const args = Array.isArray(call.args) ? call.args : [];
+    const isStar = call.agg_star === true;
+    const validArity =
+      helper === "count" && isStar
+        ? args.length === 0
+        : !isStar && args.length === 1;
+    if (helper !== undefined && validArity) {
+      const argument =
+        args[0] === undefined
+          ? undefined
+          : structuralExpression(args[0], markers, sourceRanges);
+      const filter =
+        call.agg_filter === undefined
+          ? undefined
+          : structuralExpression(call.agg_filter, markers, sourceRanges);
+      return {
+        argument,
+        filter,
+        helper,
+        isDistinct: call.agg_distinct === true,
+        isStar,
+        isWindowed: call.over !== undefined,
+        kind: "aggregate",
+        sourceChunks: mergeSourceChunks(
+          ownSourceChunks(value, sourceRanges),
+          [argument, filter].filter((item): item is StructuralExpression => {
+            return item !== undefined;
+          }),
+        ),
+      };
+    }
+  }
+
+  const sublink = recordProperty(value, "SubLink");
+  if (
+    sublink?.subLinkType === "EXISTS_SUBLINK" &&
+    sublink.subselect !== undefined
+  ) {
+    const children = collectStructuralExpressions(
+      sublink.subselect,
+      markers,
+      sourceRanges,
+    );
+    return {
+      children,
+      isHandBuiltSelect: isHandBuiltExistenceSelect(sublink.subselect, markers),
+      kind: "existence",
+      selectMarker: syntheticSelectMarker(sublink.subselect, markers),
+      sourceChunks: mergeSourceChunks(
+        ownSourceChunks(value, sourceRanges),
+        children,
+      ),
+      subselect: sublink.subselect,
     };
   }
 
@@ -461,6 +1004,7 @@ function structuralExpression(
   return {
     children,
     kind: "opaque",
+    nodeKey: opaqueNodeKey(value),
     sourceChunks: mergeSourceChunks(
       ownSourceChunks(value, sourceRanges),
       children,
@@ -477,7 +1021,9 @@ function deduplicateFindings<T extends SqlAnalysisFinding>(
     const key =
       finding.kind === "query-builder"
         ? finding.kind
-        : `${finding.kind}:${finding.helper}`;
+        : finding.kind === "empty-fragment"
+          ? finding.kind
+          : `${finding.kind}:${finding.helper}`;
     const nodeKeys = seen.get(finding.node);
     if (nodeKeys?.has(key) === true) {
       continue;
@@ -492,8 +1038,187 @@ function deduplicateFindings<T extends SqlAnalysisFinding>(
   return result;
 }
 
+interface FindingWithSignature {
+  readonly finding: SqlAnalysisFinding;
+  readonly signature: SqlFindingSignature;
+}
+
+function deduplicateFindingEntries(
+  entries: readonly FindingWithSignature[],
+): FindingWithSignature[] {
+  const findings = deduplicateFindings(
+    entries.map((entry) => {
+      return entry.finding;
+    }),
+  );
+  return findings.flatMap((finding) => {
+    const entry = entries.find((candidate) => {
+      return candidate.finding === finding;
+    });
+    return entry === undefined ? [] : [entry];
+  });
+}
+
+type DrizzleOperandRole =
+  | "array"
+  | "column"
+  | "pattern"
+  | "string-or-wrapper"
+  | "wrapper";
+
+function directMarkerMatchesRole(
+  marker: SqlMarker,
+  role: DrizzleOperandRole,
+): boolean {
+  if (role === "array") {
+    return marker.isArrayOperand;
+  }
+  if (role === "column") {
+    return marker.isColumn;
+  }
+  if (role === "pattern") {
+    return marker.isPatternOperand;
+  }
+  if (role === "string-or-wrapper") {
+    return marker.isStringOrWrapper;
+  }
+  return marker.isWrapper;
+}
+
+function nodeMatchesRole(
+  node: TSESTree.Expression,
+  role: DrizzleOperandRole,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  const type = checker.getTypeAtLocation(tsNode);
+  if (role === "array") {
+    return isDrizzleArrayOperandType(checker, type, tsNode);
+  }
+  if (role === "column") {
+    return isDrizzleColumnType(checker, type, tsNode);
+  }
+  if (role === "pattern") {
+    return isDrizzlePatternOperandType(checker, type, tsNode);
+  }
+  if (role === "string-or-wrapper") {
+    return isStringOrDrizzleWrapper(type, checker);
+  }
+  return isDrizzleWrapperType(checker, type);
+}
+
+function operandNode(
+  expression: StructuralExpression,
+  role: DrizzleOperandRole,
+  classificationContext: ClassificationContext,
+): TSESTree.Expression | undefined {
+  if (expression.kind === "marker") {
+    return directMarkerMatchesRole(expression.marker, role)
+      ? expression.marker.node
+      : undefined;
+  }
+  const boundary = exactExpressionBoundary(
+    expression,
+    classificationContext.variant,
+    classificationContext.root,
+    classificationContext.checker,
+    classificationContext.services,
+  );
+  return boundary !== undefined &&
+    nodeMatchesRole(
+      boundary,
+      role,
+      classificationContext.checker,
+      classificationContext.services,
+    )
+    ? boundary
+    : undefined;
+}
+
+function nestedClassificationContext(
+  context: ClassificationContext,
+): ClassificationContext {
+  return context.ownsResultMapping
+    ? { ...context, ownsResultMapping: false }
+    : context;
+}
+
+function classifiedFinding(
+  helper: SqlHelper,
+  node: TSESTree.Node,
+  sourceChunks: ReadonlySet<SqlSourceChunk>,
+  isolationContext: "ordering" | "predicate" | "selection" = "predicate",
+  isPartial = false,
+): ClassifiedHelperFinding {
+  return {
+    helper,
+    isolationContext,
+    isPartial,
+    kind: "helper",
+    node,
+    sourceChunks,
+  };
+}
+
+function firstClassificationNode(
+  classification: ExpressionClassification,
+): TSESTree.Node | undefined {
+  return classification.anchor ?? classification.findings[0]?.node;
+}
+
+function classifyExistence(
+  expression: Extract<StructuralExpression, { readonly kind: "existence" }>,
+  helper: "exists" | "notExists",
+  context: ClassificationContext,
+): ExpressionClassification {
+  const selectMarker = expression.selectMarker;
+  if (selectMarker?.isSelect === true) {
+    return {
+      anchor: selectMarker.node,
+      findings: [
+        classifiedFinding(helper, selectMarker.node, expression.sourceChunks),
+      ],
+      isWholeReplacement: true,
+    };
+  }
+  if (expression.isHandBuiltSelect) {
+    const handBuilt = literalBoundaryNode(
+      expression.sourceChunks,
+      context.root,
+    );
+    return {
+      anchor: handBuilt,
+      findings: [
+        {
+          helper,
+          isolationContext: "predicate",
+          isPartial: false,
+          kind: "existence-predicate",
+          node: handBuilt,
+          sourceChunks: expression.sourceChunks,
+        },
+      ],
+      isWholeReplacement: true,
+    };
+  }
+  const children = expression.children.map((child) => {
+    return classifyExpression(child, nestedClassificationContext(context));
+  });
+  return {
+    anchor: children.map(firstClassificationNode).find((node) => {
+      return node !== undefined;
+    }),
+    findings: children.flatMap((child) => {
+      return child.findings;
+    }),
+    isWholeReplacement: false,
+  };
+}
+
 function classifyExpression(
   expression: StructuralExpression,
+  context: ClassificationContext,
 ): ExpressionClassification {
   if (expression.kind === "marker") {
     return {
@@ -514,26 +1239,22 @@ function classifyExpression(
   }
   if (expression.kind === "comparison") {
     const helper = COMPARISON_HELPERS.get(expression.operator);
-    if (
-      helper !== undefined &&
-      expression.left.kind === "marker" &&
-      (expression.left.marker.isColumn || expression.left.marker.isWrapper)
-    ) {
+    const leftNode =
+      helper === undefined
+        ? undefined
+        : operandNode(expression.left, "wrapper", context);
+    if (helper !== undefined && leftNode !== undefined) {
       return {
-        anchor: expression.left.marker.node,
+        anchor: leftNode,
         findings: [
-          {
-            helper,
-            kind: "helper",
-            node: expression.left.marker.node,
-            sourceChunks: expression.sourceChunks,
-          },
+          classifiedFinding(helper, leftNode, expression.sourceChunks),
         ],
         isWholeReplacement: true,
       };
     }
-    const left = classifyExpression(expression.left);
-    const right = classifyExpression(expression.right);
+    const childContext = nestedClassificationContext(context);
+    const left = classifyExpression(expression.left, childContext);
+    const right = classifyExpression(expression.right, childContext);
     return {
       anchor:
         left.anchor ??
@@ -545,19 +1266,24 @@ function classifyExpression(
     };
   }
   if (expression.kind === "boolean") {
+    if (
+      expression.operator === "not" &&
+      expression.items[0]?.kind === "existence"
+    ) {
+      return classifyExistence(expression.items[0], "notExists", context);
+    }
+    const helper = expression.operator;
     for (const item of expression.items) {
-      const child = classifyExpression(item);
-      const reportNode = child.anchor ?? child.findings[0]?.node;
+      const child = classifyExpression(
+        item,
+        nestedClassificationContext(context),
+      );
+      const reportNode = firstClassificationNode(child);
       if (reportNode !== undefined) {
         return {
           anchor: reportNode,
           findings: [
-            {
-              helper: expression.operator,
-              kind: "helper",
-              node: reportNode,
-              sourceChunks: expression.sourceChunks,
-            },
+            classifiedFinding(helper, reportNode, expression.sourceChunks),
           ],
           isWholeReplacement: true,
         };
@@ -570,8 +1296,233 @@ function classifyExpression(
     };
   }
 
+  if (expression.kind === "null") {
+    const node = operandNode(expression.operand, "wrapper", context);
+    if (node !== undefined) {
+      return {
+        anchor: node,
+        findings: [
+          classifiedFinding(expression.helper, node, expression.sourceChunks),
+        ],
+        isWholeReplacement: true,
+      };
+    }
+    return classifyExpression(
+      expression.operand,
+      nestedClassificationContext(context),
+    );
+  }
+
+  if (expression.kind === "pattern") {
+    const left = operandNode(expression.left, "pattern", context);
+    const right = operandNode(expression.right, "string-or-wrapper", context);
+    if (left !== undefined && right !== undefined) {
+      return {
+        anchor: left,
+        findings: [
+          classifiedFinding(
+            expression.helper,
+            left,
+            expression.sourceChunks,
+            "predicate",
+            expression.escape !== undefined,
+          ),
+        ],
+        isWholeReplacement: expression.escape === undefined,
+      };
+    }
+    const childContext = nestedClassificationContext(context);
+    const children = [expression.left, expression.right, expression.escape]
+      .filter((item): item is StructuralExpression => {
+        return item !== undefined;
+      })
+      .map((item) => {
+        return classifyExpression(item, childContext);
+      });
+    return {
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
+      isWholeReplacement: false,
+    };
+  }
+
+  if (expression.kind === "array") {
+    const left = operandNode(expression.left, "array", context);
+    const right = operandNode(expression.right, "wrapper", context);
+    if (left !== undefined && right !== undefined) {
+      return {
+        anchor: left,
+        findings: [
+          classifiedFinding(expression.helper, left, expression.sourceChunks),
+        ],
+        isWholeReplacement: true,
+      };
+    }
+    const childContext = nestedClassificationContext(context);
+    const leftChild = classifyExpression(expression.left, childContext);
+    const rightChild = classifyExpression(expression.right, childContext);
+    return {
+      anchor:
+        firstClassificationNode(leftChild) ??
+        firstClassificationNode(rightChild),
+      findings: [...leftChild.findings, ...rightChild.findings],
+      isWholeReplacement: false,
+    };
+  }
+
+  if (expression.kind === "membership") {
+    const directColumn =
+      expression.left.kind === "marker" && expression.left.marker.isColumn
+        ? expression.left.marker.node
+        : undefined;
+    const lowerColumn =
+      expression.left.kind === "opaque" &&
+      expression.left.nodeKey === "FuncCall:lower" &&
+      expression.left.children.length === 1 &&
+      expression.left.children[0]?.kind === "marker" &&
+      expression.left.children[0].marker.isColumn
+        ? expression.left.children[0].marker.node
+        : undefined;
+    const value =
+      expression.values.length === 1 && expression.values[0]?.kind === "marker"
+        ? expression.values[0].marker.node
+        : undefined;
+    const validValues =
+      value !== undefined &&
+      (lowerColumn === undefined
+        ? context.capabilities.hasParameterListOrigin(value)
+        : context.capabilities.isInlineParameterList(value));
+    const left = directColumn ?? lowerColumn;
+    if (left !== undefined && validValues) {
+      return {
+        anchor: left,
+        findings: [
+          classifiedFinding(expression.helper, left, expression.sourceChunks),
+        ],
+        isWholeReplacement: true,
+      };
+    }
+    const childContext = nestedClassificationContext(context);
+    const children = [expression.left, ...expression.values].map((item) => {
+      return classifyExpression(item, childContext);
+    });
+    return {
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
+      isWholeReplacement: false,
+    };
+  }
+
+  if (expression.kind === "range") {
+    const left = operandNode(expression.left, "wrapper", context);
+    if (left !== undefined) {
+      return {
+        anchor: left,
+        findings: [
+          classifiedFinding(expression.helper, left, expression.sourceChunks),
+        ],
+        isWholeReplacement: true,
+      };
+    }
+    const childContext = nestedClassificationContext(context);
+    const children = [
+      expression.left,
+      expression.minimum,
+      expression.maximum,
+    ].map((item) => {
+      return classifyExpression(item, childContext);
+    });
+    return {
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
+      isWholeReplacement: false,
+    };
+  }
+
+  if (expression.kind === "aggregate") {
+    const childContext = nestedClassificationContext(context);
+    const argumentClassification =
+      expression.argument === undefined
+        ? undefined
+        : classifyExpression(expression.argument, childContext);
+    const filterClassification =
+      expression.filter === undefined
+        ? undefined
+        : classifyExpression(expression.filter, childContext);
+    const children = [argumentClassification, filterClassification].filter(
+      (item): item is ExpressionClassification => {
+        return item !== undefined;
+      },
+    );
+    const argumentNode =
+      expression.argument === undefined
+        ? undefined
+        : operandNode(expression.argument, "wrapper", context);
+    const validArgument = expression.isStar
+      ? expression.helper === "count"
+      : argumentNode !== undefined;
+    const helper = expression.helper;
+    const sameColumnDecoder =
+      (helper === "max" || helper === "min") &&
+      expression.argument !== undefined &&
+      operandNode(expression.argument, "column", context) !== undefined;
+    const mappingAllowed =
+      !context.ownsResultMapping ||
+      context.capabilities.hasDirectResultMapping(context.root) ||
+      sameColumnDecoder;
+    if (
+      helper !== undefined &&
+      validArgument &&
+      !expression.isWindowed &&
+      mappingAllowed
+    ) {
+      const node =
+        argumentNode ??
+        literalBoundaryNode(expression.sourceChunks, context.root);
+      return {
+        anchor: node,
+        findings: [
+          classifiedFinding(
+            helper,
+            node,
+            expression.sourceChunks,
+            "selection",
+            expression.filter !== undefined,
+          ),
+          ...(filterClassification?.findings ?? []),
+        ],
+        isWholeReplacement: expression.filter === undefined,
+      };
+    }
+    return {
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
+      isWholeReplacement: false,
+    };
+  }
+
+  if (expression.kind === "existence") {
+    return classifyExistence(expression, "exists", context);
+  }
+
   const children = expression.children.map((child) => {
-    return classifyExpression(child);
+    return classifyExpression(child, nestedClassificationContext(context));
   });
   return {
     anchor:
@@ -651,6 +1602,126 @@ function relationMatch(
   };
 }
 
+function syntheticSelectMarker(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): SqlMarker | undefined {
+  const select = recordProperty(value, "SelectStmt");
+  if (
+    select === undefined ||
+    select.limitOption !== "LIMIT_OPTION_DEFAULT" ||
+    select.op !== "SETOP_NONE" ||
+    Object.keys(select).some((key) => {
+      return !["limitOption", "op", "targetList"].includes(key);
+    }) ||
+    !Array.isArray(select.targetList) ||
+    select.targetList.length !== 1
+  ) {
+    return undefined;
+  }
+  const target = recordProperty(select.targetList[0], "ResTarget");
+  if (
+    target === undefined ||
+    Object.keys(target).some((key) => {
+      return !["location", "val"].includes(key);
+    })
+  ) {
+    return undefined;
+  }
+  return columnMarker(target.val, markers);
+}
+
+function isSelectOneTarget(value: unknown): boolean {
+  const target = recordProperty(value, "ResTarget");
+  if (
+    target === undefined ||
+    Object.keys(target).some((key) => {
+      return !["location", "val"].includes(key);
+    })
+  ) {
+    return false;
+  }
+  const constant = recordProperty(target.val, "A_Const");
+  const integer = recordProperty(constant, "ival");
+  return integer?.ival === 1;
+}
+
+function predicateMarkers(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): readonly SqlMarker[] | undefined {
+  const direct = columnMarker(value, markers);
+  if (direct !== undefined) {
+    return [direct];
+  }
+  const boolean = recordProperty(value, "BoolExpr");
+  if (
+    boolean?.boolop !== "AND_EXPR" ||
+    !Array.isArray(boolean.args) ||
+    boolean.args.length < 2
+  ) {
+    return undefined;
+  }
+  const result = boolean.args.map((argument) => {
+    return columnMarker(argument, markers);
+  });
+  return result.every((marker): marker is SqlMarker => {
+    return marker !== undefined;
+  })
+    ? result
+    : undefined;
+}
+
+function isHandBuiltExistenceSelect(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+): boolean {
+  const select = recordProperty(value, "SelectStmt");
+  if (
+    select === undefined ||
+    select.op !== "SETOP_NONE" ||
+    Object.keys(select).some((key) => {
+      return ![
+        "fromClause",
+        "limitCount",
+        "limitOption",
+        "op",
+        "targetList",
+        "whereClause",
+      ].includes(key);
+    }) ||
+    !Array.isArray(select.targetList) ||
+    select.targetList.length !== 1 ||
+    !isSelectOneTarget(select.targetList[0]) ||
+    !Array.isArray(select.fromClause) ||
+    select.fromClause.length !== 1 ||
+    select.whereClause === undefined
+  ) {
+    return false;
+  }
+  const relation = relationMatch(select.fromClause[0], markers);
+  const predicates = predicateMarkers(select.whereClause, markers);
+  const validLimit =
+    select.limitOption === "LIMIT_OPTION_DEFAULT" &&
+    select.limitCount === undefined
+      ? true
+      : select.limitOption === "LIMIT_OPTION_COUNT" &&
+        isLimitOne(select.limitCount);
+  return (
+    validLimit &&
+    relation?.sourceTable.isTable === true &&
+    relation.joinedTables.every((marker) => {
+      return marker.isTable;
+    }) &&
+    relation.joinedConditions.every((marker) => {
+      return marker.isWrapper;
+    }) &&
+    predicates?.every((marker) => {
+      return marker.isWrapper;
+    }) === true
+  );
+}
+
 function isLimitOne(value: unknown): boolean {
   const constant = recordProperty(value, "A_Const");
   const integer = recordProperty(constant, "ival");
@@ -702,6 +1773,242 @@ function predicateExpression(statement: unknown): unknown {
   return selectStatement(statement)?.whereClause;
 }
 
+function selectedExpressions(statement: unknown): readonly unknown[] {
+  const select = selectStatement(statement);
+  if (!Array.isArray(select?.targetList)) {
+    return [];
+  }
+  return select.targetList.flatMap((item) => {
+    const target = recordProperty(item, "ResTarget");
+    return target?.val === undefined ? [] : [target.val];
+  });
+}
+
+function orderingExpressions(
+  statement: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+  sourceRanges: readonly SqlSourceRange[],
+): readonly StructuralOrdering[] {
+  const select = selectStatement(statement);
+  if (!Array.isArray(select?.sortClause)) {
+    return [];
+  }
+  return select.sortClause.flatMap((item) => {
+    return structuralOrdering(item, markers, sourceRanges);
+  });
+}
+
+function structuralOrdering(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+  sourceRanges: readonly SqlSourceRange[],
+): readonly StructuralOrdering[] {
+  const sort = recordProperty(value, "SortBy");
+  if (sort?.node === undefined) {
+    return [];
+  }
+  const expression = structuralExpression(sort.node, markers, sourceRanges);
+  const direction =
+    sort.sortby_dir === "SORTBY_ASC"
+      ? "asc"
+      : sort.sortby_dir === "SORTBY_DESC"
+        ? "desc"
+        : undefined;
+  return [
+    {
+      direction,
+      expression,
+      hasExplicitNullOrdering:
+        sort.sortby_nulls === "SORTBY_NULLS_FIRST" ||
+        sort.sortby_nulls === "SORTBY_NULLS_LAST",
+      sourceChunks: expression.sourceChunks,
+    },
+  ];
+}
+
+function collectStructuralOrderings(
+  value: unknown,
+  markers: ReadonlyMap<string, SqlMarker>,
+  sourceRanges: readonly SqlSourceRange[],
+): readonly StructuralOrdering[] {
+  const orderings: StructuralOrdering[] = [];
+
+  function visit(current: unknown): void {
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        visit(item);
+      }
+      return;
+    }
+    if (!isRecord(current)) {
+      return;
+    }
+    const ordering = structuralOrdering(current, markers, sourceRanges);
+    if (ordering.length > 0) {
+      orderings.push(...ordering);
+      return;
+    }
+    for (const child of Object.values(current)) {
+      visit(child);
+    }
+  }
+
+  visit(value);
+  return orderings;
+}
+
+function structuralExpressionsForContext(
+  context: SqlAnalysisContext,
+  parsed: ParsedSql,
+): readonly StructuralExpression[] {
+  if (context === "predicate") {
+    const predicate = predicateExpression(parsed.statement);
+    return predicate === undefined
+      ? []
+      : [structuralExpression(predicate, parsed.markers, parsed.sourceRanges)];
+  }
+  if (context === "selection") {
+    return selectedExpressions(parsed.statement).map((expression) => {
+      return structuralExpression(
+        expression,
+        parsed.markers,
+        parsed.sourceRanges,
+      );
+    });
+  }
+  if (context === "relation") {
+    const from = selectStatement(parsed.statement)?.fromClause;
+    return collectStructuralExpressions(
+      from,
+      parsed.markers,
+      parsed.sourceRanges,
+    );
+  }
+  if (context === "ordering") {
+    return orderingExpressions(
+      parsed.statement,
+      parsed.markers,
+      parsed.sourceRanges,
+    ).map((ordering) => {
+      return ordering.expression;
+    });
+  }
+  return collectStructuralExpressions(
+    parsed.statement,
+    parsed.markers,
+    parsed.sourceRanges,
+  );
+}
+
+function sameOptionalExpression(
+  left: StructuralExpression | undefined,
+  right: StructuralExpression | undefined,
+): boolean {
+  return left === undefined
+    ? right === undefined
+    : right !== undefined && sameStructuralExpression(left, right);
+}
+
+function sameStructuralExpressions(
+  left: readonly StructuralExpression[],
+  right: readonly StructuralExpression[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => {
+      const other = right[index];
+      return other !== undefined && sameStructuralExpression(item, other);
+    })
+  );
+}
+
+function sameStructuralExpression(
+  left: StructuralExpression,
+  right: StructuralExpression,
+): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  if (left.kind === "marker" && right.kind === "marker") {
+    return left.marker.chunk === right.marker.chunk;
+  }
+  if (left.kind === "constant" && right.kind === "constant") {
+    return true;
+  }
+  if (left.kind === "comparison" && right.kind === "comparison") {
+    return (
+      left.operator === right.operator &&
+      sameStructuralExpression(left.left, right.left) &&
+      sameStructuralExpression(left.right, right.right)
+    );
+  }
+  if (left.kind === "boolean" && right.kind === "boolean") {
+    return (
+      left.operator === right.operator &&
+      sameStructuralExpressions(left.items, right.items)
+    );
+  }
+  if (left.kind === "null" && right.kind === "null") {
+    return (
+      left.helper === right.helper &&
+      sameStructuralExpression(left.operand, right.operand)
+    );
+  }
+  if (left.kind === "pattern" && right.kind === "pattern") {
+    return (
+      left.helper === right.helper &&
+      sameStructuralExpression(left.left, right.left) &&
+      sameStructuralExpression(left.right, right.right) &&
+      sameOptionalExpression(left.escape, right.escape)
+    );
+  }
+  if (left.kind === "array" && right.kind === "array") {
+    return (
+      left.helper === right.helper &&
+      sameStructuralExpression(left.left, right.left) &&
+      sameStructuralExpression(left.right, right.right)
+    );
+  }
+  if (left.kind === "membership" && right.kind === "membership") {
+    return (
+      left.helper === right.helper &&
+      sameStructuralExpression(left.left, right.left) &&
+      sameStructuralExpressions(left.values, right.values)
+    );
+  }
+  if (left.kind === "range" && right.kind === "range") {
+    return (
+      left.helper === right.helper &&
+      sameStructuralExpression(left.left, right.left) &&
+      sameStructuralExpression(left.minimum, right.minimum) &&
+      sameStructuralExpression(left.maximum, right.maximum)
+    );
+  }
+  if (left.kind === "aggregate" && right.kind === "aggregate") {
+    return (
+      left.helper === right.helper &&
+      left.isDistinct === right.isDistinct &&
+      left.isStar === right.isStar &&
+      left.isWindowed === right.isWindowed &&
+      sameOptionalExpression(left.argument, right.argument) &&
+      sameOptionalExpression(left.filter, right.filter)
+    );
+  }
+  if (left.kind === "existence" && right.kind === "existence") {
+    return (
+      left.isHandBuiltSelect === right.isHandBuiltSelect &&
+      left.selectMarker?.chunk === right.selectMarker?.chunk &&
+      sameStructuralExpressions(left.children, right.children)
+    );
+  }
+  return (
+    left.kind === "opaque" &&
+    right.kind === "opaque" &&
+    left.nodeKey === right.nodeKey &&
+    sameStructuralExpressions(left.children, right.children)
+  );
+}
+
 function isTrueConstant(expression: unknown): boolean {
   const constant = recordProperty(expression, "A_Const");
   const boolean = recordProperty(constant, "boolval");
@@ -738,14 +2045,11 @@ function isWithinCompositionRoot(
   return false;
 }
 
-function commonCompositionBoundaries(
+function compositionBoundariesForChunks(
   chunks: readonly SqlSourceChunk[],
   root: TSESTree.Expression,
 ): TSESTree.Expression[] {
-  const contributingChunks = chunks.filter((chunk) => {
-    return chunk.kind === "expression" || chunk.text.trim() !== "";
-  });
-  const firstChunk = contributingChunks[0];
+  const firstChunk = chunks[0];
   if (firstChunk === undefined) {
     return [];
   }
@@ -758,7 +2062,7 @@ function commonCompositionBoundaries(
         return (
           isCompositionBoundary(origin) &&
           isWithinCompositionRoot(origin, root) &&
-          contributingChunks.every((chunk) => {
+          chunks.every((chunk) => {
             return chunk.origins.includes(origin);
           })
         );
@@ -784,6 +2088,18 @@ function commonCompositionBoundaries(
   ];
 }
 
+function commonCompositionBoundaries(
+  chunks: readonly SqlSourceChunk[],
+  root: TSESTree.Expression,
+): TSESTree.Expression[] {
+  return compositionBoundariesForChunks(
+    chunks.filter((chunk) => {
+      return chunk.kind === "expression" || chunk.text.trim() !== "";
+    }),
+    root,
+  );
+}
+
 function commonCompositionBoundary(
   variant: SqlSourceVariant,
   root: TSESTree.Expression,
@@ -791,12 +2107,97 @@ function commonCompositionBoundary(
   return commonCompositionBoundaries(variant.chunks, root)[0];
 }
 
-function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
+function literalBoundaryNode(
+  chunks: ReadonlySet<SqlSourceChunk>,
+  root: TSESTree.Expression,
+): TSESTree.Expression {
+  return commonCompositionBoundaries([...chunks], root)[0] ?? root;
+}
+
+function exactExpressionBoundary(
+  expression: StructuralExpression,
+  variant: SqlSourceVariant,
+  root: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): TSESTree.Expression | undefined {
+  const candidates = commonCompositionBoundaries(
+    [...expression.sourceChunks],
+    root,
+  );
+  for (const candidate of candidates) {
+    const candidateVariant = {
+      chunks: variant.chunks.filter((chunk) => {
+        return chunk.origins.includes(candidate);
+      }),
+    };
+    const parsed = parseSqlVariant(
+      candidateVariant,
+      "selection",
+      true,
+      checker,
+      services,
+    );
+    if (parsed === null) {
+      continue;
+    }
+    const selected = selectedExpressions(parsed.statement);
+    if (selected.length !== 1 || selected[0] === undefined) {
+      continue;
+    }
+    const candidateExpression = structuralExpression(
+      selected[0],
+      parsed.markers,
+      parsed.sourceRanges,
+    );
+    if (sameStructuralExpression(expression, candidateExpression)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function classifyOrdering(
+  ordering: StructuralOrdering,
+  context: ClassificationContext,
+): ExpressionClassification {
+  const node =
+    ordering.direction === undefined
+      ? undefined
+      : operandNode(ordering.expression, "wrapper", context);
+  if (node === undefined || ordering.direction === undefined) {
+    return classifyExpression(
+      ordering.expression,
+      nestedClassificationContext(context),
+    );
+  }
   return {
-    helper: finding.helper,
-    kind: finding.kind,
-    node: finding.node,
+    anchor: node,
+    findings: [
+      classifiedFinding(
+        ordering.direction,
+        node,
+        ordering.sourceChunks,
+        "ordering",
+        ordering.hasExplicitNullOrdering,
+      ),
+    ],
+    isWholeReplacement: !ordering.hasExplicitNullOrdering,
   };
+}
+
+function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
+  return finding.kind === "existence-predicate"
+    ? {
+        helper: finding.helper,
+        kind: finding.kind,
+        node: finding.node,
+      }
+    : {
+        helper: finding.helper,
+        kind: finding.kind,
+        node: finding.node,
+      };
 }
 
 function replacementBoundaryForFinding(
@@ -805,7 +2206,11 @@ function replacementBoundaryForFinding(
   root: TSESTree.Expression,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
+  capabilities: SqlCapabilityChecks,
 ): TSESTree.Expression | undefined {
+  if (finding.isPartial) {
+    return undefined;
+  }
   // A parsed descendant can cross template boundaries because Drizzle inserts
   // nested SQL without parentheses. Reparse each editable boundary in
   // isolation before claiming that the helper can replace it.
@@ -821,23 +2226,44 @@ function replacementBoundaryForFinding(
     };
     const parsed = parseSqlVariant(
       candidateVariant,
-      "predicate",
-      false,
+      finding.isolationContext,
+      true,
       checker,
       services,
     );
-    const expression =
-      parsed === null ? undefined : predicateExpression(parsed.statement);
-    if (parsed === null || expression === undefined) {
+    if (parsed === null) {
       continue;
     }
-    const classification = classifyExpression(
-      structuralExpression(expression, parsed.markers, parsed.sourceRanges),
-    );
+    const classificationContext: ClassificationContext = {
+      capabilities,
+      checker,
+      ownsResultMapping: false,
+      root: candidate,
+      services,
+      variant: candidateVariant,
+    };
+    const classifications =
+      finding.isolationContext === "ordering"
+        ? orderingExpressions(
+            parsed.statement,
+            parsed.markers,
+            parsed.sourceRanges,
+          ).map((ordering) => {
+            return classifyOrdering(ordering, classificationContext);
+          })
+        : structuralExpressionsForContext(finding.isolationContext, parsed).map(
+            (expression) => {
+              return classifyExpression(expression, classificationContext);
+            },
+          );
+    const classification = classifications[0];
+    const candidateFinding = classification?.findings[0];
     if (
-      classification.isWholeReplacement &&
+      classifications.length === 1 &&
+      classification?.isWholeReplacement === true &&
       classification.findings.length === 1 &&
-      classification.findings[0]?.helper === finding.helper
+      candidateFinding?.kind === finding.kind &&
+      candidateFinding.helper === finding.helper
     ) {
       return candidate;
     }
@@ -853,12 +2279,23 @@ function analyzeParsed(
   variant: SqlSourceVariant,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
+  capabilities: SqlCapabilityChecks,
 ): SqlAnalysis {
   const simpleSelect =
     context === "statement" && isSimpleSelect(parsed.statement, parsed.markers);
   if (simpleSelect) {
     return {
       expandedTemplates: new Set(),
+      findingSignatures: [
+        {
+          boundaryIsRoot: true,
+          boundaryType: node.type,
+          helper: undefined,
+          isPartial: false,
+          kind: "query-builder",
+          ownsResultMapping: false,
+        },
+      ],
       findings: [{ kind: "query-builder", node }],
       hasWholeReplacementBoundary: true,
       isSimpleSelect: true,
@@ -866,48 +2303,92 @@ function analyzeParsed(
     };
   }
 
-  const expression =
-    context === "predicate"
-      ? predicateExpression(parsed.statement)
-      : parsed.statement;
   const structuralExpressions =
-    context === "predicate" && expression !== undefined
-      ? [structuralExpression(expression, parsed.markers, parsed.sourceRanges)]
-      : collectStructuralExpressions(
-          expression,
+    context === "ordering"
+      ? []
+      : structuralExpressionsForContext(context, parsed);
+  const orderings =
+    context === "ordering"
+      ? orderingExpressions(
+          parsed.statement,
           parsed.markers,
           parsed.sourceRanges,
-        );
-  const classifications = structuralExpressions.map((item) => {
-    return classifyExpression(item);
-  });
-  const predicateClassification =
-    context === "predicate" ? classifications[0] : undefined;
-  const predicateFinding = predicateClassification?.findings[0];
-  const rootNeedsCompositionBoundary =
-    hasLocalExpansion && predicateFinding !== undefined;
+        )
+      : context === "statement"
+        ? collectStructuralOrderings(
+            parsed.statement,
+            parsed.markers,
+            parsed.sourceRanges,
+          )
+        : [];
+  const ownsResultMapping =
+    context === "selection" && structuralExpressions.length === 1;
+  const classificationContext: ClassificationContext = {
+    capabilities,
+    checker,
+    ownsResultMapping,
+    root: node,
+    services,
+    variant,
+  };
+  const classifications = [
+    ...structuralExpressions.map((item) => {
+      return classifyExpression(item, classificationContext);
+    }),
+    ...orderings.map((ordering) => {
+      return classifyOrdering(ordering, classificationContext);
+    }),
+  ];
+  const rootClassification =
+    classifications.length === 1 ? classifications[0] : undefined;
+  const rootFinding = rootClassification?.findings[0];
   const canReplaceRoot =
-    predicateClassification?.isWholeReplacement === true &&
-    predicateClassification.findings.length === 1 &&
-    predicateFinding?.kind === "helper" &&
-    rootNeedsCompositionBoundary;
+    hasLocalExpansion &&
+    rootClassification?.isWholeReplacement === true &&
+    rootClassification.findings.length === 1 &&
+    rootFinding !== undefined &&
+    !rootFinding.isPartial;
   const replacementBoundary = canReplaceRoot
     ? commonCompositionBoundary(variant, node)
     : undefined;
   const hasWholeReplacementBoundary = replacementBoundary !== undefined;
-  const findings = deduplicateFindings(
+  const findingEntries = deduplicateFindingEntries(
     classifications.flatMap((classification) => {
       if (hasWholeReplacementBoundary) {
         return classification.findings.map((finding) => {
-          return publicFinding({
+          const publicResult = publicFinding({
             ...finding,
             node: replacementBoundary ?? node,
           });
+          return {
+            finding: publicResult,
+            signature: {
+              boundaryIsRoot: publicResult.node === node,
+              boundaryType: publicResult.node.type,
+              helper: finding.helper,
+              isPartial: finding.isPartial,
+              kind: finding.kind,
+              ownsResultMapping,
+            },
+          };
         });
       }
       return classification.findings.flatMap((finding) => {
         if (!hasLocalExpansion) {
-          return [publicFinding(finding)];
+          const publicResult = publicFinding(finding);
+          return [
+            {
+              finding: publicResult,
+              signature: {
+                boundaryIsRoot: publicResult.node === node,
+                boundaryType: publicResult.node.type,
+                helper: finding.helper,
+                isPartial: finding.isPartial,
+                kind: finding.kind,
+                ownsResultMapping,
+              },
+            },
+          ];
         }
         const boundary = replacementBoundaryForFinding(
           finding,
@@ -915,22 +2396,42 @@ function analyzeParsed(
           node,
           checker,
           services,
+          capabilities,
         );
-        return boundary === undefined
-          ? []
-          : [publicFinding({ ...finding, node: boundary })];
+        if (boundary === undefined) {
+          return [];
+        }
+        const publicResult = publicFinding({ ...finding, node: boundary });
+        return [
+          {
+            finding: publicResult,
+            signature: {
+              boundaryIsRoot: boundary === node,
+              boundaryType: boundary.type,
+              helper: finding.helper,
+              isPartial: finding.isPartial,
+              kind: finding.kind,
+              ownsResultMapping,
+            },
+          },
+        ];
       });
     }),
   );
   return {
     expandedTemplates: new Set(),
-    findings,
+    findingSignatures: findingEntries.map((entry) => {
+      return entry.signature;
+    }),
+    findings: findingEntries.map((entry) => {
+      return entry.finding;
+    }),
     hasWholeReplacementBoundary,
     isSimpleSelect: false,
     isTruePredicate:
       context === "predicate" &&
-      expression !== undefined &&
-      isTrueConstant(expression),
+      predicateExpression(parsed.statement) !== undefined &&
+      isTrueConstant(predicateExpression(parsed.statement)),
   };
 }
 
@@ -939,17 +2440,20 @@ function sameAnalysisSignature(left: SqlAnalysis, right: SqlAnalysis): boolean {
     left.isSimpleSelect !== right.isSimpleSelect ||
     left.isTruePredicate !== right.isTruePredicate ||
     left.hasWholeReplacementBoundary !== right.hasWholeReplacementBoundary ||
-    left.findings.length !== right.findings.length
+    left.findingSignatures.length !== right.findingSignatures.length
   ) {
     return false;
   }
-  return left.findings.every((finding, index) => {
-    const other = right.findings[index];
+  return left.findingSignatures.every((finding, index) => {
+    const other = right.findingSignatures[index];
     return (
       other !== undefined &&
+      finding.boundaryIsRoot === other.boundaryIsRoot &&
+      finding.boundaryType === other.boundaryType &&
+      finding.helper === other.helper &&
+      finding.isPartial === other.isPartial &&
       finding.kind === other.kind &&
-      (finding.kind === "query-builder" ||
-        (other.kind === "helper" && finding.helper === other.helper))
+      finding.ownsResultMapping === other.ownsResultMapping
     );
   });
 }
@@ -959,11 +2463,55 @@ function emptyAnalysis(
 ): SqlAnalysis {
   return {
     expandedTemplates,
+    findingSignatures: [],
     findings: [],
     hasWholeReplacementBoundary: false,
     isSimpleSelect: false,
     isTruePredicate: false,
   };
+}
+
+function emptyTemplateFindings(
+  variants: readonly SqlSourceVariant[],
+  root: TSESTree.Expression,
+): readonly SqlAnalysisFinding[] | undefined {
+  const boundaries: TSESTree.Expression[] = [];
+  for (const variant of variants) {
+    if (
+      variant.chunks.length === 0 ||
+      variant.chunks.some((chunk) => {
+        return chunk.kind !== "literal" || chunk.text !== "";
+      })
+    ) {
+      return undefined;
+    }
+    boundaries.push(
+      compositionBoundariesForChunks(variant.chunks, root)[0] ?? root,
+    );
+  }
+  return deduplicateFindings(
+    boundaries.map((node) => {
+      return { kind: "empty-fragment", node };
+    }),
+  );
+}
+
+const SQL_CAPABILITY_TOKEN =
+  /(?:<>|>=|<=|@>|<@|&&|(?<![-=>])=(?!=|>)|(?<![-@>])>|<(?![@=>])|\b(?:AND|ASC|AVG|BETWEEN|COUNT|DESC|EXISTS|ILIKE|IN|IS|LIKE|MAX|MIN|NOT|NULL|OR|SUM|TRUE)\b)/i;
+
+function variantMightContainCapability(
+  variant: SqlSourceVariant,
+  context: SqlAnalysisContext,
+): boolean {
+  const literalSource = variant.chunks
+    .map((chunk) => {
+      return chunk.kind === "literal" ? chunk.text : " ";
+    })
+    .join("");
+  return (
+    SQL_CAPABILITY_TOKEN.test(literalSource) ||
+    (context === "statement" && /\bSELECT\b/i.test(literalSource))
+  );
 }
 
 export function analyzeSql(
@@ -972,6 +2520,7 @@ export function analyzeSql(
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
   composer: SqlSourceComposer,
+  capabilities: SqlCapabilityChecks = NO_CAPABILITY_CHECKS,
 ): SqlAnalysis {
   let composerCache = ANALYSIS_CACHE.get(composer);
   if (composerCache === undefined) {
@@ -987,51 +2536,80 @@ export function analyzeSql(
   if (source === null) {
     analysis = emptyAnalysis(new Set());
   } else {
-    const variants: SqlAnalysis[] = [];
-    for (const variant of source.variants) {
-      const parsed = parseSqlVariant(
-        variant,
-        context,
-        source.hasLocalExpansion,
-        checker,
-        services,
-      );
-      if (parsed === null) {
-        variants.length = 0;
-        break;
-      }
-      variants.push(
-        analyzeParsed(
-          node,
-          context,
-          source.hasLocalExpansion,
-          parsed,
-          variant,
-          checker,
-          services,
-        ),
-      );
-    }
-    const first = variants[0];
-    if (
-      first === undefined ||
-      variants.some((variant) => {
-        return !sameAnalysisSignature(variant, first);
+    const emptyFindings = emptyTemplateFindings(source.variants, node);
+    if (emptyFindings !== undefined) {
+      analysis = {
+        expandedTemplates: source.expandedTemplates,
+        findingSignatures: emptyFindings.map((finding) => {
+          return {
+            boundaryIsRoot: finding.node === node,
+            boundaryType: finding.node.type,
+            helper: undefined,
+            isPartial: false,
+            kind: finding.kind,
+            ownsResultMapping: false,
+          };
+        }),
+        findings: emptyFindings,
+        hasWholeReplacementBoundary: source.hasLocalExpansion,
+        isSimpleSelect: false,
+        isTruePredicate: false,
+      };
+    } else if (
+      !source.variants.some((variant) => {
+        return variantMightContainCapability(variant, context);
       })
     ) {
       analysis = emptyAnalysis(source.expandedTemplates);
     } else {
-      analysis = {
-        expandedTemplates: source.expandedTemplates,
-        findings: deduplicateFindings(
-          variants.flatMap((variant) => {
-            return variant.findings;
-          }),
-        ),
-        hasWholeReplacementBoundary: first.hasWholeReplacementBoundary,
-        isSimpleSelect: first.isSimpleSelect,
-        isTruePredicate: first.isTruePredicate,
-      };
+      const variants: SqlAnalysis[] = [];
+      for (const variant of source.variants) {
+        const parsed = parseSqlVariant(
+          variant,
+          context,
+          source.hasLocalExpansion,
+          checker,
+          services,
+        );
+        if (parsed === null) {
+          variants.length = 0;
+          break;
+        }
+        variants.push(
+          analyzeParsed(
+            node,
+            context,
+            source.hasLocalExpansion,
+            parsed,
+            variant,
+            checker,
+            services,
+            capabilities,
+          ),
+        );
+      }
+      const first = variants[0];
+      if (
+        first === undefined ||
+        variants.some((variant) => {
+          return !sameAnalysisSignature(variant, first);
+        })
+      ) {
+        analysis = emptyAnalysis(source.expandedTemplates);
+      } else {
+        analysis = {
+          expandedTemplates: source.expandedTemplates,
+          findingSignatures: first.findingSignatures,
+          findings: deduplicateFindings(
+            variants.flatMap((variant) => {
+              return variant.findings;
+            }),
+          ),
+          hasWholeReplacementBoundary: first.hasWholeReplacementBoundary,
+          isSimpleSelect: first.isSimpleSelect,
+          isTruePredicate: first.isTruePredicate,
+        };
+      }
     }
   }
   const nodeCache = composerCache.get(node);


### PR DESCRIPTION
## Summary

- replace the remaining handwritten SQL fragment scanner with the shared PostgreSQL AST and provenance pipeline
- recognize predicate, selection, ordering, relation, existence, aggregate, lateral-join, and empty-fragment capabilities only in verified Drizzle contexts
- preserve conservative handling for ambiguous composition, unsupported ancestors, fake symbols, concrete-only consumers, result mapping, and variant disagreement
- convert all newly exposed production fragments to equivalent Drizzle helpers

## Implementation

- extend the structural IR and classifier for the remaining helper catalog, typed select builders, maximal editable boundaries, and context-specific hosts
- verify real installed Drizzle tags, helpers, methods, columns, tables, wrappers, and select builders through TypeScript
- account for Drizzle helpers such as `and(...)` and `or(...)` returning `SQL | undefined`, and only recommend them as whole replacements where the consumer accepts optional SQL
- require the parsed context host to contain one bare expression before treating an alias or factory use as a whole replacement
- retain aggregate-internal ordering and variadic syntax as structural modifiers instead of claiming an aggregate helper is equivalent
- delay expensive call-signature verification until structural analysis has an actionable finding
- migrate the legacy positive and near-miss RuleTester coverage to the public structural path, then delete the duplicate scanner and grammar

## Production SQL

- converted 12 production SQL fragments across 11 files exposed by the completed rule
- compared every before/after pair through Drizzle serialization and PostgreSQL parsing: parameter arrays, parameter typings, and normalized PostgreSQL ASTs match
- preserved aggregate decoders, `mapWith(...)`, parameter order, literal encoding, null behavior, predicate grouping, and query shape

## Performance

Five interleaved same-container API ESLint pairs against exact base
`f9360d0c979f063bc0b290c6874b37890edcf9f1` on final head
`ce7f7bc217e8919ac1fbf700317090b1cd88fe6b`:

- median wall time: 27,355.82 ms base, 26,489.50 ms candidate (-3.2%)
- median peak process-tree RSS: 3,456,704 KB base, 3,476,792 KB candidate (+0.6%)
- acceptance gates: wall <= +5%, RSS <= +10% — passed

## Exclusions

- complete read-query-builder migration
- write-query-builder migration and retirement of `prefer-drizzle-query-builder`
- the final retained-SQL audit from #22901
- runtime, schema, persisted-data, API, protocol, feature-switch, or deployment changes

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/eslint-rules lint`
- `cd turbo && pnpm -F @vm0/eslint-rules check-types`
- `cd turbo && pnpm -F @vm0/eslint-rules test` — 47 files, 866 tests
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run <10 affected API test files> --maxWorkers=4 --silent=passed-only` — 10 files, 214 tests
- `cd turbo && pnpm knip --workspace @vm0/eslint-rules`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm check-types` — 13 workspaces
- `git diff --check`
- generated Drizzle parameter, parameter-typing, and normalized PostgreSQL AST parity check — 12/12 rewrites
- five interleaved API ESLint wall/RSS benchmark pairs on the final head

Closes #23133

Parent: #23047
