### PR TITLE
test(guest-agent): cover invalid artifact prepare responses

### DIFF
--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -505,6 +505,21 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
+    struct SandboxOpsOverrideGuard;
+
+    impl SandboxOpsOverrideGuard {
+        fn set(path: &std::path::Path) -> Self {
+            guest_common::telemetry::set_sandbox_ops_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SandboxOpsOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
+
     fn test_http_client(server: &httpmock::MockServer) -> Result<HttpClient, AgentError> {
         HttpClient::with_api_config(
             server.base_url(),
@@ -558,6 +573,165 @@ mod tests {
         } else {
             http_status(400)
         }
+    }
+
+    #[tokio::test]
+    async fn snapshot_rejects_empty_prepare_response_before_upload_or_commit()
+    -> Result<(), AgentError> {
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        disable_system_log();
+        let server = MockServer::start();
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
+        let files = archive::collect_file_metadata(root.to_str().unwrap()).unwrap();
+
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200);
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200)
+                .json_body(serde_json::json!({ "success": true }));
+        });
+
+        let http = test_http_client(&server)?;
+        let result = create_snapshot(
+            &http,
+            CreateSnapshotRequest {
+                mount_path: root.to_str().unwrap(),
+                files,
+                storage_id: SNAPSHOT_STORAGE_ID,
+                run_id: "run-empty-prepare",
+                message: "snapshot message",
+                parent_version_id: "parent-v1",
+            },
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("create_snapshot unexpectedly succeeded");
+        };
+        assert!(
+            matches!(
+                &err,
+                AgentError::Checkpoint(message) if message == "Empty prepare response"
+            ),
+            "got: {err}"
+        );
+        prepare.assert_calls(1);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_rejects_shape_invalid_prepare_response_before_upload_or_commit()
+    -> Result<(), AgentError> {
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        disable_system_log();
+        let server = MockServer::start();
+
+        let artifact_dir = tempfile::tempdir().unwrap();
+        let root = artifact_dir.path();
+        std::fs::write(root.join("alpha.txt"), "alpha").unwrap();
+        let files = archive::collect_file_metadata(root.to_str().unwrap()).unwrap();
+        let archive_url = format!("{}/test/unreachable-archive", server.base_url());
+        let manifest_url = format!("{}/test/unreachable-manifest", server.base_url());
+
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(serde_json::json!({
+                "existing": false,
+                "uploads": {
+                    "archive": {
+                        "key": "archive-key",
+                        "presignedUrl": archive_url,
+                    },
+                    "manifest": {
+                        "key": "manifest-key",
+                        "presignedUrl": manifest_url,
+                    },
+                },
+            }));
+        });
+        let archive_upload = server.mock(|when, then| {
+            when.method(PUT).path("/test/unreachable-archive");
+            then.status(200);
+        });
+        let manifest_upload = server.mock(|when, then| {
+            when.method(PUT).path("/test/unreachable-manifest");
+            then.status(200);
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200)
+                .json_body(serde_json::json!({ "success": true }));
+        });
+
+        let http = test_http_client(&server)?;
+        let result = create_snapshot(
+            &http,
+            CreateSnapshotRequest {
+                mount_path: root.to_str().unwrap(),
+                files,
+                storage_id: SNAPSHOT_STORAGE_ID,
+                run_id: "run-shape-invalid-prepare",
+                message: "snapshot message",
+                parent_version_id: "parent-v1",
+            },
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("create_snapshot unexpectedly succeeded");
+        };
+        let AgentError::Checkpoint(checkpoint_message) = &err else {
+            panic!("expected checkpoint error, got: {err}");
+        };
+        assert!(
+            checkpoint_message.contains("versionId"),
+            "got: {checkpoint_message}"
+        );
+        prepare.assert_calls(1);
+        archive_upload.assert_calls(0);
+        manifest_upload.assert_calls(0);
+        commit.assert_calls(0);
+
+        let entries = std::fs::read_to_string(&telemetry_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let prepare_failure = entries
+            .iter()
+            .find(|entry| {
+                entry.get("action_type").and_then(serde_json::Value::as_str)
+                    == Some("artifact_prepare_api")
+                    && entry.get("success").and_then(serde_json::Value::as_bool) == Some(false)
+            })
+            .expect("failed artifact_prepare_api telemetry entry");
+        let telemetry_error = prepare_failure
+            .get("error")
+            .and_then(serde_json::Value::as_str)
+            .expect("artifact_prepare_api telemetry error");
+        assert_eq!(telemetry_error, checkpoint_message);
+        assert!(telemetry_error.contains("versionId"));
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- cover empty successful artifact prepare responses through `create_snapshot`
- cover shape-invalid successful prepare responses and preserve the schema diagnostic in `artifact_prepare_api` telemetry
- verify both failures stop before archive upload, manifest upload, and storage commit

## Scope

This is a test-only GuestAgent change. It does not change production control flow, API contracts, generated bindings, telemetry format, persistence, or rollout behavior.

## Validation

- `cargo test -p guest-agent --lib artifact::tests`
- `CARGO_INCREMENTAL=0 cargo test -p guest-agent`
- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo clippy -p guest-agent --all-targets --all-features`
- `CARGO_INCREMENTAL=0 cargo doc -p guest-agent --all-features --no-deps`
- repository pre-commit Rust formatting, workspace Clippy, and workspace documentation hooks

Closes #23158
