### PR TITLE
docs(python): clarify observable flow drain contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -148,10 +148,13 @@ def _write_pending_state(pending_path: str, state: dict[str, Any]) -> None:
 
 
 def increment_in_flight_flows() -> None:
-    """Track a new in-flight billable flow (call from request).
+    """Track a newly admitted usage flow (call from request).
 
-    Covers billable model-provider and connector flows — any flow that may
-    enqueue a webhook POST before response/error runs.
+    Admission is owned by ``terminal_usage.track_flow_if_needed`` and includes
+    billable model-provider and connector flows plus non-billable observable
+    model-provider flows. Holding the count through terminal release lets
+    terminal hooks enqueue billing events and model-usage observations before
+    the runner shutdown drain advances.
     """
     global _in_flight_flows
     with _counter_lock:

--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -22,10 +22,11 @@ def assert_pending(
     """Assert a usage pending-state JSON snapshot.
 
     ``flows``, ``buffered``, and ``reports`` map directly to the JSON fields
-    with the same names.  ``flows`` is the number of in-flight billable flows,
-    ``buffered`` is the number of usage source events still counted as pending
-    by the usage buffer, and ``reports`` is the number of pending webhook report
-    deliveries.
+    with the same names.  ``flows`` is the number of admitted in-flight usage
+    flows, including billable model-provider and connector flows plus
+    non-billable observable model-provider flows.  ``buffered`` is the number
+    of usage source events still counted as pending by the usage buffer, and
+    ``reports`` is the number of pending webhook report deliveries.
 
     When ``flush_request_id`` is provided, the snapshot must include a matching
     ``flushRequestId`` field.  When it is omitted, ``flushRequestId`` must be


### PR DESCRIPTION
## Summary

- align the in-flight usage counter and pending-state documentation with `terminal_usage.track_flow_if_needed()`
- document non-billable observable model-provider flows and the shutdown-drain delivery contract
- leave runtime behavior, counter identifiers, snapshot schema, test assertions, and protocols unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,277 passed)

Closes #23233
