### PR TITLE
test(mitm-addon): model getresponse failure without finalizer warning

### DIFF
--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -108,7 +108,7 @@ class FakeSocket:
     cleanup and TCP option behavior.
 
     Side-effect arguments raise at the matching boundary so tests can exercise
-    send, read, response setup, and TCP option failures.
+    send, read, and TCP option failures.
 
     Use ``request_text``, ``request_lines``, and ``request_header_values`` for
     assertions about the HTTP request that the real forwarder serialized.
@@ -120,14 +120,12 @@ class FakeSocket:
         *,
         read_side_effect: Exception | None = None,
         send_side_effect: Exception | None = None,
-        makefile_side_effect: Exception | None = None,
         setsockopt_side_effect: Exception | None = None,
         on_action: Callable[[], None] | None = None,
     ) -> None:
         self._response = response
         self._read_side_effect = read_side_effect
         self._send_side_effect = send_side_effect
-        self._makefile_side_effect = makefile_side_effect
         self._setsockopt_side_effect = setsockopt_side_effect
         self._on_action = on_action
         self.sent = bytearray()
@@ -154,8 +152,6 @@ class FakeSocket:
 
     def makefile(self, *_args, **_kwargs) -> FakeResponseFile:
         self._record_action()
-        if self._makefile_side_effect is not None:
-            raise self._makefile_side_effect
         self.response_file = FakeResponseFile(
             self._response,
             read_side_effect=self._read_side_effect,
@@ -241,7 +237,6 @@ class FakeForwarderUpstream:
         addresses: tuple[str, ...] = ("93.184.216.34",),
         read_side_effect: Exception | None = None,
         send_side_effect: Exception | None = None,
-        makefile_side_effect: Exception | None = None,
         setsockopt_side_effect: Exception | None = None,
         wrap_side_effect: Exception | None = None,
         on_action: Callable[[], None] | None = None,
@@ -251,7 +246,6 @@ class FakeForwarderUpstream:
         self._response = http_response(status=status, body=body, headers=headers)
         self._read_side_effect = read_side_effect
         self._send_side_effect = send_side_effect
-        self._makefile_side_effect = makefile_side_effect
         self._setsockopt_side_effect = setsockopt_side_effect
         self._wrap_side_effect = wrap_side_effect
         self._on_action = on_action
@@ -279,7 +273,6 @@ class FakeForwarderUpstream:
             self._response,
             read_side_effect=self._read_side_effect,
             send_side_effect=self._send_side_effect,
-            makefile_side_effect=self._makefile_side_effect,
             setsockopt_side_effect=self._setsockopt_side_effect,
             on_action=self._on_action,
         )
@@ -418,7 +411,6 @@ def fake_forwarder_upstream(
     addresses: tuple[str, ...] = ("93.184.216.34",),
     read_side_effect: Exception | None = None,
     send_side_effect: Exception | None = None,
-    makefile_side_effect: Exception | None = None,
     setsockopt_side_effect: Exception | None = None,
     wrap_side_effect: Exception | None = None,
     on_action: Callable[[], None] | None = None,
@@ -443,7 +435,6 @@ def fake_forwarder_upstream(
         addresses=addresses,
         read_side_effect=read_side_effect,
         send_side_effect=send_side_effect,
-        makefile_side_effect=makefile_side_effect,
         setsockopt_side_effect=setsockopt_side_effect,
         wrap_side_effect=wrap_side_effect,
         on_action=on_action,

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextvars
 import errno
+import http.client as http_client
 import multiprocessing
 import ssl
 import threading
@@ -844,15 +845,21 @@ class TestAuthBaseForwarderResourceCleanup:
         assert upstream.socket.closed
 
     async def test_closes_connection_when_getresponse_raises(self):
+        def create_connection(
+            _address: tuple[str, int],
+            _timeout: object,
+            _source_address: object,
+        ) -> FakeSocket:
+            return FakeSocket(b"not an HTTP response\r\n")
+
         with (
-            fake_forwarder_upstream(
-                makefile_side_effect=ConnectionError("response failed")
-            ) as upstream,
-            pytest.raises(ConnectionError, match="response failed"),
+            fake_forwarder_upstream(create_connection=create_connection) as upstream,
+            pytest.raises(http_client.BadStatusLine),
         ):
             await forwarder.forward_request("https://example.com", "GET", [], None)
 
-        assert upstream.socket.response_file is None
+        assert upstream.socket.response_file is not None
+        assert upstream.socket.response_file.closed
         assert upstream.socket.closed
 
 


### PR DESCRIPTION
## Summary

- model the forwarder `getresponse()` failure with a malformed upstream status line after `HTTPResponse` is fully initialized
- verify both the response file and upstream socket are closed without an unraisable finalizer warning
- remove the unused `makefile_side_effect` test-helper plumbing

## Scope

Test-only change. No production forwarding behavior, dependencies, APIs, persistence, deployment compatibility, migrations, or rollout behavior changed.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q -W error::pytest.PytestUnraisableExceptionWarning tests/test_auth_base_forwarder.py::TestAuthBaseForwarderResourceCleanup::test_closes_connection_when_getresponse_raises` — 1 passed
- `uv run --no-sync python -m pytest -q -W error::pytest.PytestUnraisableExceptionWarning tests/test_auth_base_forwarder.py` — 98 passed
- `uv run --no-sync python -m pytest tests/` — 4275 passed

Closes #23199
