### PR TITLE
fix(chat): classify read and usage state by event type

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { cronCompactChatThreadSnapshotsContract } from "@vm0/api-contracts/contracts/cron";
 import {
   chatThreadsContract,
+  type ChatEventResponse,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
@@ -193,6 +194,24 @@ async function waitForThreadMessages(
   return page;
 }
 
+async function waitForThreadEvents(
+  actor: ApiTestUser,
+  threadId: string,
+  predicate: (events: readonly ChatEventResponse[]) => boolean,
+) {
+  let page: Awaited<ReturnType<typeof chat.listThreadEvents>> | undefined;
+  await expect
+    .poll(async () => {
+      page = await chat.listThreadEvents(actor, threadId);
+      return predicate(page.events);
+    })
+    .toBe(true);
+  if (!page) {
+    throw new Error(`Expected chat thread ${threadId} events to be readable`);
+  }
+  return page;
+}
+
 async function waitForRunStatus(
   actor: ApiTestUser,
   runId: string,
@@ -253,14 +272,19 @@ function userMessages(messages: readonly PagedChatMessage[]): UserMessage[] {
   });
 }
 
-async function usageMessagesForRun(
+type UsageRecordedEvent = Extract<
+  ChatEventResponse,
+  { eventType: "usage.recorded" }
+>;
+
+async function usageEventsForRun(
   actor: ApiTestUser,
   threadId: string,
   runId: string,
-): Promise<PagedChatMessage[]> {
-  const page = await chat.listThreadMessages(actor, threadId);
-  return page.messages.filter((message) => {
-    return message.runId === runId && message.usage !== undefined;
+): Promise<UsageRecordedEvent[]> {
+  const page = await chat.listThreadEvents(actor, threadId);
+  return page.events.filter((event): event is UsageRecordedEvent => {
+    return event.eventType === "usage.recorded" && event.runId === runId;
   });
 }
 
@@ -320,11 +344,9 @@ async function completeChatRunInThread(
   const { sandboxHeaders } = await claimChatRun(runnerGroup, run.runId);
   chatCallbacks.mockChatOutputEvents([]);
   await completeChatRunOk(run.runId, sandboxHeaders);
-  await waitForThreadMessages(actor, run.threadId, (messages) => {
-    return assistantMessages(messages).some((message) => {
-      return (
-        message.runId === run.runId && message.runLifecycleEvent === "completed"
-      );
+  await waitForThreadEvents(actor, run.threadId, (events) => {
+    return events.some((event) => {
+      return event.runId === run.runId && event.eventType === "run.completed";
     });
   });
   return run;
@@ -1186,11 +1208,10 @@ describe("CHAT-01 chat thread read state", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(activeRun.runId, activeClaim.sandboxHeaders);
-    await waitForThreadMessages(owner, activeRun.threadId, (messages) => {
-      return assistantMessages(messages).some((message) => {
+    await waitForThreadEvents(owner, activeRun.threadId, (events) => {
+      return events.some((event) => {
         return (
-          message.runId === activeRun.runId &&
-          message.runLifecycleEvent === "completed"
+          event.runId === activeRun.runId && event.eventType === "run.completed"
         );
       });
     });
@@ -1348,11 +1369,11 @@ describe("CHAT-01 chat thread read state", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(runningRun.runId, runningClaim.sandboxHeaders);
-    await waitForThreadMessages(owner, runningRun.threadId, (messages) => {
-      return assistantMessages(messages).some((message) => {
+    await waitForThreadEvents(owner, runningRun.threadId, (events) => {
+      return events.some((event) => {
         return (
-          message.runId === runningRun.runId &&
-          message.runLifecycleEvent === "completed"
+          event.runId === runningRun.runId &&
+          event.eventType === "run.completed"
         );
       });
     });
@@ -1644,8 +1665,8 @@ describe("CHAT-01 chat thread read state", () => {
   }, 30_000);
 });
 
-describe("CHAT-03 run usage messages", () => {
-  it("emits one immutable usage message per run", async () => {
+describe("CHAT-03 run usage events", () => {
+  it("emits one immutable usage event per run", async () => {
     const { actor, agentId } = await entitledChatActorWithoutRunner(
       "Usage message agent",
     );
@@ -1689,14 +1710,14 @@ describe("CHAT-03 run usage messages", () => {
     const billing = createBillingMediaApi(context);
     await billing.processOrgUsageEvents(actor);
 
-    let usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(1);
-    const usageMessage = usageMessages[0];
-    if (!usageMessage) {
-      throw new Error("Expected one usage message");
+    let usageEvents = await usageEventsForRun(actor, threadId, runId);
+    expect(usageEvents).toHaveLength(1);
+    const usageEvent = usageEvents[0];
+    if (!usageEvent) {
+      throw new Error("Expected one usage event");
     }
-    expect(usageMessage).toMatchObject({
-      role: "assistant",
+    expect(usageEvent).toMatchObject({
+      eventType: "usage.recorded",
       content: null,
       usage: {
         version: 1,
@@ -1738,8 +1759,8 @@ describe("CHAT-03 run usage messages", () => {
     );
     mockNow(new Date("2030-01-01T00:00:00.000Z"));
     await billing.processOrgUsageEvents(actor);
-    usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toStrictEqual([usageMessage]);
+    usageEvents = await usageEventsForRun(actor, threadId, runId);
+    expect(usageEvents).toStrictEqual([usageEvent]);
 
     clearMockNow();
     await webhooks.requestAgentUsageEvent(
@@ -1760,11 +1781,11 @@ describe("CHAT-03 run usage messages", () => {
     );
     mockNow(new Date("2030-01-01T00:00:01.000Z"));
     await billing.processOrgUsageEvents(actor);
-    usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toStrictEqual([usageMessage]);
+    usageEvents = await usageEventsForRun(actor, threadId, runId);
+    expect(usageEvents).toStrictEqual([usageEvent]);
   }, 60_000);
 
-  it("emits complete allowance-covered usage in one message", async () => {
+  it("emits complete allowance-covered usage in one event", async () => {
     const seededModel = await seedVm0ManagedDefaultModelKey(context);
     const selectedModel = DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
     expect(seededModel).toBe(selectedModel);
@@ -1833,10 +1854,10 @@ describe("CHAT-03 run usage messages", () => {
     );
     await createBillingMediaApi(context).processOrgUsageEvents(actor);
 
-    const usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(1);
-    expect(usageMessages[0]).toMatchObject({
-      role: "assistant",
+    const usageEvents = await usageEventsForRun(actor, threadId, runId);
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      eventType: "usage.recorded",
       content: null,
       usage: {
         version: 1,
@@ -1864,7 +1885,7 @@ describe("CHAT-03 run usage messages", () => {
     ).toStrictEqual({ short: 70, weekly: 70 });
   }, 60_000);
 
-  it("emits zero-credit usage messages and skips runs without usage", async () => {
+  it("emits zero-credit usage events and skips runs without usage", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor(
       "Zero usage message agent",
     );
@@ -1896,11 +1917,12 @@ describe("CHAT-03 run usage messages", () => {
     await completeChatRunOk(zeroRun.runId, zeroSandboxHeaders);
     await flushWaitUntilForTest();
 
-    const zeroPage = await chat.listThreadMessages(actor, zeroRun.threadId);
-    const zeroUsageMessage = zeroPage.messages.find((message) => {
-      return message.runId === zeroRun.runId && message.usage !== undefined;
-    });
-    expect(zeroUsageMessage?.usage).toMatchObject({
+    const [zeroUsageEvent] = await usageEventsForRun(
+      actor,
+      zeroRun.threadId,
+      zeroRun.runId,
+    );
+    expect(zeroUsageEvent?.usage).toMatchObject({
       version: 1,
       totalCredits: 0,
       breakdown: [
@@ -1927,7 +1949,7 @@ describe("CHAT-03 run usage messages", () => {
     await completeChatRunOk(quietRun.runId, quietSandboxHeaders);
     await flushWaitUntilForTest();
     await expect(
-      usageMessagesForRun(actor, quietRun.threadId, quietRun.runId),
+      usageEventsForRun(actor, quietRun.threadId, quietRun.runId),
     ).resolves.toHaveLength(0);
   }, 60_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   holdChatMessageInsertTransactionFixture,
   insertChatMessageTransactionFixture,
+  insertOutputEventWithConflictingLegacyPayloadFixture,
 } from "../../../test-fixtures/chat-messages";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -1172,6 +1173,44 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 });
 
 describe("CHAT-01 chat thread read state", () => {
+  it("uses event type rather than legacy lifecycle payload for read cursors", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor(
+      "Read cursor event type agent",
+    );
+    const run = await completeChatRunInThread(actor, runnerGroup, {
+      agentId,
+      prompt: "read cursor event type",
+    });
+    const firstRead = await chat.markThreadRead(actor, run.threadId);
+    if (!firstRead.lastReadAt) {
+      throw new Error("Expected the completed run to establish a read cursor");
+    }
+
+    const conflicting =
+      await insertOutputEventWithConflictingLegacyPayloadFixture({
+        threadId: run.threadId,
+        content: "explicit output event with stale lifecycle payload",
+        createdAt: new Date(new Date(firstRead.lastReadAt).getTime() + 1000),
+        legacyPayload: "run.completed",
+      });
+    const page = await chat.listThreadEvents(actor, run.threadId);
+    expect(page.events).toContainEqual(
+      expect.objectContaining({
+        id: conflicting.id,
+        eventType: "output.message",
+      }),
+    );
+
+    await expect(chat.listThreadUnreads(actor, agentId)).resolves.toStrictEqual(
+      [],
+    );
+    await expect(
+      chat.markThreadRead(actor, run.threadId),
+    ).resolves.toMatchObject({
+      lastReadAt: firstRead.lastReadAt,
+    });
+  }, 120_000);
+
   it("lists unread agent ids behind the agent unread feature switch", async () => {
     const {
       actor: owner,
@@ -1707,6 +1746,21 @@ describe("CHAT-03 run usage events", () => {
       sandboxHeaders,
       [200],
     );
+    const conflicting =
+      await insertOutputEventWithConflictingLegacyPayloadFixture({
+        threadId,
+        runId,
+        content: "explicit output event with stale usage payload",
+        legacyPayload: "usage.recorded",
+      });
+    const page = await chat.listThreadEvents(actor, threadId);
+    expect(page.events).toContainEqual(
+      expect.objectContaining({
+        id: conflicting.id,
+        eventType: "output.message",
+      }),
+    );
+
     const billing = createBillingMediaApi(context);
     await billing.processOrgUsageEvents(actor);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -8,6 +8,7 @@ import {
   chatThreadByIdContract,
   chatThreadComputerUseHostContract,
   chatThreadDraftContract,
+  chatThreadEventsContract,
   chatThreadMarkAgentReadContract,
   chatThreadMarkReadContract,
   chatThreadModelSelectionContract,
@@ -18,6 +19,7 @@ import {
   chatThreadMessagesContract,
   type AttachFile,
   type ArtifactsListResponse,
+  type ChatEventResponse,
   type ChatSearchResponse,
   type ChatThreadArtifactRun,
   type ChatThreadDetail,
@@ -259,6 +261,10 @@ export function createChatFilesBddApi(context: TestContext) {
 
   function threadMessagesClient() {
     return chatFilesApp(context)(chatThreadMessagesContract);
+  }
+
+  function threadEventsClient() {
+    return chatFilesApp(context)(chatThreadEventsContract);
   }
 
   function threadArtifactsClient() {
@@ -899,6 +905,31 @@ export function createChatFilesBddApi(context: TestContext) {
     }> {
       const response = await accept(
         threadMessagesClient().list({
+          headers: authenticate(context, actor),
+          params: { threadId },
+          query,
+        }),
+        [200],
+      );
+      return response.body;
+    },
+
+    async listThreadEvents(
+      actor: ApiTestUser,
+      threadId: string,
+      query: {
+        readonly sinceSeqId?: number;
+        readonly beforeSeqId?: number;
+        readonly sinceId?: string;
+        readonly beforeId?: string;
+        readonly limit?: number;
+      } = {},
+    ): Promise<{
+      readonly events: readonly ChatEventResponse[];
+      readonly hasHistoryBefore?: boolean;
+    }> {
+      const response = await accept(
+        threadEventsClient().list({
           headers: authenticate(context, actor),
           params: { threadId },
           query,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import type { chatThreads } from "@vm0/db/schema/chat-thread";
 
 import type { Db } from "../external/db";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 export function latestRunFinishMessageSubquery(
   db: Pick<Db, "select">,
@@ -16,7 +17,7 @@ export function latestRunFinishMessageSubquery(
     .where(
       and(
         eq(chatMessages.chatThreadId, threadId),
-        isNotNull(chatMessages.runLifecycleEvent),
+        chatEventTypeIn(["run.completed", "run.failed", "run.cancelled"]),
       ),
     )
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, count, eq, isNotNull, max, sql, sum } from "drizzle-orm";
+import { and, count, eq, max, sql, sum } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -20,6 +20,7 @@ import {
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 
 const L = logger("ChatUsageMessage");
@@ -154,19 +155,19 @@ export const maybeEmitRunUsageMessage$ = command(
         return null;
       }
 
-      const [existingUsageMessage] = await tx
+      const [existingUsageEvent] = await tx
         .select({ id: chatMessages.id })
         .from(chatMessages)
         .where(
           and(
             eq(chatMessages.runId, runId),
-            isNotNull(chatMessages.usagePayload),
+            chatEventTypeIn(["usage.recorded"]),
           ),
         )
         .limit(1);
       signal.throwIfAborted();
 
-      if (existingUsageMessage) {
+      if (existingUsageEvent) {
         return null;
       }
 

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -771,3 +771,49 @@ export async function insertChatMessageTransactionFixture(args: {
   }
   return message;
 }
+
+/**
+ * Appends an explicit output event with a nullable compatibility payload owned
+ * by a different ChatEvent leaf. Product writers intentionally
+ * cannot create this divergent rollout shape; the fixture proves readers use
+ * `event_type` as the semantic discriminator instead of legacy payload shape.
+ */
+export async function insertOutputEventWithConflictingLegacyPayloadFixture(args: {
+  readonly threadId: string;
+  readonly runId?: string;
+  readonly content: string;
+  readonly createdAt?: Date;
+  readonly legacyPayload: "run.completed" | "usage.recorded";
+}): Promise<{ readonly id: string; readonly seqId: number }> {
+  const event = await db().transaction(async (tx) => {
+    const identity = {
+      chatThreadId: args.threadId,
+      eventType: "output.message" as const,
+      content: args.content,
+      runId: args.runId ?? null,
+      createdAt: args.createdAt,
+    };
+    const lifecyclePayloadEvent = {
+      ...identity,
+      runLifecycleEvent: "completed",
+    };
+    const usagePayloadEvent = {
+      ...identity,
+      usagePayload: {
+        version: 1 as const,
+        totalCredits: 0,
+        settledAt: (args.createdAt ?? nowDate()).toISOString(),
+        breakdown: [],
+      },
+    };
+    const inserted =
+      args.legacyPayload === "run.completed"
+        ? await insertChatEvent(tx, lifecyclePayloadEvent)
+        : await insertChatEvent(tx, usagePayloadEvent);
+    if (!inserted) {
+      throw new Error("Expected the conflicting legacy-payload event insert");
+    }
+    return inserted;
+  });
+  return event;
+}


### PR DESCRIPTION
## Summary

- classify chat-thread read cursors from the canonical terminal `ChatEvent.eventType` leaves
- make per-run usage emission idempotent on `usage.recorded` instead of nullable payload shape
- move the affected BDD coverage to the canonical `/events` response and `eventType`

## User-visible impact

Read/unread state and usage records now follow the typed `ChatEvent` discriminator, so rollout compatibility payload columns no longer define business semantics.

## Implementation

- use `chatEventTypeIn(...)` for both queries, preserving the centralized nullable rollout-tail fallback until #23287 contracts `event_type`
- treat `run.completed`, `run.failed`, and `run.cancelled` as terminal events
- leave the append-only event rows and database schema unchanged

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm turbo run lint --log-order grouped` (12/12 tasks passed)
- `pnpm -F api lint`
- `pnpm check-types` (11 non-API packages passed; the API task hit the local default 2 GB Node heap limit)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- targeted `chat-threads.bdd.test.ts` read-state and usage-idempotency cases (2 passed)
