### PR TITLE
fix(platform): preserve focus while resizing artifact previews

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -67,10 +67,6 @@ function isDocumentScrollTarget(root: HTMLElement, target: EventTarget | null) {
   );
 }
 
-function hasOpenDialog(doc: Document): boolean {
-  return doc.querySelector('[role="dialog"]') !== null;
-}
-
 function isKeyboardScrollAllowedTarget(
   root: HTMLElement,
   target: EventTarget | null,
@@ -547,46 +543,5 @@ export const setChatKeyboardScrollRoot$ = onRef(
         set(thread.prepareKeyboardScroll$);
       },
     });
-  }),
-);
-
-export const setMainChatThreadKeyboardFocusRef$ = onRef(
-  command((_, el: HTMLElement, signal: AbortSignal) => {
-    const doc = el.ownerDocument;
-    const win = doc.defaultView;
-
-    const focusMainThreadIfDocumentFocused = (
-      target: EventTarget | null = doc.activeElement,
-    ) => {
-      if (
-        !el.isConnected ||
-        hasOpenDialog(doc) ||
-        !isDocumentScrollTarget(el, target)
-      ) {
-        return;
-      }
-      el.focus({ preventScroll: true });
-    };
-
-    queueMicrotask(() => {
-      if (!signal.aborted) {
-        focusMainThreadIfDocumentFocused();
-      }
-    });
-
-    doc.addEventListener(
-      "focusin",
-      (event) => {
-        focusMainThreadIfDocumentFocused(event.target);
-      },
-      { signal },
-    );
-    win?.addEventListener(
-      "focus",
-      () => {
-        focusMainThreadIfDocumentFocused();
-      },
-      { signal },
-    );
   }),
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
@@ -1,0 +1,80 @@
+import { command, computed, state } from "ccstate";
+import { onRef } from "../utils.ts";
+
+function isDocumentScrollTarget(
+  root: HTMLElement,
+  target: EventTarget | null,
+): boolean {
+  const doc = root.ownerDocument;
+  return (
+    target === doc || target === doc.body || target === doc.documentElement
+  );
+}
+
+function hasOpenDialog(doc: Document): boolean {
+  return doc.querySelector('[role="dialog"]') !== null;
+}
+
+const attachMainThreadFocusFallback$ = command(
+  (_, el: HTMLElement, signal: AbortSignal) => {
+    const doc = el.ownerDocument;
+    const win = doc.defaultView;
+
+    const focusMainThreadIfDocumentFocused = (
+      target: EventTarget | null = doc.activeElement,
+    ) => {
+      if (
+        !el.isConnected ||
+        hasOpenDialog(doc) ||
+        !isDocumentScrollTarget(el, target)
+      ) {
+        return;
+      }
+      el.focus({ preventScroll: true });
+    };
+
+    queueMicrotask(() => {
+      if (!signal.aborted) {
+        focusMainThreadIfDocumentFocused();
+      }
+    });
+
+    doc.addEventListener(
+      "focusin",
+      (event) => {
+        focusMainThreadIfDocumentFocused(event.target);
+      },
+      { signal },
+    );
+    win?.addEventListener(
+      "focus",
+      () => {
+        focusMainThreadIfDocumentFocused();
+      },
+      { signal },
+    );
+  },
+);
+
+export function createChatThreadContainerSignals() {
+  const internalContainerEl$ = state<HTMLElement | null>(null);
+  const containerEl$ = computed((get) => {
+    return get(internalContainerEl$);
+  });
+  const attachContainer$ = command(
+    ({ set }, el: HTMLElement, signal: AbortSignal) => {
+      signal.addEventListener("abort", () => {
+        set(internalContainerEl$, null);
+      });
+      set(internalContainerEl$, el);
+    },
+  );
+  const setContainerRef$ = onRef(attachContainer$);
+  const setMainContainerRef$ = onRef(
+    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+      set(attachContainer$, el, signal);
+      set(attachMainThreadFocusFallback$, el, signal);
+    }),
+  );
+  return { containerEl$, setContainerRef$, setMainContainerRef$ };
+}

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -108,6 +108,7 @@ export interface ChatThreadSignals {
   prepareKeyboardScroll$: Command<boolean, []>;
   containerEl$: Computed<HTMLElement | null>;
   setContainerRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
+  setMainContainerRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   // True when the message list is scrolled away from the bottom - drives the
   // feature-gated scroll-to-bottom button. Read-only outside scroll signals.
   awayFromBottom$: Computed<boolean>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -151,6 +151,7 @@ import {
   type BrowserSessionCardSignalsRegistry,
   type BrowserSessionSignals,
 } from "./browser-session-block.ts";
+import { createChatThreadContainerSignals } from "./chat-thread-container.ts";
 import { searchParams$ } from "../route.ts";
 import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 import {
@@ -2695,22 +2696,6 @@ export const ensureDraft$ = command(
   },
 );
 
-function createContainerRef() {
-  const internalContainerEl$ = state<HTMLElement | null>(null);
-  const containerEl$ = computed((get) => {
-    return get(internalContainerEl$);
-  });
-  const setContainerRef$ = onRef(
-    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
-      signal.addEventListener("abort", () => {
-        set(internalContainerEl$, null);
-      });
-      set(internalContainerEl$, el);
-    }),
-  );
-  return { containerEl$, setContainerRef$ };
-}
-
 function createMessageRunIndicatorState(
   rawMessages$: Computed<ChatMessageProjectionEntry[]>,
 ) {
@@ -4359,7 +4344,7 @@ export function createChatThreadSignals(
     awayFromBottom$,
     ...scrollSignals
   } = createChatThreadScrollSignals(threadId);
-  const { containerEl$, setContainerRef$ } = createContainerRef();
+  const container = createChatThreadContainerSignals();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
   const threadOwned = createThreadOwnedSignals(threadId, threadMeta$);
@@ -4419,8 +4404,7 @@ export function createChatThreadSignals(
     ...messageActions,
     composerSendButtonStatus$: composerSendButton.composerSendButtonStatus$,
     ...scrollSignals,
-    containerEl$,
-    setContainerRef$,
+    ...container,
     awayFromBottom$,
     draft,
     ...composer,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -394,6 +394,12 @@ describe("zero artifact sidebar", () => {
     ).toBe("min(760px, 48vw)");
 
     fireEvent.pointerDown(resizeHandle, { clientX: 760 });
+
+    const chatThread = screen.getByLabelText("Chat thread");
+    chatThread.focus();
+    chatThread.blur();
+    expect(document.body).toHaveFocus();
+
     fireEvent.pointerMove(window, { clientX: 700 });
 
     await waitFor(() => {
@@ -402,6 +408,7 @@ describe("zero artifact sidebar", () => {
       ).toBe("clamp(400px, 700px, calc(100% - 600px))");
       expect(context.store.get(artifactPanelWidth$)).toBe(700);
     });
+    expect(document.body).toHaveFocus();
     expect(document.body.style.cursor).toBe("col-resize");
     expect(document.body.style.userSelect).toBe("none");
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -333,7 +333,6 @@ import {
 import {
   focusChatThreadContainer$,
   setChatKeyboardScrollRoot$,
-  setMainChatThreadKeyboardFocusRef$,
 } from "../../signals/chat-page/chat-keyboard.ts";
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
@@ -2414,27 +2413,22 @@ function HeaderAutomationSidebar({ thread }: { thread: ChatThreadSignals }) {
 // ---------------------------------------------------------------------------
 
 function ChatThread({
+  isMain,
   thread,
-  onFocusFallbackRef,
 }: {
+  isMain?: boolean;
   thread: ChatThreadSignals;
-  onFocusFallbackRef?: (el: HTMLElement | null) => (() => void) | undefined;
 }) {
-  const setContainerRef = useSet(thread.setContainerRef$);
+  const setContainerRef = useSet(
+    isMain ? thread.setMainContainerRef$ : thread.setContainerRef$,
+  );
 
   return (
     <section
       aria-label="Chat thread"
       className="flex min-w-0 basis-0 flex-1 flex-col min-h-0 bg-transparent focus:outline-none"
       data-chat-thread-container-id={thread.threadId}
-      ref={(el) => {
-        const cleanupContainerRef = setContainerRef(el);
-        const cleanupFocusFallbackRef = onFocusFallbackRef?.(el);
-        return () => {
-          cleanupFocusFallbackRef?.();
-          cleanupContainerRef?.();
-        };
-      }}
+      ref={setContainerRef}
       tabIndex={-1}
     >
       <ChatThreadContent thread={thread} />
@@ -2532,21 +2526,13 @@ function ChatThreadArea({
   rightThread: ChatThreadSignals | null;
 }) {
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
-  const setMainThreadKeyboardFocusRef = useSet(
-    setMainChatThreadKeyboardFocusRef$,
-  );
 
   return (
     <div
       ref={setKeyboardScrollRoot}
       className="flex w-full flex-1 min-w-0 min-h-0 bg-transparent"
     >
-      {leftThread && (
-        <ChatThread
-          thread={leftThread}
-          onFocusFallbackRef={setMainThreadKeyboardFocusRef}
-        />
-      )}
+      {leftThread && <ChatThread isMain thread={leftThread} />}
       {rightThread && (
         <>
           <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- preserve the current focus while the artifact preview divider updates its width
- expose stable main and secondary chat container refs from the thread signal factory
- let the main container ref own both container state and focus fallback listeners under one DOM lifecycle
- cover preview resizing without remount-driven chat focus changes

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t 'resizes the artifact preview pane and persists the width' --reporter=verbose`
