### PR TITLE
fix(runner): distinguish dns readiness timeouts

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -7,8 +7,9 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
-    SandboxFactory, SandboxId, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
-    SandboxNbdNetlinkConnectStage, SandboxStartObserver, SandboxStartStage,
+    SandboxFactory, SandboxGuestDnsReadinessReason, SandboxId, SandboxNbdCowCreateOutcome,
+    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxStartObserver,
+    SandboxStartStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -524,6 +525,14 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         let cache_hit = workspace_image
             .as_ref()
             .is_some_and(WorkspaceImageLease::is_cache_hit);
+        if failure.invalidate_consumed_workspace_cache && cache_hit {
+            invalidate_workspace_cache_hit(
+                workspace_image.as_ref(),
+                context.run_id,
+                "sandbox_prepare_failed",
+            )
+            .await;
+        }
         let retry_guest_dns = failure.retry == SandboxPrepareRetry::GuestDnsReadiness;
         let retry_without_workspace =
             failure.retry == SandboxPrepareRetry::WithoutWorkspaceImage && cache_hit;
@@ -668,6 +677,7 @@ pub(super) struct SandboxPrepareError {
     error: RunnerError,
     retry: SandboxPrepareRetry,
     cleanup_completed: bool,
+    invalidate_consumed_workspace_cache: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -693,14 +703,29 @@ impl SandboxPrepareError {
             error,
             retry: SandboxPrepareRetry::WithoutWorkspaceImage,
             cleanup_completed,
+            invalidate_consumed_workspace_cache: false,
         }
     }
 
-    fn guest_dns_readiness(error: RunnerError, cleanup_completed: bool) -> Self {
+    fn guest_dns_readiness(
+        error: RunnerError,
+        cleanup_completed: bool,
+        reason: SandboxGuestDnsReadinessReason,
+    ) -> Self {
+        let suppress_replacement = matches!(
+            reason,
+            SandboxGuestDnsReadinessReason::ProcessTimeout
+                | SandboxGuestDnsReadinessReason::Deadline
+        );
         Self {
             error,
-            retry: SandboxPrepareRetry::GuestDnsReadiness,
+            retry: if suppress_replacement {
+                SandboxPrepareRetry::None
+            } else {
+                SandboxPrepareRetry::GuestDnsReadiness
+            },
             cleanup_completed,
+            invalidate_consumed_workspace_cache: suppress_replacement,
         }
     }
 
@@ -709,6 +734,7 @@ impl SandboxPrepareError {
             error,
             retry: SandboxPrepareRetry::None,
             cleanup_completed: false,
+            invalidate_consumed_workspace_cache: false,
         }
     }
 }
@@ -1002,7 +1028,10 @@ async fn create_started_sandbox(
         sandbox.start_with_observer(&mut observer).await
     };
     if let Err(e) = start_result {
-        let guest_dns_readiness = matches!(&e, SandboxError::GuestDnsReadiness { .. });
+        let guest_dns_readiness_reason = match &e {
+            SandboxError::GuestDnsReadiness { reason, .. } => Some(*reason),
+            _ => None,
+        };
         telemetry.record(
             RUNNER_FRESH_SANDBOX_START,
             sandbox_start_started.elapsed(),
@@ -1025,7 +1054,7 @@ async fn create_started_sandbox(
         let network_log_observation = network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
-        if guest_dns_readiness {
+        if guest_dns_readiness_reason.is_some() {
             let observation = match network_log_start_offset {
                 Some(start_offset) => {
                     inspect_readiness_log_segment(&network_log_path, start_offset).await
@@ -1050,10 +1079,11 @@ async fn create_started_sandbox(
             .is_completed();
         let cleanup_completed = unregister_completed && destroy_completed;
         let error = e.into();
-        return Err(if guest_dns_readiness {
-            SandboxPrepareError::guest_dns_readiness(error, cleanup_completed)
-        } else {
-            SandboxPrepareError::retry_without_workspace_image(error, cleanup_completed)
+        return Err(match guest_dns_readiness_reason {
+            Some(reason) => {
+                SandboxPrepareError::guest_dns_readiness(error, cleanup_completed, reason)
+            }
+            None => SandboxPrepareError::retry_without_workspace_image(error, cleanup_completed),
         });
     }
     telemetry.record(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -44,8 +44,12 @@ impl SandboxFactory for CreateGateFactory {
     }
 }
 
-fn guest_dns_readiness_failure(message: &str) -> SandboxError {
+fn guest_dns_readiness_failure(
+    reason: SandboxGuestDnsReadinessReason,
+    message: &str,
+) -> SandboxError {
     SandboxError::GuestDnsReadiness {
+        reason,
         message: message.to_string(),
     }
 }
@@ -257,7 +261,10 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(guest_dns_readiness_failure("first attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "first attachment failed",
+    )));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
     let sandbox_id = SandboxId::new_v4();
@@ -317,11 +324,60 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
 }
 
 #[tokio::test]
+async fn execute_new_sandbox_does_not_replace_guest_exec_timing_failures() {
+    for (reason, message) in [
+        (
+            SandboxGuestDnsReadinessReason::ProcessTimeout,
+            "guest process timed out",
+        ),
+        (
+            SandboxGuestDnsReadinessReason::Deadline,
+            "host deadline expired",
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_result(Err(guest_dns_readiness_failure(reason, message)));
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let ctx = minimal_context();
+        let mut telemetry = test_telemetry(&config, &ctx);
+
+        let result = execute_new_sandbox(
+            &factory,
+            &ctx,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            &mut telemetry,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        let error = result
+            .err()
+            .expect("guest exec timing failure must be returned");
+        assert!(error.to_string().contains(message), "got: {error}");
+        assert_eq!(overrides.create_configs().len(), 1);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert!(overrides.start_process_calls().is_empty());
+        assert_proxy_registry_empty(dir.path()).await;
+        assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
+    }
+}
+
+#[tokio::test]
 async fn dns_readiness_retry_keeps_one_fresh_archive_owner() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(guest_dns_readiness_failure("first attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "first attachment failed",
+    )));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let server = httpmock::MockServer::start_async().await;
     let body = b"fresh archive across DNS retry".to_vec();
@@ -378,8 +434,14 @@ async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(guest_dns_readiness_failure("first attachment failed")));
-    overrides.push_start_result(Err(guest_dns_readiness_failure("second attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "first attachment failed",
+    )));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "second attachment failed",
+    )));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -460,7 +522,10 @@ async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(guest_dns_readiness_failure("attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "attachment failed",
+    )));
     overrides.push_destroy_panic("simulated destroy panic");
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
@@ -505,7 +570,10 @@ async fn execute_new_sandbox_waits_for_destroy_before_dns_retry_create() {
     let config = test_executor_config(dir.path()).await;
     let gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(guest_dns_readiness_failure("attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "attachment failed",
+    )));
     overrides.set_destroy_lifecycle_gate(gate.clone());
     let factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
     let ctx = minimal_context();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -13,7 +13,8 @@ use guest_contracts::diagnostics::{
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ExecTermination, ProcessControlMode, ProcessExit,
-    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxError, SandboxFactory, SandboxId,
+    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxError, SandboxFactory,
+    SandboxGuestDnsReadinessReason, SandboxId,
 };
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -132,6 +132,7 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        reason: SandboxGuestDnsReadinessReason::DnsPath,
         message: "first attachment failed".into(),
     }));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
@@ -203,6 +204,91 @@ async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit
 }
 
 #[tokio::test]
+async fn process_timeout_invalidates_consumed_workspace_cache_without_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        reason: SandboxGuestDnsReadinessReason::ProcessTimeout,
+        message: "guest process timed out".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let session_id = "sess-cache-dns-process-timeout";
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let expected_seed =
+        seed_workspace_image_cache(&cache, &runner_paths, session_id, params.workspace_disk_mb)
+            .await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    let error = result
+        .err()
+        .expect("guest process timeout must be returned");
+    assert!(
+        error.to_string().contains("guest process timed out"),
+        "got: {error}"
+    );
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: params.workspace_disk_mb,
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                expected_seed.clone(),
+            )),
+        })
+    );
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(!expected_seed.exists());
+    assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+    );
+
+    let checkout = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Miss);
+}
+
+#[tokio::test]
 async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
@@ -211,6 +297,7 @@ async fn dns_replacement_records_completion_when_fresh_storage_prepare_fails() {
     config.workspace_cache = Some(cache.clone());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        reason: SandboxGuestDnsReadinessReason::DnsPath,
         message: "first attachment failed".into(),
     }));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -437,7 +437,6 @@ mod tests {
 
         tokio::time::pause();
         tokio::time::advance(Duration::from_millis(1_600)).await;
-        tokio::time::resume();
         send_result(&mut guest, &first, ExecTermination::TimedOut, b"", false).await;
 
         let second = read_message(&mut guest).await;
@@ -469,7 +468,6 @@ mod tests {
 
         tokio::time::pause();
         tokio::time::advance(Duration::from_millis(250)).await;
-        tokio::time::resume();
         send_result(
             &mut guest,
             &first,

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io;
 use std::time::Duration;
 
+use sandbox::SandboxGuestDnsReadinessReason;
 use tokio::time::{Instant, timeout_at};
 use vsock_host::{ExecOperationRequest, ExecOperationResult, ExecOwnedCapturedOutput, VsockHost};
 use vsock_proto::{ExecOutputPolicy, ExecTermination};
@@ -11,19 +12,23 @@ use crate::network::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
 const RESOLVER_ENV: &[(&str, &str)] = &[("RES_OPTIONS", "attempts:1 timeout:1")];
 const LABEL: &str = "guest-dns-readiness";
 const PROCESS_TIMEOUT_MS: u32 = 1_100;
-const OPERATION_WAIT_TIMEOUT: Duration = Duration::from_millis(1_500);
+const OPERATION_START_AND_RESULT_GRACE_MS: u64 = 1_000;
+const OPERATION_WAIT_TIMEOUT: Duration =
+    Duration::from_millis(PROCESS_TIMEOUT_MS as u64 + OPERATION_START_AND_RESULT_GRACE_MS);
 const STDOUT_LIMIT_BYTES: u32 = 1_024;
 const STDERR_LIMIT_BYTES: u32 = 512;
 const EXPECTED_TRANSIENT_EXIT_CODES: &[i32] = &[2];
 
 const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
-    total_timeout: Duration::from_millis(3_500),
+    total_timeout: Duration::from_secs(7),
+    attempt_timeout: OPERATION_WAIT_TIMEOUT,
     max_attempts: 3,
 };
 
 #[derive(Clone, Copy)]
 struct ReadinessPolicy {
     total_timeout: Duration,
+    attempt_timeout: Duration,
     max_attempts: u16,
 }
 
@@ -65,6 +70,23 @@ impl GuestDnsReadinessFailure {
             Self::TimedOut | Self::ExitNonZero(2) | Self::UnexpectedAnswer
         )
     }
+
+    pub(crate) fn sandbox_reason(self) -> SandboxGuestDnsReadinessReason {
+        match self {
+            Self::TimedOut => SandboxGuestDnsReadinessReason::ProcessTimeout,
+            Self::Deadline => SandboxGuestDnsReadinessReason::Deadline,
+            Self::ExitNonZero(2) | Self::UnexpectedAnswer => {
+                SandboxGuestDnsReadinessReason::DnsPath
+            }
+            Self::Transport(_)
+            | Self::Cancelled
+            | Self::StartFailed
+            | Self::WaitFailed
+            | Self::ExitNonZero(_)
+            | Self::OutputTruncated
+            | Self::InvalidOutput => SandboxGuestDnsReadinessReason::Other,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,14 +126,14 @@ async fn wait_for_guest_dns_readiness_with_policy(
 
     loop {
         attempts += 1;
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        let failure = match probe_guest_dns_once(guest, remaining.min(OPERATION_WAIT_TIMEOUT)).await
-        {
+        let failure = match probe_guest_dns_once(guest, policy.attempt_timeout).await {
             Ok(()) => return Ok(()),
             Err(failure) => failure,
         };
 
-        if !failure.retryable() || attempts >= policy.max_attempts || Instant::now() >= deadline {
+        let complete_retry_fits =
+            deadline.saturating_duration_since(Instant::now()) >= policy.attempt_timeout;
+        if !failure.retryable() || attempts >= policy.max_attempts || !complete_retry_fits {
             return Err(GuestDnsReadinessError {
                 attempts,
                 elapsed: started.elapsed(),
@@ -234,6 +256,7 @@ mod tests {
 
     const TEST_POLICY: ReadinessPolicy = ReadinessPolicy {
         total_timeout: Duration::from_secs(1),
+        attempt_timeout: Duration::from_millis(250),
         max_attempts: 3,
     };
 
@@ -405,6 +428,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn guest_dns_readiness_retries_late_guest_process_timeout() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, PRODUCTION_POLICY).await
+        });
+        let first = read_message(&mut guest).await;
+
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_millis(1_600)).await;
+        tokio::time::resume();
+        send_result(&mut guest, &first, ExecTermination::TimedOut, b"", false).await;
+
+        let second = read_message(&mut guest).await;
+        send_result(
+            &mut guest,
+            &second,
+            ExecTermination::Exited { exit_code: 0 },
+            b"192.0.2.1 STREAM vm0-readiness.invalid\n",
+            false,
+        )
+        .await;
+
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_does_not_start_shortened_retry() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let policy = ReadinessPolicy {
+            total_timeout: Duration::from_millis(500),
+            attempt_timeout: Duration::from_millis(300),
+            max_attempts: 3,
+        };
+        let task =
+            tokio::spawn(
+                async move { wait_for_guest_dns_readiness_with_policy(&host, policy).await },
+            );
+        let first = read_message(&mut guest).await;
+
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_millis(250)).await;
+        tokio::time::resume();
+        send_result(
+            &mut guest,
+            &first,
+            ExecTermination::Exited { exit_code: 2 },
+            b"",
+            false,
+        )
+        .await;
+
+        let error = task.await.unwrap().unwrap_err();
+        assert_eq!(error.attempts, 1);
+        assert_eq!(error.last_failure, GuestDnsReadinessFailure::ExitNonZero(2));
+        assert!(error.elapsed < policy.total_timeout);
+    }
+
+    #[tokio::test]
     async fn guest_dns_readiness_stops_at_attempt_limit() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
@@ -436,6 +517,7 @@ mod tests {
         tokio::time::pause();
         let policy = ReadinessPolicy {
             total_timeout: Duration::from_millis(50),
+            attempt_timeout: Duration::from_millis(50),
             max_attempts: 3,
         };
         let readiness =

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1331,6 +1331,7 @@ impl FirecrackerSandbox {
                     );
                     self.runtime.kill_process().await;
                     return Err(SandboxError::GuestDnsReadiness {
+                        reason: error.last_failure.sandbox_reason(),
                         message: format!(
                             "guest DNS readiness for namespace {}: {error}",
                             self.network.name(),

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -31,7 +31,10 @@ pub enum SandboxError {
 
     /// A created sandbox failed the guest-path DNS readiness admission check.
     #[error("sandbox start failed: {message}")]
-    GuestDnsReadiness { message: String },
+    GuestDnsReadiness {
+        reason: SandboxGuestDnsReadinessReason,
+        message: String,
+    },
 
     /// The requested action is invalid for the current runtime, factory, or
     /// sandbox state.
@@ -71,6 +74,19 @@ pub enum SandboxInitializationPhase {
     Factory,
     /// Per-sandbox allocation before sandbox start.
     SandboxAllocation,
+}
+
+/// Root-cause category for a guest-path DNS readiness failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxGuestDnsReadinessReason {
+    /// The guest readiness process reached its own timeout and terminated.
+    ProcessTimeout,
+    /// The host stopped waiting before receiving a terminal guest result.
+    Deadline,
+    /// The guest completed the probe but DNS resolution did not become ready.
+    DnsPath,
+    /// The readiness probe failed for another reason.
+    Other,
 }
 
 impl fmt::Display for SandboxInitializationPhase {

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -33,8 +33,9 @@ pub use config::{
 };
 pub use control::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
 pub use error::{
-    Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
-    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+    Result, SandboxError, SandboxGuestDnsReadinessReason, SandboxIdleTransition,
+    SandboxInitializationPhase, SandboxInvalidStateContext, SandboxOperation,
+    SandboxOperationReason,
 };
 pub use factory::{
     SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxNbdCowCreateOutcome,

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -147,9 +147,17 @@ fn display_includes_file_operation_labels() {
 #[test]
 fn guest_dns_readiness_preserves_start_error_display_contract() {
     let err = SandboxError::GuestDnsReadiness {
+        reason: sandbox::SandboxGuestDnsReadinessReason::ProcessTimeout,
         message: "guest resolver unavailable".into(),
     };
 
+    assert!(matches!(
+        &err,
+        SandboxError::GuestDnsReadiness {
+            reason: sandbox::SandboxGuestDnsReadinessReason::ProcessTimeout,
+            ..
+        }
+    ));
     assert_eq!(
         err.to_string(),
         "sandbox start failed: guest resolver unavailable"


### PR DESCRIPTION
## Summary

- preserve typed guest DNS readiness reasons across the sandbox boundary
- align the guest process timeout, terminal-result grace, per-attempt wait, and total readiness budget
- retry completed guest process timeouts only on the existing attachment when a complete attempt fits
- suppress fresh attachment and workspace fallback for process timeouts and host deadlines while invalidating consumed cache entries
- preserve the existing bounded replacement behavior for DNS-path and other readiness failures

## Exclusions

- no host-wide startup admission or CI fan-out changes
- no runner/guest protocol, persisted-state, configuration, or deployment contract changes
- no netfilter, NAT, dnsmasq, or unrelated transport recovery changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p sandbox --all-targets --all-features`
- `cargo test -p sandbox-fc --all-targets --all-features`
- `cargo test -p runner --all-targets --all-features`

Closes #23271
