### PR TITLE
fix(guest-agent): preserve codex fast mode in app server

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -25,8 +25,8 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    CODEX_FIXED_STARTUP_CONFIGS, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
-    HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
+    CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
+    LOG_TAG, ParsedEventAction, command,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
@@ -363,8 +363,7 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
     };
     let codex_home = PathBuf::from(runtime.codex_home());
     let child_user_env = runtime.child_user_env();
-    let mut config_overrides = runtime.codex_startup_config_overrides();
-    config_overrides.extend(CODEX_FIXED_STARTUP_CONFIGS.map(str::to_string));
+    let config_overrides = runtime.codex_startup_config_overrides();
     let mut config = CodexAppServerConfig::new(binary, codex_home)
         .with_child_env(
             runtime.home_dir.as_ref(),

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -447,15 +447,6 @@ mod tests {
         args
     }
 
-    fn build_codex_fast_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
-        let _system_log_state_guard = crate::lock_system_log_test_state();
-        disable_system_log();
-        let overrides = super::super::CODEX_FAST_MODE_STARTUP_CONFIGS.map(str::to_string);
-        let args = build_codex_args(model, &overrides, resume_id, "");
-        assert!(!args.iter().any(|arg| arg == prompt));
-        args
-    }
-
     fn build_codex_args_with_startup_config_for_test(
         model: &str,
         startup_config_overrides: &[String],
@@ -548,13 +539,6 @@ mod tests {
         let args = build_codex_args_for_test("gpt-5", "", "p");
         let m_idx = args.iter().position(|a| a == "-m").unwrap();
         assert_eq!(args[m_idx + 1], "gpt-5");
-    }
-
-    #[test]
-    fn build_codex_args_with_fast_mode_configs() {
-        let args = build_codex_fast_args_for_test("gpt-5.5", "", "p");
-        assert!(codex_args_have_config(&args, "features.fast_mode=true"));
-        assert!(codex_args_have_config(&args, r#"service_tier="fast""#));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::{env, paths};
 use guest_common::log_info;
 
-use super::{CODEX_FIXED_STARTUP_CONFIGS, CliRuntimeConfig, LOG_TAG, codex_runtime_config};
+use super::{CliRuntimeConfig, LOG_TAG, codex_runtime_config};
 
 pub(super) fn build_cli_command_for_runtime(
     runtime: &CliRuntimeConfig<'_>,
@@ -35,9 +35,7 @@ pub(super) fn build_cli_command_for_runtime(
                 runtime.mock_codex_path.as_ref(),
                 CodexArgsConfig {
                     model: runtime.openai_model.as_ref(),
-                    openai_base_url: runtime.openai_base_url.as_ref(),
                     startup_config_overrides: &startup_config_overrides,
-                    fast_mode: runtime.codex_fast_mode,
                     resume_id: runtime.resume_session_id.as_ref(),
                     append_system_prompt: runtime.append_system_prompt.as_ref(),
                 },
@@ -161,11 +159,6 @@ fn build_codex_memories_config() -> String {
     "features.memories=true".to_string()
 }
 
-fn build_codex_openai_base_url_config(openai_base_url: &str) -> String {
-    let value = codex_runtime_config::quote_toml_basic_string(openai_base_url);
-    format!("openai_base_url={value}")
-}
-
 fn push_codex_config_overrides(args: &mut Vec<String>, overrides: &[String]) {
     for override_value in overrides {
         push_codex_config_override(args, override_value.clone());
@@ -175,13 +168,6 @@ fn push_codex_config_overrides(args: &mut Vec<String>, overrides: &[String]) {
 fn push_codex_config_override(args: &mut Vec<String>, override_value: impl Into<String>) {
     args.push("-c".to_string());
     args.push(override_value.into());
-}
-
-fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
-    args.push("-c".to_string());
-    args.push("features.fast_mode=true".to_string());
-    args.push("-c".to_string());
-    args.push(r#"service_tier="fast""#.to_string());
 }
 
 /// Per-model overrides for the codex `model_reasoning_effort` config.
@@ -198,18 +184,14 @@ pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'
 
 struct CodexArgsConfig<'a> {
     model: &'a str,
-    openai_base_url: &'a str,
     startup_config_overrides: &'a [String],
-    fast_mode: bool,
     resume_id: &'a str,
     append_system_prompt: &'a str,
 }
 
 fn build_codex_args(
     model: &str,
-    openai_base_url: &str,
     startup_config_overrides: &[String],
-    fast_mode: bool,
     resume_id: &str,
     append_system_prompt: &str,
 ) -> Vec<String> {
@@ -224,21 +206,7 @@ fn build_codex_args(
     ];
 
     push_codex_config_override(&mut args, build_codex_memories_config());
-
-    if startup_config_overrides.is_empty() && !openai_base_url.is_empty() {
-        push_codex_config_override(
-            &mut args,
-            build_codex_openai_base_url_config(openai_base_url),
-        );
-    }
     push_codex_config_overrides(&mut args, startup_config_overrides);
-    for override_value in CODEX_FIXED_STARTUP_CONFIGS {
-        push_codex_config_override(&mut args, override_value);
-    }
-
-    if fast_mode {
-        push_codex_fast_mode_configs(&mut args);
-    }
 
     if !model.is_empty() {
         args.push("-m".to_string());
@@ -287,9 +255,7 @@ fn build_codex_command_with_config(
     let mut cmd = vec![bin];
     cmd.extend(build_codex_args(
         config.model,
-        config.openai_base_url,
         config.startup_config_overrides,
-        config.fast_mode,
         config.resume_id,
         config.append_system_prompt,
     ));
@@ -476,7 +442,7 @@ mod tests {
     fn build_codex_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _system_log_state_guard = crate::lock_system_log_test_state();
         disable_system_log();
-        let args = build_codex_args(model, "", &[], false, resume_id, "");
+        let args = build_codex_args(model, &[], resume_id, "");
         assert!(!args.iter().any(|arg| arg == prompt));
         args
     }
@@ -484,20 +450,8 @@ mod tests {
     fn build_codex_fast_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _system_log_state_guard = crate::lock_system_log_test_state();
         disable_system_log();
-        let args = build_codex_args(model, "", &[], true, resume_id, "");
-        assert!(!args.iter().any(|arg| arg == prompt));
-        args
-    }
-
-    fn build_codex_args_with_base_url_for_test(
-        model: &str,
-        openai_base_url: &str,
-        resume_id: &str,
-        prompt: &str,
-    ) -> Vec<String> {
-        let _system_log_state_guard = crate::lock_system_log_test_state();
-        disable_system_log();
-        let args = build_codex_args(model, openai_base_url, &[], false, resume_id, "");
+        let overrides = super::super::CODEX_FAST_MODE_STARTUP_CONFIGS.map(str::to_string);
+        let args = build_codex_args(model, &overrides, resume_id, "");
         assert!(!args.iter().any(|arg| arg == prompt));
         args
     }
@@ -509,7 +463,7 @@ mod tests {
     ) -> Vec<String> {
         let _system_log_state_guard = crate::lock_system_log_test_state();
         disable_system_log();
-        let args = build_codex_args(model, "", startup_config_overrides, false, "", "");
+        let args = build_codex_args(model, startup_config_overrides, "", "");
         assert!(!args.iter().any(|arg| arg == prompt));
         args
     }
@@ -522,7 +476,7 @@ mod tests {
     ) -> Vec<String> {
         let _system_log_state_guard = crate::lock_system_log_test_state();
         disable_system_log();
-        let args = build_codex_args(model, "", &[], false, resume_id, append_system_prompt);
+        let args = build_codex_args(model, &[], resume_id, append_system_prompt);
         assert!(!args.iter().any(|arg| arg == prompt));
         args
     }
@@ -544,9 +498,7 @@ mod tests {
             },
             CodexArgsConfig {
                 model: "",
-                openai_base_url: "",
                 startup_config_overrides: &[],
-                fast_mode: false,
                 resume_id: "",
                 append_system_prompt: "",
             },
@@ -560,7 +512,7 @@ mod tests {
         let system_log_path = tmp.path().join("system.log");
         guest_common::log::set_system_log_file(system_log_path.to_string_lossy().as_ref());
 
-        let args = build_codex_args("", "", &[], false, "thread-secret-123", "");
+        let args = build_codex_args("", &[], "thread-secret-123", "");
         guest_common::log::clear_system_log_file();
         let system_log = std::fs::read_to_string(system_log_path).unwrap();
 
@@ -606,20 +558,6 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_args_with_openai_base_url() {
-        let args = build_codex_args_with_base_url_for_test(
-            "legacy-model",
-            "https://api.legacy-provider.test/v1",
-            "",
-            "p",
-        );
-        assert!(codex_args_have_config(
-            &args,
-            r#"openai_base_url="https://api.legacy-provider.test/v1""#
-        ));
-    }
-
-    #[test]
     fn build_codex_args_with_structured_runtime_config() {
         let overrides = vec![
             r#"model_provider="minimax""#.to_string(),
@@ -631,23 +569,6 @@ mod tests {
         for override_value in overrides {
             assert!(codex_args_have_config(&args, &override_value));
         }
-        assert!(!args.iter().any(|arg| arg.starts_with("openai_base_url=")));
-    }
-
-    #[test]
-    fn build_codex_args_prefers_structured_runtime_config_over_openai_base_url() {
-        let _system_log_state_guard = crate::lock_system_log_test_state();
-        disable_system_log();
-        let args = build_codex_args(
-            "MiniMax-M3",
-            "https://api.should-not-win.test/v1",
-            &[r#"model_provider="minimax""#.to_string()],
-            false,
-            "",
-            "",
-        );
-
-        assert!(codex_args_have_config(&args, r#"model_provider="minimax""#));
         assert!(!args.iter().any(|arg| arg.starts_with("openai_base_url=")));
     }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1673,68 +1673,6 @@ mod tests {
     }
 
     #[test]
-    fn codex_startup_config_keeps_legacy_openai_base_url() {
-        let user_env = HashMap::new();
-        let mut runtime =
-            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
-        runtime.openai_base_url = Cow::Borrowed("https://api.legacy-provider.test/v1");
-
-        let command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
-
-        assert!(
-            command_config_index(
-                &command,
-                r#"openai_base_url="https://api.legacy-provider.test/v1""#
-            )
-            .is_some()
-        );
-    }
-
-    #[test]
-    fn codex_startup_config_prefers_structured_provider_over_openai_base_url() {
-        let user_env = HashMap::new();
-        let mut runtime =
-            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
-        runtime.openai_base_url = Cow::Borrowed("https://api.should-not-win.test/v1");
-        runtime.codex_runtime_config = Some(codex_runtime_config::CodexRuntimeConfig {
-            provider_id: "minimax".to_string(),
-            name: "MiniMax".to_string(),
-            base_url: "https://api.minimax.io/v1".to_string(),
-            env_key: "OPENAI_API_KEY".to_string(),
-            wire_api: "responses".to_string(),
-            supports_websockets: false,
-            model_catalog: None,
-        });
-
-        let command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
-
-        assert!(command_config_index(&command, r#"model_provider="minimax""#).is_some());
-        assert!(
-            !command
-                .iter()
-                .any(|arg| arg.starts_with("openai_base_url="))
-        );
-    }
-
-    #[test]
-    fn codex_fast_mode_startup_config_covers_ordinary_exec() {
-        let user_env = HashMap::new();
-        let mut runtime =
-            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
-
-        let standard_command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
-        for config in super::CODEX_FAST_MODE_STARTUP_CONFIGS {
-            assert!(command_config_index(&standard_command, config).is_none());
-        }
-
-        runtime.codex_fast_mode = true;
-        let fast_command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
-        for config in super::CODEX_FAST_MODE_STARTUP_CONFIGS {
-            assert!(command_config_index(&fast_command, config).is_some());
-        }
-    }
-
-    #[test]
     fn claude_large_prompt_is_not_rejected_by_process_argv_guard() {
         let user_env = HashMap::new();
         let prompt = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -77,6 +77,8 @@ const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
     "features.plugins=false",
     "features.apps=false",
 ];
+const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
+    ["features.fast_mode=true", r#"service_tier="fast""#];
 const CODEX_WEB_SEARCH_DISABLED_CONFIG: &str = r#"web_search="disabled""#;
 /// Maximum retained bytes for one ordinary CLI stdout record before parsing.
 ///
@@ -405,8 +407,17 @@ impl<'a> CliRuntimeConfig<'a> {
             self.codex_runtime_config.as_ref(),
             Path::new(&codex_home),
         );
+        if self.codex_runtime_config.is_none() && !self.openai_base_url.is_empty() {
+            let base_url =
+                codex_runtime_config::quote_toml_basic_string(self.openai_base_url.as_ref());
+            overrides.push(format!("openai_base_url={base_url}"));
+        }
         if self.disable_builtin_web_search {
             overrides.push(CODEX_WEB_SEARCH_DISABLED_CONFIG.to_string());
+        }
+        overrides.extend(CODEX_FIXED_STARTUP_CONFIGS.map(str::to_string));
+        if self.codex_fast_mode {
+            overrides.extend(CODEX_FAST_MODE_STARTUP_CONFIGS.map(str::to_string));
         }
         overrides
     }
@@ -1659,6 +1670,68 @@ mod tests {
 
         assert!(overrides.contains(&r#"model_provider="minimax""#.to_string()));
         assert!(overrides.contains(&super::CODEX_WEB_SEARCH_DISABLED_CONFIG.to_string()));
+    }
+
+    #[test]
+    fn codex_startup_config_keeps_legacy_openai_base_url() {
+        let user_env = HashMap::new();
+        let mut runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
+        runtime.openai_base_url = Cow::Borrowed("https://api.legacy-provider.test/v1");
+
+        let command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+
+        assert!(
+            command_config_index(
+                &command,
+                r#"openai_base_url="https://api.legacy-provider.test/v1""#
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn codex_startup_config_prefers_structured_provider_over_openai_base_url() {
+        let user_env = HashMap::new();
+        let mut runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
+        runtime.openai_base_url = Cow::Borrowed("https://api.should-not-win.test/v1");
+        runtime.codex_runtime_config = Some(codex_runtime_config::CodexRuntimeConfig {
+            provider_id: "minimax".to_string(),
+            name: "MiniMax".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: None,
+        });
+
+        let command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+
+        assert!(command_config_index(&command, r#"model_provider="minimax""#).is_some());
+        assert!(
+            !command
+                .iter()
+                .any(|arg| arg.starts_with("openai_base_url="))
+        );
+    }
+
+    #[test]
+    fn codex_fast_mode_startup_config_covers_ordinary_exec() {
+        let user_env = HashMap::new();
+        let mut runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
+
+        let standard_command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+        for config in super::CODEX_FAST_MODE_STARTUP_CONFIGS {
+            assert!(command_config_index(&standard_command, config).is_none());
+        }
+
+        runtime.codex_fast_mode = true;
+        let fast_command = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+        for config in super::CODEX_FAST_MODE_STARTUP_CONFIGS {
+            assert!(command_config_index(&fast_command, config).is_some());
+        }
     }
 
     #[test]

--- a/crates/guest-agent/tests/codex_app_server_fast_mode.rs
+++ b/crates/guest-agent/tests/codex_app_server_fast_mode.rs
@@ -1,0 +1,24 @@
+//! Fast mode startup coverage for ChatGPT-authenticated Codex app-server runs.
+
+#[path = "common/codex_app_server_startup.rs"]
+mod codex_app_server_startup;
+mod common;
+
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn codex_app_server_enables_fast_mode_for_eligible_chatgpt_run()
+-> Result<(), Box<dyn std::error::Error>> {
+    codex_app_server_startup::assert_codex_app_server_startup_case(
+        codex_app_server_startup::CodexAppServerStartupCase {
+            run_id: "codex-app-server-fast-mode-test",
+            user_env: HashMap::from([
+                ("CHATGPT_ACCOUNT_ID".to_string(), "account-test".to_string()),
+                ("OPENAI_MODEL".to_string(), "gpt-5.5".to_string()),
+                ("VM0_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
+            ]),
+            expect_fast_mode: true,
+        },
+    )
+    .await
+}

--- a/crates/guest-agent/tests/codex_app_server_fast_mode_without_chatgpt.rs
+++ b/crates/guest-agent/tests/codex_app_server_fast_mode_without_chatgpt.rs
@@ -1,0 +1,24 @@
+//! Fast-tier rejection coverage for non-ChatGPT Codex app-server runs.
+
+#[path = "common/codex_app_server_startup.rs"]
+mod codex_app_server_startup;
+mod common;
+
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn codex_app_server_omits_fast_mode_without_chatgpt_account()
+-> Result<(), Box<dyn std::error::Error>> {
+    codex_app_server_startup::assert_codex_app_server_startup_case(
+        codex_app_server_startup::CodexAppServerStartupCase {
+            run_id: "codex-app-server-fast-mode-without-chatgpt-test",
+            user_env: HashMap::from([
+                ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+                ("OPENAI_MODEL".to_string(), "gpt-5.5".to_string()),
+                ("VM0_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
+            ]),
+            expect_fast_mode: false,
+        },
+    )
+    .await
+}

--- a/crates/guest-agent/tests/codex_app_server_standard_mode.rs
+++ b/crates/guest-agent/tests/codex_app_server_standard_mode.rs
@@ -1,0 +1,23 @@
+//! Standard-tier startup coverage for ChatGPT-authenticated Codex app-server runs.
+
+#[path = "common/codex_app_server_startup.rs"]
+mod codex_app_server_startup;
+mod common;
+
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn codex_app_server_omits_fast_mode_for_standard_chatgpt_run()
+-> Result<(), Box<dyn std::error::Error>> {
+    codex_app_server_startup::assert_codex_app_server_startup_case(
+        codex_app_server_startup::CodexAppServerStartupCase {
+            run_id: "codex-app-server-standard-mode-test",
+            user_env: HashMap::from([
+                ("CHATGPT_ACCOUNT_ID".to_string(), "account-test".to_string()),
+                ("OPENAI_MODEL".to_string(), "gpt-5.5".to_string()),
+            ]),
+            expect_fast_mode: false,
+        },
+    )
+    .await
+}

--- a/crates/guest-agent/tests/codex_prompt_stdin.rs
+++ b/crates/guest-agent/tests/codex_prompt_stdin.rs
@@ -6,6 +6,7 @@ use guest_agent::active_input::ActiveInputRuntime;
 use guest_agent::masker::SecretMasker;
 use guest_agent::run_context::GuestRuntime;
 use shell_quote::quote_shell_arg;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -16,6 +17,16 @@ const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
     "features.plugins=false",
     "features.apps=false",
 ];
+const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
+    ["features.fast_mode=true", r#"service_tier="fast""#];
+const STRUCTURED_CODEX_RUNTIME_CONFIG: &str = r#"{
+    "providerId": "minimax",
+    "name": "MiniMax",
+    "baseUrl": "https://api.minimax.io/v1",
+    "envKey": "OPENAI_API_KEY",
+    "wireApi": "responses",
+    "supportsWebsockets": false
+}"#;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
@@ -96,6 +107,100 @@ async fn fresh_and_resumed_codex_apply_fixed_startup_policy() -> TestResult {
 }
 
 #[tokio::test]
+async fn eligible_chatgpt_codex_exec_applies_fast_startup_policy() -> TestResult {
+    let mock = common::build_and_locate_mock_codex()?;
+    let root = tempfile::tempdir()?;
+    let argv_path = root.path().join("codex-argv");
+    let recording_mock = recording_codex(root.path(), &mock, &argv_path)?;
+    common::ensure_canonical_workspace_for_test()?;
+    let user_env = HashMap::from([
+        ("CHATGPT_ACCOUNT_ID".to_string(), "account-test".to_string()),
+        ("OPENAI_MODEL".to_string(), "gpt-5.5".to_string()),
+        ("VM0_CODEX_SERVICE_TIER".to_string(), "fast".to_string()),
+    ]);
+    let runtime = build_runtime_with_startup_config(
+        root.path(),
+        &recording_mock,
+        "codex-exec-fast-mode",
+        "verify fast mode",
+        false,
+        &user_env,
+        "",
+    )?;
+
+    let result = execute_with_timeout(&runtime).await?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    let args = read_recorded_args(&argv_path)?;
+    for config in CODEX_FAST_MODE_STARTUP_CONFIGS {
+        assert_config_count(&args, config, 1);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn codex_exec_preserves_provider_config_precedence() -> TestResult {
+    let mock = common::build_and_locate_mock_codex()?;
+    let root = tempfile::tempdir()?;
+    let argv_path = root.path().join("codex-argv");
+    let recording_mock = recording_codex(root.path(), &mock, &argv_path)?;
+    common::ensure_canonical_workspace_for_test()?;
+    let legacy_base_url = "https://api.legacy-provider.test/v1";
+    let legacy_user_env =
+        HashMap::from([("OPENAI_BASE_URL".to_string(), legacy_base_url.to_string())]);
+    let legacy_runtime = build_runtime_with_startup_config(
+        root.path(),
+        &recording_mock,
+        "codex-exec-legacy-provider",
+        "verify legacy provider",
+        false,
+        &legacy_user_env,
+        "",
+    )?;
+
+    let legacy_result = execute_with_timeout(&legacy_runtime).await?;
+
+    assert_eq!(legacy_result.exit_code, common::CLEAN_EXIT);
+    let legacy_args = read_recorded_args(&argv_path)?;
+    assert_config_count(
+        &legacy_args,
+        &format!(r#"openai_base_url="{legacy_base_url}""#),
+        1,
+    );
+
+    let structured_user_env = HashMap::from([
+        ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+        ("OPENAI_MODEL".to_string(), "MiniMax-M3".to_string()),
+        (
+            "OPENAI_BASE_URL".to_string(),
+            "https://api.should-not-win.test/v1".to_string(),
+        ),
+    ]);
+    let structured_runtime = build_runtime_with_startup_config(
+        root.path(),
+        &recording_mock,
+        "codex-exec-structured-provider",
+        "verify structured provider",
+        false,
+        &structured_user_env,
+        STRUCTURED_CODEX_RUNTIME_CONFIG,
+    )?;
+
+    let structured_result = execute_with_timeout(&structured_runtime).await?;
+
+    assert_eq!(structured_result.exit_code, common::CLEAN_EXIT);
+    let structured_args = read_recorded_args(&argv_path)?;
+    assert_config_count(&structured_args, r#"model_provider="minimax""#, 1);
+    assert!(
+        !structured_args
+            .iter()
+            .any(|arg| arg.starts_with("openai_base_url=")),
+        "structured provider must suppress legacy base URL: {structured_args:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn codex_exit_before_reading_stdin_preserves_exit_and_stderr() -> TestResult {
     let root = tempfile::tempdir()?;
     common::ensure_canonical_workspace_for_test()?;
@@ -150,6 +255,18 @@ fn build_runtime(
     prompt: &str,
     resume: bool,
 ) -> TestResult<GuestRuntime> {
+    build_runtime_with_startup_config(root, mock_path, run_id, prompt, resume, &HashMap::new(), "")
+}
+
+fn build_runtime_with_startup_config(
+    root: &Path,
+    mock_path: &Path,
+    run_id: &str,
+    prompt: &str,
+    resume: bool,
+    user_env: &HashMap<String, String>,
+    codex_runtime_config: &str,
+) -> TestResult<GuestRuntime> {
     let home = root.join(format!("home-{run_id}"));
     let runtime_dir = home.join("runtime");
     std::fs::create_dir_all(&home)?;
@@ -157,9 +274,14 @@ fn build_runtime(
         &runtime_dir,
         &guest_contracts::env::RunPayload {
             prompt: prompt.to_string(),
+            codex_runtime_config: codex_runtime_config.to_string(),
             ..guest_contracts::env::RunPayload::default()
         },
     )?;
+    let user_env_dir = runtime_dir.join(guest_contracts::env::USER_ENV_PRIVATE_DIR_NAME);
+    std::fs::create_dir_all(&user_env_dir)?;
+    let user_env_file = user_env_dir.join(guest_contracts::env::USER_ENV_FILENAME);
+    std::fs::write(&user_env_file, serde_json::to_vec(user_env)?)?;
     let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
         run_id: run_id.to_string(),
         api_url: "http://127.0.0.1:1".to_string(),
@@ -174,6 +296,7 @@ fn build_runtime(
         use_mock_codex: "true".to_string(),
         mock_codex_path: Some(mock_path.to_string_lossy().into_owned()),
         cli_agent_type: "codex".to_string(),
+        user_env_file: user_env_file.to_string_lossy().into_owned(),
         run_payload_file: run_payload_file.to_string_lossy().into_owned(),
         home: Some(home.to_string_lossy().into_owned()),
         guest_runtime_dir: Some(runtime_dir.clone()),
@@ -245,16 +368,27 @@ fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> TestResult<Pat
 }
 
 fn assert_fixed_startup_policy(argv_path: &Path) -> TestResult {
-    let args = std::fs::read_to_string(argv_path)?
-        .lines()
-        .map(str::to_string)
-        .collect::<Vec<_>>();
+    let args = read_recorded_args(argv_path)?;
     for expected in CODEX_FIXED_STARTUP_CONFIGS {
-        assert!(
-            args.windows(2)
-                .any(|window| matches!(window, [flag, value] if flag == "-c" && value == expected)),
-            "Codex argv should include fixed startup config {expected:?}: {args:?}"
-        );
+        assert_config_count(&args, expected, 1);
     }
     Ok(())
+}
+
+fn read_recorded_args(argv_path: &Path) -> TestResult<Vec<String>> {
+    Ok(std::fs::read_to_string(argv_path)?
+        .lines()
+        .map(str::to_string)
+        .collect())
+}
+
+fn assert_config_count(args: &[String], config: &str, expected_count: usize) {
+    let actual_count = args
+        .windows(2)
+        .filter(|window| matches!(window, [flag, value] if flag == "-c" && value == config))
+        .count();
+    assert_eq!(
+        actual_count, expected_count,
+        "unexpected count for Codex config {config:?}: {args:?}"
+    );
 }

--- a/crates/guest-agent/tests/common/codex_app_server_startup.rs
+++ b/crates/guest-agent/tests/common/codex_app_server_startup.rs
@@ -1,0 +1,123 @@
+use guest_agent::masker::SecretMasker;
+use shell_quote::quote_shell_arg;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::common;
+
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+    "analytics.enabled=false",
+    "features.plugins=false",
+    "features.apps=false",
+];
+const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
+    ["features.fast_mode=true", r#"service_tier="fast""#];
+
+pub struct CodexAppServerStartupCase {
+    pub run_id: &'static str,
+    pub user_env: HashMap<String, String>,
+    pub expect_fast_mode: bool,
+}
+
+pub async fn assert_codex_app_server_startup_case(
+    case: CodexAppServerStartupCase,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let argv_path = tmp.path().join("codex-argv");
+    let recording_mock = recording_codex(tmp.path(), &mock, &argv_path)?;
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &recording_mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: case.run_id,
+                prompt: "verify Codex app-server startup configuration",
+                scenario: Some("runtime-turn-complete-without-thread-started"),
+                resume_session_id: None,
+            },
+        )?;
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), case.run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        common::set_user_env_file_env_for_test(&runtime_dir, &case.user_env)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .map_err(|_| std::io::Error::other("Codex app-server execution timed out"))??;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.failure_diagnostic.is_none());
+    assert_startup_policy(&argv_path, case.expect_fast_mode)?;
+    Ok(())
+}
+
+fn recording_codex(root: &Path, mock: &Path, argv_path: &Path) -> Result<PathBuf, std::io::Error> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let path = root.join("recording-codex");
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexec {} \"$@\"\n",
+            quote_shell_arg(&argv_path.to_string_lossy()),
+            quote_shell_arg(&mock.to_string_lossy()),
+        ),
+    )?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}
+
+fn assert_startup_policy(argv_path: &Path, expect_fast_mode: bool) -> Result<(), std::io::Error> {
+    let args = std::fs::read_to_string(argv_path)?
+        .lines()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let app_server_index = args
+        .iter()
+        .position(|arg| arg == "app-server")
+        .ok_or_else(|| std::io::Error::other("Codex argv omitted app-server subcommand"))?;
+
+    for config in CODEX_FIXED_STARTUP_CONFIGS {
+        assert_config_count_and_order(&args, app_server_index, config, 1);
+    }
+    for config in CODEX_FAST_MODE_STARTUP_CONFIGS {
+        let expected_count = usize::from(expect_fast_mode);
+        assert_config_count_and_order(&args, app_server_index, config, expected_count);
+    }
+    Ok(())
+}
+
+fn assert_config_count_and_order(
+    args: &[String],
+    app_server_index: usize,
+    config: &str,
+    expected_count: usize,
+) {
+    let indexes = args
+        .windows(2)
+        .enumerate()
+        .filter_map(|(index, window)| {
+            matches!(window, [flag, value] if flag == "-c" && value == config).then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        indexes.len(),
+        expected_count,
+        "unexpected count for Codex app-server config {config:?}: {args:?}"
+    );
+    assert!(
+        indexes.iter().all(|index| *index < app_server_index),
+        "Codex app-server config {config:?} must precede the subcommand: {args:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- centralize Codex root startup overrides in `CliRuntimeConfig`
- apply the same provider, web-search, fixed, and Fast mode settings to ordinary exec and app-server
- preserve structured-provider precedence and the legacy `OPENAI_BASE_URL` fallback
- add process-isolated app-server integration coverage for eligible and ineligible Fast mode runs

## Scope

- no API, database, schema, persisted-state, queue-payload, or runner protocol changes
- model, reasoning effort, memories, developer instructions, resume behavior, and OAuth handling remain backend-specific and unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `git diff --check`
- pre-commit workspace Rust formatting, documentation, and Clippy checks

Closes #23200
