### PR TITLE
feat(connectors): enable meta ads app oauth callback

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -771,8 +771,9 @@ describe("connectors page", () => {
     context.mocks.browser.open(authWindow);
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
-      ({ params, respond }) => {
+      ({ body, params, respond }) => {
         expect(params.type).toBe("meta-ads");
+        expect(body.callbackTarget).toBe("app");
         return respond(200, {
           authorizationUrl: "https://oauth.test/meta-ads/authorize",
         });

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -17,6 +17,7 @@ const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
   "google-meet",
   "google-search-console",
   "google-sheets",
+  "meta-ads",
   "stripe",
   "x",
   "youtube",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
@@ -27,7 +27,6 @@ function authCodeGrant() {
   return authCodeGrantFixture([
     "ads_management",
     "ads_read",
-    "business_management",
     "pages_manage_ads",
     "pages_read_engagement",
     "pages_show_list",
@@ -60,7 +59,6 @@ describe("connector/providers/meta-ads", () => {
         new Set([
           "ads_management",
           "ads_read",
-          "business_management",
           "pages_manage_ads",
           "pages_read_engagement",
           "pages_show_list",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
@@ -27,6 +27,7 @@ function authCodeGrant() {
   return authCodeGrantFixture([
     "ads_management",
     "ads_read",
+    "business_management",
     "pages_manage_ads",
     "pages_read_engagement",
     "pages_show_list",
@@ -59,6 +60,7 @@ describe("connector/providers/meta-ads", () => {
         new Set([
           "ads_management",
           "ads_read",
+          "business_management",
           "pages_manage_ads",
           "pages_read_engagement",
           "pages_show_list",


### PR DESCRIPTION
## Summary

- allow Meta Ads OAuth to complete through the App callback page
- verify the connector UI requests the App callback target
- keep the Meta Ads test fixture aligned with the current production catalog

## Validation

- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/meta-ads.test.ts --silent=passed-only`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx --silent=passed-only`
- `pnpm knip --workspace apps/platform --workspace packages/connectors`