### PR TITLE
fix(runner): stop on unexpected kmsg monitor exit

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1184,7 +1184,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         mut mitm_crash_rx,
     } = proxy;
     let ShutdownHandles {
-        kmsg_handle,
+        mut kmsg_handle,
         dns_handle,
         mut memory_prefetch,
     } = shutdown;
@@ -1395,6 +1395,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         test_observer: test_hooks.test_observer.clone(),
     };
     let mut draining_idle_pool_drained = false;
+    let mut terminal_error = None;
     loop {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
@@ -1562,6 +1563,29 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     &provider_state.cancel_tokens,
                     &lifecycle,
                 ).await;
+            }
+            result = kmsg_handle.wait() => {
+                let mode = lifecycle.current_mode();
+                if !matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
+                    let message = match &result {
+                        Ok(exit) => format!("kmsg monitor exited unexpectedly: {exit:?}"),
+                        Err(error) => format!("kmsg monitor task failed: {error}"),
+                    };
+                    error!(
+                        component = "kmsg",
+                        ?mode,
+                        result = ?result,
+                        "required runner component exited"
+                    );
+                    terminal_error = Some(RunnerError::Internal(message));
+                    handle_stopping_signal(
+                        "kmsg-monitor",
+                        &provider_state.cancel,
+                        &provider_state.cancel_tokens,
+                        &lifecycle,
+                    ).await;
+                }
+                kmsg_handle.kill_and_reap_child().await;
             }
             // Reap completed jobs promptly in all live modes. Without this,
             // normal Running mode can retain completed JoinSet entries and
@@ -1871,7 +1895,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.phase_complete("status_stopped", phase);
     info!(total_teardown_ms = teardown.elapsed_ms(), "runner stopped");
 
-    Ok(())
+    if let Some(error) = terminal_error {
+        Err(error)
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -5,7 +5,9 @@ use super::super::support::{
     push_job, shutdown, test_profiles, wait_cancel_token, wait_cancel_token_removed,
     wait_discover_entered, wait_status_mode,
 };
+use std::process::Stdio;
 use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
 
 // -----------------------------------------------------------------------
 // Test 3: Shutdown completes without deadlock (regression #8898)
@@ -89,6 +91,74 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
     )
     .await;
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
+}
+
+#[tokio::test]
+async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    drop(stdin);
+
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
+            .await,
+        "kmsg EOF should drive runner teardown",
+    );
+    assert!(
+        !run_handle.is_finished(),
+        "blocked final heartbeat should hold teardown open",
+    );
+    assert_kmsg_child_reaped(pid, starttime).await;
+    assert!(env.cancel.is_cancelled(), "kmsg EOF should stop discovery");
+
+    env.handle.unblock_heartbeats();
+    assert_run_error_contains(run_handle, "Eof").await;
+}
+
+#[tokio::test]
+async fn kmsg_stdout_read_error_stops_runner_and_kills_child() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (mut stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    stdin.write_all(&[0xff, b'\n']).await.unwrap();
+    stdin.flush().await.unwrap();
+
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(2))
+            .await,
+        "kmsg read error should drive runner teardown",
+    );
+    assert_kmsg_child_reaped(pid, starttime).await;
+
+    env.handle.unblock_heartbeats();
+    assert_run_error_contains(run_handle, "ReadError").await;
+}
+
+#[tokio::test]
+async fn normal_shutdown_cancels_kmsg_and_reaps_child_without_error() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (_stdin, pid, starttime) = install_controllable_kmsg(&mut config).await;
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    env.trigger_stopping().await;
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "normal hard shutdown should stop the kmsg monitor",
+    )
+    .await;
+    assert_kmsg_child_reaped(pid, starttime).await;
 }
 
 /// SIGTERM while a job is in flight: per-job cancellation fires, the
@@ -272,4 +342,55 @@ async fn drain_then_hard_shutdown_upgrades() {
         "Draining → hard shutdown should exit within 3s",
     )
     .await;
+}
+
+async fn install_controllable_kmsg(
+    config: &mut RunConfig,
+) -> (tokio::process::ChildStdin, u32, u64) {
+    let mut child = tokio::process::Command::new("cat")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn controllable kmsg child");
+    let stdin = child.stdin.take().expect("capture test child stdin");
+    let pid = child.id().expect("test child pid");
+    let starttime = crate::process::read_process_stat(pid)
+        .await
+        .expect("test child should be visible in procfs")
+        .starttime;
+    config.shutdown.kmsg_handle =
+        crate::kmsg_log::KmsgHandle::from_test_child(child, NetworkLogManager::new())
+            .expect("create test kmsg handle");
+    (stdin, pid, starttime)
+}
+
+async fn assert_kmsg_child_reaped(pid: u32, starttime: u64) {
+    let observed_starttime = crate::process::read_process_stat(pid)
+        .await
+        .map(|stat| stat.starttime);
+    assert_ne!(
+        observed_starttime,
+        Some(starttime),
+        "kmsg child pid {pid} with start time {starttime} was not reaped",
+    );
+}
+
+async fn assert_run_error_contains(
+    mut run_handle: tokio::task::JoinHandle<RunnerResult<()>>,
+    expected: &str,
+) {
+    let result = match tokio::time::timeout(Duration::from_secs(5), &mut run_handle).await {
+        Ok(result) => result.expect("run task should not panic"),
+        Err(_) => {
+            run_handle.abort();
+            let _ = run_handle.await;
+            panic!("runner did not finish after kmsg failure");
+        }
+    };
+    let error = result.expect_err("kmsg failure should return a runner error");
+    assert!(
+        error.to_string().contains(expected),
+        "expected error containing {expected:?}, got {error}",
+    );
 }

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -16,7 +16,8 @@ use tracing::{info, warn};
 
 use crate::child_cleanup::kill_and_reap_child_on_drop;
 use crate::network_log_drain::{
-    NetworkLogDrainProducer, NetworkLogDrainRequest, run_drainable_line_reader,
+    DrainableLineReaderExit, NetworkLogDrainProducer, NetworkLogDrainRequest,
+    run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
 
@@ -27,15 +28,28 @@ const LOG_PREFIX: &str = "VM0:";
 /// shutdown to cancel the async task and kill the `dmesg -w` child process.
 pub struct KmsgHandle {
     cancel: CancellationToken,
-    task: tokio::task::JoinHandle<()>,
+    task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
     child: Option<tokio::process::Child>,
     drain: NetworkLogDrainProducer,
 }
 
 impl KmsgHandle {
-    /// Stop the kmsg monitor and wait for cleanup.
-    pub async fn stop(mut self) {
-        self.cancel.cancel();
+    /// Await the monitor task, or pend forever after its completion has already
+    /// been consumed.
+    ///
+    /// Keeping the task in the handle lets the runner reactor select on it
+    /// without taking ownership unless it actually completes.
+    pub(crate) async fn wait(&mut self) -> Result<DrainableLineReaderExit, tokio::task::JoinError> {
+        let result = match self.task.as_mut() {
+            Some(task) => task.await,
+            None => std::future::pending().await,
+        };
+        self.task = None;
+        result
+    }
+
+    /// Kill the dmesg child when necessary and wait for it to be reaped.
+    pub(crate) async fn kill_and_reap_child(&mut self) {
         let child_reaped = if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
             child.wait().await.is_ok()
@@ -45,7 +59,15 @@ impl KmsgHandle {
         if child_reaped {
             self.child = None;
         }
-        let _ = (&mut self.task).await;
+    }
+
+    /// Stop the kmsg monitor and wait for cleanup.
+    pub async fn stop(mut self) {
+        self.cancel.cancel();
+        self.kill_and_reap_child().await;
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
         info!("kmsg monitor stopped");
     }
 
@@ -57,19 +79,21 @@ impl KmsgHandle {
         let (drain, mut drain_rx) = NetworkLogDrainProducer::channel("kmsg");
         Self {
             cancel,
-            task: tokio::spawn(async move {
+            task: Some(tokio::spawn(async move {
                 loop {
                     tokio::select! {
-                        _ = token.cancelled() => break,
+                        _ = token.cancelled() => {
+                            return DrainableLineReaderExit::Cancelled;
+                        }
                         request = drain_rx.recv() => {
                             let Some(request) = request else {
-                                break;
+                                return DrainableLineReaderExit::DrainChannelClosed;
                             };
                             request.ack();
                         }
                     }
                 }
-            }),
+            })),
             child: None,
             drain,
         }
@@ -93,7 +117,9 @@ impl Drop for KmsgHandle {
     fn drop(&mut self) {
         kill_and_reap_child_on_drop("dmesg", &mut self.child);
         self.cancel.cancel();
-        self.task.abort();
+        if let Some(task) = &self.task {
+            task.abort();
+        }
     }
 }
 
@@ -101,53 +127,68 @@ impl Drop for KmsgHandle {
 /// network log entries. Returns a handle; call [`KmsgHandle::stop`] during
 /// shutdown so the tokio runtime can exit cleanly.
 pub fn spawn(network_log_manager: NetworkLogManager) -> std::io::Result<KmsgHandle> {
-    let mut child = tokio::process::Command::new("dmesg")
+    let child = tokio::process::Command::new("dmesg")
         .args(["-w"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| std::io::Error::other("failed to capture dmesg stdout"))?;
+    KmsgHandle::from_child(child, network_log_manager)
+}
 
-    let cancel = CancellationToken::new();
-    let token = cancel.clone();
-    let (drain, drain_rx) = NetworkLogDrainProducer::channel("kmsg");
+impl KmsgHandle {
+    fn from_child(
+        mut child: tokio::process::Child,
+        network_log_manager: NetworkLogManager,
+    ) -> std::io::Result<Self> {
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| std::io::Error::other("failed to capture dmesg stdout"))?;
 
-    // Log stderr in a background task so dmesg errors are visible.
-    // Shares the cancel token so the task exits promptly on shutdown.
-    if let Some(stderr) = child.stderr.take() {
-        let stderr_cancel = cancel.clone();
-        tokio::spawn(async move {
-            let mut lines = tokio::io::BufReader::new(stderr).lines();
-            loop {
-                tokio::select! {
-                    _ = stderr_cancel.cancelled() => break,
-                    result = lines.next_line() => {
-                        match result {
-                            Ok(Some(line)) if !line.is_empty() => {
-                                warn!(target: "dmesg", "stderr: {line}");
+        let cancel = CancellationToken::new();
+        let token = cancel.clone();
+        let (drain, drain_rx) = NetworkLogDrainProducer::channel("kmsg");
+
+        // Log stderr in a background task so dmesg errors are visible.
+        // Shares the cancel token so the task exits promptly on shutdown.
+        if let Some(stderr) = child.stderr.take() {
+            let stderr_cancel = cancel.clone();
+            tokio::spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stderr).lines();
+                loop {
+                    tokio::select! {
+                        _ = stderr_cancel.cancelled() => break,
+                        result = lines.next_line() => {
+                            match result {
+                                Ok(Some(line)) if !line.is_empty() => {
+                                    warn!(target: "dmesg", "stderr: {line}");
+                                }
+                                Ok(None) | Err(_) => break,
+                                _ => {}
                             }
-                            Ok(None) | Err(_) => break,
-                            _ => {}
                         }
                     }
                 }
-            }
-        });
+            });
+        }
+
+        let task = tokio::spawn(run_loop(network_log_manager, token, stdout, drain_rx));
+        Ok(Self {
+            cancel,
+            task: Some(task),
+            child: Some(child),
+            drain,
+        })
     }
 
-    let task = tokio::spawn(async move {
-        run_loop(network_log_manager, token, stdout, drain_rx).await;
-    });
-    Ok(KmsgHandle {
-        cancel,
-        task,
-        child: Some(child),
-        drain,
-    })
+    #[cfg(test)]
+    pub(crate) fn from_test_child(
+        child: tokio::process::Child,
+        network_log_manager: NetworkLogManager,
+    ) -> std::io::Result<Self> {
+        Self::from_child(child, network_log_manager)
+    }
 }
 
 /// Read kernel log lines from `dmesg -w` stdout, parse iptables LOG
@@ -157,14 +198,14 @@ async fn run_loop(
     cancel: CancellationToken,
     stdout: tokio::process::ChildStdout,
     drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
-) {
+) -> DrainableLineReaderExit {
     run_reader(
         network_log_manager,
         cancel,
         tokio::io::BufReader::new(stdout),
         drain_rx,
     )
-    .await;
+    .await
 }
 
 async fn run_reader<R>(
@@ -172,16 +213,17 @@ async fn run_reader<R>(
     cancel: CancellationToken,
     reader: R,
     drain_rx: mpsc::Receiver<NetworkLogDrainRequest>,
-) where
+) -> DrainableLineReaderExit
+where
     R: AsyncBufRead + Unpin,
 {
-    let _ = run_drainable_line_reader(reader, cancel, drain_rx, move |line| {
+    run_drainable_line_reader(reader, cancel, drain_rx, move |line| {
         let network_log_manager = network_log_manager.clone();
         async move {
             handle_kmsg_line(&network_log_manager, &line).await;
         }
     })
-    .await;
+    .await
 }
 
 async fn handle_kmsg_line(network_log_manager: &NetworkLogManager, line: &str) {


### PR DESCRIPTION
## Summary

- propagate the typed kmsg reader exit to the runner's main reactor
- hard-stop the runner and return a terminal error when the required kmsg
  monitor exits while the runner is live
- kill and reap the dmesg child promptly while preserving normal,
  exactly-once shutdown cleanup
- cover EOF, read-error, prompt-reap, and normal cancellation behavior with
  real controllable child processes

## Behavior

The runner previously kept accepting workloads after `dmesg -w` exited or its
stdout reader failed. It now treats any live kmsg task completion as a required
component failure, stops discovery and active work through the existing hard
shutdown path, completes teardown, and exits nonzero so systemd
`Restart=on-failure` can recover the service.

An operator shutdown that has already transitioned the authoritative lifecycle
to `Stopping` remains a normal successful shutdown.

## Explicit exclusions

- no in-process dmesg restart or retry state
- no change from `dmesg -w`
- no new runner lifecycle mode
- no API, queue, guest protocol, database, migration, or persisted-state
  change
- no DNS monitor lifecycle change

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::shutdown -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner kmsg_log::tests`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #23215
