### PR TITLE
refactor(api): move connector feature states into api

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -16,7 +16,6 @@ import type {
   PublicConnectorCatalogStatusItem,
   PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import type { ConnectorFeatureStates } from "@vm0/connectors/connector-auth-method";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   connectorCatalogActiveSnapshot,
@@ -41,6 +40,7 @@ import {
 import { connectorCatalogIconUrl } from "./connector-catalog-artifacts/icon";
 import { deriveConnectorCatalogFirewallPermissions } from "./connector-catalog-artifacts/relationships";
 import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
+import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import { connectorCatalogSource } from "./connector-catalog-source";
 
 const log = logger("connector-catalog:reader");

--- a/turbo/apps/api/src/signals/services/connector-catalog-feature-states.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-feature-states.ts
@@ -1,0 +1,6 @@
+import type { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+
+export type ConnectorFeatureStates =
+  | Partial<Record<FeatureSwitchKey, boolean>>
+  | null
+  | undefined;

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -6,9 +6,9 @@ import type {
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import type { ConnectorFeatureStates } from "@vm0/connectors/connector-auth-method";
 
 import type { ReadonlyDb } from "../external/db";
+import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import {
   ExternalConnectorCatalogUnavailableError,
   getExternalPublicConnectorCatalogDetail,

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -29,7 +29,6 @@ import {
 import {
   connectorAuthMethodOwnedSecretNames,
   connectorAuthMethodRuntimeMetadata,
-  type ConnectorFeatureStates,
 } from "@vm0/connectors/connector-auth-method";
 
 import { singleton } from "../../lib/singleton";
@@ -46,6 +45,7 @@ import {
   type AcceptedConnectorCatalogSnapshot,
   type ExternalCatalogIdentity,
 } from "./connector-catalog-external-reader.service";
+import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import {
   createAcceptedConnectorServerFirewallCatalog,
   type ConnectorServerFirewallCatalog,

--- a/turbo/packages/connectors/src/connector-auth-method.ts
+++ b/turbo/packages/connectors/src/connector-auth-method.ts
@@ -26,17 +26,11 @@ import type {
   StaticConfidentialConnectorAuthClientConfig,
   StaticPublicConnectorAuthClientConfig,
 } from "./connector-config";
-import type { FeatureSwitchKey } from "./feature-switch-key";
 
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VARIABLE_REF_PREFIX = "$vars.";
 const DEFAULT_AUTH_CODE_CALLBACK_ORIGIN: ConnectorAuthCodeCallbackOrigin =
   "web";
-
-export type ConnectorFeatureStates =
-  | Partial<Record<FeatureSwitchKey, boolean>>
-  | null
-  | undefined;
 
 export interface ConnectorManualGrantFieldNames {
   readonly secrets: readonly string[];


### PR DESCRIPTION
## Summary

- move `ConnectorFeatureStates` into an API-owned connector catalog type module
- route all three API consumers through the new internal owner
- remove the feature-switch type dependency from `@vm0/connectors`

## Scope

This is a type-only ownership refactor. It does not change connector discovery, feature-switch
values, API contracts, persisted data, R2 artifacts, or runner protocols.

Moving `FeatureSwitchKey`, removing stale switch values, narrowing package exports, and other
connector cleanup remain in their separate sibling issues.

## Validation

- `pnpm exec prettier --write <changed TypeScript files>`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts --maxWorkers=4 --silent=passed-only` (124 tests)
- `pnpm knip`
- pre-commit hooks, including full Turbo TypeScript checking

Closes #23261

Parent objective: vm0-ai/vm0-connectors#1
