### PR TITLE
refactor(storage): detach legacy type columns from runtime writes

### DIFF
--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -152,11 +152,11 @@ function buildStorageSeedSql(
   // populating the final archive-size metadata for the same shared object.
   return `
   INSERT INTO storages (
-    id, org_id, user_id, name, type, s3_prefix, size, file_count, updated_at
+    id, org_id, user_id, name, s3_prefix, size, file_count, updated_at
   )
   SELECT
-    "storageId", ${systemOrgId}, ${volumeOrgUserId}, "storageName", 'volume',
-    "s3Prefix", "storageSize", "storageFileCount", seeded_at
+    "storageId", ${systemOrgId}, ${volumeOrgUserId}, "storageName", "s3Prefix",
+    "storageSize", "storageFileCount", seeded_at
   FROM dev_seed_skill_volumes
   ON CONFLICT (org_id, user_id, name) DO UPDATE SET
     s3_prefix = excluded.s3_prefix,

--- a/turbo/apps/api/src/signals/routes/test-cron-sync-skills-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-sync-skills-state.ts
@@ -13,6 +13,7 @@ import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { storageDml } from "../services/storage-dml.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -90,7 +91,7 @@ async function seedStorageRows(
   versions: readonly TestCronSyncSkillsStateSkillVersionSeed[],
 ) {
   const storageRows = await db
-    .insert(storages)
+    .insert(storageDml)
     .values(
       versions.map((version) => {
         return {
@@ -104,14 +105,14 @@ async function seedStorageRows(
       }),
     )
     .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
+      target: [storageDml.orgId, storageDml.userId, storageDml.name],
       set: {
         s3Prefix: sql`excluded.s3_prefix`,
         size: sql`excluded.size`,
         fileCount: sql`excluded.file_count`,
       },
     })
-    .returning({ id: storages.id, name: storages.name });
+    .returning({ id: storageDml.id, name: storageDml.name });
 
   return new Map(
     storageRows.map((row) => {

--- a/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
@@ -15,6 +15,7 @@ import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { storageDml } from "../services/storage-dml.service";
 import { newStorageS3Location } from "../services/storage-s3-prefix.utils";
 import {
   commitStorageUploadForStorage$,
@@ -65,7 +66,7 @@ async function findOrCreateFixtureStorageId(args: {
 
   const location = newStorageS3Location(args.orgId);
   const [storage] = await args.db
-    .insert(storages)
+    .insert(storageDml)
     .values({
       id: location.storageId,
       orgId: args.orgId,
@@ -76,10 +77,10 @@ async function findOrCreateFixtureStorageId(args: {
       fileCount: 0,
     })
     .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
+      target: [storageDml.orgId, storageDml.userId, storageDml.name],
       set: { updatedAt: nowDate() },
     })
-    .returning({ id: storages.id });
+    .returning({ id: storageDml.id });
   if (!storage?.id) {
     throw new Error("Failed to create Storage fixture");
   }

--- a/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
@@ -11,6 +11,7 @@ import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { storageDml } from "../services/storage-dml.service";
 import { systemStoragePresignedUrlCacheKey } from "../services/system-storage-presigned-url-cache.service";
 import {
   isTestEndpointAllowed,
@@ -132,7 +133,7 @@ async function seedStorageVersionForAction(
   signal: AbortSignal,
 ) {
   const [storage] = await db
-    .insert(storages)
+    .insert(storageDml)
     .values({
       orgId: body.org_id,
       userId: body.user_id,
@@ -142,14 +143,14 @@ async function seedStorageVersionForAction(
       fileCount: 1,
     })
     .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
+      target: [storageDml.orgId, storageDml.userId, storageDml.name],
       set: {
         s3Prefix: sql`excluded.s3_prefix`,
         size: sql`excluded.size`,
         fileCount: sql`excluded.file_count`,
       },
     })
-    .returning({ id: storages.id });
+    .returning({ id: storageDml.id });
   signal.throwIfAborted();
   if (!storage) {
     throw new Error("Failed to seed storage");

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -43,6 +43,7 @@ import {
   type ApiDispatchTimingDimensionsInput,
 } from "./api-dispatch-timing.service";
 import { computeContentHashFromHashes } from "./storage-content-hash.service";
+import { storageDml } from "./storage-dml.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 type ManifestStorage = LegacyStorageManifest["storages"][number];
@@ -1169,7 +1170,7 @@ async function findOrCreateArtifactStorage(
     async () => {
       const location = newStorageS3Location(args.orgId);
       return await args.db
-        .insert(storages)
+        .insert(storageDml)
         .values({
           id: location.storageId,
           orgId: args.orgId,
@@ -1179,9 +1180,9 @@ async function findOrCreateArtifactStorage(
         })
         .onConflictDoNothing()
         .returning({
-          id: storages.id,
-          headVersionId: storages.headVersionId,
-          s3Prefix: storages.s3Prefix,
+          id: storageDml.id,
+          headVersionId: storageDml.headVersionId,
+          s3Prefix: storageDml.s3Prefix,
         });
     },
   );

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -9,6 +9,7 @@ import type {
   ConnectorCatalogArtifact,
   ConnectorCatalogArtifactConnector,
 } from "./connector-catalog-artifacts/artifacts";
+import { storageDml } from "./storage-dml.service";
 
 const SYSTEM_STORAGE_CREATOR = "system";
 
@@ -222,7 +223,7 @@ async function createAndReadCanonicalStorages(
   signal: AbortSignal,
 ): Promise<ReadonlyMap<string, CanonicalStorage>> {
   await db
-    .insert(storages)
+    .insert(storageDml)
     .values(
       registrations.map((registration) => {
         return {
@@ -334,7 +335,7 @@ async function updateNewStorageHeads(
 ): Promise<void> {
   const updatedAt = nowDate();
   const updated = await db
-    .insert(storages)
+    .insert(storageDml)
     .values(
       registrations.map((registration) => {
         return {
@@ -350,16 +351,16 @@ async function updateNewStorageHeads(
       }),
     )
     .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
+      target: [storageDml.orgId, storageDml.userId, storageDml.name],
       set: {
         headVersionId: sql`excluded.head_version_id`,
         size: sql`excluded.size`,
         fileCount: sql`excluded.file_count`,
         updatedAt: sql`excluded.updated_at`,
       },
-      setWhere: eq(storages.s3Prefix, sql`excluded.s3_prefix`),
+      setWhere: eq(storageDml.s3Prefix, sql`excluded.s3_prefix`),
     })
-    .returning({ name: storages.name });
+    .returning({ name: storageDml.name });
   signal.throwIfAborted();
   if (updated.length !== registrations.length) {
     fail("invalid-reference", false);

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -38,6 +38,7 @@ import {
 } from "../external/s3";
 import { createDeferredPromise, safeSync, tapError } from "../utils";
 import type { FileEntryWithHash } from "./storage-content-hash.service";
+import { storageDml } from "./storage-dml.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 interface SyncSkillsResult {
@@ -383,7 +384,7 @@ async function upsertSkillStorage(args: {
 }): Promise<{ readonly id: string; readonly s3Prefix: string }> {
   const location = newStorageS3Location(SYSTEM_ORG_ID);
   const [storage] = await args.db
-    .insert(storages)
+    .insert(storageDml)
     .values({
       id: location.storageId,
       orgId: SYSTEM_ORG_ID,
@@ -394,14 +395,14 @@ async function upsertSkillStorage(args: {
       fileCount: args.context.files.length,
     })
     .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
+      target: [storageDml.orgId, storageDml.userId, storageDml.name],
       set: {
         size: args.context.totalSize,
         fileCount: args.context.files.length,
         updatedAt: args.timestamp,
       },
     })
-    .returning({ id: storages.id, s3Prefix: storages.s3Prefix });
+    .returning({ id: storageDml.id, s3Prefix: storageDml.s3Prefix });
   args.signal.throwIfAborted();
 
   if (!storage) {

--- a/turbo/apps/api/src/signals/services/storage-dml.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-dml.service.ts
@@ -1,0 +1,36 @@
+import {
+  bigint,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Write-only table projections for the Storage schema contraction.
+ *
+ * Production migrations run before the new API is promoted. These projections
+ * intentionally omit the legacy `storages.type` and
+ * `storage_version_lineage.storage_type` columns so the currently deployed API
+ * remains compatible while the follow-up migration removes those columns.
+ */
+export const storageDml = pgTable("storages", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: text("user_id").notNull(),
+  name: varchar("name", { length: 256 }).notNull(),
+  orgId: text("org_id").notNull(),
+  s3Prefix: text("s3_prefix").notNull(),
+  size: bigint("size", { mode: "number" }).notNull().default(0),
+  fileCount: integer("file_count").notNull().default(0),
+  headVersionId: varchar("head_version_id", { length: 64 }),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const storageVersionLineageDml = pgTable("storage_version_lineage", {
+  storageId: uuid("storage_id").notNull(),
+  versionId: varchar("version_id", { length: 64 }).notNull(),
+  parentVersionId: varchar("parent_version_id", { length: 64 }).notNull(),
+  runId: uuid("run_id").notNull(),
+});

--- a/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
@@ -19,6 +19,7 @@ import {
   hashFileContent,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
+import { storageDml } from "./storage-dml.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 interface VolumeFileInput {
@@ -184,7 +185,7 @@ const uploadVolumeServerSideInner$ = command(
     const timestamp = nowDate();
 
     const [storage] = await writeDb
-      .insert(storages)
+      .insert(storageDml)
       .values({
         id: storageId,
         userId: VOLUME_ORG_USER_ID,
@@ -195,12 +196,12 @@ const uploadVolumeServerSideInner$ = command(
         fileCount: 0,
       })
       .onConflictDoUpdate({
-        target: [storages.orgId, storages.userId, storages.name],
+        target: [storageDml.orgId, storageDml.userId, storageDml.name],
         set: { updatedAt: timestamp },
       })
       .returning({
-        id: storages.id,
-        s3Prefix: storages.s3Prefix,
+        id: storageDml.id,
+        s3Prefix: storageDml.s3Prefix,
       });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -1,7 +1,6 @@
 import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { storageVersionLineage } from "@vm0/db/schema/storage-version-lineage";
 import { command, computed, type Computed } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
@@ -24,6 +23,7 @@ import {
   computeContentHashFromHashes,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
+import { storageVersionLineageDml } from "./storage-dml.service";
 
 const L = logger("storage-write");
 
@@ -726,7 +726,7 @@ async function recordStorageLineage(args: {
   }
 
   await tapError(
-    args.db.insert(storageVersionLineage).values({
+    args.db.insert(storageVersionLineageDml).values({
       storageId: args.storageId,
       versionId: args.versionId,
       parentVersionId,

--- a/turbo/apps/api/src/test-fixtures/private-registry-resource.ts
+++ b/turbo/apps/api/src/test-fixtures/private-registry-resource.ts
@@ -5,6 +5,7 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { writeDb$ } from "../signals/external/db";
+import { storageDml } from "../signals/services/storage-dml.service";
 
 interface PrivateRegistryResourceVersionFixture {
   readonly cleanup: () => Promise<void>;
@@ -30,7 +31,7 @@ export async function seedPrivateRegistryResourceVersionFixture(args: {
   const db = createStore().set(writeDb$);
   const fixtureId = randomUUID();
   const [storage] = await db
-    .insert(storages)
+    .insert(storageDml)
     .values({
       orgId: `org_registry_fixture_${fixtureId}`,
       userId: `user_registry_fixture_${fixtureId}`,
@@ -39,7 +40,7 @@ export async function seedPrivateRegistryResourceVersionFixture(args: {
       size: args.size,
       fileCount: args.fileCount,
     })
-    .returning({ id: storages.id });
+    .returning({ id: storageDml.id });
   if (!storage) {
     throw new Error("Failed to seed private registry resource storage");
   }


### PR DESCRIPTION
## Summary

- Add write-only DML projections for `storages` and `storage_version_lineage` that intentionally exclude the legacy `type` and `storage_type` columns.
- Route every API and test Storage insert, plus the dev seed, through those legacy-free projections.
- Keep the physical schema unchanged in this PR so the compatibility code can be released before the follow-up column-drop migration.

## Deployment safety

Production migrations run before a new API revision is promoted. Current `main` still includes `storages.type` in generated Drizzle INSERT statements even when callers omit the field, so dropping the column in the same release would break the old API during cutover. This PR removes that generated SQL dependency first; the physical drop must follow only after this revision is in Production.

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip`
- Pre-commit hooks passed: Prettier, Knip, full monorepo type checks, file-size and generated-firewall guards.
- Ran `webhooks-callbacks.bdd.test.ts` against a migrated database with both legacy columns manually removed: 40/41 passed, with zero missing-column errors. Unmodified `main` on the normal schema has the identical remaining Runner queue fixture failure (`Job not found in queue`), establishing it as baseline behavior unrelated to this change.

No database migration is included by design.