### PR TITLE
fix(runner): reject ambiguous host authorities

### DIFF
--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -77,7 +77,8 @@ class AuthorityValidationError(Exception):
     - ``missing_sni``: the HTTPS request had no TLS SNI.
     - ``invalid_sni``: the TLS SNI failed hostname normalization.
     - ``missing_authority``: the HTTPS request had no Host/``:authority``.
-    - ``invalid_authority``: Host/``:authority`` failed parsing or normalization.
+    - ``invalid_authority``: Host/``:authority`` was ambiguous or failed
+      parsing or normalization.
     - ``authority_mismatch``: the Host hostname did not match TLS SNI.
     - ``authority_port_mismatch``: the Host port did not match destination port.
     """
@@ -181,10 +182,11 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
 
     In transparent mode, mitmproxy's request host is the ``SO_ORIGINAL_DST``
     destination. For HTTPS, the TLS SNI is the domain authority used for
-    upstream TLS, while Host/``:authority`` is only a client assertion. Require
-    the HTTP authority to agree with SNI before using the URL for firewall
-    matching or credential injection. For non-HTTPS traffic there is no SNI
-    binding, so use the transparent destination host and do not trust Host.
+    upstream TLS, while Host/``:authority`` values are only client assertions.
+    Require every HTTP authority to agree with SNI before using the URL for
+    firewall matching or credential injection. For non-HTTPS traffic there is
+    no SNI binding, so use the transparent destination host and do not trust
+    Host.
 
     HTTPS validation failures raise ``AuthorityValidationError`` with one of
     the documented ``AuthorityValidationReason`` values.
@@ -202,6 +204,7 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
             url=_build_url(scheme, request_host, port, path),
         )
 
+    raw_host_headers = flow.request.headers.get_all("Host")
     raw_sni = getattr(flow.client_conn, "sni", None)
     sni = raw_sni.strip() if isinstance(raw_sni, str) else None
 
@@ -238,6 +241,13 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         ) from None
 
     trusted_url = _build_url(scheme, normalized_sni, port, path)
+    if len(raw_host_headers) > 1:
+        raise _authority_validation_error(
+            "invalid_authority",
+            message="Request blocked: HTTPS request has multiple Host fields",
+            fallback_url=trusted_url,
+        )
+
     if not host_header:
         raise _authority_validation_error(
             "missing_authority",
@@ -245,29 +255,38 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
             fallback_url=trusted_url,
         )
 
-    try:
-        header_host, header_port = _parse_host_authority(host_header)
-        normalized_header_host = _normalize_hostname(header_host)
-    except (UnicodeError, ValueError):
-        raise _authority_validation_error(
-            "invalid_authority",
-            message="Request blocked: HTTPS request has invalid Host authority",
-            fallback_url=trusted_url,
-        ) from None
+    authorities = [host_header]
+    if (
+        (flow.request.is_http2 or flow.request.is_http3)
+        and flow.request.authority
+        and raw_host_headers
+    ):
+        authorities.append(raw_host_headers[0])
 
-    if normalized_header_host != normalized_sni:
-        raise _authority_validation_error(
-            "authority_mismatch",
-            message="Request blocked: Host authority does not match TLS SNI",
-            fallback_url=trusted_url,
-        )
+    for authority in authorities:
+        try:
+            header_host, header_port = _parse_host_authority(authority)
+            normalized_header_host = _normalize_hostname(header_host)
+        except (UnicodeError, ValueError):
+            raise _authority_validation_error(
+                "invalid_authority",
+                message="Request blocked: HTTPS request has invalid Host authority",
+                fallback_url=trusted_url,
+            ) from None
 
-    if header_port is not None and header_port != port:
-        raise _authority_validation_error(
-            "authority_port_mismatch",
-            message="Request blocked: Host authority port does not match destination port",
-            fallback_url=trusted_url,
-        )
+        if normalized_header_host != normalized_sni:
+            raise _authority_validation_error(
+                "authority_mismatch",
+                message="Request blocked: Host authority does not match TLS SNI",
+                fallback_url=trusted_url,
+            )
+
+        if header_port is not None and header_port != port:
+            raise _authority_validation_error(
+                "authority_port_mismatch",
+                message="Request blocked: Host authority port does not match destination port",
+                fallback_url=trusted_url,
+            )
 
     return TrustedAuthority(host=normalized_sni, port=port, url=trusted_url)
 

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -1,5 +1,6 @@
 """Request framing integration tests through mitmproxy's real hook pipeline."""
 
+import json
 from pathlib import Path
 from typing import Literal
 from unittest.mock import AsyncMock, patch
@@ -10,7 +11,7 @@ from h2.connection import H2Connection
 from mitmproxy import connection
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.flow import Error
-from mitmproxy.proxy import events
+from mitmproxy.proxy import commands, events
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.layers.http import HttpLayer, HTTPMode
 from mitmproxy.proxy.layers.http._hooks import (
@@ -26,7 +27,11 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
-from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.request_handler_helpers import (
+    _single_firewall_vm,
+    _write_github_firewall_registry,
+    _write_registry,
+)
 
 _CLIENT_IP = "10.200.0.5"
 _PLACEHOLDER_HOST = "placeholder.example.com"
@@ -79,6 +84,7 @@ def _start_http2_request(
     *,
     method: str,
     end_stream: bool,
+    regular_headers: tuple[tuple[bytes, bytes], ...] = (),
 ) -> tuple[HttpLayer, HttpRequestHeadersHook]:
     client, http_layer = _start_http_layer(addon_context, alpn=b"h2")
 
@@ -91,6 +97,7 @@ def _start_http2_request(
             (b":scheme", b"https"),
             (b":authority", _PLACEHOLDER_HOST.encode()),
             (b":path", b"/"),
+            *regular_headers,
         ],
         end_stream=end_stream,
     )
@@ -120,6 +127,75 @@ def _start_http1_request(
         command for command in commands if isinstance(command, HttpRequestHeadersHook)
     )
     return http_layer, request_headers_hook
+
+
+async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(
+    tmp_path: Path,
+    fake_firewall_headers,
+) -> None:
+    registry_path = _write_github_firewall_registry(
+        tmp_path,
+        base=f"https://{_PLACEHOLDER_HOST}",
+        vm_fields={"captureNetworkBodies": True},
+    )
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_http2_request(
+            addon_context,
+            method="GET",
+            end_stream=True,
+            regular_headers=(
+                (b"host", b"attacker.example.com"),
+                (b"host", _PLACEHOLDER_HOST.encode()),
+            ),
+        )
+        flow = request_headers_hook.flow
+        original_headers = tuple(flow.request.headers.fields)
+        original_path = flow.request.path
+
+        assert flow.request.host_header == _PLACEHOLDER_HOST
+        assert flow.request.headers.get_all("Host") == [
+            "attacker.example.com",
+            _PLACEHOLDER_HOST,
+        ]
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+
+        get_headers.assert_not_awaited()
+        assert tuple(flow.request.headers.fields) == original_headers
+        assert flow.request.path == original_path
+
+        header_commands = list(
+            http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+        )
+        request_hook = next(
+            command for command in header_commands if isinstance(command, HttpRequestHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+
+        request_commands = list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content)["error"] == "invalid_authority"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.path == original_path
+    get_headers.assert_not_awaited()
+    assert not any(
+        isinstance(command, (commands.OpenConnection, commands.SendData))
+        and isinstance(command.connection, connection.Server)
+        for command in request_commands
+    )
 
 
 @pytest.mark.parametrize("method", ["GET", "HEAD"])

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1368,17 +1368,25 @@ async def test_matching_sni_and_host_allows_bound_firewall_auth(
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])
-async def test_pseudo_authority_without_host_allows_firewall_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, http_version
+@pytest.mark.parametrize("regular_host", [None, "api.github.com"], ids=["authority-only", "host"])
+async def test_valid_pseudo_authority_allows_firewall_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    http_version,
+    regular_host,
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
+    request_headers = headers() if regular_host is None else headers(("Host", regular_host))
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="203.0.113.10",
         sni="api.github.com",
         path="/repos",
-        request_headers=headers(),
+        request_headers=request_headers,
     )
     flow.request.http_version = http_version
     flow.request.authority = "api.github.com"
@@ -1397,8 +1405,30 @@ async def test_pseudo_authority_without_host_allows_firewall_auth(
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])
-async def test_pseudo_authority_takes_precedence_over_host_header(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, http_version
+@pytest.mark.parametrize(
+    ("pseudo_authority", "regular_host"),
+    [
+        pytest.param(
+            "attacker.example.com",
+            "api.github.com",
+            id="pseudo-authority-mismatch",
+        ),
+        pytest.param(
+            "api.github.com",
+            "attacker.example.com",
+            id="regular-host-mismatch",
+        ),
+    ],
+)
+async def test_rejects_disagreement_between_pseudo_authority_and_host(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    http_version,
+    pseudo_authority,
+    regular_host,
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -1407,10 +1437,10 @@ async def test_pseudo_authority_takes_precedence_over_host_header(
         host="203.0.113.10",
         sni="api.github.com",
         path="/repos",
-        request_headers=headers(("Host", "api.github.com")),
+        request_headers=headers(("Host", regular_host)),
     )
     flow.request.http_version = http_version
-    flow.request.authority = "attacker.example.com"
+    flow.request.authority = pseudo_authority
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -1423,7 +1453,7 @@ async def test_pseudo_authority_takes_precedence_over_host_header(
     body = json.loads(flow.response.content)
     assert body["error"] == "authority_mismatch"
     assert body["sni"] == "api.github.com"
-    assert body["host_header"] == "attacker.example.com"
+    assert body["host_header"] == pseudo_authority
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
@@ -1857,8 +1887,32 @@ async def test_matching_sni_and_host_allows_bound_vm0_api_auto_allow(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
+@pytest.mark.parametrize(
+    ("http_version", "pseudo_authority", "expected_host_header"),
+    [
+        pytest.param(
+            "HTTP/1.1",
+            "",
+            "attacker.example.com, api.github.com",
+            id="http1",
+        ),
+        pytest.param(
+            "HTTP/3",
+            "api.github.com",
+            "api.github.com",
+            id="http3",
+        ),
+    ],
+)
 async def test_rejects_duplicate_host_authority_before_firewall_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    http_version,
+    pseudo_authority,
+    expected_host_header,
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -1868,10 +1922,14 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
         sni="api.github.com",
         path="/repos",
         request_headers=headers(
-            ("Host", "api.github.com"),
             ("Host", "attacker.example.com"),
+            ("Host", "api.github.com"),
         ),
     )
+    flow.request.http_version = http_version
+    flow.request.authority = pseudo_authority
+    original_headers = tuple(flow.request.headers.fields)
+    original_path = flow.request.path
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -1884,10 +1942,12 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
     body = json.loads(flow.response.content)
     assert body["error"] == "invalid_authority"
     assert body["sni"] == "api.github.com"
-    assert body["host_header"] == "api.github.com, attacker.example.com"
+    assert body["host_header"] == expected_host_header
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.path == original_path
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 


### PR DESCRIPTION
## Summary

- reject HTTPS requests with multiple raw `Host` fields before firewall matching or auth resolution
- validate a single HTTP/2 or HTTP/3 `Host` independently alongside `:authority`, TLS SNI, and the destination port
- cover the locked HTTP/2 parser and real mitmproxy hook pipeline, HTTP/3 authority ambiguity, and valid matching authority forms

## Scope

- reuses the existing authority validation reasons and response/log contracts
- does not change h2, aioquic, mitmproxy, lockfiles, auth APIs, registry formats, or persisted state

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4274 passed`)

Closes #23164
