### PR TITLE
refactor(mitm-addon): retire silent usage wrappers

### DIFF
--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -28,7 +28,6 @@ from . import webhook
 from .anthropic_messages import (
     create_anthropic_messages_json_usage_extractor,
     create_anthropic_messages_sse_usage_extractor,
-    extract_anthropic_messages_usage_from_json,
     extract_anthropic_messages_usage_with_error_from_json,
 )
 from .buffer import (
@@ -56,7 +55,6 @@ from .openai_responses import (
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event,
     extract_openai_responses_usage_from_event_json,
-    extract_openai_responses_usage_from_json,
     extract_openai_responses_usage_with_error_from_json,
     inspect_openai_responses_event_json,
     merge_openai_responses_usage_result,
@@ -91,11 +89,9 @@ __all__ = [
     "current_usage_state_id",
     "decrement_in_flight_flows",
     "drain_usage_events_after_executor_shutdown",
-    "extract_anthropic_messages_usage_from_json",
     "extract_anthropic_messages_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event",
     "extract_openai_responses_usage_from_event_json",
-    "extract_openai_responses_usage_from_json",
     "extract_openai_responses_usage_with_error_from_json",
     "flush_usage_events",
     "has_connector_response_parser",

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -227,21 +227,6 @@ def _extract_anthropic_messages_usage_from_decoded_json_body(
     return extractor.finish()
 
 
-def extract_anthropic_messages_usage_from_json(body: bytes, headers) -> dict | None:
-    """Extract usage from a non-streaming Anthropic API JSON response.
-
-    This is the silent best-effort API: it returns ``None`` when decoding or
-    parsing fails, the decoded body is empty, or no selected usage or metadata
-    fields are found.
-    """
-    if headers:
-        body = body_decoding.decompress_body(
-            body, headers, max_output=LARGE_RESPONSE_DECOMPRESS_LIMIT
-        )
-    usage, _error = _extract_anthropic_messages_usage_from_decoded_json_body(body)
-    return usage
-
-
 def extract_anthropic_messages_usage_with_error_from_json(
     body: bytes, headers
 ) -> tuple[dict | None, str | None]:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -695,31 +695,6 @@ def _extract_openai_responses_usage_from_decoded_json_body(
     return extractor.finish()
 
 
-def extract_openai_responses_usage_from_json(
-    body: bytes, headers: http.Headers | None
-) -> dict | None:
-    """Extract usage from a complete non-streaming Responses JSON body.
-
-    ``headers`` may be mitmproxy response headers or ``None``. When headers are
-    provided, their content encoding controls one-shot decompression before
-    parsing; ``None`` skips decompression.
-
-    This is the silent best-effort API: it returns ``None`` when decoding or
-    parsing fails, the decoded body is empty, or no platform usage categories
-    can be extracted. Otherwise returns a dict keyed by platform model usage
-    categories such as ``MODEL_USAGE_CATEGORY_INPUT``,
-    ``MODEL_USAGE_CATEGORY_OUTPUT``, ``MODEL_USAGE_CATEGORY_CACHE_READ``, and
-    ``MODEL_USAGE_CATEGORY_CACHE_CREATION``.
-    """
-
-    if headers:
-        body = body_decoding.decompress_body(
-            body, headers, max_output=LARGE_RESPONSE_DECOMPRESS_LIMIT
-        )
-    usage, _error = _extract_openai_responses_usage_from_decoded_json_body(body)
-    return usage
-
-
 def extract_openai_responses_usage_with_error_from_json(
     body: bytes, headers: http.Headers | None
 ) -> tuple[dict | None, str | None]:

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -7,7 +7,6 @@ import pytest
 
 from usage import (
     create_anthropic_messages_sse_usage_extractor,
-    extract_anthropic_messages_usage_from_json,
     extract_anthropic_messages_usage_with_error_from_json,
 )
 
@@ -547,12 +546,13 @@ class TestAnthropicSseUsageExtractor:
         assert usage["tokens.input"] == 100  # unchanged (not in delta)
 
 
-class TestExtractAnthropicUsageFromJson:
-    """Tests for extract_anthropic_messages_usage_from_json helper."""
+class TestExtractAnthropicUsageWithErrorFromJson:
+    """Tests for diagnostic Anthropic Messages JSON usage extraction."""
 
     def test_extracts_model_and_tokens(self):
         body = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":500}}'
-        result = extract_anthropic_messages_usage_from_json(body, None)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "model": "claude-sonnet-4-6",
             "tokens.input": 100,
@@ -565,7 +565,8 @@ class TestExtractAnthropicUsageFromJson:
             b'{"input_tokens":10,"output_tokens":5,'
             b'"cache_read_input_tokens":50,"cache_creation_input_tokens":0}}'
         )
-        result = extract_anthropic_messages_usage_from_json(body, None)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(body, None)
+        assert error is None
         assert result is not None
         assert result["tokens.cache_read"] == 50
         assert result["tokens.cache_creation"] == 0
@@ -574,29 +575,37 @@ class TestExtractAnthropicUsageFromJson:
         original = b'{"model":"test","usage":{"input_tokens":42}}'
         compressed = gzip.compress(original)
         headers = headers(("Content-Encoding", "gzip"))
-        result = extract_anthropic_messages_usage_from_json(compressed, headers)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(compressed, headers)
+        assert error is None
         assert result is not None
         assert result["model"] == "test"
         assert result["tokens.input"] == 42
 
-    def test_truncated_gzip_stays_silent_but_diagnostic_returns_error(self, headers):
+    def test_truncated_gzip_returns_error(self, headers):
         original = b'{"model":"test","usage":{"input_tokens":42}}'
         truncated = gzip.compress(original)[:10]
         headers = headers(("Content-Encoding", "gzip"))
 
-        assert extract_anthropic_messages_usage_from_json(truncated, headers) is None
         usage, error = extract_anthropic_messages_usage_with_error_from_json(truncated, headers)
         assert usage is None
         assert error == "incomplete compressed body"
 
-    def test_invalid_json_returns_none(self):
-        assert extract_anthropic_messages_usage_from_json(b"not json", None) is None
+    def test_invalid_json_returns_error(self):
+        usage, error = extract_anthropic_messages_usage_with_error_from_json(b"not json", None)
+        assert usage is None
+        assert error == "invalid literal"
 
     def test_no_usage_field_returns_none(self):
-        assert extract_anthropic_messages_usage_from_json(b'{"id":"msg_1"}', None) is None
+        usage, error = extract_anthropic_messages_usage_with_error_from_json(
+            b'{"id":"msg_1"}', None
+        )
+        assert usage is None
+        assert error is None
 
     def test_non_dict_returns_none(self):
-        assert extract_anthropic_messages_usage_from_json(b"[1,2,3]", None) is None
+        usage, error = extract_anthropic_messages_usage_with_error_from_json(b"[1,2,3]", None)
+        assert usage is None
+        assert error is None
 
     def test_ignores_unmapped_web_search_requests(self):
         body = (
@@ -604,7 +613,8 @@ class TestExtractAnthropicUsageFromJson:
             b'{"input_tokens":10,"output_tokens":5,'
             b'"server_tool_use":{"web_search_requests":2}}}'
         )
-        result = extract_anthropic_messages_usage_from_json(body, None)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(body, None)
+        assert error is None
         assert result is not None
         assert "web_search_requests" not in result
         assert result["tokens.input"] == 10
@@ -616,7 +626,8 @@ class TestExtractAnthropicUsageFromJson:
             b'"cache_read_input_tokens":"50",'
             b'"cache_creation_input_tokens":true}}'
         )
-        result = extract_anthropic_messages_usage_from_json(body, None)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "model": "claude-sonnet-4-6",
             "tokens.output": 5,
@@ -625,12 +636,11 @@ class TestExtractAnthropicUsageFromJson:
     def test_handles_large_gzipped_body(self, headers):
         """Body that decompresses past the legacy 64 KB cap should still parse.
 
-        Regression test for the silent 64 KB default in body_decoding.decompress_body
-        which used to truncate large model-provider non-SSE responses and cause
-        usage extraction to silently fail.
+        Regression test for the legacy 64 KB decompression default, which used
+        to truncate large model-provider non-SSE responses and lose usage.
         """
         # Raw body > 64 KB (legacy STREAM_BUFFER_LIMIT) so the bug, if reintroduced,
-        # would truncate decompression output and break json.loads below.
+        # would truncate decompression output before the selective parser finds usage.
         big_text = "x" * (100 * 1024)
         payload = json.dumps(
             {
@@ -642,7 +652,8 @@ class TestExtractAnthropicUsageFromJson:
         ).encode()
         compressed = gzip.compress(payload)
         headers = headers(("Content-Encoding", "gzip"))
-        result = extract_anthropic_messages_usage_from_json(compressed, headers)
+        result, error = extract_anthropic_messages_usage_with_error_from_json(compressed, headers)
+        assert error is None
         assert result is not None
         assert result["tokens.input"] == 50
         assert result["tokens.output"] == 100

--- a/crates/runner/mitm-addon/tests/test_openai_responses_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_json.py
@@ -5,14 +5,11 @@ import json
 
 import pytest
 
-from usage import (
-    extract_openai_responses_usage_from_json,
-    extract_openai_responses_usage_with_error_from_json,
-)
+from usage import extract_openai_responses_usage_with_error_from_json
 
 
-class TestExtractOpenAIResponsesUsageFromJson:
-    """Tests for OpenAI Responses API usage extraction."""
+class TestExtractOpenAIResponsesUsageWithErrorFromJson:
+    """Tests for diagnostic OpenAI Responses JSON usage extraction."""
 
     def test_extracts_model_tokens_and_cache_details(self):
         body = json.dumps(
@@ -30,7 +27,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
                 },
             }
         ).encode()
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result is not None
         assert result == {
             "message_id": "resp_123",
@@ -44,7 +42,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
 
     def test_missing_cached_input_details_does_not_emit_cache_read(self):
         body = b'{"model":"gpt-5.4","usage":{"input_tokens":10,"output_tokens":5}}'
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result is not None
         assert result == {
             "model": "gpt-5.4",
@@ -67,14 +66,17 @@ class TestExtractOpenAIResponsesUsageFromJson:
                 },
             }
         ).encode()
-        assert extract_openai_responses_usage_from_json(body, None) is None
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert result is None
+        assert error is None
 
     def test_invalid_cached_input_does_not_suppress_valid_input(self):
         body = (
             b'{"model":"gpt-5.5","usage":{"input_tokens":10,'
             b'"input_tokens_details":{"cached_tokens":"bad"}}}'
         )
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result is not None
         assert result == {
             "model": "gpt-5.5",
@@ -88,7 +90,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
             b'"usage":{"input_tokens":10,'
             b'"input_tokens_details":{"cache_write_tokens":10}}}'
         )
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "message_id": "resp_cache_write",
             "model": "gpt-5.6-sol",
@@ -110,7 +113,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
                 },
             }
         ).encode()
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "model": "gpt-5.6-sol",
             "tokens.input": 8,
@@ -122,7 +126,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
             b'{"model":"gpt-5.6-sol","usage":{"input_tokens":10,'
             b'"input_tokens_details":{"cached_tokens":8,"cache_write_tokens":5}}}'
         )
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "model": "gpt-5.6-sol",
             "tokens.input": 0,
@@ -137,14 +142,15 @@ class TestExtractOpenAIResponsesUsageFromJson:
         )
         compressed = gzip.compress(original)
         headers = headers(("Content-Encoding", "gzip"))
-        result = extract_openai_responses_usage_from_json(compressed, headers)
+        result, error = extract_openai_responses_usage_with_error_from_json(compressed, headers)
+        assert error is None
         assert result == {
             "model": "gpt-5.3-codex",
             "tokens.input": 35,
             "tokens.cache_read": 7,
         }
 
-    def test_truncated_gzip_stays_silent_but_diagnostic_returns_error(self, headers):
+    def test_truncated_gzip_returns_error(self, headers):
         original = (
             b'{"model":"gpt-5.3-codex","usage":{"input_tokens":42,'
             b'"input_tokens_details":{"cached_tokens":7}}}'
@@ -152,7 +158,6 @@ class TestExtractOpenAIResponsesUsageFromJson:
         truncated = gzip.compress(original)[:10]
         headers = headers(("Content-Encoding", "gzip"))
 
-        assert extract_openai_responses_usage_from_json(truncated, headers) is None
         usage, error = extract_openai_responses_usage_with_error_from_json(truncated, headers)
         assert usage is None
         assert error == "incomplete compressed body"
@@ -162,7 +167,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
             b'{"model":"gpt-5.5","usage":{"input_tokens":5,'
             b'"input_tokens_details":{"cached_tokens":7}}}'
         )
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "model": "gpt-5.5",
             "tokens.input": 0,
@@ -191,7 +197,8 @@ class TestExtractOpenAIResponsesUsageFromJson:
                 },
             }
         ).encode()
-        result = extract_openai_responses_usage_from_json(body, None)
+        result, error = extract_openai_responses_usage_with_error_from_json(body, None)
+        assert error is None
         assert result == {
             "message_id": "resp_large",
             "model": "gpt-5.5",


### PR DESCRIPTION
## Summary

- Remove the unused silent Anthropic and OpenAI Responses one-shot usage wrappers.
- Contract the `usage` facade to the diagnostic and incremental production contracts.
- Migrate direct parser tests to assert both usage and diagnostic error results.

## Behavior

Production model-provider JSON fallback continues using the existing diagnostic APIs. Buffered/zstd fallback admission, decompression limits, billing suppression, and warning emission are unchanged.

The removed functions were compatibility-only runner internals with no non-test repository caller. Each runner binary embeds its own addon source, so this change does not introduce a rolling-deployment protocol boundary.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_anthropic_messages.py tests/test_openai_responses_json.py` — 61 passed
- `uv run --no-sync python -m pytest tests/test_model_provider_json_fallback.py tests/test_model_provider_json_streaming.py` — 87 passed
- `uv run --no-sync python -m pytest tests/` — 4,298 passed

Closes #23292
