### PR TITLE
fix: stabilize zero-usage-insight by scoping test usage settlement to one org

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1686,7 +1686,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     const billing = createBillingMediaApi(context);
-    await billing.processUsageEvents();
+    await billing.processUsageEvents(actor.orgId);
 
     let usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(1);
@@ -1736,7 +1736,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     mockNow(new Date("2030-01-01T00:00:00.000Z"));
-    await billing.processUsageEvents();
+    await billing.processUsageEvents(actor.orgId);
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toStrictEqual([usageMessage]);
 
@@ -1758,7 +1758,7 @@ describe("CHAT-03 run usage messages", () => {
       [200],
     );
     mockNow(new Date("2030-01-01T00:00:01.000Z"));
-    await billing.processUsageEvents();
+    await billing.processUsageEvents(actor.orgId);
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toStrictEqual([usageMessage]);
   }, 60_000);
@@ -1830,7 +1830,7 @@ describe("CHAT-03 run usage messages", () => {
       sandboxHeaders,
       [200],
     );
-    await createBillingMediaApi(context).processUsageEvents();
+    await createBillingMediaApi(context).processUsageEvents(actor.orgId);
 
     const usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -543,9 +543,17 @@ export function createBillingMediaApi(context: TestContext) {
       );
     },
 
-    async processUsageEvents() {
+    /**
+     * Settles pending usage. API test files share one database and run in
+     * parallel, so callers that hold a mocked clock must pass `orgId`;
+     * an unscoped sweep would stamp other files' rows with that clock.
+     */
+    async processUsageEvents(orgId?: string) {
       const client = setupApp({ context })(cronProcessUsageEventsContract);
-      return await accept(client.process({ headers: cronHeaders() }), [200]);
+      return await accept(
+        client.process({ query: { orgId }, headers: cronHeaders() }),
+        [200],
+      );
     },
 
     async recordSignupAttribution(actor: ApiTestUser) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -1128,6 +1128,7 @@ export function createRunsApi(context: TestContext) {
       const processUsageEvents = await accept(
         runApp(context)(cronProcessUsageEventsContract).process({
           headers,
+          query: {},
         }),
         [401],
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -198,8 +198,10 @@ async function recordPendingUsage(args: {
   });
 }
 
-async function processUsageEvents(): Promise<void> {
-  await createBillingMediaApi(context).processUsageEvents();
+async function processUsageEvents(actor: ApiTestUser): Promise<void> {
+  // Scoped to the caller's org: these tests settle under a mocked clock, and
+  // an unscoped sweep would stamp parallel test files' rows with that clock.
+  await createBillingMediaApi(context).processUsageEvents(actor.orgId);
 }
 
 async function readOrgCredits(actor: ApiTestUser): Promise<number> {
@@ -243,7 +245,7 @@ describe("Usage Allowance", () => {
 
     // Another Vitest worker can settle this org through the shared test DB, so
     // verify persisted billing behavior instead of a worker-local Ably mock.
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(10);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -270,7 +272,7 @@ describe("Usage Allowance", () => {
       quantity: 50,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(70);
     await expect(readRunCreditsCharged(actor, firstRun.runId)).resolves.toBe(
@@ -306,7 +308,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(80);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -334,7 +336,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 100,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     mockNow(addHours(startedAt, 1));
     const secondRun = await createVm0Run(actor, agentId, "same short window");
@@ -344,7 +346,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(50);
     await expect(readRunCreditsCharged(actor, firstRun.runId)).resolves.toBe(
@@ -377,7 +379,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 100,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     mockNow(addHours(startedAt, 6));
     const secondRun = await createVm0Run(actor, agentId, "fresh short window");
@@ -387,7 +389,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, secondRun.runId)).resolves.toBe(
@@ -413,7 +415,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 80,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     mockNow(addDays(startedAt, 8));
     const secondRun = await createVm0Run(actor, agentId, "fresh weekly window");
@@ -423,7 +425,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 50,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     // A continued weekly window would only have 40 units left (120 - 80), so
     // full coverage of the 50-unit event proves the weekly window refreshed.
@@ -454,7 +456,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 10,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(10);
   });
 
@@ -476,7 +478,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 1,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     const rejected = await api.requestCreateRun(
       actor,
@@ -521,7 +523,7 @@ describe("Usage Allowance", () => {
       provider,
       quantity: 2,
     });
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     const denied = await accept(client.resolve({ headers, body }), [402]);
     expect(denied.body.error.code).toBe("INSUFFICIENT_CREDITS");
@@ -563,7 +565,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -593,7 +595,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -620,7 +622,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(20);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -653,7 +655,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
@@ -687,7 +689,7 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    await processUsageEvents();
+    await processUsageEvents(actor);
 
     await expect(readOrgCredits(actor)).resolves.toBe(20);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);

--- a/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-process-usage-events.ts
@@ -1,9 +1,12 @@
 import { cronProcessUsageEventsContract } from "@vm0/api-contracts/contracts/cron";
 import { command } from "ccstate";
 
+import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { processStaleUsageEvents$ } from "../services/cron-process-usage-events.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const processQuery$ = queryOf(cronProcessUsageEventsContract.process);
 
 const processUsageEventsRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -11,7 +14,8 @@ const processUsageEventsRoute$ = command(
       return cronUnauthorized();
     }
 
-    const processed = await set(processStaleUsageEvents$, signal);
+    const query = get(processQuery$);
+    const processed = await set(processStaleUsageEvents$, query.orgId, signal);
     signal.throwIfAborted();
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/services/cron-process-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-process-usage-events.service.ts
@@ -1,21 +1,30 @@
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { command } from "ccstate";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 
 export const processStaleUsageEvents$ = command(
-  async ({ set }, signal: AbortSignal): Promise<number> => {
+  async (
+    { set },
+    orgId: string | undefined,
+    signal: AbortSignal,
+  ): Promise<number> => {
     const db = set(writeDb$);
     const orgs = await db
       .selectDistinct({ orgId: usageEvent.orgId })
       .from(usageEvent)
-      .where(eq(usageEvent.status, "pending"));
+      .where(
+        and(
+          eq(usageEvent.status, "pending"),
+          orgId === undefined ? undefined : eq(usageEvent.orgId, orgId),
+        ),
+      );
     signal.throwIfAborted();
 
-    for (const { orgId } of orgs) {
-      await set(processOrgUsageEvents$, orgId, signal);
+    for (const { orgId: pendingOrgId } of orgs) {
+      await set(processOrgUsageEvents$, pendingOrgId, signal);
       signal.throwIfAborted();
     }
 

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -209,6 +209,11 @@ export const cronProcessUsageEventsContract = c.router({
     method: "GET",
     path: "/api/cron/process-usage-events",
     headers: authHeadersSchema,
+    query: z.object({
+      // Restricts settlement to a single org. The scheduled cron omits this and
+      // keeps sweeping every org with pending usage.
+      orgId: z.string().optional(),
+    }),
     responses: {
       200: cronProcessUsageEventsResponseSchema,
       401: apiErrorSchema,


### PR DESCRIPTION
## Summary

Fixes an intermittent `test-api` failure where `zero-usage-insight.test.ts` reported `TypeError: actual value must be number or bigint, received "undefined"` — the usage insight response came back with no buckets at all, so the first assertion read `undefined`.

The cause is cross-test-file clock bleed through the shared test database, not anything in the usage insight feature itself.

- **Triggering run:** https://github.com/vm0-ai/vm0/actions/runs/30228092280
- **Event / SHA:** `push` to `main` @ `86be0973` (`refactor: contract legacy slack routing schema (#23149)`)
- **First substantive failure:** `test-api (5)` → `src/signals/routes/__tests__/zero-usage-insight.test.ts` → `GET /api/zero/usage/insight > source mapping — every TriggerSource lands in the correct bucket` (`:353`). The other `test-api` shards were fail-fast cancellations and `ci-gate-turbo` only aggregated the result.
- **Classification:** test isolation / shared-state pollution. The head commit is unrelated — it touches Slack routing schema and never reaches the usage pipeline.

## Root cause

API test files share one Postgres database (single `DATABASE_URL`, no per-file schema) and Vitest runs them in parallel workers.

1. The test helper `processUsageEvents()` calls the cron route `/api/cron/process-usage-events`.
2. Its service `processStaleUsageEvents$` selects **every** org with pending usage events and settles them.
3. Settlement stamps `processed_at` via `markUsageEventsProcessed` → `nowDate()`, which honors each worker's `mockNow` override.
4. `usage-allowance.test.ts` — in the same shard 5 — repeatedly does `mockNow(<future>)` and then calls the global settle (for example `addDays(startedAt, 8)`). `chat-threads.bdd.test.ts` does the same with `2030-01-01`.

So a file holding a mocked clock settles **another file's** pending usage events with that foreign future timestamp.

**Why it started failing now:** `#23137 refactor(api): use settlement time for finalized usage reports` moved usage insight range membership from `created_at` to `processed_at`. Before that, poisoned `processed_at` values were harmless because membership used real DB insert time. After it, a poisoned row falls outside `[todayStart-6d, now)` and vanishes from the response.

**Why it is intermittent:** it requires the victim's brief pending-usage window to overlap the other file's mocked-clock settle. `createSourceRun` cancels each run, and run cancellation settles that org's pending usage, so each event is only exposed for the short interval before the next source's cancel.

## Fix

Add an optional `orgId` filter to the process-usage-events cron so a caller holding a mocked clock settles only its own org. The scheduled cron omits the parameter and keeps sweeping every org, so production behaviour is unchanged.

Call sites updated to pass their org are exactly the two files that settle under a mocked clock (`usage-allowance.test.ts`, `chat-threads.bdd.test.ts`). Settles that run on the real clock are left unscoped — they stamp real time, which is what those rows would have received anyway.

No assertion was weakened, and no retry, sleep, timeout bump, or skip was used.

## Validation

Local Postgres 18 (UTC), migrations applied.

**Causal A/B against the exact failing test** (temporary probes, not committed) — a foreign mocked-clock settle injected mid-test:

| Foreign settle | Result |
| --- | --- |
| unscoped (pre-fix behaviour) | **FAIL** — `expected 50 to be greater than or equal to 100` |
| scoped to another org (post-fix behaviour) | **PASS** — 7/7 |

This reproduces the failure deterministically and shows the scoping removes it.

**Repeated runs**, `zero-usage-insight` + both modified files together: 5/5 green pre-rebase, 3/3 green after rebasing onto latest `main` (55 tests each).

**Regression**, shared settlement helper and cron contract: `zero-usage-runs`, `zero-usage-record`, `vercel-crons`, `run-cron.bdd` (41 tests) and `run-lifecycle.bdd` (120 tests) all pass. `run-cron.bdd` covers the cron 401 path touched by the `query: {}` addition.

**Formatting / lint / hygiene:** `prettier --check` clean, `oxlint` 0 warnings 0 errors, `git diff --check` clean.

## Evidence limitations

- The full `tsc --noEmit` type check for `apps/api` could not run here — the sandbox has 3 GB RAM and the API type check exhausts it. `@vm0/api-contracts` type-checks clean. Relying on the PR pipeline for the API type check.
- I did not reproduce the failure through natural parallel scheduling (8 attempts); the timing window is narrow. The deterministic probe above establishes the mechanism instead.
- The fix addresses this settlement route specifically. Other globally-scoped cron routes could in principle bleed the same way, but none were implicated by this failure and none are changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
