### PR TITLE
fix(platform): stabilize billing credits deep-link scrolling

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -5,9 +5,10 @@ import { isOrgAdmin$ } from "../../org.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
 import { resetSignal } from "../../utils.ts";
 import {
+  clearBillingScrollTarget$,
   clearPendingLogo$,
   initProfileName$,
-  setBillingScrollTarget$,
+  requestBuyCreditsScroll$,
   setBillingSubPage$,
 } from "./workspace-settings-state.ts";
 
@@ -100,6 +101,9 @@ export const settingsActiveSection$ = computed((get) => {
 export const setSettingsActiveSection$ = command(
   ({ get, set }, section: SettingsSection) => {
     set(internalActiveSection$, section);
+    if (section !== "billing") {
+      set(clearBillingScrollTarget$);
+    }
     if (section === "model") {
       set(reloadPersonalModelProviders$);
     }
@@ -114,7 +118,7 @@ export const setSettingsActiveSection$ = command(
 export const openSettingsBillingPlans$ = command(({ get, set }) => {
   set(internalActiveSection$, "billing");
   set(setBillingSubPage$, true);
-  set(setBillingScrollTarget$, null);
+  set(clearBillingScrollTarget$);
 
   const params = new URLSearchParams(get(searchParams$));
   params.set("settings", "billing");
@@ -149,6 +153,7 @@ export const handoffSettingsDialogSession$ = command(({ set }) => {
 export const closeSettingsModal$ = command(({ get, set }) => {
   set(resetSettingsDialogSignal$);
   set(clearSettingsDialogSession$);
+  set(clearBillingScrollTarget$);
 
   const params = new URLSearchParams(get(searchParams$));
   if (params.has("settings") || params.has("billingView")) {
@@ -208,6 +213,7 @@ export const setSettingsDialogOpen$ = command(
 export const openSettingsDialogAt$ = command(
   async ({ set }, section: SettingsSection, signal: AbortSignal) => {
     set(internalActiveSection$, section);
+    set(clearBillingScrollTarget$);
     await set(setSettingsDialogOpen$, true, signal);
   },
 );
@@ -228,9 +234,11 @@ export const checkUnifiedSettingsParam$ = command(
     const value = params.get("settings");
     const billingView = params.get("billingView");
     if (!value) {
+      set(clearBillingScrollTarget$);
       return;
     }
     if (!isSettingsSection(value)) {
+      set(clearBillingScrollTarget$);
       const next = new URLSearchParams(get(searchParams$));
       next.delete("settings");
       next.delete("billingView");
@@ -245,7 +253,7 @@ export const checkUnifiedSettingsParam$ = command(
     signal.throwIfAborted();
     if (!isAdmin && (opensBillingPlans || opensBuyCredits)) {
       set(setBillingSubPage$, false);
-      set(setBillingScrollTarget$, null);
+      set(clearBillingScrollTarget$);
       const next = new URLSearchParams(get(searchParams$));
       next.delete("settings");
       next.delete("billingView");
@@ -257,10 +265,11 @@ export const checkUnifiedSettingsParam$ = command(
       !isAdmin && isAdminOnlySettingsSection(section) ? "preference" : section;
     set(internalActiveSection$, resolved);
     set(setBillingSubPage$, opensBillingPlans && resolved === "billing");
-    set(
-      setBillingScrollTarget$,
-      opensBuyCredits && resolved === "billing" ? "buy-credits" : null,
-    );
+    if (opensBuyCredits && resolved === "billing") {
+      set(requestBuyCreditsScroll$);
+    } else {
+      set(clearBillingScrollTarget$);
+    }
     await set(setSettingsDialogOpen$, true, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { animationFrame } from "signal-timers";
 import { onRef } from "../../utils.ts";
 import {
   zeroOrgContract,
@@ -21,14 +22,36 @@ import { accept } from "../../../lib/accept.ts";
 
 const internalBillingScrollTarget$ = state<"buy-credits" | null>(null);
 
-export const billingScrollTarget$ = computed((get) => {
-  return get(internalBillingScrollTarget$);
+export const requestBuyCreditsScroll$ = command(({ set }) => {
+  set(internalBillingScrollTarget$, "buy-credits");
 });
 
-export const setBillingScrollTarget$ = command(
-  ({ set }, target: "buy-credits" | null) => {
-    set(internalBillingScrollTarget$, target);
+export const clearBillingScrollTarget$ = command(({ set }) => {
+  set(internalBillingScrollTarget$, null);
+});
+
+const scrollToBuyCreditsIfRequested$ = command(
+  ({ get, set }, element: HTMLDivElement) => {
+    if (get(internalBillingScrollTarget$) !== "buy-credits") {
+      return;
+    }
+    element.scrollIntoView({ block: "start", behavior: "smooth" });
+    set(clearBillingScrollTarget$);
   },
+);
+
+export const buyCreditsScrollRef$ = onRef(
+  command(({ get, set }, element: HTMLDivElement, signal: AbortSignal) => {
+    if (get(internalBillingScrollTarget$) !== "buy-credits") {
+      return;
+    }
+    animationFrame(
+      () => {
+        set(scrollToBuyCreditsIfRequested$, element);
+      },
+      { signal },
+    );
+  }),
 );
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -11,7 +11,7 @@ import {
   type BillingStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-billing";
 import { screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 
 import {
   click,
@@ -20,6 +20,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -184,8 +185,8 @@ function mockBillingStory(): void {
   });
 }
 
-async function openBillingTab(): Promise<void> {
-  detachedSetupPage({ context, path: "/?settings=billing" });
+async function openBillingTab(path = "/?settings=billing"): Promise<void> {
+  detachedSetupPage({ context, path });
   await waitFor(() => {
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
@@ -196,7 +197,114 @@ async function openBillingTab(): Promise<void> {
   });
 }
 
+function installScrollIntoViewMock(): Mock<HTMLElement["scrollIntoView"]> {
+  const scrollIntoView = vi.fn<HTMLElement["scrollIntoView"]>();
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+  return scrollIntoView;
+}
+
+async function openSettingsFromAccountMenu(): Promise<HTMLElement> {
+  const accountName = await screen.findByText("Test User");
+  const accountButton = accountName.closest("button");
+  if (!accountButton) {
+    throw new Error("Account menu trigger not found");
+  }
+  click(accountButton);
+  const menu = await screen.findByRole("menu");
+  click(within(menu).getByText("Settings"));
+  return screen.findByRole("dialog", { name: "Settings" });
+}
+
+async function waitForAnimationFrame(): Promise<void> {
+  const frame = createDeferredPromise<void>(context.signal);
+  window.requestAnimationFrame(() => {
+    frame.resolve(undefined);
+  });
+  await frame.promise;
+}
+
 describe("organization billing settings", () => {
+  it("scrolls to buy credits from the credits billing deep link", async () => {
+    const scrollIntoView = installScrollIntoViewMock();
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "credit-org",
+      name: "Credit Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, activeProBillingStatus());
+    });
+
+    await openBillingTab("/?settings=billing&billingView=credits");
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "start",
+        behavior: "smooth",
+      });
+    });
+  });
+
+  it("clears an unconsumed credits deep link when settings closes", async () => {
+    const scrollIntoView = installScrollIntoViewMock();
+    let billingStatus: BillingStatusResponse = {
+      ...activeProBillingStatus(),
+      canBuyCredits: false,
+    };
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "credit-org",
+      name: "Credit Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, billingStatus);
+    });
+
+    await openBillingTab("/?settings=billing&billingView=credits");
+
+    const dialog = screen.getByRole("dialog", { name: "Settings" });
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Subscription, payment method, and invoices in Stripe.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(dialog).queryByRole("heading", { name: "Buy credits" }),
+    ).not.toBeInTheDocument();
+
+    click(within(dialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Settings" }),
+      ).not.toBeInTheDocument();
+    });
+
+    billingStatus = {
+      ...activeProBillingStatus(),
+      canBuyCredits: true,
+    };
+    const reopenedDialog = await openSettingsFromAccountMenu();
+    click(buttonByText("Billing", reopenedDialog));
+
+    const buyCreditsHeading = await within(reopenedDialog).findByRole(
+      "heading",
+      {
+        name: "Buy credits",
+      },
+    );
+    expect(buyCreditsHeading).toBeInTheDocument();
+    await waitForAnimationFrame();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it("uses plan capabilities instead of the tier for gated billing controls", async () => {
     context.mocks.data.org({
       id: "org_1",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -65,9 +65,8 @@ import {
 } from "../../../../signals/zero-page/org-plan-capabilities.ts";
 import { BuyCreditsSection } from "./buy-credits-section.tsx";
 import {
-  billingScrollTarget$,
   billingSubPage$,
-  setBillingScrollTarget$,
+  buyCreditsScrollRef$,
   setBillingSubPage$,
   lockedTarget$,
   selectedTarget$,
@@ -1287,9 +1286,8 @@ function ConcurrencyBillingSection({
 }
 export function OrgBillingTab() {
   const pricingOpen = useGet(billingSubPage$);
-  const billingScrollTarget = useGet(billingScrollTarget$);
   const setBillingSubPage = useSet(setBillingSubPage$);
-  const setBillingScrollTarget = useSet(setBillingScrollTarget$);
+  const buyCreditsScrollRef = useSet(buyCreditsScrollRef$);
   const setPricingOpen = (v: boolean) => {
     return setBillingSubPage(v);
   };
@@ -1489,16 +1487,7 @@ export function OrgBillingTab() {
       </section>
 
       {showBuyCredits && (
-        <div
-          ref={(el) => {
-            if (el && billingScrollTarget === "buy-credits") {
-              window.setTimeout(() => {
-                el.scrollIntoView({ block: "start", behavior: "smooth" });
-                setBillingScrollTarget(null);
-              }, 0);
-            }
-          }}
-        >
+        <div ref={buyCreditsScrollRef}>
           <BuyCreditsSection />
         </div>
       )}


### PR DESCRIPTION
## Summary

- move the Buy Credits deep-link scroll into a stable ccstate onRef backed by an abortable animation frame
- preserve the scroll request across transient ref detach and remount, then consume it only after a successful scroll
- clear stale requests when Settings closes or navigation selects a non-credits target
- add page-level coverage for successful deep-link scrolling and close/reopen cleanup when Buy Credits is unavailable

## User impact

Credits deep links still land on Buy Credits, while closing or switching Settings can no longer leave detached work or trigger a stale scroll in a later session.

## Verification

- pnpm format
- pnpm lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx (13 tests passed)