### PR TITLE
feat: enable image style r2 globally

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3906,7 +3906,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, websiteV2.runId);
   }, 90_000);
 
-  it("switches an illustration run from GitHub to R2 through the user feature switch", async () => {
+  it("uses R2 by default and preserves GitHub fallback through the user feature switch", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const style = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
@@ -3915,6 +3915,31 @@ describe("CHAT-02: generation templates and attachments", () => {
     if (!style) {
       throw new Error("Expected the ink-storefront illustration style");
     }
+
+    const defaultR2Run = await sendChatRun(actor, {
+      agentId,
+      prompt: "draw a flower shop from the default R2 source",
+      generationTemplate: {
+        type: "illustration",
+        selection: { illustrationStyleId: style.illustrationStyleId },
+      },
+    });
+    const defaultR2Prompt =
+      (await api.readRun(actor, defaultR2Run.runId)).appendSystemPrompt ?? "";
+    expect(defaultR2Prompt).toContain(
+      "Style source: private R2 registry resource image-style:ink-storefront",
+    );
+    expect(defaultR2Prompt).toContain("--compile --style-source r2");
+    await cancelChatRun(actor, defaultR2Run.runId);
+
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.ImageStyleR2]: false },
+    );
 
     const githubRun = await sendChatRun(actor, {
       agentId,
@@ -3932,37 +3957,6 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(githubPrompt).not.toContain("private R2 registry resource");
     expect(githubPrompt).not.toContain("--style-source r2");
     await cancelChatRun(actor, githubRun.runId);
-
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ImageStyleR2]: true },
-    );
-
-    const r2Run = await sendChatRun(actor, {
-      agentId,
-      prompt: "draw a flower shop from R2",
-      generationTemplate: {
-        type: "illustration",
-        selection: { illustrationStyleId: style.illustrationStyleId },
-      },
-    });
-    const r2Prompt =
-      (await api.readRun(actor, r2Run.runId)).appendSystemPrompt ?? "";
-    expect(r2Prompt).toContain(
-      "Style source: private R2 registry resource image-style:ink-storefront",
-    );
-    expect(r2Prompt).toContain("--compile --style-source r2");
-    expect(r2Prompt).toContain(
-      "If the R2 source is unavailable, stop without generating; do not fall back to GitHub.",
-    );
-    expect(r2Prompt).not.toContain(
-      "Style source: vm0-ai/vm0-skills@main:illustration-template/ink-storefront",
-    );
-    await cancelChatRun(actor, r2Run.runId);
 
     const githubOnlyRun = await sendChatRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -4001,7 +4001,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
     expect(firstPrompt).toContain("Follow the returned packet completely");
     expect(firstPrompt).toContain(
-      "If the source is unavailable, stop without generating",
+      "If the R2 source is unavailable, stop without generating; do not fall back to GitHub.",
     );
     expect(firstPrompt).toContain("--compiled-prompt");
     expect(firstPrompt).toContain(style.illustrationStyleId);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,6 +12,7 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -34,7 +35,6 @@ describe("isFeatureEnabled", () => {
       false,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.StructuredPrompt, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(false);
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -120,7 +120,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PlanUpgradeGuidance]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(true);
@@ -151,7 +151,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.PlanUpgradeGuidance]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -464,7 +464,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Resolve archive-enabled image styles from private R2 packages. When off, image style authoring continues reading vm0-skills from GitHub.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.PlanUpgradeGuidance]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- Enable `FeatureSwitchKey.ImageStyleR2` globally so archive-backed image styles resolve from private R2 for every organization.
- Update rollout assertions and API BDD coverage for default R2 behavior, the explicit GitHub fallback override, and GitHub-only styles without archives.

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts` passed.
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts src/__tests__/illustration-template-items.spec.ts` passed: 27 tests.
- `pnpm --filter @vm0/core lint` passed.
- `pnpm --filter @vm0/core check-types` passed.
- `pnpm --filter api lint` passed.
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types` passed.
- `pnpm --filter api exec eslint src/signals/routes/__tests__/chat-messages.bdd.test.ts --max-warnings 0` passed.
- The targeted API BDD test could not start because local PostgreSQL is unavailable (`ECONNREFUSED 127.0.0.1:5432` and `::1:5432`); 52 tests were skipped before the test body ran.
