### PR TITLE
fix(platform): suppress browser network failure toasts

### DIFF
--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -39,9 +39,20 @@ function requestErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Request failed";
 }
 
+function isNetworkRequestError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    (error.message === "Failed to fetch" ||
+      error.message === "Load failed" ||
+      error.message.startsWith("NetworkError"))
+  );
+}
+
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
  * Otherwise shows a toast and throws an `ApiError`.
+ *
+ * Browser network failures propagate without showing their raw error message.
  *
  * When `signal` is provided, a rejection after that signal aborts propagates
  * as cancellation without showing a toast.
@@ -57,7 +68,9 @@ async function accept<
   const result = await onRejection(promise, (error) => {
     if (!isAbortError(error)) {
       signal?.throwIfAborted();
-      toast.error(requestErrorMessage(error));
+      if (!isNetworkRequestError(error)) {
+        toast.error(requestErrorMessage(error));
+      }
     }
   });
   if ((codes as number[]).includes(result.status)) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -374,7 +374,7 @@ describe("personal model providers settings", () => {
     });
   });
 
-  it("keeps Claude Code validation inline and toasts unexpected errors", async () => {
+  it("keeps Claude Code validation inline and suppresses transport error toasts", async () => {
     context.mocks.data.org({
       id: "org_1",
       slug: "test-org",
@@ -448,12 +448,10 @@ describe("personal model providers settings", () => {
       },
     );
     click(submit);
-    await expect(
-      screen.findByText("Failed to fetch"),
-    ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(submit).toBeEnabled();
     });
+    expect(screen.queryByText("Failed to fetch")).not.toBeInTheDocument();
   });
 
   it("shows available subscription details in the connected status", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -2187,12 +2187,10 @@ describe("connectors page", () => {
 
     click(buttonByText("Connect Stripe", dialog));
     click(await within(dialog).findByTestId("connector-oauth-device-open"));
-    await expect(
-      screen.findByText("Failed to fetch"),
-    ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(buttonByText("Connect Stripe", dialog)).toBeEnabled();
     });
+    expect(screen.queryByText("Failed to fetch")).not.toBeInTheDocument();
   });
 
   it("connects a manual token connector", async () => {
@@ -2842,7 +2840,7 @@ describe("connectors page", () => {
     });
   });
 
-  it("toasts external-code transport errors and restores a retryable state", async () => {
+  it("suppresses external-code transport error toasts and restores a retryable state", async () => {
     context.mocks.http.post(
       "*/api/zero/connectors/aws/external-code/sessions/:sessionId/complete",
       () => {
@@ -2852,12 +2850,10 @@ describe("connectors page", () => {
 
     const { complete } = await setupAwsExternalCodeConnection();
     click(complete);
-    await expect(
-      screen.findByText("Failed to fetch"),
-    ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(complete).toBeEnabled();
     });
+    expect(screen.queryByText("Failed to fetch")).not.toBeInTheDocument();
   });
 
   it("uses auth method help text for PlayStation external-code connection", async () => {


### PR DESCRIPTION
## Summary

- suppress raw browser transport error toasts from the shared platform `accept()` helper
- cover Chrome (`Failed to fetch`), Safari (`Load failed`), and Firefox (`NetworkError...`) fetch failures
- keep propagating network errors so caller retry and recovery behavior remains unchanged
- preserve existing toasts for HTTP error responses and non-network request failures

## User impact

Users no longer see low-level browser messages when an API request cannot reach the network. Product-specific HTTP errors remain visible, and affected flows still return to their existing retryable states.

## Verification

- `pnpm exec prettier --write apps/platform/src/lib/accept.ts apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/personal-providers-tab.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=1` — 60 tests passed
