### PR TITLE
perf(api): attribute connector catalog cold-path latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -234,6 +234,43 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_assemble",
   "api_dispatch_build_stored_execution_context",
 ] as const;
+const API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES = [
+  "api_dispatch_connector_catalog_load_runtime_snapshot",
+  "api_dispatch_connector_catalog_query_identity",
+] as const;
+const API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES = [
+  "api_dispatch_connector_catalog_query_payload",
+  "api_dispatch_connector_catalog_decompress",
+  "api_dispatch_connector_catalog_verify_digest",
+  "api_dispatch_connector_catalog_decode_json",
+  "api_dispatch_connector_catalog_validate_schema",
+  "api_dispatch_connector_catalog_validate_public_projection",
+  "api_dispatch_connector_catalog_validate_relationships",
+  "api_dispatch_connector_catalog_validate_compatibility",
+  "api_dispatch_connector_catalog_materialize_accepted_snapshot",
+  "api_dispatch_connector_catalog_materialize_runtime_snapshot",
+  "api_dispatch_connector_catalog_materialize_server_firewalls",
+] as const;
+const API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES = [
+  ...API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+  ...API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES,
+] as const;
+const CONNECTOR_CATALOG_COUNT_BUCKETS = [
+  "0",
+  "1",
+  "2_4",
+  "5_8",
+  "9_16",
+  "17_plus",
+] as const;
+const CONNECTOR_CATALOG_RAW_SIZE_BUCKETS = [
+  "0_255_kib",
+  "256_511_kib",
+  "512_1023_kib",
+  "1_2_mib",
+  "2_4_mib",
+  "4_8_mib",
+] as const;
 const API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_resolve_inputs",
   "api_dispatch_prepare_storage_manifest_ensure_artifacts",
@@ -757,6 +794,38 @@ function expectApiDispatchTimingEventsNotToLeak(
   }
 }
 
+function expectConnectorCatalogLoadTiming(args: {
+  readonly events: readonly Record<string, unknown>[];
+  readonly acceptedCacheOutcome: "hit" | "miss" | "in_flight";
+  readonly runtimeCacheOutcome: "hit" | "miss";
+  readonly requestedConnectorCount: "known" | "not_applicable";
+}): void {
+  const event = singleApiDispatchEvent(
+    args.events,
+    "api_dispatch_connector_catalog_load_runtime_snapshot",
+  );
+  expect(event).toStrictEqual(
+    expect.objectContaining({
+      span_kind: "nested",
+      connector_catalog_accepted_cache_outcome: args.acceptedCacheOutcome,
+      connector_catalog_runtime_cache_outcome: args.runtimeCacheOutcome,
+    }),
+  );
+  expect(CONNECTOR_CATALOG_RAW_SIZE_BUCKETS).toContain(
+    event.connector_catalog_raw_size_bucket,
+  );
+  expect(CONNECTOR_CATALOG_COUNT_BUCKETS).toContain(
+    event.connector_catalog_connector_count_bucket,
+  );
+  const requestedCountBuckets =
+    args.requestedConnectorCount === "known"
+      ? CONNECTOR_CATALOG_COUNT_BUCKETS
+      : ["not_applicable"];
+  expect(requestedCountBuckets).toContain(
+    event.connector_catalog_requested_connector_count_bucket,
+  );
+}
+
 function expectDirectAblyClaimTimingEvents(args: {
   readonly events: readonly Record<string, unknown>[];
   readonly runId: string;
@@ -1015,6 +1084,21 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
+      "nested",
+    );
+    expectConnectorCatalogLoadTiming({
+      events: timingEvents,
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+    });
     expectNoApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchActions(
       timingEvents,
@@ -1131,7 +1215,58 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
       expect(["top_level", "nested"]).toContain(event.span_kind);
     }
-    expectApiDispatchTimingEventsNotToLeak(timingEvents, [prompt, agentId]);
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      prompt,
+      agentId,
+      "test-oauth-secret",
+      "fixture-confidential-secret",
+    ]);
+
+    const {
+      actor: warmActor,
+      agentId: warmAgentId,
+      runnerGroup: warmRunnerGroup,
+    } = await entitledRunActor();
+    const warmPrompt = "warm catalog timing should not leak prompt";
+    const warmCreated = await api.createRun(warmActor, {
+      agentId: warmAgentId,
+      prompt: warmPrompt,
+      modelProvider: "anthropic-api-key",
+    });
+    const warmTimingEvents = apiDispatchTimingEventsForRun(warmCreated.runId);
+    expectApiDispatchActions(
+      warmTimingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      warmTimingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      warmTimingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+      "nested",
+    );
+    expectConnectorCatalogLoadTiming({
+      events: warmTimingEvents,
+      acceptedCacheOutcome: "hit",
+      runtimeCacheOutcome: "hit",
+      requestedConnectorCount: "known",
+    });
+    for (const event of warmTimingEvents) {
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          runner_group: warmRunnerGroup,
+          run_id: warmCreated.runId,
+        }),
+      );
+    }
+    expectApiDispatchTimingEventsNotToLeak(warmTimingEvents, [
+      warmPrompt,
+      warmAgentId,
+      "test-oauth-secret",
+      "fixture-confidential-secret",
+    ]);
   });
 
   it("retains direct plan admission and emits direct create timing", async () => {
@@ -1158,6 +1293,34 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+      "nested",
+    );
+    const connectorCatalogLoadEvent = singleApiDispatchEvent(
+      timingEvents,
+      "api_dispatch_connector_catalog_load_runtime_snapshot",
+    );
+    expect(["hit", "miss", "in_flight"]).toContain(
+      connectorCatalogLoadEvent.connector_catalog_accepted_cache_outcome,
+    );
+    expect(["hit", "miss"]).toContain(
+      connectorCatalogLoadEvent.connector_catalog_runtime_cache_outcome,
+    );
+    expect(CONNECTOR_CATALOG_RAW_SIZE_BUCKETS).toContain(
+      connectorCatalogLoadEvent.connector_catalog_raw_size_bucket,
+    );
+    expect(CONNECTOR_CATALOG_COUNT_BUCKETS).toContain(
+      connectorCatalogLoadEvent.connector_catalog_connector_count_bucket,
+    );
+    expect(
+      connectorCatalogLoadEvent.connector_catalog_requested_connector_count_bucket,
+    ).toBe("not_applicable");
     expectApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchSpanKind(
       timingEvents,
@@ -1208,6 +1371,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
       prompt,
       headVersionId,
+      "test-oauth-secret",
+      "fixture-confidential-secret",
     ]);
 
     await api.requestCancelRun(actor, created.runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6633,10 +6633,16 @@ async function prepareRunRuntimeContext(args: {
 async function connectorCatalogSnapshotForRun(args: {
   readonly db: Db;
   readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
+  readonly connectorScope: EffectiveConnectorScope;
+  readonly timing: ApiDispatchTimingCollector;
 }): Promise<ConnectorRuntimeSnapshot> {
   return (
     args.preloadedConnectorCatalogSnapshot ??
-    (await loadConnectorRuntimeSnapshot(args.db))
+    (await loadConnectorRuntimeSnapshot(args.db, {
+      timing: args.timing,
+      requestedConnectorCount:
+        args.connectorScope.allowedConnectorTypes?.length,
+    }))
   );
 }
 

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -1,8 +1,10 @@
+import { performance } from "node:perf_hooks";
+
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 
 import { now } from "../external/time";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
-import { onRejection } from "../utils";
+import { safeSync } from "../utils";
 
 type ApiDispatchTimingSpanKind = "top_level" | "nested";
 export type ApiDispatchTimingDimensions = Readonly<Record<string, string>>;
@@ -153,7 +155,20 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_storage_manifest_resolve_artifact_versions"
   | "api_dispatch_prepare_storage_manifest_generate_artifact_urls"
   | "api_dispatch_prepare_storage_manifest_assemble"
-  | "api_dispatch_build_stored_execution_context";
+  | "api_dispatch_build_stored_execution_context"
+  | "api_dispatch_connector_catalog_load_runtime_snapshot"
+  | "api_dispatch_connector_catalog_query_identity"
+  | "api_dispatch_connector_catalog_query_payload"
+  | "api_dispatch_connector_catalog_decompress"
+  | "api_dispatch_connector_catalog_verify_digest"
+  | "api_dispatch_connector_catalog_decode_json"
+  | "api_dispatch_connector_catalog_validate_schema"
+  | "api_dispatch_connector_catalog_validate_public_projection"
+  | "api_dispatch_connector_catalog_validate_relationships"
+  | "api_dispatch_connector_catalog_validate_compatibility"
+  | "api_dispatch_connector_catalog_materialize_accepted_snapshot"
+  | "api_dispatch_connector_catalog_materialize_runtime_snapshot"
+  | "api_dispatch_connector_catalog_materialize_server_firewalls";
 
 interface ApiDispatchTimingRecord {
   readonly actionType: ApiDispatchTimingActionType;
@@ -166,6 +181,22 @@ interface ApiDispatchTimingRecord {
 export class ApiDispatchTimingCollector {
   private readonly records: ApiDispatchTimingRecord[] = [];
 
+  private recordDuration(
+    actionType: ApiDispatchTimingActionType,
+    spanKind: ApiDispatchTimingSpanKind,
+    durationMs: number,
+    finishedAt: number,
+    dimensions?: ApiDispatchTimingDimensionsInput,
+  ): void {
+    this.records.push({
+      actionType,
+      spanKind,
+      durationMs: Math.max(0, durationMs),
+      timestamp: new Date(finishedAt).toISOString(),
+      dimensions: resolveApiDispatchTimingDimensions(dimensions),
+    });
+  }
+
   recordElapsed(
     actionType: ApiDispatchTimingActionType,
     spanKind: ApiDispatchTimingSpanKind,
@@ -173,13 +204,13 @@ export class ApiDispatchTimingCollector {
     finishedAt: number = now(),
     dimensions?: ApiDispatchTimingDimensionsInput,
   ): void {
-    this.records.push({
+    this.recordDuration(
       actionType,
       spanKind,
-      durationMs: Math.max(0, finishedAt - startedAt),
-      timestamp: new Date(finishedAt).toISOString(),
-      dimensions: resolveApiDispatchTimingDimensions(dimensions),
-    });
+      finishedAt - startedAt,
+      finishedAt,
+      dimensions,
+    );
   }
 
   async measure<T>(
@@ -188,17 +219,39 @@ export class ApiDispatchTimingCollector {
     operation: () => T | Promise<T>,
     dimensions?: ApiDispatchTimingDimensionsInput,
   ): Promise<T> {
-    const startedAt = now();
-    const result = await onRejection(
-      (async () => {
-        return await operation();
-      })(),
-      () => {
-        this.recordElapsed(actionType, spanKind, startedAt, now(), dimensions);
-      },
+    const startedAt = performance.now();
+    return await (async () => {
+      return await operation();
+    })().finally(() => {
+      this.recordDuration(
+        actionType,
+        spanKind,
+        performance.now() - startedAt,
+        now(),
+        dimensions,
+      );
+    });
+  }
+
+  measureSync<T>(
+    actionType: ApiDispatchTimingActionType,
+    spanKind: ApiDispatchTimingSpanKind,
+    operation: () => T,
+    dimensions?: ApiDispatchTimingDimensionsInput,
+  ): T {
+    const startedAt = performance.now();
+    const result = safeSync(operation);
+    this.recordDuration(
+      actionType,
+      spanKind,
+      performance.now() - startedAt,
+      now(),
+      dimensions,
     );
-    this.recordElapsed(actionType, spanKind, startedAt, now(), dimensions);
-    return result;
+    if ("error" in result) {
+      throw result.error;
+    }
+    return result.ok;
   }
 
   flush(args: {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -5,6 +5,8 @@ import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contrac
 import { z } from "zod";
 
 import { safeJsonParse, safeSync } from "../../utils";
+import type { ApiDispatchTimingActionType } from "../api-dispatch-timing.service";
+import type { ConnectorCatalogLoadTiming } from "../connector-catalog-load-timing.service";
 import {
   CONNECTOR_CATALOG_ACTIVE_KEY,
   CONNECTOR_CATALOG_MAX_RAW_BYTES,
@@ -145,32 +147,66 @@ function assertSupportedArtifactSchema(value: unknown): void {
   }
 }
 
+function measureSnapshotPhase<T>(
+  timing: ConnectorCatalogLoadTiming | undefined,
+  actionType: ApiDispatchTimingActionType,
+  operation: () => T,
+): T {
+  return timing ? timing.measureSync(actionType, operation) : operation();
+}
+
 function parseAndValidateCatalog(args: {
   readonly bytes: Uint8Array;
   readonly catalogVersion: string;
+  readonly timing?: ConnectorCatalogLoadTiming;
 }): ConnectorCatalogArtifact {
-  const json = decodedJson(args.bytes);
-  assertSupportedArtifactSchema(json);
-  const artifact = parseStrict(
-    json,
-    connectorCatalogArtifactSchema,
-    "invalid-artifact",
+  const json = measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_decode_json",
+    () => {
+      return decodedJson(args.bytes);
+    },
   );
-  if (artifact.catalogVersion !== args.catalogVersion) {
-    fail("invalid-reference");
-  }
-  const publicProjection = safeSync(() => {
-    validateConnectorCatalogPublicProjection(artifact);
-  });
-  if (!("ok" in publicProjection)) {
-    fail("public-leakage");
-  }
-  const relationships = safeSync(() => {
-    validateConnectorCatalogArtifact(artifact);
-  });
-  if (!("ok" in relationships)) {
-    fail("relationship-mismatch");
-  }
+  const artifact = measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_validate_schema",
+    () => {
+      assertSupportedArtifactSchema(json);
+      const parsed = parseStrict(
+        json,
+        connectorCatalogArtifactSchema,
+        "invalid-artifact",
+      );
+      if (parsed.catalogVersion !== args.catalogVersion) {
+        fail("invalid-reference");
+      }
+      return parsed;
+    },
+  );
+  measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_validate_public_projection",
+    () => {
+      const publicProjection = safeSync(() => {
+        validateConnectorCatalogPublicProjection(artifact);
+      });
+      if (!("ok" in publicProjection)) {
+        fail("public-leakage");
+      }
+    },
+  );
+  measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_validate_relationships",
+    () => {
+      const relationships = safeSync(() => {
+        validateConnectorCatalogArtifact(artifact);
+      });
+      if (!("ok" in relationships)) {
+        fail("relationship-mismatch");
+      }
+    },
+  );
   return artifact;
 }
 
@@ -242,6 +278,7 @@ export function decodeConnectorCatalogSnapshot(args: {
   readonly catalogRawSize: number;
   readonly catalogVersion: string;
   readonly catalogDigest: string;
+  readonly timing?: ConnectorCatalogLoadTiming;
 }): DecodedConnectorCatalogSnapshot {
   if (
     args.catalogGzip.byteLength > CONNECTOR_CATALOG_MAX_GZIP_BYTES ||
@@ -249,15 +286,29 @@ export function decodeConnectorCatalogSnapshot(args: {
   ) {
     fail("object-too-large");
   }
-  const rawBytes = gunzipCatalog(args.catalogGzip);
-  if (rawBytes.byteLength !== args.catalogRawSize) {
-    fail("invalid-reference");
-  }
-  assertDigest(rawBytes, args.catalogDigest);
+  const rawBytes = measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_decompress",
+    () => {
+      const decompressed = gunzipCatalog(args.catalogGzip);
+      if (decompressed.byteLength !== args.catalogRawSize) {
+        fail("invalid-reference");
+      }
+      return decompressed;
+    },
+  );
+  measureSnapshotPhase(
+    args.timing,
+    "api_dispatch_connector_catalog_verify_digest",
+    () => {
+      assertDigest(rawBytes, args.catalogDigest);
+    },
+  );
   return {
     artifact: parseAndValidateCatalog({
       bytes: rawBytes,
       catalogVersion: args.catalogVersion,
+      ...(args.timing === undefined ? {} : { timing: args.timing }),
     }),
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -41,7 +41,9 @@ import { connectorCatalogIconUrl } from "./connector-catalog-artifacts/icon";
 import { deriveConnectorCatalogFirewallPermissions } from "./connector-catalog-artifacts/relationships";
 import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
+import type { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
 import { connectorCatalogSource } from "./connector-catalog-source";
+import type { ApiDispatchTimingActionType } from "./api-dispatch-timing.service";
 
 const log = logger("connector-catalog:reader");
 
@@ -60,6 +62,7 @@ interface PrivateAuthMethodFacts {
 
 export interface AcceptedConnectorCatalogSnapshot {
   readonly identity: ExternalCatalogIdentity;
+  readonly catalogRawSize: number;
   readonly artifact: ConnectorCatalogArtifact;
   readonly connectorByRef: ReadonlyMap<
     string,
@@ -191,6 +194,24 @@ function privateMethodFacts(
   return facts;
 }
 
+async function measureCatalogLoad<T>(
+  timing: ConnectorCatalogLoadTiming | undefined,
+  actionType: ApiDispatchTimingActionType,
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  return timing
+    ? await timing.measure(actionType, operation)
+    : await operation();
+}
+
+function measureCatalogLoadSync<T>(
+  timing: ConnectorCatalogLoadTiming | undefined,
+  actionType: ApiDispatchTimingActionType,
+  operation: () => T,
+): T {
+  return timing ? timing.measureSync(actionType, operation) : operation();
+}
+
 function externalCatalogJoin() {
   return and(
     eq(
@@ -216,29 +237,39 @@ async function readCurrentIdentity(args: {
   readonly db: ReadonlyDb;
   readonly sourceId: string;
   readonly capabilityDigest: string;
+  readonly timing?: ConnectorCatalogLoadTiming;
 }): Promise<ExternalCatalogIdentity | undefined> {
-  const [row] = await args.db
-    .select({
-      schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
-      catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
-      catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
-    })
-    .from(connectorCatalogActiveSnapshot)
-    .innerJoin(connectorCatalogCompatibilityEvaluation, externalCatalogJoin())
-    .where(
-      and(
-        eq(connectorCatalogActiveSnapshot.sourceId, args.sourceId),
-        eq(
-          connectorCatalogActiveSnapshot.schemaVersion,
-          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-        ),
-        eq(
-          connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-          args.capabilityDigest,
-        ),
-      ),
-    )
-    .limit(1);
+  const [row] = await measureCatalogLoad(
+    args.timing,
+    "api_dispatch_connector_catalog_query_identity",
+    async () => {
+      return await args.db
+        .select({
+          schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
+          catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
+          catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
+        })
+        .from(connectorCatalogActiveSnapshot)
+        .innerJoin(
+          connectorCatalogCompatibilityEvaluation,
+          externalCatalogJoin(),
+        )
+        .where(
+          and(
+            eq(connectorCatalogActiveSnapshot.sourceId, args.sourceId),
+            eq(
+              connectorCatalogActiveSnapshot.schemaVersion,
+              SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+            ),
+            eq(
+              connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+              args.capabilityDigest,
+            ),
+          ),
+        )
+        .limit(1);
+    },
+  );
   return row
     ? {
         sourceId: args.sourceId,
@@ -253,38 +284,48 @@ async function readCurrentIdentity(args: {
 async function readCurrentCatalog(args: {
   readonly db: ReadonlyDb;
   readonly identity: ExternalCatalogIdentity;
+  readonly timing?: ConnectorCatalogLoadTiming;
 }): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
-  const [row] = await args.db
-    .select({
-      catalogRawSize: connectorCatalogActiveSnapshot.catalogRawSize,
-      catalogGzip: connectorCatalogActiveSnapshot.catalogGzip,
-      filteredAuthMethods:
-        connectorCatalogCompatibilityEvaluation.filteredAuthMethods,
-    })
-    .from(connectorCatalogActiveSnapshot)
-    .innerJoin(connectorCatalogCompatibilityEvaluation, externalCatalogJoin())
-    .where(
-      and(
-        eq(connectorCatalogActiveSnapshot.sourceId, args.identity.sourceId),
-        eq(
-          connectorCatalogActiveSnapshot.schemaVersion,
-          args.identity.schemaVersion,
-        ),
-        eq(
-          connectorCatalogActiveSnapshot.catalogVersion,
-          args.identity.catalogVersion,
-        ),
-        eq(
-          connectorCatalogActiveSnapshot.catalogDigest,
-          args.identity.catalogDigest,
-        ),
-        eq(
-          connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-          args.identity.capabilityDigest,
-        ),
-      ),
-    )
-    .limit(1);
+  const [row] = await measureCatalogLoad(
+    args.timing,
+    "api_dispatch_connector_catalog_query_payload",
+    async () => {
+      return await args.db
+        .select({
+          catalogRawSize: connectorCatalogActiveSnapshot.catalogRawSize,
+          catalogGzip: connectorCatalogActiveSnapshot.catalogGzip,
+          filteredAuthMethods:
+            connectorCatalogCompatibilityEvaluation.filteredAuthMethods,
+        })
+        .from(connectorCatalogActiveSnapshot)
+        .innerJoin(
+          connectorCatalogCompatibilityEvaluation,
+          externalCatalogJoin(),
+        )
+        .where(
+          and(
+            eq(connectorCatalogActiveSnapshot.sourceId, args.identity.sourceId),
+            eq(
+              connectorCatalogActiveSnapshot.schemaVersion,
+              args.identity.schemaVersion,
+            ),
+            eq(
+              connectorCatalogActiveSnapshot.catalogVersion,
+              args.identity.catalogVersion,
+            ),
+            eq(
+              connectorCatalogActiveSnapshot.catalogDigest,
+              args.identity.catalogDigest,
+            ),
+            eq(
+              connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+              args.identity.capabilityDigest,
+            ),
+          ),
+        )
+        .limit(1);
+    },
+  );
   if (!row) {
     return undefined;
   }
@@ -294,40 +335,58 @@ async function readCurrentCatalog(args: {
     catalogRawSize: row.catalogRawSize,
     catalogVersion: args.identity.catalogVersion,
     catalogDigest: args.identity.catalogDigest,
+    ...(args.timing === undefined ? {} : { timing: args.timing }),
   });
-  const filteredAuthMethods =
-    connectorCatalogFilteredAuthMethodsSchema.safeParse(
-      row.filteredAuthMethods,
-    );
-  if (!filteredAuthMethods.success) {
-    log.error("Rejected persisted connector catalog compatibility evaluation", {
-      ...identityLogFields(args.identity),
-      failureCode: "invalid-compatibility-evaluation",
-    });
-    throw new ExternalConnectorCatalogUnavailableError();
-  }
+  const filteredAuthMethods = measureCatalogLoadSync(
+    args.timing,
+    "api_dispatch_connector_catalog_validate_compatibility",
+    () => {
+      const parsed = connectorCatalogFilteredAuthMethodsSchema.safeParse(
+        row.filteredAuthMethods,
+      );
+      if (!parsed.success) {
+        log.error(
+          "Rejected persisted connector catalog compatibility evaluation",
+          {
+            ...identityLogFields(args.identity),
+            failureCode: "invalid-compatibility-evaluation",
+          },
+        );
+        throw new ExternalConnectorCatalogUnavailableError();
+      }
+      return parsed.data;
+    },
+  );
   const artifact = decoded.artifact;
 
-  return {
-    identity: args.identity,
-    artifact,
-    connectorByRef: new Map(
-      artifact.connectors.map((connector) => {
-        return [connector.connectorRef, connector];
-      }),
-    ),
-    privateMethodFacts: privateMethodFacts(artifact),
-    filteredMethodKeys: new Set(
-      filteredAuthMethods.data.map((filtered) => {
-        return authMethodKey(filtered.connectorRef, filtered.authMethodId);
-      }),
-    ),
-  };
+  return measureCatalogLoadSync(
+    args.timing,
+    "api_dispatch_connector_catalog_materialize_accepted_snapshot",
+    () => {
+      return {
+        identity: args.identity,
+        catalogRawSize: row.catalogRawSize,
+        artifact,
+        connectorByRef: new Map(
+          artifact.connectors.map((connector) => {
+            return [connector.connectorRef, connector];
+          }),
+        ),
+        privateMethodFacts: privateMethodFacts(artifact),
+        filteredMethodKeys: new Set(
+          filteredAuthMethods.map((filtered) => {
+            return authMethodKey(filtered.connectorRef, filtered.authMethodId);
+          }),
+        ),
+      };
+    },
+  );
 }
 
 async function loadCurrentCatalog(args: {
   readonly db: ReadonlyDb;
   readonly identity: ExternalCatalogIdentity;
+  readonly timing?: ConnectorCatalogLoadTiming;
 }): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
   const result = await settle(readCurrentCatalog(args));
   if (result.ok) {
@@ -357,6 +416,7 @@ function deleteInFlightCatalog(
 
 async function loadAcceptedConnectorCatalogSnapshotAttempt(
   db: ReadonlyDb,
+  timing: ConnectorCatalogLoadTiming | undefined,
 ): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
   const sourceId = connectorCatalogSource().sourceId;
   const capabilityDigest = connectorCatalogExecutableCapabilityDigest();
@@ -364,6 +424,7 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
     db,
     sourceId,
     capabilityDigest,
+    ...(timing === undefined ? {} : { timing }),
   });
   if (!currentIdentity) {
     throw new ExternalConnectorCatalogUnavailableError();
@@ -371,15 +432,22 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
   const currentKey = identityKey(currentIdentity);
   const cache = preparedCatalogCache();
   if (cache.completed?.key === currentKey) {
+    timing?.recordAcceptedCacheOutcome("hit");
     return cache.completed.catalog;
   }
 
   const existing = cache.inFlight.get(currentKey);
   if (existing) {
+    timing?.recordAcceptedCacheOutcome("in_flight");
     return await existing;
   }
 
-  const promise = loadCurrentCatalog({ db, identity: currentIdentity });
+  timing?.recordAcceptedCacheOutcome("miss");
+  const promise = loadCurrentCatalog({
+    db,
+    identity: currentIdentity,
+    ...(timing === undefined ? {} : { timing }),
+  });
   cache.inFlight.set(currentKey, promise);
   const catalog = await onRejection(promise, () => {
     deleteInFlightCatalog(cache, currentKey, promise);
@@ -394,8 +462,9 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
 
 export async function loadAcceptedConnectorCatalogSnapshot(
   db: ReadonlyDb,
+  timing?: ConnectorCatalogLoadTiming,
 ): Promise<AcceptedConnectorCatalogSnapshot> {
-  const first = await loadAcceptedConnectorCatalogSnapshotAttempt(db);
+  const first = await loadAcceptedConnectorCatalogSnapshotAttempt(db, timing);
   if (first) {
     return first;
   }
@@ -403,7 +472,7 @@ export async function loadAcceptedConnectorCatalogSnapshot(
   // The active row is intentionally the only durable catalog snapshot. If an
   // activation commits between the identity and payload queries, the old
   // identity no longer has a row; retry once against the newly active identity.
-  const second = await loadAcceptedConnectorCatalogSnapshotAttempt(db);
+  const second = await loadAcceptedConnectorCatalogSnapshotAttempt(db, timing);
   if (!second) {
     throw new ExternalConnectorCatalogUnavailableError();
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -1,0 +1,175 @@
+import type {
+  ApiDispatchTimingActionType,
+  ApiDispatchTimingCollector,
+  ApiDispatchTimingDimensions,
+} from "./api-dispatch-timing.service";
+
+type AcceptedConnectorCatalogCacheOutcome = "hit" | "miss" | "in_flight";
+type ConnectorRuntimeSnapshotCacheOutcome = "hit" | "miss";
+
+type ConnectorCatalogCountBucket =
+  | "0"
+  | "1"
+  | "2_4"
+  | "5_8"
+  | "9_16"
+  | "17_plus";
+type ConnectorCatalogRawSizeBucket =
+  | "0_255_kib"
+  | "256_511_kib"
+  | "512_1023_kib"
+  | "1_2_mib"
+  | "2_4_mib"
+  | "4_8_mib";
+
+function countBucket(count: number): ConnectorCatalogCountBucket {
+  if (count === 0) {
+    return "0";
+  }
+  if (count === 1) {
+    return "1";
+  }
+  if (count <= 4) {
+    return "2_4";
+  }
+  if (count <= 8) {
+    return "5_8";
+  }
+  if (count <= 16) {
+    return "9_16";
+  }
+  return "17_plus";
+}
+
+function rawSizeBucket(rawSize: number): ConnectorCatalogRawSizeBucket {
+  if (rawSize < 256 * 1024) {
+    return "0_255_kib";
+  }
+  if (rawSize < 512 * 1024) {
+    return "256_511_kib";
+  }
+  if (rawSize < 1024 * 1024) {
+    return "512_1023_kib";
+  }
+  if (rawSize < 2 * 1024 * 1024) {
+    return "1_2_mib";
+  }
+  if (rawSize < 4 * 1024 * 1024) {
+    return "2_4_mib";
+  }
+  return "4_8_mib";
+}
+
+function acceptedCacheOutcomeRank(
+  outcome: AcceptedConnectorCatalogCacheOutcome,
+): number {
+  switch (outcome) {
+    case "hit": {
+      return 0;
+    }
+    case "in_flight": {
+      return 1;
+    }
+    case "miss": {
+      return 2;
+    }
+  }
+}
+
+export class ConnectorCatalogLoadTiming {
+  private acceptedCacheOutcome:
+    | AcceptedConnectorCatalogCacheOutcome
+    | undefined;
+  private runtimeCacheOutcome: ConnectorRuntimeSnapshotCacheOutcome | undefined;
+  private catalogRawSize: number | undefined;
+  private connectorCount: number | undefined;
+
+  constructor(
+    private readonly collector: ApiDispatchTimingCollector,
+    private readonly requestedConnectorCount: number | undefined,
+  ) {}
+
+  recordAcceptedCacheOutcome(
+    outcome: AcceptedConnectorCatalogCacheOutcome,
+  ): void {
+    if (
+      this.acceptedCacheOutcome === undefined ||
+      acceptedCacheOutcomeRank(outcome) >
+        acceptedCacheOutcomeRank(this.acceptedCacheOutcome)
+    ) {
+      this.acceptedCacheOutcome = outcome;
+    }
+  }
+
+  recordRuntimeCacheOutcome(
+    outcome: ConnectorRuntimeSnapshotCacheOutcome,
+  ): void {
+    this.runtimeCacheOutcome = outcome;
+  }
+
+  recordCatalogFacts(args: {
+    readonly rawSize: number;
+    readonly connectorCount: number;
+  }): void {
+    this.catalogRawSize = args.rawSize;
+    this.connectorCount = args.connectorCount;
+  }
+
+  async measure<T>(
+    actionType: ApiDispatchTimingActionType,
+    operation: () => T | Promise<T>,
+  ): Promise<T> {
+    return await this.collector.measure(actionType, "nested", operation);
+  }
+
+  measureSync<T>(
+    actionType: ApiDispatchTimingActionType,
+    operation: () => T,
+  ): T {
+    return this.collector.measureSync(actionType, "nested", operation);
+  }
+
+  async measureComplete<T>(operation: () => T | Promise<T>): Promise<T> {
+    return await this.collector.measure(
+      "api_dispatch_connector_catalog_load_runtime_snapshot",
+      "nested",
+      operation,
+      () => {
+        return this.completeDimensions();
+      },
+    );
+  }
+
+  private completeDimensions(): ApiDispatchTimingDimensions {
+    return {
+      ...(this.acceptedCacheOutcome === undefined
+        ? {}
+        : {
+            connector_catalog_accepted_cache_outcome: this.acceptedCacheOutcome,
+          }),
+      ...(this.runtimeCacheOutcome === undefined
+        ? {}
+        : {
+            connector_catalog_runtime_cache_outcome: this.runtimeCacheOutcome,
+          }),
+      ...(this.catalogRawSize === undefined
+        ? {}
+        : {
+            connector_catalog_raw_size_bucket: rawSizeBucket(
+              this.catalogRawSize,
+            ),
+          }),
+      ...(this.connectorCount === undefined
+        ? {}
+        : {
+            connector_catalog_connector_count_bucket: countBucket(
+              this.connectorCount,
+            ),
+          }),
+      connector_catalog_requested_connector_count_bucket:
+        this.requestedConnectorCount === undefined
+          ? "not_applicable"
+          : countBucket(this.requestedConnectorCount),
+    };
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -33,6 +33,7 @@ import {
 
 import { singleton } from "../../lib/singleton";
 import type { ReadonlyDb } from "../external/db";
+import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import type {
   ConnectorCatalogAuthMethod,
   ConnectorCatalogSkill,
@@ -46,6 +47,7 @@ import {
   type ExternalCatalogIdentity,
 } from "./connector-catalog-external-reader.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
+import { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
 import {
   createAcceptedConnectorServerFirewallCatalog,
   type ConnectorServerFirewallCatalog,
@@ -443,9 +445,9 @@ function runtimeMethodEntry(args: {
   };
 }
 
-function runtimeSnapshot(
+function runtimeConnectors(
   acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
-): ConnectorRuntimeSnapshot {
+): ReadonlyMap<ConnectorRef, ConnectorRuntimeConnector> {
   const connectors = new Map<ConnectorRef, ConnectorRuntimeConnector>();
 
   for (const connector of acceptedSnapshot.artifact.connectors) {
@@ -499,6 +501,40 @@ function runtimeSnapshot(
       skill: connector.skill,
     });
   }
+  return connectors;
+}
+
+function runtimeSnapshot(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+  timing: ConnectorCatalogLoadTiming | undefined,
+): ConnectorRuntimeSnapshot {
+  const connectors = timing
+    ? timing.measureSync(
+        "api_dispatch_connector_catalog_materialize_runtime_snapshot",
+        () => {
+          return runtimeConnectors(acceptedSnapshot);
+        },
+      )
+    : runtimeConnectors(acceptedSnapshot);
+  const serverFirewalls = timing
+    ? timing.measureSync(
+        "api_dispatch_connector_catalog_materialize_server_firewalls",
+        () => {
+          return runtimeServerFirewalls(acceptedSnapshot, connectors);
+        },
+      )
+    : runtimeServerFirewalls(acceptedSnapshot, connectors);
+  return {
+    acceptedSnapshot,
+    connectors,
+    serverFirewalls,
+  };
+}
+
+function runtimeServerFirewalls(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+  connectors: ReadonlyMap<ConnectorRef, ConnectorRuntimeConnector>,
+): ConnectorServerFirewallCatalog {
   const runtimeMethodsByRef = new Map(
     [...connectors.entries()].map(([connectorRef, connector]) => {
       return [
@@ -509,15 +545,10 @@ function runtimeSnapshot(
       ];
     }),
   );
-  const serverFirewalls = createAcceptedConnectorServerFirewallCatalog({
+  return createAcceptedConnectorServerFirewallCatalog({
     artifact: acceptedSnapshot.artifact,
     runtimeMethodsByRef,
   });
-  return {
-    acceptedSnapshot,
-    connectors,
-    serverFirewalls,
-  };
 }
 
 function runtimeSnapshotKey(identity: ExternalCatalogIdentity): string {
@@ -539,19 +570,48 @@ const runtimeSnapshotCache = singleton((): RuntimeSnapshotCache => {
   return { key: undefined, snapshot: undefined };
 });
 
-export async function loadConnectorRuntimeSnapshot(
+async function loadConnectorRuntimeSnapshotWithTiming(
   db: ReadonlyDb,
+  timing: ConnectorCatalogLoadTiming | undefined,
 ): Promise<ConnectorRuntimeSnapshot> {
-  const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(db);
+  const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(
+    db,
+    timing,
+  );
+  timing?.recordCatalogFacts({
+    rawSize: acceptedSnapshot.catalogRawSize,
+    connectorCount: acceptedSnapshot.artifact.connectors.length,
+  });
   const key = runtimeSnapshotKey(acceptedSnapshot.identity);
   const cache = runtimeSnapshotCache();
   if (cache.key === key && cache.snapshot !== undefined) {
+    timing?.recordRuntimeCacheOutcome("hit");
     return cache.snapshot;
   }
-  const snapshot = runtimeSnapshot(acceptedSnapshot);
+  timing?.recordRuntimeCacheOutcome("miss");
+  const snapshot = runtimeSnapshot(acceptedSnapshot, timing);
   cache.key = key;
   cache.snapshot = snapshot;
   return snapshot;
+}
+
+export async function loadConnectorRuntimeSnapshot(
+  db: ReadonlyDb,
+  options?: {
+    readonly timing: ApiDispatchTimingCollector;
+    readonly requestedConnectorCount: number | undefined;
+  },
+): Promise<ConnectorRuntimeSnapshot> {
+  if (options === undefined) {
+    return await loadConnectorRuntimeSnapshotWithTiming(db, undefined);
+  }
+  const timing = new ConnectorCatalogLoadTiming(
+    options.timing,
+    options.requestedConnectorCount,
+  );
+  return await timing.measureComplete(async () => {
+    return await loadConnectorRuntimeSnapshotWithTiming(db, timing);
+  });
 }
 
 export function getConnectorRuntimeConnector(

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -852,7 +852,10 @@ async function loadZeroRunPostAuthorizationContext(
   );
   signal.throwIfAborted();
 
-  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db);
+  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db, {
+    timing: args.timing,
+    requestedConnectorCount: bootstrapContext.allowedConnectorTypes.length,
+  });
   signal.throwIfAborted();
   const runPermissionPolicies = await measureZeroPreCreate(
     args.timing,


### PR DESCRIPTION
## Summary

- attribute connector catalog identity/payload reads and synchronous decode,
  validation, indexing, runtime, and firewall phases through the existing
  run-scoped API dispatch telemetry
- distinguish accepted-catalog `hit`/`miss`/`in_flight` from runtime snapshot
  `hit`/`miss`, with bounded catalog size and connector-count cohorts
- use monotonic measured durations, wire both Zero/Web and direct run creation,
  and verify cold miss plus same-identity warm hit behavior at the API/Axiom
  boundary

## Compatibility and exclusions

- no database schema or persisted catalog representation changes
- no API response, runner protocol, queue payload, run-state, cache-key, retry,
  fallback, or exception behavior changes
- non-run catalog callers do not allocate the observer or emit run timing
- no connector refs, catalog identities/digests, OAuth data, firewall values,
  credentials, payloads, or private catalog content are emitted

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (120 passed)
- `cd turbo && pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks

Closes #23290
