### PR TITLE
test(vsock-test): bound guest thread teardown

### DIFF
--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -113,13 +113,7 @@ fn start_guest(socket_path: &str) -> JoinHandle<io::Result<()>> {
 
 fn cleanup_guest(guest: &mut Option<JoinHandle<io::Result<()>>>, timeout: Duration) {
     if let Some(g) = guest.take() {
-        let Some(result) = try_join_guest_with_timeout(g, timeout) else {
-            eprintln!(
-                "guest thread did not terminate within {timeout:?} after host disconnect during cleanup"
-            );
-            return;
-        };
-        let _ = result;
+        let _ = try_join_guest_with_timeout(g, timeout);
     }
 }
 

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -193,7 +193,8 @@ pub(crate) fn captured_output_bytes(output: &ExecOwnedCapturedOutput) -> &[u8] {
 
 /// Test harness: creates temp dir, starts guest thread, connects host.
 ///
-/// Implements `Drop` to clean up temp dirs and join guest threads even on panic.
+/// Implements `Drop` to clean up temp dirs and wait a bounded time for guest threads,
+/// including during panic unwinding.
 pub(crate) struct Harness {
     pub(crate) dir: std::path::PathBuf,
     _dir_guard: tempfile::TempDir,
@@ -325,7 +326,7 @@ fn drain_inotify_fd(fd: std::os::fd::BorrowedFd<'_>) {
 
 impl Drop for Harness {
     fn drop(&mut self) {
-        // Drop host first to close the connection, then join guest thread.
+        // Drop host first to close the connection, then wait briefly for the guest thread.
         drop(self.host.take());
         cleanup_guest(&mut self.guest, GUEST_FINISH_TIMEOUT);
     }

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Once;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -40,8 +41,7 @@ pub(crate) fn start_raw_guest_connection() -> (RawGuestHandle, UnixStream) {
 }
 
 pub(crate) fn join_raw_guest_connection(handle: RawGuestHandle) {
-    handle
-        .join()
+    join_guest_with_timeout(handle)
         .expect("raw guest connection thread panicked")
         .expect("raw guest connection returned an error");
 }
@@ -111,22 +111,38 @@ fn start_guest(socket_path: &str) -> JoinHandle<io::Result<()>> {
     })
 }
 
-fn cleanup_guest(guest: &mut Option<JoinHandle<io::Result<()>>>) {
+fn cleanup_guest(guest: &mut Option<JoinHandle<io::Result<()>>>, timeout: Duration) {
     if let Some(g) = guest.take() {
-        let _ = g.join();
+        let Some(result) = try_join_guest_with_timeout(g, timeout) else {
+            eprintln!(
+                "guest thread did not terminate within {timeout:?} after host disconnect during cleanup"
+            );
+            return;
+        };
+        let _ = result;
     }
 }
 
 fn join_guest_with_timeout(guest: JoinHandle<io::Result<()>>) -> thread::Result<io::Result<()>> {
+    try_join_guest_with_timeout(guest, GUEST_FINISH_TIMEOUT).unwrap_or_else(|| {
+        panic!(
+            "guest thread did not terminate within {GUEST_FINISH_TIMEOUT:?} after host disconnect"
+        )
+    })
+}
+
+fn try_join_guest_with_timeout(
+    guest: JoinHandle<io::Result<()>>,
+    timeout: Duration,
+) -> Option<thread::Result<io::Result<()>>> {
     let started = Instant::now();
     while !guest.is_finished() {
-        assert!(
-            started.elapsed() < GUEST_FINISH_TIMEOUT,
-            "guest thread did not terminate within {GUEST_FINISH_TIMEOUT:?} after host disconnect",
-        );
+        if started.elapsed() >= timeout {
+            return None;
+        }
         thread::sleep(Duration::from_millis(10));
     }
-    guest.join()
+    Some(guest.join())
 }
 
 fn create_temp_dir(prefix: &str) -> tempfile::TempDir {
@@ -216,11 +232,11 @@ impl Harness {
         let host = match host_task.await {
             Ok(Ok(host)) => host,
             Ok(Err(err)) => {
-                cleanup_guest(&mut guest);
+                cleanup_guest(&mut guest, GUEST_FINISH_TIMEOUT);
                 panic!("host connection failed: {err}");
             }
             Err(err) => {
-                cleanup_guest(&mut guest);
+                cleanup_guest(&mut guest, GUEST_FINISH_TIMEOUT);
                 panic!("host listener task failed: {err}");
             }
         };
@@ -317,7 +333,7 @@ impl Drop for Harness {
     fn drop(&mut self) {
         // Drop host first to close the connection, then join guest thread.
         drop(self.host.take());
-        cleanup_guest(&mut self.guest);
+        cleanup_guest(&mut self.guest, GUEST_FINISH_TIMEOUT);
     }
 }
 
@@ -330,10 +346,57 @@ fn cleanup_guest_joins_guest() {
         Ok(())
     }));
 
-    cleanup_guest(&mut guest);
+    cleanup_guest(&mut guest, GUEST_FINISH_TIMEOUT);
 
     assert!(guest.is_none());
     assert!(guest_finished.load(Ordering::SeqCst));
+}
+
+#[test]
+fn cleanup_guest_returns_after_timeout_for_stalled_guest() {
+    const CLEANUP_TIMEOUT: Duration = Duration::from_millis(20);
+    const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(5);
+
+    let (guest_started_tx, guest_started_rx) = mpsc::channel();
+    let (release_guest_tx, release_guest_rx) = mpsc::channel();
+    let (guest_finished_tx, guest_finished_rx) = mpsc::channel();
+    let guest = thread::spawn(move || {
+        guest_started_tx.send(()).expect("report guest start");
+        release_guest_rx.recv().expect("wait for guest release");
+        guest_finished_tx.send(()).expect("report guest completion");
+        Ok(())
+    });
+    guest_started_rx
+        .recv_timeout(WATCHDOG_TIMEOUT)
+        .expect("guest should reach blocked state");
+
+    let (cleanup_finished_tx, cleanup_finished_rx) = mpsc::channel();
+    let cleanup_thread = thread::spawn(move || {
+        let mut guest = Some(guest);
+        cleanup_guest(&mut guest, CLEANUP_TIMEOUT);
+        cleanup_finished_tx
+            .send(guest.is_none())
+            .expect("report cleanup completion");
+    });
+
+    let cleanup_result = cleanup_finished_rx.recv_timeout(WATCHDOG_TIMEOUT);
+    release_guest_tx.send(()).expect("release stalled guest");
+    guest_finished_rx
+        .recv_timeout(WATCHDOG_TIMEOUT)
+        .expect("guest should finish after release");
+    if matches!(&cleanup_result, Err(mpsc::RecvTimeoutError::Timeout)) {
+        cleanup_finished_rx
+            .recv_timeout(WATCHDOG_TIMEOUT)
+            .expect("cleanup should finish after guest release");
+    }
+    cleanup_thread
+        .join()
+        .expect("cleanup helper thread should not panic");
+
+    assert!(
+        matches!(cleanup_result, Ok(true)),
+        "cleanup did not consume the guest handle before the watchdog: {cleanup_result:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- separate timeout detection from strict guest completion so teardown callers can choose safe failure behavior
- bound constructor, `Drop`, and raw guest joins to the existing five-second integration timeout
- add synchronized watchdog coverage proving stalled cleanup returns without leaving the test blocked

## Scope

This changes only the `vsock-test` integration support layer. It does not change production guest or host behavior, the vsock protocol, dependencies, CI configuration, or deployment compatibility.

On cleanup timeout, the owned `JoinHandle` is detached because stable Rust cannot safely terminate an arbitrary thread. Explicit harness and raw completion paths continue to fail on timeout and preserve their existing guest panic and `io::Error` assertions.

## Validation

- `cargo test -p vsock-test --test integration`
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-test --all-targets --all-features`
- `cargo doc -p vsock-test --all-features --no-deps`
- `lefthook run pre-commit` (workspace Rust formatting, Clippy, and documentation checks)
- commit-time pre-commit and commitlint hooks

Closes #23196
