### PR TITLE
perf(python): reuse public destination host classifications

### DIFF
--- a/crates/runner/mitm-addon/src/public_destination.py
+++ b/crates/runner/mitm-addon/src/public_destination.py
@@ -40,6 +40,7 @@ from host_normalization import (
     normalize_idna_hostname,
     translate_idna_dot_separators,
 )
+from url_utils import normalize_trusted_hostname
 
 # Native IPv4 addresses that are not public unicast, coalesced from the IANA
 # special-purpose registry and non-unicast space. The public 192.0.0.9 and
@@ -118,6 +119,128 @@ class RuntimeDestinationCheck:
     reason: DestinationDenialReason | None = None
 
 
+@dataclass(frozen=True)
+class RuntimeDestinationHostClassification:
+    """One interpretation of host text within a runtime-destination pass.
+
+    ``validation`` preserves the concrete-IP contract exposed by
+    ``validate_runtime_destination_host()``. ``is_hostname`` distinguishes an
+    ordinary IDNA hostname from malformed text so connected endpoint collection
+    can ignore unresolved names. ``deferable_hostname`` additionally requires
+    trusted-authority syntax and is true only when ``is_hostname`` is true.
+    """
+
+    validation: RuntimeDestinationCheck
+    is_hostname: bool = False
+    deferable_hostname: bool = False
+
+
+def classify_runtime_destination_host(
+    destination_host: object,
+) -> RuntimeDestinationHostClassification:
+    """Classify runtime host text once for collection, deferral, and validation."""
+
+    if not isinstance(destination_host, str):
+        return RuntimeDestinationHostClassification(
+            validation=RuntimeDestinationCheck(
+                allowed=False,
+                destination_host="",
+                reason="missing_destination",
+            )
+        )
+
+    normalized_destination = destination_host.strip()
+    if not normalized_destination:
+        return RuntimeDestinationHostClassification(
+            validation=RuntimeDestinationCheck(
+                allowed=False,
+                destination_host=normalized_destination,
+                reason="missing_destination",
+            )
+        )
+    if normalized_destination != destination_host:
+        return RuntimeDestinationHostClassification(
+            validation=RuntimeDestinationCheck(
+                allowed=False,
+                destination_host=destination_host,
+                reason="invalid_destination",
+            )
+        )
+
+    ip_text = normalized_destination
+    bracketed = ip_text.startswith("[") or ip_text.endswith("]")
+    if bracketed:
+        if not (ip_text.startswith("[") and ip_text.endswith("]")):
+            return RuntimeDestinationHostClassification(
+                validation=RuntimeDestinationCheck(
+                    allowed=False,
+                    destination_host=normalized_destination,
+                    reason="invalid_destination",
+                )
+            )
+        ip_text = ip_text[1:-1]
+        if not ip_text:
+            return RuntimeDestinationHostClassification(
+                validation=RuntimeDestinationCheck(
+                    allowed=False,
+                    destination_host=normalized_destination,
+                    reason="invalid_destination",
+                )
+            )
+
+    try:
+        ip = ipaddress.ip_address(ip_text)
+    except ValueError:
+        invalid_validation = RuntimeDestinationCheck(
+            allowed=False,
+            destination_host=normalized_destination,
+            reason="invalid_destination",
+        )
+        if bracketed or _looks_like_legacy_ipv4_literal(ip_text):
+            return RuntimeDestinationHostClassification(validation=invalid_validation)
+        try:
+            normalize_trusted_hostname(ip_text)
+        except (UnicodeError, ValueError):
+            try:
+                normalize_idna_hostname(ip_text)
+            except (UnicodeError, ValueError):
+                return RuntimeDestinationHostClassification(validation=invalid_validation)
+            return RuntimeDestinationHostClassification(
+                validation=invalid_validation,
+                is_hostname=True,
+            )
+        return RuntimeDestinationHostClassification(
+            validation=invalid_validation,
+            is_hostname=True,
+            deferable_hostname=True,
+        )
+
+    if bracketed and not isinstance(ip, ipaddress.IPv6Address):
+        return RuntimeDestinationHostClassification(
+            validation=RuntimeDestinationCheck(
+                allowed=False,
+                destination_host=normalized_destination,
+                reason="invalid_destination",
+            )
+        )
+
+    if not _ip_address_is_public(ip):
+        return RuntimeDestinationHostClassification(
+            validation=RuntimeDestinationCheck(
+                allowed=False,
+                destination_host=normalized_destination,
+                reason="non_public_destination",
+            )
+        )
+
+    return RuntimeDestinationHostClassification(
+        validation=RuntimeDestinationCheck(
+            allowed=True,
+            destination_host=normalized_destination,
+        )
+    )
+
+
 def public_ip_literal_is_public(hostname: str) -> bool | None:
     """Classify exact host text as a public literal, rejected input, or hostname.
 
@@ -135,33 +258,10 @@ def public_ip_literal_is_public(hostname: str) -> bool | None:
     endpoint rather than treating ``None`` as approval.
     """
 
-    ip_text = hostname.strip()
-    if not ip_text or ip_text != hostname:
-        return False
-    bracketed = ip_text.startswith("[") or ip_text.endswith("]")
-    if bracketed:
-        if not (ip_text.startswith("[") and ip_text.endswith("]")):
-            return False
-        ip_text = ip_text[1:-1]
-        if not ip_text:
-            return False
-    if "%" in ip_text:
-        return False
-    try:
-        ip = ipaddress.ip_address(ip_text)
-    except ValueError:
-        if bracketed:
-            return False
-        if _looks_like_legacy_ipv4_literal(ip_text):
-            return False
-        try:
-            normalize_idna_hostname(ip_text)
-        except (UnicodeError, ValueError):
-            return False
+    classification = classify_runtime_destination_host(hostname)
+    if classification.is_hostname:
         return None
-    if bracketed and not isinstance(ip, ipaddress.IPv6Address):
-        return False
-    return _ip_address_is_public(ip)
+    return classification.validation.allowed
 
 
 def validate_runtime_destination_host(destination_host: object) -> RuntimeDestinationCheck:
@@ -179,67 +279,7 @@ def validate_runtime_destination_host(destination_host: object) -> RuntimeDestin
     ``RuntimeDestinationCheck`` for the diagnostic host-field contract.
     """
 
-    if not isinstance(destination_host, str):
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host="",
-            reason="missing_destination",
-        )
-
-    normalized_destination = destination_host.strip()
-    if not normalized_destination:
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=normalized_destination,
-            reason="missing_destination",
-        )
-    if normalized_destination != destination_host:
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=destination_host,
-            reason="invalid_destination",
-        )
-
-    ip_text = normalized_destination
-    bracketed = ip_text.startswith("[") or ip_text.endswith("]")
-    if bracketed:
-        if not (ip_text.startswith("[") and ip_text.endswith("]")):
-            return RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=normalized_destination,
-                reason="invalid_destination",
-            )
-        ip_text = ip_text[1:-1]
-        if not ip_text:
-            return RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=normalized_destination,
-                reason="invalid_destination",
-            )
-
-    try:
-        ip = ipaddress.ip_address(ip_text)
-    except ValueError:
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=normalized_destination,
-            reason="invalid_destination",
-        )
-    if bracketed and not isinstance(ip, ipaddress.IPv6Address):
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=normalized_destination,
-            reason="invalid_destination",
-        )
-
-    if not _ip_address_is_public(ip):
-        return RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=normalized_destination,
-            reason="non_public_destination",
-        )
-
-    return RuntimeDestinationCheck(allowed=True, destination_host=normalized_destination)
+    return classify_runtime_destination_host(destination_host).validation
 
 
 def ip_address_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:

--- a/crates/runner/mitm-addon/src/public_destination.py
+++ b/crates/runner/mitm-addon/src/public_destination.py
@@ -99,6 +99,15 @@ DestinationDenialReason = Literal[
     "invalid_destination",
     "non_public_destination",
 ]
+_RuntimeDestinationHostKind = Literal[
+    "missing",
+    "invalid",
+    "non_public",
+    "public",
+    "hostname",
+    "deferable_hostname",
+]
+_HostnameClassificationMode = Literal["skip", "generic", "deferable"]
 
 
 @dataclass(frozen=True)
@@ -140,104 +149,97 @@ def classify_runtime_destination_host(
 ) -> RuntimeDestinationHostClassification:
     """Classify runtime host text once for collection, deferral, and validation."""
 
+    kind = _runtime_destination_host_kind(
+        destination_host,
+        hostname_classification="deferable",
+    )
+    return RuntimeDestinationHostClassification(
+        validation=_runtime_destination_check(destination_host, kind),
+        is_hostname=kind in ("hostname", "deferable_hostname"),
+        deferable_hostname=kind == "deferable_hostname",
+    )
+
+
+def _runtime_destination_host_kind(
+    destination_host: object,
+    *,
+    hostname_classification: _HostnameClassificationMode,
+) -> _RuntimeDestinationHostKind:
+    """Parse only the hostname detail required by the calling contract.
+
+    ``skip`` treats non-IP text as invalid concrete evidence. ``generic``
+    distinguishes ordinary IDNA hostnames for the tri-state literal adapter.
+    ``deferable`` additionally records trusted-authority eligibility.
+    """
+
     if not isinstance(destination_host, str):
-        return RuntimeDestinationHostClassification(
-            validation=RuntimeDestinationCheck(
-                allowed=False,
-                destination_host="",
-                reason="missing_destination",
-            )
-        )
+        return "missing"
 
-    normalized_destination = destination_host.strip()
-    if not normalized_destination:
-        return RuntimeDestinationHostClassification(
-            validation=RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=normalized_destination,
-                reason="missing_destination",
-            )
-        )
-    if normalized_destination != destination_host:
-        return RuntimeDestinationHostClassification(
-            validation=RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=destination_host,
-                reason="invalid_destination",
-            )
-        )
+    ip_text = destination_host.strip()
+    if not ip_text:
+        return "missing"
+    if ip_text != destination_host:
+        return "invalid"
 
-    ip_text = normalized_destination
     bracketed = ip_text.startswith("[") or ip_text.endswith("]")
     if bracketed:
         if not (ip_text.startswith("[") and ip_text.endswith("]")):
-            return RuntimeDestinationHostClassification(
-                validation=RuntimeDestinationCheck(
-                    allowed=False,
-                    destination_host=normalized_destination,
-                    reason="invalid_destination",
-                )
-            )
+            return "invalid"
         ip_text = ip_text[1:-1]
         if not ip_text:
-            return RuntimeDestinationHostClassification(
-                validation=RuntimeDestinationCheck(
-                    allowed=False,
-                    destination_host=normalized_destination,
-                    reason="invalid_destination",
-                )
-            )
+            return "invalid"
 
     try:
         ip = ipaddress.ip_address(ip_text)
     except ValueError:
-        invalid_validation = RuntimeDestinationCheck(
-            allowed=False,
-            destination_host=normalized_destination,
-            reason="invalid_destination",
-        )
         if bracketed or _looks_like_legacy_ipv4_literal(ip_text):
-            return RuntimeDestinationHostClassification(validation=invalid_validation)
-        try:
-            normalize_trusted_hostname(ip_text)
-        except (UnicodeError, ValueError):
+            return "invalid"
+        if hostname_classification == "skip":
+            return "invalid"
+        if hostname_classification == "deferable":
             try:
-                normalize_idna_hostname(ip_text)
+                normalize_trusted_hostname(ip_text)
             except (UnicodeError, ValueError):
-                return RuntimeDestinationHostClassification(validation=invalid_validation)
-            return RuntimeDestinationHostClassification(
-                validation=invalid_validation,
-                is_hostname=True,
-            )
-        return RuntimeDestinationHostClassification(
-            validation=invalid_validation,
-            is_hostname=True,
-            deferable_hostname=True,
-        )
+                pass
+            else:
+                return "deferable_hostname"
+        try:
+            normalize_idna_hostname(ip_text)
+        except (UnicodeError, ValueError):
+            return "invalid"
+        return "hostname"
 
     if bracketed and not isinstance(ip, ipaddress.IPv6Address):
-        return RuntimeDestinationHostClassification(
-            validation=RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=normalized_destination,
-                reason="invalid_destination",
-            )
-        )
+        return "invalid"
 
     if not _ip_address_is_public(ip):
-        return RuntimeDestinationHostClassification(
-            validation=RuntimeDestinationCheck(
-                allowed=False,
-                destination_host=normalized_destination,
-                reason="non_public_destination",
-            )
-        )
+        return "non_public"
 
-    return RuntimeDestinationHostClassification(
-        validation=RuntimeDestinationCheck(
+    return "public"
+
+
+def _runtime_destination_check(
+    destination_host: object,
+    kind: _RuntimeDestinationHostKind,
+) -> RuntimeDestinationCheck:
+    diagnostic_host = (
+        destination_host if isinstance(destination_host, str) and kind != "missing" else ""
+    )
+    if kind == "public":
+        return RuntimeDestinationCheck(
             allowed=True,
-            destination_host=normalized_destination,
+            destination_host=diagnostic_host,
         )
+    if kind == "missing":
+        reason: DestinationDenialReason = "missing_destination"
+    elif kind == "non_public":
+        reason = "non_public_destination"
+    else:
+        reason = "invalid_destination"
+    return RuntimeDestinationCheck(
+        allowed=False,
+        destination_host=diagnostic_host,
+        reason=reason,
     )
 
 
@@ -258,10 +260,13 @@ def public_ip_literal_is_public(hostname: str) -> bool | None:
     endpoint rather than treating ``None`` as approval.
     """
 
-    classification = classify_runtime_destination_host(hostname)
-    if classification.is_hostname:
+    kind = _runtime_destination_host_kind(
+        hostname,
+        hostname_classification="generic",
+    )
+    if kind in ("hostname", "deferable_hostname"):
         return None
-    return classification.validation.allowed
+    return kind == "public"
 
 
 def validate_runtime_destination_host(destination_host: object) -> RuntimeDestinationCheck:
@@ -279,7 +284,11 @@ def validate_runtime_destination_host(destination_host: object) -> RuntimeDestin
     ``RuntimeDestinationCheck`` for the diagnostic host-field contract.
     """
 
-    return classify_runtime_destination_host(destination_host).validation
+    kind = _runtime_destination_host_kind(
+        destination_host,
+        hostname_classification="skip",
+    )
+    return _runtime_destination_check(destination_host, kind)
 
 
 def ip_address_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -29,7 +29,7 @@ import registry
 import registry_firewalls
 import upstream_admission
 import upstream_destination_binding
-from url_utils import AuthorityValidationError, get_trusted_authority, normalize_trusted_hostname
+from url_utils import AuthorityValidationError, get_trusted_authority
 
 REQUEST_CLASSIFICATION_METADATA_KEY = "_request_classification"
 # Metadata that the requestheaders probe path may write while using this
@@ -67,6 +67,10 @@ type StaleTlsAdmissionReason = Literal[
     "client_ip_mismatch",
     "registry_entry_missing",
     "run_id_mismatch",
+]
+type _PublicDestinationClassifications = dict[
+    str,
+    public_destination.RuntimeDestinationHostClassification,
 ]
 
 
@@ -595,12 +599,13 @@ def _public_destination_runtime_denial(
     *,
     defer_unresolved_hostnames: bool = False,
 ) -> public_destination.RuntimeDestinationCheck | None:
-    for runtime_host in _public_destination_runtime_hosts(flow):
-        validation = public_destination.validate_runtime_destination_host(runtime_host)
+    classifications: _PublicDestinationClassifications = {}
+    for classification in _public_destination_runtime_hosts(flow, classifications):
+        validation = classification.validation
         if (
             not validation.allowed
             and defer_unresolved_hostnames
-            and _public_destination_runtime_host_is_deferable(runtime_host)
+            and classification.deferable_hostname
         ):
             continue
         if not validation.allowed:
@@ -608,24 +613,61 @@ def _public_destination_runtime_denial(
     return None
 
 
-def _public_destination_runtime_hosts(flow: http.HTTPFlow) -> tuple[object, ...]:
+def _public_destination_runtime_host_classification(
+    runtime_host: object,
+    classifications: _PublicDestinationClassifications,
+) -> public_destination.RuntimeDestinationHostClassification:
+    if not isinstance(runtime_host, str):
+        return public_destination.classify_runtime_destination_host(runtime_host)
+
+    classification = classifications.get(runtime_host)
+    if classification is None:
+        classification = public_destination.classify_runtime_destination_host(runtime_host)
+        classifications[runtime_host] = classification
+    return classification
+
+
+def _public_destination_runtime_hosts(
+    flow: http.HTTPFlow,
+    classifications: _PublicDestinationClassifications,
+) -> tuple[public_destination.RuntimeDestinationHostClassification, ...]:
     original_address = upstream_destination_binding.server_binding_original_address(
         flow.server_conn
     )
 
     if flow.server_conn.connected:
-        hosts = _public_destination_original_and_request_hosts(flow, original_address)
-        hosts.extend(_public_destination_connected_runtime_hosts(flow))
+        hosts = _public_destination_original_and_request_hosts(
+            flow,
+            original_address,
+            classifications,
+        )
+        hosts.extend(_public_destination_connected_runtime_hosts(flow, classifications))
         return tuple(hosts)
 
     if original_address is not None:
-        return tuple(_public_destination_original_and_request_hosts(flow, original_address))
+        return tuple(
+            _public_destination_original_and_request_hosts(
+                flow,
+                original_address,
+                classifications,
+            )
+        )
 
     server_address = connection_endpoints.server_address(flow.server_conn)
     if server_address is not None:
-        return (_public_destination_endpoint_host_for_request(flow, server_address),)
+        return (
+            _public_destination_runtime_host_classification(
+                _public_destination_endpoint_host_for_request(flow, server_address),
+                classifications,
+            ),
+        )
 
-    return (flow.request.host,)
+    return (
+        _public_destination_runtime_host_classification(
+            flow.request.host,
+            classifications,
+        ),
+    )
 
 
 def _public_destination_endpoint_host_for_request(
@@ -641,23 +683,35 @@ def _public_destination_endpoint_host_for_request(
 def _public_destination_original_and_request_hosts(
     flow: http.HTTPFlow,
     original_address: tuple[str, int] | None,
-) -> list[object]:
-    hosts: list[object] = []
+    classifications: _PublicDestinationClassifications,
+) -> list[public_destination.RuntimeDestinationHostClassification]:
+    hosts: list[public_destination.RuntimeDestinationHostClassification] = []
     if original_address is not None:
         endpoint_host = _public_destination_endpoint_host_for_request(flow, original_address)
+        endpoint_classification = _public_destination_runtime_host_classification(
+            endpoint_host,
+            classifications,
+        )
         if (
             endpoint_host is None
-            or public_destination.public_ip_literal_is_public(endpoint_host) is not None
+            or not endpoint_classification.is_hostname
             or not flow.server_conn.connected
         ):
-            hosts.append(endpoint_host)
-    if public_destination.public_ip_literal_is_public(flow.request.host) is not None:
-        hosts.append(flow.request.host)
+            hosts.append(endpoint_classification)
+    request_classification = _public_destination_runtime_host_classification(
+        flow.request.host,
+        classifications,
+    )
+    if not request_classification.is_hostname:
+        hosts.append(request_classification)
     return hosts
 
 
-def _public_destination_connected_runtime_hosts(flow: http.HTTPFlow) -> tuple[object, ...]:
-    hosts: list[object] = []
+def _public_destination_connected_runtime_hosts(
+    flow: http.HTTPFlow,
+    classifications: _PublicDestinationClassifications,
+) -> tuple[public_destination.RuntimeDestinationHostClassification, ...]:
+    hosts: list[public_destination.RuntimeDestinationHostClassification] = []
     for endpoint in (
         connection_endpoints.server_peername(flow.server_conn),
         connection_endpoints.server_address(flow.server_conn),
@@ -666,14 +720,23 @@ def _public_destination_connected_runtime_hosts(flow: http.HTTPFlow) -> tuple[ob
             continue
 
         endpoint_host, endpoint_port = endpoint
-        if public_destination.public_ip_literal_is_public(endpoint_host) is None:
+        classification = _public_destination_runtime_host_classification(
+            endpoint_host,
+            classifications,
+        )
+        if classification.is_hostname:
             continue
 
         if endpoint_port != flow.request.port:
-            hosts.append(None)
+            hosts.append(
+                _public_destination_runtime_host_classification(
+                    None,
+                    classifications,
+                )
+            )
             continue
 
-        hosts.append(endpoint_host)
+        hosts.append(classification)
 
     if hosts:
         return tuple(hosts)
@@ -683,16 +746,9 @@ def _public_destination_connected_runtime_hosts(flow: http.HTTPFlow) -> tuple[ob
         port=flow.request.port,
         extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
     )
-    return (connected_endpoint[0] if connected_endpoint is not None else None,)
-
-
-def _public_destination_runtime_host_is_deferable(runtime_host: object) -> bool:
-    if not isinstance(runtime_host, str):
-        return False
-    if public_destination.public_ip_literal_is_public(runtime_host) is not None:
-        return False
-    try:
-        normalize_trusted_hostname(runtime_host)
-    except (UnicodeError, ValueError):
-        return False
-    return True
+    return (
+        _public_destination_runtime_host_classification(
+            connected_endpoint[0] if connected_endpoint is not None else None,
+            classifications,
+        ),
+    )

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -69,16 +69,18 @@ def _public_destination_flow(
     )
 
 
-def _track_public_destination_validations(monkeypatch: pytest.MonkeyPatch) -> list[object]:
-    validated_hosts: list[object] = []
-    validate_runtime_destination_host = public_destination.validate_runtime_destination_host
+def _track_public_destination_classifications(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    classified_hosts: list[object] = []
+    classify_runtime_destination_host = public_destination.classify_runtime_destination_host
 
-    def track(runtime_host: object) -> public_destination.RuntimeDestinationCheck:
-        validated_hosts.append(runtime_host)
-        return validate_runtime_destination_host(runtime_host)
+    def track(
+        runtime_host: object,
+    ) -> public_destination.RuntimeDestinationHostClassification:
+        classified_hosts.append(runtime_host)
+        return classify_runtime_destination_host(runtime_host)
 
-    monkeypatch.setattr(public_destination, "validate_runtime_destination_host", track)
-    return validated_hosts
+    monkeypatch.setattr(public_destination, "classify_runtime_destination_host", track)
+    return classified_hosts
 
 
 def _assert_public_destination_denied(flow, *, destination_host: str, reason: str) -> None:
@@ -174,7 +176,7 @@ async def test_public_destination_allows_public_runtime_destination(
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host=destination_host)
-    validated_hosts = _track_public_destination_validations(monkeypatch)
+    classified_hosts = _track_public_destination_classifications(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -183,7 +185,7 @@ async def test_public_destination_allows_public_runtime_destination(
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert validated_hosts == [destination_host]
+    assert classified_hosts == [destination_host]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://service.example.com"
@@ -192,7 +194,7 @@ async def test_public_destination_allows_public_runtime_destination(
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
-async def test_public_destination_policy_allow_validates_public_runtime_destination_once(
+async def test_public_destination_policy_allow_classifies_public_runtime_destination_once(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -211,7 +213,7 @@ async def test_public_destination_policy_allow_validates_public_runtime_destinat
         method="OPTIONS",
         path="*",
     )
-    validated_hosts = _track_public_destination_validations(monkeypatch)
+    classified_hosts = _track_public_destination_classifications(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -220,7 +222,7 @@ async def test_public_destination_policy_allow_validates_public_runtime_destinat
         await mitm_addon.request(flow)
 
     auth_fetch.assert_not_awaited()
-    assert validated_hosts == ["93.184.216.34"]
+    assert classified_hosts == ["93.184.216.34"]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert "Authorization" not in flow.request.headers
@@ -549,6 +551,41 @@ async def test_public_destination_allows_connected_prebound_public_original_dest
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+async def test_public_destination_classifies_connected_host_values_once(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    monkeypatch,
+):
+    reg_path = _write_public_destination_firewall_registry(tmp_path)
+    flow = _public_destination_flow(
+        real_flow,
+        headers,
+        destination_host="service.example.com",
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
+    classified_hosts = _track_public_destination_classifications(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert classified_hosts == ["service.example.com", "93.184.216.35"]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.request.headers["Authorization"] == "Bearer x"
@@ -1191,14 +1228,14 @@ async def test_public_destination_revalidates_cached_policy_allow_classification
         path="*",
         extra_headers=(("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),),
     )
-    validated_hosts = _track_public_destination_validations(monkeypatch)
+    classified_hosts = _track_public_destination_classifications(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
     ):
         assert mitm_addon.requestheaders(flow) is None
-        assert validated_hosts == ["93.184.216.34"]
+        assert classified_hosts == ["93.184.216.34"]
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
 
         mark_connected_tls_upstream(
@@ -1211,8 +1248,8 @@ async def test_public_destination_revalidates_cached_policy_allow_classification
         await mitm_addon.request(flow)
 
     auth_fetch.assert_not_awaited()
-    request_phase_validated_hosts = validated_hosts[1:]
-    assert "10.0.0.1" in request_phase_validated_hosts
+    request_phase_classified_hosts = classified_hosts[1:]
+    assert "10.0.0.1" in request_phase_classified_hosts
     _assert_public_destination_denied(
         flow,
         destination_host="10.0.0.1",


### PR DESCRIPTION
## Summary

- centralize runtime destination host parsing in one immutable classification
- reuse equal host-string classifications within one public-destination validation pass
- preserve ordered evidence, fail-closed denial semantics, and cross-hook revalidation
- cover connected duplicate hostname evidence at the request-hook boundary

## Exclusions

- no persistent or cross-hook classification cache
- no public-address range policy changes
- no API, protocol, configuration, or persisted-state changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_public_destination.py tests/test_request_handler_public_destination.py -q` (144 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4269 passed)

The representative 20,000-call best-of-five runtime-denial benchmark improved from
24.35 microseconds per call on current `main` to 15.46 microseconds per call on this branch.
This diagnostic benchmark is not an automated test or a user-visible latency claim.

Closes #23163
