### PR TITLE
refactor: require slack file id and permalink for delivered assets

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -766,6 +766,98 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     expect(lifecycleMarker?.attachFiles).toBeUndefined();
   }, 20_000);
 
+  it("keeps a canonical Slack delivery failed when file info has no permalink", async () => {
+    const { orgId, userId, runId } = await seedRunScoped();
+    const objectStore = chatCallbacks.acceptChatObjectStorage();
+    const operationId = randomUUID();
+    const token = zeroToken({ userId, orgId, runId });
+    const fileId = "F-MISSING-PERMALINK";
+    context.mocks.slack.files.getUploadURLExternal.mockResolvedValue({
+      ok: true,
+      upload_url: "https://files.slack.com/upload/v1/missing-permalink",
+      file_id: fileId,
+    });
+    context.mocks.slack.files.info.mockResolvedValue({
+      ok: true,
+      file: {
+        id: fileId,
+        name: "report.csv",
+        title: "Slack Report",
+        mimetype: "text/csv",
+        filetype: "csv",
+        size: 42,
+      },
+    });
+
+    const initClient = setupApp({ context })(
+      integrationsSlackUploadInitContract,
+    );
+    const initialized = await accept(
+      initClient.init({
+        body: {
+          filename: "report.csv",
+          length: 42,
+          canonical: {
+            operationId,
+            contentType: "text/csv",
+            checksumSha256: "c".repeat(64),
+            channel: "C123",
+          },
+        },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    if (!("kind" in initialized.body)) {
+      throw new Error("Expected canonical Slack upload initialization");
+    }
+    const canonicalAssetId = initialized.body.assetId;
+    objectStore.addObject({
+      bucket: "test-user-artifacts",
+      key: `artifacts/${userId}/${canonicalAssetId}/report.csv`,
+      size: 42,
+      body: Buffer.alloc(42, "a"),
+    });
+
+    const materializeClient = setupApp({ context })(
+      integrationsSlackUploadMaterializeContract,
+    );
+    const materialized = await accept(
+      materializeClient.materialize({
+        body: { assetId: canonicalAssetId, operationId },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    expect(materialized.body.delivery).toMatchObject({
+      status: "pending",
+      fileId,
+    });
+
+    const completeClient = setupApp({ context })(
+      integrationsSlackUploadCompleteContract,
+    );
+    const completed = await accept(
+      completeClient.complete({
+        body: {
+          fileId,
+          channel: "C123",
+          canonicalAssetId,
+          operationId,
+        },
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      [200],
+    );
+    expect(completed.body).toMatchObject({
+      fileId,
+      assetId: canonicalAssetId,
+      permalink: "",
+      deliveryStatus: "failed",
+      deliveryError: "Slack file info did not include a permalink",
+    });
+  });
+
   it("keeps one Slack delivery authoritative across concurrent retries", async () => {
     const { orgId, userId, runId } = await seedRunScoped();
     const objectStore = chatCallbacks.acceptChatObjectStorage();

--- a/turbo/apps/api/src/signals/services/canonical-slack-asset-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-asset-delivery.service.ts
@@ -61,6 +61,13 @@ function requiredSlackFileId(externalId: string | null): string {
   return externalId;
 }
 
+function requiredSlackPermalink(deliveryUrl: string | null): string {
+  if (!deliveryUrl) {
+    throw new Error("Delivered Slack asset is missing its permalink");
+  }
+  return deliveryUrl;
+}
+
 async function canonicalSlackDeliveryRow(
   db: Db,
   args: {
@@ -110,7 +117,7 @@ function deliveredResult(
   return {
     status: "delivered",
     fileId: requiredSlackFileId(row.externalId),
-    permalink: row.deliveryUrl ?? "",
+    permalink: requiredSlackPermalink(row.deliveryUrl),
   };
 }
 
@@ -122,6 +129,35 @@ interface CanonicalSlackDeliveryFailure {
   readonly code: string;
   readonly message: string;
   readonly retryable: boolean;
+}
+
+function resolveSlackFilePermalink(
+  info: Awaited<ReturnType<typeof getFileInfo>>,
+):
+  | { readonly ok: true; readonly permalink: string }
+  | { readonly ok: false; readonly error: CanonicalSlackDeliveryFailure } {
+  if (info.kind === "slack_error") {
+    return {
+      ok: false,
+      error: {
+        code: info.error,
+        message: `Slack delivery failed: ${info.error}`,
+        retryable: true,
+      },
+    };
+  }
+  const permalink = info.file?.permalink;
+  if (!permalink) {
+    return {
+      ok: false,
+      error: {
+        code: "missing_permalink",
+        message: "Slack file info did not include a permalink",
+        retryable: true,
+      },
+    };
+  }
+  return { ok: true, permalink };
 }
 
 function failedResult(
@@ -174,7 +210,7 @@ async function deliveryResultAfterTransitionConflict(
     return {
       status: "delivered",
       fileId: requiredSlackFileId(current.externalId),
-      permalink: current.deliveryUrl ?? "",
+      permalink: requiredSlackPermalink(current.deliveryUrl),
     };
   }
   if (current?.status === "failed" && current.lastError) {
@@ -212,11 +248,12 @@ async function markDeliveryDelivered(
   permalink: string,
 ): Promise<CanonicalSlackDeliveryResult> {
   const fileId = requiredSlackFileId(row.externalId);
+  const deliveryUrl = requiredSlackPermalink(permalink);
   const [delivered] = await db
     .update(canonicalAssetDeliveries)
     .set({
       status: "delivered",
-      url: permalink || null,
+      url: deliveryUrl,
       lastError: null,
       updatedAt: sql`now()`,
     })
@@ -226,7 +263,7 @@ async function markDeliveryDelivered(
     ? {
         status: "delivered",
         fileId,
-        permalink,
+        permalink: deliveryUrl,
       }
     : await deliveryResultAfterTransitionConflict(db, row);
 }
@@ -286,9 +323,11 @@ async function completeExistingSlackFile(
     });
   }
   const info = await getFileInfo(client, row.externalId);
-  const permalink =
-    info.kind === "ok" ? (info.file?.permalink ?? row.deliveryUrl ?? "") : "";
-  return await markDeliveryDelivered(db, row, permalink);
+  const permalinkResult = resolveSlackFilePermalink(info);
+  if (!permalinkResult.ok) {
+    return await markDeliveryFailed(db, row, permalinkResult.error);
+  }
+  return await markDeliveryDelivered(db, row, permalinkResult.permalink);
 }
 
 export const prepareCanonicalSlackDelivery$ = command(
@@ -436,10 +475,18 @@ export const completeCanonicalSlackDelivery$ = command(
       signal,
     );
     signal.throwIfAborted();
-    const permalink =
-      infoResult.ok && infoResult.value.kind === "ok"
-        ? (infoResult.value.file?.permalink ?? "")
-        : "";
-    return await markDeliveryDelivered(db, row, permalink);
+    if (!infoResult.ok) {
+      return await markDeliveryFailed(db, row, {
+        code: "slack-request-failed",
+        message: providerFailureMessage(infoResult.error),
+        retryable: true,
+      });
+    }
+    const info = infoResult.value;
+    const permalinkResult = resolveSlackFilePermalink(info);
+    if (!permalinkResult.ok) {
+      return await markDeliveryFailed(db, row, permalinkResult.error);
+    }
+    return await markDeliveryDelivered(db, row, permalinkResult.permalink);
   },
 );


### PR DESCRIPTION
## Summary

- Require canonical Slack deliveries marked `delivered` to have both a Slack file ID and permalink.
- Convert Slack file-info errors or missing permalinks into retryable delivery failures instead of persisting and returning an empty link.
- Add an API integration regression test for Slack file info without a permalink.

## Scan

- Timestamp: `2026-07-26T20:02:15.084Z`
- Base commit: `cc415c5c844343ab573c0d9de5a31d1fd378ad69`
- Files scanned: 4,384
- Total matches: 19,818
- High-confidence production `actionable_total`: 234
- `edit_budget`: 12
- Logical candidates changed: 1 (6 actionable scanner records across 4 related fallback sites)

Matches by category:

- `nullish`: 6,118
- `nullish-chain`: 136
- `field-fallback-chain`: 108
- `optional-prop`: 5,932
- `zod-optional`: 2,522
- `zod-loose-optional`: 3
- `loose-record`: 1,092
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 30
- `empty-fallback`: 720
- `string-fallback`: 749
- `null-undefined-fallback`: 1,587
- `empty-catch`: 3
- `promise-catch-swallow`: 16
- `rust-unwrap-or`: 652
- `rust-ok-discard`: 147

## Files changed

- `canonical-slack-asset-delivery.service.ts`: the delivered-result contract already requires a permalink, so readers now reject invalid persisted delivered state and writers only transition to `delivered` after Slack supplies a non-empty permalink. Missing file info remains retryable.
- `zero-integrations-slack-upload-complete.test.ts`: covers the missing-permalink response and verifies that the canonical delivery remains failed.

A post-change rescan reports zero actionable matches in the changed service. This workflow intentionally leaves the remaining repository candidates for later daily runs.

## Verification

- Targeted Prettier: passed.
- API lint: passed; the final two-file Oxlint and ESLint rerun also passed.
- API `tsc --noEmit`: passed with a 4 GB Node heap. The default approximately 2 GB invocation exhausted its heap without emitting TypeScript diagnostics.
- Targeted Vitest regression: passed (`1 passed`, `11 skipped`).
- Full related test file attempt: `10 passed`, while 2 pre-existing runner-claim cases timed out because the local runner endpoint remained at 404; neither failure reached the changed Slack delivery path.
- `git diff --check`: passed.
- Pre-commit Prettier and Knip passed; the hook's full-workspace type check exceeded its 120-second timeout, so the commit was created after the scoped checks above. The PR pipeline will run the complete checks.
