### PR TITLE
test(api): isolate usage settlement across workers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1686,7 +1686,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     const billing = createBillingMediaApi(context);
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     let usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(1);
@@ -1736,7 +1736,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     mockNow(new Date("2030-01-01T00:00:00.000Z"));
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toStrictEqual([usageMessage]);
 
@@ -1758,7 +1758,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     mockNow(new Date("2030-01-01T00:00:01.000Z"));
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toStrictEqual([usageMessage]);
   }, 60_000);
@@ -1830,7 +1830,7 @@ describe("CHAT-03 run usage messages", () => {
       sandboxHeaders,
       [200],
     );
-    await createBillingMediaApi(context).processUsageEvents();
+    await createBillingMediaApi(context).processOrgUsageEvents(actor);
 
     const usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type StripeSDK from "stripe";
-import { cronProcessUsageEventsContract } from "@vm0/api-contracts/contracts/cron";
+import { testUsageSettlementContract } from "@vm0/api-contracts/contracts/test-usage-settlement";
 import { usageContract } from "@vm0/api-contracts/contracts/usage";
 import { zeroAttributionContract } from "@vm0/api-contracts/contracts/zero-attribution";
 import { zeroBankingContract } from "@vm0/api-contracts/contracts/zero-banking";
@@ -54,6 +54,7 @@ import {
   mockStripeClient,
 } from "../../../external/stripe-client";
 import { modelStatsContract } from "../../model-stats";
+import { testUsageSettlementRoutes } from "../../test-usage-settlement";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -110,10 +111,6 @@ interface AutoRechargeUpdateBody {
   readonly enabled: boolean;
   readonly threshold?: number;
   readonly amount?: number;
-}
-
-interface CronHeaders {
-  readonly authorization: string;
 }
 
 type CheckoutStatus = 200 | 400 | 401 | 403 | 500 | 503;
@@ -211,10 +208,6 @@ function stripeInvoices(value: unknown): readonly StripeInvoice[] {
       typeof invoice.amount_paid === "number"
     );
   });
-}
-
-function cronHeaders(): CronHeaders {
-  return { authorization: "Bearer test-cron-secret" };
 }
 
 export function createBillingMediaApi(context: TestContext) {
@@ -543,9 +536,18 @@ export function createBillingMediaApi(context: TestContext) {
       );
     },
 
-    async processUsageEvents() {
-      const client = setupApp({ context })(cronProcessUsageEventsContract);
-      return await accept(client.process({ headers: cronHeaders() }), [200]);
+    async processOrgUsageEvents(actor: ApiTestUser) {
+      if (!actor.orgId) {
+        throw new Error("Cannot process usage without an organization");
+      }
+      const client = setupApp({
+        context,
+        routes: testUsageSettlementRoutes,
+      })(testUsageSettlementContract);
+      return await accept(
+        client.process({ body: { org_id: actor.orgId } }),
+        [200],
+      );
     },
 
     async recordSignupAttribution(actor: ApiTestUser) {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10114,7 +10114,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
       { authorization: `Bearer ${claim.sandboxToken}` },
       [200],
     );
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     const usageRuns = await billing.readUsageRuns(actor, [200]);
     if (usageRuns.status !== 200) {
@@ -10160,7 +10160,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
       sandboxHeaders,
       [200],
     );
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     const usageRuns = await billing.readUsageRuns(actor, [200]);
     if (usageRuns.status !== 200) {
@@ -10278,7 +10278,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
       { authorization: `Bearer ${memberClaim.sandboxToken}` },
       [200],
     );
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     const aggregated = await billing.readUsageMembers(actor, {
       range: "7d",

--- a/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
@@ -1,0 +1,30 @@
+import { testUsageSettlementContract } from "@vm0/api-contracts/contracts/test-usage-settlement";
+
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
+import { testUsageSettlementRoutes } from "../test-usage-settlement";
+
+const context = testContext();
+
+describe("POST /api/test/usage-settlement/process", () => {
+  it("returns 404 when the test endpoint is not allowed", async () => {
+    mockEnv("ENV", "production");
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: testUsageSettlementRoutes,
+    });
+
+    const response = await app.request(
+      testUsageSettlementContract.process.path,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ org_id: "org_test" }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -198,8 +198,8 @@ async function recordPendingUsage(args: {
   });
 }
 
-async function processUsageEvents(): Promise<void> {
-  await createBillingMediaApi(context).processUsageEvents();
+async function processOrgUsageEvents(actor: ApiTestUser): Promise<void> {
+  await createBillingMediaApi(context).processOrgUsageEvents(actor);
 }
 
 async function readOrgCredits(actor: ApiTestUser): Promise<number> {
@@ -241,9 +241,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    // Another Vitest worker can settle this org through the shared test DB, so
-    // verify persisted billing behavior instead of a worker-local Ably mock.
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(10);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -270,7 +268,7 @@ describe("Usage Allowance", () => {
       quantity: 50,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(70);
     await expect(readRunCreditsCharged(actor, firstRun.runId)).resolves.toBe(
@@ -306,7 +304,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(80);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -334,7 +332,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 100,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     mockNow(addHours(startedAt, 1));
     const secondRun = await createVm0Run(actor, agentId, "same short window");
@@ -344,7 +342,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(50);
     await expect(readRunCreditsCharged(actor, firstRun.runId)).resolves.toBe(
@@ -377,7 +375,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 100,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     mockNow(addHours(startedAt, 6));
     const secondRun = await createVm0Run(actor, agentId, "fresh short window");
@@ -387,7 +385,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, secondRun.runId)).resolves.toBe(
@@ -413,7 +411,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 80,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     mockNow(addDays(startedAt, 8));
     const secondRun = await createVm0Run(actor, agentId, "fresh weekly window");
@@ -423,7 +421,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     // A continued weekly window would only have 40 units left (120 - 80), so
     // full coverage of the 50-unit event proves the weekly window refreshed.
@@ -454,7 +452,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 10,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(10);
   });
 
@@ -476,7 +474,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 1,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     const rejected = await api.requestCreateRun(
       actor,
@@ -521,7 +519,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 2,
     });
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     const denied = await accept(client.resolve({ headers, body }), [402]);
     expect(denied.body.error.code).toBe("INSUFFICIENT_CREDITS");
@@ -563,7 +561,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -593,7 +591,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -620,7 +618,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(20);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -653,7 +651,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -687,7 +685,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processOrgUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(20);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -159,9 +159,9 @@ async function reportRunUsage(
   );
 }
 
-async function processPendingUsage(): Promise<void> {
+async function processPendingUsage(actor: ApiTestUser): Promise<void> {
   const billing = createBillingMediaApi(context);
-  await billing.processUsageEvents();
+  await billing.processOrgUsageEvents(actor);
 }
 
 /**
@@ -295,7 +295,7 @@ describe("GET /api/zero/usage/insight", () => {
       { kind: "model", category: "tokens.input", quantity: 1000, credits: 100 },
       { kind: "model", category: "tokens.output", quantity: 500, credits: 0 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
     authenticateInsightActor(actor);
 
     const response = await accept(
@@ -332,7 +332,7 @@ describe("GET /api/zero/usage/insight", () => {
         { kind: "connector", category: "call", quantity: 1, credits: 50 },
       ]);
     }
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(
@@ -375,7 +375,7 @@ describe("GET /api/zero/usage/insight", () => {
         },
       ]);
     }
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(
@@ -403,7 +403,7 @@ describe("GET /api/zero/usage/insight", () => {
     await reportRunUsage(actor, runId, [
       { kind: "connector", category: "call", quantity: 1, credits: 10 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(
@@ -427,7 +427,7 @@ describe("GET /api/zero/usage/insight", () => {
     await reportRunUsage(actor, runId, [
       { kind: "connector", category: "call", quantity: 1, credits: 42 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
     const selectedDate = nowDate().toISOString().split("T")[0];
     expect(selectedDate).toBeDefined();
 
@@ -524,7 +524,7 @@ describe("GET /api/zero/usage/insight", () => {
       { kind: "model", category: "tokens.input", quantity: 999, credits: 999 },
       { kind: "connector", category: "tweet.read", quantity: 1, credits: 999 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(
@@ -557,7 +557,7 @@ describe("GET /api/zero/usage/insight", () => {
         credits: 4,
       },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
     // Reported after processing and never settled: pending rows must stay
     // out of every total.
     await reportRunUsage(actor, runId, [
@@ -594,7 +594,7 @@ describe("GET /api/zero/usage/insight", () => {
       { kind: "connector", category: "tweet.read", quantity: 1, credits: 40 },
       { kind: "model", category: "tokens.output", quantity: 15, credits: 5 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(
@@ -649,7 +649,7 @@ describe("GET /api/zero/usage/insight", () => {
     await reportRunUsage(actor, sent.body.runId, [
       { kind: "connector", category: "call", quantity: 1, credits: 225 },
     ]);
-    await processPendingUsage();
+    await processPendingUsage(actor);
 
     authenticateInsightActor(actor);
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -379,7 +379,7 @@ describe("GET /api/zero/usage/record", () => {
       25,
     );
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const response = await accept(
@@ -449,7 +449,7 @@ describe("GET /api/zero/usage/record", () => {
       );
     }
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const response = await accept(
@@ -512,7 +512,7 @@ describe("GET /api/zero/usage/record", () => {
     );
     await recordImageUsage(fixture.actor, deletedNewer.runId, imageProvider, 1);
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     await chatApi.deleteThread(fixture.actor, deletedOlder.threadId);
     await chatApi.deleteThread(fixture.actor, deletedNewer.threadId);
 
@@ -584,7 +584,7 @@ describe("GET /api/zero/usage/record", () => {
       12,
     );
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const slackResponse = await accept(
@@ -628,7 +628,7 @@ describe("GET /api/zero/usage/record", () => {
       output: 5,
     });
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const response = await accept(
@@ -669,7 +669,7 @@ describe("GET /api/zero/usage/record", () => {
       );
     }
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const response = await accept(
@@ -707,7 +707,7 @@ describe("GET /api/zero/usage/record", () => {
     await recordImageUsage(fixture.actor, run.runId, imageProvider, 4);
     await recordConnectorUsage(fixture.actor, run.runId, connectorProvider, 2);
 
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(fixture.actor);
     mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-runs.test.ts
@@ -288,7 +288,7 @@ describe("GET /api/zero/usage/runs", () => {
       input: 2000,
       output: 1000,
     });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -325,7 +325,7 @@ describe("GET /api/zero/usage/runs", () => {
       input: 999,
       output: 999,
     });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -397,7 +397,7 @@ describe("GET /api/zero/usage/runs", () => {
       input: 100,
       output: 50,
     });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(otherActor);
 
     mockClerkUserLookup();
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
@@ -429,7 +429,7 @@ describe("GET /api/zero/usage/runs", () => {
         output: (index + 1) * 10,
       });
     }
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -473,7 +473,7 @@ describe("GET /api/zero/usage/runs", () => {
     });
     await recordModelUsage(actor, actorRun.runId, model, { output: 50 });
     await recordModelUsage(member, memberRun.runId, model, { output: 100 });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -504,7 +504,7 @@ describe("GET /api/zero/usage/runs", () => {
     });
     await recordModelUsage(actor, included.runId, model, { output: 50 });
     await recordModelUsage(actor, excluded.runId, model, { output: 100 });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -547,7 +547,7 @@ describe("GET /api/zero/usage/runs", () => {
     for (const run of [before, inside, endBoundary, after]) {
       await recordModelUsage(actor, run.runId, model, { output: 50 });
     }
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -580,7 +580,7 @@ describe("GET /api/zero/usage/runs", () => {
       createdAt: createdAt(2),
     });
     await recordModelUsage(actor, processed.runId, model, { output: 50 });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     const pending = await createBillableRun(actor, {
       createdAt: createdAt(1),
@@ -600,6 +600,38 @@ describe("GET /api/zero/usage/runs", () => {
     expect(response.body.runs[0]?.creditsCharged).toBe(50);
   });
 
+  it("processes usage events only for the requested organization", async () => {
+    const actor = await entitledUsageActor();
+    const otherActor = await entitledUsageActor();
+    const model = uniqueModelName();
+    await seedModelPricing(model);
+
+    const run = await createBillableRun(actor);
+    const otherRun = await createBillableRun(otherActor);
+    await recordModelUsage(actor, run.runId, model, { output: 50 });
+    await recordModelUsage(otherActor, otherRun.runId, model, { output: 100 });
+
+    await billing.processOrgUsageEvents(actor);
+
+    const response = await billing.readUsageRuns(actor, [200]);
+    const otherResponse = await billing.readUsageRuns(otherActor, [200]);
+
+    await billing.processOrgUsageEvents(otherActor);
+
+    if (response.status !== 200 || otherResponse.status !== 200) {
+      throw new Error("Expected usage runs reads to succeed");
+    }
+    expect(response.body.runs).toHaveLength(1);
+    expect(response.body.runs[0]).toMatchObject({
+      runId: run.runId,
+      creditsCharged: 50,
+    });
+    expect(otherResponse.body).toStrictEqual({
+      runs: [],
+      pagination: { page: 1, pageSize: 20, total: 0 },
+    });
+  });
+
   // Run-less usage events (built-in generation charges without a run) are
   // exercised through their own product surfaces in zero-image-io-generate
   // tests; the agent usage-event webhook always requires a run.
@@ -613,7 +645,7 @@ describe("GET /api/zero/usage/runs", () => {
     const run = await createBillableRun(actor);
     await recordModelUsage(actor, run.runId, model, { input: 300 });
     await recordConnectorUsage(actor, run.runId, connectorProvider, 2);
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     mockClerkUserLookup();
     mocks.clerk.session(actor.userId, actor.orgId);
@@ -653,7 +685,7 @@ describe("GET /api/zero/usage/runs", () => {
       cacheRead: 11,
       cacheCreation: 13,
     });
-    await billing.processUsageEvents();
+    await billing.processOrgUsageEvents(actor);
 
     // A later, still-pending event must not contribute to the totals.
     await recordModelUsage(actor, run.runId, model, { input: 9999 });

--- a/turbo/apps/api/src/signals/routes/test-usage-settlement.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-settlement.ts
@@ -1,0 +1,38 @@
+import { testUsageSettlementContract } from "@vm0/api-contracts/contracts/test-usage-settlement";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { processOrgUsageEvents$ } from "../services/zero-credit-usage.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const body$ = bodyResultOf(testUsageSettlementContract.process);
+
+const processUsageSettlement$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    await set(processOrgUsageEvents$, bodyResult.data.org_id, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body: { ok: true as const } };
+  },
+);
+
+export const testUsageSettlementRoutes: readonly RouteEntry[] = [
+  {
+    route: testUsageSettlementContract.process,
+    handler: processUsageSettlement$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -369,6 +369,14 @@ export {
   type TestUsageInsightStateFixture,
 } from "./test-usage-insight-state";
 export {
+  testUsageSettlementContract,
+  testUsageSettlementRequestSchema,
+  testUsageSettlementResponseSchema,
+  type TestUsageSettlementContract,
+  type TestUsageSettlementRequest,
+  type TestUsageSettlementResponse,
+} from "./test-usage-settlement";
+export {
   testCronCleanupSandboxesStateActionBodySchema,
   testCronCleanupSandboxesStateActionResponseSchema,
   testCronCleanupSandboxesStateContract,

--- a/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-usage-settlement.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testUsageSettlementRequestSchema = z.object({
+  org_id: z.string().min(1),
+});
+
+export const testUsageSettlementResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const testUsageSettlementContract = c.router({
+  process: {
+    method: "POST",
+    path: "/api/test/usage-settlement/process",
+    body: testUsageSettlementRequestSchema,
+    responses: {
+      200: testUsageSettlementResponseSchema,
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Process one organization's usage in API tests",
+  },
+});
+
+export type TestUsageSettlementRequest = z.infer<
+  typeof testUsageSettlementRequestSchema
+>;
+export type TestUsageSettlementResponse = z.infer<
+  typeof testUsageSettlementResponseSchema
+>;
+export type TestUsageSettlementContract = typeof testUsageSettlementContract;


### PR DESCRIPTION
## Summary

- add a guarded, explicitly mounted test API that settles usage for exactly one organization through the existing production settlement command
- migrate fixture-owned usage tests away from the global all-organization cron sweep
- add deterministic cross-organization isolation coverage and production-denial coverage for the test endpoint

## Scope

- production cron discovery and settlement behavior are unchanged
- the new route is not registered in the production route set
- no database schema, persisted data, public API, runner protocol, or queue payload changes

## Validation

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/api-contracts`
- `pnpm knip --workspace api`
- focused settlement route and usage-runs tests with 2 workers: 17 tests passed
- original allowance/insight reproduction with 2 workers: 20 consecutive passes, 30 tests per pass
- all 6 affected suites plus endpoint coverage with 4 workers: 204 tests passed
- pre-commit hook: formatting, full Turbo Knip, and full Turbo type checking passed

Closes #23144
