### PR TITLE
refactor(api): remove legacy thread session fallbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -33,7 +33,6 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
   completeRunWithoutCallbacksFixture,
   holdOrgAdmissionLockFixture,
-  rewriteWorkflowQueueEventAsPreviousVersionFixture,
   setQueuedUserMessageCreatedAtFixture,
   setWorkflowQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/chat-messages";
@@ -913,7 +912,7 @@ describe("workflow queue", () => {
     expect(resumed.body.running?.runId).toStrictEqual(expect.any(String));
   });
 
-  it("drains a previous-version queued one-time event through the canonical session", async () => {
+  it("drains a queued one-time event through the canonical session", async () => {
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const webhookAutomation = await createWebhookAutomation(scenario);
@@ -953,16 +952,12 @@ describe("workflow queue", () => {
       }),
       [200],
     );
-    const previousEvent = queued.body.pending.find((event) => {
+    const queuedEvent = queued.body.pending.find((event) => {
       return event.automationId === created.body.id;
     });
-    if (!previousEvent) {
+    if (!queuedEvent) {
       throw new Error("Expected the claimed one-time event to remain queued");
     }
-    await rewriteWorkflowQueueEventAsPreviousVersionFixture({
-      eventId: previousEvent.id,
-      automationId: created.body.id,
-    });
 
     const busyBinding = await readThreadSessionBinding(
       context,
@@ -976,7 +971,7 @@ describe("workflow queue", () => {
     expect(runIds).toHaveLength(2);
     const drainedRunId = runIds[1];
     if (!drainedRunId) {
-      throw new Error("Expected the previous-version event to drain");
+      throw new Error("Expected the queued one-time event to drain");
     }
     const drainedBinding = await readThreadSessionBinding(
       context,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -9,7 +9,6 @@ import {
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import {
@@ -19,7 +18,6 @@ import {
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
-import { conversations } from "@vm0/db/schema/conversation";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -123,7 +121,7 @@ import {
   chatThreadServiceTierFromCodex,
 } from "../services/zero-chat-thread-event.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
-import { shouldStartNewChatSession } from "../services/chat-session-continuity.service";
+import { resolveChatThreadSession } from "../services/chat-session-continuity.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import { bestEffort, tapError } from "../utils";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -186,7 +184,6 @@ type ThreadModelPin = ModelFirstPin;
 
 interface ResolvedThread {
   readonly threadId: string;
-  readonly sessionId: string | undefined;
   readonly incompleteContext: string;
   readonly computerUseHostId: string | null;
   readonly isNewThread: boolean;
@@ -206,13 +203,6 @@ interface WebChatPriorRun {
   readonly status: string;
   readonly prompt: string;
   readonly messages: readonly WebChatPriorRunMessage[];
-}
-
-interface LatestThreadSession {
-  readonly sessionId: string;
-  readonly selectedModel: string | null;
-  readonly modelProvider: string | null;
-  readonly cliAgentType: string | null;
 }
 
 type ModelFirstProviderAdmission = Awaited<
@@ -584,18 +574,6 @@ function normalizeNormalSendBody(body: NormalSendBody):
   };
 }
 
-function hasAgentSessionId(
-  value: unknown,
-): value is { readonly agentSessionId: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "agentSessionId" in value &&
-    typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
-      "string"
-  );
-}
-
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
@@ -819,51 +797,6 @@ async function loadAgentForChatSend(
     .where(eq(zeroAgents.id, agentId))
     .limit(1);
   return agent;
-}
-
-async function latestSessionForThread(
-  db: Db,
-  threadId: string,
-): Promise<LatestThreadSession | undefined> {
-  const rows = await db
-    .select({
-      result: agentRuns.result,
-      selectedModel: zeroRuns.selectedModel,
-      modelProvider: zeroRuns.modelProvider,
-      cliAgentType: conversations.cliAgentType,
-    })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
-    .leftJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
-    // Only web-source runs join the thread's session-continuity chain, so
-    // Workflow Automation runs never resume a web session and a later web turn
-    // never resumes an automated one. The 'web' filter (before .limit) is
-    // mirrored in latestSessionForThreadFromDb
-    // (internal-chat-run-callback.service.ts) and latestSessionIdForThread
-    // (zero-goal-continuation.service.ts) — keep them in sync. This is a
-    // continuity filter ONLY; it must NOT be copied into the thread admission
-    // check.
-    .where(
-      and(
-        eq(zeroRuns.chatThreadId, threadId),
-        eq(zeroRuns.triggerSource, "web"),
-      ),
-    )
-    .orderBy(desc(agentRuns.createdAt))
-    .limit(5);
-
-  for (const row of rows) {
-    if (hasAgentSessionId(row.result)) {
-      return {
-        sessionId: row.result.agentSessionId,
-        selectedModel: row.selectedModel,
-        modelProvider: row.modelProvider,
-        cliAgentType: row.cliAgentType,
-      };
-    }
-  }
-  return undefined;
 }
 
 async function getLatestRunsByThreadId(
@@ -1475,7 +1408,6 @@ async function resolveThread(params: {
     return {
       thread: {
         threadId: thread.id,
-        sessionId: undefined,
         incompleteContext: "",
         computerUseHostId: null,
         isNewThread: !thread.clientThreadAlreadyExisted,
@@ -1526,27 +1458,30 @@ async function resolveThread(params: {
     };
   }
 
-  const [latestSession, incompleteContext] = await Promise.all([
-    latestSessionForThread(params.db, thread.id),
+  const [sessionResolution, incompleteContext] = await Promise.all([
+    resolveChatThreadSession({
+      db: params.db,
+      threadId: thread.id,
+      userId: params.userId,
+      orgId: params.orgId,
+      agentComposeId: params.agentId,
+      route: {
+        selectedModel: runConfiguration.modelPin.selectedModel,
+        modelProvider:
+          runConfiguration.providerAdmission.effectiveModelProvider ?? null,
+        cliAgentType: runConfiguration.providerAdmission.cliAgentType,
+      },
+    }),
     loadWebChatIncompleteContext(
       params.db,
       thread.id,
       params.structuredPromptEnabled,
     ),
   ]);
-  const startNewSession = shouldStartNewChatSession({
-    latestModel: latestSession?.selectedModel,
-    nextModel: runConfiguration.modelPin.selectedModel,
-    latestModelProvider: latestSession?.modelProvider,
-    nextModelProvider:
-      runConfiguration.providerAdmission.effectiveModelProvider,
-    latestCliAgentType: latestSession?.cliAgentType,
-    nextCliAgentType: runConfiguration.providerAdmission.cliAgentType,
-  });
+  const startNewSession = sessionResolution.action === "rotated";
   return {
     thread: {
       threadId: thread.id,
-      sessionId: startNewSession ? undefined : latestSession?.sessionId,
       incompleteContext: startNewSession ? "" : incompleteContext,
       computerUseHostId: thread.computerUseHostId,
       isNewThread: false,
@@ -3033,9 +2968,6 @@ function buildCreateZeroRunArgs(params: {
     body: {
       prompt: prepared.body.agentPrompt,
       agentId: args.body.agentId,
-      ...(prepared.thread.sessionId
-        ? { sessionId: prepared.thread.sessionId }
-        : {}),
       ...(providerAdmission.effectiveModelProvider
         ? { modelProvider: providerAdmission.effectiveModelProvider }
         : {}),

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -29,7 +29,6 @@ const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
 
 const workflowQueueEventParamsWireSchema = z.object({
   version: z.literal(1),
-  sessionId: z.string().optional(),
   prompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),
   callbacks: z
@@ -43,7 +42,7 @@ const workflowQueueEventParamsWireSchema = z.object({
     .optional(),
   recordLastRunId: z.boolean().optional(),
   recordLastRunAt: z.boolean().optional(),
-  activePreviousRunPolicy: z.enum(["block", "allow"]).optional(),
+  activePreviousRunPolicy: z.enum(["block", "allow"]),
   allowClaimedOnceScheduleAutomation: z.boolean().optional(),
 });
 
@@ -55,7 +54,6 @@ const workflowQueueEventParamsWireSchema = z.object({
  */
 export interface WorkflowQueueEventParams {
   readonly version: 1;
-  readonly sessionId?: string;
   readonly prompt?: string;
   readonly appendSystemPrompt?: string;
   readonly callbacks?: readonly {
@@ -65,7 +63,7 @@ export interface WorkflowQueueEventParams {
   }[];
   readonly recordLastRunId?: boolean;
   readonly recordLastRunAt?: boolean;
-  readonly activePreviousRunPolicy?: "block" | "allow";
+  readonly activePreviousRunPolicy: "block" | "allow";
   readonly allowClaimedOnceScheduleAutomation?: boolean;
 }
 

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -70,7 +70,7 @@ function chatSessionModelFamily(model: string): string {
   return modelName.split(/[-_.]/, 1)[0] ?? modelName;
 }
 
-export function shouldStartNewChatSession(args: {
+function shouldStartNewChatSession(args: {
   readonly latestModel: string | null | undefined;
   readonly nextModel: string | null;
   readonly latestModelProvider?: string | null;
@@ -252,43 +252,4 @@ export async function resolveChatThreadSession(args: {
       conversationId: historical.conversationId,
     },
   };
-}
-
-export async function canReuseChatSessionForModelRoute(args: {
-  readonly db: Db | ReadonlyDb;
-  readonly threadId: string;
-  readonly sessionId: string;
-  readonly nextModel: string | null;
-  readonly nextModelProvider: string | null | undefined;
-  readonly nextCliAgentType: string | null | undefined;
-}): Promise<boolean> {
-  const [previous] = await args.db
-    .select({
-      selectedModel: zeroRuns.selectedModel,
-      modelProvider: zeroRuns.modelProvider,
-      cliAgentType: conversations.cliAgentType,
-    })
-    .from(agentRuns)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
-    .where(
-      and(
-        eq(zeroRuns.chatThreadId, args.threadId),
-        sql`${agentRuns.result}->>'agentSessionId' = ${args.sessionId}`,
-      ),
-    )
-    .orderBy(desc(agentRuns.createdAt))
-    .limit(1);
-  return (
-    !previous ||
-    !shouldStartNewChatSession({
-      latestModel: previous.selectedModel,
-      nextModel: args.nextModel,
-      latestModelProvider: previous.modelProvider,
-      nextModelProvider: args.nextModelProvider,
-      latestCliAgentType: previous.cliAgentType,
-      nextCliAgentType: args.nextCliAgentType,
-    })
-  );
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -7,7 +7,6 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
 import {
   chatMessages,
@@ -16,7 +15,6 @@ import {
   type ChatMessageStructuredPrompt,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { conversations } from "@vm0/db/schema/conversation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
@@ -111,7 +109,7 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
-import { shouldStartNewChatSession } from "./chat-session-continuity.service";
+import { resolveChatThreadSession } from "./chat-session-continuity.service";
 import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 import { resolveRunChatThreadModelContext } from "./zero-chat-run-message.service";
 import { releaseThreadBrowsersForRun$ } from "./zero-browser.service";
@@ -366,13 +364,6 @@ interface PriorRun {
   readonly messages: readonly PriorRunMessage[];
 }
 
-interface LatestThreadSession {
-  readonly sessionId: string;
-  readonly selectedModel: string | null;
-  readonly modelProvider: string | null;
-  readonly cliAgentType: string | null;
-}
-
 interface AgentForAutoSend {
   readonly id: string;
   readonly orgId: string;
@@ -498,7 +489,6 @@ interface CreateQueuedChatRunInput {
   readonly userId: string;
   readonly agentId: string;
   readonly prompt: string;
-  readonly sessionId: string | null;
   readonly appendSystemPrompt: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
@@ -657,7 +647,6 @@ function buildQueuedCreateZeroRunArgs(
     body: {
       prompt: input.prompt,
       agentId: input.agentId,
-      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
       ...(input.effectiveModelProvider
         ? { modelProvider: input.effectiveModelProvider }
         : {}),
@@ -1880,74 +1869,6 @@ async function chatThreadForRunFromDb(
   };
 }
 
-function hasAgentSessionId(
-  value: unknown,
-): value is { readonly agentSessionId: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "agentSessionId" in value &&
-    typeof (value as { readonly agentSessionId: unknown }).agentSessionId ===
-      "string"
-  );
-}
-
-async function latestSessionForThreadFromDb(
-  db: Db,
-  threadId: string,
-  triggerSource: "web" | "slack" | "feishu",
-): Promise<LatestThreadSession | null> {
-  const rows = await db
-    .select({
-      result: agentRuns.result,
-      selectedModel: zeroRuns.selectedModel,
-      modelProvider: zeroRuns.modelProvider,
-      cliAgentType: conversations.cliAgentType,
-    })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
-    .leftJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
-    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
-    // D7 session-continuity exclusion: Web and canonical Slack messages share
-    // the thread queue but keep independent source-specific session chains.
-    .where(
-      and(
-        eq(zeroRuns.chatThreadId, threadId),
-        eq(zeroRuns.triggerSource, triggerSource),
-      ),
-    )
-    .orderBy(desc(agentRuns.createdAt))
-    .limit(5);
-
-  for (const row of rows) {
-    if (hasAgentSessionId(row.result)) {
-      return {
-        sessionId: row.result.agentSessionId,
-        selectedModel: row.selectedModel,
-        modelProvider: row.modelProvider,
-        cliAgentType: row.cliAgentType,
-      };
-    }
-  }
-  return null;
-}
-
-function shouldStartNewSessionForQueuedMessage(params: {
-  readonly latestSession: LatestThreadSession | null;
-  readonly modelPin: ModelFirstPin;
-  readonly effectiveModelProvider: string | null | undefined;
-  readonly cliAgentType: string | null;
-}): boolean {
-  return shouldStartNewChatSession({
-    latestModel: params.latestSession?.selectedModel,
-    nextModel: params.modelPin.selectedModel,
-    latestModelProvider: params.latestSession?.modelProvider,
-    nextModelProvider: params.effectiveModelProvider,
-    latestCliAgentType: params.latestSession?.cliAgentType,
-    nextCliAgentType: params.cliAgentType,
-  });
-}
-
 async function loadAgentForAutoSend(
   db: Db,
   agentId: string,
@@ -2243,18 +2164,28 @@ interface CreateQueuedChatRunInputArgs {
   readonly timing?: ChatCallbackPreCreateTimingCollector;
 }
 
-function loadQueuedMessageSessionState(args: CreateQueuedChatRunInputArgs) {
+function loadQueuedMessageSessionState(
+  args: CreateQueuedChatRunInputArgs,
+  modelRoute: QueuedMessageModelRoute,
+) {
   return measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
     "nested",
     async () => {
-      const [latestSession, featureSwitchContext] = await Promise.all([
-        latestSessionForThreadFromDb(
-          args.db,
-          args.threadId,
-          args.queuedMessage.triggerSource,
-        ),
+      const [sessionResolution, featureSwitchContext] = await Promise.all([
+        resolveChatThreadSession({
+          db: args.db,
+          threadId: args.threadId,
+          userId: args.userId,
+          orgId: args.agent.orgId,
+          agentComposeId: args.agent.id,
+          route: {
+            selectedModel: modelRoute.modelPin.selectedModel,
+            modelProvider: modelRoute.effectiveModelProvider ?? null,
+            cliAgentType: modelRoute.cliAgentType,
+          },
+        }),
         loadUserFeatureSwitchContext(args.db, args.agent.orgId, args.userId),
       ]);
       const structuredPromptEnabled = isFeatureEnabled(
@@ -2269,7 +2200,11 @@ function loadQueuedMessageSessionState(args: CreateQueuedChatRunInputArgs) {
               structuredPromptEnabled,
             )
           : "";
-      return [latestSession, incompleteContext, featureSwitchContext] as const;
+      return [
+        sessionResolution.action === "rotated",
+        incompleteContext,
+        featureSwitchContext,
+      ] as const;
     },
   );
 }
@@ -2350,8 +2285,8 @@ async function buildCreateQueuedChatRunInput(
   }
   const modelRoute = modelRouteResolution.route;
 
-  const [latestSession, loadedIncompleteContext, featureSwitchContext] =
-    await loadQueuedMessageSessionState(args);
+  const [startNewSession, loadedIncompleteContext, featureSwitchContext] =
+    await loadQueuedMessageSessionState(args, modelRoute);
   const structuredPromptEnabled = isFeatureEnabled(
     FeatureSwitchKey.StructuredPrompt,
     featureSwitchContext,
@@ -2360,12 +2295,6 @@ async function buildCreateQueuedChatRunInput(
     structuredPromptEnabled && args.queuedMessage.structuredPrompt
       ? projectStructuredUserMessage(args.queuedMessage.structuredPrompt)
       : undefined;
-  const startNewSession = shouldStartNewSessionForQueuedMessage({
-    latestSession,
-    modelPin: modelRoute.modelPin,
-    effectiveModelProvider: modelRoute.effectiveModelProvider,
-    cliAgentType: modelRoute.cliAgentType,
-  });
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,
@@ -2422,7 +2351,6 @@ async function buildCreateQueuedChatRunInput(
     userId: args.userId,
     agentId: args.agent.id,
     prompt,
-    sessionId: startNewSession ? null : (latestSession?.sessionId ?? null),
     appendSystemPrompt: buildAppendSystemPrompt(
       sourceParams?.appendSystemPrompt ?? buildWebChatPrompt(),
       incompleteContext,

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -8,10 +8,8 @@ import {
   isSupportedRunModel,
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { agentSessions } from "@vm0/db/schema/agent-session";
 import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
-import { feishuOrgThreadSessions } from "@vm0/db/schema/feishu-org-thread-session";
 import { feishuUserAgentPreferences } from "@vm0/db/schema/feishu-user-agent-preference";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
@@ -42,7 +40,6 @@ import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
 } from "./integration-model-route.service";
-import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import { publishFeishuOrgChanged } from "./zero-feishu-realtime.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
@@ -347,53 +344,6 @@ function sessionKey(message: FeishuInboundMessage): string {
   const threadKey =
     message.rootId ?? message.threadId ?? message.parentId ?? message.messageId;
   return `${message.chatId}:${threadKey}`;
-}
-
-async function resolveSession(args: {
-  readonly db: Db;
-  readonly connectionId: string;
-  readonly sessionKey: string;
-  readonly userId: string;
-  readonly agentId: string;
-  readonly modelRoute: IntegrationModelRoutePin | undefined;
-}): Promise<string | undefined> {
-  const [thread] = await args.db
-    .select({ agentSessionId: feishuOrgThreadSessions.agentSessionId })
-    .from(feishuOrgThreadSessions)
-    .where(
-      and(
-        eq(feishuOrgThreadSessions.connectionId, args.connectionId),
-        eq(feishuOrgThreadSessions.feishuChatId, args.sessionKey),
-      ),
-    )
-    .limit(1);
-  if (!thread?.agentSessionId) {
-    return undefined;
-  }
-  const [session] = await args.db
-    .select({ agentComposeId: agentSessions.agentComposeId })
-    .from(agentSessions)
-    .where(
-      and(
-        eq(agentSessions.id, thread.agentSessionId),
-        eq(agentSessions.userId, args.userId),
-      ),
-    )
-    .limit(1);
-  if (session?.agentComposeId !== args.agentId) {
-    return undefined;
-  }
-  if (
-    args.modelRoute &&
-    !(await canReuseIntegrationSessionForModelRoute({
-      db: args.db,
-      sessionId: thread.agentSessionId,
-      modelRoute: args.modelRoute,
-    }))
-  ) {
-    return undefined;
-  }
-  return thread.agentSessionId;
 }
 
 export function feishuPromptFile(args: {
@@ -1054,7 +1004,6 @@ const runFeishuAgent$ = command(
       readonly connection: FeishuDispatchConnection;
       readonly message: FeishuInboundMessage;
       readonly agent: FeishuAgent;
-      readonly sessionId: string | undefined;
       readonly sessionKey: string;
       readonly history: FeishuPromptContext;
       readonly modelRoute: IntegrationModelRoutePin | undefined;
@@ -1074,7 +1023,6 @@ const runFeishuAgent$ = command(
         body: {
           prompt: args.message.text,
           agentId: args.agent.id,
-          sessionId: args.sessionId,
           ...(args.modelRoute
             ? { modelProvider: args.modelRoute.modelProviderType }
             : {}),
@@ -1105,7 +1053,6 @@ const runFeishuAgent$ = command(
               connectionId: args.connection.id,
               sessionKey: args.sessionKey,
               agentId: args.agent.id,
-              existingSessionId: args.sessionId,
               reactionId: args.reactionId,
               replyInThread: args.message.chatType !== "p2p",
               files: [
@@ -1199,23 +1146,13 @@ const prepareFeishuRun$ = command(
       signal,
     );
     const key = sessionKey(args.message);
-    const [history, sessionId] = await Promise.all([
-      loadFeishuConversationHistory({
-        db: args.db,
-        message: args.message,
-        signal,
-      }),
-      resolveSession({
-        db: args.db,
-        connectionId: args.connection.id,
-        sessionKey: key,
-        userId: args.connection.vm0UserId,
-        agentId: args.agentId,
-        modelRoute,
-      }),
-    ]);
+    const history = await loadFeishuConversationHistory({
+      db: args.db,
+      message: args.message,
+      signal,
+    });
     signal.throwIfAborted();
-    return { modelRoute, key, history, sessionId };
+    return { modelRoute, key, history };
   },
 );
 
@@ -1299,7 +1236,6 @@ const dispatchConnectedFeishuMessage$ = command(
           connection: args.connection,
           message: args.message,
           agent: effectiveAgent.agent,
-          sessionId: prepared.sessionId,
           sessionKey: prepared.key,
           history: prepared.history,
           modelRoute: prepared.modelRoute,

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
-import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
@@ -14,7 +14,6 @@ import {
   postRunUserMessage,
   resolveRunChatThreadModelContext,
 } from "./zero-chat-run-message.service";
-import { canReuseChatSessionForModelRoute } from "./chat-session-continuity.service";
 import { hasUnclaimedQueuedUserMessage } from "./zero-chat-queued-message.service";
 import {
   pauseActiveGoalForThread,
@@ -92,18 +91,6 @@ function isTerminalStatus(status: string): status is TerminalRunStatus {
     status === "timeout" ||
     status === "cancelled"
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function agentSessionIdFromResult(result: unknown): string | null {
-  if (!isRecord(result)) {
-    return null;
-  }
-  const agentSessionId = result.agentSessionId;
-  return typeof agentSessionId === "string" ? agentSessionId : null;
 }
 
 function failureMessage(error: RunGoalResult): string {
@@ -187,29 +174,6 @@ async function threadIsIdle(db: Db, chatThreadId: string): Promise<boolean> {
   return activeRun === undefined;
 }
 
-async function latestSessionIdForThread(
-  db: Db,
-  chatThreadId: string,
-): Promise<string | undefined> {
-  const rows = await db
-    .select({ result: agentRuns.result })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(
-      and(eq(zeroRuns.chatThreadId, chatThreadId), isNotNull(agentRuns.result)),
-    )
-    .orderBy(desc(agentRuns.createdAt))
-    .limit(10);
-
-  for (const row of rows) {
-    const sessionId = agentSessionIdFromResult(row.result);
-    if (sessionId) {
-      return sessionId;
-    }
-  }
-  return undefined;
-}
-
 function buildGoalChatCallbacks(args: {
   readonly threadId: string;
   readonly agentId: string;
@@ -277,7 +241,6 @@ const runGoalNow$ = command(
     { set },
     args: {
       readonly goal: GoalBootstrap;
-      readonly sessionId?: string;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
     },
     signal: AbortSignal,
@@ -297,19 +260,6 @@ const runGoalNow$ = command(
     }
     const { modelPin, effectiveModelProvider, cliAgentType, codexServiceTier } =
       modelContext;
-    const sessionId =
-      args.sessionId &&
-      (await canReuseChatSessionForModelRoute({
-        db,
-        threadId: goal.threadId,
-        sessionId: args.sessionId,
-        nextModel: modelPin.selectedModel,
-        nextModelProvider: effectiveModelProvider,
-        nextCliAgentType: cliAgentType,
-      }))
-        ? args.sessionId
-        : undefined;
-    signal.throwIfAborted();
 
     const normalizedGoal = {
       ...goal,
@@ -331,7 +281,6 @@ const runGoalNow$ = command(
         body: {
           prompt,
           agentId: goal.agentId,
-          ...(sessionId ? { sessionId } : {}),
           ...(effectiveModelProvider
             ? { modelProvider: effectiveModelProvider }
             : {}),
@@ -441,8 +390,6 @@ export const continueGoalIfIdle$ = command(
     }
     signal.throwIfAborted();
 
-    const sessionId = await latestSessionIdForThread(db, run.chatThreadId);
-    signal.throwIfAborted();
     const runResult = await set(
       runGoalNow$,
       {
@@ -455,7 +402,6 @@ export const continueGoalIfIdle$ = command(
           objective: goal.objective,
           objectiveBrief: goal.objectiveBrief,
         },
-        ...(sessionId ? { sessionId } : {}),
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },
       signal,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -79,7 +79,6 @@ type ModelContext =
 export interface RunWorkflowAutomationNowArgs {
   readonly due: DueWorkflowAutomation;
   readonly apiStartTime: number;
-  readonly sessionId?: string;
   // Overrides the default `/<workflowName>` slash-command prompt.
   readonly prompt?: string;
   // Display-only source context surfaced through workflowSnapshot.triggerBrief.
@@ -525,7 +524,6 @@ export const launchQueuedWorkflowAutomation$ = command(
         body: {
           prompt: runInput.prompt,
           agentId,
-          ...(args.sessionId ? { sessionId: args.sessionId } : {}),
           ...(effectiveModelProvider
             ? { modelProvider: effectiveModelProvider }
             : {}),

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -30,7 +30,6 @@ function queueEventParams(
 ): WorkflowQueueEventParams {
   return {
     version: 1,
-    ...(args.sessionId ? { sessionId: args.sessionId } : {}),
     ...(args.prompt !== undefined ? { prompt: args.prompt } : {}),
     ...(args.appendSystemPrompt !== undefined
       ? { appendSystemPrompt: args.appendSystemPrompt }

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -17,7 +17,6 @@ import {
   loadNextWorkflowQueueEvent,
   pauseWorkflowQueueEventAfterRunFailure,
   type PendingWorkflowQueueEvent,
-  type WorkflowQueueEventParams,
 } from "./chat-message-queue.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import {
@@ -85,29 +84,6 @@ interface DrainWorkflowQueueArgs {
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
   readonly queueItemCreatedBefore?: Date;
   readonly workflowEventLaunch?: WorkflowEventLaunch;
-}
-
-function allowClaimedOnceScheduleAutomation(
-  target: DequeueTarget,
-  params: WorkflowQueueEventParams,
-): boolean | undefined {
-  if (params.allowClaimedOnceScheduleAutomation !== undefined) {
-    return params.allowClaimedOnceScheduleAutomation;
-  }
-
-  const automation = target.automation;
-  if (
-    automation.kind === "schedule" &&
-    automation.scheduleType === "once" &&
-    !automation.enabled &&
-    automation.nextRunAt === null &&
-    automation.lastRunAt !== null
-  ) {
-    // Previous writers disabled a claimed one-time automation before inserting
-    // its v1 queue payload, which did not carry the explicit claim marker.
-    return true;
-  }
-  return undefined;
 }
 
 const CONTINUE_DRAIN = Symbol("continue-workflow-queue-drain");
@@ -278,19 +254,16 @@ export const drainWorkflowQueueForThread$ = command(
             workflowName: target.workflowName,
             chatThreadId: event.chatThreadId,
             allowClaimedOnceScheduleAutomation:
-              allowClaimedOnceScheduleAutomation(target, params),
+              params.allowClaimedOnceScheduleAutomation,
           },
           queueEventId: event.id,
           apiStartTime: launchHint?.apiStartTime ?? now(),
-          sessionId: params.sessionId,
           prompt: params.prompt,
           triggerBrief: event.triggerBrief ?? undefined,
           triggerSource: triggerSource.success ? triggerSource.data : undefined,
           appendSystemPrompt: params.appendSystemPrompt,
           callbacks: params.callbacks,
-          // Rows written before queue-first ingress always dequeued with
-          // "allow"; new rows persist their caller policy explicitly.
-          activePreviousRunPolicy: params.activePreviousRunPolicy ?? "allow",
+          activePreviousRunPolicy: params.activePreviousRunPolicy,
           recordLastRunId: params.recordLastRunId,
           recordLastRunAt: params.recordLastRunAt,
           dispatchFailedCallbacks: args.dispatchFailedCallbacks,

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -2,17 +2,12 @@ import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
-import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { and, count, eq, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
 import { nowDate } from "../lib/time";
-import {
-  decryptPersistentSecretsMap,
-  encryptPersistentSecretsMap,
-} from "../signals/services/crypto.utils";
 import { insertChatMessage } from "../signals/services/zero-chat-message.service";
 import { createDeferredPromise } from "../signals/utils";
 
@@ -27,15 +22,6 @@ const VM0_BDD_API_KEY_PREFIXES = [
 ] as const;
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
-const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
-const previousWorkflowQueueEventParamsSchema = z.object({
-  version: z.literal(1),
-  prompt: z.string().optional(),
-  appendSystemPrompt: z.string().optional(),
-  callbacks: z.array(z.unknown()).optional(),
-  recordLastRunId: z.boolean().optional(),
-  recordLastRunAt: z.boolean().optional(),
-});
 
 /**
  * Move one exact workflow event into historical state without waiting for real
@@ -99,87 +85,6 @@ export async function completeRunWithoutCallbacksFixture(args: {
   if (updated.length !== 1) {
     throw new Error("Expected one running run to complete without callbacks");
   }
-}
-
-/**
- * Rewrites one current workflow event to the persisted shape and automation
- * state produced by the previous API version.
- *
- * Why product APIs cannot construct this state: the current writer always
- * includes its new v1 fields and keeps a claimed one-time automation enabled
- * until final run claim. This fixture is limited to one exact queue event and
- * one exact one-time automation so the cross-version reader path can be tested.
- */
-export async function rewriteWorkflowQueueEventAsPreviousVersionFixture(args: {
-  readonly eventId: string;
-  readonly automationId: string;
-}): Promise<void> {
-  const [event] = await db()
-    .select({
-      orgId: chatMessageQueue.orgId,
-      userId: chatMessageQueue.userId,
-      encryptedParams: chatMessageQueue.encryptedParams,
-    })
-    .from(chatMessageQueue)
-    .where(
-      and(
-        eq(chatMessageQueue.id, args.eventId),
-        eq(chatMessageQueue.automationId, args.automationId),
-        eq(chatMessageQueue.itemType, "workflow_event"),
-      ),
-    )
-    .limit(1);
-  if (!event?.encryptedParams) {
-    throw new Error("Expected a persisted workflow queue event");
-  }
-
-  const ctx = { orgId: event.orgId, userId: event.userId };
-  const decrypted = await decryptPersistentSecretsMap(
-    event.encryptedParams,
-    ctx,
-  );
-  const raw = decrypted?.[WORKFLOW_QUEUE_EVENT_PARAMS_KEY];
-  if (!raw) {
-    throw new Error("Expected workflow queue event params");
-  }
-  const previousParams = previousWorkflowQueueEventParamsSchema.parse(
-    JSON.parse(raw) as unknown,
-  );
-  const encryptedParams = await encryptPersistentSecretsMap(
-    { [WORKFLOW_QUEUE_EVENT_PARAMS_KEY]: JSON.stringify(previousParams) },
-    ctx,
-  );
-  if (!encryptedParams) {
-    throw new Error("Failed to encrypt previous workflow queue event params");
-  }
-
-  await db().transaction(async (tx) => {
-    const rewritten = await tx
-      .update(chatMessageQueue)
-      .set({ encryptedParams })
-      .where(
-        and(
-          eq(chatMessageQueue.id, args.eventId),
-          eq(chatMessageQueue.automationId, args.automationId),
-          eq(chatMessageQueue.itemType, "workflow_event"),
-        ),
-      )
-      .returning({ id: chatMessageQueue.id });
-    const disabled = await tx
-      .update(zeroWorkflowAutomations)
-      .set({ enabled: false })
-      .where(
-        and(
-          eq(zeroWorkflowAutomations.id, args.automationId),
-          eq(zeroWorkflowAutomations.kind, "schedule"),
-          eq(zeroWorkflowAutomations.scheduleType, "once"),
-        ),
-      )
-      .returning({ id: zeroWorkflowAutomations.id });
-    if (rewritten.length !== 1 || disabled.length !== 1) {
-      throw new Error("Failed to reproduce previous workflow queue state");
-    }
-  });
 }
 
 async function transitiveBlockedWaiterCount(


### PR DESCRIPTION
## Summary

- Remove source-specific session history scans and run-body session hints from web, queued chat callbacks, goal continuation, and Feishu dispatch. Canonical chat-thread resolution at final admission remains the single owner.
- Remove expired workflow queue payload compatibility for embedded sessions, missing active-run policy, and inferred one-time schedule claims while preserving queue ordering and drain behavior.
- Retire the previous-version queue fixture while retaining canonical-session drain coverage.

This is the focused Stage 3 cleanup for #23102 after canonical reads and lazy adoption were deployed and accepted in production.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip`
- `zero-workflow-queue.test.ts`: 14 passed
- Focused web/callback continuity cases: 6 passed
- Focused Slack/Feishu canonical-session cases: 3 passed
- Feishu dispatch follow-up: 2 passed

The local lefthook binary was unavailable, so its relevant checks were run explicitly above. Full Vitest was intentionally not run; affected tests were targeted per repository guidance.