### PR TITLE
refactor(guest-agent): narrow session metadata visibility

### DIFF
--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -34,7 +34,7 @@ pub mod reuse_preparation;
 pub mod run_context;
 pub mod session_history;
 pub mod session_history_identity;
-pub mod session_metadata;
+mod session_metadata;
 pub mod telemetry;
 pub mod timing;
 mod urls;

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -144,7 +144,7 @@ pub(crate) fn resolve_history_marker_payload_from(
     Ok(payload)
 }
 
-pub fn resolve_history_marker_payload_for_diagnostics_from(
+pub(crate) fn resolve_history_marker_payload_for_diagnostics_from(
     framework: Framework,
     home_dir: &str,
     session_id_file: &str,


### PR DESCRIPTION
## Summary

- make the internal `session_metadata` module private to the `guest-agent`
  library
- restrict the diagnostic history-marker resolver to crate visibility
- preserve all marker resolution and diagnostic behavior

## Scope

This intentionally narrows an unused Rust API left behind after the diagnostic
caller moved into the library. It does not move implementation, add a
replacement facade, or change runtime logic, persisted data, protocols, or
deployment compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features`
- pre-commit workspace Rust formatting, Clippy, and documentation checks

Closes #23216
