### PR TITLE
chore(api): refresh preview verification marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-26)
+// (no-op API release marker refreshed on 2026-07-27 for preview verification)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the existing no-op API release marker comment to create an isolated PR preview
- leave runtime behavior and the API contract unchanged

## Preview verification

- use the deployed App/API preview to rerun the `cli-e2e-02-browser` Clerk sign-up and sign-in path

## Verification

- `git diff --check`
- local tests not run (comment-only change); rely on the PR pipeline for runtime checks
