### PR TITLE
docs(mitm-addon): clarify authoritative endpoint tuple projection

### DIFF
--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -39,7 +39,9 @@ def authoritative_connected_endpoint(endpoint: object) -> tuple[str, int] | None
     The endpoint must have an ``address_pair`` shape and its host must parse as an IPv4 or IPv6
     literal. DNS names, malformed endpoints, loopback addresses, and unspecified addresses return
     ``None``. Other parsed IP address categories are not filtered: ``authoritative`` describes
-    connected endpoint evidence, not public routability. Accepted endpoints are returned unchanged.
+    connected endpoint evidence, not public routability. Accepted inputs return their first
+    ``(host, port)`` pair. Additional tuple elements are discarded, while the host and port values
+    themselves are not normalized.
     """
     endpoint_pair = address_pair(endpoint)
     if endpoint_pair is None:


### PR DESCRIPTION
## Summary

- clarify that accepted authoritative connection endpoints return their first `(host, port)` pair
- document that trailing tuple elements are discarded without normalizing the selected values
- keep runtime behavior, return types, and existing tests unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4268 passed`)

Closes #23154
