### PR TITLE
fix(runner): revalidate connector admission after auth waits

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -9,6 +9,7 @@ import asyncio
 import hashlib
 import json
 import urllib.parse
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -42,7 +43,10 @@ from firewall_auth_client import (
     FirewallAuthRequest,
     InsufficientCreditsError,
 )
-from firewall_auth_config import auth_config_injects_credentials
+from firewall_auth_config import (
+    auth_config_injects_credentials,
+    auth_config_injects_ordinary_upstream_credentials,
+)
 from logging_utils import log_proxy_entry
 from url_syntax import has_unsafe_runtime_url_syntax
 from url_utils import build_rewrite_url
@@ -61,6 +65,9 @@ class FirewallHeaderPhaseAuthResult(Enum):
 
     APPLIED = "applied"
     FALLBACK = "fallback"
+
+
+type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 
 
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
@@ -1002,9 +1009,19 @@ def _finish_firewall_auth_result(
 
 
 async def handle_firewall_request(
-    flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+    *,
+    revalidate_ordinary_upstream_credentials: OrdinaryUpstreamCredentialsGuard,
 ) -> FirewallAuthHandlingResult:
-    """Handle firewall auth and return who owns the next response lifecycle."""
+    """Handle firewall auth and return who owns the next response lifecycle.
+
+    The required guard runs after resolution and before ordinary upstream
+    credential mutation. A rejecting caller must first create its local
+    response; this function then returns ``LOCAL_RESPONSE`` without applying
+    resolved credentials.
+    """
     try:
         _prepare_firewall_metadata(flow, allow, vm_info)
         context = _build_firewall_auth_context(flow, allow, vm_info)
@@ -1061,6 +1078,18 @@ async def handle_firewall_request(
         else:
             token_meta = _empty_firewall_auth_metadata()
 
+        if (
+            context.auth_request.auth_base is None
+            and auth_config_injects_ordinary_upstream_credentials(
+                context.allow.api_entry.get("auth")
+            )
+            and not revalidate_ordinary_upstream_credentials()
+        ):
+            return _finish_firewall_auth_result(
+                flow,
+                FirewallAuthHandlingResult.LOCAL_RESPONSE,
+            )
+
         auth_result = await _apply_resolved_firewall_auth(
             flow,
             context=context,
@@ -1081,12 +1110,16 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     vm_info: dict,
+    *,
+    revalidate_ordinary_upstream_credentials: OrdinaryUpstreamCredentialsGuard,
 ) -> FirewallHeaderPhaseAuthResult:
     """Apply successful header/query firewall auth before request streaming.
 
     This helper intentionally falls back instead of creating local responses.
     The request hook owns auth failure semantics; requestheaders() only keeps a
-    success that is safe before mitmproxy sends upstream request headers.
+    success that is safe before mitmproxy sends upstream request headers. A
+    rejected ordinary-credential guard restores the probe snapshot and falls
+    back before mutation.
     """
     auth_config = allow.api_entry.get("auth", {})
     if _auth_config_uses_body_dependent_auth(auth_config):
@@ -1147,6 +1180,15 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
     if token_meta.get("base") or token_meta.get("aws_sigv4") is not None:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    if injects_credentials and not revalidate_ordinary_upstream_credentials():
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -383,6 +383,22 @@ def _builtin_host_policy_error_for_firewall_allow(
     return None
 
 
+def _has_current_direct_connector_auth_binding(
+    flow: http.HTTPFlow,
+    *,
+    admitted_server: connection.Server,
+    require_connected: bool,
+) -> bool:
+    if flow.server_conn is not admitted_server:
+        return False
+    if require_connected and not flow.server_conn.connected:
+        return False
+    return upstream_destination_binding.flow_matches_direct_bound_destination(
+        flow,
+        allowed_kinds=frozenset(("connector_auth",)),
+    )
+
+
 def _auth_base_body_header_check(
     flow: http.HTTPFlow,
     *,
@@ -785,8 +801,22 @@ async def _try_firewall_request_stream_capture_from_headers(
 
     _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
     _start_request_timing(flow)
+    admitted_server = flow.server_conn
+    require_connected = flow.server_conn.connected
     try:
-        result = await try_apply_stream_safe_firewall_auth_for_requestheaders(flow, allow, vm_info)
+        result = await try_apply_stream_safe_firewall_auth_for_requestheaders(
+            flow,
+            allow,
+            vm_info,
+            revalidate_ordinary_upstream_credentials=lambda: (
+                _has_current_direct_connector_auth_binding(
+                    flow,
+                    admitted_server=admitted_server,
+                    require_connected=require_connected,
+                )
+                and _builtin_host_policy_error_for_firewall_allow(flow, allow) is None
+            ),
+        )
     except (asyncio.CancelledError, Exception):
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         upstream_admission.forget_server_binding(flow.server_conn)
@@ -831,6 +861,41 @@ def _block_public_destination_denied(
         reason=denial.reason,
         send_response=send_response,
     )
+
+
+def _revalidate_ordinary_upstream_credentials_for_request(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    *,
+    admitted_server: connection.Server,
+    require_connected: bool,
+) -> bool:
+    if not _has_current_direct_connector_auth_binding(
+        flow,
+        admitted_server=admitted_server,
+        require_connected=require_connected,
+    ):
+        _block_upstream_destination_unbound(flow, reason="connector_auth")
+        return False
+
+    public_destination_denial = request_classification.current_public_destination_denial(
+        flow,
+        allow,
+    )
+    if public_destination_denial is not None:
+        _block_public_destination_denied(flow, public_destination_denial)
+        return False
+
+    host_policy_error = _builtin_host_policy_error_for_firewall_allow(flow, allow)
+    if host_policy_error is not None:
+        _block_builtin_host_policy_denied(
+            flow,
+            allow=allow,
+            error=host_policy_error,
+        )
+        return False
+
+    return True
 
 
 def _unhandled_request_classification(classification: NoReturn) -> NoReturn:
@@ -962,7 +1027,21 @@ async def request(flow: http.HTTPFlow) -> None:
                 is_billable_firewall(allow.name, vm_info),
                 _is_model_provider_usage_observable(allow.name, vm_info),
             )
-            auth_result = await handle_firewall_request(flow, allow, vm_info)
+            admitted_server = flow.server_conn
+            require_connected = flow.server_conn.connected
+            auth_result = await handle_firewall_request(
+                flow,
+                allow,
+                vm_info,
+                revalidate_ordinary_upstream_credentials=lambda: (
+                    _revalidate_ordinary_upstream_credentials_for_request(
+                        flow,
+                        allow,
+                        admitted_server=admitted_server,
+                        require_connected=require_connected,
+                    )
+                ),
+            )
             if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
                 # Local firewall/auth errors never reach a provider. They only
                 # need pre-tracking to keep shutdown from racing while auth is

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -310,11 +310,14 @@ def _binding_matches(
 def _server_binding_matches_current_destination(
     server: object,
     binding: UpstreamDestinationBinding,
+    *,
+    extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
 ) -> bool:
     if bool(getattr(server, "connected", False)):
         connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
             server,
             port=binding.port,
+            extra_endpoints=extra_endpoints,
         )
         return (
             binding.original_address is not None
@@ -509,31 +512,15 @@ def flow_matches_direct_bound_destination(
     binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
     if binding is None:
         return False
-    if bool(getattr(server, "connected", False)):
-        connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
-            server,
-            port=binding.port,
-            extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
-        )
-        current_destination_matches = (
-            binding.original_address is not None
-            and connected_endpoint is not None
-            and _endpoint_matches(connected_endpoint, binding.original_address)
-        )
-    else:
-        current_destination_matches = _address_matches(
-            binding.host,
-            binding.port,
-            getattr(server, "address", None),
-        )
-    return (
-        _binding_matches(
-            binding,
-            host=normalized_host,
-            port=flow.request.port,
-            allowed_kinds=allowed_kinds,
-        )
-        and current_destination_matches
+    return _binding_matches(
+        binding,
+        host=normalized_host,
+        port=flow.request.port,
+        allowed_kinds=allowed_kinds,
+    ) and _server_binding_matches_current_destination(
+        server,
+        binding,
+        extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
     )
 
 

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -33,6 +33,7 @@ __all__ = (
     "bound_destination_endpoint_for_flow",
     "diagnostic_snapshot_for_flow",
     "flow_matches_bound_destination",
+    "flow_matches_direct_bound_destination",
     "forget_client_bindings",
     "forget_server_binding",
     "has_server_binding",

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -486,6 +486,57 @@ def flow_matches_bound_destination(
     return _address_matches(normalized_host, port, getattr(server, "address", None))
 
 
+def flow_matches_direct_bound_destination(
+    flow: http.HTTPFlow,
+    *,
+    allowed_kinds: frozenset[BindingKind],
+) -> bool:
+    """Return whether the current server has a matching direct binding.
+
+    Connected transparent flows include the client socket endpoint as the same
+    authoritative evidence accepted when the direct binding was created.
+    """
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
+        return False
+    try:
+        normalized_host = normalize_trusted_hostname(trusted_host)
+    except (UnicodeError, ValueError):
+        return False
+
+    server = flow.server_conn
+    server_id = _connection_id(server)
+    binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
+    if binding is None:
+        return False
+    if bool(getattr(server, "connected", False)):
+        connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
+            server,
+            port=binding.port,
+            extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
+        )
+        current_destination_matches = (
+            binding.original_address is not None
+            and connected_endpoint is not None
+            and _endpoint_matches(connected_endpoint, binding.original_address)
+        )
+    else:
+        current_destination_matches = _address_matches(
+            binding.host,
+            binding.port,
+            getattr(server, "address", None),
+        )
+    return (
+        _binding_matches(
+            binding,
+            host=normalized_host,
+            port=flow.request.port,
+            allowed_kinds=allowed_kinds,
+        )
+        and current_destination_matches
+    )
+
+
 def bound_destination_endpoint_for_flow(
     flow: http.HTTPFlow,
     *,

--- a/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
@@ -1,6 +1,41 @@
 """Shared helpers for firewall auth handler tests."""
 
+from mitmproxy import http
+
+import auth
 import matching
+
+
+def _allow_ordinary_upstream_credentials() -> bool:
+    return True
+
+
+async def handle_firewall_request_without_upstream_admission(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> auth.FirewallAuthHandlingResult:
+    """Exercise firewall auth independently of production upstream admission."""
+    return await auth.handle_firewall_request(
+        flow,
+        allow,
+        vm_info,
+        revalidate_ordinary_upstream_credentials=_allow_ordinary_upstream_credentials,
+    )
+
+
+async def apply_requestheaders_auth_without_upstream_admission(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> auth.FirewallHeaderPhaseAuthResult:
+    """Exercise early firewall auth independently of production admission."""
+    return await auth.try_apply_stream_safe_firewall_auth_for_requestheaders(
+        flow,
+        allow,
+        vm_info,
+        revalidate_ordinary_upstream_credentials=_allow_ordinary_upstream_credentials,
+    )
 
 
 def make_allow(

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -29,6 +29,7 @@ from tests.aws_sigv4_helpers import (
     aws_sigv4_presigned_query_path,
     resolved_aws_sigv4_credentials,
 )
+from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from url_utils import get_original_url
 
 DEFAULT_SANDBOX_TOKEN = "sandbox-token"
@@ -287,7 +288,7 @@ async def handle_firewall_request_with_auth_endpoint(
     prepare_firewall_request(flow, run_id=resolved_vm_info["runId"])
 
     with resolved_endpoint.run(), mitm_ctx(api_url=resolved_endpoint.api_url):
-        return await auth.handle_firewall_request(
+        return await handle_firewall_request_without_upstream_admission(
             flow,
             aws_allow() if allow is None else allow,
             dict(resolved_vm_info),

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -5,7 +5,10 @@ from urllib.parse import parse_qs, urlparse
 
 import auth
 import flow_metadata_keys as metadata_keys
-from tests.firewall_auth_helpers import make_allow
+from tests.firewall_auth_helpers import (
+    handle_firewall_request_without_upstream_admission,
+    make_allow,
+)
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 
 
@@ -90,7 +93,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
@@ -112,7 +115,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         # auth.query overwrites the agent's api_key
         assert flow.request.query["api_key"] == "real-secret-key"
         assert list(flow.request.query.get_all("api_key")) == ["real-secret-key"]
@@ -143,7 +146,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["key"] == "resolved-query-value"
 
@@ -175,7 +178,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         # Verify the forwarded URL contains the auth.query params
         call_args = mock_forward.call_args
@@ -229,7 +232,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         forwarded = urlparse(mock_forward.call_args[0][0])
         query = parse_qs(forwarded.query, keep_blank_values=True)
@@ -266,7 +269,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         forwarded = urlparse(mock_forward.call_args[0][0])
         assert forwarded.path == "/webhook/secret;v=1/callback"
@@ -304,7 +307,7 @@ class TestAuthQueryInjection:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert flow.request.headers["Authorization"] == "Bearer real"
         # No query params should have been added
         assert len(flow.request.query) == 0

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -39,11 +39,19 @@ from tests.aws_sigv4_helpers import (
     aws_sigv4_authorization,
     resolved_aws_sigv4_credentials,
 )
+from tests.firewall_auth_helpers import (
+    apply_requestheaders_auth_without_upstream_admission,
+    handle_firewall_request_without_upstream_admission,
+)
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from url_utils import get_original_url
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
+
+
+def _fail_if_ordinary_upstream_credentials_are_revalidated() -> bool:
+    raise AssertionError("ordinary upstream credential guard must not run")
 
 
 def _upstream_headers(*pairs: tuple[str, str]) -> Message:
@@ -806,7 +814,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
 
@@ -863,7 +871,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         mock_get_firewall_headers.assert_not_called()
@@ -903,7 +911,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
             mitm_ctx(),
         ):
-            result = await auth.try_apply_stream_safe_firewall_auth_for_requestheaders(
+            result = await apply_requestheaders_auth_without_upstream_admission(
                 flow,
                 allow,
                 vm_info,
@@ -916,6 +924,31 @@ class TestHandleFirewallRequest:
         assert flow.metadata[metadata_keys.FIREWALL_NAME] == "cloudflare"
         assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
         assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+
+    async def test_billable_only_auth_does_not_require_upstream_admission(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow = _firewall_flow(real_flow)
+        api_entry = _api_entry(auth_config={})
+        vm_info = _vm_info(tmp_path, billable_firewalls=["github"])
+        allow = _allow(api_entry)
+        token_meta = _token_meta(headers={})
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(
+                flow,
+                allow,
+                vm_info,
+                revalidate_ordinary_upstream_credentials=(
+                    _fail_if_ordinary_upstream_credentials_are_revalidated
+                ),
+            )
+
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        assert flow.response is None
 
     async def test_auth_cache_identity_tracks_request_auth_inputs(
         self, real_flow, mitm_ctx, tmp_path
@@ -938,8 +971,12 @@ class TestHandleFirewallRequest:
         )
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch), mitm_ctx():
-            first_result = await auth.handle_firewall_request(first_flow, allow, first_vm_info)
-            second_result = await auth.handle_firewall_request(second_flow, allow, second_vm_info)
+            first_result = await handle_firewall_request_without_upstream_admission(
+                first_flow, allow, first_vm_info
+            )
+            second_result = await handle_firewall_request_without_upstream_admission(
+                second_flow, allow, second_vm_info
+            )
 
         assert first_result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert second_result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -1041,12 +1078,12 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(
+            await handle_firewall_request_without_upstream_admission(
                 first_flow,
                 _allow(first_api_entry, name=first_name),
                 first_vm_info,
             )
-            await auth.handle_firewall_request(
+            await handle_firewall_request_without_upstream_admission(
                 second_flow,
                 _allow(second_api_entry, name=second_name),
                 second_vm_info,
@@ -1114,7 +1151,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         header_names = {name.lower() for name, _value in flow.request.headers.items(multi=True)}
@@ -1180,7 +1217,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert flow.request.headers["host"] == STS_HOST
@@ -1229,7 +1266,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1259,7 +1296,7 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
 
@@ -1278,7 +1315,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1327,7 +1364,7 @@ class TestHandleFirewallRequest:
             patch("firewall_auth_client._opener.open", side_effect=network_error),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -1365,7 +1402,7 @@ class TestHandleFirewallRequest:
             patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -1409,7 +1446,7 @@ class TestHandleFirewallRequest:
             patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1448,7 +1485,7 @@ class TestHandleFirewallRequest:
             patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -1487,7 +1524,7 @@ class TestHandleFirewallRequest:
             patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -1527,7 +1564,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1567,7 +1604,7 @@ class TestHandleFirewallRequest:
             ),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1607,7 +1644,7 @@ class TestHandleFirewallRequest:
             ),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1650,7 +1687,7 @@ class TestHandleFirewallRequest:
             ),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is None
 
@@ -1676,7 +1713,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1706,7 +1743,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1742,7 +1779,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 424
@@ -1775,7 +1812,7 @@ class TestHandleFirewallRequest:
             mitm_ctx(),
             patch.object(platform_api, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 424
@@ -1796,7 +1833,7 @@ class TestHandleFirewallRequest:
         auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
 
         with mitm_ctx():
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
@@ -1836,7 +1873,9 @@ class TestHandleFirewallRequest:
                 AsyncMock(side_effect=wait_for_auth_resolution),
             ),
         ):
-            task = asyncio.create_task(auth.handle_firewall_request(flow, allow, vm_info))
+            task = asyncio.create_task(
+                handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+            )
             try:
                 await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
                 task.cancel()

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -21,6 +21,7 @@ from tests.aws_sigv4_helpers import (
     quote_sigv4_value,
     resolved_aws_sigv4_credentials,
 )
+from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from tests.firewall_aws_sigv4_helpers import (
     FAR_FUTURE_EXPIRES_AT,
     assert_sigv4_failed_closed,
@@ -521,7 +522,9 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+        result = await handle_firewall_request_without_upstream_admission(
+            flow, allow, dict(vm_info)
+        )
 
     assert_sigv4_failed_closed(result, flow, "Invalid AWS secret access key")
 
@@ -546,7 +549,7 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(
+        result = await handle_firewall_request_without_upstream_admission(
             flow,
             allow,
             dict(vm_info),
@@ -624,7 +627,9 @@ async def test_header_sigv4_seeded_cache_matches_allow_context_identity(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+        result = await handle_firewall_request_without_upstream_admission(
+            flow, allow, dict(vm_info)
+        )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
@@ -690,7 +695,9 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+        result = await handle_firewall_request_without_upstream_admission(
+            flow, allow, dict(vm_info)
+        )
 
     assert_sigv4_failed_closed(result, flow, "AWS request URL is unavailable")
 
@@ -722,7 +729,9 @@ async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+        result = await handle_firewall_request_without_upstream_admission(
+            flow, allow, dict(vm_info)
+        )
 
     assert_sigv4_failed_closed(result, flow, "AWS request URL is malformed")
 
@@ -745,7 +754,9 @@ async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+        result = await handle_firewall_request_without_upstream_admission(
+            flow, allow, dict(vm_info)
+        )
 
     assert_sigv4_failed_closed(result, flow, "Invalid AWS session token")
 

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -12,6 +12,7 @@ import auth
 import auth_base_forwarder as forwarder
 import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
@@ -82,7 +83,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
@@ -180,7 +181,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.response is not None
@@ -222,7 +223,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         assert upstream.socket.request_header_values("Authorization") == ["Bearer real-token"]
         assert upstream.socket.request_header_values("X-Api-Key") == ["real-api-key"]
@@ -269,7 +270,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert upstream.socket.request_header_values("Connection") == []
         assert upstream.socket.request_header_values("Authorization") == []
@@ -328,7 +329,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert upstream.socket.request_header_values("Connection") == []
         assert upstream.socket.request_header_values("X-Remove") == []
@@ -405,7 +406,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert upstream.socket.request_header_values("Connection") == []
         assert upstream.socket.request_header_values("Content-Length") == []
@@ -447,7 +448,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         mock_forward.assert_not_called()
@@ -496,7 +497,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert f"cOnTeNt-TyPe: {content_type}" in upstream.socket.request_lines()
         assert upstream.socket.request_header_values("X-Drop") == []
@@ -527,7 +528,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         get_headers.assert_not_called()
@@ -556,7 +557,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         method, _request_target, _version = _request_line_parts(upstream)
         assert method == "DELETE"
@@ -578,7 +579,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         method, _request_target, _version = _request_line_parts(upstream)
         assert method == "POST"
@@ -600,7 +601,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         method, _request_target, _version = _request_line_parts(upstream)
         assert method == "GET"
@@ -621,7 +622,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", get_headers),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert get_headers.await_count == 1
         assert upstream.socket.request_header_values("Content-Length") == ["4"]
@@ -654,7 +655,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         get_headers.assert_not_called()
@@ -711,7 +712,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert mock_forward.call_count == 1
@@ -754,7 +755,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "get_firewall_headers", get_headers),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert get_headers.await_count == 1
@@ -808,7 +809,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         failed_url = mock_forward.call_args[0][0]
         failed_query = parse_qs(urlparse(failed_url).query, keep_blank_values=True)
@@ -869,7 +870,7 @@ class TestAuthBaseUrlRewriteForwarding:
             patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -11,6 +11,7 @@ import auth
 import auth_base_forwarder as forwarder
 import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from tests.firewall_rewrite_helpers import make_safety_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
@@ -37,7 +38,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert flow.response is not None
         assert b"super-secret-token" not in flow.response.content
@@ -79,7 +80,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 1
         assert flow.response is not None
@@ -128,7 +129,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
@@ -193,7 +194,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 0
         assert flow.response is not None
@@ -225,7 +226,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 0
         assert flow.response is not None
@@ -253,7 +254,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 0
         assert flow.response is not None
@@ -289,7 +290,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 0
         assert flow.response is not None
@@ -337,7 +338,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "log_proxy_entry", mock_log),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert mock_forward.call_count == 0
         assert flow.response is not None
@@ -367,7 +368,7 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         updated_url = urlparse(flow.request.url)
         assert updated_url.scheme == original_url.scheme
         assert updated_url.netloc == original_url.netloc

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
@@ -6,8 +6,13 @@ from unittest.mock import AsyncMock, patch
 import auth
 import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from tests.firewall_rewrite_helpers import make_allow, make_success_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
+
+
+def _fail_if_ordinary_upstream_credentials_are_revalidated() -> bool:
+    raise AssertionError("ordinary upstream credential guard must not run")
 
 
 class TestAuthBaseUrlRewriteSuccess:
@@ -46,7 +51,7 @@ class TestAuthBaseUrlRewriteSuccess:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         # URL should not be modified
         assert flow.request.url == original_url
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -72,7 +77,14 @@ class TestAuthBaseUrlRewriteSuccess:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(
+                flow,
+                allow,
+                vm_info,
+                revalidate_ordinary_upstream_credentials=(
+                    _fail_if_ordinary_upstream_credentials_are_revalidated
+                ),
+            )
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
@@ -98,7 +110,7 @@ class TestAuthBaseUrlRewriteSuccess:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.response is not None
@@ -135,7 +147,7 @@ class TestAuthBaseUrlRewriteSuccess:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
         assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -247,13 +247,14 @@ async def test_public_destination_allows_public_runtime_destination(
     ],
 )
 @pytest.mark.parametrize(
-    "disconnect_hook_state",
+    "upstream_change",
     [
         pytest.param("completed", id="disconnect-hook-completed"),
         pytest.param("pending", id="disconnect-hook-pending"),
+        pytest.param("peer-changed", id="connected-peer-changed"),
     ],
 )
-async def test_public_destination_disconnect_during_auth_prevents_credential_application(
+async def test_public_destination_upstream_change_during_auth_prevents_credential_application(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -261,7 +262,7 @@ async def test_public_destination_disconnect_during_auth_prevents_credential_app
     monkeypatch,
     auth_config,
     token_meta,
-    disconnect_hook_state,
+    upstream_change,
 ):
     reg_path = _write_public_destination_firewall_registry(
         tmp_path,
@@ -295,9 +296,12 @@ async def test_public_destination_disconnect_during_auth_prevents_credential_app
         request_task = asyncio.create_task(mitm_addon.request(flow))
         try:
             await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
-            flow.server_conn.state = connection.ConnectionState.CLOSED
-            if disconnect_hook_state == "completed":
-                mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            if upstream_change == "peer-changed":
+                flow.server_conn.peername = ("10.0.0.1", 443)
+            else:
+                flow.server_conn.state = connection.ConnectionState.CLOSED
+                if upstream_change == "completed":
+                    mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
             release_auth_resolution.set()
             await request_task
         finally:

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -1,10 +1,15 @@
 """Public destination request-hook tests."""
 
+import asyncio
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+from mitmproxy import connection
 from mitmproxy.flow import Error
 
+import auth
 import auth_base_forwarder
 import builtin_host_policy
 import flow_metadata_keys as metadata_keys
@@ -13,6 +18,8 @@ import public_destination
 import request_classification
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.aws_sigv4_helpers import resolved_aws_sigv4_credentials
+from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import _assert_no_request_stream
@@ -185,13 +192,125 @@ async def test_public_destination_allows_public_runtime_destination(
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert classified_hosts == [destination_host]
+    assert classified_hosts == [destination_host, destination_host]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://service.example.com"
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "call"
     assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+@pytest.mark.parametrize(
+    ("auth_config", "token_meta"),
+    [
+        pytest.param(
+            {"headers": {"Authorization": "Bearer ${{ secrets.EXAMPLE_TOKEN }}"}},
+            {
+                "headers": {"Authorization": "Bearer resolved"},
+                "resolved_secrets": ["EXAMPLE_TOKEN"],
+                "refreshed_connectors": [],
+                "refreshed_secrets": [],
+                "cache_hit": False,
+            },
+            id="header",
+        ),
+        pytest.param(
+            {"query": {"api_key": "${{ secrets.EXAMPLE_TOKEN }}"}},
+            {
+                "headers": {},
+                "query": {"api_key": "resolved"},
+                "resolved_secrets": ["EXAMPLE_TOKEN"],
+                "refreshed_connectors": [],
+                "refreshed_secrets": [],
+                "cache_hit": False,
+            },
+            id="query",
+        ),
+        pytest.param(
+            {
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                }
+            },
+            {
+                "headers": {},
+                "aws_sigv4": resolved_aws_sigv4_credentials(session_token=None),
+                "resolved_secrets": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+                "refreshed_connectors": [],
+                "refreshed_secrets": [],
+                "cache_hit": False,
+            },
+            id="aws-sigv4",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "disconnect_hook_state",
+    [
+        pytest.param("completed", id="disconnect-hook-completed"),
+        pytest.param("pending", id="disconnect-hook-pending"),
+    ],
+)
+async def test_public_destination_disconnect_during_auth_prevents_credential_application(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    monkeypatch,
+    auth_config,
+    token_meta,
+    disconnect_hook_state,
+):
+    reg_path = _write_public_destination_firewall_registry(
+        tmp_path,
+        auth_config=auth_config,
+    )
+    flow = _public_destination_flow(
+        real_flow,
+        headers,
+        destination_host="93.184.216.34",
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("93.184.216.34", 443),
+        peername=("93.184.216.34", 443),
+    )
+    original_headers = flow.request.headers.fields
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return token_meta
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            flow.server_conn.state = connection.ConnectionState.CLOSED
+            if disconnect_hook_state == "completed":
+                mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            release_auth_resolution.set()
+            await request_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
+    assert flow.request.headers.fields == original_headers
+    assert flow.request.path == original_path
+    assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 async def test_public_destination_policy_allow_classifies_public_runtime_destination_once(
@@ -556,7 +675,7 @@ async def test_public_destination_allows_connected_prebound_public_original_dest
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
-async def test_public_destination_classifies_connected_host_values_once(
+async def test_public_destination_classifies_connected_hosts_once_per_admission_check(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -585,7 +704,12 @@ async def test_public_destination_classifies_connected_host_values_once(
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    assert classified_hosts == ["service.example.com", "93.184.216.35"]
+    assert classified_hosts == [
+        "service.example.com",
+        "93.184.216.35",
+        "93.184.216.35",
+        "service.example.com",
+    ]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.request.headers["Authorization"] == "Bearer x"

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -1,14 +1,20 @@
 """Connector requestheaders upstream-admission tests."""
 
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 from mitmproxy import connection
 
+import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 import upstream_admission
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import (
     _single_firewall_vm,
     _write_github_firewall_registry,
@@ -264,6 +270,101 @@ async def test_firewall_allow_header_auth_uses_connected_upstream_when_tls_verif
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("172.66.0.243", 443)
+
+
+async def test_firewall_allow_disconnect_during_header_auth_restores_probe_state(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    monkeypatch,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="example",
+            api_entry={
+                "base": "https://service.example.com",
+                "auth": {
+                    "headers": {"Authorization": "Bearer ${{ secrets.EXAMPLE_TOKEN }}"},
+                    "query": {"api_key": "${{ secrets.EXAMPLE_TOKEN }}"},
+                },
+                "permissions": [{"name": "write", "rules": ["POST /items"]}],
+            },
+            network_policy={
+                "allow": ["write"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="93.184.216.34",
+        sni="service.example.com",
+        method="POST",
+        path="/items?client=visible",
+        request_headers=headers(
+            ("Host", "service.example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("93.184.216.34", 443),
+        peername=("93.184.216.34", 443),
+    )
+    flow.metadata["preexisting"] = "keep"
+    original_headers = flow.request.headers.fields
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return {
+            "headers": {"Authorization": "Bearer resolved"},
+            "query": {"api_key": "resolved"},
+            "resolved_secrets": ["EXAMPLE_TOKEN"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        requestheaders_task = asyncio.create_task(
+            await_requestheaders_result(mitm_addon.requestheaders(flow))
+        )
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            flow.server_conn.state = connection.ConnectionState.CLOSED
+            mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            release_auth_resolution.set()
+            await requestheaders_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(requestheaders_task)
+
+    auth_fetch.assert_awaited_once()
+    _assert_no_request_stream(flow)
+    assert flow.response is None
+    assert flow.error is None
+    assert flow.request.headers.fields == original_headers
+    assert flow.request.path == original_path
+    assert flow.metadata["preexisting"] == "keep"
+    for key in request_classification.REQUEST_HEADERS_PROBE_METADATA_KEYS:
+        assert key not in flow.metadata
+    assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 async def test_firewall_allow_header_auth_blocks_without_verified_connected_tls(


### PR DESCRIPTION
## Summary

- require both firewall auth entry points to revalidate ordinary upstream
  credential admission after auth resolution and before request mutation
- verify the same direct server binding, connection state, connected endpoint,
  runtime `publicDestination` policy, and built-in host policy without renewing
  admission
- restore request-header probe state and fall back when admission becomes stale
- add deterministic disconnect- and peer-change-during-auth coverage for header,
  query, and AWS SigV4 credentials

## Compatibility

- preserves `auth.base` forwarding and billable-only auth resolution
- adds no DNS, API, KMS, schema, protocol, registry, or persisted-state changes
- remains local to the runner mitm addon

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4,287 passed

Closes #23204
