### PR TITLE
feat(billing): add monthly invoice downloads

### DIFF
--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -12,28 +12,39 @@ interface StripeInvoice {
   readonly invoice_pdf: string | null;
 }
 
+interface StripeInvoiceCreatedRange {
+  readonly gte: number;
+  readonly lt: number;
+}
+
 const {
   get: getMockedListInvoices,
   set: setMockedListInvoices,
   clear: clearMockedListInvoices,
 } = testOverride<
-  ((customerId: string) => Promise<readonly StripeInvoice[]>) | undefined
+  | ((
+      customerId: string,
+      created?: StripeInvoiceCreatedRange,
+    ) => Promise<readonly StripeInvoice[]>)
+  | undefined
 >(() => {
   return undefined;
 });
 
 export async function listStripeInvoices(
   customerId: string,
+  created?: StripeInvoiceCreatedRange,
 ): Promise<readonly StripeInvoice[]> {
   const mocked = getMockedListInvoices();
   if (mocked) {
-    return await mocked(customerId);
+    return await mocked(customerId, created);
   }
 
   const stripe = new StripeSDK(env("STRIPE_SECRET_KEY"));
   const result = await stripe.invoices.list({
     customer: customerId,
-    limit: 24,
+    limit: created ? 100 : 24,
+    ...(created ? { created } : {}),
   });
 
   return result.data.map((inv) => {
@@ -50,7 +61,10 @@ export async function listStripeInvoices(
 }
 
 export function mockListStripeInvoices(
-  fn: (customerId: string) => Promise<readonly StripeInvoice[]>,
+  fn: (
+    customerId: string,
+    created?: StripeInvoiceCreatedRange,
+  ) => Promise<readonly StripeInvoice[]>,
 ): void {
   setMockedListInvoices(fn);
 }

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -9,6 +9,7 @@ interface StripeInvoice {
   readonly amount_paid: number;
   readonly status: string | null;
   readonly hosted_invoice_url: string | null;
+  readonly invoice_pdf: string | null;
 }
 
 const {
@@ -43,6 +44,7 @@ export async function listStripeInvoices(
       amount_paid: inv.amount_paid,
       status: inv.status ?? null,
       hosted_invoice_url: inv.hosted_invoice_url ?? null,
+      invoice_pdf: inv.invoice_pdf ?? null,
     };
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -196,6 +196,7 @@ describe("BILL-01: billing status and Stripe-backed actions through public API",
           amount_paid: 2500,
           status: "paid",
           hosted_invoice_url: "https://billing.stripe.test/invoices/in_bdd",
+          invoice_pdf: "https://billing.stripe.test/invoices/in_bdd.pdf",
         },
       ],
     });
@@ -208,6 +209,7 @@ describe("BILL-01: billing status and Stripe-backed actions through public API",
         amount: 2500,
         status: "paid",
         hostedInvoiceUrl: "https://billing.stripe.test/invoices/in_bdd",
+        invoicePdfUrl: "https://billing.stripe.test/invoices/in_bdd.pdf",
       },
     ]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -209,9 +209,9 @@ describe("BILL-01: billing status and Stripe-backed actions through public API",
         amount: 2500,
         status: "paid",
         hostedInvoiceUrl: "https://billing.stripe.test/invoices/in_bdd",
-        invoicePdfUrl: "https://billing.stripe.test/invoices/in_bdd.pdf",
       },
     ]);
+    expect(invoices.receiptDownloadsSupported).toBeTruthy();
 
     const memberInvoices = await api.requestInvoices(member, [403]);
     expectApiError(memberInvoices.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -94,6 +94,7 @@ interface StripeInvoice {
   readonly amount_paid: number;
   readonly status: string | null;
   readonly hosted_invoice_url: string | null;
+  readonly invoice_pdf: string | null;
 }
 
 interface CheckoutBody {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -214,11 +214,12 @@ function stripeInvoices(value: unknown): readonly StripeInvoice[] {
 export function createBillingMediaApi(context: TestContext) {
   const routeMocks = createZeroRouteMocks(context);
   mockStripeClient(context.mocks.stripe as unknown as StripeSDK);
-  mockListStripeInvoices(async (customerId) => {
+  mockListStripeInvoices(async (customerId, created) => {
     return stripeInvoices(
       await context.mocks.stripe.invoices.list({
         customer: customerId,
-        limit: 24,
+        limit: created ? 100 : 24,
+        ...(created ? { created } : {}),
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroBillingInvoicesContract } from "@vm0/api-contracts/contracts/zero-billing";
+import AdmZip from "adm-zip";
 import { createStore } from "ccstate";
+import { http, HttpResponse } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
 import { mockListStripeInvoices } from "../../external/stripe-client";
 import {
   deleteInvoicesOrg$,
@@ -133,6 +136,7 @@ describe("GET /api/zero/billing/invoices", () => {
 
     expect(receivedCustomerId).toBe(customerId);
     expect(response.body).toStrictEqual({
+      receiptDownloadsSupported: true,
       invoices: [
         {
           id: "inv_001",
@@ -141,7 +145,6 @@ describe("GET /api/zero/billing/invoices", () => {
           amount: 4000,
           status: "paid",
           hostedInvoiceUrl: "https://stripe.com/invoice/inv_001",
-          invoicePdfUrl: "https://stripe.com/invoice/inv_001.pdf",
         },
         {
           id: "inv_002",
@@ -150,10 +153,93 @@ describe("GET /api/zero/billing/invoices", () => {
           amount: 4000,
           status: "paid",
           hostedInvoiceUrl: "https://stripe.com/invoice/inv_002",
-          invoicePdfUrl: "https://stripe.com/invoice/inv_002.pdf",
         },
       ],
     });
+  });
+
+  it("downloads all receipts for a selected month as a ZIP", async () => {
+    const customerId = `cus-receipts-${randomUUID().slice(0, 8)}`;
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: `sub-receipts-${randomUUID().slice(0, 8)}`,
+          subscriptionStatus: "active",
+          tier: "pro",
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    let receivedCustomerId: string | null = null;
+    let receivedRange: { readonly gte: number; readonly lt: number } | null =
+      null;
+    mockListStripeInvoices((stripeCustomerId, created) => {
+      receivedCustomerId = stripeCustomerId;
+      receivedRange = created ?? null;
+      return Promise.resolve([
+        {
+          id: "inv_july_001",
+          number: "INV-JULY-001",
+          created: Date.UTC(2026, 6, 10) / 1000,
+          amount_paid: 2000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.test/invoice/inv_july_001",
+          invoice_pdf: "https://stripe.test/invoice/inv_july_001.pdf",
+        },
+        {
+          id: "inv_july_002",
+          number: "INV-JULY-002",
+          created: Date.UTC(2026, 6, 20) / 1000,
+          amount_paid: 3000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.test/invoice/inv_july_002",
+          invoice_pdf: "https://stripe.test/invoice/inv_july_002.pdf",
+        },
+      ]);
+    });
+    server.use(
+      http.get("https://stripe.test/invoice/inv_july_001.pdf", () => {
+        return new HttpResponse("first receipt", {
+          headers: { "Content-Type": "application/pdf" },
+        });
+      }),
+      http.get("https://stripe.test/invoice/inv_july_002.pdf", () => {
+        return new HttpResponse("second receipt", {
+          headers: { "Content-Type": "application/pdf" },
+        });
+      }),
+    );
+
+    const client = setupApp({ context })(zeroBillingInvoicesContract);
+    const response = await accept(
+      client.downloadReceipts({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { startMonth: "2026-06", endMonth: "2026-07" },
+      }),
+      [200],
+    );
+
+    expect(receivedCustomerId).toBe(customerId);
+    expect(receivedRange).toStrictEqual({
+      gte: Date.UTC(2026, 5, 1) / 1000,
+      lt: Date.UTC(2026, 7, 1) / 1000,
+    });
+    const archive = new AdmZip(Buffer.from(await response.body.arrayBuffer()));
+    expect(
+      archive.getEntries().map((entry) => {
+        return entry.entryName;
+      }),
+    ).toStrictEqual(["receipt-INV-JULY-001.pdf", "receipt-INV-JULY-002.pdf"]);
+    expect(archive.readAsText("receipt-INV-JULY-001.pdf")).toBe(
+      "first receipt",
+    );
+    expect(archive.readAsText("receipt-INV-JULY-002.pdf")).toBe(
+      "second receipt",
+    );
   });
 
   it("returns an empty list when the org has no Stripe customer", async () => {
@@ -174,7 +260,10 @@ describe("GET /api/zero/billing/invoices", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ invoices: [] });
+    expect(response.body).toStrictEqual({
+      invoices: [],
+      receiptDownloadsSupported: true,
+    });
   });
 
   it("returns an empty list when Stripe returns no invoices", async () => {
@@ -205,6 +294,9 @@ describe("GET /api/zero/billing/invoices", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ invoices: [] });
+    expect(response.body).toStrictEqual({
+      invoices: [],
+      receiptDownloadsSupported: true,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-invoices.test.ts
@@ -108,6 +108,7 @@ describe("GET /api/zero/billing/invoices", () => {
           amount_paid: 4000,
           status: "paid",
           hosted_invoice_url: "https://stripe.com/invoice/inv_001",
+          invoice_pdf: "https://stripe.com/invoice/inv_001.pdf",
         },
         {
           id: "inv_002",
@@ -116,6 +117,7 @@ describe("GET /api/zero/billing/invoices", () => {
           amount_paid: 4000,
           status: "paid",
           hosted_invoice_url: "https://stripe.com/invoice/inv_002",
+          invoice_pdf: "https://stripe.com/invoice/inv_002.pdf",
         },
       ]);
     });
@@ -139,6 +141,7 @@ describe("GET /api/zero/billing/invoices", () => {
           amount: 4000,
           status: "paid",
           hostedInvoiceUrl: "https://stripe.com/invoice/inv_001",
+          invoicePdfUrl: "https://stripe.com/invoice/inv_001.pdf",
         },
         {
           id: "inv_002",
@@ -147,6 +150,7 @@ describe("GET /api/zero/billing/invoices", () => {
           amount: 4000,
           status: "paid",
           hostedInvoiceUrl: "https://stripe.com/invoice/inv_002",
+          invoicePdfUrl: "https://stripe.com/invoice/inv_002.pdf",
         },
       ],
     });

--- a/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
@@ -1,9 +1,13 @@
-import { computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroBillingInvoicesContract } from "@vm0/api-contracts/contracts/zero-billing";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { zeroOrgInvoices } from "../services/zero-billing-invoices.service";
+import { queryOf } from "../context/request";
+import {
+  downloadZeroOrgReceiptArchive$,
+  zeroOrgInvoices,
+} from "../services/zero-billing-invoices.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -25,12 +29,71 @@ const getInvoicesInner$ = computed(async (get) => {
   return { status: 200 as const, body: invoices };
 });
 
+const downloadReceiptsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+    const query = get(queryOf(zeroBillingInvoicesContract.downloadReceipts));
+    const result = await set(
+      downloadZeroOrgReceiptArchive$,
+      {
+        orgId: auth.orgId,
+        startMonth: query.startMonth,
+        endMonth: query.endMonth,
+      },
+      signal,
+    );
+    if (result.kind === "not_found") {
+      return Response.json(
+        {
+          error: {
+            message: "No receipts are available for the selected month",
+            code: "NOT_FOUND",
+          },
+        },
+        { status: 404 },
+      );
+    }
+    if (result.kind === "upstream_error") {
+      return Response.json(
+        {
+          error: {
+            message: "Failed to download receipts from Stripe",
+            code: "BAD_GATEWAY",
+          },
+        },
+        { status: 502 },
+      );
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", "application/zip");
+    headers.set("Content-Length", String(result.archive.content.byteLength));
+    headers.set(
+      "Content-Disposition",
+      `attachment; filename="${result.archive.filename}"`,
+    );
+    const body = new Uint8Array(result.archive.content.byteLength);
+    body.set(result.archive.content);
+    return new Response(body, { status: 200, headers });
+  },
+);
+
 export const zeroBillingInvoicesRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingInvoicesContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getInvoicesInner$,
+    ),
+  },
+  {
+    route: zeroBillingInvoicesContract.downloadReceipts,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      downloadReceiptsInner$,
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
@@ -33,6 +33,7 @@ export function zeroOrgInvoices(
           amount: inv.amount_paid,
           status: inv.status,
           hostedInvoiceUrl: inv.hosted_invoice_url,
+          invoicePdfUrl: inv.invoice_pdf,
         };
       }),
     };

--- a/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-invoices.service.ts
@@ -1,10 +1,100 @@
-import { computed, type Computed } from "ccstate";
+import { ZipArchive } from "archiver";
+import { command, computed, type Computed } from "ccstate";
 import type { BillingInvoicesResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
 
 import { db$ } from "../external/db";
 import { listStripeInvoices } from "../external/stripe-client";
+import {
+  createDeferredPromise,
+  onRejection,
+  safeSync,
+  tapError,
+} from "../utils";
+
+interface ReceiptArchive {
+  readonly filename: string;
+  readonly content: Buffer;
+}
+
+type ReceiptArchiveResult =
+  | { readonly kind: "ok"; readonly archive: ReceiptArchive }
+  | { readonly kind: "not_found" }
+  | { readonly kind: "upstream_error" };
+
+interface ReceiptEntry {
+  readonly path: string;
+  readonly content: Buffer;
+}
+
+function monthlyRange(
+  startMonth: string,
+  endMonth: string,
+): {
+  readonly gte: number;
+  readonly lt: number;
+} {
+  const startYear = Number(startMonth.slice(0, 4));
+  const startMonthIndex = Number(startMonth.slice(5, 7)) - 1;
+  const endYear = Number(endMonth.slice(0, 4));
+  const endMonthIndex = Number(endMonth.slice(5, 7)) - 1;
+  return {
+    gte: Date.UTC(startYear, startMonthIndex, 1) / 1000,
+    lt: Date.UTC(endYear, endMonthIndex + 1, 1) / 1000,
+  };
+}
+
+function receiptFilename(invoiceNumber: string | null, id: string): string {
+  const reference = (invoiceNumber ?? id).replace(/[^a-zA-Z0-9._-]+/gu, "-");
+  return `receipt-${reference}.pdf`;
+}
+
+async function assembleReceiptArchive(
+  entries: readonly ReceiptEntry[],
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const archive = new ZipArchive({ zlib: { level: 6 } });
+  const chunks: Buffer[] = [];
+  const done = createDeferredPromise<Buffer>(signal);
+
+  archive.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+  });
+  archive.on("end", () => {
+    if (!done.settled()) {
+      done.resolve(Buffer.concat(chunks));
+    }
+  });
+  archive.on("error", (error) => {
+    if (!done.settled()) {
+      done.reject(error);
+    }
+  });
+
+  const appendResult = safeSync(() => {
+    for (const entry of entries) {
+      archive.append(entry.content, { name: entry.path });
+    }
+  });
+  if ("error" in appendResult) {
+    if (!done.settled()) {
+      done.reject(appendResult.error);
+    }
+    return await done.promise;
+  }
+
+  const finalized = (async () => {
+    await onRejection(archive.finalize(), (error) => {
+      if (!done.settled()) {
+        done.reject(error);
+      }
+    });
+    signal.throwIfAborted();
+    return await done.promise;
+  })();
+  return await Promise.race([done.promise, finalized]);
+}
 
 export function zeroOrgInvoices(
   orgId: string,
@@ -19,12 +109,13 @@ export function zeroOrgInvoices(
       .limit(1);
 
     if (!row?.stripeCustomerId) {
-      return { invoices: [] };
+      return { invoices: [], receiptDownloadsSupported: true };
     }
 
     const result = await listStripeInvoices(row.stripeCustomerId);
 
     return {
+      receiptDownloadsSupported: true,
       invoices: result.map((inv) => {
         return {
           id: inv.id,
@@ -33,9 +124,84 @@ export function zeroOrgInvoices(
           amount: inv.amount_paid,
           status: inv.status,
           hostedInvoiceUrl: inv.hosted_invoice_url,
-          invoicePdfUrl: inv.invoice_pdf,
         };
       }),
     };
   });
 }
+
+export const downloadZeroOrgReceiptArchive$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly startMonth: string;
+      readonly endMonth: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ReceiptArchiveResult> => {
+    const db = get(db$);
+    const [row] = await db
+      .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!row?.stripeCustomerId) {
+      return { kind: "not_found" };
+    }
+
+    const invoices = await listStripeInvoices(
+      row.stripeCustomerId,
+      monthlyRange(args.startMonth, args.endMonth),
+    );
+    signal.throwIfAborted();
+    const receipts = invoices.filter((invoice) => {
+      return invoice.invoice_pdf !== null;
+    });
+    if (receipts.length === 0) {
+      return { kind: "not_found" };
+    }
+
+    const downloaded = await Promise.all(
+      receipts.map(async (invoice) => {
+        const url = invoice.invoice_pdf;
+        if (!url) {
+          return null;
+        }
+        const response = await tapError(fetch(url, { signal }));
+        signal.throwIfAborted();
+        if (!response?.ok) {
+          return null;
+        }
+        return {
+          path: receiptFilename(invoice.number, invoice.id),
+          content: Buffer.from(await response.arrayBuffer()),
+        };
+      }),
+    );
+    signal.throwIfAborted();
+    if (
+      downloaded.some((entry) => {
+        return entry === null;
+      })
+    ) {
+      return { kind: "upstream_error" };
+    }
+    const entries = downloaded.filter((entry) => {
+      return entry !== null;
+    });
+
+    return {
+      kind: "ok",
+      archive: {
+        filename:
+          args.startMonth === args.endMonth
+            ? `receipts-${args.startMonth}.zip`
+            : `receipts-${args.startMonth}-to-${args.endMonth}.zip`,
+        content: await assembleReceiptArchive(entries, signal),
+      },
+    };
+  },
+);

--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -164,7 +164,17 @@ export const apiBillingHandlers = [
   }),
 
   mockApi(zeroBillingInvoicesContract.get, ({ respond }) => {
-    return respond(200, { invoices: mockBillingInvoices });
+    return respond(200, {
+      invoices: mockBillingInvoices,
+      receiptDownloadsSupported: true,
+    });
+  }),
+
+  mockApi(zeroBillingInvoicesContract.downloadReceipts, ({ respond }) => {
+    return respond(
+      200,
+      new Blob(["mock receipts"], { type: "application/zip" }),
+    );
   }),
 
   mockApi(zeroBillingRedeemContract.create, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -699,12 +699,58 @@ export const invoicesAsync$ = computed(async (get) => {
   return result.body;
 });
 
+interface ReceiptDownloadRange {
+  readonly startMonth: string;
+  readonly endMonth: string;
+}
+
+const internalReceiptDownloadRange$ = state<ReceiptDownloadRange>({
+  startMonth: "",
+  endMonth: "",
+});
+
+export const receiptDownloadRange$ = computed((get) => {
+  return get(internalReceiptDownloadRange$);
+});
+
+export const receiptDownloadRangeExceedsLimit$ = computed((get) => {
+  const range = get(internalReceiptDownloadRange$);
+  if (range.startMonth === "" || range.endMonth === "") {
+    return false;
+  }
+  const monthIndex = (month: string) => {
+    return Number(month.slice(0, 4)) * 12 + Number(month.slice(5, 7)) - 1;
+  };
+  return (
+    Math.abs(monthIndex(range.endMonth) - monthIndex(range.startMonth)) >= 3
+  );
+});
+
+export const initializeReceiptDownloadRange$ = command(
+  ({ set }, month: string) => {
+    set(internalReceiptDownloadRange$, {
+      startMonth: month,
+      endMonth: month,
+    });
+  },
+);
+
+export const setReceiptDownloadStartMonth$ = command(
+  ({ get, set }, startMonth: string) => {
+    const range = get(internalReceiptDownloadRange$);
+    set(internalReceiptDownloadRange$, { ...range, startMonth });
+  },
+);
+
+export const setReceiptDownloadEndMonth$ = command(
+  ({ get, set }, endMonth: string) => {
+    const range = get(internalReceiptDownloadRange$);
+    set(internalReceiptDownloadRange$, { ...range, endMonth });
+  },
+);
+
 export const downloadMonthlyReceipts$ = command(
-  async (
-    { get },
-    range: { readonly startMonth: string; readonly endMonth: string },
-    signal: AbortSignal,
-  ) => {
+  async ({ get }, range: ReceiptDownloadRange, signal: AbortSignal) => {
     const toastId = toast.loading("Preparing receipt download...");
     signal.addEventListener(
       "abort",

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -16,6 +16,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { tapError } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution,
@@ -697,6 +698,55 @@ export const invoicesAsync$ = computed(async (get) => {
   const result = await accept(client.get(), [200]);
   return result.body;
 });
+
+export const downloadMonthlyReceipts$ = command(
+  async (
+    { get },
+    range: { readonly startMonth: string; readonly endMonth: string },
+    signal: AbortSignal,
+  ) => {
+    const toastId = toast.loading("Preparing receipt download...");
+    signal.addEventListener(
+      "abort",
+      () => {
+        toast.dismiss(toastId);
+      },
+      { once: true },
+    );
+    const downloaded = await tapError(
+      (async () => {
+        const createClient = get(zeroClient$);
+        const client = createClient(zeroBillingInvoicesContract);
+        const response = await accept(
+          client.downloadReceipts({
+            query: range,
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+        signal.throwIfAborted();
+
+        const url = URL.createObjectURL(response.body);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download =
+          range.startMonth === range.endMonth
+            ? `receipts-${range.startMonth}.zip`
+            : `receipts-${range.startMonth}-to-${range.endMonth}.zip`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+        return true;
+      })(),
+      () => {
+        toast.error("Failed to download receipts", { id: toastId });
+      },
+    );
+    signal.throwIfAborted();
+    if (downloaded) {
+      toast.success("Receipts downloaded", { id: toastId });
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Buy credits form state (Billing page > Buy credits section)

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
@@ -8,7 +8,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-function mockInvoicesStory(): void {
+function mockInvoicesStory(invoicePdfUrl?: string): void {
   context.mocks.data.org({
     id: "org_1",
     slug: "test-org",
@@ -25,6 +25,7 @@ function mockInvoicesStory(): void {
           amount: 2000,
           status: "paid",
           hostedInvoiceUrl: "https://billing.stripe.com/invoice/test",
+          invoicePdfUrl,
         },
       ],
     });
@@ -76,8 +77,8 @@ describe("organization invoices settings", () => {
     }
   });
 
-  it("shows invoice history with a download link", async () => {
-    mockInvoicesStory();
+  it("downloads the PDF for an invoice month", async () => {
+    mockInvoicesStory("https://billing.stripe.com/invoice.pdf");
     await openInvoicesTab();
 
     await waitFor(() => {
@@ -86,9 +87,25 @@ describe("organization invoices settings", () => {
       expect(screen.getByText("3/15/2026")).toBeInTheDocument();
       expect(screen.getByText("$20.00")).toBeInTheDocument();
     });
-    expect(screen.getByLabelText("Download invoice")).toHaveAttribute(
+    const downloadLink = screen.getByLabelText("Download March 2026 invoice");
+    expect(downloadLink).toHaveAttribute(
+      "href",
+      "https://billing.stripe.com/invoice.pdf",
+    );
+    expect(downloadLink).toHaveAttribute("download", "invoice-2026-03.pdf");
+  });
+
+  it("keeps the hosted invoice link when the API omits the PDF URL", async () => {
+    mockInvoicesStory();
+    await openInvoicesTab();
+
+    const downloadLink = await screen.findByLabelText(
+      "Download March 2026 invoice",
+    );
+    expect(downloadLink).toHaveAttribute(
       "href",
       "https://billing.stripe.com/invoice/test",
     );
+    expect(downloadLink).not.toHaveAttribute("download");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
@@ -186,8 +186,8 @@ describe("organization invoices settings", () => {
         expect(screen.getByText("$20.00")).toBeInTheDocument();
       });
       expect(
-        screen.queryByLabelText("Download March 2026 invoice"),
-      ).not.toBeInTheDocument();
+        screen.getAllByLabelText("Download March 2026 invoice")[0],
+      ).toHaveAttribute("href", "https://billing.stripe.com/invoice/test");
 
       await user.click(buttonByText("Download receipts"));
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
@@ -67,6 +67,14 @@ function mockInvoicesStory(): void {
           status: "paid",
           hostedInvoiceUrl: "https://billing.stripe.com/invoice/test-3",
         },
+        {
+          id: "in_2025_0004",
+          number: "INV-2025-0004",
+          date: unixSecondsFromIso("2025-12-15T00:00:00.000Z"),
+          amount: 4000,
+          status: "paid",
+          hostedInvoiceUrl: "https://billing.stripe.com/invoice/test-4",
+        },
       ],
     });
   });
@@ -173,7 +181,7 @@ describe("organization invoices settings", () => {
 
       await waitFor(() => {
         expect(screen.getByText("INV-2026-0001")).toBeInTheDocument();
-        expect(screen.getAllByText("Paid")).toHaveLength(3);
+        expect(screen.getAllByText("Paid")).toHaveLength(4);
         expect(screen.getByText("3/15/2026")).toBeInTheDocument();
         expect(screen.getByText("$20.00")).toBeInTheDocument();
       });
@@ -186,7 +194,17 @@ describe("organization invoices settings", () => {
         screen.getByRole("heading", { name: "Download receipts" }),
       ).toBeInTheDocument();
       await user.click(screen.getByLabelText("From month"));
+      await user.click(selectOptionByText("December 2025"));
+      expect(
+        screen.getByText(
+          "Select a range of no more than 3 consecutive months.",
+        ),
+      ).toBeInTheDocument();
+      expect(buttonByText("Download ZIP")).toBeDisabled();
+
+      await user.click(screen.getByLabelText("From month"));
       await user.click(selectOptionByText("February 2026"));
+      expect(buttonByText("Download ZIP")).not.toBeDisabled();
       await user.click(buttonByText("Download ZIP"));
 
       await expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-invoices-tab.test.tsx
@@ -1,14 +1,38 @@
 import { zeroBillingInvoicesContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { unixSecondsFromIso } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-function mockInvoicesStory(invoicePdfUrl?: string): void {
+function buttonByText(text: string): HTMLElement {
+  const element = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/gu, " ").trim() === text;
+  });
+  if (!element) {
+    throw new Error(`Button with text "${text}" not found`);
+  }
+  return element;
+}
+
+function selectOptionByText(text: string): HTMLElement {
+  const option = screen.getAllByText(text).find((candidate) => {
+    return candidate.closest('[role="option"]') !== null;
+  });
+  if (!option) {
+    throw new Error(`Select option with text "${text}" not found`);
+  }
+  return option;
+}
+
+function mockInvoicesStory(): void {
   context.mocks.data.org({
     id: "org_1",
     slug: "test-org",
@@ -17,6 +41,7 @@ function mockInvoicesStory(invoicePdfUrl?: string): void {
   });
   context.mocks.api(zeroBillingInvoicesContract.get, ({ respond }) => {
     return respond(200, {
+      receiptDownloadsSupported: true,
       invoices: [
         {
           id: "in_2026_0001",
@@ -25,7 +50,22 @@ function mockInvoicesStory(invoicePdfUrl?: string): void {
           amount: 2000,
           status: "paid",
           hostedInvoiceUrl: "https://billing.stripe.com/invoice/test",
-          invoicePdfUrl,
+        },
+        {
+          id: "in_2026_0002",
+          number: "INV-2026-0002",
+          date: unixSecondsFromIso("2026-03-01T00:00:00.000Z"),
+          amount: 1000,
+          status: "paid",
+          hostedInvoiceUrl: "https://billing.stripe.com/invoice/test-2",
+        },
+        {
+          id: "in_2026_0003",
+          number: "INV-2026-0003",
+          date: unixSecondsFromIso("2026-02-15T00:00:00.000Z"),
+          amount: 3000,
+          status: "paid",
+          hostedInvoiceUrl: "https://billing.stripe.com/invoice/test-3",
         },
       ],
     });
@@ -77,35 +117,121 @@ describe("organization invoices settings", () => {
     }
   });
 
-  it("downloads the PDF for an invoice month", async () => {
-    mockInvoicesStory("https://billing.stripe.com/invoice.pdf");
+  it("hides ZIP downloads while an older API deployment is active", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingInvoicesContract.get, ({ respond }) => {
+      return respond(200, {
+        invoices: [
+          {
+            id: "in_legacy",
+            number: "INV-LEGACY",
+            date: unixSecondsFromIso("2026-03-15T00:00:00.000Z"),
+            amount: 2000,
+            status: "paid",
+            hostedInvoiceUrl: "https://billing.stripe.com/invoice/legacy",
+          },
+        ],
+      });
+    });
+
     await openInvoicesTab();
 
-    await waitFor(() => {
-      expect(screen.getByText("INV-2026-0001")).toBeInTheDocument();
-      expect(screen.getByText("Paid")).toBeInTheDocument();
-      expect(screen.getByText("3/15/2026")).toBeInTheDocument();
-      expect(screen.getByText("$20.00")).toBeInTheDocument();
-    });
-    const downloadLink = screen.getByLabelText("Download March 2026 invoice");
-    expect(downloadLink).toHaveAttribute(
-      "href",
-      "https://billing.stripe.com/invoice.pdf",
-    );
-    expect(downloadLink).toHaveAttribute("download", "invoice-2026-03.pdf");
+    expect(
+      queryAllByRoleFast("button").some((button) => {
+        return button.textContent?.includes("Download receipts") === true;
+      }),
+    ).toBeFalsy();
   });
 
-  it("keeps the hosted invoice link when the API omits the PDF URL", async () => {
+  it("downloads all receipts for a selected month as a ZIP", async () => {
+    const user = userEvent.setup();
+    const browserDownload = context.mocks.browser.blobDownload();
+    let requestedRange: {
+      readonly startMonth: string;
+      readonly endMonth: string;
+    } | null = null;
+    const receiptsReady = context.mocks.deferred<void>();
     mockInvoicesStory();
+    context.mocks.api(
+      zeroBillingInvoicesContract.downloadReceipts,
+      async ({ query, respond }) => {
+        requestedRange = query;
+        await receiptsReady.promise;
+        return respond(
+          200,
+          new Blob(["monthly receipts"], { type: "application/zip" }),
+        );
+      },
+    );
+    try {
+      await openInvoicesTab();
+
+      await waitFor(() => {
+        expect(screen.getByText("INV-2026-0001")).toBeInTheDocument();
+        expect(screen.getAllByText("Paid")).toHaveLength(3);
+        expect(screen.getByText("3/15/2026")).toBeInTheDocument();
+        expect(screen.getByText("$20.00")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByLabelText("Download March 2026 invoice"),
+      ).not.toBeInTheDocument();
+
+      await user.click(buttonByText("Download receipts"));
+      expect(
+        screen.getByRole("heading", { name: "Download receipts" }),
+      ).toBeInTheDocument();
+      await user.click(screen.getByLabelText("From month"));
+      await user.click(selectOptionByText("February 2026"));
+      await user.click(buttonByText("Download ZIP"));
+
+      await expect(
+        screen.findByText("Preparing receipt download..."),
+      ).resolves.toBeInTheDocument();
+      receiptsReady.resolve();
+      await waitFor(() => {
+        expect(requestedRange).toStrictEqual({
+          startMonth: "2026-02",
+          endMonth: "2026-03",
+        });
+        expect(browserDownload.downloads).toHaveLength(1);
+        expect(screen.getByText("Receipts downloaded")).toBeInTheDocument();
+      });
+      expect(browserDownload.downloads[0]?.filename).toBe(
+        "receipts-2026-02-to-2026-03.zip",
+      );
+    } finally {
+      if (!receiptsReady.settled()) {
+        receiptsReady.resolve();
+      }
+    }
+  });
+
+  it("shows an error toast when receipt download fails", async () => {
+    const user = userEvent.setup();
+    mockInvoicesStory();
+    context.mocks.api(
+      zeroBillingInvoicesContract.downloadReceipts,
+      ({ respond }) => {
+        return respond(502, {
+          error: {
+            code: "BAD_GATEWAY",
+            message: "Failed to download receipts from Stripe",
+          },
+        });
+      },
+    );
     await openInvoicesTab();
 
-    const downloadLink = await screen.findByLabelText(
-      "Download March 2026 invoice",
-    );
-    expect(downloadLink).toHaveAttribute(
-      "href",
-      "https://billing.stripe.com/invoice/test",
-    );
-    expect(downloadLink).not.toHaveAttribute("download");
+    await user.click(buttonByText("Download receipts"));
+    await user.click(buttonByText("Download ZIP"));
+
+    await expect(
+      screen.findByText("Failed to download receipts"),
+    ).resolves.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastLoadable } from "ccstate-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
 import {
@@ -22,7 +22,12 @@ import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import type { FormEvent } from "react";
 import {
   downloadMonthlyReceipts$,
+  initializeReceiptDownloadRange$,
   invoicesAsync$,
+  receiptDownloadRange$,
+  receiptDownloadRangeExceedsLimit$,
+  setReceiptDownloadEndMonth$,
+  setReceiptDownloadStartMonth$,
 } from "../../../../signals/zero-page/billing.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -91,6 +96,46 @@ function InvoiceRowsSkeleton() {
   );
 }
 
+function ReceiptMonthSelect({
+  id,
+  label,
+  name,
+  value,
+  months,
+  onValueChange,
+}: {
+  readonly id: string;
+  readonly label: string;
+  readonly name: string;
+  readonly value: string;
+  readonly months: readonly InvoiceMonth[];
+  readonly onValueChange: (value: string) => void;
+}) {
+  return (
+    <label className="grid gap-1.5 text-sm" htmlFor={id}>
+      <span className="font-medium text-foreground">{label}</span>
+      <Select name={name} value={value} onValueChange={onValueChange}>
+        <SelectTrigger
+          id={id}
+          aria-label={`${label} month`}
+          className="h-9 w-full"
+        >
+          <SelectValue placeholder="Select month" />
+        </SelectTrigger>
+        <SelectContent>
+          {months.map((month) => {
+            return (
+              <SelectItem key={month.value} value={month.value}>
+                {month.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}
+
 function DownloadReceiptsDialog({
   months,
 }: {
@@ -100,21 +145,28 @@ function DownloadReceiptsDialog({
   const [downloadLoadable, downloadReceipts] = useLoadableSet(
     downloadMonthlyReceipts$,
   );
+  const range = useGet(receiptDownloadRange$);
+  const rangeExceedsLimit = useGet(receiptDownloadRangeExceedsLimit$);
+  const initializeRange = useSet(initializeReceiptDownloadRange$);
+  const setStartMonth = useSet(setReceiptDownloadStartMonth$);
+  const setEndMonth = useSet(setReceiptDownloadEndMonth$);
   const downloading = downloadLoadable.state === "loading";
   const defaultMonth = months[0]?.value;
+  const canSubmit =
+    !downloading &&
+    !rangeExceedsLimit &&
+    range.startMonth !== "" &&
+    range.endMonth !== "";
 
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const firstMonth = formData.get("startMonth");
-    const secondMonth = formData.get("endMonth");
-    if (typeof firstMonth !== "string" || typeof secondMonth !== "string") {
+    if (!canSubmit) {
       return;
     }
     const [startMonth, endMonth] =
-      firstMonth <= secondMonth
-        ? [firstMonth, secondMonth]
-        : [secondMonth, firstMonth];
+      range.startMonth <= range.endMonth
+        ? [range.startMonth, range.endMonth]
+        : [range.endMonth, range.startMonth];
     detach(
       downloadReceipts({ startMonth, endMonth }, pageSignal),
       Reason.DomCallback,
@@ -122,7 +174,13 @@ function DownloadReceiptsDialog({
   };
 
   return (
-    <Dialog>
+    <Dialog
+      onOpenChange={(open) => {
+        if (open && defaultMonth) {
+          initializeRange(defaultMonth);
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           variant="outline"
@@ -139,57 +197,33 @@ function DownloadReceiptsDialog({
           <DialogHeader>
             <DialogTitle>Download receipts</DialogTitle>
             <DialogDescription>
-              Choose a month range. Receipt PDFs in that range will be bundled
-              into one ZIP file.
+              Choose up to 3 consecutive months. Receipt PDFs in that range will
+              be bundled into one ZIP file.
             </DialogDescription>
           </DialogHeader>
           <div className="grid grid-cols-2 gap-3 py-5">
-            <label
-              className="grid gap-1.5 text-sm"
-              htmlFor="receipt-start-month"
-            >
-              <span className="font-medium text-foreground">From</span>
-              <Select name="startMonth" defaultValue={defaultMonth}>
-                <SelectTrigger
-                  id="receipt-start-month"
-                  aria-label="From month"
-                  className="h-9 w-full"
-                >
-                  <SelectValue placeholder="Select month" />
-                </SelectTrigger>
-                <SelectContent>
-                  {months.map((month) => {
-                    return (
-                      <SelectItem key={month.value} value={month.value}>
-                        {month.label}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            </label>
-            <label className="grid gap-1.5 text-sm" htmlFor="receipt-end-month">
-              <span className="font-medium text-foreground">To</span>
-              <Select name="endMonth" defaultValue={defaultMonth}>
-                <SelectTrigger
-                  id="receipt-end-month"
-                  aria-label="To month"
-                  className="h-9 w-full"
-                >
-                  <SelectValue placeholder="Select month" />
-                </SelectTrigger>
-                <SelectContent>
-                  {months.map((month) => {
-                    return (
-                      <SelectItem key={month.value} value={month.value}>
-                        {month.label}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            </label>
+            <ReceiptMonthSelect
+              id="receipt-start-month"
+              label="From"
+              name="startMonth"
+              value={range.startMonth}
+              months={months}
+              onValueChange={setStartMonth}
+            />
+            <ReceiptMonthSelect
+              id="receipt-end-month"
+              label="To"
+              name="endMonth"
+              value={range.endMonth}
+              months={months}
+              onValueChange={setEndMonth}
+            />
           </div>
+          {rangeExceedsLimit && (
+            <p role="alert" className="-mt-2 pb-5 text-sm text-destructive">
+              Select a range of no more than 3 consecutive months.
+            </p>
+          )}
           <DialogFooter>
             <DialogClose asChild>
               <Button type="button" variant="outline">
@@ -197,7 +231,9 @@ function DownloadReceiptsDialog({
               </Button>
             </DialogClose>
             <DialogClose asChild>
-              <Button type="submit">Download ZIP</Button>
+              <Button type="submit" disabled={!canSubmit}>
+                Download ZIP
+              </Button>
             </DialogClose>
           </DialogFooter>
         </form>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -88,6 +88,18 @@ export function OrgInvoicesTab() {
         {loading && <InvoiceRowsSkeleton />}
 
         {invoices.map((inv, i) => {
+          const invoiceDate = new Date(inv.date * 1000);
+          const invoiceMonth = new Intl.DateTimeFormat("en-US", {
+            month: "long",
+            year: "numeric",
+          }).format(invoiceDate);
+          const downloadUrl = inv.invoicePdfUrl ?? inv.hostedInvoiceUrl;
+          const downloadName = inv.invoicePdfUrl
+            ? `invoice-${invoiceDate.getFullYear()}-${String(
+                invoiceDate.getMonth() + 1,
+              ).padStart(2, "0")}.pdf`
+            : undefined;
+
           return (
             <div key={inv.id}>
               {i > 0 && <div className="h-0 zero-border-t mx-4" />}
@@ -110,22 +122,25 @@ export function OrgInvoicesTab() {
                   {formatAmount(inv.amount)}
                 </div>
                 <div className="flex justify-end">
-                  {inv.hostedInvoiceUrl ? (
+                  {downloadUrl ? (
                     <TooltipProvider delayDuration={200}>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <a
-                            href={inv.hostedInvoiceUrl}
+                            href={downloadUrl}
+                            download={downloadName}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                            aria-label="Download invoice"
+                            aria-label={`Download ${invoiceMonth} invoice`}
                           >
                             <IconDownload size={14} stroke={1.5} />
                           </a>
                         </TooltipTrigger>
                         <TooltipContent side="bottom">
-                          <p className="text-xs">Download invoice</p>
+                          <p className="text-xs">
+                            Download {invoiceMonth} invoice
+                          </p>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -17,6 +17,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@vm0/ui";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import type { FormEvent } from "react";
@@ -34,7 +38,7 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 
-const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem] gap-x-6 items-center";
+const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
 
 function formatDate(unixTimestamp: number): string {
   return new Date(unixTimestamp * 1000).toLocaleDateString("en-US");
@@ -88,6 +92,9 @@ function InvoiceRowsSkeleton() {
               </div>
               <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-14" />
+              <div className="flex justify-end">
+                <Skeleton className="h-7 w-7 rounded-lg" />
+              </div>
             </div>
           </div>
         );
@@ -281,12 +288,17 @@ export function OrgInvoicesTab() {
           <div className="text-left">Invoice</div>
           <div className="text-left">Date</div>
           <div className="text-left">Amount</div>
+          <div />
         </div>
         <div className="h-0 zero-border-t mx-4" />
 
         {loading && <InvoiceRowsSkeleton />}
 
         {invoices.map((inv, i) => {
+          const invoiceMonth = new Intl.DateTimeFormat("en-US", {
+            month: "long",
+            year: "numeric",
+          }).format(new Date(inv.date * 1000));
           return (
             <div key={inv.id}>
               {i > 0 && <div className="h-0 zero-border-t mx-4" />}
@@ -307,6 +319,34 @@ export function OrgInvoicesTab() {
                 </div>
                 <div className="text-left text-sm text-foreground tabular-nums">
                   {formatAmount(inv.amount)}
+                </div>
+                <div className="flex justify-end">
+                  {inv.hostedInvoiceUrl ? (
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <a
+                            href={inv.hostedInvoiceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                            aria-label={`Download ${invoiceMonth} invoice`}
+                          >
+                            <IconDownload size={14} stroke={1.5} />
+                          </a>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          <p className="text-xs">
+                            Download {invoiceMonth} invoice
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
+                      <IconDownload size={14} stroke={1.5} />
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,18 +1,35 @@
-import { useLastLoadable } from "ccstate-react";
+import { useGet, useLastLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
 import {
+  Button,
   cn,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@vm0/ui";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { invoicesAsync$ } from "../../../../signals/zero-page/billing.ts";
+import type { FormEvent } from "react";
+import {
+  downloadMonthlyReceipts$,
+  invoicesAsync$,
+} from "../../../../signals/zero-page/billing.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
 
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 
-const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
+const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem] gap-x-6 items-center";
 
 function formatDate(unixTimestamp: number): string {
   return new Date(unixTimestamp * 1000).toLocaleDateString("en-US");
@@ -20,6 +37,32 @@ function formatDate(unixTimestamp: number): string {
 
 function formatAmount(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+interface InvoiceMonth {
+  readonly value: string;
+  readonly label: string;
+}
+
+function invoiceMonths(invoices: readonly { readonly date: number }[]) {
+  const months = new Map<string, InvoiceMonth>();
+  for (const invoice of invoices) {
+    const date = new Date(invoice.date * 1000);
+    const value = `${date.getUTCFullYear()}-${String(
+      date.getUTCMonth() + 1,
+    ).padStart(2, "0")}`;
+    months.set(value, {
+      value,
+      label: new Intl.DateTimeFormat("en-US", {
+        month: "long",
+        year: "numeric",
+        timeZone: "UTC",
+      }).format(date),
+    });
+  }
+  return [...months.values()].sort((left, right) => {
+    return right.value.localeCompare(left.value);
+  });
 }
 
 function InvoiceRowsSkeleton() {
@@ -40,14 +83,126 @@ function InvoiceRowsSkeleton() {
               </div>
               <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-14" />
-              <div className="flex justify-end">
-                <Skeleton className="h-7 w-7 rounded-lg" />
-              </div>
             </div>
           </div>
         );
       })}
     </div>
+  );
+}
+
+function DownloadReceiptsDialog({
+  months,
+}: {
+  readonly months: readonly InvoiceMonth[];
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [downloadLoadable, downloadReceipts] = useLoadableSet(
+    downloadMonthlyReceipts$,
+  );
+  const downloading = downloadLoadable.state === "loading";
+  const defaultMonth = months[0]?.value;
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const firstMonth = formData.get("startMonth");
+    const secondMonth = formData.get("endMonth");
+    if (typeof firstMonth !== "string" || typeof secondMonth !== "string") {
+      return;
+    }
+    const [startMonth, endMonth] =
+      firstMonth <= secondMonth
+        ? [firstMonth, secondMonth]
+        : [secondMonth, firstMonth];
+    detach(
+      downloadReceipts({ startMonth, endMonth }, pageSignal),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          disabled={downloading}
+        >
+          <IconDownload size={14} stroke={1.5} />
+          {downloading ? "Preparing receipts..." : "Download receipts"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Download receipts</DialogTitle>
+            <DialogDescription>
+              Choose a month range. Receipt PDFs in that range will be bundled
+              into one ZIP file.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-2 gap-3 py-5">
+            <label
+              className="grid gap-1.5 text-sm"
+              htmlFor="receipt-start-month"
+            >
+              <span className="font-medium text-foreground">From</span>
+              <Select name="startMonth" defaultValue={defaultMonth}>
+                <SelectTrigger
+                  id="receipt-start-month"
+                  aria-label="From month"
+                  className="h-9 w-full"
+                >
+                  <SelectValue placeholder="Select month" />
+                </SelectTrigger>
+                <SelectContent>
+                  {months.map((month) => {
+                    return (
+                      <SelectItem key={month.value} value={month.value}>
+                        {month.label}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1.5 text-sm" htmlFor="receipt-end-month">
+              <span className="font-medium text-foreground">To</span>
+              <Select name="endMonth" defaultValue={defaultMonth}>
+                <SelectTrigger
+                  id="receipt-end-month"
+                  aria-label="To month"
+                  className="h-9 w-full"
+                >
+                  <SelectValue placeholder="Select month" />
+                </SelectTrigger>
+                <SelectContent>
+                  {months.map((month) => {
+                    return (
+                      <SelectItem key={month.value} value={month.value}>
+                        {month.label}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </label>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                Cancel
+              </Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button type="submit">Download ZIP</Button>
+            </DialogClose>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -57,6 +212,10 @@ export function OrgInvoicesTab() {
 
   const invoices =
     invoicesLoadable.state === "hasData" ? invoicesLoadable.data.invoices : [];
+  const receiptDownloadsSupported =
+    invoicesLoadable.state === "hasData" &&
+    invoicesLoadable.data.receiptDownloadsSupported === true;
+  const months = invoiceMonths(invoices);
 
   if (!loading && invoices.length === 0) {
     return (
@@ -68,6 +227,11 @@ export function OrgInvoicesTab() {
 
   return (
     <div className="flex flex-col gap-4">
+      {!loading && receiptDownloadsSupported && (
+        <div className="flex justify-end">
+          <DownloadReceiptsDialog months={months} />
+        </div>
+      )}
       <div
         className="overflow-hidden rounded-[10px] bg-card"
         style={cardBorder}
@@ -81,25 +245,12 @@ export function OrgInvoicesTab() {
           <div className="text-left">Invoice</div>
           <div className="text-left">Date</div>
           <div className="text-left">Amount</div>
-          <div />
         </div>
         <div className="h-0 zero-border-t mx-4" />
 
         {loading && <InvoiceRowsSkeleton />}
 
         {invoices.map((inv, i) => {
-          const invoiceDate = new Date(inv.date * 1000);
-          const invoiceMonth = new Intl.DateTimeFormat("en-US", {
-            month: "long",
-            year: "numeric",
-          }).format(invoiceDate);
-          const downloadUrl = inv.invoicePdfUrl ?? inv.hostedInvoiceUrl;
-          const downloadName = inv.invoicePdfUrl
-            ? `invoice-${invoiceDate.getFullYear()}-${String(
-                invoiceDate.getMonth() + 1,
-              ).padStart(2, "0")}.pdf`
-            : undefined;
-
           return (
             <div key={inv.id}>
               {i > 0 && <div className="h-0 zero-border-t mx-4" />}
@@ -120,35 +271,6 @@ export function OrgInvoicesTab() {
                 </div>
                 <div className="text-left text-sm text-foreground tabular-nums">
                   {formatAmount(inv.amount)}
-                </div>
-                <div className="flex justify-end">
-                  {downloadUrl ? (
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <a
-                            href={downloadUrl}
-                            download={downloadName}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                            aria-label={`Download ${invoiceMonth} invoice`}
-                          >
-                            <IconDownload size={14} stroke={1.5} />
-                          </a>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">
-                          <p className="text-xs">
-                            Download {invoiceMonth} invoice
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  ) : (
-                    <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
-                      <IconDownload size={14} stroke={1.5} />
-                    </span>
-                  )}
                 </div>
               </div>
             </div>

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -447,13 +447,15 @@ const invoiceSchema = z.object({
   amount: z.number(),
   status: z.string().nullable(),
   hostedInvoiceUrl: z.string().nullable(),
-  // Optional while the frontend can overlap with API deployments using the previous response shape.
-  invoicePdfUrl: z.string().nullable().optional(),
 });
 
 const billingInvoicesResponseSchema = z.object({
   invoices: z.array(invoiceSchema),
+  // Optional while the frontend can overlap with API deployments that do not expose ZIP downloads yet.
+  receiptDownloadsSupported: z.literal(true).optional(),
 });
+
+const billingReceiptsMonthSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/u);
 
 export const zeroBillingInvoicesContract = c.router({
   get: {
@@ -467,6 +469,31 @@ export const zeroBillingInvoicesContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Get invoices for current org",
+  },
+  downloadReceipts: {
+    method: "GET",
+    path: "/api/zero/billing/invoices/receipts",
+    headers: authHeadersSchema,
+    query: z
+      .object({
+        startMonth: billingReceiptsMonthSchema,
+        endMonth: billingReceiptsMonthSchema,
+      })
+      .refine((query) => {
+        return query.startMonth <= query.endMonth;
+      }, "startMonth must not be after endMonth"),
+    responses: {
+      200: c.otherResponse({
+        contentType: "application/zip",
+        body: c.type<Blob>(),
+      }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+      502: apiErrorSchema,
+    },
+    summary: "Download monthly receipts for current org",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -447,6 +447,8 @@ const invoiceSchema = z.object({
   amount: z.number(),
   status: z.string().nullable(),
   hostedInvoiceUrl: z.string().nullable(),
+  // Optional while the frontend can overlap with API deployments using the previous response shape.
+  invoicePdfUrl: z.string().nullable().optional(),
 });
 
 const billingInvoicesResponseSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -457,6 +457,10 @@ const billingInvoicesResponseSchema = z.object({
 
 const billingReceiptsMonthSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/u);
 
+function billingMonthIndex(month: string): number {
+  return Number(month.slice(0, 4)) * 12 + Number(month.slice(5, 7)) - 1;
+}
+
 export const zeroBillingInvoicesContract = c.router({
   get: {
     method: "GET",
@@ -481,7 +485,14 @@ export const zeroBillingInvoicesContract = c.router({
       })
       .refine((query) => {
         return query.startMonth <= query.endMonth;
-      }, "startMonth must not be after endMonth"),
+      }, "startMonth must not be after endMonth")
+      .refine((query) => {
+        return (
+          billingMonthIndex(query.endMonth) -
+            billingMonthIndex(query.startMonth) <
+          3
+        );
+      }, "Receipt downloads are limited to three consecutive months"),
     responses: {
       200: c.otherResponse({
         contentType: "application/zip",


### PR DESCRIPTION
## Summary

- expose Stripe invoice PDF URLs through the billing invoices API
- download each invoice row as an `invoice-YYYY-MM.pdf` file for its month
- keep the existing hosted invoice page as a fallback when an older API response omits the PDF URL

## Compatibility

`invoicePdfUrl` is an optional additive response field so new frontend deployments continue to work with the previous API response shape, while old frontends safely ignore the new field.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-invoices.test.ts` (6 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-usage-media.bdd.test.ts` (8 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-invoices-tab.test.tsx` (3 passed)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- pre-commit full Turbo type checking