### PR TITLE
test(api): stabilize the chat thread session snapshot retry test with a precise barrier

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -53,7 +53,6 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   clearThreadSessionBinding,
-  clearThreadSessionConversation,
   deleteVm0ManagedDefaultModelKey,
   readThreadSessionBinding,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
@@ -69,6 +68,7 @@ import {
   holdChatMessageFixture,
   holdChatMessageQueueItemFixture,
   holdOrgAdmissionLockFixture,
+  holdThreadSessionConversationClearFixture,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
 
@@ -3018,9 +3018,6 @@ describe("CHAT-02: run-level model overrides", () => {
 
   it("retries preparation when the canonical conversation snapshot changes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor for snapshot retry");
-    }
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await sendChatRun(actor, {
@@ -3039,24 +3036,27 @@ describe("CHAT-02: run-level model overrides", () => {
       throw new Error("Expected the first run to establish a session");
     }
 
-    const admissionLock = await holdOrgAdmissionLockFixture({
-      orgId: actor.orgId,
+    const conversationClear = await holdThreadSessionConversationClearFixture({
+      threadId: first.threadId,
       signal: context.signal,
     });
     onTestFinished(async () => {
-      admissionLock.release();
-      await admissionLock.done;
+      conversationClear.release();
+      await conversationClear.done;
     });
     const secondPromise = sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
       prompt: "retry after the checkpoint changes",
     });
-    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    // The staged clear is still uncommitted, so the run resolves the pre-clear
+    // snapshot and only blocks once its commit re-reads the session row.
+    await expect
+      .poll(conversationClear.blockedWaiterCount)
+      .toBeGreaterThanOrEqual(1);
 
-    await clearThreadSessionConversation(context, first.threadId);
-    admissionLock.release();
-    await admissionLock.done;
+    conversationClear.release();
+    await conversationClear.done;
     const second = await secondPromise;
 
     const retryEvents = sandboxOperationEvents().filter((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -245,16 +245,6 @@ export async function clearThreadSessionBinding(
   });
 }
 
-export async function clearThreadSessionConversation(
-  context: TestContext,
-  threadId: string,
-): Promise<void> {
-  await postAction(context, {
-    action: "clear-thread-session-conversation",
-    thread_id: threadId,
-  });
-}
-
 export async function insertLegacyArtifactCatalogFile(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -314,31 +314,6 @@ async function clearThreadSessionBinding(
   }
 }
 
-async function clearThreadSessionConversation(
-  db: Db,
-  threadId: string,
-  signal: AbortSignal,
-): Promise<void> {
-  const [thread] = await db
-    .select({ agentSessionId: chatThreads.agentSessionId })
-    .from(chatThreads)
-    .where(eq(chatThreads.id, threadId))
-    .limit(1);
-  signal.throwIfAborted();
-  if (!thread?.agentSessionId) {
-    throw new Error("Expected a bound chat thread session");
-  }
-  const [session] = await db
-    .update(agentSessions)
-    .set({ conversationId: null })
-    .where(eq(agentSessions.id, thread.agentSessionId))
-    .returning({ id: agentSessions.id });
-  signal.throwIfAborted();
-  if (!session) {
-    throw new Error("Expected a bound agent session");
-  }
-}
-
 async function mutateRunnerJobSecretValueEnvironmentKeys(
   db: Db,
   runId: string,
@@ -522,10 +497,7 @@ async function timingStateActionResponse(
 type ThreadSessionStateAction = Extract<
   TestRuntimeStateActionBody,
   {
-    action:
-      | "read-thread-session-binding"
-      | "clear-thread-session-binding"
-      | "clear-thread-session-conversation";
+    action: "read-thread-session-binding" | "clear-thread-session-binding";
   }
 >;
 
@@ -534,8 +506,7 @@ function isThreadSessionStateAction(
 ): body is ThreadSessionStateAction {
   return (
     body.action === "read-thread-session-binding" ||
-    body.action === "clear-thread-session-binding" ||
-    body.action === "clear-thread-session-conversation"
+    body.action === "clear-thread-session-binding"
   );
 }
 
@@ -560,10 +531,6 @@ async function threadSessionStateActionResponse(
     }
     case "clear-thread-session-binding": {
       await clearThreadSessionBinding(db, body.thread_id, signal);
-      return { status: 200 as const, body: { ok: true as const } };
-    }
-    case "clear-thread-session-conversation": {
-      await clearThreadSessionConversation(db, body.thread_id, signal);
       return { status: 200 as const, body: { ok: true as const } };
     }
   }

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,5 +1,7 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { and, count, eq, like, or, sql } from "drizzle-orm";
@@ -273,6 +275,87 @@ export async function holdOrgAdmissionLockFixture(args: {
               SELECT held.classid, held.objid, held.objsubid
               FROM pg_locks AS held
               WHERE held.locktype = 'advisory'
+                AND held.pid = ${holderPid}
+                AND held.granted
+            )
+        `,
+        waiterCountRowSchema,
+      );
+      return rows[0]?.waiterCount ?? 0;
+    },
+  };
+}
+
+/**
+ * Stages the canonical conversation clear inside an open transaction so a
+ * concurrent run still resolves the pre-clear snapshot, then blocks on this
+ * transaction when its launch commit re-reads the session row `FOR UPDATE`.
+ *
+ * Waiting on this transaction is a precise barrier for "the run captured its
+ * snapshot and reached commit". Counting waiters on the org admission key is
+ * not: the background queue drain takes that same key, so it can satisfy the
+ * barrier before the run has resolved its session at all.
+ */
+export async function holdThreadSessionConversationClearFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const [thread] = await tx
+      .select({ agentSessionId: chatThreads.agentSessionId })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .limit(1);
+    if (!thread?.agentSessionId) {
+      throw new Error("Expected a bound chat thread session");
+    }
+    const [session] = await tx
+      .update(agentSessions)
+      .set({ conversationId: null })
+      .where(eq(agentSessions.id, thread.agentSessionId))
+      .returning({ id: agentSessions.id });
+    if (!session) {
+      throw new Error("Expected a bound agent session");
+    }
+    const rows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the conversation clear holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          SELECT ${count()}::int AS "waiterCount"
+          FROM pg_locks AS waiting
+          WHERE waiting.locktype = 'transactionid'
+            AND NOT waiting.granted
+            AND waiting.transactionid IN (
+              SELECT held.transactionid
+              FROM pg_locks AS held
+              WHERE held.locktype = 'transactionid'
                 AND held.pid = ${holderPid}
                 AND held.granted
             )

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -79,10 +79,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     thread_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("clear-thread-session-conversation"),
-    thread_id: z.uuid(),
-  }),
-  z.object({
     action: z.literal("insert-legacy-artifact-catalog-file"),
     user_id: z.string(),
     org_id: z.string(),


### PR DESCRIPTION
## Summary

Fixes the intermittent `test-api` failure in `chat-messages.bdd.test.ts > CHAT-02: run-level model overrides > retries preparation when the canonical conversation snapshot changes`, which failed with `AssertionError: expected [] to deep equally contain ObjectContaining{…}` — no `chat_thread_session_binding_retry` event was emitted.

- **Triggering run:** https://github.com/vm0-ai/vm0/actions/runs/30229041948
- **Event / SHA:** `push` to `main` @ `abb6e4de` (`fix(platform): suppress browser network failure toasts (#23142)`)
- **First substantive failure:** `test-api (8)` → `chat-messages.bdd.test.ts:3067`. The other `test-api` shards were fail-fast cancellations and `ci-gate-turbo` only aggregated the result.
- **Classification:** missing synchronization in the test. The head commit is unrelated — it changes platform toast behaviour and never reaches run admission.

## Root cause

The test wants to pause the second chat run *after* it resolves its thread-session snapshot but *before* the launch commit re-validates that snapshot, mutate the conversation in that window, and assert the run retries with `retry_reason: "session_changed"`.

It created that window by holding the org admission advisory key and waiting for `waiterCount >= 1` on it. That key is not exclusive to run admission: `loadDrainCandidates` in `zero-run-queue.service.ts` takes the same `hashtext(orgId)` key, and the background run-queue drain runs concurrently after the first run completes.

So the barrier could be satisfied by the drain rather than by the run's commit. Instrumented locally on `main`, the failing interleaving is unambiguous:

```
LOCKWAIT QUEUE229  ...401   <- background drain blocks on hashtext(orgId)
POLL_OK            ...446   <- barrier satisfied by the DRAIN
CLEARED            ...459   <- test clears the conversation
CAPTURE            ...460   <- second run only now resolves its session (conversationId already NULL)
LOCKWAIT COMMIT    ...473   <- commit validates: expected NULL == actual NULL -> not stale
```

The run resolved an already-cleared snapshot, so `validateThreadSessionSnapshot` found nothing stale, no retry happened, and `retryEvents` stayed empty. When the drain was not in flight, the only waiter was the run's own commit — which *is* after capture — and the test passed. Hence the intermittency.

## Fix

Stage the conversation clear inside an open transaction (`holdThreadSessionConversationClearFixture`) instead of holding the org key:

- the update stays uncommitted, so the run's snapshot resolution (a plain read) still sees the **pre-clear** conversation;
- the run blocks only when its launch commit re-reads the session row `FOR UPDATE`, which is exactly the window the test wants;
- the barrier counts backends waiting on *this transaction*, which the queue drain never touches.

That makes the ordering deterministic rather than dependent on which backend happens to contend for the org key first. The business assertion is unchanged, and no retry, sleep, timeout bump, skip, or weakened assertion was used.

The route-backed `clearThreadSessionConversation` helper had no remaining caller after this change (Knip flagged it), so it is removed together with its `test-runtime-state` action and contract variant. The now-redundant `actor.orgId` guard in the test is dropped too.

## Validation

Local Postgres 18 (UTC), migrations applied.

**Reproduced first**, target test in isolation on unmodified `main`: **3 of 6 runs failed** with the exact CI assertion. This is a self-contained race, not cross-file pollution.

**After the fix:** target test 8/8 green, then 5/5 more after the final cleanup, and 5/5 after rebasing onto current `main`.

**Full suite / regression:** `chat-messages.bdd.test.ts` 52/52 green on 3 consecutive runs pre-rebase and 5 consecutive runs post-rebase. All consumers of the touched `helpers/runtime-state` and admission-lock fixtures pass together — `chat-messages.bdd`, `zero-workflow-queue`, `chat-threads.bdd`, `artifact-catalog.bdd`, `artifacts.bdd`, `usage-allowance`, `run-lifecycle.bdd`: 255/255.

**Static checks:** `knip --workspace api` and `knip --workspace @vm0/api-contracts` both clean, `@vm0/api-contracts check-types` clean, `oxlint` 0 warnings 0 errors, `prettier --check` clean, `git diff --check` clean.

## Evidence limitations

- The full `tsc --noEmit` for `apps/api` could not run here — the sandbox has 3 GB RAM and the API type check exhausts it. Contracts type-check clean and the removals are consistent (no references to the deleted action remain anywhere in `apps/api` or `api-contracts`). Relying on the PR pipeline for the API type check.
- The instrumentation quoted above was temporary and is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
