### PR TITLE
perf(platform): rebase oversized chat thread event caches

### DIFF
--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -48,14 +48,21 @@ function isNetworkRequestError(error: unknown): boolean {
   );
 }
 
+interface AcceptOptions {
+  readonly showErrorToast?: boolean;
+}
+
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
- * Otherwise shows a toast and throws an `ApiError`.
+ * Otherwise throws an `ApiError` and, by default, shows a toast.
  *
  * Browser network failures propagate without showing their raw error message.
  *
  * When `signal` is provided, a rejection after that signal aborts propagates
  * as cancellation without showing a toast.
+ *
+ * Best-effort background work may disable the error toast while preserving the
+ * same typed response handling and thrown error.
  */
 async function accept<
   T extends { status: number; body: unknown },
@@ -64,11 +71,13 @@ async function accept<
   promise: Promise<T>,
   codes: S[],
   signal?: AbortSignal,
+  options: AcceptOptions = {},
 ): Promise<Extract<T, { status: S }>> {
+  const showErrorToast = options.showErrorToast ?? true;
   const result = await onRejection(promise, (error) => {
     if (!isAbortError(error)) {
       signal?.throwIfAborted();
-      if (!isNetworkRequestError(error)) {
+      if (showErrorToast && !isNetworkRequestError(error)) {
         toast.error(requestErrorMessage(error));
       }
     }
@@ -77,7 +86,9 @@ async function accept<
     return result as Extract<T, { status: S }>;
   }
   const { message, code } = extractError(result.body, result.status);
-  toast.error(message);
+  if (showErrorToast) {
+    toast.error(message);
+  }
   throw new ApiError(message, code, result.status);
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-persistence.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-persistence.test.ts
@@ -1,3 +1,4 @@
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   chatThreadsContract,
   type ChatThreadEvent,
@@ -20,13 +21,13 @@ vi.mock("idb", async () => {
 
 const context = testContext();
 
-const USER_ID = "thread-event-persistence-user";
-const ORG_ID = "thread-event-persistence-org";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000901";
 const THREAD_ID = "b0000000-0000-4000-a000-000000000901";
 const SNAPSHOT_EVENT_ID = "d0000000-0000-4000-a000-000000000900";
-const EVENT_COUNT = 1200;
-const LATEST_TITLE = "Title restored from the latest cached event";
+const REBASED_SNAPSHOT_EVENT_ID = "d2000000-0000-4000-a000-000000000001";
+const POST_SNAPSHOT_EVENT_ID = "d3000000-0000-4000-a000-000000000001";
+const LATEST_CACHED_TITLE = "Title restored from the latest cached event";
+const POST_SNAPSHOT_TITLE = "Title from the post-snapshot event";
 
 const snapshotThread = {
   id: THREAD_ID,
@@ -42,28 +43,48 @@ const snapshotThread = {
   computerUseHostId: null,
 } satisfies ChatThreadSnapshotProjection;
 
-const cachedEvents = Array.from({ length: EVENT_COUNT }, (_, index) => {
-  const eventNumber = index + 1;
+function createRenamedEvent(
+  eventNumber: number,
+  title: string,
+): ChatThreadEvent {
   return {
     id: `d1000000-0000-4000-a000-${String(eventNumber).padStart(12, "0")}`,
     kind: "renamed",
     chatThreadId: THREAD_ID,
     agentId: AGENT_ID,
-    title:
-      eventNumber === EVENT_COUNT
-        ? LATEST_TITLE
-        : `Cached title ${eventNumber}`,
+    title,
     selectedModel: null,
     serviceTier: null,
     computerUseHostId: null,
     createdAt: new Date(
       Date.parse("2026-07-24T10:00:00.000Z") + eventNumber * 1000,
     ).toISOString(),
-  } satisfies ChatThreadEvent;
-});
+  };
+}
 
-async function seedCachedThreadEventLog(): Promise<void> {
-  const db = await openChatIdb(USER_ID, ORG_ID);
+function createCachedEvents(
+  count: number,
+  latestTitle = `Cached title ${count}`,
+): readonly ChatThreadEvent[] {
+  return Array.from({ length: count }, (_, index) => {
+    const eventNumber = index + 1;
+    return createRenamedEvent(
+      eventNumber,
+      eventNumber === count ? latestTitle : `Cached title ${eventNumber}`,
+    );
+  });
+}
+
+async function writeCachedThreadEventLog(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly snapshot: {
+    readonly chatThreads: readonly ChatThreadSnapshotProjection[];
+    readonly latestEventId: string | null;
+  } | null;
+  readonly events: readonly ChatThreadEvent[];
+}): Promise<void> {
+  const db = await openChatIdb(args.userId, args.orgId);
   try {
     const tx = db.transaction(
       [CHAT_THREAD_SNAPSHOT_STORE, CHAT_THREAD_EVENTS_STORE],
@@ -72,12 +93,16 @@ async function seedCachedThreadEventLog(): Promise<void> {
     const snapshotStore = tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE);
     const eventStore = tx.objectStore(CHAT_THREAD_EVENTS_STORE);
     const requests = [
-      snapshotStore.put({
-        id: "current",
-        chatThreads: [snapshotThread],
-        latestEventId: SNAPSHOT_EVENT_ID,
-      }),
-      ...cachedEvents.map((event) => {
+      ...(args.snapshot
+        ? [
+            snapshotStore.put({
+              id: "current",
+              chatThreads: [...args.snapshot.chatThreads],
+              latestEventId: args.snapshot.latestEventId,
+            }),
+          ]
+        : []),
+      ...args.events.map((event) => {
         return eventStore.put(event);
       }),
     ];
@@ -87,11 +112,116 @@ async function seedCachedThreadEventLog(): Promise<void> {
   }
 }
 
-describe("chat thread event persistence", () => {
-  it("hydrates a cached event log across read pages and resumes from its latest event", async () => {
-    await seedCachedThreadEventLog();
+async function setupAuthenticatedPage(userId: string, orgId: string) {
+  await setupPage({
+    context,
+    path: "/error",
+    withoutRender: true,
+    user: { id: userId, fullName: "Thread Event Persistence User" },
+    session: { token: "test-token" },
+    org: {
+      activeOrg: { id: orgId, name: "Thread Event Persistence Org" },
+      memberships: [{ id: orgId }],
+    },
+  });
+}
 
+describe("chat thread event persistence", () => {
+  it("hydrates a paged event log, then rebases it to the remote snapshot", async () => {
+    const userId = "thread-event-rebase-user";
+    const orgId = "thread-event-rebase-org";
+    const cachedEvents = createCachedEvents(1200, LATEST_CACHED_TITLE);
+    await writeCachedThreadEventLog({
+      userId,
+      orgId,
+      snapshot: {
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      },
+      events: cachedEvents,
+    });
+
+    const postSnapshotEvent = {
+      ...createRenamedEvent(1201, POST_SNAPSHOT_TITLE),
+      id: POST_SNAPSHOT_EVENT_ID,
+    } satisfies ChatThreadEvent;
     const requestedEventIds: (string | undefined)[] = [];
+    const snapshotGate = context.mocks.deferred<void>();
+    let snapshotRequests = 0;
+    context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+      snapshotRequests += 1;
+      await snapshotGate.promise;
+      return respond(200, {
+        chatThreads: [{ ...snapshotThread, title: "Rebased snapshot title" }],
+        latestEventId: REBASED_SNAPSHOT_EVENT_ID,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ query, respond }) => {
+      requestedEventIds.push(query.sinceEventId);
+      if (query.sinceEventId === REBASED_SNAPSHOT_EVENT_ID) {
+        return respond(200, {
+          events: [postSnapshotEvent],
+          hasMore: false,
+        });
+      }
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    await setupAuthenticatedPage(userId, orgId);
+
+    await vi.waitFor(() => {
+      expect(snapshotRequests).toBe(1);
+    });
+    expect((await context.store.get(eventDrivenChatThreads$))[0]?.title).toBe(
+      LATEST_CACHED_TITLE,
+    );
+
+    snapshotGate.resolve(undefined);
+    const appDb = await context.store.get(chatIdb$);
+    try {
+      await vi.waitFor(async () => {
+        expect(requestedEventIds).toStrictEqual([
+          cachedEvents.at(-1)?.id,
+          REBASED_SNAPSHOT_EVENT_ID,
+        ]);
+        expect(
+          (await context.store.get(eventDrivenChatThreads$))[0]?.title,
+        ).toBe(POST_SNAPSHOT_TITLE);
+
+        const tx = appDb.transaction(
+          [CHAT_THREAD_SNAPSHOT_STORE, CHAT_THREAD_EVENTS_STORE],
+          "readonly",
+        );
+        const [storedSnapshot, storedEvents] = await Promise.all([
+          tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE).get("current"),
+          tx.objectStore(CHAT_THREAD_EVENTS_STORE).getAll(),
+          tx.done,
+        ]);
+        expect(storedSnapshot).toMatchObject({
+          latestEventId: REBASED_SNAPSHOT_EVENT_ID,
+        });
+        expect(storedEvents).toStrictEqual([postSnapshotEvent]);
+      });
+    } finally {
+      appDb.close();
+    }
+  });
+
+  it("does not rebase when the first sync leaves exactly 100 events", async () => {
+    const userId = "thread-event-threshold-user";
+    const orgId = "thread-event-threshold-org";
+    const cachedEvents = createCachedEvents(99);
+    const hundredthEvent = createRenamedEvent(100, "Hundredth event title");
+    await writeCachedThreadEventLog({
+      userId,
+      orgId,
+      snapshot: {
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      },
+      events: cachedEvents,
+    });
+
     let snapshotRequests = 0;
     context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
       snapshotRequests += 1;
@@ -100,34 +230,112 @@ describe("chat thread event persistence", () => {
         latestEventId: SNAPSHOT_EVENT_ID,
       });
     });
-    context.mocks.api(chatThreadsContract.events, ({ query, respond }) => {
-      requestedEventIds.push(query.sinceEventId);
-      return respond(200, { events: [], hasMore: false });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [hundredthEvent], hasMore: false });
     });
 
-    await setupPage({
-      context,
-      path: "/error",
-      withoutRender: true,
-      user: { id: USER_ID, fullName: "Thread Event Persistence User" },
-      session: { token: "test-token" },
-      org: {
-        activeOrg: { id: ORG_ID, name: "Thread Event Persistence Org" },
-        memberships: [{ id: ORG_ID }],
-      },
-    });
+    await setupAuthenticatedPage(userId, orgId);
 
     const appDb = await context.store.get(chatIdb$);
     try {
       await vi.waitFor(async () => {
-        expect(requestedEventIds[0]).toBe(cachedEvents.at(-1)?.id);
         expect(
           (await context.store.get(eventDrivenChatThreads$))[0]?.title,
-        ).toBe(LATEST_TITLE);
+        ).toBe("Hundredth event title");
+        await expect(
+          appDb.transaction(CHAT_THREAD_EVENTS_STORE, "readonly").store.count(),
+        ).resolves.toBe(100);
       });
       expect(snapshotRequests).toBe(0);
     } finally {
       appDb.close();
     }
+  });
+
+  it("does not pull a second snapshot when the first sync replaced it", async () => {
+    const userId = "thread-event-initial-snapshot-user";
+    const orgId = "thread-event-initial-snapshot-org";
+    const remoteEvents = createCachedEvents(101, "Latest remote title");
+    await writeCachedThreadEventLog({
+      userId,
+      orgId,
+      snapshot: null,
+      events: [],
+    });
+
+    let snapshotRequests = 0;
+    let eventRequests = 0;
+    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+      snapshotRequests += 1;
+      return respond(200, {
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ query, respond }) => {
+      eventRequests += 1;
+      return respond(200, {
+        events:
+          query.sinceEventId === SNAPSHOT_EVENT_ID ? [...remoteEvents] : [],
+        hasMore: false,
+      });
+    });
+
+    await setupAuthenticatedPage(userId, orgId);
+
+    await vi.waitFor(async () => {
+      expect((await context.store.get(eventDrivenChatThreads$))[0]?.title).toBe(
+        "Latest remote title",
+      );
+    });
+    context.mocks.ably.trigger("threadListChanged");
+    await vi.waitFor(() => {
+      expect(eventRequests).toBe(2);
+    });
+    expect(snapshotRequests).toBe(1);
+  });
+
+  it("silently skips a failed rebase for the rest of the session", async () => {
+    const userId = "thread-event-failed-rebase-user";
+    const orgId = "thread-event-failed-rebase-org";
+    const cachedEvents = createCachedEvents(101);
+    await writeCachedThreadEventLog({
+      userId,
+      orgId,
+      snapshot: {
+        chatThreads: [snapshotThread],
+        latestEventId: SNAPSHOT_EVENT_ID,
+      },
+      events: cachedEvents,
+    });
+
+    const errorToast = vi.spyOn(toast, "error");
+    context.signal.addEventListener("abort", () => {
+      errorToast.mockRestore();
+    });
+    let snapshotRequests = 0;
+    let eventRequests = 0;
+    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+      snapshotRequests += 1;
+      return respond(403, {
+        error: { message: "Snapshot unavailable", code: "FORBIDDEN" },
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      eventRequests += 1;
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    await setupAuthenticatedPage(userId, orgId);
+
+    await vi.waitFor(() => {
+      expect(snapshotRequests).toBe(1);
+    });
+    context.mocks.ably.trigger("threadListChanged");
+    await vi.waitFor(() => {
+      expect(eventRequests).toBe(2);
+    });
+    expect(snapshotRequests).toBe(1);
+    expect(errorToast).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -69,8 +69,10 @@ async function seedThreadEventCache(args: {
 }): Promise<void> {
   await clearThreadEventCache();
   if (args.snapshot) {
-    await threadEventStores.writeStore.replaceFromSnapshot(args.snapshot);
-    await threadEventStores.writeStore.upsertEvents([...(args.events ?? [])]);
+    await threadEventStores.writeStore.replaceFromSnapshot(
+      args.snapshot,
+      args.events ?? [],
+    );
   }
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -20,11 +20,14 @@ import { logger } from "../log.ts";
 import { reloadChatActiveRunIdsCounter$ } from "../chat-thread-list-reload.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { pathParams$ } from "../route.ts";
+import { bestEffort } from "../utils.ts";
 
 const L = logger("ChatThreadEventSourcing");
+const EVENT_LOG_SNAPSHOT_REBASE_THRESHOLD = 100;
 
 type Stores = ReturnType<typeof createIdbChatThreadEventStores>;
 type ChatThreadsClient = InitClientReturn<ChatThreadsContract, InitClientArgs>;
+type ChatThreadEventSyncMode = "incremental" | "snapshot-rebase";
 
 interface ChatThreadEventData {
   readonly snapshot: readonly ChatThreadSnapshotProjection[];
@@ -46,6 +49,11 @@ interface ChatThreadEventUpdate {
   readonly state: ChatThreadEventState;
   readonly replacementSnapshot: ChatThreadSnapshotData | null;
   readonly newEvents: readonly ChatThreadEvent[];
+}
+
+interface ChatThreadEventSyncResult {
+  readonly eventCount: number;
+  readonly snapshotReplaced: boolean;
 }
 
 export interface ThreadMeta {
@@ -127,20 +135,39 @@ const lastEventId$ = computed((get): string | null => {
 
 async function fetchRemoteSnapshot(
   client: ChatThreadsClient,
+  mode: ChatThreadEventSyncMode,
   signal?: AbortSignal,
 ): Promise<ChatThreadSnapshotData> {
   const result = await accept(
     client.snapshot({ fetchOptions: { signal } }),
     [200],
+    signal,
+    { showErrorToast: mode !== "snapshot-rebase" },
   );
   signal?.throwIfAborted();
   return result.body;
+}
+
+async function fetchRemoteEvents(
+  client: ChatThreadsClient,
+  cursor: string | null,
+  mode: ChatThreadEventSyncMode,
+  signal?: AbortSignal,
+) {
+  const request = client.events({
+    query: cursor ? { sinceEventId: cursor } : {},
+    fetchOptions: { signal },
+  });
+  return await accept(request, [200, 410], signal, {
+    showErrorToast: mode !== "snapshot-rebase",
+  });
 }
 
 async function fetchChatThreadEventUpdate(
   currentState: ChatThreadEventState,
   initialCursor: string | null,
   client: ChatThreadsClient,
+  mode: ChatThreadEventSyncMode,
   signal?: AbortSignal,
 ): Promise<ChatThreadEventUpdate | null> {
   let snapshot = currentState.snapshot;
@@ -149,26 +176,20 @@ async function fetchChatThreadEventUpdate(
   let snapshotReplaced = false;
   let newEvents: readonly ChatThreadEvent[] = [];
 
-  if (!snapshot || cursor === null) {
-    snapshot = await fetchRemoteSnapshot(client, signal);
+  if (mode === "snapshot-rebase" || !snapshot || cursor === null) {
+    snapshot = await fetchRemoteSnapshot(client, mode, signal);
     events = [];
     cursor = snapshot.latestEventId;
     snapshotReplaced = true;
   }
 
   for (let page = 0; page < 20; page++) {
-    const result = await accept(
-      client.events({
-        query: cursor ? { sinceEventId: cursor } : {},
-        fetchOptions: { signal },
-      }),
-      [200, 410],
-    );
+    const result = await fetchRemoteEvents(client, cursor, mode, signal);
     signal?.throwIfAborted();
 
     if (result.status === 410) {
       L.debug("events cursor expired, reloading snapshot");
-      snapshot = await fetchRemoteSnapshot(client, signal);
+      snapshot = await fetchRemoteSnapshot(client, mode, signal);
       events = [];
       newEvents = [];
       cursor = snapshot.latestEventId;
@@ -225,8 +246,12 @@ const initializeChatThreadEventState$ = command(
   },
 );
 
-export const syncEventDrivenChatThreads$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+const syncChatThreadEvents$ = command(
+  async (
+    { get, set },
+    mode: ChatThreadEventSyncMode,
+    signal: AbortSignal,
+  ): Promise<ChatThreadEventSyncResult> => {
     const store = get(chatThreadEventStores$);
     const state = get(chatThreadEventState$);
     const client = get(zeroClient$)(chatThreadsContract);
@@ -234,34 +259,63 @@ export const syncEventDrivenChatThreads$ = command(
       state,
       get(lastEventId$),
       client,
+      mode,
       signal,
     );
     signal.throwIfAborted();
     if (!update) {
-      return;
+      return {
+        eventCount: state.events.length,
+        snapshotReplaced: false,
+      };
     }
 
     if (update.replacementSnapshot) {
       await store.writeStore.replaceFromSnapshot(
         update.replacementSnapshot,
+        update.newEvents,
         signal,
       );
+    } else {
+      await store.writeStore.upsertEvents(update.newEvents, signal);
     }
-    await store.writeStore.upsertEvents(update.newEvents, signal);
     set(chatThreadEventState$, update.state);
     set(reconcileOptimisticChatThreadEvents$, {
       snapshot: update.state.snapshot?.chatThreads ?? [],
       events: update.state.events,
     });
     set(syncCurrentChatThreadDocumentTitle$, signal);
+    return {
+      eventCount: update.state.events.length,
+      snapshotReplaced: update.replacementSnapshot !== null,
+    };
+  },
+);
+
+export const syncEventDrivenChatThreads$ = command(
+  async ({ set }, signal: AbortSignal): Promise<void> => {
+    await set(syncChatThreadEvents$, "incremental", signal);
   },
 );
 
 export const subscribeEventDrivenChatThreads$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
+    let initialSnapshotRebasePending = true;
     const syncOnThreadListChanged$ = command(
       async ({ set }, signal: AbortSignal): Promise<boolean> => {
-        await set(syncEventDrivenChatThreads$, signal);
+        const result = await set(syncChatThreadEvents$, "incremental", signal);
+        if (initialSnapshotRebasePending) {
+          initialSnapshotRebasePending = false;
+          if (
+            !result.snapshotReplaced &&
+            result.eventCount > EVENT_LOG_SNAPSHOT_REBASE_THRESHOLD
+          ) {
+            await bestEffort(
+              set(syncChatThreadEvents$, "snapshot-rebase", signal),
+              signal,
+            );
+          }
+        }
         return false;
       },
     );

--- a/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
@@ -196,6 +196,7 @@ function createWriteStore(getDb: GetDb) {
   return {
     async replaceFromSnapshot(
       snapshot: ChatThreadSnapshotRecord,
+      events: readonly ChatThreadEvent[],
       signal?: AbortSignal,
     ) {
       await chatIdbWriteBestEffort(
@@ -208,12 +209,20 @@ function createWriteStore(getDb: GetDb) {
             "readwrite",
           );
           await tx.objectStore(CHAT_THREAD_EVENTS_STORE).clear();
-          await tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE).put({
-            id: SINGLETON_ID,
-            chatThreads: [...snapshot.chatThreads],
-            latestEventId: snapshot.latestEventId,
-          } satisfies StoredChatThreadSnapshot);
-          await tx.done;
+          const eventStore = tx.objectStore(CHAT_THREAD_EVENTS_STORE);
+          const requests = events.map((event) => {
+            signal?.throwIfAborted();
+            return eventStore.put(event);
+          });
+          await Promise.all([
+            tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE).put({
+              id: SINGLETON_ID,
+              chatThreads: [...snapshot.chatThreads],
+              latestEventId: snapshot.latestEventId,
+            } satisfies StoredChatThreadSnapshot),
+            ...requests,
+            tx.done,
+          ]);
         },
         signal,
       );


### PR DESCRIPTION
## Summary

- Rebase the persisted chat thread event cache after the first successful sync when its event tail exceeds 100 entries, unless that sync already replaced the snapshot.
- Fetch the latest snapshot and its post-snapshot event tail before atomically replacing both IndexedDB stores in one transaction.
- Treat the optional rebase as a silent best-effort operation and attempt it only once per page and organization lifecycle.

## User impact

Returning users with large local thread event logs stop replaying an indefinitely growing tail after startup. A failed compaction does not interrupt the already-successful incremental sync, show an error toast, or retry repeatedly in the same session.

## Await and latency

The added await does not block page rendering or cached thread hydration because authenticated daemons run detached from router rendering. It affects only sessions whose post-sync cache exceeds 100 events and adds one snapshot request, at least one event catch-up request (up to 1,000 events per page), and one IndexedDB transaction. Realtime notifications received during that window are coalesced and processed immediately afterward, preserving serialization without losing events.

## Verification

- Prettier 3.8.1 check on all touched files
- Targeted Oxlint, type-aware Oxlint, and ESLint checks on all touched files
- Platform production and test TypeScript checks
- Targeted Vitest: chat-thread-event-persistence and chat-thread-event-sourcing-local-first (14 tests passed)
- Full local Vitest suite and dev server intentionally not run per repository PR policy