### PR TITLE
docs(api): clarify node server entry comment

### DIFF
--- a/turbo/apps/api/src/server.ts
+++ b/turbo/apps/api/src/server.ts
@@ -1,5 +1,5 @@
-// Long-lived Node server entry point. Used by `pnpm dev` (tsx watch) and
-// `pnpm start`. Distinct from `./index.ts`, which is the Vercel-function
+// Long-lived Node server entry point for `pnpm dev` (tsx watch) and
+// `pnpm start`. It stays separate from `./index.ts`, the Vercel function
 // entry built by `@hono/vite-build/vercel`.
 
 import "./instrument";


### PR DESCRIPTION
## Summary

Clarify the API Node server entry-point comment and its relationship to the Vercel function entry.

This is a documentation-only change with no runtime behavior impact. It intentionally provides a fresh PR preview for validating the Clerk browser E2E path.

## Verification

- `git diff --check`
- App preview: https://pr-23223-app.omby.ai
- App and API preview deployments succeeded
- `cli-e2e-02-browser` passed both Clerk UI cases: sign-up in 26.1s and sign-out/sign-in in 30.4s
- Run: https://github.com/vm0-ai/vm0/actions/runs/30240130085/job/89895799986
- Independent cold-load check observed the SignUp chunks begin around 7.5s and finish around 8.0s before the form rendered; all observed requests returned successfully