### PR TITLE
feat(cli): add complete json output for built-in media generation

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
@@ -116,6 +116,53 @@ describe("zero generate image command", () => {
     expect(stdout).toContain("Provider: fal");
   });
 
+  it("should print the complete image result as one JSON object", async () => {
+    server.use(
+      http.post(IMAGE_URL, () => {
+        return HttpResponse.json(IMAGE_RESULT);
+      }),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--raw-prompt",
+      "A watercolor fox",
+      "--json",
+    ]);
+
+    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(IMAGE_RESULT)]]);
+  });
+
+  it.each([
+    ["provider listing", ["image", "--json"]],
+    ["connector guidance", ["image", "--provider", "replicate", "--json"]],
+    [
+      "prompt compilation",
+      [
+        "image",
+        "--style",
+        "image-style:ink-storefront",
+        "--prompt",
+        "A florist named Luna Floral",
+        "--compile",
+        "--json",
+      ],
+    ],
+  ])("should reject JSON output for %s", async (_mode, args) => {
+    await expect(async () => {
+      await generateCommand.parseAsync(["node", "cli", ...args]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "--json is only available for direct built-in generation",
+      ),
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("should pass fal model controls to the image API", async () => {
     let capturedBody: unknown;
     server.use(
@@ -535,7 +582,7 @@ describe("zero generate image command", () => {
     expect(helpOutput).toContain("--compiled-prompt");
     expect(helpOutput).toContain("--raw-prompt");
     expect(helpOutput).not.toContain("--skip-style");
-    expect(helpOutput).not.toContain("--json");
+    expect(helpOutput).toContain("--json");
     expect(helpOutput).not.toContain("--styled ");
     expect(helpOutput).toContain("provider");
     expect(helpOutput).toContain("default");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -184,6 +184,52 @@ describe("zero generate video command", () => {
     expect(stdout).toContain("Credits charged: 720");
   });
 
+  it("should print the complete video result as one JSON object", async () => {
+    server.use(
+      http.post(VIDEO_URL, () => {
+        return HttpResponse.json(VIDEO_RESULT);
+      }),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "video",
+      "--prompt",
+      "A neon market tracking shot",
+      "--json",
+    ]);
+
+    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(VIDEO_RESULT)]]);
+  });
+
+  it.each([
+    ["provider listing", ["video", "--json"]],
+    ["connector guidance", ["video", "--provider", "heygen", "--json"]],
+    [
+      "template selection",
+      [
+        "video",
+        "--template",
+        "video-template:epic-grandeur",
+        "--prompt",
+        "A cinematic mountain reveal",
+        "--json",
+      ],
+    ],
+  ])("should reject JSON output for %s", async (_mode, args) => {
+    await expect(async () => {
+      await generateCommand.parseAsync(["node", "cli", ...args]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "--json is only available for direct built-in generation",
+      ),
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("should reject frame images that do not match --aspect-ratio before generating", async () => {
     const postVideo = vi.fn();
     server.use(
@@ -290,7 +336,7 @@ describe("zero generate video command", () => {
     expect(helpOutput).toContain("--image-url");
     expect(helpOutput).toContain("--first-frame-image-url");
     expect(helpOutput).toContain("--last-frame-image-url");
-    expect(helpOutput).not.toContain("--json");
+    expect(helpOutput).toContain("--json");
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
@@ -80,6 +80,41 @@ describe("zero generate voice command", () => {
     expect(stdout).toContain("Credits charged: 1");
   });
 
+  it("should print the complete voice result as one JSON object", async () => {
+    server.use(
+      http.post(SPEECH_URL, () => {
+        return HttpResponse.json(VOICE_RESULT);
+      }),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "voice",
+      "--text",
+      "Hello from vm0",
+      "--json",
+    ]);
+
+    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(VOICE_RESULT)]]);
+  });
+
+  it.each([
+    ["provider listing", ["voice", "--json"]],
+    ["connector guidance", ["voice", "--provider", "elevenlabs", "--json"]],
+  ])("should reject JSON output for %s", async (_mode, args) => {
+    await expect(async () => {
+      await generateCommand.parseAsync(["node", "cli", ...args]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "--json is only available for direct built-in generation",
+      ),
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("should surface API errors", async () => {
     server.use(
       http.post(SPEECH_URL, () => {

--- a/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
@@ -9,6 +9,7 @@ interface DispatchOptions {
   readonly all?: boolean;
   readonly listOnMissingPrompt?: boolean;
   readonly missingPromptError?: string;
+  readonly requireExecutionFor?: string;
 }
 
 /**
@@ -27,6 +28,11 @@ export async function dispatchGenerate(
   const provider = options.provider?.trim();
 
   if (provider && provider !== "built-in") {
+    if (options.requireExecutionFor) {
+      throw new Error(
+        `${options.requireExecutionFor} is only available for direct built-in generation`,
+      );
+    }
     await printConnectorGuidance(options.generationType, provider);
     return { outcome: "handled" };
   }
@@ -34,6 +40,11 @@ export async function dispatchGenerate(
   const resolvedPrompt = resolvePrompt(options.prompt);
 
   if (resolvedPrompt === null) {
+    if (options.requireExecutionFor) {
+      throw new Error(
+        `${options.requireExecutionFor} is only available for direct built-in generation`,
+      );
+    }
     if (options.listOnMissingPrompt === false) {
       throw new Error(options.missingPromptError ?? "Prompt is required");
     }

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -35,6 +35,7 @@ interface ImageOptions {
   styleSource: "github" | "r2";
   compile?: boolean;
   all?: boolean;
+  json?: boolean;
 }
 
 interface ImageGenerateCommandConfig {
@@ -209,6 +210,7 @@ export function createImageGenerateCommand(
       "--all",
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
+    .option("--json", "Print the complete generation result as JSON")
     .option(
       "--model <model>",
       "Model: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4, or nano-banana-2",
@@ -279,8 +281,9 @@ ${config.examples}
 
 Output:
   Prints the generated /f/ image file URL and metadata with --compiled-prompt
-  or --raw-prompt. With --style <id> --prompt "..." --compile, prints a
-  prompt-compilation packet for the current agent.
+  or --raw-prompt. Use --json for the complete result object. With
+  --style <id> --prompt "..." --compile, prints a prompt-compilation packet
+  for the current agent.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -335,12 +338,18 @@ ${formatRegistryListing(styles, "image styles")}`;
             options.compile || options.style
               ? "--compile requires --prompt <text> or piped stdin"
               : undefined,
+          requireExecutionFor: options.json ? "--json" : undefined,
         });
         if (dispatch.outcome === "handled") return;
         const resolvedPrompt = dispatch.prompt;
         const mode = resolveImagePromptMode(options, config.usageCommand);
 
         if (mode === "compile") {
+          if (options.json) {
+            throw new Error(
+              "--json is only available for direct built-in generation",
+            );
+          }
           const styleId = options.style;
           if (!styleId) {
             throw new Error("--compile requires --style <id>");
@@ -405,6 +414,11 @@ ${formatRegistryListing(styles, "image styles")}`;
           inputFidelity,
           imagePromptStrength,
         });
+
+        if (options.json) {
+          console.log(JSON.stringify(result));
+          return;
+        }
 
         console.log(chalk.green(`✓ Image generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));

--- a/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
@@ -35,6 +35,7 @@ interface VideoOptions {
   firstFrameImageUrl?: string;
   lastFrameImageUrl?: string;
   all?: boolean;
+  json?: boolean;
 }
 
 interface VideoGenerateCommandConfig {
@@ -387,6 +388,7 @@ export function createVideoGenerateCommand(
       "--all",
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
+    .option("--json", "Print the complete generation result as JSON")
     .option(
       "--model <model>",
       "Model: dreamina-seedance-2.0-fast, dreamina-seedance-2.0, seedance-1.5-pro, veo3.1-fast, or kling-v3-4k",
@@ -435,7 +437,8 @@ Examples:
 ${config.examples}
 
 Output:
-  Prints the generated /f/ video file URL and metadata
+  Prints the generated /f/ video file URL and metadata. Use --json for the
+  complete result object.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -462,11 +465,17 @@ Models:
           provider: options.provider,
           prompt: options.prompt,
           all: options.all,
+          requireExecutionFor: options.json ? "--json" : undefined,
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
 
         if (options.template) {
+          if (options.json) {
+            throw new Error(
+              "--json is only available for direct built-in generation",
+            );
+          }
           const template = findVideoTemplate(options.template);
           if (!template) {
             throw unknownTemplateError(options.template, config.usageCommand);
@@ -511,6 +520,11 @@ Models:
           firstFrameImageUrl: options.firstFrameImageUrl,
           lastFrameImageUrl: options.lastFrameImageUrl,
         });
+
+        if (options.json) {
+          console.log(JSON.stringify(result));
+          return;
+        }
 
         console.log(chalk.green(`✓ Video generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));

--- a/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
@@ -12,6 +12,7 @@ interface VoiceOptions {
   voice: string;
   instructions?: string;
   all?: boolean;
+  json?: boolean;
 }
 
 interface VoiceGenerateCommandConfig {
@@ -37,6 +38,7 @@ export function createVoiceGenerateCommand(
       "--all",
       "When listing providers (no --prompt given), include unavailable or not-yet-authorized connectors",
     )
+    .option("--json", "Print the complete generation result as JSON")
     .option("--voice <voice>", "OpenAI voice to use", "marin")
     .option("--instructions <text>", "Voice style instructions")
     .addHelpText(
@@ -46,8 +48,9 @@ Examples:
 ${config.examples}
 
 Output:
-  Prints the generated /f/ audio file URL and metadata. With no --prompt
-  and no piped input, prints the provider menu instead.
+  Prints the generated /f/ audio file URL and metadata. Use --json for the
+  complete result object. With no --prompt and no piped input, prints the
+  provider menu instead.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -61,6 +64,7 @@ Notes:
           provider: options.provider,
           prompt: options.prompt ?? options.text,
           all: options.all,
+          requireExecutionFor: options.json ? "--json" : undefined,
         });
         if (dispatch.outcome === "handled") return;
         const text = dispatch.prompt;
@@ -70,6 +74,11 @@ Notes:
           voice: options.voice,
           instructions: options.instructions,
         });
+
+        if (options.json) {
+          console.log(JSON.stringify(result));
+          return;
+        }
 
         console.log(chalk.green(`✓ Voice generated: ${result.url}`));
         console.log(chalk.dim(`  File: ${result.filename}`));


### PR DESCRIPTION
## Summary

- Add `--json` to direct built-in `zero generate image`, `video`, and `voice` execution.
- Print the complete API result as one JSON object while preserving the existing human-readable default.
- Reject `--json` before provider listing, connector guidance, image prompt compilation, or video template selection can emit non-generation output.

## User impact

Agents and scripts can consume the artifact URL, filename, credits charged, model, and media-specific metadata without filtering human-readable output or rerunning a billed generation.

## Verification

- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/generate/__tests__/image.test.ts src/commands/zero/generate/__tests__/video.test.ts src/commands/zero/generate/__tests__/voice.test.ts` — 33 tests passed
- `pnpm exec prettier --check` on all changed TypeScript files

## Companion PR

- https://github.com/vm0-ai/vm0-skills/pull/315
- Merge this PR first so the documented `--json` capability is available before the skill update lands.
