### PR TITLE
fix(platform): hydrate feature switches during bootstrap

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-feature-switches.helpers.ts
@@ -24,6 +24,7 @@ export function setMockFeatureSwitches(
       return respond(200, {
         switches: sanitized,
         effectiveSwitches: sanitized,
+        supportsStructuredFeedbackParts: true,
       });
     }),
   );

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts
@@ -1,0 +1,55 @@
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import { setupPage } from "../../__tests__/page-helper.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+describe("bootstrap feature switch hydration", () => {
+  it("hydrates persisted feature switches for authenticated users", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: { [FeatureSwitchKey.AhrefsConnector]: true },
+        effectiveSwitches: { [FeatureSwitchKey.AhrefsConnector]: true },
+        supportsStructuredFeedbackParts: true,
+      });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+    });
+
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeTruthy();
+  });
+
+  it("skips feature switch hydration without an authenticated organization", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(500, {
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Feature switches must not load while signed out",
+        },
+      });
+    });
+
+    await setupPage({
+      context,
+      path: "/sign-in",
+      user: null,
+      session: null,
+      org: { activeOrg: null, memberships: [] },
+      withoutRender: true,
+    });
+
+    expect(
+      context.store.get(featureSwitch$)[FeatureSwitchKey.AhrefsConnector],
+    ).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -83,6 +83,7 @@ import { updatePage$ } from "./react-router.ts";
 import { NotFoundPage } from "../views/not-found-page.tsx";
 
 import { setupGlobalKeyboardShortcuts$ } from "./zero-page/zero-nav.ts";
+import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
 import { reloadBillingStatus$ } from "./zero-page/billing.ts";
 import { checkUnifiedSettingsParam$ } from "./zero-page/settings/settings-dialog.ts";
 
@@ -518,6 +519,7 @@ export const bootstrap$ = command(
       set(setupGlobalKeyboardShortcuts$, signal),
       set(setupClerk$, signal),
       set(watchOrgSwitch$, signal),
+      set(reloadFeatureSwitch$, signal),
     ]);
 
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -2,7 +2,7 @@ import { command, computed } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { authenticatedIdentity$, clerk$ } from "../auth";
+import { clerk$ } from "../auth";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
 import { createAuthedContractClient } from "../api-client-base.ts";
@@ -68,10 +68,13 @@ export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   );
 });
 
-const reloadFeatureSwitch$ = command(
+export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const identity = await get(authenticatedIdentity$);
+    const clerk = await get(clerk$);
     signal.throwIfAborted();
+    if (!clerk.user || !clerk.organization) {
+      return;
+    }
 
     const client = get(apiFeatureSwitchClient$);
     const result = await accept(
@@ -81,9 +84,9 @@ const reloadFeatureSwitch$ = command(
     signal.throwIfAborted();
 
     const combined = getAllFeatureStates({
-      userId: identity.userId,
-      email: identity.email,
-      orgId: identity.orgId,
+      userId: clerk.user.id,
+      email: clerk.user.primaryEmailAddress?.emailAddress,
+      orgId: clerk.organization.id,
     });
     applySwitches(
       combined,


### PR DESCRIPTION
## Summary

- restore feature switch hydration as part of Web bootstrap so invalidated or empty local caches reload persisted user and organization overrides
- keep signed-out and organization-selection bootstraps safe by skipping the API request until Clerk has both a user and an active organization
- add bootstrap-level regression coverage for authenticated hydration and signed-out startup

This restores the startup refresh removed in #22622. The missing refresh became user-visible when #22893 invalidated the previous feature-switch cache key.

## User impact

Web no longer falls back indefinitely to registry defaults after the feature-switch cache key changes or local storage is cleared. Persisted Lab overrides are restored during startup.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/bootstrap.ts apps/platform/src/signals/external/feature-switch.ts apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts`
- `pnpm -F @vm0/app lint` (passed; existing unrelated warnings remain)
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/bootstrap-feature-switch.test.ts --silent=passed-only` (2 tests)
