### PR TITLE
fix(runner): enforce auth.base forwarding deadline

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -22,8 +22,8 @@ from contextlib import suppress
 from enum import Enum, auto
 from typing import NamedTuple, Protocol
 
+import mitmproxy_rs
 from mitmproxy import http
-from mitmproxy_rs import dns as mitmproxy_rs_dns
 
 import flow_metadata_keys as metadata_keys
 import public_destination
@@ -834,7 +834,7 @@ def _get_dns_resolver() -> _AddressResolver:
 
     resolver = _dns_resolver
     if resolver is None:
-        resolver = mitmproxy_rs_dns.DnsResolver()
+        resolver = mitmproxy_rs.dns.DnsResolver()
         _dns_resolver = resolver
     return resolver
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -14,12 +14,16 @@ import socket
 import ssl
 import sys
 import threading
+import time
 import urllib.parse
+from collections.abc import Callable
 from concurrent.futures import Future, InvalidStateError
 from contextlib import suppress
+from enum import Enum, auto
 from typing import NamedTuple, Protocol
 
 from mitmproxy import http
+from mitmproxy_rs import dns as mitmproxy_rs_dns
 
 import flow_metadata_keys as metadata_keys
 import public_destination
@@ -52,6 +56,7 @@ MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
+AUTH_BASE_FORWARD_DEADLINE_SECONDS = 30.0
 _FORWARD_REQUEST_CLEANUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
     Exception,
     asyncio.CancelledError,
@@ -70,14 +75,15 @@ _forward_request_pending_futures_lock = threading.Lock()
 _forward_request_budget_lock = threading.Lock()
 _forward_request_admitted_count = 0
 _forward_request_admitted_body_bytes = 0
-_forward_request_active_closeables: set["_Closeable"] = set()
-_forward_request_active_closeables_lock = threading.Lock()
+_forward_request_active_handles: set["_ForwardRequestAbortHandle"] = set()
+_forward_request_active_handles_lock = threading.Lock()
 _https_context: ssl.SSLContext | None = None
 _https_context_lock = threading.Lock()
+_dns_resolver: "_AddressResolver | None" = None
 
 
-class _Closeable(Protocol):
-    def close(self) -> object:
+class _AddressResolver(Protocol):
+    async def lookup_ip(self, host: str) -> list[str]:
         raise NotImplementedError
 
 
@@ -91,26 +97,24 @@ class _ForwardRequestAdmissionState(NamedTuple):
 _forward_request_admission_state: _ForwardRequestAdmissionState | None = None
 
 
-def _track_active_closeable(closeable: _Closeable) -> bool:
-    with _forward_request_lifecycle_lock, _forward_request_active_closeables_lock:
+def _track_active_forward_request_handle(handle: "_ForwardRequestAbortHandle") -> bool:
+    with _forward_request_lifecycle_lock, _forward_request_active_handles_lock:
         if not _forward_request_accepting:
             return False
-        _forward_request_active_closeables.add(closeable)
+        _forward_request_active_handles.add(handle)
         return True
 
 
-def _untrack_active_closeable(closeable: _Closeable) -> None:
-    with _forward_request_active_closeables_lock:
-        _forward_request_active_closeables.discard(closeable)
+def _untrack_active_forward_request_handle(handle: "_ForwardRequestAbortHandle") -> None:
+    with _forward_request_active_handles_lock:
+        _forward_request_active_handles.discard(handle)
 
 
-def _close_active_forward_request_closeables() -> None:
-    with _forward_request_active_closeables_lock:
-        closeables = tuple(_forward_request_active_closeables)
-        _forward_request_active_closeables.clear()
-    for closeable in closeables:
-        with suppress(Exception):
-            closeable.close()
+def _abort_active_forward_request_handles() -> None:
+    with _forward_request_active_handles_lock:
+        handles = tuple(_forward_request_active_handles)
+    for handle in handles:
+        handle.abort_for_shutdown()
 
 
 def _cancel_pending_forward_request_futures() -> None:
@@ -161,6 +165,7 @@ def _join_forward_request_workers() -> None:
 
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
+    global _dns_resolver
     global _forward_request_accepting
     global _forward_request_admitted_body_bytes
     global _forward_request_admitted_count
@@ -172,6 +177,7 @@ def reset_forward_request_state_for_tests() -> None:
         _forward_request_admitted_body_bytes = 0
     with _https_context_lock:
         _https_context = None
+    _dns_resolver = None
     _forward_request_accepting = True
 
 
@@ -185,8 +191,8 @@ def shutdown_forward_request_workers(*, wait: bool) -> None:
         admission_state = _forward_request_admission_state
         _forward_request_admission_state = None
     _wake_forward_request_admission_waiters(admission_state)
+    _abort_active_forward_request_handles()
     _cancel_pending_forward_request_futures()
-    _close_active_forward_request_closeables()
     if wait:
         _join_forward_request_workers()
 
@@ -203,6 +209,10 @@ class AuthBaseForwardingSaturatedError(Exception):
     """Raised when auth.base forwarding admission is saturated."""
 
 
+class AuthBaseForwardingDeadlineExceededError(Exception):
+    """Raised when one auth.base forwarding attempt exceeds its total lifetime."""
+
+
 class UnsafeAuthBaseDestinationError(Exception):
     """Raised when an auth.base upstream destination is not public internet."""
 
@@ -213,6 +223,135 @@ class InvalidResolvedAuthHeaderError(Exception):
 
 class InvalidAuthBaseRequestHeadersError(Exception):
     """Raised when client representation headers cannot be forwarded safely."""
+
+
+class _ForwardRequestTerminalState(Enum):
+    COMPLETED = auto()
+    DEADLINE_EXPIRED = auto()
+    SHUTDOWN_ABORTED = auto()
+
+
+def _abort_socket(sock: socket.socket) -> None:
+    with suppress(Exception):
+        sock.shutdown(socket.SHUT_RDWR)
+    with suppress(Exception):
+        sock.close()
+
+
+class _ForwardRequestAbortHandle:
+    """Serialize one forward's async lookup, socket, deadline, and shutdown."""
+
+    __slots__ = ("_async_cancel", "_lock", "_loop", "_socket", "_terminal_state")
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._async_cancel: Callable[[], object] | None = None
+        self._lock = threading.Lock()
+        self._loop = loop
+        self._socket: socket.socket | None = None
+        self._terminal_state: _ForwardRequestTerminalState | None = None
+
+    def register_async_cancel(self, cancel: Callable[[], object]) -> None:
+        with self._lock:
+            terminal_state = self._terminal_state
+            if terminal_state is None:
+                self._async_cancel = cancel
+                return
+        cancel()
+        self._raise_terminal(terminal_state)
+
+    def clear_async_cancel(self, cancel: Callable[[], object]) -> None:
+        with self._lock:
+            if self._async_cancel is cancel:
+                self._async_cancel = None
+
+    def register_socket(self, sock: socket.socket) -> None:
+        with self._lock:
+            terminal_state = self._terminal_state
+            if terminal_state is None:
+                self._socket = sock
+                return
+        _abort_socket(sock)
+        self._raise_terminal(terminal_state)
+
+    def replace_socket(self, current: socket.socket, replacement: socket.socket) -> None:
+        with self._lock:
+            terminal_state = self._terminal_state
+            if terminal_state is None and self._socket is current:
+                self._socket = replacement
+                return
+        _abort_socket(replacement)
+        if terminal_state is None:
+            raise RuntimeError("auth.base forwarding socket ownership changed unexpectedly")
+        self._raise_terminal(terminal_state)
+
+    def clear_socket(self, sock: socket.socket) -> None:
+        with self._lock:
+            if self._socket is sock:
+                self._socket = None
+
+    def abort_for_deadline(self) -> bool:
+        return self._abort(_ForwardRequestTerminalState.DEADLINE_EXPIRED)
+
+    def abort_for_shutdown(self) -> bool:
+        return self._abort(_ForwardRequestTerminalState.SHUTDOWN_ABORTED)
+
+    def finish(self, deadline: float) -> _ForwardRequestTerminalState:
+        async_cancel: Callable[[], object] | None = None
+        sock: socket.socket | None = None
+        with self._lock:
+            if self._terminal_state is None:
+                if time.monotonic() >= deadline:
+                    self._terminal_state = _ForwardRequestTerminalState.DEADLINE_EXPIRED
+                    async_cancel = self._async_cancel
+                    sock = self._socket
+                else:
+                    self._terminal_state = _ForwardRequestTerminalState.COMPLETED
+                self._async_cancel = None
+                self._socket = None
+            terminal_state = self._terminal_state
+        self._cancel_async(async_cancel)
+        if sock is not None:
+            _abort_socket(sock)
+        return terminal_state
+
+    @property
+    def terminal_state(self) -> _ForwardRequestTerminalState | None:
+        with self._lock:
+            return self._terminal_state
+
+    def raise_if_aborted(self) -> None:
+        terminal_state = self.terminal_state
+        if terminal_state is not None:
+            self._raise_terminal(terminal_state)
+
+    def _abort(self, terminal_state: _ForwardRequestTerminalState) -> bool:
+        async_cancel: Callable[[], object] | None = None
+        sock: socket.socket | None = None
+        with self._lock:
+            if self._terminal_state is not None:
+                return False
+            self._terminal_state = terminal_state
+            async_cancel = self._async_cancel
+            sock = self._socket
+            self._async_cancel = None
+            self._socket = None
+        self._cancel_async(async_cancel)
+        if sock is not None:
+            _abort_socket(sock)
+        return True
+
+    def _cancel_async(self, cancel: Callable[[], object] | None) -> None:
+        if cancel is not None:
+            with suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(cancel)
+
+    @staticmethod
+    def _raise_terminal(terminal_state: _ForwardRequestTerminalState) -> None:
+        if terminal_state is _ForwardRequestTerminalState.DEADLINE_EXPIRED:
+            raise AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded")
+        if terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
+            raise RuntimeError("auth.base forwarding workers are shut down")
+        raise RuntimeError("auth.base forwarding attempt is already completed")
 
 
 class AuthBaseForwardingAdmission:
@@ -226,27 +365,31 @@ class AuthBaseForwardingAdmission:
 
 
 class _ValidatedAddress(NamedTuple):
+    family: socket.AddressFamily
     host: str
     port: int
 
 
-def _connect_to_validated_addresses(validated_addresses: tuple[_ValidatedAddress, ...]):
-    def create_connection(_address, timeout, source_address):
-        last_error: OSError | None = None
-        for address in validated_addresses:
-            try:
-                return socket.create_connection(
-                    (address.host, address.port),
-                    timeout,
-                    source_address,
-                )
-            except OSError as exc:
-                last_error = exc
-        if last_error is not None:
-            raise last_error
-        raise OSError("getaddrinfo returns an empty list")
+class _PreparedForwardRequest(NamedTuple):
+    host: str
+    port: int | None
+    target: str
 
-    return create_connection
+
+type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
+
+
+def _validated_socket_address(address: _ValidatedAddress) -> _SocketAddress:
+    if address.family == socket.AF_INET6:
+        return address.host, address.port, 0, 0
+    return address.host, address.port
+
+
+def _remaining_deadline_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded")
+    return remaining
 
 
 def _create_https_context() -> ssl.SSLContext:
@@ -280,71 +423,99 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
         host: str,
         port: int | None,
         *,
-        timeout,
+        deadline: float,
+        abort_handle: _ForwardRequestAbortHandle,
         validated_addresses: tuple[_ValidatedAddress, ...],
     ) -> None:
-        super().__init__(host, port=port, timeout=timeout)
+        super().__init__(
+            host,
+            port=port,
+            timeout=_remaining_deadline_seconds(deadline),
+        )
+        self._abort_handle = abort_handle
+        self._deadline = deadline
         self._validated_addresses = validated_addresses
         self._context = _get_https_context()
-        self._tracked_closeables: list[_Closeable] = []
 
-    def _track_closeable(self, closeable: _Closeable) -> None:
-        if not _track_active_closeable(closeable):
-            with suppress(Exception):
-                closeable.close()
-            raise RuntimeError("auth.base forwarding workers are shut down")
-        self._tracked_closeables.append(closeable)
-
-    def _untrack_closeables(self) -> None:
-        for closeable in self._tracked_closeables:
-            _untrack_active_closeable(closeable)
-        self._tracked_closeables.clear()
-
-    def _close_and_untrack_after_connect_failure(self, closeable: _Closeable) -> None:
+    def _close_and_clear_socket(self, sock: socket.socket) -> None:
+        self._abort_handle.clear_socket(sock)
         with suppress(Exception):
-            closeable.close()
-        self._untrack_closeables()
+            sock.close()
+
+    def _connect_raw_socket(self) -> socket.socket:
+        last_error: OSError | None = None
+        for address in self._validated_addresses:
+            self._abort_handle.raise_if_aborted()
+            raw_sock = socket.socket(address.family, socket.SOCK_STREAM)
+            try:
+                self._abort_handle.register_socket(raw_sock)
+                raw_sock.settimeout(_remaining_deadline_seconds(self._deadline))
+                raw_sock.connect(_validated_socket_address(address))
+                self._abort_handle.raise_if_aborted()
+            except OSError as exc:
+                last_error = exc
+                self._close_and_clear_socket(raw_sock)
+                continue
+            except Exception:
+                self._close_and_clear_socket(raw_sock)
+                raise
+            return raw_sock
+        if last_error is not None:
+            raise last_error
+        raise OSError("address resolver returned an empty list")
 
     def connect(self) -> None:
-        raw_sock = _connect_to_validated_addresses(self._validated_addresses)(
-            (self.host, self.port),
-            self.timeout,
-            None,
-        )
-        self._track_closeable(raw_sock)
+        raw_sock = self._connect_raw_socket()
         try:
             raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except OSError as exc:
             if exc.errno != errno.ENOPROTOOPT:
-                self._close_and_untrack_after_connect_failure(raw_sock)
+                self._close_and_clear_socket(raw_sock)
                 raise
         try:
-            wrapped_sock = self._context.wrap_socket(raw_sock, server_hostname=self.host)
+            wrapped_sock = self._context.wrap_socket(
+                raw_sock,
+                server_hostname=self.host,
+                do_handshake_on_connect=False,
+            )
             if wrapped_sock is not raw_sock:
-                self._track_closeable(wrapped_sock)
+                self._abort_handle.replace_socket(raw_sock, wrapped_sock)
             self.sock = wrapped_sock
+            self.set_remaining_timeout()
+            wrapped_sock.do_handshake()
         except Exception:
-            self._close_and_untrack_after_connect_failure(raw_sock)
+            current_sock = self.sock
+            self.sock = None
+            self._close_and_clear_socket(current_sock if current_sock is not None else raw_sock)
             raise
 
+    def set_remaining_timeout(self) -> None:
+        self._abort_handle.raise_if_aborted()
+        if self.sock is not None:
+            self.sock.settimeout(_remaining_deadline_seconds(self._deadline))
+
     def close(self) -> None:
+        sock = self.sock
         try:
             super().close()
         finally:
-            self._untrack_closeables()
+            if sock is not None:
+                self._abort_handle.clear_socket(sock)
 
 
 def _make_validated_https_connection(
     host: str,
     port: int | None,
     *,
-    timeout,
+    deadline: float,
+    abort_handle: _ForwardRequestAbortHandle,
     validated_addresses: tuple[_ValidatedAddress, ...],
-) -> http_client.HTTPConnection:
+) -> _ValidatedTLSConnection:
     return _ValidatedTLSConnection(
         host,
         port=port,
-        timeout=timeout,
+        deadline=deadline,
+        abort_handle=abort_handle,
         validated_addresses=validated_addresses,
     )
 
@@ -658,38 +829,61 @@ def _raise_unsafe_destination() -> None:
     raise UnsafeAuthBaseDestinationError("Unsafe auth.base upstream destination")
 
 
-def _resolve_validated_addresses(host: str, port: int) -> tuple[_ValidatedAddress, ...]:
-    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+def _get_dns_resolver() -> _AddressResolver:
+    global _dns_resolver
+
+    resolver = _dns_resolver
+    if resolver is None:
+        resolver = mitmproxy_rs_dns.DnsResolver()
+        _dns_resolver = resolver
+    return resolver
+
+
+def _validated_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address, port: int):
+    family = socket.AF_INET6 if address.version == IPV6_VERSION else socket.AF_INET
+    return _ValidatedAddress(family, address.compressed, port)
+
+
+async def _resolve_validated_addresses(
+    host: str,
+    port: int,
+    abort_handle: _ForwardRequestAbortHandle,
+) -> tuple[_ValidatedAddress, ...]:
+    try:
+        literal_address = ipaddress.ip_address(host)
+    except ValueError:
+        lookup_future = asyncio.ensure_future(_get_dns_resolver().lookup_ip(host))
+
+        def cancel_lookup() -> object:
+            return lookup_future.cancel()
+
+        abort_handle.register_async_cancel(cancel_lookup)
+        try:
+            resolved_hosts = await lookup_future
+        finally:
+            abort_handle.clear_async_cancel(cancel_lookup)
+    else:
+        resolved_hosts = [literal_address.compressed]
+
     seen: set[str] = set()
     addresses: list[_ValidatedAddress] = []
-    for _family, _socktype, _proto, _canonname, sockaddr in infos:
-        address = ipaddress.ip_address(sockaddr[0])
+    for resolved_host in resolved_hosts:
+        address = ipaddress.ip_address(resolved_host)
         key = address.compressed
         if key in seen:
             continue
         seen.add(key)
         if not _is_public_unicast_address(address):
             _raise_unsafe_destination()
-        addresses.append(_ValidatedAddress(address.compressed, port))
+        addresses.append(_validated_address(address, port))
     if not addresses:
         raise ValueError("Invalid upstream URL: host did not resolve")
     return tuple(addresses)
 
 
-def _forward_request_sync(
-    url: str,
-    method: str,
-    headers: list[tuple[str, str]],
-    body: bytes | None,
-) -> tuple[int, bytes, http.Headers]:
-    """Forward an HTTPS request to the real URL and return (status, body, headers).
-
-    Security: only https URLs are allowed, and redirects are returned
-    to the sandbox client instead of being followed inside the addon.
-    """
-    _validate_request_body_size(body)
+def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
     parsed = urllib.parse.urlsplit(url)
-    conn_factory = _connection_factory(parsed.scheme.lower())
+    _connection_factory(parsed.scheme.lower())
     _reject_userinfo(parsed)
     host = _normalized_forward_request_host(parsed)
     if authority_has_empty_port(parsed.netloc):
@@ -698,21 +892,50 @@ def _forward_request_sync(
         port = parsed.port
     except ValueError as exc:
         raise ValueError("Invalid upstream URL: invalid port") from exc
-    effective_port = port if port is not None else DEFAULT_HTTPS_PORT
-    validated_addresses = _resolve_validated_addresses(host, effective_port)
-    conn = conn_factory(host, port=port, timeout=30, validated_addresses=validated_addresses)
+    return _PreparedForwardRequest(host, port, _request_target(parsed))
+
+
+def _forward_request_sync(
+    prepared: _PreparedForwardRequest,
+    method: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline: float,
+) -> tuple[int, bytes, http.Headers]:
+    """Forward an HTTPS request to the real URL and return (status, body, headers).
+
+    Security: only https URLs are allowed, and redirects are returned
+    to the sandbox client instead of being followed inside the addon.
+    """
+    abort_handle.raise_if_aborted()
+    conn = _make_validated_https_connection(
+        prepared.host,
+        port=prepared.port,
+        deadline=deadline,
+        abort_handle=abort_handle,
+        validated_addresses=validated_addresses,
+    )
     resp = None
     try:
         conn.putrequest(
             method,
-            _request_target(parsed),
+            prepared.target,
             skip_host=True,
             skip_accept_encoding=True,
         )
-        for header_name, header_value in _outbound_request_headers(headers, host, port, body):
+        for header_name, header_value in _outbound_request_headers(
+            headers,
+            prepared.host,
+            prepared.port,
+            body,
+        ):
             conn.putheader(header_name, header_value)
         conn.endheaders(body)
+        conn.set_remaining_timeout()
         resp = conn.getresponse()
+        conn.set_remaining_timeout()
         resp_body = _read_response_body(resp)
         return resp.status, resp_body, _filter_response_headers(resp.getheaders())
     finally:
@@ -766,21 +989,41 @@ def _release_forward_request_resources(
     loop: asyncio.AbstractEventLoop,
     semaphore: asyncio.Semaphore,
     admission: AuthBaseForwardingAdmission,
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline_timer: asyncio.TimerHandle,
     _future: Future[tuple[int, bytes, http.Headers]],
 ) -> None:
+    _untrack_active_forward_request_handle(abort_handle)
     release_forward_request_admission(admission)
+
+    def release_on_loop() -> None:
+        deadline_timer.cancel()
+        semaphore.release()
+
     with suppress(RuntimeError):
-        loop.call_soon_threadsafe(semaphore.release)
+        loop.call_soon_threadsafe(release_on_loop)
 
 
 def _forward_request_sync_in_context(
     context: contextvars.Context,
-    url: str,
+    prepared: _PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline: float,
 ) -> tuple[int, bytes, http.Headers]:
-    return context.run(_forward_request_sync, url, method, headers, body)
+    return context.run(
+        _forward_request_sync,
+        prepared,
+        method,
+        headers,
+        body,
+        validated_addresses,
+        abort_handle,
+        deadline,
+    )
 
 
 def _set_forward_request_future_exception(
@@ -791,13 +1034,35 @@ def _set_forward_request_future_exception(
         future.set_exception(exc)
 
 
+def _set_forward_request_terminal_exception(
+    future: Future[tuple[int, bytes, http.Headers]],
+    terminal_state: _ForwardRequestTerminalState,
+) -> bool:
+    if terminal_state is _ForwardRequestTerminalState.DEADLINE_EXPIRED:
+        _set_forward_request_future_exception(
+            future,
+            AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded"),
+        )
+        return True
+    if terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
+        _set_forward_request_future_exception(
+            future,
+            RuntimeError("auth.base forwarding workers are shut down"),
+        )
+        return True
+    return False
+
+
 def _run_forward_request_worker(
     future: Future[tuple[int, bytes, http.Headers]],
     context: contextvars.Context,
-    url: str,
+    prepared: _PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline: float,
 ) -> None:
     try:
         with _forward_request_lifecycle_lock:
@@ -810,33 +1075,61 @@ def _run_forward_request_worker(
                 return
             _discard_pending_forward_request_future(future)
         try:
-            result = _forward_request_sync_in_context(context, url, method, headers, body)
+            result = _forward_request_sync_in_context(
+                context,
+                prepared,
+                method,
+                headers,
+                body,
+                validated_addresses,
+                abort_handle,
+                deadline,
+            )
         except Exception as exc:
-            _set_forward_request_future_exception(future, exc)
+            terminal_state = abort_handle.finish(deadline)
+            if not _set_forward_request_terminal_exception(future, terminal_state):
+                _set_forward_request_future_exception(future, exc)
         else:
-            with suppress(InvalidStateError):
-                future.set_result(result)
+            terminal_state = abort_handle.finish(deadline)
+            if not _set_forward_request_terminal_exception(future, terminal_state):
+                with suppress(InvalidStateError):
+                    future.set_result(result)
     finally:
         if sys.exc_info()[1] is not None and future.running():
-            _set_forward_request_future_exception(
-                future,
-                RuntimeError("auth.base forwarding worker exited without completing future"),
-            )
+            terminal_state = abort_handle.finish(deadline)
+            if not _set_forward_request_terminal_exception(future, terminal_state):
+                _set_forward_request_future_exception(
+                    future,
+                    RuntimeError("auth.base forwarding worker exited without completing future"),
+                )
         with _forward_request_workers_lock:
             _forward_request_workers.discard(threading.current_thread())
 
 
 def _start_forward_request_worker(
     context: contextvars.Context,
-    url: str,
+    prepared: _PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline: float,
 ) -> Future[tuple[int, bytes, http.Headers]]:
     future: Future[tuple[int, bytes, http.Headers]] = Future()
     worker = threading.Thread(
         target=_run_forward_request_worker,
-        args=(future, context, url, method, headers, body),
+        args=(
+            future,
+            context,
+            prepared,
+            method,
+            headers,
+            body,
+            validated_addresses,
+            abort_handle,
+            deadline,
+        ),
         name="auth-base-forward",
         daemon=True,
     )
@@ -867,18 +1160,21 @@ async def forward_request(
     *,
     admission: AuthBaseForwardingAdmission | None = None,
 ) -> tuple[int, bytes, http.Headers]:
-    """Forward an auth.base request through the synchronous worker lifecycle.
+    """Forward an auth.base request within one absolute worker lifetime.
 
     When this coroutine starts, it reserves admission capacity unless `admission` is supplied.
     A supplied admission is consumed: it is resized to the actual request body or released if
     validation or resizing fails. The caller must not release or reuse it after scheduling or
     awaiting this coroutine.
 
-    If the coroutine exits before submitting a worker, it releases the admission. After
-    submission, the future's completion callback releases both admission and concurrency
-    capacity. Cancellation before submission creates no worker, while cancelling a pending worker
-    future prevents it from running. Once synchronous work has started, cancelling the await does
-    not stop it; the worker retains both resources until completion.
+    One monotonic deadline covers active-slot waiting, DNS, connect, TLS, request, and response
+    work. Deadline expiry cancels async resolution or aborts the request's active socket. After
+    worker submission, only the worker future's completion callback releases admission and
+    concurrency capacity.
+
+    Cancellation before submission creates no worker, while cancelling a pending worker future
+    prevents it from running. Once synchronous work has started, caller cancellation does not stop
+    it; the independent deadline remains armed and the worker retains resources until completion.
 
     Request body size, admission saturation, shutdown, URL/header/destination validation, upstream
     forwarding, and response processing failures propagate to the caller.
@@ -899,40 +1195,90 @@ async def forward_request(
             release_forward_request_admission(admission)
             raise
 
+    deadline = time.monotonic() + AUTH_BASE_FORWARD_DEADLINE_SECONDS
     submitted = False
+    semaphore_acquired = False
+    abort_handle: _ForwardRequestAbortHandle | None = None
+    deadline_timer: asyncio.TimerHandle | None = None
     try:
         loop = asyncio.get_running_loop()
         semaphore = _get_forward_request_admission_semaphore()
         context = contextvars.copy_context()
-        await semaphore.acquire()
-        if not _can_submit_forward_request(semaphore):
-            semaphore.release()
-            raise RuntimeError("auth.base forwarding workers are shut down")
         try:
-            future = _start_forward_request_worker(
-                context,
-                url,
-                method,
-                headers,
-                body,
-            )
-        except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
-            semaphore.release()
+            async with asyncio.timeout(_remaining_deadline_seconds(deadline)):
+                await semaphore.acquire()
+                semaphore_acquired = True
+        except TimeoutError as exc:
+            raise AuthBaseForwardingDeadlineExceededError(
+                "auth.base forwarding deadline exceeded"
+            ) from exc
+        if not _can_submit_forward_request(semaphore):
+            raise RuntimeError("auth.base forwarding workers are shut down")
+
+        abort_handle = _ForwardRequestAbortHandle(loop)
+        if not _track_active_forward_request_handle(abort_handle):
+            abort_handle.abort_for_shutdown()
+            raise RuntimeError("auth.base forwarding workers are shut down")
+
+        prepared = _prepare_forward_request(url)
+        effective_port = prepared.port if prepared.port is not None else DEFAULT_HTTPS_PORT
+        try:
+            async with asyncio.timeout(_remaining_deadline_seconds(deadline)):
+                validated_addresses = await _resolve_validated_addresses(
+                    prepared.host,
+                    effective_port,
+                    abort_handle,
+                )
+        except TimeoutError as exc:
+            abort_handle.abort_for_deadline()
+            raise AuthBaseForwardingDeadlineExceededError(
+                "auth.base forwarding deadline exceeded"
+            ) from exc
+        except asyncio.CancelledError:
+            if abort_handle.terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
+                raise RuntimeError("auth.base forwarding workers are shut down") from None
             raise
+
+        deadline_timer = loop.call_later(
+            _remaining_deadline_seconds(deadline),
+            abort_handle.abort_for_deadline,
+        )
+        future = _start_forward_request_worker(
+            context,
+            prepared,
+            method,
+            headers,
+            body,
+            validated_addresses,
+            abort_handle,
+            deadline,
+        )
         future.add_done_callback(
             lambda completed_future: _release_forward_request_resources(
                 loop,
                 semaphore,
                 admission,
+                abort_handle,
+                deadline_timer,
                 completed_future,
             )
         )
         submitted = True
+        semaphore_acquired = False
         try:
             return await asyncio.wrap_future(future, loop=loop)
         except asyncio.CancelledError:
             future.cancel()
+            if abort_handle.terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
+                raise RuntimeError("auth.base forwarding workers are shut down") from None
             raise
     finally:
         if not submitted:
+            if deadline_timer is not None:
+                deadline_timer.cancel()
+            if abort_handle is not None:
+                abort_handle.finish(deadline)
+                _untrack_active_forward_request_handle(abort_handle)
+            if semaphore_acquired:
+                semaphore.release()
             release_forward_request_admission(admission)

--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -6,7 +6,7 @@ import http.client as http_client
 import io
 import threading
 import time
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from unittest.mock import patch
 
 from mitmproxy import http
@@ -27,24 +27,7 @@ __all__ = [
 _FORWARD_START_TIMEOUT_SECONDS = 2.0
 _FORWARD_CLEANUP_TIMEOUT_SECONDS = 5.0
 _ForwardResult = tuple[int, bytes, http.Headers]
-
-
-def _addrinfo(address: str, port: int):
-    if ":" in address:
-        return (
-            forwarder.socket.AF_INET6,
-            forwarder.socket.SOCK_STREAM,
-            6,
-            "",
-            (address, port, 0, 0),
-        )
-    return (
-        forwarder.socket.AF_INET,
-        forwarder.socket.SOCK_STREAM,
-        6,
-        "",
-        (address, port),
-    )
+_SocketAddress = tuple[str, int] | tuple[str, int, int, int]
 
 
 def http_response(
@@ -121,28 +104,58 @@ class FakeSocket:
         read_side_effect: Exception | None = None,
         send_side_effect: Exception | None = None,
         setsockopt_side_effect: Exception | None = None,
+        handshake_side_effect: Exception | None = None,
         on_action: Callable[[], None] | None = None,
+        on_connect: Callable[["FakeSocket", _SocketAddress], None] | None = None,
     ) -> None:
         self._response = response
         self._read_side_effect = read_side_effect
         self._send_side_effect = send_side_effect
         self._setsockopt_side_effect = setsockopt_side_effect
+        self._handshake_side_effect = handshake_side_effect
         self._on_action = on_action
+        self._on_connect = on_connect
         self.sent = bytearray()
         self.response_file: FakeResponseFile | None = None
         self.closed = False
         self.close_count = 0
+        self.connect_calls: list[_SocketAddress] = []
+        self.handshake_count = 0
         self.setsockopt_calls: list[tuple[int, int, int]] = []
+        self.shutdown_calls: list[int] = []
+        self.timeout_calls: list[float | None] = []
 
     def _record_action(self) -> None:
         if self._on_action is not None:
             self._on_action()
+
+    def set_connect_callback(
+        self,
+        on_connect: Callable[["FakeSocket", _SocketAddress], None],
+    ) -> None:
+        self._on_connect = on_connect
 
     def setsockopt(self, level: int, optname: int, value: int) -> None:
         self._record_action()
         self.setsockopt_calls.append((level, optname, value))
         if self._setsockopt_side_effect is not None:
             raise self._setsockopt_side_effect
+
+    def settimeout(self, timeout: float | None) -> None:
+        self._record_action()
+        self.timeout_calls.append(timeout)
+
+    def connect(self, address: _SocketAddress) -> None:
+        self._record_action()
+        self.connect_calls.append(address)
+        if self._on_connect is not None:
+            self._on_connect(self, address)
+
+    def do_handshake(self) -> None:
+        self._record_action()
+        self.handshake_count += 1
+        if self._handshake_side_effect is not None:
+            raise self._handshake_side_effect
 
     def sendall(self, data: bytes) -> None:
         self._record_action()
@@ -164,6 +177,10 @@ class FakeSocket:
         self.closed = True
         self.close_count += 1
 
+    def shutdown(self, how: int) -> None:
+        self._record_action()
+        self.shutdown_calls.append(how)
+
     def request_text(self) -> str:
         return bytes(self.sent).decode("latin1")
 
@@ -181,7 +198,9 @@ class FakeSocket:
         return values
 
 
-_CreateConnection = Callable[[tuple[str, int], object, object], FakeSocket]
+_ConnectSideEffect = Callable[[_SocketAddress], None]
+_LookupSideEffect = Callable[[str], Awaitable[list[str]]]
+_SocketFactory = Callable[[], FakeSocket]
 
 
 class FakeTLSContext:
@@ -202,15 +221,23 @@ class FakeTLSContext:
         self._on_action = on_action
         self.alpn_protocols: list[str] = []
         self.post_handshake_auth = False
+        self.do_handshake_on_connect: list[bool] = []
         self.server_hostnames: list[str] = []
 
     def set_alpn_protocols(self, protocols: list[str]) -> None:
         self.alpn_protocols = protocols
 
-    def wrap_socket(self, raw_sock: FakeSocket, *, server_hostname: str):
+    def wrap_socket(
+        self,
+        raw_sock: FakeSocket,
+        *,
+        server_hostname: str,
+        do_handshake_on_connect: bool,
+    ):
         if self._on_action is not None:
             self._on_action()
         self.server_hostnames.append(server_hostname)
+        self.do_handshake_on_connect.append(do_handshake_on_connect)
         if self._wrap_side_effect is not None:
             raise self._wrap_side_effect
         return raw_sock
@@ -239,8 +266,11 @@ class FakeForwarderUpstream:
         send_side_effect: Exception | None = None,
         setsockopt_side_effect: Exception | None = None,
         wrap_side_effect: Exception | None = None,
+        handshake_side_effect: Exception | None = None,
         on_action: Callable[[], None] | None = None,
-        create_connection: _CreateConnection | None = None,
+        connect_side_effect: _ConnectSideEffect | None = None,
+        lookup_side_effect: _LookupSideEffect | None = None,
+        socket_factory: _SocketFactory | None = None,
     ) -> None:
         self._addresses = addresses
         self._response = http_response(status=status, body=body, headers=headers)
@@ -248,25 +278,34 @@ class FakeForwarderUpstream:
         self._send_side_effect = send_side_effect
         self._setsockopt_side_effect = setsockopt_side_effect
         self._wrap_side_effect = wrap_side_effect
+        self._handshake_side_effect = handshake_side_effect
         self._on_action = on_action
-        self._create_connection = create_connection
+        self._connect_side_effect = connect_side_effect
+        self._lookup_side_effect = lookup_side_effect
+        self._socket_factory = socket_factory
         self.sockets: list[FakeSocket] = []
         self.contexts: list[FakeTLSContext] = []
-        self.getaddrinfo_calls: list[tuple[str, int]] = []
-        self.create_connection_calls: list[tuple[tuple[str, int], object, object]] = []
+        self.resolve_calls: list[str] = []
+        self.socket_calls: list[tuple[int, int]] = []
+        self.connect_calls: list[_SocketAddress] = []
 
-    def getaddrinfo(self, host: str, port: int, *_args, **_kwargs):
-        self.getaddrinfo_calls.append((host, port))
-        return [_addrinfo(address, port) for address in self._addresses]
+    async def lookup_ip(self, host: str) -> list[str]:
+        self.resolve_calls.append(host)
+        if self._lookup_side_effect is not None:
+            return await self._lookup_side_effect(host)
+        return list(self._addresses)
 
-    def create_connection(self, address: tuple[str, int], timeout, source_address):
-        self.create_connection_calls.append((address, timeout, source_address))
-        if self._create_connection is not None:
-            sock = self._create_connection(address, timeout, source_address)
-        else:
-            sock = self.make_socket()
+    def create_socket(self, family: int, kind: int) -> FakeSocket:
+        self.socket_calls.append((family, kind))
+        sock = self._socket_factory() if self._socket_factory is not None else self.make_socket()
+        sock.set_connect_callback(self._connect)
         self.sockets.append(sock)
         return sock
+
+    def _connect(self, sock: FakeSocket, address: _SocketAddress) -> None:
+        self.connect_calls.append(address)
+        if self._connect_side_effect is not None:
+            self._connect_side_effect(address)
 
     def make_socket(self) -> FakeSocket:
         return FakeSocket(
@@ -274,6 +313,7 @@ class FakeForwarderUpstream:
             read_side_effect=self._read_side_effect,
             send_side_effect=self._send_side_effect,
             setsockopt_side_effect=self._setsockopt_side_effect,
+            handshake_side_effect=self._handshake_side_effect,
             on_action=self._on_action,
         )
 
@@ -304,12 +344,7 @@ class ForwarderConcurrencyHarness:
         self._workers: set[threading.Thread] = set()
         self._tasks: set[asyncio.Task[_ForwardResult]] = set()
 
-    def create_connection(
-        self,
-        _address: tuple[str, int],
-        _timeout: object,
-        _source_address: object,
-    ) -> FakeSocket:
+    def connect(self, _address: _SocketAddress) -> None:
         """Record and optionally block a worker at the connection boundary."""
         with self._condition:
             self._started += 1
@@ -324,7 +359,6 @@ class ForwarderConcurrencyHarness:
                 timeout=_FORWARD_CLEANUP_TIMEOUT_SECONDS
             ):
                 raise TimeoutError("test did not release blocked forwards")
-            return FakeSocket(http_response())
         finally:
             with self._condition:
                 self._active -= 1
@@ -413,19 +447,22 @@ def fake_forwarder_upstream(
     send_side_effect: Exception | None = None,
     setsockopt_side_effect: Exception | None = None,
     wrap_side_effect: Exception | None = None,
+    handshake_side_effect: Exception | None = None,
     on_action: Callable[[], None] | None = None,
-    create_connection: _CreateConnection | None = None,
+    connect_side_effect: _ConnectSideEffect | None = None,
+    lookup_side_effect: _LookupSideEffect | None = None,
+    socket_factory: _SocketFactory | None = None,
 ) -> Iterator[FakeForwarderUpstream]:
     """Patch auth.base DNS/connect/TLS boundaries and yield an upstream handle.
 
-    The context manager patches only ``auth_base_forwarder.socket.getaddrinfo``,
-    ``auth_base_forwarder.socket.create_connection``, and
+    The context manager patches only the forwarder's external resolver,
+    ``auth_base_forwarder.socket.socket``, and
     ``auth_base_forwarder.ssl.create_default_context``. ``addresses`` controls
     the DNS answers returned to the real forwarder before any socket is opened.
     Socket and TLS side effects raise at their matching fake boundary.
 
-    The yielded handle exposes stable assertion state: ``getaddrinfo_calls``,
-    ``create_connection_calls``, ``sockets``, ``contexts``, and ``socket`` for
+    The yielded handle exposes stable assertion state: ``resolve_calls``,
+    ``connect_calls``, ``sockets``, ``contexts``, and ``socket`` for
     the most recent connection.
     """
     upstream = FakeForwarderUpstream(
@@ -437,15 +474,18 @@ def fake_forwarder_upstream(
         send_side_effect=send_side_effect,
         setsockopt_side_effect=setsockopt_side_effect,
         wrap_side_effect=wrap_side_effect,
+        handshake_side_effect=handshake_side_effect,
         on_action=on_action,
-        create_connection=create_connection,
+        connect_side_effect=connect_side_effect,
+        lookup_side_effect=lookup_side_effect,
+        socket_factory=socket_factory,
     )
     with (
-        patch.object(forwarder.socket, "getaddrinfo", side_effect=upstream.getaddrinfo),
+        patch.object(forwarder, "_dns_resolver", upstream),
         patch.object(
             forwarder.socket,
-            "create_connection",
-            side_effect=upstream.create_connection,
+            "socket",
+            side_effect=upstream.create_socket,
         ),
         patch.object(
             forwarder.ssl,
@@ -463,7 +503,7 @@ async def forwarder_concurrency_harness(
 ) -> AsyncIterator[tuple[ForwarderConcurrencyHarness, FakeForwarderUpstream]]:
     """Yield a blocked upstream harness and fully drain its workers on exit."""
     harness = ForwarderConcurrencyHarness(blocked_connections=blocked_connections)
-    with fake_forwarder_upstream(create_connection=harness.create_connection) as upstream:
+    with fake_forwarder_upstream(connect_side_effect=harness.connect) as upstream:
         try:
             yield harness, upstream
         finally:

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -7,6 +7,7 @@ import http.client as http_client
 import multiprocessing
 import ssl
 import threading
+import time
 from concurrent.futures import Future
 from unittest.mock import MagicMock, call, patch
 
@@ -30,17 +31,40 @@ async def _run_ready_tasks() -> None:
     await ready.wait()
 
 
+class _BlockingConnectSocket(FakeSocket):
+    def __init__(
+        self,
+        entered: threading.Event,
+        release: threading.Event,
+    ) -> None:
+        super().__init__(http_response())
+        self._entered = entered
+        self._release = release
+
+    def connect(
+        self,
+        address: tuple[str, int] | tuple[str, int, int, int],
+    ) -> None:
+        super().connect(address)
+        self._entered.set()
+        if not self._release.wait(timeout=2):
+            raise TimeoutError("test did not release connect")
+
+    def shutdown(self, how: int) -> None:
+        super().shutdown(how)
+        self._release.set()
+
+
 def _run_blocked_forward_then_shutdown_wait_false() -> None:
     async def main():
         forward_started = threading.Event()
         never_release = threading.Event()
 
-        def create_connection(_address, _timeout, _source_address):
+        def block_connect(_address):
             forward_started.set()
             never_release.wait()
-            return FakeSocket(http_response())
 
-        with fake_forwarder_upstream(create_connection=create_connection):
+        with fake_forwarder_upstream(connect_side_effect=block_connect):
             task = asyncio.create_task(
                 forwarder.forward_request("https://example.com", "GET", [], None)
             )
@@ -117,7 +141,7 @@ class TestAuthBaseForwarderSecurity:
         ):
             await forwarder.forward_request(url, "GET", [], None)
 
-        assert upstream.create_connection_calls == []
+        assert upstream.connect_calls == []
         assert upstream.sockets == []
 
     async def test_rejects_dns_private_destination_without_opening_connection(self):
@@ -127,8 +151,8 @@ class TestAuthBaseForwarderSecurity:
         ):
             await forwarder.forward_request("https://hooks.example.com/path", "GET", [], None)
 
-        assert upstream.getaddrinfo_calls == [("hooks.example.com", 443)]
-        assert upstream.create_connection_calls == []
+        assert upstream.resolve_calls == ["hooks.example.com"]
+        assert upstream.connect_calls == []
 
     async def test_rejects_mixed_dns_answers_without_opening_connection(self):
         with (
@@ -137,8 +161,8 @@ class TestAuthBaseForwarderSecurity:
         ):
             await forwarder.forward_request("https://hooks.example.com/path", "GET", [], None)
 
-        assert upstream.getaddrinfo_calls == [("hooks.example.com", 443)]
-        assert upstream.create_connection_calls == []
+        assert upstream.resolve_calls == ["hooks.example.com"]
+        assert upstream.connect_calls == []
 
     async def test_allows_public_dns_destination_and_forwards_with_original_host(self):
         with fake_forwarder_upstream(
@@ -154,8 +178,8 @@ class TestAuthBaseForwarderSecurity:
         assert status == 200
         assert body == b"ok"
         assert list(headers.items(multi=True)) == []
-        assert upstream.getaddrinfo_calls == [("hooks.example.com", 443)]
-        assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+        assert upstream.resolve_calls == ["hooks.example.com"]
+        assert upstream.connect_calls == [("93.184.216.34", 443)]
         assert upstream.contexts[-1].server_hostnames == ["hooks.example.com"]
         assert upstream.socket.request_lines()[0] == "GET /path HTTP/1.1"
         assert upstream.socket.request_header_values("Host") == ["hooks.example.com"]
@@ -181,13 +205,10 @@ class TestAuthBaseForwarderSecurity:
         assert second_body == b"ok"
         assert len(upstream.contexts) == 1
         assert upstream.contexts[0].server_hostnames == ["example.com", "example.com"]
-        assert upstream.getaddrinfo_calls == [
-            ("example.com", 443),
-            ("example.com", 443),
-        ]
-        assert upstream.create_connection_calls == [
-            (("93.184.216.34", 443), 30, None),
-            (("93.184.216.34", 443), 30, None),
+        assert upstream.resolve_calls == ["example.com", "example.com"]
+        assert upstream.connect_calls == [
+            ("93.184.216.34", 443),
+            ("93.184.216.34", 443),
         ]
         assert [socket.request_lines()[0] for socket in upstream.sockets] == [
             "GET /one HTTP/1.1",
@@ -206,21 +227,21 @@ class TestAuthBaseForwarderSecurity:
     )
     async def test_rejects_unsupported_scheme_before_dns(self, url: str):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Unsupported URL scheme"),
         ):
             await forwarder.forward_request(url, "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     async def test_rejects_missing_host_before_dns(self):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Invalid upstream URL: missing host"),
         ):
             await forwarder.forward_request("https:///path", "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     @pytest.mark.parametrize(
         "url",
@@ -231,21 +252,21 @@ class TestAuthBaseForwarderSecurity:
     )
     async def test_rejects_invalid_port_before_dns(self, url: str):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Invalid upstream URL: invalid port"),
         ):
             await forwarder.forward_request(url, "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     async def test_rejects_bracketed_non_ipv6_authority_before_dns(self):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Invalid upstream URL: invalid host"),
         ):
             await forwarder.forward_request("https://[v1.invalid]/path", "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     @pytest.mark.parametrize(
         "url",
@@ -263,12 +284,12 @@ class TestAuthBaseForwarderSecurity:
     )
     async def test_rejects_unsafe_raw_host_before_dns(self, url: str):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Invalid upstream URL: invalid host"),
         ):
             await forwarder.forward_request(url, "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     @pytest.mark.parametrize(
         ("url", "expected_host"),
@@ -282,7 +303,7 @@ class TestAuthBaseForwarderSecurity:
         with fake_forwarder_upstream() as upstream:
             await forwarder.forward_request(url, "GET", [], None)
 
-        assert upstream.getaddrinfo_calls == [(expected_host, 443)]
+        assert upstream.resolve_calls == [expected_host]
         assert upstream.contexts[-1].server_hostnames == [expected_host]
         assert upstream.socket.request_header_values("Host") == [expected_host]
 
@@ -295,12 +316,12 @@ class TestAuthBaseForwarderSecurity:
     )
     async def test_rejects_userinfo_authority_before_dns(self, url: str):
         with (
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(ValueError, match="Unsupported URL authority"),
         ):
             await forwarder.forward_request(url, "GET", [], None)
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
 
 class TestAuthBaseForwarderTransportSecurity:
@@ -309,61 +330,98 @@ class TestAuthBaseForwarderTransportSecurity:
         wrapped_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
+            ),
         )
         vars(conn)["_context"] = context
 
-        with patch.object(forwarder.socket, "create_connection", return_value=raw_sock) as connect:
+        with patch.object(forwarder.socket, "socket", return_value=raw_sock) as create_socket:
             conn.connect()
 
-        connect.assert_called_once_with(("93.184.216.34", 443), 30, None)
+        create_socket.assert_called_once_with(
+            forwarder.socket.AF_INET,
+            forwarder.socket.SOCK_STREAM,
+        )
+        raw_sock.connect.assert_called_once_with(("93.184.216.34", 443))
         raw_sock.setsockopt.assert_called_once_with(
             forwarder.socket.IPPROTO_TCP,
             forwarder.socket.TCP_NODELAY,
             1,
         )
-        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        context.wrap_socket.assert_called_once_with(
+            raw_sock,
+            server_hostname="hooks.example.com",
+            do_handshake_on_connect=False,
+        )
+        wrapped_sock.do_handshake.assert_called_once_with()
         assert conn.sock is wrapped_sock
 
     def test_validated_connection_retries_checked_addresses_without_new_dns(self):
+        failed_sock = MagicMock()
+        failed_sock.connect.side_effect = OSError("no route")
         raw_sock = MagicMock()
         wrapped_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress("2001:4860:4860::8888", 443),
-                forwarder._ValidatedAddress("93.184.216.34", 443),
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET6,
+                    "2001:4860:4860::8888",
+                    443,
+                ),
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
             ),
         )
         vars(conn)["_context"] = context
 
         with patch.object(
             forwarder.socket,
-            "create_connection",
-            side_effect=[OSError("no route"), raw_sock],
-        ) as connect:
+            "socket",
+            side_effect=[failed_sock, raw_sock],
+        ) as create_socket:
             conn.connect()
 
-        connect.assert_has_calls(
+        create_socket.assert_has_calls(
             [
-                call(("2001:4860:4860::8888", 443), 30, None),
-                call(("93.184.216.34", 443), 30, None),
+                call(forwarder.socket.AF_INET6, forwarder.socket.SOCK_STREAM),
+                call(forwarder.socket.AF_INET, forwarder.socket.SOCK_STREAM),
             ]
         )
+        failed_sock.connect.assert_called_once_with(("2001:4860:4860::8888", 443, 0, 0))
+        failed_sock.close.assert_called_once_with()
+        raw_sock.connect.assert_called_once_with(("93.184.216.34", 443))
         raw_sock.setsockopt.assert_called_once_with(
             forwarder.socket.IPPROTO_TCP,
             forwarder.socket.TCP_NODELAY,
             1,
         )
-        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        context.wrap_socket.assert_called_once_with(
+            raw_sock,
+            server_hostname="hooks.example.com",
+            do_handshake_on_connect=False,
+        )
+        wrapped_sock.do_handshake.assert_called_once_with()
         assert conn.sock is wrapped_sock
 
     def test_validated_connection_context_keeps_https_security_defaults(self):
@@ -380,87 +438,125 @@ class TestAuthBaseForwarderTransportSecurity:
         wrapped_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
+            ),
         )
         vars(conn)["_context"] = context
 
-        with patch.object(forwarder.socket, "create_connection", return_value=raw_sock):
+        with patch.object(forwarder.socket, "socket", return_value=raw_sock):
             conn.connect()
 
         raw_sock.close.assert_not_called()
-        context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
+        context.wrap_socket.assert_called_once_with(
+            raw_sock,
+            server_hostname="hooks.example.com",
+            do_handshake_on_connect=False,
+        )
         assert conn.sock is wrapped_sock
 
-    def test_validated_connection_untracks_raw_socket_when_setsockopt_cleanup_close_fails(self):
+    def test_validated_connection_clears_raw_socket_when_setsockopt_cleanup_close_fails(
+        self,
+    ):
         raw_sock = MagicMock()
         raw_sock.setsockopt.side_effect = OSError(errno.EINVAL, "setsockopt failed")
         raw_sock.close.side_effect = OSError("close failed")
         context = MagicMock()
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
+            ),
         )
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            patch.object(forwarder.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="setsockopt failed"),
         ):
             conn.connect()
 
         raw_sock.close.assert_called_once_with()
         context.wrap_socket.assert_not_called()
-        with forwarder._forward_request_active_closeables_lock:
-            assert raw_sock not in forwarder._forward_request_active_closeables
+        assert abort_handle.abort_for_shutdown()
+        raw_sock.shutdown.assert_not_called()
 
     def test_validated_connection_closes_raw_socket_when_tls_wrap_fails(self):
         raw_sock = MagicMock()
         context = MagicMock()
         context.wrap_socket.side_effect = OSError("tls failed")
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
+            ),
         )
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            patch.object(forwarder.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="tls failed"),
         ):
             conn.connect()
 
         raw_sock.close.assert_called_once_with()
 
-    def test_validated_connection_untracks_raw_socket_when_tls_cleanup_close_fails(self):
+    def test_validated_connection_clears_raw_socket_when_tls_cleanup_close_fails(self):
         raw_sock = MagicMock()
         raw_sock.close.side_effect = OSError("close failed")
         context = MagicMock()
         context.wrap_socket.side_effect = OSError("tls failed")
+        abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
         conn = forwarder._make_validated_https_connection(
             "hooks.example.com",
             port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+            deadline=time.monotonic() + 30,
+            abort_handle=abort_handle,
+            validated_addresses=(
+                forwarder._ValidatedAddress(
+                    forwarder.socket.AF_INET,
+                    "93.184.216.34",
+                    443,
+                ),
+            ),
         )
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            patch.object(forwarder.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="tls failed"),
         ):
             conn.connect()
 
         raw_sock.close.assert_called_once_with()
-        with forwarder._forward_request_active_closeables_lock:
-            assert raw_sock not in forwarder._forward_request_active_closeables
+        assert abort_handle.abort_for_shutdown()
+        raw_sock.shutdown.assert_not_called()
 
 
 class TestAuthBaseForwarderRequestBehavior:
@@ -599,10 +695,14 @@ class TestAuthBaseForwarderRequestBehavior:
                 None,
             )
 
-        assert upstream.getaddrinfo_calls == [(expected_dns_host, expected_connection_port)]
-        assert upstream.create_connection_calls == [
-            (("93.184.216.34", expected_connection_port), 30, None)
-        ]
+        expected_resolve_calls = [] if ":" in expected_dns_host else [expected_dns_host]
+        assert upstream.resolve_calls == expected_resolve_calls
+        expected_connect_address = (
+            (expected_dns_host, expected_connection_port, 0, 0)
+            if ":" in expected_dns_host
+            else ("93.184.216.34", expected_connection_port)
+        )
+        assert upstream.connect_calls == [expected_connect_address]
         assert upstream.socket.request_header_values("Host") == [expected_host_header]
 
     async def test_filters_request_hop_by_hop_headers_and_recomputes_content_length(self):
@@ -658,10 +758,7 @@ class TestAuthBaseForwarderRequestBehavior:
             b"ok"
         )
 
-        def create_connection(_address, _timeout, _source_address):
-            return FakeSocket(raw_response)
-
-        with fake_forwarder_upstream(create_connection=create_connection):
+        with fake_forwarder_upstream(socket_factory=lambda: FakeSocket(raw_response)):
             status, body, headers = await forwarder.forward_request(
                 "https://example.com",
                 "GET",
@@ -756,7 +853,7 @@ class TestAuthBaseForwarderRequestBodyLimit:
     async def test_rejects_body_over_limit_before_connection_setup(self):
         with (
             patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(forwarder.ForwardedRequestTooLargeError),
         ):
             await forwarder.forward_request(
@@ -766,7 +863,7 @@ class TestAuthBaseForwarderRequestBodyLimit:
                 b"12345",
             )
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
 
 class TestAuthBaseForwarderResourceCleanup:
@@ -845,15 +942,10 @@ class TestAuthBaseForwarderResourceCleanup:
         assert upstream.socket.closed
 
     async def test_closes_connection_when_getresponse_raises(self):
-        def create_connection(
-            _address: tuple[str, int],
-            _timeout: object,
-            _source_address: object,
-        ) -> FakeSocket:
-            return FakeSocket(b"not an HTTP response\r\n")
-
         with (
-            fake_forwarder_upstream(create_connection=create_connection) as upstream,
+            fake_forwarder_upstream(
+                socket_factory=lambda: FakeSocket(b"not an HTTP response\r\n")
+            ) as upstream,
             pytest.raises(http_client.BadStatusLine),
         ):
             await forwarder.forward_request("https://example.com", "GET", [], None)
@@ -881,6 +973,401 @@ class TestForwardRequestAsyncWrapper:
 
         assert process.exitcode == 0
 
+    async def test_deadline_covers_waiting_for_active_slot(self):
+        with patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1):
+            async with forwarder_concurrency_harness() as (scenario, _upstream):
+                with patch.object(
+                    forwarder,
+                    "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                    5,
+                ):
+                    running_task = scenario.track_task(
+                        asyncio.create_task(
+                            forwarder.forward_request(
+                                "https://example.com",
+                                "GET",
+                                [],
+                                None,
+                            )
+                        )
+                    )
+                    assert await scenario.wait_started(1)
+
+                with (
+                    patch.object(
+                        forwarder,
+                        "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                        0.05,
+                    ),
+                    pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
+                ):
+                    await forwarder.forward_request(
+                        "https://example.com",
+                        "GET",
+                        [],
+                        None,
+                    )
+
+                assert scenario.started == 1
+                assert forwarder.forward_request_admission_state_for_tests() == (
+                    1,
+                    0,
+                )
+                scenario.release()
+                status, body, _headers = await running_task
+
+        assert status == 200
+        assert body == b"ok"
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+    async def test_deadline_cancels_async_dns_and_releases_capacity(self):
+        lookup_entered = asyncio.Event()
+        lookup_cancelled = asyncio.Event()
+
+        async def blocked_lookup(_host: str) -> list[str]:
+            lookup_entered.set()
+            try:
+                await asyncio.Event().wait()
+                raise AssertionError("blocked DNS lookup unexpectedly resumed")
+            finally:
+                lookup_cancelled.set()
+
+        with (
+            patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                0.05,
+            ),
+            fake_forwarder_upstream(lookup_side_effect=blocked_lookup) as upstream,
+            pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
+        ):
+            await forwarder.forward_request(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert lookup_entered.is_set()
+        assert lookup_cancelled.is_set()
+        assert upstream.sockets == []
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+        with forwarder._forward_request_active_handles_lock:
+            assert not forwarder._forward_request_active_handles
+
+    async def test_shutdown_cancels_dns_before_socket_registration(self):
+        lookup_entered = asyncio.Event()
+        lookup_cancelled = asyncio.Event()
+
+        async def blocked_lookup(_host: str) -> list[str]:
+            lookup_entered.set()
+            try:
+                await asyncio.Event().wait()
+                raise AssertionError("blocked DNS lookup unexpectedly resumed")
+            finally:
+                lookup_cancelled.set()
+
+        with fake_forwarder_upstream(lookup_side_effect=blocked_lookup) as upstream:
+            task = asyncio.create_task(
+                forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                )
+            )
+            await lookup_entered.wait()
+            forwarder.shutdown_forward_request_workers(wait=False)
+
+            with pytest.raises(RuntimeError, match="workers are shut down"):
+                await task
+
+        assert lookup_cancelled.is_set()
+        assert upstream.sockets == []
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+    async def test_deadline_aborts_connect_before_reusing_capacity(self):
+        connect_entered = threading.Event()
+        release_connect = threading.Event()
+        blocked_socket = _BlockingConnectSocket(connect_entered, release_connect)
+        sockets = iter(
+            (
+                blocked_socket,
+                FakeSocket(http_response()),
+            )
+        )
+
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            fake_forwarder_upstream(socket_factory=lambda: next(sockets)),
+        ):
+            with (
+                patch.object(
+                    forwarder,
+                    "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                    0.05,
+                ),
+                pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
+            ):
+                await forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                )
+
+            assert connect_entered.is_set()
+            assert blocked_socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+            assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+            with patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                1,
+            ):
+                status, body, _headers = await forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                )
+
+        assert status == 200
+        assert body == b"ok"
+
+    async def test_deadline_aborts_deferred_tls_handshake(self):
+        handshake_entered = threading.Event()
+        release_handshake = threading.Event()
+
+        class BlockingHandshakeSocket(FakeSocket):
+            def do_handshake(self) -> None:
+                self.handshake_count += 1
+                handshake_entered.set()
+                if not release_handshake.wait(timeout=2):
+                    raise TimeoutError("test did not release TLS handshake")
+
+            def shutdown(self, how: int) -> None:
+                super().shutdown(how)
+                release_handshake.set()
+
+        socket = BlockingHandshakeSocket(http_response())
+        with (
+            patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                0.05,
+            ),
+            fake_forwarder_upstream(socket_factory=lambda: socket),
+            pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
+        ):
+            await forwarder.forward_request(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert handshake_entered.is_set()
+        assert socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+        assert socket.closed
+
+    async def test_absolute_deadline_stops_trickling_socket_response(self):
+        client_socket, server_socket = forwarder.socket.socketpair()
+        sent_body_bytes: list[bytes] = []
+        response_body = b"0123456789abcdef"
+
+        class SocketBackedForwardSocket(FakeSocket):
+            def settimeout(self, timeout: float | None) -> None:
+                super().settimeout(timeout)
+                client_socket.settimeout(timeout)
+
+            def sendall(self, data: bytes) -> None:
+                self.sent.extend(data)
+                client_socket.sendall(data)
+
+            def makefile(self, *args, **kwargs):
+                return client_socket.makefile(*args, **kwargs)
+
+            def shutdown(self, how: int) -> None:
+                super().shutdown(how)
+                client_socket.shutdown(how)
+
+            def close(self) -> None:
+                super().close()
+                client_socket.close()
+
+        def serve_trickling_response() -> None:
+            try:
+                request = bytearray()
+                while b"\r\n\r\n" not in request:
+                    chunk = server_socket.recv(4096)
+                    if not chunk:
+                        return
+                    request.extend(chunk)
+                server_socket.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    + f"Content-Length: {len(response_body)}\r\n\r\n".encode()
+                )
+                for byte in response_body:
+                    server_socket.sendall(bytes((byte,)))
+                    sent_body_bytes.append(bytes((byte,)))
+                    time.sleep(0.02)
+            except OSError:
+                pass
+            finally:
+                server_socket.close()
+
+        server_thread = threading.Thread(
+            target=serve_trickling_response,
+            name="auth-base-trickle-server",
+        )
+        socket = SocketBackedForwardSocket(b"")
+        server_thread.start()
+        try:
+            with (
+                patch.object(
+                    forwarder,
+                    "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                    0.2,
+                ),
+                fake_forwarder_upstream(socket_factory=lambda: socket),
+                pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
+            ):
+                await forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                )
+        finally:
+            client_socket.close()
+            server_socket.close()
+            await asyncio.to_thread(server_thread.join, 2)
+
+        assert not server_thread.is_alive()
+        assert 2 <= len(sent_body_bytes) < len(response_body)
+        assert socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+
+    async def test_deadline_does_not_abort_unrelated_forward(self):
+        first_entered = threading.Event()
+        first_release = threading.Event()
+        second_entered = threading.Event()
+        second_release = threading.Event()
+        first_socket = _BlockingConnectSocket(first_entered, first_release)
+        second_socket = _BlockingConnectSocket(second_entered, second_release)
+        sockets = iter((first_socket, second_socket))
+
+        with fake_forwarder_upstream(socket_factory=lambda: next(sockets)):
+            with patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                0.08,
+            ):
+                first_task = asyncio.create_task(
+                    forwarder.forward_request(
+                        "https://example.com",
+                        "GET",
+                        [],
+                        None,
+                    )
+                )
+                assert await asyncio.to_thread(first_entered.wait, 1)
+
+            with patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                1,
+            ):
+                second_task = asyncio.create_task(
+                    forwarder.forward_request(
+                        "https://example.com",
+                        "GET",
+                        [],
+                        None,
+                    )
+                )
+                assert await asyncio.to_thread(second_entered.wait, 1)
+
+                with pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError):
+                    await first_task
+
+                assert not second_task.done()
+                assert second_socket.shutdown_calls == []
+                second_release.set()
+                status, body, _headers = await second_task
+
+        assert status == 200
+        assert body == b"ok"
+        assert first_socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+        assert second_socket.shutdown_calls == []
+
+    async def test_caller_cancellation_keeps_worker_deadline_armed(self):
+        first_entered = threading.Event()
+        first_release = threading.Event()
+        first_socket = _BlockingConnectSocket(first_entered, first_release)
+        sockets = iter((first_socket, FakeSocket(http_response())))
+
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            fake_forwarder_upstream(socket_factory=lambda: next(sockets)),
+        ):
+            with patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                0.08,
+            ):
+                cancelled_task = asyncio.create_task(
+                    forwarder.forward_request(
+                        "https://example.com",
+                        "GET",
+                        [],
+                        None,
+                    )
+                )
+                assert await asyncio.to_thread(first_entered.wait, 1)
+                cancelled_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await cancelled_task
+
+            with patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                1,
+            ):
+                status, body, _headers = await forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                )
+
+        assert status == 200
+        assert body == b"ok"
+        assert first_socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+
+    async def test_completed_forward_cancels_deadline_timer(self):
+        with (
+            patch.object(
+                forwarder,
+                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
+                0.1,
+            ),
+            fake_forwarder_upstream() as upstream,
+        ):
+            status, body, _headers = await forwarder.forward_request(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+            await asyncio.sleep(0.15)
+
+        assert status == 200
+        assert body == b"ok"
+        assert upstream.socket.shutdown_calls == []
+        with forwarder._forward_request_active_handles_lock:
+            assert not forwarder._forward_request_active_handles
+
     def test_shutdown_before_worker_start_cancels_pending_forward(self):
         future: Future[tuple[int, bytes, http.Headers]] = Future()
         with forwarder._forward_request_pending_futures_lock:
@@ -896,10 +1383,13 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                "https://example.com",
+                forwarder._prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,
+                (),
+                forwarder._ForwardRequestAbortHandle(MagicMock()),
+                time.monotonic() + 30,
             )
 
         forward_sync.assert_not_called()
@@ -916,7 +1406,7 @@ class TestForwardRequestAsyncWrapper:
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (
             patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
-            patch.object(forwarder.socket, "getaddrinfo") as getaddrinfo,
+            fake_forwarder_upstream() as upstream,
             pytest.raises(forwarder.ForwardedRequestTooLargeError),
         ):
             await forwarder.forward_request(
@@ -926,7 +1416,7 @@ class TestForwardRequestAsyncWrapper:
                 b"12345",
             )
 
-        getaddrinfo.assert_not_called()
+        assert upstream.resolve_calls == []
 
     async def test_rejects_when_admitted_forward_count_is_saturated(self):
         with patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 1):
@@ -940,8 +1430,8 @@ class TestForwardRequestAsyncWrapper:
                 with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
                     await forwarder.forward_request("https://example.com", "GET", [], None)
 
-        assert upstream.getaddrinfo_calls == [("example.com", 443)]
-        assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+        assert upstream.resolve_calls == ["example.com"]
+        assert upstream.connect_calls == [("93.184.216.34", 443)]
 
     async def test_rejects_when_admitted_forward_body_bytes_are_saturated(self):
         with (
@@ -958,13 +1448,13 @@ class TestForwardRequestAsyncWrapper:
                 with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
                     await forwarder.forward_request("https://example.com", "POST", [], b"x")
 
-        assert upstream.getaddrinfo_calls == [("example.com", 443)]
-        assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+        assert upstream.resolve_calls == ["example.com"]
+        assert upstream.connect_calls == [("93.184.216.34", 443)]
 
     async def test_releases_forward_slot_when_forwarding_raises(self):
         first = True
 
-        def create_connection(_address, _timeout, _source_address):
+        def make_socket():
             nonlocal first
 
             if first:
@@ -977,7 +1467,7 @@ class TestForwardRequestAsyncWrapper:
 
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
-            fake_forwarder_upstream(create_connection=create_connection),
+            fake_forwarder_upstream(socket_factory=make_socket),
         ):
             with pytest.raises(ConnectionError, match="upstream unavailable"):
                 await forwarder.forward_request("https://example.com", "GET", [], None)
@@ -1174,10 +1664,13 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                "https://example.com",
+                forwarder._prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,
+                (),
+                forwarder._ForwardRequestAbortHandle(MagicMock()),
+                time.monotonic() + 30,
             )
 
         assert future.done()
@@ -1256,10 +1749,7 @@ class TestForwardRequestAsyncWrapper:
 
         socket = BlockingSetsockoptSocket(http_response())
 
-        def create_connection(_address, _timeout, _source_address):
-            return socket
-
-        with fake_forwarder_upstream(create_connection=create_connection):
+        with fake_forwarder_upstream(socket_factory=lambda: socket):
             task = asyncio.create_task(
                 forwarder.forward_request("https://example.com", "GET", [], None)
             )
@@ -1267,33 +1757,38 @@ class TestForwardRequestAsyncWrapper:
                 assert await asyncio.to_thread(setsockopt_entered.wait, 2)
                 forwarder.shutdown_forward_request_workers(wait=False)
                 assert await asyncio.to_thread(socket_closed.wait, 2)
-                with forwarder._forward_request_active_closeables_lock:
-                    assert socket not in forwarder._forward_request_active_closeables
             finally:
                 release_setsockopt.set()
                 await asyncio.gather(task, return_exceptions=True)
 
         assert socket.closed
+        assert socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
+        with forwarder._forward_request_active_handles_lock:
+            assert not forwarder._forward_request_active_handles
 
-    async def test_shutdown_closes_socket_created_after_active_close_snapshot(self):
+    async def test_shutdown_aborts_socket_during_connect(self):
         connect_entered = threading.Event()
         release_connect = threading.Event()
-        socket = FakeSocket(http_response())
 
-        def create_connection(_address, _timeout, _source_address):
-            connect_entered.set()
-            if not release_connect.wait(timeout=5):
-                raise TimeoutError("test did not release connect")
-            return socket
+        class BlockingConnectSocket(FakeSocket):
+            def connect(self, address) -> None:
+                self.connect_calls.append(address)
+                connect_entered.set()
+                if not release_connect.wait(timeout=5):
+                    raise TimeoutError("test did not release connect")
 
-        with fake_forwarder_upstream(create_connection=create_connection):
+            def shutdown(self, how: int) -> None:
+                super().shutdown(how)
+                release_connect.set()
+
+        socket = BlockingConnectSocket(http_response())
+        with fake_forwarder_upstream(socket_factory=lambda: socket):
             task = asyncio.create_task(
                 forwarder.forward_request("https://example.com", "GET", [], None)
             )
             try:
                 assert await asyncio.to_thread(connect_entered.wait, 2)
                 forwarder.shutdown_forward_request_workers(wait=False)
-                release_connect.set()
 
                 with pytest.raises(RuntimeError, match="workers are shut down"):
                     await asyncio.wait_for(task, timeout=2)
@@ -1302,9 +1797,10 @@ class TestForwardRequestAsyncWrapper:
                 await asyncio.gather(task, return_exceptions=True)
 
         assert socket.closed
+        assert socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
         assert not socket.setsockopt_calls
-        with forwarder._forward_request_active_closeables_lock:
-            assert socket not in forwarder._forward_request_active_closeables
+        with forwarder._forward_request_active_handles_lock:
+            assert not forwarder._forward_request_active_handles
         assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
     async def test_offloads_request_work_from_event_loop_thread(self):

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1214,6 +1214,7 @@ class TestForwardRequestAsyncWrapper:
                     sent_body_bytes.append(bytes((byte,)))
                     time.sleep(0.01)
             except OSError:
+                # Deadline expiry intentionally closes the peer while this thread is sending.
                 pass
             finally:
                 server_socket.close()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -8,6 +8,7 @@ import multiprocessing
 import ssl
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import Future
 from unittest.mock import MagicMock, call, patch
 
@@ -1174,7 +1175,7 @@ class TestForwardRequestAsyncWrapper:
     async def test_absolute_deadline_stops_trickling_socket_response(self):
         client_socket, server_socket = forwarder.socket.socketpair()
         sent_body_bytes: list[bytes] = []
-        response_body = b"0123456789abcdef"
+        response_body = bytes(range(256))
 
         class SocketBackedForwardSocket(FakeSocket):
             def settimeout(self, timeout: float | None) -> None:
@@ -1211,7 +1212,7 @@ class TestForwardRequestAsyncWrapper:
                 for byte in response_body:
                     server_socket.sendall(bytes((byte,)))
                     sent_body_bytes.append(bytes((byte,)))
-                    time.sleep(0.02)
+                    time.sleep(0.01)
             except OSError:
                 pass
             finally:
@@ -1228,7 +1229,7 @@ class TestForwardRequestAsyncWrapper:
                 patch.object(
                     forwarder,
                     "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
-                    0.2,
+                    0.5,
                 ),
                 fake_forwarder_upstream(socket_factory=lambda: socket),
                 pytest.raises(forwarder.AuthBaseForwardingDeadlineExceededError),
@@ -1346,12 +1347,27 @@ class TestForwardRequestAsyncWrapper:
         assert first_socket.shutdown_calls == [forwarder.socket.SHUT_RDWR]
 
     async def test_completed_forward_cancels_deadline_timer(self):
+        loop = asyncio.get_running_loop()
+        original_call_later = loop.call_later
+        deadline_handles: list[asyncio.TimerHandle] = []
+
+        def record_deadline_handle(
+            delay: float,
+            callback: Callable[..., object],
+            *args: object,
+            context: contextvars.Context | None = None,
+        ) -> asyncio.TimerHandle:
+            handle = original_call_later(
+                delay,
+                callback,
+                *args,
+                context=context,
+            )
+            deadline_handles.append(handle)
+            return handle
+
         with (
-            patch.object(
-                forwarder,
-                "AUTH_BASE_FORWARD_DEADLINE_SECONDS",
-                0.1,
-            ),
+            patch.object(loop, "call_later", side_effect=record_deadline_handle),
             fake_forwarder_upstream() as upstream,
         ):
             status, body, _headers = await forwarder.forward_request(
@@ -1360,10 +1376,11 @@ class TestForwardRequestAsyncWrapper:
                 [],
                 None,
             )
-            await asyncio.sleep(0.15)
 
         assert status == 200
         assert body == b"ok"
+        assert len(deadline_handles) == 1
+        assert deadline_handles[0].cancelled()
         assert upstream.socket.shutdown_calls == []
         with forwarder._forward_request_active_handles_lock:
             assert not forwarder._forward_request_active_handles

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -86,9 +86,9 @@ class TestAuthBaseUrlRewriteForwarding:
             result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
-        assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
-        assert upstream.create_connection_calls
-        assert upstream.create_connection_calls[0][0] == ("93.184.216.34", 443)
+        assert upstream.resolve_calls == ["real.example.com"]
+        assert upstream.connect_calls
+        assert upstream.connect_calls[0] == ("93.184.216.34", 443)
         assert upstream.contexts[0].server_hostnames == ["real.example.com"]
 
         request_line = upstream.socket.request_lines()[0]

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -132,8 +132,8 @@ class TestAuthBaseUrlRewriteSafety:
             result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
-        assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
-        assert upstream.create_connection_calls == []
+        assert upstream.resolve_calls == ["real.example.com"]
+        assert upstream.connect_calls == []
 
         assert flow.response is not None
         assert flow.response.status_code == 502

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1227,8 +1227,8 @@ async def test_reflection_method_firewall_with_managed_credentials_blocks_before
         await mitm_addon.request(flow)
 
     auth_fetch.assert_not_called()
-    assert upstream.getaddrinfo_calls == []
-    assert upstream.create_connection_calls == []
+    assert upstream.resolve_calls == []
+    assert upstream.connect_calls == []
     assert upstream.sockets == []
     assert flow.response is not None
     assert flow.response.status_code == 403

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -13,11 +13,7 @@ import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
-from tests.auth_base_forwarder_helpers import (
-    FakeSocket,
-    fake_forwarder_upstream,
-    http_response,
-)
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import await_requestheaders_result
@@ -735,17 +731,10 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
     forward_started = threading.Event()
     release_forward = threading.Event()
 
-    def create_connection(_address, _timeout, _source_address):
+    def block_connect(_address):
         forward_started.set()
         if not release_forward.wait(timeout=5):
             raise TimeoutError("test did not release blocked auth.base forward")
-        return FakeSocket(
-            http_response(
-                status=200,
-                body=b'{"delivered":true}',
-                headers=[("Content-Type", "application/json")],
-            )
-        )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -754,14 +743,18 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
             "get_firewall_headers",
             AsyncMock(return_value=token_meta),
         ),
-        fake_forwarder_upstream(create_connection=create_connection) as upstream,
+        fake_forwarder_upstream(
+            body=b'{"delivered":true}',
+            headers=[("Content-Type", "application/json")],
+            connect_side_effect=block_connect,
+        ) as upstream,
     ):
         request_task = asyncio.create_task(mitm_addon.request(flow))
         try:
             await _wait_for_forward_start(forward_started, request_task)
 
-            assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
-            assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+            assert upstream.resolve_calls == ["real.example.com"]
+            assert upstream.connect_calls == [("93.184.216.34", 443)]
             usage.write_pending_snapshot(flush_request_id="request-1")
             assert_pending(
                 usage_pending_path,
@@ -823,8 +816,8 @@ async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
     ):
         await mitm_addon.request(flow)
 
-    assert upstream.getaddrinfo_calls == [("real.example.com", 443)]
-    assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+    assert upstream.resolve_calls == ["real.example.com"]
+    assert upstream.connect_calls == [("93.184.216.34", 443)]
     assert flow.response is not None
     assert flow.response.status_code == 502
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
@@ -850,12 +843,11 @@ async def test_billable_auth_url_rewrite_forward_cancellation_releases_tracking(
     release_forward = threading.Event()
     forward_unblocked = threading.Event()
 
-    def create_connection(_address, _timeout, _source_address):
+    def block_connect(_address):
         forward_started.set()
         try:
             if not release_forward.wait(timeout=5):
                 raise TimeoutError("test did not release blocked auth.base forward")
-            return FakeSocket(http_response())
         finally:
             forward_unblocked.set()
 
@@ -866,7 +858,7 @@ async def test_billable_auth_url_rewrite_forward_cancellation_releases_tracking(
             "get_firewall_headers",
             AsyncMock(return_value=token_meta),
         ),
-        fake_forwarder_upstream(create_connection=create_connection),
+        fake_forwarder_upstream(connect_side_effect=block_connect),
     ):
         request_task = asyncio.create_task(mitm_addon.request(flow))
         try:


### PR DESCRIPTION
## Summary

- enforce one 30-second monotonic deadline across auth.base active-slot waiting,
  DNS, TCP connect, TLS negotiation, request transmission, response headers,
  and response body delivery
- resolve hostnames through the bundled asynchronous Rust resolver, validate
  every resolved address, and connect only to those numeric addresses
- track one request-local abort lifecycle so deadline expiry and runner
  shutdown interrupt connect, TLS, and socket-backed response reads without
  releasing admission or active capacity before the worker actually exits
- update the external DNS/socket/TLS test boundary and add deterministic
  deadline, cleanup, capacity-recovery, cancellation, and cross-request
  isolation coverage

The existing redacted local forwarding-failure response remains unchanged.
This PR does not add tenant-aware scheduling, API or runner protocol changes,
schema or persisted-state changes, dependencies, environment variables, or
configuration knobs.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (0 errors)
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder.py -q`
  (107 passed)
- affected shared-forwarder integration files (168 passed)
- `uv run --no-sync python -m pytest tests/ --disable-warnings -q`
  (4297 passed)

Closes #23239
