### PR TITLE
refactor(storage): remove legacy type residue

### DIFF
--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -65,7 +65,7 @@ interface CommitStorageForStorageInput extends CommitStorageUploadInput {
   readonly storageId: string;
 }
 
-type StorageRow = Omit<typeof storages.$inferSelect, "type">;
+type StorageRow = typeof storages.$inferSelect;
 type StorageVersionRow = typeof storageVersions.$inferSelect;
 
 function storageRowSelection() {

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -399,7 +399,7 @@ describe("Rust type bindings", () => {
     ]);
 
     expect(rendered).toContain("pub delivery_mode: String,");
-    expect(rendered).not.toContain("pub enum RequestStorageType");
+    expect(rendered).not.toContain("pub enum RequestDeliveryMode");
   });
 
   it("renames Rust keyword fields", () => {

--- a/turbo/packages/core/src/storage-names.ts
+++ b/turbo/packages/core/src/storage-names.ts
@@ -4,10 +4,10 @@
  */
 
 /**
- * Sentinel userId for org-level storages (volumes).
- * Volumes are shared resources within an org — they use this constant
- * instead of a real userId so the (orgId, userId, name, type)
- * constraint keeps them unique per org, not per user.
+ * Sentinel userId for organization-owned storages.
+ * Organization-owned storages are shared resources within an organization.
+ * They use this constant instead of a real userId so the
+ * (orgId, userId, name) constraint keeps them unique per organization.
  */
 export const VOLUME_ORG_USER_ID = "__org__";
 
@@ -51,8 +51,8 @@ export function getCustomSkillStorageName(skillName: string): string {
 }
 
 /**
- * Reserved name of the per-user "memory" artifact that Zero auto-injects into
- * every agent run. Stored as an artifact (type='artifact') scoped per user,
- * and mounted into the sandbox at a framework-specific path.
+ * Reserved name of the per-user memory storage that Zero auto-injects into
+ * every agent run. It is owned by the user and mounted into the sandbox at a
+ * framework-specific path.
  */
 export const MEMORY_ARTIFACT_NAME = "memory";


### PR DESCRIPTION
## Summary

- simplify the Storage write row type now that `storages.type` no longer exists
- update Storage identity and memory ownership comments to describe the canonical model
- fix the Rust binding override test to assert against `RequestDeliveryMode`

## Impact

This removes the remaining active-code references to the legacy Storage type model. Historical migrations, snapshots, and the migration contraction test remain unchanged because they are required to replay and verify the schema transition.

## Verification

- Prettier passed for all three changed files
- `@vm0/core` lint and type-check passed
- `@vm0/api-contracts` lint and type-check passed
- targeted API Oxlint, type-aware Oxlint, and ESLint passed
- active-code residual scan found no legacy Storage type references
- latest migration snapshot confirms canonical Storage columns and indexes

Repository-wide API lint and type-check currently hit unrelated `main` baseline errors in the maps and archive services; none of those files are changed by this PR. The PR pipeline will run the full repository checks.
