### PR TITLE
fix: fork feishu dm thread sessions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1705,7 +1705,7 @@ describe("Feishu integration", () => {
     expect(wrongRunResponse.status).toBe(400);
   });
 
-  it("uses Slack-aligned session boundaries for Feishu DMs", async () => {
+  it("forks Feishu DM threads without replacing the main session", async () => {
     const fixture = await setupFeishuRunFixture({
       useAlternateInstallationDefault: true,
     });
@@ -1940,53 +1940,130 @@ describe("Feishu integration", () => {
     const followUp = await findRun(actor, "continue the Feishu task");
     await runsApi.heartbeatRunner(runnerGroup);
     const followUpClaim = await runsApi.claimRunnerJob(followUp.id);
-    expect(followUpClaim.resumeSession).toBeNull();
-    await webhooksApi.requestAgentComplete(
-      {
-        runId: followUp.id,
-        exitCode: 1,
-        error: "Cannot continue session from checkpoint",
-      },
-      { authorization: `Bearer ${followUpClaim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const failedReply = [...outboundMessages].reverse().find((message) => {
-      return (
-        message.kind === "send" &&
-        messageContent(message).includes(
-          "Cannot continue session from checkpoint",
-        )
-      );
+    expect(followUpClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+    await completeRunSession({
+      runId: followUp.id,
+      sandboxToken: followUpClaim.sandboxToken,
+      sessionId: cliAgentSessionId,
+      history: `bdd continued feishu history ${followUp.id}`,
+      assistantText: "Continued canonical Feishu answer",
     });
-    expect(failedReply?.msgType).toBe("interactive");
-    const failedReplyContent = failedReply ? messageContent(failedReply) : "";
-    expect(failedReplyContent).toContain("Audit");
-    expect(failedReplyContent).toContain("Claude Sonnet");
-    expect(failedReplyContent).toContain("Responded by Feishu default agent");
-    expect(removedReactions).toHaveLength(2);
 
+    const quotedReplyMessageId = `om_${randomUUID()}`;
     await postEvent(
       callbackUrl,
       directMessage(
         appId,
-        "reply in the original Feishu thread",
+        "reply without opening a Feishu thread",
         "ou_feishu_user",
         {
+          messageId: quotedReplyMessageId,
           rootId: firstMessageId,
         },
       ),
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const threadReplyRun = await findRun(
+    const quotedReplyRun = await findRun(
       actor,
-      "reply in the original Feishu thread",
+      "reply without opening a Feishu thread",
     );
     await runsApi.heartbeatRunner(runnerGroup);
-    const threadReplyClaim = await runsApi.claimRunnerJob(threadReplyRun.id);
-    expect(threadReplyClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
-    await runsApi.requestCancelRun(actor, threadReplyRun.id, [200]);
+    const quotedReplyClaim = await runsApi.claimRunnerJob(quotedReplyRun.id);
+    expect(quotedReplyClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+    await completeRunSession({
+      runId: quotedReplyRun.id,
+      sandboxToken: quotedReplyClaim.sandboxToken,
+      sessionId: cliAgentSessionId,
+      history: `bdd quoted feishu history ${quotedReplyRun.id}`,
+      assistantText: "Canonical Feishu quoted reply answer",
+    });
+    const completedQuotedReply = [...outboundMessages]
+      .reverse()
+      .find((message) => {
+        return (
+          message.kind === "send" &&
+          messageContent(message).includes(
+            "Canonical Feishu quoted reply answer",
+          )
+        );
+      });
+    expect(completedQuotedReply?.replyInThread).toBeFalsy();
+
+    const feishuThreadId = `omt_${randomUUID()}`;
+    const threadMessageId = `om_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, "open a new Feishu thread", "ou_feishu_user", {
+        messageId: threadMessageId,
+        rootId: quotedReplyMessageId,
+        threadId: feishuThreadId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const threadRun = await findRun(actor, "open a new Feishu thread");
+    await runsApi.heartbeatRunner(runnerGroup);
+    const threadClaim = await runsApi.claimRunnerJob(threadRun.id);
+    expect(threadClaim.resumeSession).toBeNull();
+    const threadCliAgentSessionId = randomUUID();
+    await completeRunSession({
+      runId: threadRun.id,
+      sandboxToken: threadClaim.sandboxToken,
+      sessionId: threadCliAgentSessionId,
+      history: `bdd feishu thread history ${threadRun.id}`,
+      assistantText: "Canonical Feishu thread answer",
+    });
+    const completedThreadReply = [...outboundMessages]
+      .reverse()
+      .find((message) => {
+        return (
+          message.kind === "reply" &&
+          message.target === threadMessageId &&
+          messageContent(message).includes("Canonical Feishu thread answer")
+        );
+      });
+    expect(completedThreadReply?.replyInThread).toBeTruthy();
+
+    await postEvent(
+      callbackUrl,
+      directMessage(
+        appId,
+        "continue in the original Feishu thread",
+        "ou_feishu_user",
+        {
+          rootId: quotedReplyMessageId,
+          threadId: feishuThreadId,
+        },
+      ),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const threadFollowUpRun = await findRun(
+      actor,
+      "continue in the original Feishu thread",
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    const threadFollowUpClaim = await runsApi.claimRunnerJob(
+      threadFollowUpRun.id,
+    );
+    expect(threadFollowUpClaim.resumeSession?.sessionId).toBe(
+      threadCliAgentSessionId,
+    );
+    await runsApi.requestCancelRun(actor, threadFollowUpRun.id, [200]);
+    await flushWaitUntilForTest();
+
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, "return to the main Feishu DM"),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const mainDmRun = await findRun(actor, "return to the main Feishu DM");
+    await runsApi.heartbeatRunner(runnerGroup);
+    const mainDmClaim = await runsApi.claimRunnerJob(mainDmRun.id);
+    expect(mainDmClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+    await runsApi.requestCancelRun(actor, mainDmRun.id, [200]);
     await flushWaitUntilForTest();
 
     const client = setupApp({ context })(zeroFeishuConnectContract);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1709,8 +1709,14 @@ describe("Feishu integration", () => {
     const fixture = await setupFeishuRunFixture({
       useAlternateInstallationDefault: true,
     });
-    const { actor, runnerGroup, appId, callbackUrl, alternateAgentId } =
-      fixture;
+    const {
+      actor,
+      runnerGroup,
+      appId,
+      callbackUrl,
+      defaultAgentId,
+      alternateAgentId,
+    } = fixture;
     await connectFixtureUser(fixture);
     await postEvent(callbackUrl, directMessage(appId, "/model"), {
       encrypted: true,
@@ -1990,6 +1996,40 @@ describe("Feishu integration", () => {
       });
     expect(completedQuotedReply?.replyInThread).toBeFalsy();
 
+    await postEvent(callbackUrl, directMessage(appId, "/switch default"), {
+      encrypted: true,
+    });
+    await flushWaitUntilForTest();
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, "use the switched Feishu agent"),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const switchedAgentRun = await findRun(
+      actor,
+      "use the switched Feishu agent",
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    const switchedAgentClaim = await runsApi.claimRunnerJob(
+      switchedAgentRun.id,
+    );
+    expect(switchedAgentClaim.environment?.ZERO_AGENT_ID).toBe(defaultAgentId);
+    expect(switchedAgentClaim.resumeSession).toBeNull();
+    await completeRunSession({
+      runId: switchedAgentRun.id,
+      sandboxToken: switchedAgentClaim.sandboxToken,
+      sessionId: randomUUID(),
+      history: `bdd switched feishu history ${switchedAgentRun.id}`,
+      assistantText: "Switched canonical Feishu answer",
+    });
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, `/switch ${alternateAgentId}`),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+
     const feishuThreadId = `omt_${randomUUID()}`;
     const threadMessageId = `om_${randomUUID()}`;
     await postEvent(
@@ -2025,6 +2065,26 @@ describe("Feishu integration", () => {
       });
     expect(completedThreadReply?.replyInThread).toBeTruthy();
 
+    const threadHelpMessageId = `om_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      directMessage(appId, "/help", "ou_feishu_user", {
+        messageId: threadHelpMessageId,
+        rootId: quotedReplyMessageId,
+        threadId: feishuThreadId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const threadHelpReply = [...outboundMessages].reverse().find((message) => {
+      return (
+        message.kind === "reply" &&
+        message.target === threadHelpMessageId &&
+        messageContent(message).includes("Zero commands")
+      );
+    });
+    expect(threadHelpReply?.replyInThread).toBeTruthy();
+
     await postEvent(
       callbackUrl,
       directMessage(
@@ -2032,7 +2092,6 @@ describe("Feishu integration", () => {
         "continue in the original Feishu thread",
         "ou_feishu_user",
         {
-          rootId: quotedReplyMessageId,
           threadId: feishuThreadId,
         },
       ),
@@ -2085,11 +2144,19 @@ describe("Feishu integration", () => {
       "second concurrent Feishu task",
       "queued Feishu task",
     ] as const;
+    const queuedMessageId = `om_${randomUUID()}`;
     for (const [index, prompt] of prompts.entries()) {
       await postEvent(
         callbackUrl,
         directMessage(appId, prompt, "ou_feishu_user", {
           chatId: `oc_feishu_concurrent_${index}`,
+          ...(index === 2
+            ? {
+                messageId: queuedMessageId,
+                rootId: `om_${randomUUID()}`,
+                threadId: `omt_${randomUUID()}`,
+              }
+            : {}),
         }),
         {
           encrypted: true,
@@ -2100,6 +2167,11 @@ describe("Feishu integration", () => {
 
     const queueNotice = outboundMessages.find((message) => {
       return messageContent(message).includes("Run queued");
+    });
+    expect(queueNotice).toMatchObject({
+      kind: "reply",
+      target: queuedMessageId,
+      replyInThread: true,
     });
     expect(queueNotice?.msgType).toBe("interactive");
     const queueNoticeContent = queueNotice ? messageContent(queueNotice) : "";

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -54,7 +54,6 @@ import {
 const L = logger("CanonicalFeishuIngressProcessor");
 const PROCESSING_STALE_AFTER_MS = 5 * 60 * 1000;
 const SWEEP_LIMIT = 20;
-const FEISHU_DIRECT_MESSAGE_THREAD_ID = "direct-message";
 
 const feishuPromptFileSchema = z.object({
   fileId: z.string(),
@@ -80,13 +79,18 @@ const feishuInboundMessageSchema = z.object({
   file: feishuPromptFileSchema.nullable(),
 });
 
-function canonicalThreadId(message: FeishuInboundMessage): string {
+function canonicalThreadId(args: {
+  readonly message: FeishuInboundMessage;
+  readonly agentId: string;
+  readonly selectedModel: string | null;
+}): string {
+  const { message } = args;
   const replyThreadId =
     message.rootId ?? message.threadId ?? message.parentId ?? null;
   if (message.chatType === "p2p") {
     return message.threadId
-      ? `thread:${replyThreadId ?? message.threadId}`
-      : FEISHU_DIRECT_MESSAGE_THREAD_ID;
+      ? `thread:${message.threadId}`
+      : `direct-message:${args.agentId}:${args.selectedModel ?? "default"}`;
   }
   return replyThreadId ?? message.messageId;
 }
@@ -242,7 +246,11 @@ async function persistCanonicalFeishuIngress(args: {
   readonly appendSystemPrompt: string;
   readonly signal: AbortSignal;
 }): Promise<PersistedCanonicalFeishuIngress> {
-  const threadId = canonicalThreadId(args.message);
+  const threadId = canonicalThreadId({
+    message: args.message,
+    agentId: args.agentId,
+    selectedModel: args.selectedModel,
+  });
   const route = await ensureFeishuChatThreadRoute(args.db, {
     connectionId: args.connection.id,
     chatId: args.message.chatId,

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -44,6 +44,7 @@ import {
   replyFeishuAgentUnavailable,
   replyToUnconnectedFeishuMessage,
   resolveEffectiveFeishuAgent,
+  shouldReplyInFeishuThread,
   type FeishuDispatchConnection,
   type FeishuDispatchInstallation,
   type FeishuInboundMessage,
@@ -53,6 +54,7 @@ import {
 const L = logger("CanonicalFeishuIngressProcessor");
 const PROCESSING_STALE_AFTER_MS = 5 * 60 * 1000;
 const SWEEP_LIMIT = 20;
+const FEISHU_DIRECT_MESSAGE_THREAD_ID = "direct-message";
 
 const feishuPromptFileSchema = z.object({
   fileId: z.string(),
@@ -79,9 +81,14 @@ const feishuInboundMessageSchema = z.object({
 });
 
 function canonicalThreadId(message: FeishuInboundMessage): string {
-  return (
-    message.rootId ?? message.threadId ?? message.parentId ?? message.messageId
-  );
+  const replyThreadId =
+    message.rootId ?? message.threadId ?? message.parentId ?? null;
+  if (message.chatType === "p2p") {
+    return message.threadId
+      ? `thread:${replyThreadId ?? message.threadId}`
+      : FEISHU_DIRECT_MESSAGE_THREAD_ID;
+  }
+  return replyThreadId ?? message.messageId;
 }
 
 async function claimIngress(
@@ -260,7 +267,7 @@ async function persistCanonicalFeishuIngress(args: {
         chatId: args.message.chatId,
         messageId: args.message.messageId,
         threadId,
-        replyInThread: args.message.chatType !== "p2p",
+        replyInThread: shouldReplyInFeishuThread(args.message),
         reactionId: args.reactionId,
         files: [
           ...(args.message.file ? [args.message.file] : []),
@@ -365,7 +372,7 @@ async function notifyQueuedFeishuRun(args: {
     text: `Concurrency limit reached. Will start automatically when a slot is available.\n\n[View queue](${env("APP_URL")}/?queue=1)`,
     kind: "warning",
   });
-  if (args.message.chatType === "p2p") {
+  if (!shouldReplyInFeishuThread(args.message)) {
     await sendFeishuMessage({
       db: args.db,
       installationId: args.message.installationId,

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -78,6 +78,12 @@ export interface FeishuInboundMessage {
   readonly file: FeishuPromptFile | null;
 }
 
+export function shouldReplyInFeishuThread(
+  message: FeishuInboundMessage,
+): boolean {
+  return message.chatType !== "p2p" || message.threadId !== null;
+}
+
 interface FeishuAgent {
   readonly id: string;
   readonly name: string;
@@ -145,7 +151,7 @@ async function reply(args: {
   readonly outbound: FeishuOutboundMessage;
   readonly signal: AbortSignal;
 }): Promise<void> {
-  if (args.message.chatType === "p2p") {
+  if (!shouldReplyInFeishuThread(args.message)) {
     await sendFeishuMessage({
       db: args.db,
       installationId: args.message.installationId,


### PR DESCRIPTION
## Summary

- reuse one session for top-level Feishu direct messages, including quoted replies that do not open a thread
- fork a separate session when a real Feishu DM thread starts and reuse it within that thread
- deliver agent responses and queue notices inside real Feishu DM threads without changing the main DM session

## Verification

- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts --maxWorkers=1 --silent=passed-only
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- pre-commit hooks: full Knip and Turbo type checks