### PR TITLE
fix(api): validate and recover canonical chat session bindings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -63,13 +63,16 @@ import { overwriteModelProviderSecretForTests } from "./helpers/zero-model-provi
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import {
+  deleteAgentRunFixture,
   deleteBddVm0ApiKeys,
   hasVm0ApiKeyLabel,
   holdChatMessageFixture,
   holdChatMessageQueueItemFixture,
   holdOrgAdmissionLockFixture,
+  holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
   replaceBddVm0ApiKeys,
+  replaceThreadSessionBindingFixture,
 } from "../../../test-fixtures/chat-messages";
 
 /**
@@ -3016,6 +3019,154 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
+  it("refuses a canonical session owned by another user and organization", async () => {
+    const primary = await entitledChatActor();
+    const foreign = await entitledChatActor();
+    const runnerGroup = api.configureRunnerGroup();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const primaryFirst = await sendChatRun(primary.actor, {
+      agentId: primary.agentId,
+      prompt: "establish the correctly owned canonical session",
+    });
+    const primaryClaim = await claimChatRun(runnerGroup, primaryFirst.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(primaryFirst.runId, primaryClaim.sandboxHeaders);
+
+    const foreignFirst = await sendChatRun(foreign.actor, {
+      agentId: foreign.agentId,
+      prompt: "establish a foreign canonical session",
+    });
+    const foreignClaim = await claimChatRun(runnerGroup, foreignFirst.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(foreignFirst.runId, foreignClaim.sandboxHeaders);
+
+    const primaryBinding = await readThreadSessionBinding(
+      context,
+      primaryFirst.threadId,
+    );
+    const foreignBinding = await readThreadSessionBinding(
+      context,
+      foreignFirst.threadId,
+    );
+    if (!primaryBinding.agent_session_id || !foreignBinding.agent_session_id) {
+      throw new Error("Expected both threads to establish canonical sessions");
+    }
+    await replaceThreadSessionBindingFixture({
+      threadId: primaryFirst.threadId,
+      sessionId: foreignBinding.agent_session_id,
+      runId: foreignFirst.runId,
+    });
+
+    const primarySecond = await sendChatRun(primary.actor, {
+      agentId: primary.agentId,
+      threadId: primaryFirst.threadId,
+      prompt: "continue without reusing the foreign session",
+    });
+    const repairedBinding = await readThreadSessionBinding(
+      context,
+      primaryFirst.threadId,
+    );
+    expect(repairedBinding).toMatchObject({
+      agent_session_id: primaryBinding.agent_session_id,
+      agent_session_run_id: primarySecond.runId,
+      run_session_id: primaryBinding.agent_session_id,
+    });
+    expect(repairedBinding.agent_session_id).not.toBe(
+      foreignBinding.agent_session_id,
+    );
+    expect(sandboxOperationEventsForRun(primarySecond.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type: "chat_thread_session_binding_persisted",
+        chat_thread_id: primaryFirst.threadId,
+        agent_session_id: primaryBinding.agent_session_id,
+        agent_session_run_id: primarySecond.runId,
+        binding_action: "adopted",
+      }),
+    );
+    const primarySecondClaim = await claimChatRun(
+      runnerGroup,
+      primarySecond.runId,
+    );
+    expect(primarySecondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${primaryFirst.runId}`,
+    );
+    await cancelChatRun(primary.actor, primarySecond.runId);
+  }, 90_000);
+
+  it("retries preparation when the canonical binding changes", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for binding validation");
+    }
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the binding snapshot",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+    const firstBinding = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    if (!firstBinding.agent_session_id) {
+      throw new Error("Expected the first run to establish a session");
+    }
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: actor.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+    const secondPromise = sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "retry after the binding changes",
+    });
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+
+    await clearThreadSessionBinding(context, first.threadId);
+    admissionLock.release();
+    await admissionLock.done;
+    const second = await secondPromise;
+
+    const retryEvents = sandboxOperationEvents().filter((event) => {
+      return (
+        event.op_type === "chat_thread_session_binding_retry" &&
+        event.chat_thread_id === first.threadId
+      );
+    });
+    expect(retryEvents).toContainEqual(
+      expect.objectContaining({
+        agent_session_id: firstBinding.agent_session_id,
+        binding_action: "retried",
+        resolution_action: "reused",
+        retry_reason: "binding_changed",
+      }),
+    );
+    const secondBinding = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    expect(secondBinding).toMatchObject({
+      agent_session_id: firstBinding.agent_session_id,
+      agent_session_run_id: second.runId,
+      run_session_id: firstBinding.agent_session_id,
+    });
+    const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
+    await cancelChatRun(actor, second.runId);
+  }, 90_000);
+
   it("retries preparation when the canonical conversation snapshot changes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -3085,6 +3236,187 @@ describe("CHAT-02: run-level model overrides", () => {
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
     expect(secondClaim.claim.resumeSession).toBeNull();
     await cancelChatRun(actor, second.runId);
+  }, 90_000);
+
+  it("fails after every canonical session preparation snapshot changes", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the snapshot before retry exhaustion",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    const firstBinding = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    if (!firstBinding.agent_session_id) {
+      throw new Error("Expected the first run to establish a session");
+    }
+
+    const preparationAttempts = 3;
+    const conversationChanges =
+      await holdThreadSessionConversationChangesFixture({
+        threadId: first.threadId,
+        changeCount: preparationAttempts,
+        signal: context.signal,
+      });
+    onTestFinished(async () => {
+      conversationChanges.releaseAll();
+      await conversationChanges.done;
+    });
+    const failedPromise = requestSendMessageRaw(actor, {
+      agentId,
+      threadId: first.threadId,
+      clientMessageId: randomUUID(),
+      prompt: "exhaust every session preparation attempt",
+    });
+
+    for (let attempt = 0; attempt < preparationAttempts; attempt += 1) {
+      await expect
+        .poll(conversationChanges.blockedWaiterCount)
+        .toBeGreaterThanOrEqual(1);
+      conversationChanges.release();
+      if (attempt + 1 < preparationAttempts) {
+        await expect
+          .poll(conversationChanges.stagedChangeCount)
+          .toBe(attempt + 2);
+      }
+    }
+    await conversationChanges.done;
+    const failed = await failedPromise;
+    expect(failed).toStrictEqual({
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+
+    const retryEvents = sandboxOperationEvents().filter((event) => {
+      return (
+        event.op_type === "chat_thread_session_binding_retry" &&
+        event.chat_thread_id === first.threadId
+      );
+    });
+    expect(retryEvents).toHaveLength(preparationAttempts);
+    expect(retryEvents).toStrictEqual(
+      expect.arrayContaining(
+        Array.from({ length: preparationAttempts }, () => {
+          return expect.objectContaining({
+            agent_session_id: firstBinding.agent_session_id,
+            binding_action: "retried",
+            resolution_action: "reused",
+            retry_reason: "session_changed",
+          });
+        }),
+      ),
+    );
+    await expect(
+      readThreadSessionBinding(context, first.threadId),
+    ).resolves.toMatchObject({
+      agent_session_id: firstBinding.agent_session_id,
+      agent_session_run_id: first.runId,
+      run_session_id: firstBinding.agent_session_id,
+    });
+  }, 90_000);
+
+  it("rotates from the latest session run when binding provenance is deleted", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the original provider route",
+      model: "claude-sonnet-4-6",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "advance binding provenance on the same route",
+    });
+    const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
+    const originalBinding = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    if (!originalBinding.agent_session_id) {
+      throw new Error("Expected the original route to bind a session");
+    }
+
+    await deleteAgentRunFixture({ runId: second.runId });
+    await expect(
+      readThreadSessionBinding(context, first.threadId),
+    ).resolves.toMatchObject({
+      agent_session_id: originalBinding.agent_session_id,
+      agent_session_run_id: null,
+      run_session_id: null,
+    });
+
+    const { providerId: openRouterProviderId } = await upsertOrgModelProvider(
+      actor,
+      {
+        type: "openrouter-api-key",
+        secret: "provenance-fallback-openrouter-key",
+      },
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "openrouter-api-key",
+        credentialScope: "org",
+        modelProviderId: openRouterProviderId,
+      },
+    ]);
+
+    const third = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "rotate after the provenance run is removed",
+    });
+    const rotatedBinding = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    expect(rotatedBinding.agent_session_id).not.toBe(
+      originalBinding.agent_session_id,
+    );
+    expect(rotatedBinding).toMatchObject({
+      agent_session_run_id: third.runId,
+      run_session_id: rotatedBinding.agent_session_id,
+    });
+    expect(sandboxOperationEventsForRun(third.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type: "chat_thread_session_binding_persisted",
+        chat_thread_id: first.threadId,
+        agent_session_id: rotatedBinding.agent_session_id,
+        agent_session_run_id: third.runId,
+        binding_action: "rotated",
+      }),
+    );
+    const thirdClaim = await claimChatRun(runnerGroup, third.runId);
+    expect(thirdClaim.claim.resumeSession).toBeNull();
+    await cancelChatRun(actor, third.runId);
   }, 90_000);
 
   it("re-resolves a sticky model through the current provider policy", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -69,6 +69,7 @@ import {
   holdChatMessageFixture,
   holdChatMessageQueueItemFixture,
   holdOrgAdmissionLockFixture,
+  holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
   replaceBddVm0ApiKeys,
@@ -3125,16 +3126,41 @@ describe("CHAT-02: run-level model overrides", () => {
       admissionLock.release();
       await admissionLock.done;
     });
+    const messageId = randomUUID();
     const secondPromise = sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
       prompt: "retry after the binding changes",
+      clientMessageId: messageId,
     });
-    await expect.poll(admissionLock.waiterCount).toBe(1);
+    // The queue-first insert must complete before a fixture owns the parent
+    // thread row; otherwise its FK check would block before session resolution.
+    await expect
+      .poll(async () => {
+        const messages = await chat.listThreadMessages(actor, first.threadId);
+        return messages.messages.some((message) => {
+          return message.id === messageId;
+        });
+      })
+      .toBe(true);
 
-    await clearThreadSessionBinding(context, first.threadId);
+    const bindingClear = await holdThreadSessionBindingClearFixture({
+      threadId: first.threadId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      bindingClear.release();
+      await bindingClear.done;
+    });
     admissionLock.release();
     await admissionLock.done;
+    // Unlike the shared org advisory key, this row lock can only be reached
+    // after the target preparation has captured its binding snapshot.
+    await expect
+      .poll(bindingClear.blockedWaiterCount)
+      .toBeGreaterThanOrEqual(1);
+    bindingClear.release();
+    await bindingClear.done;
     const second = await secondPromise;
 
     const retryEvents = sandboxOperationEvents().filter((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -24,6 +24,7 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
+import { readThreadSessionBinding } from "./helpers/runtime-state";
 
 /*
 helper gap:
@@ -1465,6 +1466,15 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     const run1Id = await pollSlackRun(runnerGroup);
     const claim1 = await runs.claimRunnerJob(run1Id);
+    const slackBinding = await readThreadSessionBinding(
+      context,
+      canonicalChatThreadId,
+    );
+    expect(slackBinding.agent_session_id).toMatch(/[0-9a-f-]{36}/);
+    expect(slackBinding).toMatchObject({
+      agent_session_run_id: run1Id,
+      run_session_id: slackBinding.agent_session_id,
+    });
 
     const visibleThreadEvents = await chat.requestThreadEvents(
       actor,

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -44,6 +44,11 @@ interface HistoricalThreadSession {
   readonly route: ChatThreadSessionRoute;
 }
 
+interface SessionRunRoute {
+  readonly selectedModel: string | null;
+  readonly modelProvider: string | null;
+}
+
 function isKnownModelProvider(
   value: string | null | undefined,
 ): value is ModelProviderType {
@@ -151,6 +156,23 @@ async function latestHistoricalThreadSession(args: {
   };
 }
 
+async function latestSessionRunRoute(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly sessionId: string;
+}): Promise<SessionRunRoute | null> {
+  const [row] = await args.db
+    .select({
+      selectedModel: zeroRuns.selectedModel,
+      modelProvider: zeroRuns.modelProvider,
+    })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(eq(agentRuns.sessionId, args.sessionId))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(1);
+  return row ?? null;
+}
+
 function shouldRotateCanonicalSession(args: {
   readonly previousRoute: ChatThreadSessionRoute;
   readonly nextRoute: ChatThreadSessionRoute;
@@ -181,10 +203,19 @@ export async function resolveChatThreadSession(args: {
       conversationId: agentSessions.conversationId,
       selectedModel: zeroRuns.selectedModel,
       modelProvider: zeroRuns.modelProvider,
+      routeRunId: zeroRuns.id,
       cliAgentType: conversations.cliAgentType,
     })
     .from(chatThreads)
-    .leftJoin(agentSessions, eq(agentSessions.id, chatThreads.agentSessionId))
+    .leftJoin(
+      agentSessions,
+      and(
+        eq(agentSessions.id, chatThreads.agentSessionId),
+        eq(agentSessions.userId, args.userId),
+        eq(agentSessions.orgId, args.orgId),
+        eq(agentSessions.agentComposeId, args.agentComposeId),
+      ),
+    )
     .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
     .leftJoin(zeroRuns, eq(zeroRuns.id, chatThreads.agentSessionRunId))
     .where(
@@ -199,20 +230,24 @@ export async function resolveChatThreadSession(args: {
     throw new Error("Chat thread not found while resolving session binding");
   }
 
-  if (thread.agentSessionId !== null) {
-    if (thread.sessionId === null) {
-      throw new Error("Canonical chat thread session is missing");
-    }
+  if (thread.agentSessionId !== null && thread.sessionId !== null) {
     const expected = {
       agentSessionId: thread.agentSessionId,
       agentSessionRunId: thread.agentSessionRunId,
       sessionId: thread.sessionId,
       conversationId: thread.conversationId,
     };
+    const latestRoute =
+      thread.routeRunId === null
+        ? await latestSessionRunRoute({
+            db: args.db,
+            sessionId: thread.sessionId,
+          })
+        : null;
     const rotate = shouldRotateCanonicalSession({
       previousRoute: {
-        selectedModel: thread.selectedModel,
-        modelProvider: thread.modelProvider,
+        selectedModel: latestRoute?.selectedModel ?? thread.selectedModel,
+        modelProvider: latestRoute?.modelProvider ?? thread.modelProvider,
         cliAgentType: thread.cliAgentType,
       },
       nextRoute: args.route,
@@ -230,7 +265,7 @@ export async function resolveChatThreadSession(args: {
       sessionId: undefined,
       action: "initialized",
       expected: {
-        agentSessionId: null,
+        agentSessionId: thread.agentSessionId,
         agentSessionRunId: thread.agentSessionRunId,
         sessionId: null,
         conversationId: null,
@@ -246,7 +281,7 @@ export async function resolveChatThreadSession(args: {
     sessionId: rotate ? undefined : historical.sessionId,
     action: rotate ? "rotated" : "adopted",
     expected: {
-      agentSessionId: null,
+      agentSessionId: thread.agentSessionId,
       agentSessionRunId: thread.agentSessionRunId,
       sessionId: historical.sessionId,
       conversationId: historical.conversationId,

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -11,7 +11,7 @@ import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
 import { nowDate } from "../lib/time";
 import { insertChatMessage } from "../signals/services/zero-chat-message.service";
-import { createDeferredPromise } from "../signals/utils";
+import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
  * BDD-scoped vm0 managed key prefixes. Fixture writes below only ever touch
@@ -363,6 +363,155 @@ export async function holdThreadSessionConversationClearFixture(args: {
         waiterCountRowSchema,
       );
       return rows[0]?.waiterCount ?? 0;
+    },
+  };
+}
+
+/**
+ * Replaces one canonical binding with an otherwise valid session/run pair.
+ * Product APIs cannot bind a thread to another owner's session, so this is the
+ * narrow state boundary for ownership-corruption coverage.
+ */
+export async function replaceThreadSessionBindingFixture(args: {
+  readonly threadId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+}): Promise<void> {
+  const updated = await db()
+    .update(chatThreads)
+    .set({
+      agentSessionId: args.sessionId,
+      agentSessionRunId: args.runId,
+    })
+    .where(eq(chatThreads.id, args.threadId))
+    .returning({ id: chatThreads.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one chat thread session binding to be replaced");
+  }
+}
+
+/**
+ * Deletes one completed run to reproduce retention cleanup of binding
+ * provenance. No product endpoint exposes historical run deletion.
+ */
+export async function deleteAgentRunFixture(args: {
+  readonly runId: string;
+}): Promise<void> {
+  const deleted = await db()
+    .delete(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .returning({ id: agentRuns.id });
+  if (deleted.length !== 1) {
+    throw new Error("Expected one agent run to be deleted");
+  }
+}
+
+/**
+ * Alternates the bound session's conversation snapshot while consecutive run
+ * preparations reach final admission. This is the timing boundary for proving
+ * the retry limit without mocking the resolver or admission service.
+ */
+export async function holdThreadSessionConversationChangesFixture(args: {
+  readonly threadId: string;
+  readonly changeCount: number;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly releaseAll: () => void;
+  readonly done: Promise<void>;
+  readonly stagedChangeCount: () => number;
+  readonly blockedWaiterCount: () => Promise<number>;
+}> {
+  if (args.changeCount < 1) {
+    throw new Error("Expected at least one conversation snapshot change");
+  }
+  const [boundSession] = await db()
+    .select({
+      id: agentSessions.id,
+      conversationId: agentSessions.conversationId,
+    })
+    .from(chatThreads)
+    .innerJoin(agentSessions, eq(agentSessions.id, chatThreads.agentSessionId))
+    .where(eq(chatThreads.id, args.threadId))
+    .limit(1);
+  if (!boundSession?.conversationId) {
+    throw new Error("Expected a bound chat thread conversation");
+  }
+
+  const firstStaged = createDeferredPromise<void>(args.signal);
+  const releases = Array.from({ length: args.changeCount }, () => {
+    return createDeferredPromise<void>(args.signal);
+  });
+  let currentHolderPid: number | null = null;
+  let stagedChanges = 0;
+  const done = onRejection(
+    (async () => {
+      for (let index = 0; index < args.changeCount; index += 1) {
+        const release = releases[index];
+        if (!release) {
+          throw new Error("Missing conversation snapshot release gate");
+        }
+        await db().transaction(async (tx) => {
+          const [session] = await tx
+            .update(agentSessions)
+            .set({
+              conversationId:
+                index % 2 === 0 ? null : boundSession.conversationId,
+            })
+            .where(eq(agentSessions.id, boundSession.id))
+            .returning({ id: agentSessions.id });
+          if (!session) {
+            throw new Error("Expected the bound agent session");
+          }
+          const rows = await executeRawRows(
+            tx,
+            sql`SELECT pg_backend_pid() AS "pid"`,
+            databasePidRowSchema,
+          );
+          const holderPid = rows[0]?.pid;
+          if (!holderPid) {
+            throw new Error("Expected the conversation change holder pid");
+          }
+          currentHolderPid = holderPid;
+          stagedChanges = index + 1;
+          if (!firstStaged.settled()) {
+            firstStaged.resolve(undefined);
+          }
+          await release.promise;
+        });
+        currentHolderPid = null;
+      }
+    })(),
+    (error) => {
+      if (!firstStaged.settled()) {
+        firstStaged.reject(error);
+      }
+    },
+  );
+  await firstStaged.promise;
+
+  return {
+    release: () => {
+      const release = releases[stagedChanges - 1];
+      if (release && !release.settled()) {
+        release.resolve(undefined);
+      }
+    },
+    releaseAll: () => {
+      for (const release of releases) {
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+      }
+    },
+    done,
+    stagedChangeCount: () => {
+      return stagedChanges;
+    },
+    blockedWaiterCount: async () => {
+      return currentHolderPid === null
+        ? 0
+        : await directBlockedWaiterCount(currentHolderPid);
     },
   };
 }

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -391,6 +391,58 @@ export async function replaceThreadSessionBindingFixture(args: {
 }
 
 /**
+ * Stages a canonical binding clear after the queue-first message row is
+ * visible. Starting this transaction earlier would block that row's parent FK
+ * check; once the row exists, the uncommitted clear remains invisible to
+ * resolution and blocks only final snapshot validation on the thread row.
+ */
+export async function holdThreadSessionBindingClearFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const [thread] = await tx
+      .update(chatThreads)
+      .set({ agentSessionId: null, agentSessionRunId: null })
+      .where(eq(chatThreads.id, args.threadId))
+      .returning({ id: chatThreads.id });
+    if (!thread) {
+      throw new Error("Expected a bound chat thread session");
+    }
+    const rows = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS "pid"`,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the binding clear holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(holderPid);
+    },
+  };
+}
+
+/**
  * Deletes one completed run to reproduce retention cleanup of binding
  * provenance. No product endpoint exposes historical run deletion.
  */

--- a/turbo/packages/db/src/schema/chat-thread.ts
+++ b/turbo/packages/db/src/schema/chat-thread.ts
@@ -59,7 +59,7 @@ export const chatThreads = pgTable(
     ),
     /**
      * Run whose final admission most recently established agentSessionId.
-     * Kept as provenance for rollout validation and future snapshot checks.
+     * Provides route provenance for session rotation and binding snapshots.
      */
     agentSessionRunId: uuid("agent_session_run_id").references(
       () => {


### PR DESCRIPTION
## Summary

- validate canonical session ownership against user, organization, and agent compose before reuse; invalid bindings now fall through to safe historical adoption or initialization
- recover model and provider route provenance from the latest surviving run in the bound session when the binding run has been deleted, preserving required session rotation
- add deterministic BDD coverage for cross-owner bindings, rotated telemetry, binding-change retries, retry exhaustion, and direct Slack canonical-binding persistence

## User-visible impact

Thread-bound runs can no longer continue a canonical session owned by another user or organization. Session rotation also remains correct after provenance-run retention cleanup, including provider changes, without changing queue behavior, append-only chat messages, or admission locking.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip`
- 5 targeted `chat-messages.bdd.test.ts` session-continuity cases
- targeted `integrations.bdd.test.ts` Slack canonical retry case

Fixes #23177