### PR TITLE
fix(platform): select or append recommended follow-ups in composer

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -190,6 +190,7 @@ export interface WorkflowComposerSignals {
   readonly insertPromptMarkdown$: Command<void, [string]>;
   readonly insertStructuredPrompt$: Command<void, [UserMessageDocument]>;
   readonly insertText$: Command<void, [string]>;
+  readonly selectText$: Command<boolean, [string]>;
   readonly appendText$: Command<void, [string]>;
   readonly readInputForSubmission$: Command<
     Promise<WorkflowComposerSubmissionSnapshot>,
@@ -1652,6 +1653,43 @@ function createInsertTextCommands(editor: Editor) {
       .scrollIntoView()
       .run();
   });
+  const selectText$ = command((_context, value: string): boolean => {
+    const text = value.trim();
+    if (!text) {
+      return false;
+    }
+
+    let textRun = "";
+    let textRunStart = -1;
+    let textRunEnd = -1;
+    let selection: { from: number; to: number } | null = null;
+    editor.state.doc.descendants((node, position) => {
+      if (selection || !node.isText || !node.text) {
+        return;
+      }
+      if (position === textRunEnd) {
+        textRun += node.text;
+      } else {
+        textRun = node.text;
+        textRunStart = position;
+      }
+      textRunEnd = position + node.nodeSize;
+
+      const matchIndex = textRun.indexOf(text);
+      if (matchIndex !== -1) {
+        selection = {
+          from: textRunStart + matchIndex,
+          to: textRunStart + matchIndex + text.length,
+        };
+      }
+    });
+    if (!selection) {
+      return false;
+    }
+
+    editor.chain().focus().setTextSelection(selection).scrollIntoView().run();
+    return true;
+  });
   const appendText$ = command((_context, value: string) => {
     const text = value.trim();
     if (!text) {
@@ -1662,7 +1700,7 @@ function createInsertTextCommands(editor: Editor) {
     const content = textblock?.value.trimEnd() ? `\n${text}` : text;
     editor.commands.insertContent(content);
   });
-  return { insertText$, insertPromptMarkdown$, appendText$ };
+  return { insertText$, insertPromptMarkdown$, selectText$, appendText$ };
 }
 
 function createInsertStructuredPromptCommand(editor: Editor) {

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -190,8 +190,8 @@ export interface WorkflowComposerSignals {
   readonly insertPromptMarkdown$: Command<void, [string]>;
   readonly insertStructuredPrompt$: Command<void, [UserMessageDocument]>;
   readonly insertText$: Command<void, [string]>;
-  readonly selectText$: Command<boolean, [string]>;
   readonly appendText$: Command<void, [string]>;
+  readonly selectOrAppendText$: Command<void, [string]>;
   readonly readInputForSubmission$: Command<
     Promise<WorkflowComposerSubmissionSnapshot>,
     [AbortSignal]
@@ -1653,7 +1653,8 @@ function createInsertTextCommands(editor: Editor) {
       .scrollIntoView()
       .run();
   });
-  const selectText$ = command((_context, value: string): boolean => {
+
+  const selectText = (value: string): boolean => {
     const text = value.trim();
     if (!text) {
       return false;
@@ -1689,8 +1690,9 @@ function createInsertTextCommands(editor: Editor) {
 
     editor.chain().focus().setTextSelection(selection).scrollIntoView().run();
     return true;
-  });
-  const appendText$ = command((_context, value: string) => {
+  };
+
+  const appendText = (value: string) => {
     const text = value.trim();
     if (!text) {
       return;
@@ -1699,8 +1701,23 @@ function createInsertTextCommands(editor: Editor) {
     const textblock = activeTextblock(editor);
     const content = textblock?.value.trimEnd() ? `\n${text}` : text;
     editor.commands.insertContent(content);
+  };
+
+  const appendText$ = command((_context, value: string) => {
+    appendText(value);
   });
-  return { insertText$, insertPromptMarkdown$, selectText$, appendText$ };
+  const selectOrAppendText$ = command((_context, value: string) => {
+    if (!selectText(value)) {
+      appendText(value);
+    }
+  });
+
+  return {
+    insertText$,
+    insertPromptMarkdown$,
+    appendText$,
+    selectOrAppendText$,
+  };
 }
 
 function createInsertStructuredPromptCommand(editor: Editor) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { click } from "../../../__tests__/page-helper.ts";
+import { click, fill } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
 import {
@@ -11,6 +11,7 @@ import {
   FOLLOWUP_THREAD_ID,
   HISTORY_THREAD_ID,
   buttonByText,
+  findWorkflowComposerEditor,
   queryButtonByText,
 } from "./chat-lifecycle-test-helpers.ts";
 
@@ -44,9 +45,10 @@ describe("chat lifecycle", () => {
       ).toBeInTheDocument();
     });
   });
-  it("sends a recommended follow-up from the latest assistant reply", async () => {
+  it("selects or appends a recommended follow-up without sending it", async () => {
     const assistantReply = "I can turn this into a launch package.";
     const followupPrompt = "Create a presentation outline";
+    const existingDraft = "Keep the current launch context";
     const completedAt = "2026-06-09T10:01:01Z";
     const completedAtLabel = new Date(completedAt).toLocaleString("en-US", {
       month: "short",
@@ -54,7 +56,6 @@ describe("chat lifecycle", () => {
       hour: "numeric",
       minute: "2-digit",
     });
-    const sendGate = context.mocks.deferred<void>();
     const sentMessages: {
       prompt?: string;
       revokesMessageId?: string;
@@ -64,7 +65,6 @@ describe("chat lifecycle", () => {
     mockChatLifecycle(context, {
       threadId: FOLLOWUP_THREAD_ID,
       threadTitle: "Launch package",
-      sendGate: sendGate.promise,
       chatMessages: [
         {
           id: "msg-followup-user",
@@ -133,6 +133,8 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
     });
 
+    const composer = await findWorkflowComposerEditor();
+    await fill(composer, existingDraft);
     await waitFor(() => {
       expect(screen.getByText(assistantReply)).toBeInTheDocument();
       expect(
@@ -149,24 +151,20 @@ describe("chat lifecycle", () => {
     click(buttonByText(followupPrompt));
 
     await waitFor(() => {
-      expect(queryButtonByText(followupPrompt)).not.toBeInTheDocument();
-      expect(screen.getByText(followupPrompt)).toBeInTheDocument();
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(composer.textContent).toBe(`${existingDraft}\n${followupPrompt}`);
+      expect(buttonByText(followupPrompt)).toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
     });
     expect(sentMessages).toHaveLength(0);
 
-    sendGate.resolve();
+    click(buttonByText(followupPrompt));
 
     await waitFor(() => {
-      expect(sentMessages).toHaveLength(1);
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(composer).toHaveFocus();
+      expect(window.getSelection()?.toString()).toBe(followupPrompt);
     });
-    expect(sentMessages[0]).toMatchObject({ prompt: followupPrompt });
-    expect(sentMessages[0]?.revokesMessageId).toBeUndefined();
-    expect(sentMessages[0]?.structuredPrompt).toStrictEqual({
-      version: 1,
-      parts: [{ type: "text", text: followupPrompt }],
-    });
+    expect(composer.textContent).toBe(`${existingDraft}\n${followupPrompt}`);
+    expect(sentMessages).toHaveLength(0);
   });
 
   it("shows recommended follow-ups after an appended follow-up event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3848,8 +3848,10 @@ function RecommendedFollowupList({
   thread: ChatThreadSignals;
   source: RecommendedFollowupSource;
 }) {
-  const sendMessage = useSet(thread.sendMessage$);
-  const rootSignal = useGet(rootSignal$);
+  const selectComposerText = useSet(thread.workflowComposer.selectText$);
+  const appendComposerText = useSet(thread.workflowComposer.appendText$);
+  const queueDraftSync = useSet(thread.queueDraftSync$);
+  const pageSignal = useGet(pageSignal$);
   const handleRecommendedFollowupsRef = (element: HTMLDivElement | null) => {
     reportRecommendedFollowupsShown(element, source);
   };
@@ -3864,16 +3866,10 @@ function RecommendedFollowupList({
       followupCount: source.followups.length,
       followup,
     });
-    detach(
-      sendMessage(
-        followup.prompt,
-        {
-          includeDraftAttachments: false,
-        },
-        rootSignal,
-      ),
-      Reason.DomCallback,
-    );
+    if (!selectComposerText(followup.prompt)) {
+      appendComposerText(followup.prompt);
+      detach(queueDraftSync(pageSignal), Reason.DomCallback);
+    }
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3848,10 +3848,9 @@ function RecommendedFollowupList({
   thread: ChatThreadSignals;
   source: RecommendedFollowupSource;
 }) {
-  const selectComposerText = useSet(thread.workflowComposer.selectText$);
-  const appendComposerText = useSet(thread.workflowComposer.appendText$);
-  const queueDraftSync = useSet(thread.queueDraftSync$);
-  const pageSignal = useGet(pageSignal$);
+  const selectOrAppendComposerText = useSet(
+    thread.workflowComposer.selectOrAppendText$,
+  );
   const handleRecommendedFollowupsRef = (element: HTMLDivElement | null) => {
     reportRecommendedFollowupsShown(element, source);
   };
@@ -3866,10 +3865,7 @@ function RecommendedFollowupList({
       followupCount: source.followups.length,
       followup,
     });
-    if (!selectComposerText(followup.prompt)) {
-      appendComposerText(followup.prompt);
-      detach(queueDraftSync(pageSignal), Reason.DomCallback);
-    }
+    selectOrAppendComposerText(followup.prompt);
   };
 
   return (


### PR DESCRIPTION
## Summary

- keep recommended follow-up clicks in the composer instead of starting a run
- select the first exact matching prompt already in the composer; otherwise append it at the end and sync the draft
- preserve the existing follow-up selection telemetry

## User impact

Users can review or edit a recommended follow-up before sending it. Repeated clicks select the existing text instead of duplicating or automatically sending it.

## Verification

- `pnpm exec prettier --write apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx` (6 tests passed)
