### PR TITLE
fix(platform): resume thread event sync from indexeddb cache

### DIFF
--- a/turbo/apps/platform/src/mocks/idb.ts
+++ b/turbo/apps/platform/src/mocks/idb.ts
@@ -9,7 +9,9 @@
 function fakeIndex() {
   return {
     get: () => Promise.resolve(undefined),
+    getAll: () => Promise.resolve([]),
     openCursor: () => Promise.resolve(null),
+    openKeyCursor: () => Promise.resolve(null),
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-persistence.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-persistence.test.ts
@@ -1,0 +1,133 @@
+import {
+  chatThreadsContract,
+  type ChatThreadEvent,
+  type ChatThreadSnapshotProjection,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { describe, expect, it, vi } from "vitest";
+
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import {
+  CHAT_THREAD_EVENTS_STORE,
+  CHAT_THREAD_SNAPSHOT_STORE,
+} from "../../external/chat-idb-schema.ts";
+import { chatIdb$, openChatIdb } from "../../external/chat-idb-store.ts";
+import { eventDrivenChatThreads$ } from "../chat-thread-event-sourcing.ts";
+
+vi.mock("idb", async () => {
+  return await vi.importActual<typeof import("idb")>("idb-real");
+});
+
+const context = testContext();
+
+const USER_ID = "thread-event-persistence-user";
+const ORG_ID = "thread-event-persistence-org";
+const AGENT_ID = "c0000000-0000-4000-a000-000000000901";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000901";
+const SNAPSHOT_EVENT_ID = "d0000000-0000-4000-a000-000000000900";
+const EVENT_COUNT = 1200;
+const LATEST_TITLE = "Title restored from the latest cached event";
+
+const snapshotThread = {
+  id: THREAD_ID,
+  agentId: AGENT_ID,
+  title: "Snapshot title",
+  sortAt: "2026-07-24T10:00:00.000Z",
+  createdAt: "2026-07-24T10:00:00.000Z",
+  updatedAt: "2026-07-24T10:00:00.000Z",
+  pinnedAt: null,
+  renamedAt: null,
+  selectedModel: null,
+  serviceTier: null,
+  computerUseHostId: null,
+} satisfies ChatThreadSnapshotProjection;
+
+const cachedEvents = Array.from({ length: EVENT_COUNT }, (_, index) => {
+  const eventNumber = index + 1;
+  return {
+    id: `d1000000-0000-4000-a000-${String(eventNumber).padStart(12, "0")}`,
+    kind: "renamed",
+    chatThreadId: THREAD_ID,
+    agentId: AGENT_ID,
+    title:
+      eventNumber === EVENT_COUNT
+        ? LATEST_TITLE
+        : `Cached title ${eventNumber}`,
+    selectedModel: null,
+    serviceTier: null,
+    computerUseHostId: null,
+    createdAt: new Date(
+      Date.parse("2026-07-24T10:00:00.000Z") + eventNumber * 1000,
+    ).toISOString(),
+  } satisfies ChatThreadEvent;
+});
+
+async function seedCachedThreadEventLog(): Promise<void> {
+  const db = await openChatIdb(USER_ID, ORG_ID);
+  try {
+    const tx = db.transaction(
+      [CHAT_THREAD_SNAPSHOT_STORE, CHAT_THREAD_EVENTS_STORE],
+      "readwrite",
+    );
+    const snapshotStore = tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE);
+    const eventStore = tx.objectStore(CHAT_THREAD_EVENTS_STORE);
+    const requests = [
+      snapshotStore.put({
+        id: "current",
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      }),
+      ...cachedEvents.map((event) => {
+        return eventStore.put(event);
+      }),
+    ];
+    await Promise.all([...requests, tx.done]);
+  } finally {
+    db.close();
+  }
+}
+
+describe("chat thread event persistence", () => {
+  it("hydrates a cached event log across read pages and resumes from its latest event", async () => {
+    await seedCachedThreadEventLog();
+
+    const requestedEventIds: (string | undefined)[] = [];
+    let snapshotRequests = 0;
+    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+      snapshotRequests += 1;
+      return respond(200, {
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ query, respond }) => {
+      requestedEventIds.push(query.sinceEventId);
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+      user: { id: USER_ID, fullName: "Thread Event Persistence User" },
+      session: { token: "test-token" },
+      org: {
+        activeOrg: { id: ORG_ID, name: "Thread Event Persistence Org" },
+        memberships: [{ id: ORG_ID }],
+      },
+    });
+
+    const appDb = await context.store.get(chatIdb$);
+    try {
+      await vi.waitFor(async () => {
+        expect(requestedEventIds[0]).toBe(cachedEvents.at(-1)?.id);
+        expect(
+          (await context.store.get(eventDrivenChatThreads$))[0]?.title,
+        ).toBe(LATEST_TITLE);
+      });
+      expect(snapshotRequests).toBe(0);
+    } finally {
+      appDb.close();
+    }
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -44,8 +44,11 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
   const readSnapshot = vi.fn(() => {
     return Promise.resolve(snapshot);
   });
-  const readEvents = vi.fn(() => {
-    return Promise.resolve(events);
+  const readEventLog = vi.fn(() => {
+    return Promise.resolve({
+      events,
+      latestEventId: events.at(-1)?.id ?? null,
+    });
   });
   const replaceFromSnapshot = vi.fn(
     (nextSnapshot: {
@@ -72,7 +75,7 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
 
   return {
     readSnapshot,
-    readEvents,
+    readEventLog,
     replaceFromSnapshot,
     upsertEvents,
     setData(args: {
@@ -89,7 +92,7 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
       snapshot = null;
       events = [];
       readSnapshot.mockClear();
-      readEvents.mockClear();
+      readEventLog.mockClear();
       replaceFromSnapshot.mockClear();
       upsertEvents.mockClear();
     },
@@ -102,7 +105,7 @@ vi.mock("../../external/idb-chat-thread-event-store.ts", () => {
       return {
         readStore: {
           readSnapshot: idbThreadEventStoreMock.readSnapshot,
-          readEvents: idbThreadEventStoreMock.readEvents,
+          readEventLog: idbThreadEventStoreMock.readEventLog,
         },
         writeStore: {
           replaceFromSnapshot: idbThreadEventStoreMock.replaceFromSnapshot,
@@ -323,7 +326,8 @@ describe("chat thread event sourcing local-first list", () => {
     const before = await context.store.get(chatThreads$);
     const snapshotReads =
       idbThreadEventStoreMock.readSnapshot.mock.calls.length;
-    const eventReads = idbThreadEventStoreMock.readEvents.mock.calls.length;
+    const eventLogReads =
+      idbThreadEventStoreMock.readEventLog.mock.calls.length;
     idbThreadEventStoreMock.replaceFromSnapshot.mockClear();
     idbThreadEventStoreMock.upsertEvents.mockClear();
 
@@ -334,8 +338,8 @@ describe("chat thread event sourcing local-first list", () => {
     expect(idbThreadEventStoreMock.readSnapshot).toHaveBeenCalledTimes(
       snapshotReads,
     );
-    expect(idbThreadEventStoreMock.readEvents).toHaveBeenCalledTimes(
-      eventReads,
+    expect(idbThreadEventStoreMock.readEventLog).toHaveBeenCalledTimes(
+      eventLogReads,
     );
     expect(idbThreadEventStoreMock.replaceFromSnapshot).not.toHaveBeenCalled();
     expect(idbThreadEventStoreMock.upsertEvents).not.toHaveBeenCalled();

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -39,6 +39,7 @@ interface ChatThreadSnapshotData {
 interface ChatThreadEventState {
   readonly snapshot: ChatThreadSnapshotData | null;
   readonly events: readonly ChatThreadEvent[];
+  readonly latestEventId: string | null;
 }
 
 interface ChatThreadEventUpdate {
@@ -61,6 +62,7 @@ const optimisticChatThreadEventsState$ = state<readonly ChatThreadEvent[]>([]);
 const chatThreadEventState$ = state<ChatThreadEventState>({
   snapshot: null,
   events: [],
+  latestEventId: null,
 });
 
 const optimisticChatThreadCreateIds$ = computed((get): ReadonlySet<string> => {
@@ -92,13 +94,14 @@ async function readChatThreadEventState(
   store: Stores,
   signal?: AbortSignal,
 ): Promise<ChatThreadEventState> {
-  const [snapshot, events] = await Promise.all([
+  const [snapshot, eventLog] = await Promise.all([
     store.readStore.readSnapshot(signal),
-    store.readStore.readEvents(signal),
+    store.readStore.readEventLog(signal),
   ]);
   return {
     snapshot,
-    events,
+    events: eventLog.events,
+    latestEventId: eventLog.latestEventId ?? snapshot?.latestEventId ?? null,
   };
 }
 
@@ -119,8 +122,7 @@ const chatThreadEventStores$ = computed((get): Stores => {
 });
 
 const lastEventId$ = computed((get): string | null => {
-  const state = get(chatThreadEventState$);
-  return state.events.at(-1)?.id ?? state.snapshot?.latestEventId ?? null;
+  return get(chatThreadEventState$).latestEventId;
 });
 
 async function fetchRemoteSnapshot(
@@ -188,6 +190,7 @@ async function fetchChatThreadEventUpdate(
         state: {
           snapshot,
           events,
+          latestEventId: cursor,
         },
         replacementSnapshot: snapshotReplaced ? snapshot : null,
         newEvents,
@@ -201,6 +204,7 @@ async function fetchChatThreadEventUpdate(
     state: {
       snapshot,
       events,
+      latestEventId: cursor,
     },
     replacementSnapshot: snapshotReplaced ? snapshot : null,
     newEvents,

--- a/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
@@ -14,10 +14,23 @@ import {
 import { chatIdbReadOr, chatIdbWriteBestEffort } from "./chat-idb-safe.ts";
 
 const SINGLETON_ID = "current";
+const EVENT_READ_PAGE_SIZE = 300;
+
+type ChatThreadEventOrderKey = [createdAt: string, id: string];
 
 interface ChatThreadSnapshotRecord {
   readonly chatThreads: readonly ChatThreadSnapshotProjection[];
   readonly latestEventId: string | null;
+}
+
+interface ChatThreadEventLog {
+  readonly events: readonly ChatThreadEvent[];
+  readonly latestEventId: string | null;
+}
+
+interface ChatThreadEventReadBoundary {
+  readonly latestEventId: string;
+  readonly latestEventOrderKey: ChatThreadEventOrderKey;
 }
 
 interface StoredChatThreadSnapshot extends ChatThreadSnapshotRecord {
@@ -44,6 +57,89 @@ function validateEvent(raw: unknown): ChatThreadEvent {
   return chatThreadEventSchema.parse(raw);
 }
 
+function validateLatestEventId(raw: unknown): string | null {
+  if (raw === null) {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    throw new Error("Invalid IndexedDB chat thread event primary key");
+  }
+  return raw;
+}
+
+function validateEventOrderKey(raw: unknown): ChatThreadEventOrderKey {
+  if (
+    !Array.isArray(raw) ||
+    raw.length !== 2 ||
+    typeof raw[0] !== "string" ||
+    typeof raw[1] !== "string"
+  ) {
+    throw new Error("Invalid IndexedDB chat thread event order key");
+  }
+  return [raw[0], raw[1]];
+}
+
+function emptyEventLog(): ChatThreadEventLog {
+  return { events: [], latestEventId: null };
+}
+
+async function readEventBoundary(
+  getDb: GetDb,
+  signal?: AbortSignal,
+): Promise<ChatThreadEventReadBoundary | null> {
+  return await chatIdbReadOr(
+    "threadEvents:readBoundary",
+    async () => {
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const latestCursor = await db
+        .transaction(CHAT_THREAD_EVENTS_STORE, "readonly")
+        .store.index(CHAT_THREAD_EVENTS_ORDER_INDEX)
+        .openKeyCursor(undefined, "prev");
+      signal?.throwIfAborted();
+      if (!latestCursor) {
+        return null;
+      }
+      const latestEventId = validateLatestEventId(latestCursor.primaryKey);
+      const latestEventOrderKey = validateEventOrderKey(latestCursor.key);
+      if (latestEventOrderKey[1] !== latestEventId) {
+        throw new Error("IndexedDB chat thread event boundary is inconsistent");
+      }
+      return {
+        latestEventId,
+        latestEventOrderKey,
+      };
+    },
+    null,
+    signal,
+  );
+}
+
+async function readEventPage(
+  getDb: GetDb,
+  after: ChatThreadEventOrderKey | null,
+  through: ChatThreadEventOrderKey,
+  signal?: AbortSignal,
+): Promise<readonly ChatThreadEvent[] | null> {
+  return await chatIdbReadOr(
+    "threadEvents:readPage",
+    async () => {
+      const db = await getDb();
+      signal?.throwIfAborted();
+      const tx = db.transaction(CHAT_THREAD_EVENTS_STORE, "readonly");
+      const index = tx.store.index(CHAT_THREAD_EVENTS_ORDER_INDEX);
+      const range = after
+        ? IDBKeyRange.bound(after, through, true)
+        : IDBKeyRange.upperBound(through);
+      const storedEvents = await index.getAll(range, EVENT_READ_PAGE_SIZE);
+      signal?.throwIfAborted();
+      return storedEvents.map(validateEvent);
+    },
+    null,
+    signal,
+  );
+}
+
 function createReadStore(getDb: GetDb) {
   return {
     async readSnapshot(signal?: AbortSignal) {
@@ -62,26 +158,36 @@ function createReadStore(getDb: GetDb) {
       );
     },
 
-    async readEvents(signal?: AbortSignal) {
-      return await chatIdbReadOr(
-        "threadEvents:readEvents",
-        async () => {
-          const db = await getDb();
-          signal?.throwIfAborted();
-          const tx = db.transaction(CHAT_THREAD_EVENTS_STORE, "readonly");
-          const index = tx.store.index(CHAT_THREAD_EVENTS_ORDER_INDEX);
-          const events: ChatThreadEvent[] = [];
-          let cursor = await index.openCursor();
-          while (cursor) {
-            signal?.throwIfAborted();
-            events.push(validateEvent(cursor.value));
-            cursor = await cursor.continue();
-          }
-          return events;
-        },
-        [],
-        signal,
-      );
+    async readEventLog(signal?: AbortSignal) {
+      const boundary = await readEventBoundary(getDb, signal);
+      if (!boundary) {
+        return emptyEventLog();
+      }
+
+      const events: ChatThreadEvent[] = [];
+      let after: ChatThreadEventOrderKey | null = null;
+      while (events.at(-1)?.id !== boundary.latestEventId) {
+        const page = await readEventPage(
+          getDb,
+          after,
+          boundary.latestEventOrderKey,
+          signal,
+        );
+        if (!page) {
+          return emptyEventLog();
+        }
+        const lastEvent = page.at(-1);
+        if (!lastEvent) {
+          return emptyEventLog();
+        }
+        events.push(...page);
+        after = [lastEvent.createdAt, lastEvent.id];
+      }
+
+      return {
+        events,
+        latestEventId: boundary.latestEventId,
+      } satisfies ChatThreadEventLog;
     },
   };
 }
@@ -127,11 +233,11 @@ function createWriteStore(getDb: GetDb) {
           signal?.throwIfAborted();
           const tx = db.transaction(CHAT_THREAD_EVENTS_STORE, "readwrite");
           const eventStore = tx.store;
-          for (const event of events) {
+          const requests = events.map((event) => {
             signal?.throwIfAborted();
-            await eventStore.put(event);
-          }
-          await tx.done;
+            return eventStore.put(event);
+          });
+          await Promise.all([...requests, tx.done]);
         },
         signal,
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -77,8 +77,11 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
   const readSnapshot = vi.fn(() => {
     return Promise.resolve(snapshot);
   });
-  const readEvents = vi.fn(() => {
-    return Promise.resolve(events);
+  const readEventLog = vi.fn(() => {
+    return Promise.resolve({
+      events,
+      latestEventId: events.at(-1)?.id ?? null,
+    });
   });
   const replaceFromSnapshot = vi.fn(
     (nextSnapshot: {
@@ -105,7 +108,7 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
 
   return {
     readSnapshot,
-    readEvents,
+    readEventLog,
     replaceFromSnapshot,
     upsertEvents,
     setData(args: {
@@ -122,7 +125,7 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
       snapshot = null;
       events = [];
       readSnapshot.mockClear();
-      readEvents.mockClear();
+      readEventLog.mockClear();
       replaceFromSnapshot.mockClear();
       upsertEvents.mockClear();
     },
@@ -150,7 +153,7 @@ vi.mock("../../../signals/external/idb-chat-thread-event-store.ts", () => {
       return {
         readStore: {
           readSnapshot: idbThreadEventStoreMock.readSnapshot,
-          readEvents: idbThreadEventStoreMock.readEvents,
+          readEventLog: idbThreadEventStoreMock.readEventLog,
         },
         writeStore: {
           replaceFromSnapshot: idbThreadEventStoreMock.replaceFromSnapshot,


### PR DESCRIPTION
## Summary

- read cached chat thread events in ordered 300-event IndexedDB pages, giving each page its own 200ms cache deadline instead of timing out the full scan
- capture the latest persisted event with a reverse key cursor and bound every page to that event before exposing it as the remote sync cursor
- enqueue event batch writes before awaiting the transaction, matching the chat message persistence path
- keep state initialization atomic from the UI perspective: all cached pages load first, then ccstate replays the event log once

## User impact

Refreshing a previously opened chat thread page can restore a large persisted event backlog without falling back to the older snapshot cursor simply because the complete IndexedDB scan took longer than 200ms. Remote event sync resumes from the latest fully restored cached event.

## Verification

- targeted Vitest suites for thread event persistence and affected local-first behavior: 16 tests passed
- the persistence regression restores 1,200 cached events across four IndexedDB pages
- `pnpm -F @vm0/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint on changed files
