### PR TITLE
fix: fork slack and teams dm thread sessions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -1158,6 +1158,18 @@ export function createBddIntegrationApi(context: TestContext) {
       );
     },
 
+    async enableSlackDmSessionRoutingSwitch(actor: ApiTestUser): Promise<void> {
+      await accept(
+        setupApp({ context })(zeroFeatureSwitchesContract).update({
+          headers: authenticate(context, routeMocks, actor),
+          body: {
+            switches: { [FeatureSwitchKey.SlackDmSessionRouting]: true },
+          },
+        }),
+        [200],
+      );
+    },
+
     async configureUnpinnedSlackModelRoute(actor: ApiTestUser): Promise<void> {
       const providers = setupApp({ context })(zeroModelProvidersMainContract);
       // openrouter-api-key is a claude-code provider whose catalog entry has

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1862,6 +1862,134 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(run2.result?.agentSessionId).toBe(webSessionId);
   });
 
+  it("forks Slack DM threads without replacing the main session", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    integrations.configureSlackAppMocks();
+    integrations.acceptSlackSessionHistoryDownloads();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await integrations.configureSlackRunModelPolicies(actor);
+    await bdd.readOnboardingStatus(actor);
+    const slackUserId = uniqueSlackUserId();
+    const { teamId } = await integrations.installSlackWorkspace(actor, {
+      installerSlackUserId: slackUserId,
+    });
+    integrations.clearSlackCallHistory();
+
+    const channelId = "D_BDD_SESSION_ROUTING";
+    const firstMessageTs = "2950.000100";
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "remember the main Slack DM",
+      ts: firstMessageTs,
+      channel: channelId,
+    });
+    const firstRunId = await pollSlackRun(runnerGroup);
+    const firstClaim = await runs.claimRunnerJob(firstRunId);
+    expect(firstClaim.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      cliAgentType: firstClaim.cliAgentType,
+      assistantText: "Main Slack DM answer",
+    });
+    await flushWaitUntilForTest();
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: channelId,
+        thread_ts: firstMessageTs,
+        text: "Main Slack DM answer",
+      }),
+    );
+
+    const secondMessageTs = "2950.000200";
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "continue the main Slack DM",
+      ts: secondMessageTs,
+      channel: channelId,
+    });
+    const secondRunId = await pollSlackRun(runnerGroup);
+    const secondClaim = await runs.claimRunnerJob(secondRunId);
+    expect(secondClaim.resumeSession?.sessionId).toBe(
+      `bdd-slack-cli-${firstRunId}`,
+    );
+    await completeSlackTriggeredRun({
+      runId: secondRunId,
+      sandboxToken: secondClaim.sandboxToken,
+      cliAgentType: secondClaim.cliAgentType,
+      assistantText: "Continued main Slack DM answer",
+    });
+    await flushWaitUntilForTest();
+    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: channelId,
+        thread_ts: secondMessageTs,
+        text: "Continued main Slack DM answer",
+      }),
+    );
+
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "open a Slack DM thread",
+      ts: "2950.000300",
+      thread_ts: secondMessageTs,
+      channel: channelId,
+    });
+    const threadRunId = await pollSlackRun(runnerGroup);
+    const threadClaim = await runs.claimRunnerJob(threadRunId);
+    expect(threadClaim.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: threadRunId,
+      sandboxToken: threadClaim.sandboxToken,
+      cliAgentType: threadClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
+
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "continue the Slack DM thread",
+      ts: "2950.000400",
+      thread_ts: secondMessageTs,
+      channel: channelId,
+    });
+    const threadFollowUpRunId = await pollSlackRun(runnerGroup);
+    const threadFollowUpClaim = await runs.claimRunnerJob(threadFollowUpRunId);
+    expect(threadFollowUpClaim.resumeSession?.sessionId).toBe(
+      `bdd-slack-cli-${threadRunId}`,
+    );
+    await completeSlackTriggeredRun({
+      runId: threadFollowUpRunId,
+      sandboxToken: threadFollowUpClaim.sandboxToken,
+      cliAgentType: threadFollowUpClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
+
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "return to the main Slack DM",
+      ts: "2950.000500",
+      channel: channelId,
+    });
+    const returnToMainRunId = await pollSlackRun(runnerGroup);
+    const returnToMainClaim = await runs.claimRunnerJob(returnToMainRunId);
+    expect(returnToMainClaim.resumeSession?.sessionId).toBe(
+      `bdd-slack-cli-${secondRunId}`,
+    );
+  });
+
   it("admits a later canonical-route retry after its first ingress insert fails", async () => {
     const actor = bdd.user();
     const blockerActor = bdd.user();
@@ -3265,6 +3393,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       user: slackUserId,
       text: "run with my override",
       ts: "5000.000200",
+      thread_ts: "5000.000100",
       channel: "D_BDD_FAIL",
     });
     await flushWaitUntilAndAssert(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1864,6 +1864,8 @@ describe("INT-01: Slack app deep webhook flows", () => {
 
   it("forks Slack DM threads without replacing the main session", async () => {
     const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    await integrations.enableSlackDmSessionRoutingSwitch(actor);
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
     integrations.configureSlackAppMocks();
@@ -1932,6 +1934,43 @@ describe("INT-01: Slack app deep webhook flows", () => {
         channel: channelId,
         thread_ts: secondMessageTs,
         text: "Continued main Slack DM answer",
+      }),
+    );
+
+    const alternateAgent = await bdd.createAgent(actor, {
+      displayName: "BDD alternate Slack DM agent",
+    });
+    await integrations.postSlackInteractive(
+      integrations.agentPickerSubmission({
+        workspaceId: teamId,
+        slackUserId,
+        selectedValue: alternateAgent.agentId,
+        channelId,
+      }),
+    );
+    await integrations.postSlackEvent(teamId, {
+      type: "message",
+      channel_type: "im",
+      user: slackUserId,
+      text: "use an alternate Slack DM agent",
+      ts: "2950.000250",
+      channel: channelId,
+    });
+    const alternateRunId = await pollSlackRun(runnerGroup);
+    const alternateClaim = await runs.claimRunnerJob(alternateRunId);
+    expect(alternateClaim.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: alternateRunId,
+      sandboxToken: alternateClaim.sandboxToken,
+      cliAgentType: alternateClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
+    await integrations.postSlackInteractive(
+      integrations.agentPickerSubmission({
+        workspaceId: teamId,
+        slackUserId,
+        selectedValue: "__org_default__",
+        channelId,
       }),
     );
 
@@ -3393,7 +3432,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
       user: slackUserId,
       text: "run with my override",
       ts: "5000.000200",
-      thread_ts: "5000.000100",
       channel: "D_BDD_FAIL",
     });
     await flushWaitUntilAndAssert(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -81,6 +81,7 @@ interface ConnectedTeamsActor {
   readonly fixture: TeamsConnectFixture;
   readonly actor: ReturnType<typeof authOrgApi.user>;
   readonly runnerGroup: string;
+  readonly defaultAgentId: string;
 }
 
 function teamsServiceBaseUrl(serviceUrl: string): string {
@@ -388,7 +389,12 @@ async function setupConnectedTeamsActor(
   await flushWaitUntilForTest();
   clearTeamsApiCalls(setupTeamsApi);
 
-  return { fixture, actor, runnerGroup };
+  return {
+    fixture,
+    actor,
+    runnerGroup,
+    defaultAgentId: defaultAgent.body.agentId,
+  };
 }
 
 async function dispatchTeamsRun(args: {
@@ -467,6 +473,39 @@ async function dispatchTeamsPersonalRun(args: {
     orgRole: "org:admin",
   });
   return await runIdForPrompt(actor, args.text);
+}
+
+async function switchTeamsAgent(args: {
+  readonly fixture: TeamsConnectFixture;
+  readonly activityId: string;
+  readonly agentId: string;
+}): Promise<void> {
+  const response = await postTeamsActivityForTest({
+    signal: context.signal,
+    activity: teamsMessageActivityForTest(args.fixture, {
+      id: args.activityId,
+      conversation: {
+        id: `a:personal-${args.fixture.teamsUserId}`,
+        conversationType: "personal",
+      },
+      channelData: {
+        tenant: {
+          id: args.fixture.teamsTenantId,
+          name: args.fixture.teamsTenantName,
+        },
+        teamsAppId: BOT_APP_ID,
+      },
+      text: "",
+      entities: [],
+      value: {
+        zeroTeamsAction: "switch_agent",
+        selectedComposeId: args.agentId,
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+  await response.json();
+  await flushWaitUntilForTest();
 }
 
 async function claimTeamsRun(args: {
@@ -604,6 +643,37 @@ describe("Teams org internal callbacks", () => {
       runId: secondRunId,
       sandboxToken: secondClaim.sandboxToken,
       exitCode: 0,
+    });
+
+    const alternateAgent = await authOrgApi.createAgent(teams.actor, {
+      displayName: "Alternate Teams DM agent",
+      visibility: "public",
+    });
+    await switchTeamsAgent({
+      fixture: teams.fixture,
+      activityId: "activity-personal-switch-alternate",
+      agentId: alternateAgent.agentId,
+    });
+    const alternateRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-alternate-agent",
+      text: "use an alternate Teams DM agent",
+    });
+    const alternateClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: alternateRunId,
+    });
+    expect(alternateClaim.resumeSession).toBeNull();
+    clearTeamsApiCalls(teamsApi);
+    await completeSandboxRun({
+      runId: alternateRunId,
+      sandboxToken: alternateClaim.sandboxToken,
+      exitCode: 0,
+    });
+    await switchTeamsAgent({
+      fixture: teams.fixture,
+      activityId: "activity-personal-switch-default",
+      agentId: teams.defaultAgentId,
     });
 
     const rootActivityId = "activity-personal-main-second";

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -569,20 +569,21 @@ afterEach(async () => {
 });
 
 describe("Teams org internal callbacks", () => {
-  it("starts a new agent session for each top-level personal message", async () => {
+  it("forks personal message threads without replacing the main session", async () => {
     const teams = await setupConnectedTeamsActor();
     const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
     const firstRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-first",
+      activityId: "activity-personal-main-first",
       text: "remember this DM context",
     });
     const firstClaim = await claimTeamsRun({
       runnerGroup: teams.runnerGroup,
       runId: firstRunId,
     });
+    expect(firstClaim.resumeSession).toBeNull();
     clearTeamsApiCalls(teamsApi);
-    await completeSandboxRun({
+    const firstMainSessionId = await completeSandboxRun({
       runId: firstRunId,
       sandboxToken: firstClaim.sandboxToken,
       exitCode: 0,
@@ -590,49 +591,70 @@ describe("Teams org internal callbacks", () => {
 
     const secondRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-second",
+      activityId: "activity-personal-main-second",
       text: "use the previous DM context",
     });
     const secondClaim = await claimTeamsRun({
       runnerGroup: teams.runnerGroup,
       runId: secondRunId,
     });
-
-    expect(secondClaim.resumeSession).toBeNull();
-  });
-
-  it("resumes the same agent session within a personal message thread", async () => {
-    const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
-    const rootActivityId = "activity-personal-thread-root";
-    const firstRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: rootActivityId,
-      text: "remember this personal thread context",
-    });
-    const firstClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: firstRunId,
-    });
+    expect(secondClaim.resumeSession?.sessionId).toBe(firstMainSessionId);
     clearTeamsApiCalls(teamsApi);
-    const cliAgentSessionId = await completeSandboxRun({
-      runId: firstRunId,
-      sandboxToken: firstClaim.sandboxToken,
+    const latestMainSessionId = await completeSandboxRun({
+      runId: secondRunId,
+      sandboxToken: secondClaim.sandboxToken,
       exitCode: 0,
     });
 
-    const secondRunId = await dispatchTeamsPersonalRun({
+    const rootActivityId = "activity-personal-main-second";
+    const threadRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-thread-reply",
+      activityId: "activity-personal-thread-first",
       threadId: rootActivityId,
-      text: "use the personal thread context",
+      text: "open a personal message thread",
     });
-    const secondClaim = await claimTeamsRun({
+    const threadClaim = await claimTeamsRun({
       runnerGroup: teams.runnerGroup,
-      runId: secondRunId,
+      runId: threadRunId,
+    });
+    expect(threadClaim.resumeSession).toBeNull();
+    clearTeamsApiCalls(teamsApi);
+    const threadSessionId = await completeSandboxRun({
+      runId: threadRunId,
+      sandboxToken: threadClaim.sandboxToken,
+      exitCode: 0,
     });
 
-    expect(secondClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+    const threadFollowUpRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-thread-follow-up",
+      threadId: rootActivityId,
+      text: "continue the personal message thread",
+    });
+    const threadFollowUpClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: threadFollowUpRunId,
+    });
+    expect(threadFollowUpClaim.resumeSession?.sessionId).toBe(threadSessionId);
+    clearTeamsApiCalls(teamsApi);
+    await completeSandboxRun({
+      runId: threadFollowUpRunId,
+      sandboxToken: threadFollowUpClaim.sandboxToken,
+      exitCode: 0,
+    });
+
+    const returnToMainRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-main-return",
+      text: "return to the main DM",
+    });
+    const returnToMainClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: returnToMainRunId,
+    });
+    expect(returnToMainClaim.resumeSession?.sessionId).toBe(
+      latestMainSessionId,
+    );
   });
 
   it("posts completed run replies and persists Teams thread sessions", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -2055,9 +2055,10 @@ describe("POST /api/zero/teams/bot", () => {
     outboundRequests.splice(0, outboundRequests.length);
 
     const firstResponse = await postTeamsActivity({
-      activity: teamsPersonalMessageActivity({
+      activity: teamsPersonalThreadMessageActivity({
         fixture,
         id: "activity-queue-active-1",
+        threadId: "activity-queue-thread-1",
         text: "active run one",
       }),
       token: teamsToken(),
@@ -2068,9 +2069,10 @@ describe("POST /api/zero/teams/bot", () => {
     const firstRunId = await runIdForPrompt(actor, "active run one");
 
     const secondResponse = await postTeamsActivity({
-      activity: teamsPersonalMessageActivity({
+      activity: teamsPersonalThreadMessageActivity({
         fixture,
         id: "activity-queue-active-2",
+        threadId: "activity-queue-thread-2",
         text: "active run two",
       }),
       token: teamsToken(),
@@ -2081,9 +2083,10 @@ describe("POST /api/zero/teams/bot", () => {
     const secondRunId = await runIdForPrompt(actor, "active run two");
 
     const queuedResponse = await postTeamsActivity({
-      activity: teamsPersonalMessageActivity({
+      activity: teamsPersonalThreadMessageActivity({
         fixture,
         id: "activity-queue-third",
+        threadId: "activity-queue-thread-3",
         text: "queued run three",
       }),
       token: teamsToken(),

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -39,6 +39,7 @@ import {
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { slackSessionThreadTs } from "./slack-chat-ingress.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-message-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import {
@@ -94,6 +95,10 @@ function slackChannelType(
     return "group_dm";
   }
   return "channel";
+}
+
+function slackPhysicalThreadTs(event: SlackAgentEvent): string {
+  return event.thread_ts ?? event.ts;
 }
 
 function buildSlackSystemPrompt(args: {
@@ -233,7 +238,11 @@ function requireMatchingEvent(
     parsed.team_id !== route.workspaceId ||
     event.user !== route.slackUserId ||
     event.channel !== route.channelId ||
-    (event.thread_ts ?? event.ts) !== route.threadTs
+    slackSessionThreadTs({
+      channelType: slackChannelType(event),
+      messageTs: event.ts,
+      ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
+    }) !== route.threadTs
   ) {
     throw new Error("Canonical Slack ingress payload does not match its route");
   }
@@ -272,17 +281,22 @@ interface PersistedCanonicalSlackIngress {
   readonly chatThreadId: string;
   readonly channelId: string;
   readonly threadTs: string;
+  readonly routeThreadTs?: string;
 }
 
 function persistedCanonicalSlackIngress(
   ingress: NonNullable<Awaited<ReturnType<typeof loadClaimedIngress>>>,
+  threadTs: string,
   chatThreadId: string,
 ): PersistedCanonicalSlackIngress {
   return {
     userId: ingress.userId,
     chatThreadId,
     channelId: ingress.channelId,
-    threadTs: ingress.threadTs,
+    threadTs,
+    ...(threadTs === ingress.threadTs
+      ? {}
+      : { routeThreadTs: ingress.threadTs }),
   };
 }
 
@@ -394,6 +408,7 @@ const persistClaimedCanonicalSlackIngress$ = command(
     const chatThreadId = ingress.chatThreadId;
     const orgId = ingress.orgId;
     const event = requireMatchingEvent(ingress.payload, ingress);
+    const threadTs = slackPhysicalThreadTs(event);
     const featureContext = await loadUserFeatureSwitchContext(
       db,
       orgId,
@@ -410,7 +425,7 @@ const persistClaimedCanonicalSlackIngress$ = command(
       client,
       ingressId,
       channelId: ingress.channelId,
-      threadTs: ingress.threadTs,
+      threadTs,
     });
     signal.throwIfAborted();
     const userInfoResolver = createSlackUserInfoResolver(client);
@@ -472,12 +487,15 @@ const persistClaimedCanonicalSlackIngress$ = command(
           botUserId: ingress.botUserId,
           channelId: ingress.channelId,
           channelType: slackChannelType(event),
-          threadTs: ingress.threadTs,
+          threadTs,
           executionContext: context.executionContext,
         }),
         slackDelivery: {
           channelId: ingress.channelId,
-          threadTs: ingress.threadTs,
+          threadTs,
+          ...(threadTs === ingress.threadTs
+            ? {}
+            : { routeThreadTs: ingress.threadTs }),
         },
         userInfoExtras: enriched.userInfoExtras,
       },
@@ -499,7 +517,7 @@ const persistClaimedCanonicalSlackIngress$ = command(
       signal,
     );
     signal.throwIfAborted();
-    return persistedCanonicalSlackIngress(ingress, chatThreadId);
+    return persistedCanonicalSlackIngress(ingress, threadTs, chatThreadId);
   },
 );
 
@@ -547,6 +565,9 @@ export const processCanonicalSlackIngress$ = command(
               chatThreadId: ingress.chatThreadId,
               channelId: ingress.channelId,
               threadTs: ingress.threadTs,
+              ...(ingress.routeThreadTs
+                ? { routeThreadTs: ingress.routeThreadTs }
+                : {}),
             },
             signal,
           ),

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -39,7 +39,10 @@ import {
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { slackSessionThreadTs } from "./slack-chat-ingress.service";
+import {
+  isSlackDirectMessageSessionThreadTs,
+  slackSessionThreadTs,
+} from "./slack-chat-ingress.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-message-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import {
@@ -234,15 +237,21 @@ function requireMatchingEvent(
 ) {
   const parsed = slackEventCallbackSchema.parse(JSON.parse(payload) as unknown);
   const event = parsed.event;
+  const channelType = slackChannelType(event);
+  const matchesThread =
+    channelType === "dm" && !event.thread_ts
+      ? isSlackDirectMessageSessionThreadTs(route.threadTs) ||
+        route.threadTs === event.ts
+      : slackSessionThreadTs({
+          channelType,
+          messageTs: event.ts,
+          ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
+        }) === route.threadTs;
   if (
     parsed.team_id !== route.workspaceId ||
     event.user !== route.slackUserId ||
     event.channel !== route.channelId ||
-    slackSessionThreadTs({
-      channelType: slackChannelType(event),
-      messageTs: event.ts,
-      ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
-    }) !== route.threadTs
+    !matchesThread
   ) {
     throw new Error("Canonical Slack ingress payload does not match its route");
   }

--- a/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
@@ -170,7 +170,7 @@ async function canonicalSlackThreadHasOutstandingWorkInSnapshot(
     )
     .innerJoin(
       slackChatIngress,
-      eq(slackChatIngress.id, chatMessages.revokesMessageId),
+      eq(slackChatIngress.id, chatMessages.revokesEventId),
     )
     .where(
       and(

--- a/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-thread-status.service.ts
@@ -1,11 +1,13 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { slackChatIngress } from "@vm0/db/schema/slack-chat-ingress";
 import { slackChatThreadRoutes } from "@vm0/db/schema/slack-chat-thread-route";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
 
 import type { Db } from "../external/db";
 import {
@@ -18,10 +20,18 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
 const ACTIVE_INGRESS_STATUSES = ["pending", "processing"] as const;
 
+const slackStatusIngressPayloadSchema = z.object({
+  event: z.object({
+    ts: z.string(),
+    thread_ts: z.string().optional(),
+  }),
+});
+
 export interface CanonicalSlackThreadStatusTarget {
   readonly chatThreadId: string;
   readonly channelId: string;
   readonly threadTs: string;
+  readonly routeThreadTs?: string;
 }
 
 interface CanonicalSlackThreadStatusBinding {
@@ -58,7 +68,10 @@ async function loadCanonicalSlackThreadStatusBinding(
       and(
         eq(slackChatThreadRoutes.chatThreadId, target.chatThreadId),
         eq(slackChatThreadRoutes.channelId, target.channelId),
-        eq(slackChatThreadRoutes.threadTs, target.threadTs),
+        eq(
+          slackChatThreadRoutes.threadTs,
+          target.routeThreadTs ?? target.threadTs,
+        ),
         eq(slackOrgConnections.vm0UserId, slackChatThreadRoutes.userId),
       ),
     )
@@ -74,6 +87,8 @@ async function canonicalSlackThreadHasOutstandingWorkInSnapshot(
   target: CanonicalSlackThreadStatusTarget,
   workspaceId: string,
 ): Promise<boolean> {
+  const routeThreadTs = target.routeThreadTs ?? target.threadTs;
+  const spansPhysicalThreads = routeThreadTs !== target.threadTs;
   const routes = await db
     .select({
       id: slackChatThreadRoutes.id,
@@ -88,7 +103,7 @@ async function canonicalSlackThreadHasOutstandingWorkInSnapshot(
       and(
         eq(slackOrgConnections.slackWorkspaceId, workspaceId),
         eq(slackChatThreadRoutes.channelId, target.channelId),
-        eq(slackChatThreadRoutes.threadTs, target.threadTs),
+        eq(slackChatThreadRoutes.threadTs, routeThreadTs),
       ),
     );
   const routeIds = routes.map((route) => {
@@ -102,46 +117,81 @@ async function canonicalSlackThreadHasOutstandingWorkInSnapshot(
   }
 
   const activeIngress = await db
-    .select({ id: slackChatIngress.id })
+    .select({ payload: slackChatIngress.payload })
     .from(slackChatIngress)
     .where(
       and(
         inArray(slackChatIngress.routeId, routeIds),
         inArray(slackChatIngress.status, ACTIVE_INGRESS_STATUSES),
       ),
-    )
-    .limit(1);
-  if (activeIngress.length > 0) {
+    );
+  if (
+    activeIngress.some((ingress) => {
+      return (
+        !spansPhysicalThreads ||
+        slackPhysicalThreadTs(ingress.payload) === target.threadTs
+      );
+    })
+  ) {
     return true;
   }
   const queuedSlackMessages = await db
-    .select({ id: chatMessageQueue.id })
+    .select({ payload: slackChatIngress.payload })
     .from(chatMessageQueue)
+    .innerJoin(
+      slackChatIngress,
+      eq(slackChatIngress.id, chatMessageQueue.chatMessageId),
+    )
     .where(
       and(
         inArray(chatMessageQueue.chatThreadId, chatThreadIds),
         eq(chatMessageQueue.itemType, "slack_user_message"),
       ),
-    )
-    .limit(1);
+    );
   // Dequeue atomically replaces this row with an active run, so the row
   // itself keeps the physical Slack thread busy during that handoff.
-  if (queuedSlackMessages.length > 0) {
+  if (
+    queuedSlackMessages.some((message) => {
+      return (
+        !spansPhysicalThreads ||
+        slackPhysicalThreadTs(message.payload) === target.threadTs
+      );
+    })
+  ) {
     return true;
   }
   const activeRuns = await db
-    .select({ triggerSource: zeroRuns.triggerSource })
+    .select({ payload: slackChatIngress.payload })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .innerJoin(
+      chatMessages,
+      and(eq(chatMessages.runId, zeroRuns.id), eq(chatMessages.role, "user")),
+    )
+    .innerJoin(
+      slackChatIngress,
+      eq(slackChatIngress.id, chatMessages.revokesMessageId),
+    )
     .where(
       and(
         inArray(zeroRuns.chatThreadId, chatThreadIds),
         inArray(agentRuns.status, ACTIVE_RUN_STATUSES),
+        eq(zeroRuns.triggerSource, "slack"),
       ),
     );
   return activeRuns.some((run) => {
-    return run.triggerSource === "slack";
+    return (
+      !spansPhysicalThreads ||
+      slackPhysicalThreadTs(run.payload) === target.threadTs
+    );
   });
+}
+
+function slackPhysicalThreadTs(payload: string): string {
+  const parsed = slackStatusIngressPayloadSchema.parse(
+    JSON.parse(payload) as unknown,
+  );
+  return parsed.event.thread_ts ?? parsed.event.ts;
 }
 
 async function canonicalSlackThreadHasOutstandingWork(
@@ -172,7 +222,8 @@ export async function canonicalSlackThreadStatusTargetForIngress(
     .select({
       chatThreadId: slackChatThreadRoutes.chatThreadId,
       channelId: slackChatThreadRoutes.channelId,
-      threadTs: slackChatThreadRoutes.threadTs,
+      routeThreadTs: slackChatThreadRoutes.threadTs,
+      payload: slackChatIngress.payload,
     })
     .from(slackChatIngress)
     .innerJoin(
@@ -184,10 +235,14 @@ export async function canonicalSlackThreadStatusTargetForIngress(
   if (!target) {
     return undefined;
   }
+  const threadTs = slackPhysicalThreadTs(target.payload);
   return {
     chatThreadId: target.chatThreadId,
     channelId: target.channelId,
-    threadTs: target.threadTs,
+    threadTs,
+    ...(threadTs === target.routeThreadTs
+      ? {}
+      : { routeThreadTs: target.routeThreadTs }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -299,6 +299,7 @@ const chatCallbackPayloadSchema = z
       .object({
         channelId: z.string(),
         threadTs: z.string(),
+        routeThreadTs: z.string().optional(),
       })
       .optional(),
     feishuDelivery: feishuDeliveryTargetSchema.optional(),
@@ -473,6 +474,7 @@ interface ChatCallbackDependencies {
       readonly agentId: string;
       readonly channelId: string;
       readonly threadTs: string;
+      readonly routeThreadTs?: string;
       readonly chatMessageId: string;
     },
     signal: AbortSignal,
@@ -541,6 +543,7 @@ interface CreateQueuedChatRunInput {
   readonly slackDelivery?: {
     readonly channelId: string;
     readonly threadTs: string;
+    readonly routeThreadTs?: string;
   };
   readonly feishuDelivery?: FeishuDeliveryTarget;
   readonly teamsDelivery?: TeamsDeliveryTarget;
@@ -566,6 +569,7 @@ interface SlackQueuedMessageAdmissionFailure {
   readonly slackDelivery: {
     readonly channelId: string;
     readonly threadTs: string;
+    readonly routeThreadTs?: string;
   };
   readonly error: QueuedMessageModelRouteError;
 }
@@ -1034,6 +1038,7 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 interface SlackDeliveryTarget {
   readonly channelId: string;
   readonly threadTs: string;
+  readonly routeThreadTs?: string;
 }
 
 async function insertSlackChatDeliveryCallback(args: {
@@ -1069,8 +1074,7 @@ async function insertSlackChatDeliveryCallback(args: {
       internalKind: "slack:chat",
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
-        channelId: args.target.channelId,
-        threadTs: args.target.threadTs,
+        ...args.target,
         chatMessageId: args.chatMessageId,
       },
     })
@@ -2822,6 +2826,9 @@ async function handleSlackQueuedMessageAdmissionFailure(args: {
         agentId: args.failure.agentId,
         channelId: args.failure.slackDelivery.channelId,
         threadTs: args.failure.slackDelivery.threadTs,
+        ...(args.failure.slackDelivery.routeThreadTs
+          ? { routeThreadTs: args.failure.slackDelivery.routeThreadTs }
+          : {}),
         chatMessageId: failed.assistantMessageId,
       },
       args.signal,
@@ -3309,6 +3316,9 @@ async function clearSlackThreadStatusAfterTerminalCallback(args: {
         chatThreadId: args.chatThreadId,
         channelId: args.slackDelivery.channelId,
         threadTs: args.slackDelivery.threadTs,
+        ...(args.slackDelivery.routeThreadTs
+          ? { routeThreadTs: args.slackDelivery.routeThreadTs }
+          : {}),
       },
       args.signal,
     ),
@@ -3706,6 +3716,11 @@ async function handleChatInternalCallback(args: {
               chatThreadId: payload.data.threadId,
               channelId: payload.data.slackDelivery.channelId,
               threadTs: payload.data.slackDelivery.threadTs,
+              ...(payload.data.slackDelivery.routeThreadTs
+                ? {
+                    routeThreadTs: payload.data.slackDelivery.routeThreadTs,
+                  }
+                : {}),
             },
             backgroundSignal,
           ),

--- a/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
@@ -166,7 +166,10 @@ async function loadSlackChatDeliveryContext(args: {
       and(
         eq(slackChatThreadRoutes.chatThreadId, run.chatThreadId),
         eq(slackChatThreadRoutes.channelId, payload.channelId),
-        eq(slackChatThreadRoutes.threadTs, payload.threadTs),
+        eq(
+          slackChatThreadRoutes.threadTs,
+          payload.routeThreadTs ?? payload.threadTs,
+        ),
         eq(slackChatThreadRoutes.userId, run.userId),
         eq(slackOrgConnections.vm0UserId, run.userId),
         eq(slackOrgInstallations.orgId, run.orgId),
@@ -216,7 +219,7 @@ async function deliverClaimedSlackChatCallback(args: {
       db: args.db,
       workspaceId: binding.workspaceId,
       channelId: payload.channelId,
-      threadTs: payload.threadTs,
+      threadTs: payload.routeThreadTs ?? payload.threadTs,
     }),
     loadUserFeatureSwitchContext(args.db, run.orgId, run.userId),
   ]);
@@ -320,6 +323,7 @@ export async function deliverSlackChatAdmissionFailure(args: {
   readonly agentId: string;
   readonly channelId: string;
   readonly threadTs: string;
+  readonly routeThreadTs?: string;
   readonly chatMessageId: string;
   readonly signal: AbortSignal;
 }): Promise<void> {
@@ -358,7 +362,10 @@ export async function deliverSlackChatAdmissionFailure(args: {
         and(
           eq(slackChatThreadRoutes.chatThreadId, args.chatThreadId),
           eq(slackChatThreadRoutes.channelId, args.channelId),
-          eq(slackChatThreadRoutes.threadTs, args.threadTs),
+          eq(
+            slackChatThreadRoutes.threadTs,
+            args.routeThreadTs ?? args.threadTs,
+          ),
           eq(slackChatThreadRoutes.userId, args.userId),
           eq(slackOrgConnections.vm0UserId, args.userId),
           eq(slackOrgInstallations.orgId, args.orgId),
@@ -379,7 +386,7 @@ export async function deliverSlackChatAdmissionFailure(args: {
         db: args.db,
         workspaceId: binding.workspaceId,
         channelId: args.channelId,
-        threadTs: args.threadTs,
+        threadTs: args.routeThreadTs ?? args.threadTs,
       }),
       loadUserFeatureSwitchContext(args.db, args.orgId, args.userId),
       args.db

--- a/turbo/apps/api/src/signals/services/slack-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/slack-chat-callback-payload.ts
@@ -3,5 +3,6 @@ import { z } from "zod";
 export const slackChatCallbackPayloadSchema = z.object({
   channelId: z.string(),
   threadTs: z.string(),
+  routeThreadTs: z.string().optional(),
   chatMessageId: z.string(),
 });

--- a/turbo/apps/api/src/signals/services/slack-chat-ingress.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-chat-ingress.service.ts
@@ -21,6 +21,19 @@ interface SlackChatThreadRouteBinding extends SlackChatThreadRouteKey {
   readonly chatThreadId: string;
 }
 
+const SLACK_DIRECT_MESSAGE_THREAD_TS = "direct-message";
+
+export function slackSessionThreadTs(args: {
+  readonly channelType: "channel" | "dm" | "group_dm";
+  readonly messageTs: string;
+  readonly threadTs?: string;
+}): string {
+  if (args.channelType === "dm" && !args.threadTs) {
+    return SLACK_DIRECT_MESSAGE_THREAD_TS;
+  }
+  return args.threadTs ?? args.messageTs;
+}
+
 function slackChatThreadRouteWhere(key: SlackChatThreadRouteKey) {
   return and(
     eq(slackChatThreadRoutes.connectionId, key.connectionId),

--- a/turbo/apps/api/src/signals/services/slack-chat-ingress.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-chat-ingress.service.ts
@@ -27,11 +27,17 @@ export function slackSessionThreadTs(args: {
   readonly channelType: "channel" | "dm" | "group_dm";
   readonly messageTs: string;
   readonly threadTs?: string;
+  readonly agentComposeId?: string;
+  readonly selectedModel?: string | null;
 }): string {
-  if (args.channelType === "dm" && !args.threadTs) {
-    return SLACK_DIRECT_MESSAGE_THREAD_TS;
+  if (args.channelType === "dm" && !args.threadTs && args.agentComposeId) {
+    return `${SLACK_DIRECT_MESSAGE_THREAD_TS}:${args.agentComposeId}:${args.selectedModel ?? "default"}`;
   }
   return args.threadTs ?? args.messageTs;
+}
+
+export function isSlackDirectMessageSessionThreadTs(threadTs: string): boolean {
+  return threadTs.startsWith(`${SLACK_DIRECT_MESSAGE_THREAD_TS}:`);
 }
 
 function slackChatThreadRouteWhere(key: SlackChatThreadRouteKey) {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -48,6 +48,7 @@ const queuedUserMessageRunParamsSchema = z.object({
     .object({
       channelId: z.string(),
       threadTs: z.string(),
+      routeThreadTs: z.string().optional(),
     })
     .optional(),
   feishuDelivery: z

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1,6 +1,10 @@
 import { command, computed, type Computed } from "ccstate";
 import type { Block, KnownBlock } from "@slack/web-api";
-import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   getVm0VisibleModels,
   isSupportedRunModel,
@@ -211,6 +215,18 @@ type SlackAgentRouteAdmission =
       readonly kind: "ignored";
     };
 
+interface SlackAgentRouteArgs {
+  readonly db: Db;
+  readonly workspaceId: string;
+  readonly channelId: string;
+  readonly channelType: SlackChannelType;
+  readonly slackUserId: string;
+  readonly messageTs: string;
+  readonly threadTs?: string;
+  readonly eventId: string;
+  readonly isRetry: boolean;
+}
+
 interface WorkspaceAgentSummary {
   readonly id: string;
   readonly name: string;
@@ -226,6 +242,11 @@ type EffectiveComposeResolution =
   | {
       readonly status: "not_configured" | "not_found" | "not_accessible";
     };
+
+type ResolvedEffectiveCompose = Extract<
+  EffectiveComposeResolution,
+  { readonly status: "resolved" }
+>;
 
 interface SlackAgentAdmissionNoticeBase {
   readonly installation: SlackInstallation;
@@ -687,20 +708,168 @@ const postSlackAgentAdmissionNotice$ = command(
   },
 );
 
+const resolveSlackRouteCompose$ = command(
+  async (
+    { set },
+    args: SlackAgentAdmissionNoticeBase & {
+      readonly db: Db;
+      readonly connection: SlackConnection;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ResolvedEffectiveCompose | undefined> => {
+    const effectiveCompose = await resolveEffectiveCompose(
+      args.db,
+      args.connection.vm0UserId,
+      args.orgId,
+    );
+    signal.throwIfAborted();
+    if (effectiveCompose.status === "resolved") {
+      return effectiveCompose;
+    }
+    waitUntil(
+      tapError(
+        set(postSlackAgentAdmissionNotice$, {
+          kind: effectiveCompose.status,
+          installation: args.installation,
+          connection: args.connection,
+          workspaceId: args.workspaceId,
+          channelId: args.channelId,
+          channelType: args.channelType,
+          slackUserId: args.slackUserId,
+          messageTs: args.messageTs,
+          ...(args.threadTs ? { threadTs: args.threadTs } : {}),
+        }),
+        (error) => {
+          L.error("Failed to post Slack admission notice", { error });
+        },
+      ),
+    );
+    return undefined;
+  },
+);
+
+const resolveConnectedSlackAgentRouteAdmission$ = command(
+  async (
+    { get, set },
+    args: SlackAgentRouteArgs & {
+      readonly installation: SlackInstallation;
+      readonly connection: SlackConnection;
+      readonly orgId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<SlackAgentRouteAdmission> => {
+    const overrides = await get(
+      userFeatureSwitchOverrides(args.orgId, args.connection.vm0UserId),
+    );
+    signal.throwIfAborted();
+    const reuseMainDirectMessageSession =
+      args.channelType === "dm" &&
+      args.threadTs === undefined &&
+      isFeatureEnabled(FeatureSwitchKey.SlackDmSessionRouting, {
+        orgId: args.orgId,
+        userId: args.connection.vm0UserId,
+        overrides,
+      });
+    let effectiveCompose = reuseMainDirectMessageSession
+      ? await set(
+          resolveSlackRouteCompose$,
+          {
+            db: args.db,
+            connection: args.connection,
+            orgId: args.orgId,
+            installation: args.installation,
+            workspaceId: args.workspaceId,
+            channelId: args.channelId,
+            channelType: args.channelType,
+            slackUserId: args.slackUserId,
+            messageTs: args.messageTs,
+          },
+          signal,
+        )
+      : undefined;
+    if (reuseMainDirectMessageSession && !effectiveCompose) {
+      return { kind: "ignored" };
+    }
+    const mainDirectMessageModelRoute = reuseMainDirectMessageSession
+      ? await set(
+          resolveIntegrationModelRouteForUser$,
+          {
+            orgId: args.orgId,
+            userId: args.connection.vm0UserId,
+          },
+          signal,
+        )
+      : undefined;
+    signal.throwIfAborted();
+    const sessionThreadTs = slackSessionThreadTs({
+      channelType: args.channelType,
+      messageTs: args.messageTs,
+      ...(args.threadTs ? { threadTs: args.threadTs } : {}),
+      ...(effectiveCompose
+        ? { agentComposeId: effectiveCompose.composeId }
+        : {}),
+      selectedModel: mainDirectMessageModelRoute?.selectedModel ?? null,
+    });
+    const routeKey = {
+      connectionId: args.connection.id,
+      channelId: args.channelId,
+      threadTs: sessionThreadTs,
+      userId: args.connection.vm0UserId,
+    };
+    const existingRoute = await findSlackChatThreadRoute(args.db, routeKey);
+    signal.throwIfAborted();
+    if (existingRoute) {
+      return { kind: "canonical", routeId: existingRoute.id };
+    }
+
+    effectiveCompose ??= await set(
+      resolveSlackRouteCompose$,
+      {
+        db: args.db,
+        connection: args.connection,
+        orgId: args.orgId,
+        installation: args.installation,
+        workspaceId: args.workspaceId,
+        channelId: args.channelId,
+        channelType: args.channelType,
+        slackUserId: args.slackUserId,
+        messageTs: args.messageTs,
+        ...(args.threadTs ? { threadTs: args.threadTs } : {}),
+      },
+      signal,
+    );
+    if (!effectiveCompose) {
+      return { kind: "ignored" };
+    }
+
+    const modelRoute = reuseMainDirectMessageSession
+      ? mainDirectMessageModelRoute
+      : await set(
+          resolveIntegrationModelRouteForUser$,
+          {
+            orgId: args.orgId,
+            userId: args.connection.vm0UserId,
+          },
+          signal,
+        );
+    signal.throwIfAborted();
+    const route = await ensureCanonicalSlackChatThreadRoute(args.db, {
+      ...routeKey,
+      orgId: args.orgId,
+      agentComposeId: effectiveCompose.composeId,
+      selectedModel: modelRoute?.selectedModel ?? null,
+      currentTime: nowDate(),
+    });
+    signal.throwIfAborted();
+    return { kind: "canonical", routeId: route.id };
+  },
+);
+
 const resolveSlackAgentRouteAdmission$ = command(
   async (
     { set },
-    args: {
-      readonly db: Db;
-      readonly workspaceId: string;
-      readonly channelId: string;
-      readonly channelType: SlackChannelType;
-      readonly slackUserId: string;
-      readonly messageTs: string;
-      readonly threadTs?: string;
-      readonly eventId: string;
-      readonly isRetry: boolean;
-    },
+    args: SlackAgentRouteArgs,
     signal: AbortSignal,
   ): Promise<SlackAgentRouteAdmission> => {
     const installation = await installationForWorkspace(
@@ -740,70 +909,11 @@ const resolveSlackAgentRouteAdmission$ = command(
       }
       return { kind: "ignored" };
     }
-
-    const sessionThreadTs = slackSessionThreadTs({
-      channelType: args.channelType,
-      messageTs: args.messageTs,
-      ...(args.threadTs ? { threadTs: args.threadTs } : {}),
-    });
-    const routeKey = {
-      connectionId: connection.id,
-      channelId: args.channelId,
-      threadTs: sessionThreadTs,
-      userId: connection.vm0UserId,
-    };
-    const existingRoute = await findSlackChatThreadRoute(args.db, routeKey);
-    signal.throwIfAborted();
-    if (existingRoute) {
-      return { kind: "canonical", routeId: existingRoute.id };
-    }
-
-    const effectiveCompose = await resolveEffectiveCompose(
-      args.db,
-      connection.vm0UserId,
-      orgId,
-    );
-    signal.throwIfAborted();
-    if (effectiveCompose.status !== "resolved") {
-      waitUntil(
-        tapError(
-          set(postSlackAgentAdmissionNotice$, {
-            kind: effectiveCompose.status,
-            installation,
-            connection,
-            workspaceId: args.workspaceId,
-            channelId: args.channelId,
-            channelType: args.channelType,
-            slackUserId: args.slackUserId,
-            messageTs: args.messageTs,
-            ...(args.threadTs ? { threadTs: args.threadTs } : {}),
-          }),
-          (error) => {
-            L.error("Failed to post Slack admission notice", { error });
-          },
-        ),
-      );
-      return { kind: "ignored" };
-    }
-
-    const modelRoute = await set(
-      resolveIntegrationModelRouteForUser$,
-      {
-        orgId,
-        userId: connection.vm0UserId,
-      },
+    return await set(
+      resolveConnectedSlackAgentRouteAdmission$,
+      { ...args, installation, connection, orgId },
       signal,
     );
-    signal.throwIfAborted();
-    const route = await ensureCanonicalSlackChatThreadRoute(args.db, {
-      ...routeKey,
-      orgId,
-      agentComposeId: effectiveCompose.composeId,
-      selectedModel: modelRoute?.selectedModel ?? null,
-      currentTime: nowDate(),
-    });
-    signal.throwIfAborted();
-    return { kind: "canonical", routeId: route.id };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -62,6 +62,7 @@ import {
   admitCanonicalSlackChatEvent,
   ensureCanonicalSlackChatThreadRoute,
   findSlackChatThreadRoute,
+  slackSessionThreadTs,
 } from "./slack-chat-ingress.service";
 import { processCanonicalSlackIngress$ } from "./canonical-slack-ingress-processor.service";
 import { onRejection, safeJsonParse, tapError } from "../utils";
@@ -740,11 +741,15 @@ const resolveSlackAgentRouteAdmission$ = command(
       return { kind: "ignored" };
     }
 
-    const physicalThreadTs = args.threadTs ?? args.messageTs;
+    const sessionThreadTs = slackSessionThreadTs({
+      channelType: args.channelType,
+      messageTs: args.messageTs,
+      ...(args.threadTs ? { threadTs: args.threadTs } : {}),
+    });
     const routeKey = {
       connectionId: connection.id,
       channelId: args.channelId,
-      threadTs: physicalThreadTs,
+      threadTs: sessionThreadTs,
       userId: connection.vm0UserId,
     };
     const existingRoute = await findSlackChatThreadRoute(args.db, routeKey);

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -100,6 +100,7 @@ const TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE =
   "application/vnd.microsoft.teams.file.download.info";
 const TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE = "reference";
 const TEAMS_CHAT_MESSAGE_ID_NAMESPACE = "b60a5846-d85f-4db8-b9aa-d7d803efbb57";
+const TEAMS_DIRECT_MESSAGE_THREAD_ID = "direct-message";
 
 type TeamsBotCommand = "help" | "connect" | "disconnect" | "switch" | "model";
 type TeamsCardAction = "switch_agent" | "switch_model";
@@ -1229,6 +1230,16 @@ function isTeamsThreadReply(activity: TeamsMessageActivity): boolean {
   );
 }
 
+function teamsSessionThreadId(activity: TeamsMessageActivity): string {
+  if (
+    activity.conversationType === "personal" &&
+    !isTeamsThreadReply(activity)
+  ) {
+    return TEAMS_DIRECT_MESSAGE_THREAD_ID;
+  }
+  return activity.threadId;
+}
+
 function currentTeamsActivityIds(
   activity: TeamsMessageActivity,
 ): ReadonlySet<string> {
@@ -1548,7 +1559,7 @@ function teamsDeliveryTarget(args: {
     channelId: args.activity.channelId,
     conversationId: args.activity.conversationId,
     conversationType: args.activity.conversationType,
-    threadId: args.activity.threadId,
+    threadId: teamsSessionThreadId(args.activity),
     activityId: args.activity.activityId,
     serviceUrl: args.activity.serviceUrl,
     connectionId: args.connection.id,
@@ -1603,7 +1614,7 @@ async function persistTeamsChatMessage(args: {
   const route = await ensureTeamsChatThreadRoute(args.db, {
     connectionId: args.connection.id,
     conversationId: args.activity.conversationId,
-    threadId: args.activity.threadId,
+    threadId: teamsSessionThreadId(args.activity),
     userId: args.connection.vm0UserId,
     orgId: args.installation.orgId,
     agentComposeId: args.composeId,

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -1230,12 +1230,17 @@ function isTeamsThreadReply(activity: TeamsMessageActivity): boolean {
   );
 }
 
-function teamsSessionThreadId(activity: TeamsMessageActivity): string {
+function teamsSessionThreadId(args: {
+  readonly activity: TeamsMessageActivity;
+  readonly agentId: string;
+  readonly selectedModel: string | null;
+}): string {
+  const { activity } = args;
   if (
     activity.conversationType === "personal" &&
     !isTeamsThreadReply(activity)
   ) {
-    return TEAMS_DIRECT_MESSAGE_THREAD_ID;
+    return `${TEAMS_DIRECT_MESSAGE_THREAD_ID}:${args.agentId}:${args.selectedModel ?? "default"}`;
   }
   return activity.threadId;
 }
@@ -1549,6 +1554,8 @@ function teamsDeliveryTarget(args: {
   readonly activity: TeamsMessageActivity;
   readonly installation: TeamsInstallation;
   readonly connection: TeamsConnection;
+  readonly composeId: string;
+  readonly modelRoute: IntegrationModelRoutePin | undefined;
   readonly files: readonly TeamsPromptFile[];
 }): TeamsDeliveryTarget {
   return teamsDeliveryTargetSchema.parse({
@@ -1559,7 +1566,11 @@ function teamsDeliveryTarget(args: {
     channelId: args.activity.channelId,
     conversationId: args.activity.conversationId,
     conversationType: args.activity.conversationType,
-    threadId: teamsSessionThreadId(args.activity),
+    threadId: teamsSessionThreadId({
+      activity: args.activity,
+      agentId: args.composeId,
+      selectedModel: args.modelRoute?.selectedModel ?? null,
+    }),
     activityId: args.activity.activityId,
     serviceUrl: args.activity.serviceUrl,
     connectionId: args.connection.id,
@@ -1614,7 +1625,11 @@ async function persistTeamsChatMessage(args: {
   const route = await ensureTeamsChatThreadRoute(args.db, {
     connectionId: args.connection.id,
     conversationId: args.activity.conversationId,
-    threadId: teamsSessionThreadId(args.activity),
+    threadId: teamsSessionThreadId({
+      activity: args.activity,
+      agentId: args.composeId,
+      selectedModel: args.modelRoute?.selectedModel ?? null,
+    }),
     userId: args.connection.vm0UserId,
     orgId: args.installation.orgId,
     agentComposeId: args.composeId,
@@ -1627,6 +1642,8 @@ async function persistTeamsChatMessage(args: {
     activity: args.activity,
     installation: args.installation,
     connection: args.connection,
+    composeId: args.composeId,
+    modelRoute: args.modelRoute,
     files: [...args.promptFiles, ...args.promptContext.files],
   });
   const prompt = promptForTeamsRun(args);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -68,6 +68,7 @@ export enum FeatureSwitchKey {
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ComposerSkillSubstringSearch = "composerSkillSubstringSearch",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
+  SlackDmSessionRouting = "slackDmSessionRouting",
   TeamsIntegration = "teamsIntegration",
   FeishuIntegration = "feishuIntegration",
   Artifacts = "artifacts",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -419,6 +419,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.SlackDmSessionRouting]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Reuse agent/model-scoped sessions for top-level Slack direct messages after compatible callback readers are deployed.",
+    enabled: false,
+  },
   [FeatureSwitchKey.TeamsIntegration]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- reuse one agent/model-scoped session for top-level Slack and Teams direct messages
- fork genuine direct-message threads into independent sessions and reuse each thread session
- preserve each main-DM session when switching agents and restore it when switching back
- keep Slack replies and thinking status scoped to the physical message thread while routing the main DM through a stable session key
- stage Slack canonical-route writes behind the disabled-by-default `slackDmSessionRouting` switch

## Rollout

Deploy the compatible Slack callback reader first. Enable `slackDmSessionRouting` only after that reader version is fully deployed; with the switch disabled, Slack continues writing the legacy route shape. Teams does not require this staged activation.

## Verification

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- targeted Slack and Teams integration tests: 5 files, 73 tests passed
- full Vitest suite: 557 files, 7,152 tests passed, 1 benchmark skipped
- `git diff --check`

Follows the Feishu session-routing pattern from #23274.