### PR TITLE
fix(platform): keep clerk profile inside settings dialog

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -156,6 +156,7 @@ export function clearMockedAuth() {
   mockedClerk.signOut.mockReset();
   mockedClerk.openSignIn.mockReset();
   mockedClerk.openUserProfile.mockReset();
+  mockedClerk.closeUserProfile.mockReset();
   mockedClerk.setActive.mockReset();
   mockedClerk.setActive.mockImplementation(defaultSetActiveImpl);
   mockedClerk.createOrganization.mockReset();
@@ -239,6 +240,11 @@ const initialize =
     (publishableKey: string, options?: { readonly domain?: string }) => void
   >();
 
+interface MockedUserProfileOptions {
+  apiKeysProps?: { hide?: boolean };
+  getContainer?: () => HTMLElement | null;
+}
+
 export const mockedClerk = {
   initialize,
   get user() {
@@ -269,9 +275,8 @@ export const mockedClerk = {
   openSignIn: vi.fn(() => {
     return Promise.resolve();
   }),
-  openUserProfile: vi.fn(() => {
-    return Promise.resolve();
-  }),
+  openUserProfile: vi.fn<(options?: MockedUserProfileOptions) => void>(),
+  closeUserProfile: vi.fn<() => void>(),
   load: vi.fn(defaultLoadImpl),
   addListener: (cb: () => void) => {
     clerkListeners.push(cb);

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -1,9 +1,11 @@
 import { command, computed, state } from "ccstate";
+import type { UserProfileModalProps } from "@clerk/react/types";
+import { clerk$ } from "../../auth.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
-import { resetSignal } from "../../utils.ts";
+import { onRef, resetSignal } from "../../utils.ts";
 import {
   clearPendingLogo$,
   initProfileName$,
@@ -45,7 +47,8 @@ const resetSettingsDialogSignal$ = resetSignal();
 const internalSettingsDialogSessionActive$ = state(false);
 const internalSettingsDialogInitialized$ = state(false);
 const internalSettingsDialogHandoffPending$ = state(false);
-const internalExternalProfileModalOpen$ = state(false);
+const internalSettingsClerkProfilePortalContainer$ =
+  state<HTMLDivElement | null>(null);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
   readonly section: SettingsSection;
@@ -57,13 +60,43 @@ export const settingsDialogOpen$ = computed((get) => {
 
 export { internalSettingsDialogSignal$ as settingsDialogSignal$ };
 
-export const externalProfileModalOpen$ = computed((get) => {
-  return get(internalExternalProfileModalOpen$);
+export const settingsClerkProfilePortalContainer$ = computed((get) => {
+  return get(internalSettingsClerkProfilePortalContainer$);
 });
 
-export const setExternalProfileModalOpen$ = command(
-  ({ set }, open: boolean) => {
-    set(internalExternalProfileModalOpen$, open);
+export const setSettingsClerkProfilePortalContainer$ = onRef(
+  command(
+    async ({ get, set }, container: HTMLDivElement, signal: AbortSignal) => {
+      const clerk = await get(clerk$);
+      signal.throwIfAborted();
+      signal.addEventListener(
+        "abort",
+        () => {
+          clerk.closeUserProfile();
+          set(internalSettingsClerkProfilePortalContainer$, null);
+        },
+        { once: true },
+      );
+      set(internalSettingsClerkProfilePortalContainer$, container);
+    },
+  ),
+);
+
+export const openSettingsUserProfile$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const container = get(internalSettingsClerkProfilePortalContainer$);
+    if (!container) {
+      return;
+    }
+    const props = {
+      apiKeysProps: { hide: true },
+      getContainer: () => {
+        return container;
+      },
+    } satisfies UserProfileModalProps;
+    clerk.openUserProfile(props);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -588,7 +588,7 @@ describe("zero sidebar account menu", () => {
     });
   });
 
-  it("opens settings from the account menu and changes debug capture", async () => {
+  it("keeps the user profile inside settings and changes debug capture", async () => {
     prepareDefaultAgent();
     context.mocks.data.userPreferences({
       captureNetworkBodiesRemaining: 0,
@@ -648,20 +648,33 @@ describe("zero sidebar account menu", () => {
       );
     });
 
+    const clerkProfileModals: HTMLDivElement[] = [];
+    mockedClerk.openUserProfile.mockImplementation((options) => {
+      const container = options?.getContainer?.();
+      if (!container) {
+        throw new Error("Clerk profile portal container not found");
+      }
+      const modal = document.createElement("div");
+      modal.dataset.clerkUserProfile = "";
+      container.append(modal);
+      clerkProfileModals.push(modal);
+    });
+
     click(buttonByText("Manage"));
 
     await waitFor(() => {
+      expect(clerkProfileModals).toHaveLength(1);
       expect(mockedClerk.openUserProfile).toHaveBeenCalledWith({
         apiKeysProps: { hide: true },
+        getContainer: expect.any(Function),
       });
     });
 
-    const clerkProfileModal = document.createElement("div");
-    clerkProfileModal.dataset.clerkUserProfile = "";
-    document.body.append(clerkProfileModal);
-    await waitFor(() => {
-      expect(clerkProfileModal).toBeInTheDocument();
-    });
+    const clerkProfileModal = clerkProfileModals[0];
+    if (!clerkProfileModal) {
+      throw new Error("Clerk profile modal not found");
+    }
+    expect(openedSettingsDialog).toContainElement(clerkProfileModal);
     clerkProfileModal.remove();
 
     await waitFor(() => {
@@ -695,6 +708,7 @@ describe("zero sidebar account menu", () => {
     });
 
     const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
+    mockedClerk.closeUserProfile.mockClear();
     click(buttonByLabel("Close", settingsDialog));
 
     await waitFor(() => {
@@ -703,6 +717,7 @@ describe("zero sidebar account menu", () => {
       ).not.toBeInTheDocument();
       expect(document.querySelector(".zero-dialog-overlay")).toBeNull();
     });
+    expect(mockedClerk.closeUserProfile).toHaveBeenCalledTimes(1);
     expect(document.body.style.pointerEvents).not.toBe("none");
 
     const reopenedMenu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -1,60 +1,26 @@
-import { useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { IconUser } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
-import { clerk$, currentUserInfo$ } from "../../../../../signals/auth.ts";
-import { setExternalProfileModalOpen$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
+import { currentUserInfo$ } from "../../../../../signals/auth.ts";
+import {
+  openSettingsUserProfile$,
+  settingsClerkProfilePortalContainer$,
+  settingsDialogSignal$,
+} from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { detach, Reason } from "../../../../../signals/utils.ts";
 
-const CLERK_PROFILE_SELECTORS = [
-  "[data-clerk-user-profile]",
-  "[data-clerk-modal]",
-  '[class*="cl-userProfile"]',
-  '[class*="cl-modal"]',
-].join(",");
-
-function watchClerkProfileClose(onClose: () => void): void {
-  if (typeof document === "undefined") {
-    return;
-  }
-  let sawProfile = document.querySelector(CLERK_PROFILE_SELECTORS) !== null;
-  const observer = new MutationObserver(() => {
-    const hasProfile = document.querySelector(CLERK_PROFILE_SELECTORS) !== null;
-    if (hasProfile) {
-      sawProfile = true;
-      return;
-    }
-    if (sawProfile) {
-      observer.disconnect();
-      onClose();
-    }
-  });
-  observer.observe(document.body, { childList: true, subtree: true });
-}
-
 export function AccountSection() {
-  const clerkLoadable = useLoadable(clerk$);
-  const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
+  const clerkProfilePortalContainer = useGet(
+    settingsClerkProfilePortalContainer$,
+  );
+  const settingsDialogSignal = useGet(settingsDialogSignal$);
+  const openUserProfile = useSet(openSettingsUserProfile$);
   const userLoadable = useLoadable(currentUserInfo$);
   const user = userLoadable.state === "hasData" ? userLoadable.data : undefined;
-  const setExternalProfileModalOpen = useSet(setExternalProfileModalOpen$);
 
   const displayName = user?.fullName ?? user?.firstName ?? "";
   const email = user?.primaryEmailAddress?.emailAddress ?? "";
   const initial = (displayName || email || "U").charAt(0).toUpperCase();
-
-  const handleOpen = () => {
-    if (!clerk) {
-      return;
-    }
-    setExternalProfileModalOpen(true);
-    watchClerkProfileClose(() => {
-      setExternalProfileModalOpen(false);
-    });
-    detach(
-      clerk.openUserProfile({ apiKeysProps: { hide: true } }),
-      Reason.DomCallback,
-    );
-  };
 
   return (
     <div className="flex items-center gap-4 bg-card rounded-xl zero-border p-5">
@@ -79,7 +45,15 @@ export function AccountSection() {
           <div className="text-sm text-muted-foreground truncate">{email}</div>
         )}
       </div>
-      <Button onClick={handleOpen} disabled={!clerk} className="shrink-0">
+      <Button
+        onClick={() => {
+          if (settingsDialogSignal) {
+            detach(openUserProfile(settingsDialogSignal), Reason.DomCallback);
+          }
+        }}
+        disabled={!clerkProfilePortalContainer || !settingsDialogSignal}
+        className="shrink-0"
+      >
         <IconUser size={14} />
         Manage
       </Button>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -29,8 +29,8 @@ import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import {
   isAdminOnlySettingsSection,
+  setSettingsClerkProfilePortalContainer$,
   settingsActiveSection$,
-  externalProfileModalOpen$,
   setSettingsActiveSection$,
   type SettingsSection,
 } from "../../../../signals/zero-page/settings/settings-dialog.ts";
@@ -182,26 +182,12 @@ function SectionContent({ section }: { section: SettingsSection }) {
   return <Component />;
 }
 
-function isClerkModalTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-  return (
-    target.closest(
-      [
-        "[data-clerk-user-profile]",
-        "[data-clerk-modal]",
-        '[class*="cl-userProfile"]',
-        '[class*="cl-modal"]',
-      ].join(","),
-    ) !== null
-  );
-}
-
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
-  const externalProfileModalOpen = useGet(externalProfileModalOpen$);
+  const setClerkProfilePortalContainer = useSet(
+    setSettingsClerkProfilePortalContainer$,
+  );
   const features = useGet(featureSwitch$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
@@ -240,18 +226,10 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      modal={!externalProfileModalOpen}
-    >
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        ref={setClerkProfilePortalContainer}
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
-        onInteractOutside={(event) => {
-          if (isClerkModalTarget(event.target)) {
-            event.preventDefault();
-          }
-        }}
       >
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">


### PR DESCRIPTION
## Summary

- render Clerk UserProfile inside the Settings DialogContent through the supported `getContainer` API
- keep the Radix Settings dialog modal and remove the document-wide MutationObserver, Clerk selector checks, and temporary modal state
- close the Clerk profile through ccstate `onRef` cleanup whenever the Settings content unmounts

## User impact

Account profile controls remain interactive without weakening Settings focus isolation. Failed or aborted Clerk opens can no longer leave Settings non-modal or accumulate observers for the rest of the SPA session.

## Verification

- `pnpm -F @vm0/app check-types`
- targeted Oxlint and ESLint on changed files
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx -t "keeps the user profile inside settings and changes debug capture"`
- Prettier 3.8.1 check on changed files