### PR TITLE
ci: add optional production migration smoke check

### DIFF
--- a/.github/actions/production-migration-smoke/action.yml
+++ b/.github/actions/production-migration-smoke/action.yml
@@ -44,7 +44,7 @@ runs:
         echo "Waiting for smoke branch $BRANCH_NAME ($BRANCH_ID) to become ready"
         CURRENT_STATE=""
         for attempt in {1..30}; do
-          CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg id "$BRANCH_ID" '.[] | select(.id == $id) | .current_state')
+          CURRENT_STATE=$(neonctl branches get "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --output json | jq -r '.current_state')
           if [ "$CURRENT_STATE" = "ready" ]; then
             echo "Smoke branch ready"
             break
@@ -79,11 +79,5 @@ runs:
         NEON_PROJECT_ID: ${{ inputs.neon-project-id }}
       run: |
         echo "Cleaning up smoke branch $BRANCH_ID"
-        BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
-
-        if jq -e --arg id "$BRANCH_ID" '.[] | select(.id == $id)' <<< "$BRANCHES_JSON" > /dev/null; then
-          neonctl branches delete "$BRANCH_ID" --project-id "$NEON_PROJECT_ID"
-          echo "Smoke branch $BRANCH_ID deleted"
-        else
-          echo "Smoke branch $BRANCH_ID does not exist; cleanup skipped"
-        fi
+        neonctl branches delete "$BRANCH_ID" --project-id "$NEON_PROJECT_ID"
+        echo "Smoke branch $BRANCH_ID deleted"

--- a/.github/actions/production-migration-smoke/action.yml
+++ b/.github/actions/production-migration-smoke/action.yml
@@ -63,7 +63,6 @@ runs:
         echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 
     - name: Run Production Migration Smoke Test
-      if: steps.create-migration-smoke-branch.outputs.database-url != ''
       shell: bash
       working-directory: turbo
       env:

--- a/.github/actions/production-migration-smoke/action.yml
+++ b/.github/actions/production-migration-smoke/action.yml
@@ -1,0 +1,89 @@
+name: "Production Migration Smoke"
+description: "Run migrations on an expiring Neon branch cloned from production"
+
+inputs:
+  neon-api-key:
+    description: "Neon API key for branch lifecycle operations"
+    required: true
+  neon-project-id:
+    description: "Neon production project ID"
+    required: true
+  branch-name:
+    description: "Unique temporary branch name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install neonctl
+      shell: bash
+      run: npm install -g neonctl@2.15.0
+
+    - name: Create Production Migration Smoke Branch
+      id: create-migration-smoke-branch
+      shell: bash
+      env:
+        BRANCH_NAME: ${{ inputs.branch-name }}
+        NEON_API_KEY: ${{ inputs.neon-api-key }}
+        NEON_PROJECT_ID: ${{ inputs.neon-project-id }}
+      run: |
+        EXPIRES_AT=$(date -u -d "+6 hours" +"%Y-%m-%dT%H:%M:%SZ")
+
+        echo "Creating smoke branch $BRANCH_NAME from production"
+        CREATE_OUTPUT=$(
+          neonctl branches create \
+            --name "$BRANCH_NAME" \
+            --parent production \
+            --expires-at "$EXPIRES_AT" \
+            --project-id "$NEON_PROJECT_ID" \
+            --output json
+        )
+        BRANCH_ID=$(jq -er '.branch.id' <<< "$CREATE_OUTPUT")
+        echo "branch-id=$BRANCH_ID" >> "$GITHUB_OUTPUT"
+
+        echo "Waiting for smoke branch $BRANCH_NAME ($BRANCH_ID) to become ready"
+        CURRENT_STATE=""
+        for attempt in {1..30}; do
+          CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg id "$BRANCH_ID" '.[] | select(.id == $id) | .current_state')
+          if [ "$CURRENT_STATE" = "ready" ]; then
+            echo "Smoke branch ready"
+            break
+          fi
+          echo "Smoke branch state: ${CURRENT_STATE:-missing} (attempt $attempt/30)"
+          sleep 2
+        done
+
+        if [ "$CURRENT_STATE" != "ready" ]; then
+          echo "::error::Smoke branch $BRANCH_NAME not ready after 60 seconds (state: ${CURRENT_STATE:-missing})"
+          exit 1
+        fi
+
+        DATABASE_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+        echo "::add-mask::$DATABASE_URL"
+        echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
+    - name: Run Production Migration Smoke Test
+      if: steps.create-migration-smoke-branch.outputs.database-url != ''
+      shell: bash
+      working-directory: turbo
+      env:
+        DATABASE_URL: ${{ steps.create-migration-smoke-branch.outputs.database-url }}
+      run: pnpm -F @vm0/db db:migrate
+
+    - name: Delete Production Migration Smoke Branch
+      if: ${{ always() && steps.create-migration-smoke-branch.outputs.branch-id != '' }}
+      shell: bash
+      env:
+        BRANCH_ID: ${{ steps.create-migration-smoke-branch.outputs.branch-id }}
+        NEON_API_KEY: ${{ inputs.neon-api-key }}
+        NEON_PROJECT_ID: ${{ inputs.neon-project-id }}
+      run: |
+        echo "Cleaning up smoke branch $BRANCH_ID"
+        BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
+
+        if jq -e --arg id "$BRANCH_ID" '.[] | select(.id == $id)' <<< "$BRANCHES_JSON" > /dev/null; then
+          neonctl branches delete "$BRANCH_ID" --project-id "$NEON_PROJECT_ID"
+          echo "Smoke branch $BRANCH_ID deleted"
+        else
+          echo "Smoke branch $BRANCH_ID does not exist; cleanup skipped"
+        fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -619,9 +619,6 @@ jobs:
 
       - uses: ./.github/actions/toolchain-init
 
-      - name: Install neonctl
-        run: npm install -g neonctl@2.15.0
-
       - name: Notify Slack - Starting
         id: slack-start
         if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}
@@ -642,72 +639,13 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Create Production Migration Smoke Branch
-        id: create-migration-smoke-branch
-        env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-          BRANCH_NAME: release-smoke/production-migration
-        run: |
-          if neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
-            echo "Smoke branch $BRANCH_NAME already exists, resetting..."
-            neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
-          else
-            echo "Creating smoke branch $BRANCH_NAME from production"
-            neonctl branches create --name "$BRANCH_NAME" --parent production --project-id "$NEON_PROJECT_ID"
-          fi
-
-          echo "Waiting for smoke branch $BRANCH_NAME to become ready"
-          CURRENT_STATE=""
-          for i in $(seq 1 30); do
-            CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
-            if [ "$CURRENT_STATE" = "ready" ]; then
-              echo "Smoke branch ready"
-              break
-            fi
-            echo "Smoke branch state: ${CURRENT_STATE:-missing} (attempt $i/30)"
-            sleep 2
-          done
-
-          if [ "$CURRENT_STATE" != "ready" ]; then
-            echo "::error::Smoke branch $BRANCH_NAME not ready after 60 seconds (state: ${CURRENT_STATE:-missing})"
-            exit 1
-          fi
-
       - name: Run Production Migration Smoke Test
         id: run-migration-smoke-test
-        env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-          BRANCH_NAME: release-smoke/production-migration
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-        run: |
-          echo "Getting pooled database URL for smoke branch $BRANCH_NAME"
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-
-          echo "Running production migration smoke test on $BRANCH_NAME"
-          cd turbo
-          DATABASE_URL="$DATABASE_URL" pnpm -F @vm0/db db:migrate
-          echo "Production migration smoke test completed"
-
-      - name: Delete Production Migration Smoke Branch
-        id: delete-migration-smoke-branch
-        if: ${{ always() && steps.create-migration-smoke-branch.outcome != 'skipped' }}
-        env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-          BRANCH_NAME: release-smoke/production-migration
-        run: |
-          echo "Cleaning up smoke branch $BRANCH_NAME"
-          BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
-
-          if echo "$BRANCHES_JSON" | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
-            neonctl branches delete "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
-            echo "Smoke branch $BRANCH_NAME deleted"
-          else
-            echo "Smoke branch $BRANCH_NAME does not exist; cleanup skipped"
-          fi
+        uses: ./.github/actions/production-migration-smoke
+        with:
+          neon-api-key: ${{ secrets.NEON_API_KEY }}
+          neon-project-id: ${{ vars.NEON_PROJECT_ID }}
+          branch-name: release-smoke/migrate-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Get Production Database URL
         id: get-db-url
@@ -759,11 +697,7 @@ jobs:
           ${{
             failure() &&
             steps.slack-start.outputs.ts &&
-            (
-              steps.create-migration-smoke-branch.outcome == 'failure' ||
-              steps.run-migration-smoke-test.outcome == 'failure' ||
-              steps.delete-migration-smoke-branch.outcome == 'failure'
-            )
+            steps.run-migration-smoke-test.outcome == 'failure'
           }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
@@ -777,16 +711,14 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Database Migration Smoke* ❌ Smoke check failed\n📦 Version: `${{ needs.release-please.outputs.api_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n⚠️ Production database migration was not run. The failure happened before the real production DB migration, on the Neon smoke branch `release-smoke/production-migration` or its cleanup.\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/api-v${{ needs.release-please.outputs.api_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  text: "*Database Migration Smoke* ❌ Smoke check failed\n📦 Version: `${{ needs.release-please.outputs.api_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n⚠️ Production database migration was not run. The failure happened before the real production DB migration, on its temporary Neon production clone or during cleanup.\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/api-v${{ needs.release-please.outputs.api_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
       - name: Notify Slack - Failure
         if: >-
           ${{
             failure() &&
             steps.slack-start.outputs.ts &&
-            steps.create-migration-smoke-branch.outcome != 'failure' &&
-            steps.run-migration-smoke-test.outcome != 'failure' &&
-            steps.delete-migration-smoke-branch.outcome != 'failure'
+            steps.run-migration-smoke-test.outcome != 'failure'
           }}
         uses: slackapi/slack-github-action@v4.0.0
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -616,31 +616,23 @@ jobs:
       - name: Check JSONB Contract Usage
         working-directory: turbo/packages/db
         run: pnpm lint:jsonb-contracts
-      - name: Check Migration History Integrity
+      - name: Check Migration Immutability
         if: vars.CI_CHECK_IMMUTABLE_MIGRATE != '0'
         run: |
           BASE_REF="${{ needs.prepare.outputs.base-ref }}"
-          # SQL edits are allowed so a pending migration can be corrected after
-          # a production smoke failure. Deletions and snapshot rewrites still
-          # break the migration chain and must use a new migration instead.
-          DELETED_MIGRATIONS=$(git diff --no-renames --diff-filter=D --name-only "$BASE_REF" -- \
-            'turbo/packages/db/src/migrations/*.sql')
-          CHANGED_SNAPSHOTS=$(git diff --no-renames --diff-filter=MD --name-only "$BASE_REF" -- \
+          # Check that migration SQL files and snapshots are only added, never modified or deleted
+          CHANGED=$(git diff --diff-filter=MD --name-only "$BASE_REF" -- \
+            'turbo/packages/db/src/migrations/*.sql' \
             'turbo/packages/db/src/migrations/meta/*_snapshot.json')
 
           # _journal.json is modified on every new migration, so only flag deletion
-          DELETED_JOURNAL=$(git diff --no-renames --diff-filter=D --name-only "$BASE_REF" -- \
+          DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/packages/db/src/migrations/meta/_journal.json')
 
           FAILED=0
-          if [ -n "$DELETED_MIGRATIONS" ]; then
-            echo "::error::Migration SQL files must not be deleted:"
-            echo "$DELETED_MIGRATIONS"
-            FAILED=1
-          fi
-          if [ -n "$CHANGED_SNAPSHOTS" ]; then
-            echo "::error::Migration snapshots must not be modified or deleted:"
-            echo "$CHANGED_SNAPSHOTS"
+          if [ -n "$CHANGED" ]; then
+            echo "::error::Migration files must not be modified or deleted once on main:"
+            echo "$CHANGED"
             FAILED=1
           fi
           if [ -n "$DELETED_JOURNAL" ]; then
@@ -650,7 +642,8 @@ jobs:
           fi
           if [ "$FAILED" -eq 1 ]; then
             echo ""
-            echo "Create a NEW migration instead of breaking existing migration history."
+            echo "These files may already be deployed to production."
+            echo "Create a NEW migration instead of modifying existing ones."
             exit 1
           fi
       - name: Test Migration Consistency

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -652,6 +652,132 @@ jobs:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
         run: pnpm test:migration-consistency
 
+  # This production-data check is intentionally informational: it is not part
+  # of ci-gate-turbo and does not run for merge-group validation.
+  production-migration-smoke:
+    name: Production migration smoke (optional)
+    needs: prepare
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        needs.prepare.outputs.migration-changed == 'true' ||
+        github.head_ref == 'ci/pr-production-migration-smoke'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    concurrency:
+      group: production-migration-smoke-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    permissions:
+      contents: read
+      pull-requests: read
+    environment: production
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check Pull Request Is Current
+        id: current-pr
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid)
+          CURRENT_STATE=$(jq -r .state <<< "$PR_JSON")
+          CURRENT_HEAD_SHA=$(jq -r .headRefOid <<< "$PR_JSON")
+
+          if [ "$CURRENT_STATE" != "OPEN" ] || [ "$CURRENT_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::warning::Skipping stale migration smoke request for PR #$PR_NUMBER"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - if: steps.current-pr.outputs.run == 'true'
+        uses: actions/checkout@v7.0.1
+      - if: steps.current-pr.outputs.run == 'true'
+        uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        if: steps.current-pr.outputs.run == 'true'
+        run: npm install -g neonctl@2.15.0
+
+      - name: Create Production Migration Smoke Branch
+        if: steps.current-pr.outputs.run == 'true'
+        id: create-migration-smoke-branch
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BRANCH_NAME="pr-smoke/migrate-${PR_NUMBER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          EXPIRES_AT=$(date -u -d "+6 hours" +"%Y-%m-%dT%H:%M:%SZ")
+          echo "branch-name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+          echo "Creating smoke branch $BRANCH_NAME from production"
+          neonctl branches create \
+            --name "$BRANCH_NAME" \
+            --parent production \
+            --expires-at "$EXPIRES_AT" \
+            --project-id "$NEON_PROJECT_ID"
+
+          echo "Waiting for smoke branch $BRANCH_NAME to become ready"
+          CURRENT_STATE=""
+          for attempt in {1..30}; do
+            CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
+            if [ "$CURRENT_STATE" = "ready" ]; then
+              echo "Smoke branch ready"
+              break
+            fi
+            echo "Smoke branch state: ${CURRENT_STATE:-missing} (attempt $attempt/30)"
+            sleep 2
+          done
+
+          if [ "$CURRENT_STATE" != "ready" ]; then
+            echo "::error::Smoke branch $BRANCH_NAME not ready after 60 seconds (state: ${CURRENT_STATE:-missing})"
+            exit 1
+          fi
+
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+          echo "::add-mask::$DATABASE_URL"
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run Production Migration Smoke Test
+        if: steps.current-pr.outputs.run == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.create-migration-smoke-branch.outputs.branch-name }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          DATABASE_URL: ${{ steps.create-migration-smoke-branch.outputs.database-url }}
+        run: |
+          echo "Running production migration smoke test on $BRANCH_NAME"
+          cd turbo
+          pnpm -F @vm0/db db:migrate
+          echo "Production migration smoke test completed"
+
+      - name: Delete Production Migration Smoke Branch
+        if: ${{ always() && steps.create-migration-smoke-branch.outputs.branch-name != '' }}
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          BRANCH_NAME: ${{ steps.create-migration-smoke-branch.outputs.branch-name }}
+        run: |
+          echo "Cleaning up smoke branch $BRANCH_NAME"
+          BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
+
+          if echo "$BRANCHES_JSON" | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
+            neonctl branches delete "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
+            echo "Smoke branch $BRANCH_NAME deleted"
+          else
+            echo "Smoke branch $BRANCH_NAME does not exist; cleanup skipped"
+          fi
+
   test-cli:
     needs: [detect-turbo-ts-checks]
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -168,7 +168,6 @@ jobs:
       platform-changed: ${{ steps.detect.outputs.platform-changed }}
       e2b-changed: ${{ steps.detect.outputs.e2b-changed }}
       migration-changed: ${{ steps.detect.outputs.migration-changed }}
-      migration-added: ${{ steps.detect.outputs.migration-added }}
       crates-changed: ${{ steps.detect.outputs.crates-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect.outputs.e2e-changed }}
@@ -236,16 +235,6 @@ jobs:
           else
             echo "No migration, schema, or JSONB contract changes"
             echo "migration-changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if git diff --diff-filter=A --name-only "$BASE_REF" HEAD -- \
-            'turbo/packages/db/src/migrations/*.sql' |
-            grep -q .; then
-            echo "New migration SQL detected"
-            echo "migration-added=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No new migration SQL"
-            echo "migration-added=false" >> "$GITHUB_OUTPUT"
           fi
 
           if printf '%s\n' "$CHANGED_FILES" | grep -q "^crates/"; then
@@ -627,23 +616,31 @@ jobs:
       - name: Check JSONB Contract Usage
         working-directory: turbo/packages/db
         run: pnpm lint:jsonb-contracts
-      - name: Check Migration Immutability
+      - name: Check Migration History Integrity
         if: vars.CI_CHECK_IMMUTABLE_MIGRATE != '0'
         run: |
           BASE_REF="${{ needs.prepare.outputs.base-ref }}"
-          # Check that migration SQL files and snapshots are only added, never modified or deleted
-          CHANGED=$(git diff --diff-filter=MD --name-only "$BASE_REF" -- \
-            'turbo/packages/db/src/migrations/*.sql' \
+          # SQL edits are allowed so a pending migration can be corrected after
+          # a production smoke failure. Deletions and snapshot rewrites still
+          # break the migration chain and must use a new migration instead.
+          DELETED_MIGRATIONS=$(git diff --no-renames --diff-filter=D --name-only "$BASE_REF" -- \
+            'turbo/packages/db/src/migrations/*.sql')
+          CHANGED_SNAPSHOTS=$(git diff --no-renames --diff-filter=MD --name-only "$BASE_REF" -- \
             'turbo/packages/db/src/migrations/meta/*_snapshot.json')
 
           # _journal.json is modified on every new migration, so only flag deletion
-          DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
+          DELETED_JOURNAL=$(git diff --no-renames --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/packages/db/src/migrations/meta/_journal.json')
 
           FAILED=0
-          if [ -n "$CHANGED" ]; then
-            echo "::error::Migration files must not be modified or deleted once on main:"
-            echo "$CHANGED"
+          if [ -n "$DELETED_MIGRATIONS" ]; then
+            echo "::error::Migration SQL files must not be deleted:"
+            echo "$DELETED_MIGRATIONS"
+            FAILED=1
+          fi
+          if [ -n "$CHANGED_SNAPSHOTS" ]; then
+            echo "::error::Migration snapshots must not be modified or deleted:"
+            echo "$CHANGED_SNAPSHOTS"
             FAILED=1
           fi
           if [ -n "$DELETED_JOURNAL" ]; then
@@ -653,8 +650,7 @@ jobs:
           fi
           if [ "$FAILED" -eq 1 ]; then
             echo ""
-            echo "These files may already be deployed to production."
-            echo "Create a NEW migration instead of modifying existing ones."
+            echo "Create a NEW migration instead of breaking existing migration history."
             exit 1
           fi
       - name: Test Migration Consistency
@@ -672,7 +668,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        needs.prepare.outputs.migration-added == 'true' ||
+        needs.prepare.outputs.migration-changed == 'true' ||
         github.head_ref == 'ci/pr-production-migration-smoke'
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -684,16 +684,26 @@ jobs:
       - name: Check Pull Request Is Current
         id: current-pr
         env:
+          API_URL: ${{ github.api_url }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid)
+          PR_JSON=$(
+            curl --fail --silent --show-error \
+              --retry 3 \
+              --retry-delay 1 \
+              --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$API_URL/repos/$REPO/pulls/$PR_NUMBER"
+          )
           CURRENT_STATE=$(jq -r .state <<< "$PR_JSON")
-          CURRENT_HEAD_SHA=$(jq -r .headRefOid <<< "$PR_JSON")
+          CURRENT_HEAD_SHA=$(jq -r .head.sha <<< "$PR_JSON")
 
-          if [ "$CURRENT_STATE" != "OPEN" ] || [ "$CURRENT_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+          if [ "$CURRENT_STATE" != "open" ] || [ "$CURRENT_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
             echo "::warning::Skipping stale migration smoke request for PR #$PR_NUMBER"
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -168,6 +168,7 @@ jobs:
       platform-changed: ${{ steps.detect.outputs.platform-changed }}
       e2b-changed: ${{ steps.detect.outputs.e2b-changed }}
       migration-changed: ${{ steps.detect.outputs.migration-changed }}
+      migration-added: ${{ steps.detect.outputs.migration-added }}
       crates-changed: ${{ steps.detect.outputs.crates-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect.outputs.e2e-changed }}
@@ -235,6 +236,16 @@ jobs:
           else
             echo "No migration, schema, or JSONB contract changes"
             echo "migration-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --diff-filter=A --name-only "$BASE_REF" HEAD -- \
+            'turbo/packages/db/src/migrations/*.sql' |
+            grep -q .; then
+            echo "New migration SQL detected"
+            echo "migration-added=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new migration SQL"
+            echo "migration-added=false" >> "$GITHUB_OUTPUT"
           fi
 
           if printf '%s\n' "$CHANGED_FILES" | grep -q "^crates/"; then
@@ -661,7 +672,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        needs.prepare.outputs.migration-changed == 'true' ||
+        needs.prepare.outputs.migration-added == 'true' ||
         github.head_ref == 'ci/pr-production-migration-smoke'
       )
     runs-on: ubuntu-latest
@@ -674,7 +685,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    environment: production
+    environment:
+      name: production
+      deployment: false
     defaults:
       run:
         shell: bash
@@ -704,79 +717,13 @@ jobs:
       - if: steps.current-pr.outputs.run == 'true'
         uses: ./.github/actions/toolchain-init
 
-      - name: Install neonctl
-        if: steps.current-pr.outputs.run == 'true'
-        run: npm install -g neonctl@2.15.0
-
-      - name: Create Production Migration Smoke Branch
-        if: steps.current-pr.outputs.run == 'true'
-        id: create-migration-smoke-branch
-        env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          BRANCH_NAME="pr-smoke/migrate-${PR_NUMBER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          EXPIRES_AT=$(date -u -d "+6 hours" +"%Y-%m-%dT%H:%M:%SZ")
-          echo "branch-name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-          echo "Creating smoke branch $BRANCH_NAME from production"
-          neonctl branches create \
-            --name "$BRANCH_NAME" \
-            --parent production \
-            --expires-at "$EXPIRES_AT" \
-            --project-id "$NEON_PROJECT_ID"
-
-          echo "Waiting for smoke branch $BRANCH_NAME to become ready"
-          CURRENT_STATE=""
-          for attempt in {1..30}; do
-            CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r --arg name "$BRANCH_NAME" '.[] | select(.name == $name) | .current_state')
-            if [ "$CURRENT_STATE" = "ready" ]; then
-              echo "Smoke branch ready"
-              break
-            fi
-            echo "Smoke branch state: ${CURRENT_STATE:-missing} (attempt $attempt/30)"
-            sleep 2
-          done
-
-          if [ "$CURRENT_STATE" != "ready" ]; then
-            echo "::error::Smoke branch $BRANCH_NAME not ready after 60 seconds (state: ${CURRENT_STATE:-missing})"
-            exit 1
-          fi
-
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-          echo "::add-mask::$DATABASE_URL"
-          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
-
       - name: Run Production Migration Smoke Test
         if: steps.current-pr.outputs.run == 'true'
-        env:
-          BRANCH_NAME: ${{ steps.create-migration-smoke-branch.outputs.branch-name }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-          DATABASE_URL: ${{ steps.create-migration-smoke-branch.outputs.database-url }}
-        run: |
-          echo "Running production migration smoke test on $BRANCH_NAME"
-          cd turbo
-          pnpm -F @vm0/db db:migrate
-          echo "Production migration smoke test completed"
-
-      - name: Delete Production Migration Smoke Branch
-        if: ${{ always() && steps.create-migration-smoke-branch.outputs.branch-name != '' }}
-        env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-          BRANCH_NAME: ${{ steps.create-migration-smoke-branch.outputs.branch-name }}
-        run: |
-          echo "Cleaning up smoke branch $BRANCH_NAME"
-          BRANCHES_JSON=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json)
-
-          if echo "$BRANCHES_JSON" | jq -e --arg name "$BRANCH_NAME" '.[] | select(.name == $name)' > /dev/null; then
-            neonctl branches delete "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
-            echo "Smoke branch $BRANCH_NAME deleted"
-          else
-            echo "Smoke branch $BRANCH_NAME does not exist; cleanup skipped"
-          fi
+        uses: ./.github/actions/production-migration-smoke
+        with:
+          neon-api-key: ${{ secrets.NEON_API_KEY }}
+          neon-project-id: ${{ vars.NEON_PROJECT_ID }}
+          branch-name: pr-smoke/migrate-${{ github.event.pull_request.number }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   test-cli:
     needs: [detect-turbo-ts-checks]


### PR DESCRIPTION
## Summary

- add an informational PR migration smoke job for same-repository pull requests covered by the existing `migration-changed` signal
- cover migration, schema, and persistent JSONB contract changes without maintaining a second change detector
- preserve the existing migration immutability policy unchanged
- require the existing `production` environment approval while avoiding a production deployment record
- reuse one composite action for release and PR smoke checks
- isolate every run with a unique, expiring Neon branch cloned from production and clean it up by branch ID
- keep the job outside `ci-gate-turbo` and merge-group validation so skip, rejection, or failure cannot block merging

## Release behavior

The release path keeps its safety gate: production migration runs only after branch creation, readiness, connection-string generation, and migration on the production clone all succeed. Cleanup failure also remains visible and blocks the release.

The shared action intentionally improves the old lifecycle by using a unique branch per attempt, adding a six-hour expiration backstop, deleting the exact returned branch ID, and withholding Clerk and Neon credentials from the migration command. An empty generated database URL now reaches `db:migrate` and fails closed instead of skipping the smoke command.

## Bootstrap validation

This PR head intentionally lets the `ci/pr-production-migration-smoke` branch trigger the job without a migration change. The temporary condition will be removed after the approved smoke run validates the shared action end to end.

The live experiment confirms that a PR job can reference the protected `production` environment: it waits for required-reviewer approval and receives no production secrets before approval.

## Security

- skip fork pull requests
- re-check that the pull request is open and still at the expected head after environment approval
- expose the Neon API key only to branch lifecycle steps; the migration step receives only the temporary branch database URL
- capture the Neon-generated branch ID and delete that exact branch
- expire branches after six hours as a cancellation and runner-loss backstop

## Verification

- Prettier checks for both workflows and the composite action
- actionlint 1.7.12 across all workflows
- workflow shell compatibility checker and its regression test
- ShellCheck for every composite-action script
- pinned `neonctl@2.15.0` source verification for create/get/connection-string/delete arguments and JSON shapes
- real `db:migrate` entry-point verification that an empty database URL fails
- historical Git diff checks for the `migration-changed` signal
- `git diff --check`
