### PR TITLE
perf(mitm-addon): share websocket event type probing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -10,7 +10,6 @@ from mitmproxy import http
 
 import flow_metadata
 import usage
-from usage.json_probe import probe_top_level_string_field
 from usage.reporting_context import usage_reporting_context
 
 FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
@@ -38,14 +37,11 @@ class _RunTimingState:
 _run_states: OrderedDict[str, _RunTimingState] = OrderedDict()
 
 
-def observe_server_event(flow: http.HTTPFlow, content: bytes | str) -> None:
+def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
     """Observe one server-originated Codex Responses WebSocket event."""
-    body = content.encode() if isinstance(content, str) else content
-    event_type_result = probe_top_level_string_field(body)
-    if event_type_result.status != "found" or event_type_result.value is None:
+    if event_type is None:
         return
 
-    event_type = event_type_result.value
     run_id = flow_metadata.run_id(flow.metadata)
     if not run_id:
         return

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1103,9 +1103,11 @@ def websocket_message(flow: http.HTTPFlow) -> None:
         return
     if getattr(message, "from_client", False):
         return
+    body = message.content.encode() if isinstance(message.content, str) else message.content
+    event = usage.inspect_openai_responses_event_json(body)
     if response_streaming.uses_openai_responses_usage_protocol(flow):
-        codex_output_timing.observe_server_event(flow, message.content)
-    response_streaming.feed_model_websocket_usage(flow, message.content)
+        codex_output_timing.observe_server_event(flow, event.event_type)
+    response_streaming.feed_model_websocket_usage(flow, event)
 
 
 def _response_size(flow: http.HTTPFlow) -> int:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -481,12 +481,15 @@ def finalize_model_sse_usage(flow: http.HTTPFlow) -> None:
         finish()
 
 
-def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> None:
+def feed_model_websocket_usage(
+    flow: http.HTTPFlow,
+    event: usage.OpenAIResponsesEvent,
+) -> None:
     """Merge model-provider usage from one server WebSocket frame.
 
-    Called from ``websocket_message()`` only for server-originated frames. Reads
-    ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via ``is_model_websocket_usage_enabled()``
-    and temporarily writes per-response sources to
+    Called from ``websocket_message()`` only for server-originated frames after
+    provider event inspection. Reads ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via
+    ``is_model_websocket_usage_enabled()`` and temporarily writes per-response sources to
     ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES`` while attempting a
     source-preserving report, then releases them from flow metadata. Frames
     without a response id fall back to ``metadata_keys.MODEL_PROVIDER_USAGE``.
@@ -495,8 +498,7 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     """
     if not is_model_websocket_usage_enabled(flow):
         return
-    body = content.encode() if isinstance(content, str) else content
-    usage_result = usage.extract_openai_responses_usage_from_event_json(body)
+    usage_result = usage.extract_openai_responses_usage_from_event(event)
     if not usage_result:
         return
     message_id = usage_result.get("message_id")

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -51,11 +51,14 @@ from .counters import (
     write_pending_snapshot,
 )
 from .openai_responses import (
+    OpenAIResponsesEvent,
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
+    extract_openai_responses_usage_from_event,
     extract_openai_responses_usage_from_event_json,
     extract_openai_responses_usage_from_json,
     extract_openai_responses_usage_with_error_from_json,
+    inspect_openai_responses_event_json,
     merge_openai_responses_usage_result,
 )
 from .providers.connectors import (
@@ -74,6 +77,7 @@ from .providers.model_provider import (
 
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
+    "OpenAIResponsesEvent",
     "buffer_model_usage_observations",
     "buffer_source_model_usage_observations",
     "buffer_source_usage_events",
@@ -89,6 +93,7 @@ __all__ = [
     "drain_usage_events_after_executor_shutdown",
     "extract_anthropic_messages_usage_from_json",
     "extract_anthropic_messages_usage_with_error_from_json",
+    "extract_openai_responses_usage_from_event",
     "extract_openai_responses_usage_from_event_json",
     "extract_openai_responses_usage_from_json",
     "extract_openai_responses_usage_with_error_from_json",
@@ -96,6 +101,7 @@ __all__ = [
     "has_connector_response_parser",
     "has_positive_model_provider_usage",
     "increment_in_flight_flows",
+    "inspect_openai_responses_event_json",
     "is_model_provider_usage_observable",
     "merge_openai_responses_usage_result",
     "needs_connector_response_buffer_fallback",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -11,14 +11,18 @@ model-provider usage billing:
   ``mitm_addon.py`` fallback used by legacy/test flows without
   response-streaming parser state.
 - Single-frame WebSocket event JSON via
-  ``extract_openai_responses_usage_from_event_json``, consumed by
-  ``response_streaming.py`` for Responses events received over upgrades.
+  ``inspect_openai_responses_event_json`` and
+  ``extract_openai_responses_usage_from_event``, consumed by
+  ``mitm_addon.py`` and ``response_streaming.py`` for Responses events received
+  over upgrades. ``extract_openai_responses_usage_from_event_json`` remains the
+  one-shot entry point.
 - Per-event usage aggregation via ``merge_openai_responses_usage_result``,
   used by ``response_streaming.py`` to fold terminal SSE and WebSocket event
   usage into a per-flow accumulator.
 """
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Literal, TypeGuard
 
 from mitmproxy import http
@@ -26,7 +30,7 @@ from mitmproxy import http
 import body_decoding
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
-from .json_probe import probe_top_level_string_field
+from .json_probe import TopLevelStringFieldProbeResult, probe_top_level_string_field
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import (
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
@@ -121,6 +125,16 @@ _JSON_PREFILTER_MAX_STRING_BYTES = 1024
 # terminal frames with late ``type`` fields still report usage.
 _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES = 4096
 
+
+@dataclass(frozen=True)
+class OpenAIResponsesEvent:
+    """One inspected Responses WebSocket event."""
+
+    event_type: str | None
+    _body: bytes = field(repr=False)
+    _classification: _ResponsesEventTypeClassification
+
+
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
@@ -147,13 +161,33 @@ _RESPONSES_SSE_SCALAR_FIELDS = {
 }
 
 
-def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
-    result = probe_top_level_string_field(
+def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
+    """Inspect one complete Responses WebSocket event with one bounded type probe."""
+    result = _probe_responses_event_type(body)
+    event_type = result.value if result.status == "found" and result.value is not None else None
+    return OpenAIResponsesEvent(
+        event_type=event_type,
+        _body=body,
+        _classification=_classify_responses_event_type_result(result),
+    )
+
+
+def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:
+    return probe_top_level_string_field(
         body,
         "type",
         max_depth=_JSON_PREFILTER_MAX_DEPTH,
         max_string_bytes=_JSON_PREFILTER_MAX_STRING_BYTES,
     )
+
+
+def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
+    return _classify_responses_event_type_result(_probe_responses_event_type(body))
+
+
+def _classify_responses_event_type_result(
+    result: TopLevelStringFieldProbeResult,
+) -> _ResponsesEventTypeClassification:
     if result.status == "incomplete":
         return _RESPONSES_EVENT_PENDING
     if result.status != "found" or result.value is None:
@@ -723,7 +757,14 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     ``event:`` / ``data:`` envelope, so reuse the SSE field map and event gate
     directly.
     """
-    event_type = _classify_responses_event_type(body)
+    return extract_openai_responses_usage_from_event(inspect_openai_responses_event_json(body))
+
+
+def extract_openai_responses_usage_from_event(
+    event: OpenAIResponsesEvent,
+) -> dict | None:
+    """Extract usage from a previously inspected Responses WebSocket event."""
+    event_type = event._classification
     if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
         return None
 
@@ -734,7 +775,7 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
         else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
     )
     extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
-    extractor.feed(body)
+    extractor.feed(event._body)
     result = extractor.finish()
     if not result.complete:
         return None

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -1,8 +1,10 @@
 """Tests for default Codex provider-output timing observations."""
 
 import json
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from types import FrameType
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +23,7 @@ from tests.model_provider_websocket_helpers import (
 )
 from tests.usage_helpers import CapturedWebhookRequest, UsageWebhookServer
 from tests.webhook_test_helpers import QueuedUsageExecutor
+from usage import json_probe
 
 _TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
 _FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
@@ -193,6 +196,31 @@ def test_irrelevant_websocket_messages_do_not_report_timings(
         mitm_addon.websocket_message(unobservable)
 
     assert _timing_requests(usage_webhook_server) == []
+
+
+def test_server_websocket_event_type_is_probed_once(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    probe_code = json_probe.probe_top_level_string_field.__code__
+    probe_calls = 0
+
+    def count_probe(frame: FrameType, event: str, _arg: object) -> None:
+        nonlocal probe_calls
+        if event == "call" and frame.f_code is probe_code:
+            probe_calls += 1
+
+    with mitm_ctx():
+        mitm_addon.responseheaders(flow)
+        sys.setprofile(count_probe)
+        try:
+            feed_websocket_server_message(flow, _event("response.output_text.delta"))
+        finally:
+            sys.setprofile(None)
+
+    assert probe_calls == 1
 
 
 def test_saturated_delivery_retries_with_original_observation_times(

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -212,13 +212,14 @@ def test_server_websocket_event_type_is_probed_once(
         if event == "call" and frame.f_code is probe_code:
             probe_calls += 1
 
+    previous_profile = sys.getprofile()
     with mitm_ctx():
         mitm_addon.responseheaders(flow)
         sys.setprofile(count_probe)
         try:
             feed_websocket_server_message(flow, _event("response.output_text.delta"))
         finally:
-            sys.setprofile(None)
+            sys.setprofile(previous_profile)
 
     assert probe_calls == 1
 


### PR DESCRIPTION
## Summary

- inspect each enabled Codex server WebSocket event once and retain its body, event name, and usage classification in a provider-owned immutable descriptor
- pass the content-free event name to output timing and reuse the same descriptor for usage extraction
- preserve the one-shot event JSON extractor, conservative unknown/malformed fallback, known-non-usage fast path, timing order, and WebSocket lifecycle behavior
- add a hook-level regression that counts the actual bounded probe calls without wall-clock assertions

## Scope

This does not change Responses event sets, usage field mapping, SSE behavior, persisted state, external APIs, dependencies, migrations, or deployment contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_codex_output_timing.py tests/test_openai_responses_event_json.py tests/test_model_provider_websocket_usage.py`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_lifecycle.py tests/test_websocket_retention.py tests/test_openai_responses_sse.py`
- `uv run --no-sync python -m pytest tests/` (`4275 passed`)
- applicable Lefthook pre-commit and commit-message checks

An isolated best-of-five, 100,000-iteration benchmark of the known-non-usage path measured approximately `9.373 us/call` for duplicate probing and `5.045 us/call` for shared inspection on the development host. This is a synchronous CPU-path comparison, not an end-to-end latency claim.

Closes #23198
