### PR TITLE
feat(feishu): improve setup and oauth callback flow

### DIFF
--- a/turbo/apps/api/src/lib/feishu-message-card.ts
+++ b/turbo/apps/api/src/lib/feishu-message-card.ts
@@ -95,28 +95,22 @@ export function buildFeishuWelcomeMessage(args: {
 }
 
 export function buildFeishuHelpMessage(): FeishuOutboundMessage {
-  return cardMessage({
-    title: "Zero commands",
-    template: "blue",
-    summary: "Available Zero commands for Feishu.",
-    elements: [
-      {
-        tag: "markdown",
-        content: [
-          "• `/help` — Show this help",
-          "• `/connect` — Connect your VM0 account",
-          "• `/disconnect` — Disconnect your VM0 account",
-          "• `/switch` — Choose which agent responds",
-          "• `/model` — Choose your model",
-        ].join("\n"),
-      },
-      {
-        tag: "markdown",
-        content:
-          "Send a task in a direct message, or mention the bot with a task in a group chat.",
-      },
-    ],
-  });
+  return {
+    msgType: "text",
+    content: {
+      text: [
+        "Zero commands",
+        "",
+        "/help — Show this help",
+        "/connect — Connect your VM0 account",
+        "/disconnect — Disconnect your VM0 account",
+        "/switch — Choose which agent responds",
+        "/model — Choose your model",
+        "",
+        "Send a task in a direct message, or mention the bot with a task in a group chat.",
+      ].join("\n"),
+    },
+  };
 }
 
 export function buildFeishuNoticeMessage(args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1025,7 +1025,7 @@ describe("Feishu integration", () => {
     const connectUrl = status.body.installations?.[0]?.connectUrl;
     expect(connectUrl).toBeDefined();
     expect(status.body.oauthRedirectUrl).toBe(
-      `${APP_ORIGIN}/connectors/feishu/callback`,
+      "https://www.vm0.test/api/zero/feishu/oauth/callback",
     );
     if (!connectUrl) {
       throw new Error("Expected Feishu status to return an OAuth connect URL");
@@ -1057,12 +1057,25 @@ describe("Feishu integration", () => {
     expect(authorizationUrl.origin).toBe("https://accounts.feishu.cn");
     expect(authorizationUrl.searchParams.get("client_id")).toBe(appId);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      `${APP_ORIGIN}/connectors/feishu/callback`,
+      "https://www.vm0.test/api/zero/feishu/oauth/callback",
     );
     const state = authorizationUrl.searchParams.get("state");
     if (!state) {
       throw new Error("Expected Feishu authorization URL to include state");
     }
+
+    const handoffResponse = await oauthApp.request(
+      `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
+        code: "feishu-oauth-code",
+        state,
+      })}`,
+    );
+    expect(handoffResponse.status).toBe(307);
+    const handoffUrl = new URL(handoffResponse.headers.get("location") ?? "");
+    expect(handoffUrl.origin).toBe(APP_ORIGIN);
+    expect(handoffUrl.pathname).toBe("/connectors/feishu/callback");
+    expect(handoffUrl.searchParams.get("code")).toBe("feishu-oauth-code");
+    expect(handoffUrl.searchParams.get("state")).toBe(state);
 
     const callbackResponse = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1025,7 +1025,7 @@ describe("Feishu integration", () => {
     const connectUrl = status.body.installations?.[0]?.connectUrl;
     expect(connectUrl).toBeDefined();
     expect(status.body.oauthRedirectUrl).toBe(
-      "https://www.vm0.test/api/zero/feishu/oauth/callback",
+      `${APP_ORIGIN}/connectors/feishu/callback`,
     );
     if (!connectUrl) {
       throw new Error("Expected Feishu status to return an OAuth connect URL");
@@ -1039,7 +1039,17 @@ describe("Feishu integration", () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
-    const connectResponse = await oauthApp.request(connectUrl);
+    const legacyConnectResponse = await oauthApp.request(connectUrl);
+    expect(legacyConnectResponse.status).toBe(307);
+    expect(
+      new URL(
+        legacyConnectResponse.headers.get("location") ?? "",
+      ).searchParams.get("redirect_uri"),
+    ).toBe("https://www.vm0.test/api/zero/feishu/oauth/callback");
+
+    const appConnectUrl = new URL(connectUrl);
+    appConnectUrl.searchParams.set("callbackTarget", "app");
+    const connectResponse = await oauthApp.request(appConnectUrl);
     expect(connectResponse.status).toBe(307);
     const authorizationUrl = new URL(
       connectResponse.headers.get("location") ?? "",
@@ -1047,7 +1057,7 @@ describe("Feishu integration", () => {
     expect(authorizationUrl.origin).toBe("https://accounts.feishu.cn");
     expect(authorizationUrl.searchParams.get("client_id")).toBe(appId);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://www.vm0.test/api/zero/feishu/oauth/callback",
+      `${APP_ORIGIN}/connectors/feishu/callback`,
     );
     const state = authorizationUrl.searchParams.get("state");
     if (!state) {
@@ -1057,13 +1067,14 @@ describe("Feishu integration", () => {
     const callbackResponse = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
         code: "feishu-oauth-code",
+        responseMode: "json",
         state,
       })}`,
     );
-    expect(callbackResponse.status).toBe(307);
-    expect(callbackResponse.headers.get("location")).toBe(
-      `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
-    );
+    expect(callbackResponse.status).toBe(200);
+    await expect(callbackResponse.json()).resolves.toStrictEqual({
+      redirectUrl: `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
+    });
     await flushWaitUntilForTest();
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
@@ -1516,6 +1527,13 @@ describe("Feishu integration", () => {
         return message.kind === "send";
       })
       .map(messageContent);
+    const helpReply = requireValue(
+      outboundMessages.find((message) => {
+        return messageContent(message).includes("Zero commands");
+      }),
+      "Expected Feishu help reply",
+    );
+    expect(helpReply.msgType).toBe("text");
     expect(
       commandReplies.some((content) => {
         return content.includes("Zero commands");

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -18,10 +18,12 @@ import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route-entry";
 import {
   feishuBotOpenUrl,
+  feishuOAuthApiCallbackUrl,
   feishuOAuthCallbackUrl,
   loadFeishuInstallationConfig,
 } from "../services/feishu-config";
 import {
+  createFeishuOAuthAuthorizationState,
   type FeishuOAuthState,
   verifyFeishuOAuthState,
 } from "../services/feishu-oauth-state";
@@ -49,17 +51,40 @@ function jsonErrorResponse(error: string): Response {
 }
 
 function settingsRedirect(params: Readonly<Record<string, string>>): Response {
+  return redirectResponse(settingsUrl(params));
+}
+
+function settingsUrl(params: Readonly<Record<string, string>>): string {
   const url = new URL("/settings/feishu", env("APP_URL"));
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
-  return redirectResponse(url.toString());
+  return url.toString();
+}
+
+function callbackRedirectResponse(
+  url: string,
+  responseMode: "json" | undefined,
+):
+  | Response
+  | {
+      readonly status: 200;
+      readonly body: { readonly redirectUrl: string };
+    } {
+  if (responseMode === "json") {
+    return {
+      status: 200,
+      body: { redirectUrl: url },
+    };
+  }
+  return redirectResponse(url);
 }
 
 async function exchangeOAuthUserInfo(args: {
   readonly appId: string;
   readonly appSecret: string;
   readonly code: string;
+  readonly redirectUri: string;
   readonly installationId: string;
   readonly signal: AbortSignal;
 }): Promise<FeishuUserInfo | undefined> {
@@ -69,7 +94,7 @@ async function exchangeOAuthUserInfo(args: {
         appId: args.appId,
         appSecret: args.appSecret,
         code: args.code,
-        redirectUri: feishuOAuthCallbackUrl(),
+        redirectUri: args.redirectUri,
         signal: args.signal,
       });
       return await fetchFeishuUserInfo({
@@ -198,10 +223,18 @@ const connect$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const authorizationUrl = new URL(FEISHU_AUTHORIZATION_URL);
+  const oauthState = createFeishuOAuthAuthorizationState(
+    state,
+    query.callbackTarget,
+  );
+  const redirectUri =
+    query.callbackTarget === "app"
+      ? feishuOAuthCallbackUrl()
+      : feishuOAuthApiCallbackUrl();
   authorizationUrl.searchParams.set("client_id", installation.appId);
-  authorizationUrl.searchParams.set("redirect_uri", feishuOAuthCallbackUrl());
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
   authorizationUrl.searchParams.set("response_type", "code");
-  authorizationUrl.searchParams.set("state", query.state);
+  authorizationUrl.searchParams.set("state", oauthState);
   return redirectResponse(authorizationUrl.toString());
 });
 
@@ -212,9 +245,12 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
     return jsonErrorResponse("Invalid or expired connect state");
   }
   if (query.error) {
-    return settingsRedirect({
-      error: query.error_description ?? query.error,
-    });
+    return callbackRedirectResponse(
+      settingsUrl({
+        error: query.error_description ?? query.error,
+      }),
+      query.responseMode,
+    );
   }
   if (!query.code) {
     return jsonErrorResponse("Missing authorization code");
@@ -224,7 +260,10 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
   const config = await loadFeishuInstallationConfig(db, state.installationId);
   signal.throwIfAborted();
   if (!config || config.orgId !== state.orgId) {
-    return settingsRedirect({ error: "Feishu bot not found." });
+    return callbackRedirectResponse(
+      settingsUrl({ error: "Feishu bot not found." }),
+      query.responseMode,
+    );
   }
   const [installation] = await db
     .select({
@@ -236,33 +275,43 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
     .limit(1);
   signal.throwIfAborted();
   if (!installation?.setupCompletedAt) {
-    return settingsRedirect({
-      error: "Finish setting up this Feishu bot before connecting.",
-    });
+    return callbackRedirectResponse(
+      settingsUrl({
+        error: "Finish setting up this Feishu bot before connecting.",
+      }),
+      query.responseMode,
+    );
   }
 
   const userInfo = await exchangeOAuthUserInfo({
     appId: config.appId,
     appSecret: config.appSecret,
     code: query.code,
+    redirectUri: state.redirectUri ?? feishuOAuthApiCallbackUrl(),
     installationId: state.installationId,
     signal,
   });
   signal.throwIfAborted();
   if (!userInfo) {
-    return settingsRedirect({
-      error: "Failed to connect Feishu account. Please try again.",
-    });
+    return callbackRedirectResponse(
+      settingsUrl({
+        error: "Failed to connect Feishu account. Please try again.",
+      }),
+      query.responseMode,
+    );
   }
   if (
     installation.tenantKey &&
     userInfo.tenantKey &&
     installation.tenantKey !== userInfo.tenantKey
   ) {
-    return settingsRedirect({
-      error:
-        "Use an account from the Feishu tenant connected to this workspace.",
-    });
+    return callbackRedirectResponse(
+      settingsUrl({
+        error:
+          "Use an account from the Feishu tenant connected to this workspace.",
+      }),
+      query.responseMode,
+    );
   }
 
   const connectionResult = await upsertFeishuConnection({
@@ -272,9 +321,12 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   });
   if (!connectionResult.connected) {
-    return settingsRedirect({
-      error: "This Feishu account is already connected.",
-    });
+    return callbackRedirectResponse(
+      settingsUrl({
+        error: "This Feishu account is already connected.",
+      }),
+      query.responseMode,
+    );
   }
 
   if (!installation.tenantKey && userInfo.tenantKey) {
@@ -311,7 +363,10 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
       ),
     );
   }
-  return redirectResponse(feishuBotOpenUrl(config.appId));
+  return callbackRedirectResponse(
+    feishuBotOpenUrl(config.appId),
+    query.responseMode,
+  );
 });
 
 export const zeroFeishuOauthRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -18,7 +18,7 @@ import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route-entry";
 import {
   feishuBotOpenUrl,
-  feishuOAuthApiCallbackUrl,
+  feishuOAuthAppCallbackUrl,
   feishuOAuthCallbackUrl,
   loadFeishuInstallationConfig,
 } from "../services/feishu-config";
@@ -60,6 +60,37 @@ function settingsUrl(params: Readonly<Record<string, string>>): string {
     url.searchParams.set(key, value);
   }
   return url.toString();
+}
+
+interface FeishuOAuthCallbackQuery {
+  readonly code?: string;
+  readonly error?: string;
+  readonly error_description?: string;
+  readonly responseMode?: "json";
+  readonly state?: string;
+}
+
+function appCallbackUrl(query: FeishuOAuthCallbackQuery): string {
+  const url = new URL(feishuOAuthAppCallbackUrl());
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+function resolveCallbackState(
+  query: FeishuOAuthCallbackQuery,
+): FeishuOAuthState | Response {
+  const state = query.state ? verifyFeishuOAuthState(query.state) : null;
+  if (!state) {
+    return jsonErrorResponse("Invalid or expired connect state");
+  }
+  if (state.callbackTarget === "app" && query.responseMode !== "json") {
+    return redirectResponse(appCallbackUrl(query));
+  }
+  return state;
 }
 
 function callbackRedirectResponse(
@@ -227,12 +258,8 @@ const connect$ = command(async ({ get }, signal: AbortSignal) => {
     state,
     query.callbackTarget,
   );
-  const redirectUri =
-    query.callbackTarget === "app"
-      ? feishuOAuthCallbackUrl()
-      : feishuOAuthApiCallbackUrl();
   authorizationUrl.searchParams.set("client_id", installation.appId);
-  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizationUrl.searchParams.set("redirect_uri", feishuOAuthCallbackUrl());
   authorizationUrl.searchParams.set("response_type", "code");
   authorizationUrl.searchParams.set("state", oauthState);
   return redirectResponse(authorizationUrl.toString());
@@ -240,9 +267,9 @@ const connect$ = command(async ({ get }, signal: AbortSignal) => {
 
 const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
   const query = get(queryOf(zeroFeishuOauthContract.callback));
-  const state = query.state ? verifyFeishuOAuthState(query.state) : null;
-  if (!state) {
-    return jsonErrorResponse("Invalid or expired connect state");
+  const state = resolveCallbackState(query);
+  if (state instanceof Response) {
+    return state;
   }
   if (query.error) {
     return callbackRedirectResponse(
@@ -287,7 +314,7 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
     appId: config.appId,
     appSecret: config.appSecret,
     code: query.code,
-    redirectUri: state.redirectUri ?? feishuOAuthApiCallbackUrl(),
+    redirectUri: feishuOAuthCallbackUrl(),
     installationId: state.installationId,
     signal,
   });

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -70,6 +70,10 @@ export function feishuCallbackUrl(installationId: string): string {
 }
 
 export function feishuOAuthCallbackUrl(): string {
+  return new URL("/connectors/feishu/callback", env("APP_URL")).toString();
+}
+
+export function feishuOAuthApiCallbackUrl(): string {
   return new URL(
     "/api/zero/feishu/oauth/callback",
     env("FEISHU_CALLBACK_BASE_URL"),

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -70,14 +70,14 @@ export function feishuCallbackUrl(installationId: string): string {
 }
 
 export function feishuOAuthCallbackUrl(): string {
-  return new URL("/connectors/feishu/callback", env("APP_URL")).toString();
-}
-
-export function feishuOAuthApiCallbackUrl(): string {
   return new URL(
     "/api/zero/feishu/oauth/callback",
     env("FEISHU_CALLBACK_BASE_URL"),
   ).toString();
+}
+
+export function feishuOAuthAppCallbackUrl(): string {
+  return new URL("/connectors/feishu/callback", env("APP_URL")).toString();
 }
 
 export function feishuOAuthConnectUrl(state: string): string {

--- a/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
+++ b/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { env } from "../../lib/env";
 import { now } from "../external/time";
 import { safeJsonParse } from "../utils";
-import { feishuOAuthConnectUrl } from "./feishu-config";
+import { feishuOAuthCallbackUrl, feishuOAuthConnectUrl } from "./feishu-config";
 
 const FEISHU_OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60;
 
@@ -13,6 +13,7 @@ const feishuOAuthStateSchema = z.object({
   installationId: z.string().uuid(),
   orgId: z.string().min(1),
   userId: z.string().min(1),
+  redirectUri: z.url().optional(),
   timestamp: z.number().int(),
 });
 
@@ -28,6 +29,7 @@ function createFeishuOAuthState(args: {
   readonly installationId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly redirectUri?: string;
 }): string {
   const encodedPayload = Buffer.from(
     JSON.stringify({
@@ -72,4 +74,17 @@ export function buildFeishuOAuthConnectUrl(args: {
   readonly userId: string;
 }): string {
   return feishuOAuthConnectUrl(createFeishuOAuthState(args));
+}
+
+export function createFeishuOAuthAuthorizationState(
+  state: FeishuOAuthState,
+  callbackTarget: "app" | undefined,
+): string {
+  return createFeishuOAuthState({
+    installationId: state.installationId,
+    orgId: state.orgId,
+    userId: state.userId,
+    redirectUri:
+      callbackTarget === "app" ? feishuOAuthCallbackUrl() : undefined,
+  });
 }

--- a/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
+++ b/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { env } from "../../lib/env";
 import { now } from "../external/time";
 import { safeJsonParse } from "../utils";
-import { feishuOAuthCallbackUrl, feishuOAuthConnectUrl } from "./feishu-config";
+import { feishuOAuthConnectUrl } from "./feishu-config";
 
 const FEISHU_OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60;
 
@@ -13,7 +13,7 @@ const feishuOAuthStateSchema = z.object({
   installationId: z.string().uuid(),
   orgId: z.string().min(1),
   userId: z.string().min(1),
-  redirectUri: z.url().optional(),
+  callbackTarget: z.literal("app").optional(),
   timestamp: z.number().int(),
 });
 
@@ -29,12 +29,13 @@ function createFeishuOAuthState(args: {
   readonly installationId: string;
   readonly orgId: string;
   readonly userId: string;
-  readonly redirectUri?: string;
+  readonly callbackTarget?: "app";
+  readonly timestamp?: number;
 }): string {
   const encodedPayload = Buffer.from(
     JSON.stringify({
       ...args,
-      timestamp: Math.floor(now() / 1000),
+      timestamp: args.timestamp ?? Math.floor(now() / 1000),
     }),
   ).toString("base64url");
   return `${encodedPayload}.${sign(encodedPayload)}`;
@@ -84,7 +85,7 @@ export function createFeishuOAuthAuthorizationState(
     installationId: state.installationId,
     orgId: state.orgId,
     userId: state.userId,
-    redirectUri:
-      callbackTarget === "app" ? feishuOAuthCallbackUrl() : undefined,
+    callbackTarget,
+    timestamp: state.timestamp,
   });
 }

--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -32,9 +32,17 @@ export const platformFeishuEventRequestUrlImg = platformStaticAssetUrl(
 export const platformFeishuEncryptionStrategyImg = platformStaticAssetUrl(
   "views/zero-page/assets/feishu/encryption-strategy-e50ee6b26d77.png",
 );
-export const platformFeishuCreateAppVersionImg = platformStaticAssetUrl(
-  "views/zero-page/assets/feishu/create-app-version-6a84ea716a76.png",
+export const platformFeishuVersionManagementCreateVersionImg =
+  platformStaticAssetUrl(
+    "views/zero-page/assets/feishu/version-management-create-version-43e32042dc81.png",
+  );
+export const platformFeishuVersionAvailabilityEditImg = platformStaticAssetUrl(
+  "views/zero-page/assets/feishu/version-availability-edit-5990fd6c7eae.png",
 );
+export const platformFeishuAvailabilitySettingsAllMembersImg =
+  platformStaticAssetUrl(
+    "views/zero-page/assets/feishu/availability-settings-all-members-2cf582a888ed.png",
+  );
 export const platformFeishuSecuritySettingsRedirectUrlImg =
   platformStaticAssetUrl(
     "views/zero-page/assets/feishu/security-settings-redirect-url-e7cf83ec76d4.png",

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -26,6 +26,7 @@ import { setupTeamsConnectPage$ } from "./zero-page/teams-connect-page.ts";
 import { setupTelegramConnectPage$ } from "./zero-page/telegram-connect-page.ts";
 import { setupTelegramSettingsPage$ } from "./zero-page/telegram-settings-page.ts";
 import { setupFeishuSettingsPage$ } from "./zero-page/feishu-settings-page.ts";
+import { setupFeishuOAuthCallbackPage$ } from "./zero-page/feishu-oauth-callback-page.ts";
 import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
 import { setupActivityDetailPage$ } from "./activity-page/activity-detail-page-setup.ts";
 import { setupActivityInspectPage$ } from "./activity-page/activity-inspect-page-setup.ts";
@@ -183,6 +184,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.connectorCallbackResult,
     setup: setupConnectorCallbackPage$,
+  },
+  {
+    path: ROUTES.feishuOAuthCallback,
+    setup: setupFeishuOAuthCallbackPage$,
   },
   {
     path: ROUTES.connectorCallback,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -22,6 +22,7 @@ export const ROUTES = {
   connectors: "/connectors",
   customConnectorProposal: "/connectors/custom/proposal",
   computerUseAuthorize: "/computer-use/authorize/:requestToken",
+  feishuOAuthCallback: "/connectors/feishu/callback",
   connectorCallback: "/connectors/:type/callback",
   connectorCallbackResult: "/connectors/:type/callback/:status",
   connectorRedirecting: "/connectors/:type/redirecting",

--- a/turbo/apps/platform/src/signals/zero-page/feishu-oauth-callback-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/feishu-oauth-callback-page.ts
@@ -1,0 +1,46 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { zeroFeishuOauthContract } from "@vm0/api-contracts/contracts/zero-feishu-oauth";
+
+import { accept } from "../../lib/accept.ts";
+import { FeishuOAuthCallbackPage } from "../../views/zero-page/feishu-oauth-callback-page.tsx";
+import { zeroClient$ } from "../api-client.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { searchParams$ } from "../route.ts";
+
+function searchParam(
+  searchParams: URLSearchParams,
+  name: string,
+): string | undefined {
+  return searchParams.get(name) ?? undefined;
+}
+
+export const setupFeishuOAuthCallbackPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const searchParams = get(searchParams$);
+    set(updatePage$, createElement(FeishuOAuthCallbackPage));
+    set(updateDocumentTitle$, "Connect Feishu");
+    await set(hideAppSkeleton$, signal);
+
+    const client = get(zeroClient$)(zeroFeishuOauthContract, {
+      apiBase: "api",
+    });
+    const result = await accept(
+      client.callback({
+        query: {
+          code: searchParam(searchParams, "code"),
+          error: searchParam(searchParams, "error"),
+          error_description: searchParam(searchParams, "error_description"),
+          responseMode: "json",
+          state: searchParam(searchParams, "state"),
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    window.location.assign(result.body.redirectUrl);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
@@ -16,6 +16,7 @@ const internalDialogExisting$ = state(false);
 const internalDialogInstallationId$ = state<string | null>(null);
 const internalUninstallInstallationId$ = state<string | null>(null);
 const internalSetupStep$ = state<FeishuSetupStep>("create");
+const internalGuideImageIndex$ = state(0);
 const internalSetupForm$ = state<FeishuSetupInput>({
   appId: "",
   appSecret: "",
@@ -27,8 +28,8 @@ const FEISHU_SETUP_STEP_ORDER = [
   "create",
   "credentials",
   "tokens",
-  "redirect",
   "events",
+  "redirect",
   "publish",
 ] as const satisfies readonly FeishuSetupStep[];
 
@@ -145,6 +146,10 @@ export const feishuSetupStep$ = computed((get) => {
   return get(internalSetupStep$);
 });
 
+export const feishuGuideImageIndex$ = computed((get) => {
+  return get(internalGuideImageIndex$);
+});
+
 export const feishuDialogExisting$ = computed((get) => {
   return get(internalDialogExisting$);
 });
@@ -174,6 +179,7 @@ export const openFeishuDialog$ = command(
     set(internalDialogExisting$, installationId !== undefined);
     set(internalDialogInstallationId$, installationId ?? null);
     set(internalSetupStep$, step);
+    set(internalGuideImageIndex$, 0);
     set(internalSetupForm$, {
       ...formDefaults,
       appSecret: "",
@@ -188,6 +194,7 @@ export const closeFeishuDialog$ = command(({ set }) => {
   set(internalDialogExisting$, false);
   set(internalDialogInstallationId$, null);
   set(internalSetupStep$, "create");
+  set(internalGuideImageIndex$, 0);
   set(internalSetupForm$, (previous) => {
     return {
       ...previous,
@@ -203,6 +210,7 @@ export const advanceFeishuSetupStep$ = command(({ set }) => {
     const index = FEISHU_SETUP_STEP_ORDER.indexOf(step);
     return FEISHU_SETUP_STEP_ORDER[index + 1] ?? step;
   });
+  set(internalGuideImageIndex$, 0);
 });
 
 export const goBackFeishuSetupStep$ = command(({ set }) => {
@@ -210,7 +218,22 @@ export const goBackFeishuSetupStep$ = command(({ set }) => {
     const index = FEISHU_SETUP_STEP_ORDER.indexOf(step);
     return index > 0 ? (FEISHU_SETUP_STEP_ORDER[index - 1] ?? step) : step;
   });
+  set(internalGuideImageIndex$, 0);
 });
+
+export const setFeishuGuideImageIndex$ = command(
+  ({ set }, imageIndex: number) => {
+    set(internalGuideImageIndex$, imageIndex);
+  },
+);
+
+export const moveFeishuGuideImage$ = command(
+  ({ set }, offset: number, imageCount: number) => {
+    set(internalGuideImageIndex$, (imageIndex) => {
+      return (imageIndex + offset + imageCount) % imageCount;
+    });
+  },
+);
 
 export const updateFeishuSetupForm$ = command(
   ({ set }, update: Partial<FeishuSetupInput>) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-feishu-oauth-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-feishu-oauth-callback-page.test.tsx
@@ -1,0 +1,86 @@
+import { zeroFeishuOauthContract } from "@vm0/api-contracts/contracts/zero-feishu-oauth";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function feishuConnectorStatus(): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef: "lark",
+    label: "Feishu",
+    description: "Connect Feishu to VM0.",
+    icon: getStaticConnectorIconMetadata("lark"),
+    category: "communication",
+    generation: [],
+    tags: [],
+    authMethods: [],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+  };
+}
+
+describe("feishu OAuth callback page", () => {
+  it("completes OAuth through the API and opens the Feishu bot", async () => {
+    const redirectUrl =
+      "https://applink.feishu.cn/client/bot/open?appId=cli_test";
+    const locationAssign = context.mocks.browser.locationAssign();
+    let callbackQuery: unknown;
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, { connectors: [feishuConnectorStatus()] });
+    });
+    context.mocks.api(
+      zeroFeishuOauthContract.callback,
+      ({ query, respond }) => {
+        callbackQuery = query;
+        return respond(200, { redirectUrl });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/feishu/callback?code=oauth-code&state=oauth-state",
+      user: null,
+      session: null,
+    });
+
+    const heading = await screen.findByRole("heading", {
+      name: "Connecting Feishu…",
+    });
+    const connectorIcon = heading.parentElement?.querySelector("img");
+    if (!(connectorIcon instanceof HTMLImageElement)) {
+      throw new Error("Feishu connector icon not found");
+    }
+    expect(connectorIcon).toHaveAttribute(
+      "src",
+      getStaticConnectorIconMetadata("lark").url,
+    );
+    await waitFor(() => {
+      expect(locationAssign.calls).toStrictEqual([redirectUrl]);
+    });
+    expect(callbackQuery).toStrictEqual({
+      code: "oauth-code",
+      responseMode: "json",
+      state: "oauth-state",
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -496,7 +496,7 @@ describe("works page", () => {
         isConnected,
         appId: "cli_feishu",
         callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
-        oauthRedirectUrl: "https://app.vm0.test/connectors/feishu/callback",
+        oauthRedirectUrl: "https://api.vm0.test/api/zero/feishu/oauth/callback",
         callbackVerified,
         messageReceived: false,
         tenantKey: null,
@@ -540,6 +540,7 @@ describe("works page", () => {
 
     await waitFor(() => {
       expect(screen.getAllByText("Waiting for callback")).not.toHaveLength(0);
+      expect(document.body).toHaveTextContent("im.message.receive_v1");
       expect(context.mocks.ably.hasSubscription("feishu:changed")).toBeTruthy();
     });
 
@@ -561,7 +562,7 @@ describe("works page", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByDisplayValue(
-        "https://app.vm0.test/connectors/feishu/callback",
+        "https://api.vm0.test/api/zero/feishu/oauth/callback",
       ),
     ).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -477,7 +477,10 @@ describe("works page", () => {
       return null;
     });
     click(getRole("button", "Connect"));
-    expect(open).toHaveBeenCalledWith(connectUrl, "_blank");
+    expect(open).toHaveBeenCalledWith(
+      `${connectUrl}&callbackTarget=app`,
+      "_blank",
+    );
     expect(queryRole("button", "More options for Member bot")).toBeNull();
   });
 
@@ -493,7 +496,7 @@ describe("works page", () => {
         isConnected,
         appId: "cli_feishu",
         callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
-        oauthRedirectUrl: "https://api.vm0.test/api/zero/feishu/oauth/callback",
+        oauthRedirectUrl: "https://app.vm0.test/connectors/feishu/callback",
         callbackVerified,
         messageReceived: false,
         tenantKey: null,
@@ -524,18 +527,19 @@ describe("works page", () => {
     click(getRole("button", "More options for Feishu bot"));
     click(getRole("button", "Manage"));
     expect(
-      screen.getByText("Configure the OAuth redirect URL"),
+      screen.getByRole("img", {
+        name: "Feishu Event Configuration screen with the subscription mode edit control highlighted",
+      }),
     ).toBeInTheDocument();
+    click(getRole("button", "Show next Feishu guide image"));
     expect(
-      screen.getByDisplayValue(
-        "https://api.vm0.test/api/zero/feishu/oauth/callback",
-      ),
+      screen.getByRole("img", {
+        name: "Feishu Event Configuration screen with the Request URL field highlighted",
+      }),
     ).toBeInTheDocument();
-    click(getRole("button", "Next"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Waiting for callback")).not.toHaveLength(0);
-      expect(document.body).toHaveTextContent("im.message.receive_v1");
       expect(context.mocks.ably.hasSubscription("feishu:changed")).toBeTruthy();
     });
 
@@ -550,6 +554,16 @@ describe("works page", () => {
         screen.getByText("Feishu connected successfully"),
       ).toBeInTheDocument();
     });
+
+    click(getRole("button", "Next"));
+    expect(
+      screen.getByText("Configure the OAuth redirect URL"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(
+        "https://app.vm0.test/connectors/feishu/callback",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows the guided Feishu custom app setup for organization members", async () => {
@@ -565,6 +579,12 @@ describe("works page", () => {
       screen.findByText("Create an enterprise custom app"),
     ).resolves.toBeInTheDocument();
     expect(
+      screen.getByRole("img", {
+        name: "Feishu app creation form with the app name, icon, and Create button highlighted",
+      }),
+    ).toBeInTheDocument();
+    expect(queryRole("button", "Show creating a Feishu app guide")).toBeNull();
+    expect(
       screen.getByText("Download the VM0 icon").closest("a"),
     ).toHaveAttribute("download", "vm0-feishu-app-icon.png");
 
@@ -572,6 +592,11 @@ describe("works page", () => {
 
     await expect(screen.findByLabelText("App ID")).resolves.toBeInTheDocument();
     expect(screen.getByLabelText("App Secret")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", {
+        name: "Feishu app creation result showing where to find the App ID and App Secret",
+      }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Verification Token"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -576,7 +576,12 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
         <p className="leading-relaxed">
           Open Event Configuration. Under Subscription mode, select “Send
           notifications to developer&apos;s server”. Then open Callback
-          Configuration and paste the callback URL.
+          Configuration and paste the callback URL. After Feishu verifies it,
+          add the “Receive message v1” event (
+          <code className="font-mono text-xs text-foreground">
+            im.message.receive_v1
+          </code>
+          ).
         </p>
         <div className="mt-4">
           <FeishuGuideCarousel
@@ -603,7 +608,8 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
       </div>
       {!data?.callbackVerified ? (
         <p className="text-sm text-muted-foreground">
-          Continue after Feishu verifies the callback URL.
+          Continue after Feishu verifies the callback URL and the message event
+          is subscribed.
         </p>
       ) : null}
     </div>

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -4,10 +4,11 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconArrowLeft,
   IconArrowRight,
+  IconChevronLeft,
+  IconChevronRight,
   IconCircleCheck,
   IconCopy,
   IconDotsVertical,
-  IconInfoCircle,
   IconLoader2,
   IconPlus,
   IconSettings,
@@ -37,21 +38,17 @@ import {
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@vm0/ui/components/ui/tooltip";
 
 import {
   platformFeishuAppCreatedCredentialsImg,
-  platformFeishuCreateAppVersionImg,
+  platformFeishuAvailabilitySettingsAllMembersImg,
   platformFeishuCreateEnterpriseCustomAppImg,
   platformFeishuEncryptionStrategyImg,
   platformFeishuEventRequestUrlImg,
   platformFeishuEventSubscriptionModeImg,
   platformFeishuSecuritySettingsRedirectUrlImg,
+  platformFeishuVersionAvailabilityEditImg,
+  platformFeishuVersionManagementCreateVersionImg,
 } from "../../lib/static-assets.ts";
 import {
   defaultAgentId$,
@@ -70,13 +67,16 @@ import {
   feishuDialogExisting$,
   feishuDialogInstallationId$,
   feishuDialogOpen$,
+  feishuGuideImageIndex$,
   feishuInstallations$,
   feishuOrgData$,
   feishuSetupForm$,
   feishuSetupStep$,
   feishuUninstallInstallationId$,
   goBackFeishuSetupStep$,
+  moveFeishuGuideImage$,
   openFeishuDialog$,
+  setFeishuGuideImageIndex$,
   setFeishuUninstallInstallationId$,
   setupFeishuOrg$,
   updateFeishuInstallationAgent$,
@@ -158,50 +158,82 @@ function FeishuGuideImage({ src, alt }: { src: string; alt: string }) {
   );
 }
 
-function FeishuGuideTooltip({
-  label,
+interface FeishuGuideCarouselImage {
+  readonly src: string;
+  readonly alt: string;
+  readonly label: string;
+}
+
+function FeishuGuideCarousel({
   images,
 }: {
-  label: string;
-  images: readonly { src: string; alt: string }[];
+  images: readonly [FeishuGuideCarouselImage, ...FeishuGuideCarouselImage[]];
 }) {
+  const activeIndex = useGet(feishuGuideImageIndex$);
+  const moveImage = useSet(moveFeishuGuideImage$);
+  const setActiveIndex = useSet(setFeishuGuideImageIndex$);
+  const activeImage = images[activeIndex] ?? images[0];
+  const move = (offset: number): void => {
+    moveImage(offset, images.length);
+  };
+
   return (
-    <TooltipProvider delayDuration={150}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label={`Show ${label} guide`}
-            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <IconInfoCircle size={16} stroke={1.7} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent
-          side="right"
-          align="start"
-          className="z-[60] max-h-[70vh] w-[min(640px,calc(100vw-2rem))] max-w-none overflow-y-auto rounded-lg border border-border p-2"
-          style={{
-            backgroundColor: "hsl(var(--card))",
-            color: "hsl(var(--card-foreground))",
-            boxShadow:
-              "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+    <div className="space-y-2">
+      <div className="relative overflow-hidden rounded-lg border border-border bg-white">
+        <img
+          src={activeImage.src}
+          alt={activeImage.alt}
+          loading="lazy"
+          className="aspect-video w-full object-contain"
+        />
+        <button
+          type="button"
+          className="absolute left-3 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background/90 text-foreground shadow-sm"
+          aria-label="Show previous Feishu guide image"
+          onClick={() => {
+            move(-1);
           }}
         >
-          <div className="space-y-2">
-            {images.map((image) => {
-              return (
-                <FeishuGuideImage
-                  key={image.src}
-                  src={image.src}
-                  alt={image.alt}
-                />
-              );
-            })}
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          <IconChevronLeft size={20} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className="absolute right-3 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background/90 text-foreground shadow-sm"
+          aria-label="Show next Feishu guide image"
+          onClick={() => {
+            move(1);
+          }}
+        >
+          <IconChevronRight size={20} aria-hidden="true" />
+        </button>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">
+          {activeImage.label}
+        </span>
+        <div className="flex items-center gap-1.5">
+          {images.map((image, index) => {
+            const active = index === activeIndex;
+            return (
+              <button
+                key={image.src}
+                type="button"
+                aria-label={`Show Feishu guide image ${index + 1}`}
+                aria-current={active ? "true" : undefined}
+                className={
+                  active
+                    ? "h-1.5 w-4 rounded-full bg-foreground"
+                    : "h-1.5 w-1.5 rounded-full bg-muted-foreground/35"
+                }
+                onClick={() => {
+                  setActiveIndex(index);
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -211,8 +243,8 @@ const FEISHU_SETUP_STEPS = [
   { key: "create", label: "Create" },
   { key: "credentials", label: "Credentials" },
   { key: "tokens", label: "Tokens" },
-  { key: "redirect", label: "Redirect" },
   { key: "events", label: "Events" },
+  { key: "redirect", label: "Redirect" },
   { key: "publish", label: "Publish" },
 ] as const satisfies readonly {
   key: FeishuSetupStep;
@@ -410,17 +442,8 @@ function FeishuCreateStep() {
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 flex items-center gap-1 font-medium text-foreground">
-          <span>Create an enterprise custom app</span>
-          <FeishuGuideTooltip
-            label="creating a Feishu app"
-            images={[
-              {
-                src: platformFeishuCreateEnterpriseCustomAppImg,
-                alt: "Feishu app creation form with the app name, icon, and Create button highlighted",
-              },
-            ]}
-          />
+        <div className="mb-2 font-medium text-foreground">
+          Create an enterprise custom app
         </div>
         <p className="leading-relaxed">
           In the{" "}
@@ -435,6 +458,12 @@ function FeishuCreateStep() {
           , create an enterprise custom app named VM0, upload the VM0 icon, then
           add the Bot capability.
         </p>
+        <div className="mt-4">
+          <FeishuGuideImage
+            src={platformFeishuCreateEnterpriseCustomAppImg}
+            alt="Feishu app creation form with the app name, icon, and Create button highlighted"
+          />
+        </div>
       </div>
       <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-4">
         <div>
@@ -472,22 +501,19 @@ function FeishuCredentialsStep({
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 flex items-center gap-1 font-medium text-foreground">
-          <span>Add the app credentials</span>
-          <FeishuGuideTooltip
-            label="finding Feishu app credentials"
-            images={[
-              {
-                src: platformFeishuAppCreatedCredentialsImg,
-                alt: "Feishu app creation result showing where to find the App ID and App Secret",
-              },
-            ]}
-          />
+        <div className="mb-2 font-medium text-foreground">
+          Add the app credentials
         </div>
         <p className="leading-relaxed">
           Copy the App ID and App Secret from Credentials &amp; Basic
           Information.
         </p>
+        <div className="mt-4">
+          <FeishuGuideImage
+            src={platformFeishuAppCreatedCredentialsImg}
+            alt="Feishu app creation result showing where to find the App ID and App Secret"
+          />
+        </div>
       </div>
       <FeishuAppCredentialFields form={form} saving={saving} />
     </div>
@@ -504,17 +530,8 @@ function FeishuTokensStep({
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 flex items-center gap-1 font-medium text-foreground">
-          <span>Add the event verification tokens</span>
-          <FeishuGuideTooltip
-            label="finding Feishu event verification tokens"
-            images={[
-              {
-                src: platformFeishuEncryptionStrategyImg,
-                alt: "Feishu Encryption Strategy screen showing the Encrypt Key and Verification Token",
-              },
-            ]}
-          />
+        <div className="mb-2 font-medium text-foreground">
+          Add the event verification tokens
         </div>
         <p className="leading-relaxed">
           Open the{" "}
@@ -530,6 +547,12 @@ function FeishuTokensStep({
           Open Event Configuration → Encryption Strategy, then copy the Encrypt
           Key and Verification Token.
         </p>
+        <div className="mt-4">
+          <FeishuGuideImage
+            src={platformFeishuEncryptionStrategyImg}
+            alt="Feishu Encryption Strategy screen showing the Encrypt Key and Verification Token"
+          />
+        </div>
       </div>
       <FeishuEventCredentialFields form={form} saving={saving} />
     </div>
@@ -541,21 +564,8 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-          <span className="flex items-center gap-1 font-medium text-foreground">
-            <span>Configure event delivery</span>
-            <FeishuGuideTooltip
-              label="configuring Feishu event delivery"
-              images={[
-                {
-                  src: platformFeishuEventSubscriptionModeImg,
-                  alt: "Feishu Event Configuration screen with the subscription mode edit control highlighted",
-                },
-                {
-                  src: platformFeishuEventRequestUrlImg,
-                  alt: "Feishu Event Configuration screen with the Request URL field highlighted",
-                },
-              ]}
-            />
+          <span className="font-medium text-foreground">
+            Configure event delivery
           </span>
           <SetupStatus complete={data?.callbackVerified ?? false}>
             {data?.callbackVerified
@@ -566,13 +576,24 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
         <p className="leading-relaxed">
           Open Event Configuration. Under Subscription mode, select “Send
           notifications to developer&apos;s server”. Then open Callback
-          Configuration and paste the callback URL. After Feishu verifies it,
-          add the “Receive message v1” event (
-          <code className="font-mono text-xs text-foreground">
-            im.message.receive_v1
-          </code>
-          ).
+          Configuration and paste the callback URL.
         </p>
+        <div className="mt-4">
+          <FeishuGuideCarousel
+            images={[
+              {
+                src: platformFeishuEventSubscriptionModeImg,
+                alt: "Feishu Event Configuration screen with the subscription mode edit control highlighted",
+                label: "Select the event subscription mode",
+              },
+              {
+                src: platformFeishuEventRequestUrlImg,
+                alt: "Feishu Event Configuration screen with the Request URL field highlighted",
+                label: "Add the callback request URL",
+              },
+            ]}
+          />
+        </div>
       </div>
       <div className="flex gap-2">
         <Input value={data?.callbackUrl ?? ""} readOnly />
@@ -582,8 +603,7 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
       </div>
       {!data?.callbackVerified ? (
         <p className="text-sm text-muted-foreground">
-          Continue after Feishu verifies the callback URL and the message event
-          is subscribed.
+          Continue after Feishu verifies the callback URL.
         </p>
       ) : null}
     </div>
@@ -594,17 +614,8 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 flex items-center gap-1 font-medium text-foreground">
-          <span>Configure the OAuth redirect URL</span>
-          <FeishuGuideTooltip
-            label="configuring the Feishu OAuth redirect URL"
-            images={[
-              {
-                src: platformFeishuSecuritySettingsRedirectUrlImg,
-                alt: "Feishu Security Settings page showing where to add an OAuth redirect URL",
-              },
-            ]}
-          />
+        <div className="mb-2 font-medium text-foreground">
+          Configure the OAuth redirect URL
         </div>
         <p className="leading-relaxed">
           In the{" "}
@@ -630,6 +641,10 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
           />
         ) : null}
       </div>
+      <FeishuGuideImage
+        src={platformFeishuSecuritySettingsRedirectUrlImg}
+        alt="Feishu Security Settings page showing where to add an OAuth redirect URL"
+      />
     </div>
   );
 }
@@ -654,22 +669,33 @@ function FeishuPublishStep({
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 flex items-center gap-1 font-medium text-foreground">
-          <span>Publish the app</span>
-          <FeishuGuideTooltip
-            label="publishing a Feishu app version"
+        <div className="mb-2 font-medium text-foreground">Publish the app</div>
+        <p className="leading-relaxed">
+          Create and publish an app version, then edit its availability settings
+          and select All members. The app can only be used by other members of
+          your organization after you grant them access.
+        </p>
+        <div className="mt-4">
+          <FeishuGuideCarousel
             images={[
               {
-                src: platformFeishuCreateAppVersionImg,
-                alt: "Feishu app version creation page with the create version action highlighted",
+                src: platformFeishuVersionManagementCreateVersionImg,
+                alt: "Feishu Version Management page with the Create a version button highlighted",
+                label: "Create an app version",
+              },
+              {
+                src: platformFeishuVersionAvailabilityEditImg,
+                alt: "Feishu version details page with the availability settings edit action highlighted",
+                label: "Edit the availability settings",
+              },
+              {
+                src: platformFeishuAvailabilitySettingsAllMembersImg,
+                alt: "Feishu availability settings with All members selected",
+                label: "Make the app available to all members",
               },
             ]}
           />
         </div>
-        <p className="leading-relaxed">
-          Create and publish an app version. Once published, you can send the
-          bot a direct message or mention it in a group chat.
-        </p>
       </div>
       <div className="space-y-3 rounded-lg border border-border p-4">
         <div>
@@ -1108,7 +1134,7 @@ function FeishuBotMenu({
                   open({
                     appId: bot.appId,
                     defaultAgentId: bot.defaultAgentId,
-                    step: "redirect",
+                    step: "events",
                     installationId: bot.id,
                   });
                 }}
@@ -1198,7 +1224,9 @@ function FeishuBotRow({
             size="sm"
             className="h-9 justify-center"
             onClick={() => {
-              window.open(connectUrl, "_blank");
+              const url = new URL(connectUrl);
+              url.searchParams.set("callbackTarget", "app");
+              window.open(url.toString(), "_blank");
             }}
           >
             Connect

--- a/turbo/apps/platform/src/views/zero-page/feishu-oauth-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-oauth-callback-page.tsx
@@ -1,0 +1,22 @@
+import { useLastLoadable } from "ccstate-react";
+
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
+import { ZeroConnectorCallbackPage } from "./zero-connector-callback-page.tsx";
+
+export function FeishuOAuthCallbackPage(): React.JSX.Element {
+  const catalogLoadable = useLastLoadable(connectorCatalogStatusByRef$);
+  const connectorIcon =
+    catalogLoadable.state === "hasData"
+      ? catalogLoadable.data.get("lark")?.icon
+      : undefined;
+
+  return (
+    <ZeroConnectorCallbackPage
+      connectorIcon={connectorIcon}
+      connectorLabel="Feishu"
+      status="loading"
+      username={null}
+      errorMessage={null}
+    />
+  );
+}

--- a/turbo/packages/api-contracts/src/contracts/zero-feishu-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feishu-oauth.ts
@@ -7,6 +7,7 @@ const c = initContract();
 const jsonErrorSchema = z.object({ error: z.string() });
 
 export const zeroFeishuOauthConnectQuerySchema = z.object({
+  callbackTarget: z.literal("app").optional(),
   state: z.string().optional(),
 });
 
@@ -14,6 +15,7 @@ export const zeroFeishuOauthCallbackQuerySchema = z.object({
   code: z.string().optional(),
   error: z.string().optional(),
   error_description: z.string().optional(),
+  responseMode: z.literal("json").optional(),
   state: z.string().optional(),
 });
 
@@ -33,6 +35,7 @@ export const zeroFeishuOauthContract = c.router({
     path: "/api/zero/feishu/oauth/callback",
     query: zeroFeishuOauthCallbackQuerySchema,
     responses: {
+      200: z.object({ redirectUrl: z.url() }),
       307: c.noBody(),
       400: jsonErrorSchema,
     },


### PR DESCRIPTION
## Summary

- route Feishu app OAuth through the platform callback page and render the catalog icon
- expand the Feishu setup guide with inline screenshots and carousels
- send the `/help` response as plain text for reliable client rendering
- preserve the API callback path for legacy connections

## Validation

- API Feishu integration tests: 14 passed
- Platform Feishu tests: 18 passed
- affected lint and type checks passed
- Knip passed