### PR TITLE
test(runner): cover debootstrap gc dry-run preservation

### DIFF
--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -155,7 +155,7 @@ mod tests {
     use nix::fcntl::{Flock, FlockArg};
 
     use super::*;
-    use crate::cmd::gc::test_support::test_home;
+    use crate::cmd::gc::test_support::{old_gc_time, set_mtime, test_home};
     use crate::lock;
 
     #[tokio::test]
@@ -289,8 +289,6 @@ mod tests {
 
     #[tokio::test]
     async fn gc_debootstrap_dry_run_preserves_and_reports_eligible_tarballs() {
-        use std::fs::FileTimes;
-
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let debootstrap_dir = home.debootstrap_dir();
@@ -301,13 +299,9 @@ mod tests {
         std::fs::write(&temp_tar, b"partial cache").unwrap();
         let expected_bytes = std::fs::metadata(&stable_tar).unwrap().len()
             + std::fs::metadata(&temp_tar).unwrap().len();
-        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-        for path in [&stable_tar, &temp_tar] {
-            std::fs::File::open(path)
-                .unwrap()
-                .set_times(FileTimes::new().set_modified(old_time))
-                .unwrap();
-        }
+        let old_time = old_gc_time();
+        set_mtime(&stable_tar, old_time);
+        set_mtime(&temp_tar, old_time);
 
         let report = gc_debootstrap(&home, Some(0), true).await.unwrap();
 

--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -288,6 +288,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_debootstrap_dry_run_preserves_and_reports_eligible_tarballs() {
+        use std::fs::FileTimes;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let debootstrap_dir = home.debootstrap_dir();
+        std::fs::create_dir_all(&debootstrap_dir).unwrap();
+        let stable_tar = debootstrap_dir.join("noble-amd64.tar");
+        let temp_tar = debootstrap_dir.join("noble-amd64.tmp.123.tar");
+        std::fs::write(&stable_tar, b"stable cache").unwrap();
+        std::fs::write(&temp_tar, b"partial cache").unwrap();
+        let expected_bytes = std::fs::metadata(&stable_tar).unwrap().len()
+            + std::fs::metadata(&temp_tar).unwrap().len();
+        let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        for path in [&stable_tar, &temp_tar] {
+            std::fs::File::open(path)
+                .unwrap()
+                .set_times(FileTimes::new().set_modified(old_time))
+                .unwrap();
+        }
+
+        let report = gc_debootstrap(&home, Some(0), true).await.unwrap();
+
+        assert_eq!(report.freed_bytes, expected_bytes);
+        assert_eq!(report.activity_count, 2);
+        assert!(
+            stable_tar.exists(),
+            "dry-run must preserve an eligible stable tarball"
+        );
+        assert!(
+            temp_tar.exists(),
+            "dry-run must preserve an eligible temporary tarball"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_debootstrap_removes_stale_temp_tarballs_but_keeps_recent_ones() {
         use std::fs::FileTimes;
 


### PR DESCRIPTION
## Summary

- exercise debootstrap GC dry-run behavior with a real temporary filesystem
- cover both an eligible stable tarball and a recognized temporary tarball
- verify dry-run preserves both files while reporting both activities and their aggregate bytes

## Scope

- test-only change in `crates/runner/src/cmd/gc/debootstrap.rs`
- no production behavior, tracing contract, schema, persisted data, API, protocol, dependency, or deployment change

## Validation

- `cargo test -p runner --bin runner gc_debootstrap_dry_run_preserves_and_reports_eligible_tarballs`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner --all-targets --all-features`
- repository pre-commit and commit-message hooks

Closes #23157
