### PR TITLE
fix(runner): trace guest dns through root netfilter

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -131,7 +131,6 @@ start_netfilter_trace() {
   NETFILTER_TRACE_FILE=$(mktemp "/tmp/vm0-${SVC}-netfilter-trace.XXXXXX")
   sudo xtables-monitor --trace --ipv4 >"$NETFILTER_TRACE_FILE" 2>&1 &
   NETFILTER_TRACE_PID=$!
-  sleep 0.1
   sudo kill -0 "$NETFILTER_TRACE_PID" 2>/dev/null \
     || fail "xtables-monitor exited before DNS trace probes"
 }
@@ -572,28 +571,45 @@ if printf '%s\n' "$ATTACKER_TCP_TRACE_RULE" \
 fi
 
 start_netfilter_trace
-send_dns_trace_probes "$ATTACKER_NS" "8.8.8.8" \
-  || fail "DNS trace probes failed"
-sleep 0.1
-stop_netfilter_trace || fail "xtables-monitor failed while capturing DNS probes"
-
-UDP_TRACE_EVENT=$(grep -F -- "raw:PREROUTING:" "$NETFILTER_TRACE_FILE" \
-  | grep -F -- "-p udp" \
-  | grep -F -- "--dport 53" \
-  | grep -E -- "--length 67(:67)?([[:space:]]|$)" \
-  | grep -F -- "--comment ${ATTACKER_NS}" \
-  | grep -F -- "-j TRACE" \
-  | tail -n 1 || true)
-TCP_TRACE_EVENT=$(grep -F -- "nat:PREROUTING:" "$NETFILTER_TRACE_FILE" \
-  | grep -F -- "-p tcp" \
-  | grep -F -- "--dport 53" \
-  | grep -F -- "--comment ${ATTACKER_NS}" \
-  | grep -F -- "-j REDIRECT" \
-  | head -n 1 || true)
+UDP_TRACE_EVENT=""
+TCP_TRACE_EVENT=""
+for _ in $(seq 1 3); do
+  send_dns_trace_probes "$ATTACKER_NS" "8.8.8.8" \
+    || fail "DNS trace probes failed"
+  for _ in $(seq 1 20); do
+    UDP_TRACE_EVENT=$(grep -F -- "raw:PREROUTING:" "$NETFILTER_TRACE_FILE" \
+      | grep -F -- "-p udp" \
+      | grep -F -- "--dport 53" \
+      | grep -E -- "--length 67(:67)?([[:space:]]|$)" \
+      | grep -F -- "--comment ${ATTACKER_NS}" \
+      | grep -F -- "-j TRACE" \
+      | tail -n 1 || true)
+    TCP_TRACE_EVENT=$(grep -F -- "nat:PREROUTING:" "$NETFILTER_TRACE_FILE" \
+      | grep -F -- "-p tcp" \
+      | grep -F -- "--dport 53" \
+      | grep -F -- "--comment ${ATTACKER_NS}" \
+      | grep -F -- "-j REDIRECT" \
+      | head -n 1 || true)
+    if [ -n "$UDP_TRACE_EVENT" ] && [ -n "$TCP_TRACE_EVENT" ]; then
+      UDP_TRACE_ID=$(printf '%s\n' "$UDP_TRACE_EVENT" | awk '{print $3}')
+      TCP_TRACE_ID=$(printf '%s\n' "$TCP_TRACE_EVENT" | awk '{print $3}')
+      if grep -E "TRACE: 2 ${UDP_TRACE_ID} filter:INPUT:policy:ACCEPT" \
+        "$NETFILTER_TRACE_FILE" >/dev/null \
+        && grep -E "TRACE: 2 ${TCP_TRACE_ID} filter:INPUT:policy:ACCEPT" \
+          "$NETFILTER_TRACE_FILE" >/dev/null; then
+        break 2
+      fi
+    fi
+    sudo kill -0 "$NETFILTER_TRACE_PID" 2>/dev/null \
+      || fail "xtables-monitor exited while capturing DNS probes"
+    sleep 0.05
+  done
+done
 [ -n "$UDP_TRACE_EVENT" ] \
   || fail "xtables-monitor did not capture the UDP readiness TRACE rule"
 [ -n "$TCP_TRACE_EVENT" ] \
   || fail "xtables-monitor did not capture the TCP DNS redirect TRACE rule"
+stop_netfilter_trace || fail "xtables-monitor failed while capturing DNS probes"
 UDP_TRACE_ID=$(printf '%s\n' "$UDP_TRACE_EVENT" | awk '{print $3}')
 TCP_TRACE_ID=$(printf '%s\n' "$TCP_TRACE_EVENT" | awk '{print $3}')
 UDP_TRACE_PACKET=$(grep -E \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -36,6 +36,8 @@ DNS_ISOLATION_HOST_IF=""
 DNS_ISOLATION_LOCK_FD=""
 SPOOF_NS=""
 SPOOF_IP=""
+NETFILTER_TRACE_FILE=""
+NETFILTER_TRACE_PID=""
 POOL_LOCK_GUARD_DIR=""
 POOL_LOCK_HOLDER_PID=""
 POOL_LOCK_RELEASE_FD=""
@@ -105,6 +107,33 @@ cleanup_spoof_address() {
   fi
   SPOOF_NS=""
   SPOOF_IP=""
+}
+
+stop_netfilter_trace() {
+  local pid status
+  if [ -n "$NETFILTER_TRACE_PID" ]; then
+    pid=$NETFILTER_TRACE_PID
+    NETFILTER_TRACE_PID=""
+    sudo kill -TERM "$pid" 2>/dev/null || true
+    if wait "$pid"; then
+      :
+    else
+      status=$?
+      case "$status" in
+        130 | 137 | 143) ;;
+        *) return "$status" ;;
+      esac
+    fi
+  fi
+}
+
+start_netfilter_trace() {
+  NETFILTER_TRACE_FILE=$(mktemp "/tmp/vm0-${SVC}-netfilter-trace.XXXXXX")
+  sudo xtables-monitor --trace --ipv4 >"$NETFILTER_TRACE_FILE" 2>&1 &
+  NETFILTER_TRACE_PID=$!
+  sleep 0.1
+  sudo kill -0 "$NETFILTER_TRACE_PID" 2>/dev/null \
+    || fail "xtables-monitor exited before DNS trace probes"
 }
 
 cleanup_pool_lock_guard() {
@@ -190,8 +219,49 @@ sock.close()
 PY
 }
 
+send_dns_trace_probes() {
+  local namespace=$1 destination_ip=$2
+  sudo ip netns exec "$namespace" python3 - "$destination_ip" <<'PY'
+import socket
+import struct
+import sys
+
+destination = sys.argv[1]
+query = bytes.fromhex(
+    "123401000001000000000000"
+    "0d766d302d72656164696e657373"
+    "07696e76616c69640000010001"
+)
+
+udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+udp.settimeout(2)
+udp.sendto(query, (destination, 53))
+response, _ = udp.recvfrom(4096)
+assert response[:2] == query[:2] and response[2] & 128
+udp.close()
+
+tcp = socket.create_connection((destination, 53), 2)
+tcp.sendall(struct.pack("!H", len(query)) + query)
+header = tcp.recv(2)
+assert len(header) == 2
+length = struct.unpack("!H", header)[0]
+response = b""
+while len(response) < length:
+    chunk = tcp.recv(length - len(response))
+    assert chunk
+    response += chunk
+assert response[:2] == query[:2] and response[2] & 128
+tcp.close()
+PY
+}
+
 cleanup() {
   echo "--- Cleanup ---"
+  stop_netfilter_trace || true
+  if [ -n "$NETFILTER_TRACE_FILE" ]; then
+    rm -f "$NETFILTER_TRACE_FILE"
+    NETFILTER_TRACE_FILE=""
+  fi
   cleanup_spoof_address
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   cleanup_pool_lock_guard
@@ -467,6 +537,106 @@ VICTIM_DNS_RULE=$(printf '%s\n' "$NAT_RULES" \
   || fail "victim DNS redirect is not bound to $VICTIM_IF"
 [ "$(rule_value "$VICTIM_DNS_RULE" -s)" = "$VICTIM_CIDR" ] \
   || fail "victim DNS redirect does not use the exact peer"
+
+ATTACKER_UDP_TRACE_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-j TRACE" \
+  | grep -F -- "-p udp" \
+  | head -n 1 || true)
+ATTACKER_TCP_TRACE_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-j TRACE" \
+  | grep -F -- "-p tcp" \
+  | head -n 1 || true)
+[ -n "$ATTACKER_UDP_TRACE_RULE" ] \
+  || fail "attacker UDP DNS trace rule not found"
+[ -n "$ATTACKER_TCP_TRACE_RULE" ] \
+  || fail "attacker TCP DNS trace rule not found"
+for trace_rule in "$ATTACKER_UDP_TRACE_RULE" "$ATTACKER_TCP_TRACE_RULE"; do
+  [ "$(rule_value "$trace_rule" -i)" = "$ATTACKER_IF" ] \
+    || fail "DNS trace rule is not bound to $ATTACKER_IF: $trace_rule"
+  [ "$(rule_value "$trace_rule" -s)" = "$ATTACKER_CIDR" ] \
+    || fail "DNS trace rule does not use the exact attacker peer: $trace_rule"
+  [ "$(rule_value "$trace_rule" -d)" = "8.8.8.8/32" ] \
+    || fail "DNS trace rule does not use the readiness destination: $trace_rule"
+  [ "$(rule_value "$trace_rule" --dport)" = 53 ] \
+    || fail "DNS trace rule does not use DNS port 53: $trace_rule"
+done
+case "$(rule_value "$ATTACKER_UDP_TRACE_RULE" --length)" in
+  67 | 67:67) ;;
+  *) fail "UDP DNS trace rule does not use the readiness packet length" ;;
+esac
+if printf '%s\n' "$ATTACKER_TCP_TRACE_RULE" \
+  | grep -F -- "--length" >/dev/null; then
+  fail "TCP DNS trace rule unexpectedly requires a fixed packet length"
+fi
+
+start_netfilter_trace
+send_dns_trace_probes "$ATTACKER_NS" "8.8.8.8" \
+  || fail "DNS trace probes failed"
+sleep 0.1
+stop_netfilter_trace || fail "xtables-monitor failed while capturing DNS probes"
+
+UDP_TRACE_EVENT=$(grep -F -- "raw:PREROUTING:" "$NETFILTER_TRACE_FILE" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--length 67(:67)?([[:space:]]|$)" \
+  | grep -F -- "--comment ${ATTACKER_NS}" \
+  | grep -F -- "-j TRACE" \
+  | tail -n 1 || true)
+TCP_TRACE_EVENT=$(grep -F -- "nat:PREROUTING:" "$NETFILTER_TRACE_FILE" \
+  | grep -F -- "-p tcp" \
+  | grep -F -- "--dport 53" \
+  | grep -F -- "--comment ${ATTACKER_NS}" \
+  | grep -F -- "-j REDIRECT" \
+  | head -n 1 || true)
+[ -n "$UDP_TRACE_EVENT" ] \
+  || fail "xtables-monitor did not capture the UDP readiness TRACE rule"
+[ -n "$TCP_TRACE_EVENT" ] \
+  || fail "xtables-monitor did not capture the TCP DNS redirect TRACE rule"
+UDP_TRACE_ID=$(printf '%s\n' "$UDP_TRACE_EVENT" | awk '{print $3}')
+TCP_TRACE_ID=$(printf '%s\n' "$TCP_TRACE_EVENT" | awk '{print $3}')
+UDP_TRACE_PACKET=$(grep -E \
+  "PACKET: 2 ${UDP_TRACE_ID} .*IN=${ATTACKER_IF} .*SRC=${ATTACKER_PEER} .*DST=8\\.8\\.8\\.8 .*LEN=67 .*(DPT|DPORT)=53([[:space:]]|$)" \
+  "$NETFILTER_TRACE_FILE" | head -n 1 || true)
+TCP_TRACE_PACKET=$(grep -E \
+  "PACKET: 2 ${TCP_TRACE_ID} .*IN=${ATTACKER_IF} .*SRC=${ATTACKER_PEER} .*DST=8\\.8\\.8\\.8 .*(DPT|DPORT)=53([[:space:]]|$)" \
+  "$NETFILTER_TRACE_FILE" | head -n 1 || true)
+[ -n "$UDP_TRACE_PACKET" ] \
+  || fail "xtables-monitor did not capture the exact UDP readiness packet"
+[ -n "$TCP_TRACE_PACKET" ] \
+  || fail "xtables-monitor did not capture the TCP DNS packet"
+TRACE_DNS_FILTER_COMMENT="${RUNNER_POOL_PREFIX%-}-dns"
+for trace_identity in "UDP:$UDP_TRACE_ID" "TCP:$TCP_TRACE_ID"; do
+  protocol=${trace_identity%%:*}
+  trace_id=${trace_identity#*:}
+  case "$protocol" in
+    UDP) trace_protocol=udp ;;
+    TCP) trace_protocol=tcp ;;
+    *) fail "unknown DNS trace protocol: $protocol" ;;
+  esac
+  grep -E "TRACE: 2 ${trace_id} raw:PREROUTING:" \
+    "$NETFILTER_TRACE_FILE" >/dev/null \
+    || fail "$protocol DNS trace did not reach root raw PREROUTING"
+  grep -E "TRACE: 2 ${trace_id} nat:PREROUTING:" \
+    "$NETFILTER_TRACE_FILE" >/dev/null \
+    || fail "$protocol DNS trace did not reach root nat PREROUTING"
+  POOL_INPUT_TRACE_EVENT=$(grep -E \
+    "TRACE: 2 ${trace_id} filter:INPUT:rule:.*:CONTINUE " \
+    "$NETFILTER_TRACE_FILE" \
+    | grep -F -- "-p ${trace_protocol}" \
+    | grep -F -- "--dport ${DNS_PORT}" \
+    | grep -F -- "--comment ${TRACE_DNS_FILTER_COMMENT}" \
+    | head -n 1 || true)
+  [ -n "$POOL_INPUT_TRACE_EVENT" ] \
+    || fail "$protocol DNS trace did not reach the exact pool INPUT rule"
+  grep -E "TRACE: 2 ${trace_id} filter:INPUT:policy:ACCEPT" \
+    "$NETFILTER_TRACE_FILE" >/dev/null \
+    || fail "$protocol DNS trace did not reach the accepting INPUT policy"
+done
+rm -f "$NETFILTER_TRACE_FILE"
+NETFILTER_TRACE_FILE=""
+echo "PASS: root DNS netfilter trace"
 
 ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
   | grep -F -- "$ATTACKER_NS" \
@@ -1802,10 +1972,15 @@ if sudo ip6tables-save -t filter \
 fi
 RAW_RULES_AFTER_STOP=$(sudo iptables-save -t raw) \
   || fail "failed to read raw rules after runner stop"
-LEAKED_SOURCE_GUARDS=$(printf '%s\n' "$RAW_RULES_AFTER_STOP" \
+LEAKED_TRACE_RULES=$(printf '%s\n' "$RAW_RULES_AFTER_STOP" \
+  | grep -F -- "$RUNNER_POOL_PREFIX" \
+  | grep -F -- "-j TRACE" || true)
+[ -z "$LEAKED_TRACE_RULES" ] \
+  || fail "DNS trace rules leaked after runner stop: $LEAKED_TRACE_RULES"
+LEAKED_NAMESPACE_RAW_RULES=$(printf '%s\n' "$RAW_RULES_AFTER_STOP" \
   | grep -F -- "$RUNNER_POOL_PREFIX" || true)
-[ -z "$LEAKED_SOURCE_GUARDS" ] \
-  || fail "IPv4 source guards leaked after runner stop: $LEAKED_SOURCE_GUARDS"
+[ -z "$LEAKED_NAMESPACE_RAW_RULES" ] \
+  || fail "IPv4 namespace raw rules leaked after runner stop: $LEAKED_NAMESPACE_RAW_RULES"
 NAMESPACES_AFTER_STOP=$(sudo ip netns list) \
   || fail "failed to read network namespaces after runner stop"
 LEAKED_NAMESPACES=$(printf '%s\n' "$NAMESPACES_AFTER_STOP" \

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -179,6 +179,7 @@ pub async fn run_benchmark(
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
             dns_port: None, // benchmark does not use custom DNS proxy
+            guest_dns_netfilter_trace: false,
         })
         .await
     {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -553,6 +553,7 @@ async fn run_start_with_home(
             .create_runtime(sandbox::RuntimeConfig {
                 proxy_port: Some(mitm.port()),
                 dns_port: Some(dns_port),
+                guest_dns_netfilter_trace: args.local,
             })
             .await
             .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -290,11 +290,14 @@ impl FirecrackerFactory {
                         }
                     }),
                 )?;
-            let network_evidence_target = self.config.dns_port.map(|_| {
+            let network_evidence_target = self.config.dns_port.map(|dns_port| {
                 (
                     GuestDnsNetworkEvidenceTarget::new(
                         network.info().name(),
                         network.info().host_device(),
+                        network.info().peer_ip(),
+                        dns_port,
+                        network.info().guest_dns_netfilter_trace(),
                     ),
                     network.take_dns_network_baseline(),
                 )

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -7,6 +7,7 @@ use vsock_host::{ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutpu
 
 use crate::command::{CommandError, exec_with_timeout};
 use crate::duration::duration_ms;
+use crate::guest_dns_netfilter_trace::GuestDnsNetfilterTraceAttachment;
 use crate::guest_dns_network_evidence::{
     GuestDnsNetworkEvidenceBaseline, GuestDnsNetworkEvidenceTarget,
     capture_guest_dns_network_evidence_report,
@@ -42,6 +43,7 @@ pub(crate) struct GuestDnsFailureDiagnosticContext<'a> {
     pub(crate) dns_port: u16,
     pub(crate) attachment_generation: u64,
     pub(crate) readiness_attempts: u16,
+    pub(crate) root_netfilter_trace: &'a GuestDnsNetfilterTraceAttachment,
     pub(crate) network_evidence_baseline: Option<&'a GuestDnsNetworkEvidenceBaseline>,
     pub(crate) startup_mode: &'static str,
 }
@@ -74,8 +76,13 @@ pub(crate) async fn capture_guest_dns_failure_diagnostics(
 async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
     let namespace = context.namespace;
     let peer_ip = context.peer_ip;
-    let network_evidence_target =
-        GuestDnsNetworkEvidenceTarget::new(namespace, context.host_device);
+    let network_evidence_target = GuestDnsNetworkEvidenceTarget::new(
+        namespace,
+        context.host_device,
+        peer_ip,
+        context.dns_port,
+        context.root_netfilter_trace,
+    );
     let conntrack_source_args = ["-L", "-s", peer_ip];
     let conntrack_destination_args = ["-L", "-d", peer_ip];
     let namespace_conntrack_args = [

--- a/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
+++ b/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
@@ -1229,15 +1229,22 @@ mod tests {
             .await
             .unwrap();
 
-        for _ in 0..50 {
-            if matches!(
-                lock_state(&monitor.reader.state).status,
-                TraceMonitorStatus::Unavailable(_)
-            ) {
-                break;
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let notified = monitor.reader.changed.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if matches!(
+                    lock_state(&monitor.reader.state).status,
+                    TraceMonitorStatus::Unavailable(_)
+                ) {
+                    break;
+                }
+                notified.await;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        })
+        .await
+        .expect("monitor process should report its exit");
         {
             let state = lock_state(&monitor.reader.state);
             assert!(matches!(state.status, TraceMonitorStatus::Unavailable(_)));

--- a/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
+++ b/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
@@ -8,13 +8,16 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::{Child, Command};
+use tokio::process::{Child, ChildStderr, ChildStdout, Command};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant, timeout, timeout_at};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+use crate::guest_dns_readiness::{
+    GUEST_DNS_READINESS_MAX_ATTEMPTS, GUEST_DNS_READINESS_PACKET_BYTES,
+};
 use crate::network::{make_pool_dns_filter_comment, parse_netns_name};
 
 const MAX_PACKETS: usize = 256;
@@ -24,12 +27,11 @@ const MAX_STEPS_PER_PACKET: usize = 16;
 const MAX_TRACE_LINE_BYTES: usize = 1_024;
 const MAX_RULE_DETAIL_BYTES: usize = 192;
 const MAX_STDERR_BYTES: usize = 1_024;
-const MAX_REPORTED_PACKETS: usize = 3;
+const MAX_REPORTED_PACKETS: usize = GUEST_DNS_READINESS_MAX_ATTEMPTS as usize;
 const MONITOR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const TRACE_CAPTURE_WAIT: Duration = Duration::from_millis(250);
 const READ_CHUNK_BYTES: usize = 4 * 1_024;
 const READINESS_DNS_IPV4: &str = "8.8.8.8";
-const READINESS_PACKET_BYTES: u64 = 67;
 
 static NEXT_MONITOR_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -121,8 +123,7 @@ impl GuestDnsNetfilterTraceMonitor {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         let mut child = command.spawn()?;
-        let stdout = take_pipe(&mut child, PipeKind::Stdout).await?;
-        let stderr = take_pipe(&mut child, PipeKind::Stderr).await?;
+        let (stdout, stderr) = take_pipes(&mut child).await?;
         let state = Arc::new(Mutex::new(TraceState::new(
             NEXT_MONITOR_ID.fetch_add(1, Ordering::Relaxed),
         )));
@@ -172,49 +173,13 @@ impl Drop for GuestDnsNetfilterTraceMonitor {
     }
 }
 
-enum PipeKind {
-    Stdout,
-    Stderr,
-}
-
-async fn take_pipe(
-    child: &mut Child,
-    kind: PipeKind,
-) -> io::Result<impl AsyncRead + Unpin + Send + 'static> {
-    let pipe = match kind {
-        PipeKind::Stdout => child.stdout.take().map(PipedOutput::Stdout),
-        PipeKind::Stderr => child.stderr.take().map(PipedOutput::Stderr),
-    };
-    match pipe {
-        Some(PipedOutput::Stdout(stdout)) => Ok(TracePipe::Stdout(stdout)),
-        Some(PipedOutput::Stderr(stderr)) => Ok(TracePipe::Stderr(stderr)),
-        None => {
+async fn take_pipes(child: &mut Child) -> io::Result<(ChildStdout, ChildStderr)> {
+    match (child.stdout.take(), child.stderr.take()) {
+        (Some(stdout), Some(stderr)) => Ok((stdout, stderr)),
+        _ => {
             let _ = child.start_kill();
             let _ = child.wait().await;
             Err(io::Error::other("xtables-monitor pipe unavailable"))
-        }
-    }
-}
-
-enum PipedOutput {
-    Stdout(tokio::process::ChildStdout),
-    Stderr(tokio::process::ChildStderr),
-}
-
-enum TracePipe {
-    Stdout(tokio::process::ChildStdout),
-    Stderr(tokio::process::ChildStderr),
-}
-
-impl AsyncRead for TracePipe {
-    fn poll_read(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buffer: &mut tokio::io::ReadBuf<'_>,
-    ) -> std::task::Poll<io::Result<()>> {
-        match &mut *self {
-            Self::Stdout(stdout) => std::pin::Pin::new(stdout).poll_read(cx, buffer),
-            Self::Stderr(stderr) => std::pin::Pin::new(stderr).poll_read(cx, buffer),
         }
     }
 }
@@ -452,7 +417,7 @@ enum TraceMonitorStatus {
     Stopped,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct TracePacket {
     sequence: u64,
     family: u8,
@@ -461,7 +426,6 @@ struct TracePacket {
     steps: Vec<TraceStep>,
     farthest_observed_boundary: Option<RootNetfilterBoundary>,
     truncated: bool,
-    #[serde(skip)]
     complete: bool,
 }
 
@@ -510,7 +474,7 @@ impl TracePacket {
                 && step.rule.as_deref().is_some_and(|rule| {
                     rule_has_option_value(rule, "-p", "udp")
                         && rule_has_option_value(rule, "--dport", "53")
-                        && rule_has_option_value(rule, "--length", "67")
+                        && rule_has_exact_packet_length(rule, GUEST_DNS_READINESS_PACKET_BYTES)
                         && rule_has_option_value(rule, "--comment", namespace)
                         && rule_has_option_value(rule, "-j", "TRACE")
                 })
@@ -519,7 +483,7 @@ impl TracePacket {
             header.input.as_deref() == Some(host_device)
                 && header.source.as_deref() == Some(peer_ip)
                 && header.destination.as_deref() == Some(READINESS_DNS_IPV4)
-                && header.length == Some(READINESS_PACKET_BYTES)
+                && header.length == Some(GUEST_DNS_READINESS_PACKET_BYTES)
                 && (header
                     .protocol
                     .as_deref()
@@ -640,16 +604,28 @@ impl TracePacket {
 }
 
 fn rule_has_option_value(rule: &str, option: &str, expected: &str) -> bool {
+    rule_option_value(rule, option) == Some(expected)
+}
+
+fn rule_has_exact_packet_length(rule: &str, expected: u64) -> bool {
+    let Some(value) = rule_option_value(rule, "--length") else {
+        return false;
+    };
+    let (minimum, maximum) = value.split_once(':').unwrap_or((value, value));
+    minimum.parse() == Ok(expected) && maximum.parse() == Ok(expected)
+}
+
+fn rule_option_value<'a>(rule: &'a str, option: &str) -> Option<&'a str> {
     let mut tokens = rule.split_whitespace();
     while let Some(token) = tokens.next() {
         if token == option {
-            return tokens.next() == Some(expected);
+            return tokens.next();
         }
     }
-    false
+    None
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct TracePacketHeader {
     input: Option<String>,
     source: Option<String>,
@@ -689,13 +665,12 @@ struct TracePacketReport {
     complete: bool,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct TraceStep {
     table: String,
     chain: String,
     kind: String,
     verdict: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     rule: Option<String>,
 }
 
@@ -986,21 +961,12 @@ impl GuestDnsNetfilterTraceReader {
         let matches = state
             .packets
             .iter()
-            .filter_map(|packet| {
-                (packet.sequence > cursor.sequence)
-                    .then(|| packet.report(namespace, host_device, peer_ip, dns_port))
-                    .flatten()
-            })
+            .filter(|packet| packet.sequence > cursor.sequence)
+            .filter_map(|packet| packet.report(namespace, host_device, peer_ip, dns_port))
             .collect::<Vec<_>>();
         let matched_packets = matches.len();
-        let packets = matches
-            .into_iter()
-            .rev()
-            .take(MAX_REPORTED_PACKETS)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>();
+        let first_reported = matched_packets.saturating_sub(MAX_REPORTED_PACKETS);
+        let packets: Vec<_> = matches.into_iter().skip(first_reported).collect();
         let buffer_truncated = state
             .packets
             .front()
@@ -1186,24 +1152,24 @@ mod tests {
     async fn capture_waits_for_expected_packet_and_keeps_report_bounded() {
         let (reader, state) = reader_and_state();
         let cursor = reader.cursor();
-        let ingest_state = Arc::clone(&state);
         let changed = Arc::clone(&reader.changed);
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            ingest_verified_fixture(&ingest_state);
-            changed.notify_waiters();
-        });
+        let capture = reader.capture(
+            cursor,
+            "vm0-ns-00-01",
+            "vm0-ve-00-01",
+            "10.200.0.2",
+            5300,
+            1,
+        );
+        tokio::pin!(capture);
+        assert!(
+            futures_util::poll!(capture.as_mut()).is_pending(),
+            "capture should wait for the expected packet"
+        );
+        ingest_verified_fixture(&state);
+        changed.notify_waiters();
 
-        let report = reader
-            .capture(
-                cursor,
-                "vm0-ns-00-01",
-                "vm0-ve-00-01",
-                "10.200.0.2",
-                5300,
-                1,
-            )
-            .await;
+        let report = capture.await;
         let output = serde_json::to_string(&report).unwrap();
 
         assert!(matches!(report.status, TraceReportStatus::Captured));
@@ -1248,6 +1214,13 @@ mod tests {
         assert!(packet.truncated);
     }
 
+    #[test]
+    fn exact_packet_length_accepts_single_value_and_equal_range() {
+        assert!(rule_has_exact_packet_length("--length 67", 67));
+        assert!(rule_has_exact_packet_length("--length 67:67", 67));
+        assert!(!rule_has_exact_packet_length("--length 66:67", 67));
+    }
+
     #[tokio::test]
     async fn process_exit_marks_monitor_unavailable() {
         let mut command = Command::new("sh");
@@ -1270,5 +1243,22 @@ mod tests {
             assert!(matches!(state.status, TraceMonitorStatus::Unavailable(_)));
         }
         monitor.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_kills_and_reaps_monitor_process() {
+        let mut command = Command::new("sleep");
+        command.arg("60");
+        let mut monitor = GuestDnsNetfilterTraceMonitor::start_command(command)
+            .await
+            .unwrap();
+
+        monitor.shutdown().await;
+
+        assert!(monitor.task.is_none());
+        assert!(matches!(
+            lock_state(&monitor.reader.state).status,
+            TraceMonitorStatus::Stopped
+        ));
     }
 }

--- a/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
+++ b/crates/sandbox-fc/src/guest_dns_netfilter_trace.rs
@@ -1,0 +1,1274 @@
+//! Bounded root netfilter trace capture for guest DNS readiness diagnostics.
+
+use std::collections::VecDeque;
+use std::io;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::{Child, Command};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, Instant, timeout, timeout_at};
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use crate::network::{make_pool_dns_filter_comment, parse_netns_name};
+
+const MAX_PACKETS: usize = 256;
+const MAX_HEADERS_PER_PACKET: usize = 4;
+const MAX_IDENTIFIER_BYTES: usize = 64;
+const MAX_STEPS_PER_PACKET: usize = 16;
+const MAX_TRACE_LINE_BYTES: usize = 1_024;
+const MAX_RULE_DETAIL_BYTES: usize = 192;
+const MAX_STDERR_BYTES: usize = 1_024;
+const MAX_REPORTED_PACKETS: usize = 3;
+const MONITOR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const TRACE_CAPTURE_WAIT: Duration = Duration::from_millis(250);
+const READ_CHUNK_BYTES: usize = 4 * 1_024;
+const READINESS_DNS_IPV4: &str = "8.8.8.8";
+const READINESS_PACKET_BYTES: u64 = 67;
+
+static NEXT_MONITOR_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GuestDnsNetfilterTraceCursor {
+    monitor_id: u64,
+    sequence: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GuestDnsNetfilterTraceReader {
+    state: Arc<Mutex<TraceState>>,
+    changed: Arc<Notify>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum GuestDnsNetfilterTraceAttachment {
+    Disabled,
+    Unavailable(&'static str),
+    Enabled(GuestDnsNetfilterTraceReader),
+}
+
+impl GuestDnsNetfilterTraceAttachment {
+    pub(crate) fn unavailable(reason: &'static str) -> Self {
+        Self::Unavailable(reason)
+    }
+
+    pub(crate) fn enabled(reader: GuestDnsNetfilterTraceReader) -> Self {
+        Self::Enabled(reader)
+    }
+
+    pub(crate) fn cursor(&self) -> Option<GuestDnsNetfilterTraceCursor> {
+        match self {
+            Self::Enabled(reader) => Some(reader.cursor()),
+            Self::Disabled | Self::Unavailable(_) => None,
+        }
+    }
+
+    pub(crate) async fn capture(
+        &self,
+        cursor: Option<GuestDnsNetfilterTraceCursor>,
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+        dns_port: u16,
+        readiness_attempts: u16,
+    ) -> Option<GuestDnsNetfilterTraceReport> {
+        match self {
+            Self::Disabled => None,
+            Self::Unavailable(reason) => {
+                Some(GuestDnsNetfilterTraceReport::attachment_unavailable(reason))
+            }
+            Self::Enabled(reader) => Some(match cursor {
+                Some(cursor) => {
+                    reader
+                        .capture(
+                            cursor,
+                            namespace,
+                            host_device,
+                            peer_ip,
+                            dns_port,
+                            readiness_attempts,
+                        )
+                        .await
+                }
+                None => GuestDnsNetfilterTraceReport::baseline_unavailable(),
+            }),
+        }
+    }
+}
+
+pub(crate) struct GuestDnsNetfilterTraceMonitor {
+    reader: GuestDnsNetfilterTraceReader,
+    cancel: CancellationToken,
+    task: Option<JoinHandle<()>>,
+}
+
+impl GuestDnsNetfilterTraceMonitor {
+    pub(crate) async fn start() -> io::Result<Self> {
+        let mut command = Command::new("xtables-monitor");
+        command.args(["--trace", "--ipv4"]);
+        Self::start_command(command).await
+    }
+
+    async fn start_command(mut command: Command) -> io::Result<Self> {
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn()?;
+        let stdout = take_pipe(&mut child, PipeKind::Stdout).await?;
+        let stderr = take_pipe(&mut child, PipeKind::Stderr).await?;
+        let state = Arc::new(Mutex::new(TraceState::new(
+            NEXT_MONITOR_ID.fetch_add(1, Ordering::Relaxed),
+        )));
+        let changed = Arc::new(Notify::new());
+        let reader = GuestDnsNetfilterTraceReader {
+            state: Arc::clone(&state),
+            changed: Arc::clone(&changed),
+        };
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(supervise_monitor(
+            child,
+            stdout,
+            stderr,
+            state,
+            changed,
+            cancel.clone(),
+        ));
+        Ok(Self {
+            reader,
+            cancel,
+            task: Some(task),
+        })
+    }
+
+    pub(crate) fn reader(&self) -> GuestDnsNetfilterTraceReader {
+        self.reader.clone()
+    }
+
+    pub(crate) async fn shutdown(&mut self) {
+        self.cancel.cancel();
+        let Some(mut task) = self.task.take() else {
+            return;
+        };
+        if timeout(MONITOR_SHUTDOWN_TIMEOUT, &mut task).await.is_err() {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for GuestDnsNetfilterTraceMonitor {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+enum PipeKind {
+    Stdout,
+    Stderr,
+}
+
+async fn take_pipe(
+    child: &mut Child,
+    kind: PipeKind,
+) -> io::Result<impl AsyncRead + Unpin + Send + 'static> {
+    let pipe = match kind {
+        PipeKind::Stdout => child.stdout.take().map(PipedOutput::Stdout),
+        PipeKind::Stderr => child.stderr.take().map(PipedOutput::Stderr),
+    };
+    match pipe {
+        Some(PipedOutput::Stdout(stdout)) => Ok(TracePipe::Stdout(stdout)),
+        Some(PipedOutput::Stderr(stderr)) => Ok(TracePipe::Stderr(stderr)),
+        None => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            Err(io::Error::other("xtables-monitor pipe unavailable"))
+        }
+    }
+}
+
+enum PipedOutput {
+    Stdout(tokio::process::ChildStdout),
+    Stderr(tokio::process::ChildStderr),
+}
+
+enum TracePipe {
+    Stdout(tokio::process::ChildStdout),
+    Stderr(tokio::process::ChildStderr),
+}
+
+impl AsyncRead for TracePipe {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buffer: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        match &mut *self {
+            Self::Stdout(stdout) => std::pin::Pin::new(stdout).poll_read(cx, buffer),
+            Self::Stderr(stderr) => std::pin::Pin::new(stderr).poll_read(cx, buffer),
+        }
+    }
+}
+
+async fn supervise_monitor(
+    mut child: Child,
+    stdout: impl AsyncRead + Unpin + Send + 'static,
+    stderr: impl AsyncRead + Unpin + Send + 'static,
+    state: Arc<Mutex<TraceState>>,
+    changed: Arc<Notify>,
+    cancel: CancellationToken,
+) {
+    let stdout_state = Arc::clone(&state);
+    let stdout_changed = Arc::clone(&changed);
+    let stdout_task = tokio::spawn(async move {
+        if let Err(error) =
+            read_trace_stream(stdout, stdout_state.clone(), stdout_changed.clone()).await
+        {
+            lock_state(&stdout_state).set_unavailable(format!("stdout read failed: {error}"));
+            stdout_changed.notify_waiters();
+        }
+    });
+    let stderr_task = tokio::spawn(read_bounded_output(stderr, MAX_STDERR_BYTES));
+
+    let stopped = tokio::select! {
+        () = cancel.cancelled() => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            true
+        }
+        result = child.wait() => {
+            let detail = match result {
+                Ok(status) => format!("xtables-monitor exited with {status}"),
+                Err(error) => format!("xtables-monitor wait failed: {error}"),
+            };
+            lock_state(&state).set_unavailable(detail);
+            changed.notify_waiters();
+            false
+        }
+    };
+
+    let _ = stdout_task.await;
+    let stderr = match stderr_task.await {
+        Ok(Ok(stderr)) => stderr,
+        Ok(Err(error)) => format!("stderr read failed: {error}"),
+        Err(error) => format!("stderr task failed: {error}"),
+    };
+    let mut state = lock_state(&state);
+    if stopped {
+        state.status = TraceMonitorStatus::Stopped;
+    } else if !stderr.is_empty() {
+        state.append_unavailable_detail(&stderr);
+    }
+    if !stopped && let TraceMonitorStatus::Unavailable(detail) = &state.status {
+        warn!(detail, "root netfilter trace monitor exited unexpectedly");
+    }
+}
+
+async fn read_trace_stream(
+    reader: impl AsyncRead + Unpin,
+    state: Arc<Mutex<TraceState>>,
+    changed: Arc<Notify>,
+) -> io::Result<()> {
+    read_bounded_lines(reader, MAX_TRACE_LINE_BYTES, |line, truncated| {
+        let mut state = lock_state(&state);
+        if truncated {
+            state.truncated_lines = state.truncated_lines.saturating_add(1);
+        } else {
+            state.ingest(&line);
+        }
+        drop(state);
+        changed.notify_waiters();
+    })
+    .await
+}
+
+async fn read_bounded_lines(
+    mut reader: impl AsyncRead + Unpin,
+    limit: usize,
+    mut on_line: impl FnMut(String, bool),
+) -> io::Result<()> {
+    let mut chunk = [0_u8; READ_CHUNK_BYTES];
+    let mut line = Vec::with_capacity(limit);
+    let mut truncated = false;
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            if !line.is_empty() || truncated {
+                on_line(String::from_utf8_lossy(&line).into_owned(), truncated);
+            }
+            return Ok(());
+        }
+        for byte in chunk.iter().copied().take(read) {
+            if byte == b'\n' {
+                on_line(String::from_utf8_lossy(&line).into_owned(), truncated);
+                line.clear();
+                truncated = false;
+            } else if line.len() < limit {
+                line.push(byte);
+            } else {
+                truncated = true;
+            }
+        }
+    }
+}
+
+async fn read_bounded_output(
+    mut reader: impl AsyncRead + Unpin,
+    limit: usize,
+) -> io::Result<String> {
+    let mut chunk = [0_u8; READ_CHUNK_BYTES];
+    let mut output = Vec::with_capacity(limit);
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(String::from_utf8_lossy(&output).trim().to_string());
+        }
+        let remaining = limit.saturating_sub(output.len());
+        output.extend(chunk.iter().copied().take(read.min(remaining)));
+    }
+}
+
+fn lock_state(state: &Mutex<TraceState>) -> MutexGuard<'_, TraceState> {
+    match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[derive(Debug)]
+struct TraceState {
+    monitor_id: u64,
+    next_sequence: u64,
+    packets: VecDeque<TracePacket>,
+    evicted_packets: u64,
+    malformed_lines: u64,
+    truncated_lines: u64,
+    status: TraceMonitorStatus,
+}
+
+impl TraceState {
+    fn new(monitor_id: u64) -> Self {
+        Self {
+            monitor_id,
+            next_sequence: 1,
+            packets: VecDeque::with_capacity(MAX_PACKETS),
+            evicted_packets: 0,
+            malformed_lines: 0,
+            truncated_lines: 0,
+            status: TraceMonitorStatus::Running,
+        }
+    }
+
+    fn ingest(&mut self, line: &str) {
+        match parse_monitor_line(line) {
+            Some(ParsedMonitorLine::Packet {
+                family,
+                packet_id,
+                header,
+            }) => self.ingest_packet(family, packet_id, header),
+            Some(ParsedMonitorLine::Trace {
+                family,
+                packet_id,
+                step,
+            }) => self.ingest_trace(family, packet_id, step),
+            None if !line.trim().is_empty() => {
+                self.malformed_lines = self.malformed_lines.saturating_add(1);
+            }
+            None => {}
+        }
+    }
+
+    fn ingest_packet(&mut self, family: u8, packet_id: String, header: TracePacketHeader) {
+        let existing = self
+            .packets
+            .iter()
+            .rposition(|packet| {
+                packet.family == family && packet.packet_id == packet_id && !packet.complete
+            })
+            .and_then(|position| self.packets.get_mut(position));
+        if let Some(packet) = existing {
+            packet.push_header(header);
+            return;
+        }
+        let mut packet = TracePacket::new(self.next_sequence, family, packet_id);
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        packet.push_header(header);
+        self.push_packet(packet);
+    }
+
+    fn ingest_trace(&mut self, family: u8, packet_id: String, step: TraceStep) {
+        let existing = self
+            .packets
+            .iter()
+            .rposition(|packet| {
+                packet.family == family && packet.packet_id == packet_id && !packet.complete
+            })
+            .and_then(|position| self.packets.get_mut(position));
+        if let Some(packet) = existing {
+            packet.push_step(step);
+            return;
+        }
+        let mut packet = TracePacket::new(self.next_sequence, family, packet_id);
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        packet.push_step(step);
+        self.push_packet(packet);
+    }
+
+    fn push_packet(&mut self, packet: TracePacket) {
+        if self.packets.len() == MAX_PACKETS {
+            self.packets.pop_front();
+            self.evicted_packets = self.evicted_packets.saturating_add(1);
+        }
+        self.packets.push_back(packet);
+    }
+
+    fn set_unavailable(&mut self, detail: String) {
+        self.status =
+            TraceMonitorStatus::Unavailable(bounded_string(detail.trim(), MAX_STDERR_BYTES));
+    }
+
+    fn append_unavailable_detail(&mut self, detail: &str) {
+        let TraceMonitorStatus::Unavailable(current) = &mut self.status else {
+            return;
+        };
+        let combined = format!("{current}; {}", detail.trim());
+        *current = bounded_string(&combined, MAX_STDERR_BYTES);
+    }
+}
+
+#[derive(Debug)]
+enum TraceMonitorStatus {
+    Running,
+    Unavailable(String),
+    Stopped,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TracePacket {
+    sequence: u64,
+    family: u8,
+    packet_id: String,
+    headers: Vec<TracePacketHeader>,
+    steps: Vec<TraceStep>,
+    farthest_observed_boundary: Option<RootNetfilterBoundary>,
+    truncated: bool,
+    #[serde(skip)]
+    complete: bool,
+}
+
+impl TracePacket {
+    fn new(sequence: u64, family: u8, packet_id: String) -> Self {
+        Self {
+            sequence,
+            family,
+            packet_id,
+            headers: Vec::new(),
+            steps: Vec::new(),
+            farthest_observed_boundary: None,
+            truncated: false,
+            complete: false,
+        }
+    }
+
+    fn push_header(&mut self, header: TracePacketHeader) {
+        if self.headers.len() < MAX_HEADERS_PER_PACKET {
+            self.headers.push(header);
+        } else {
+            self.truncated = true;
+        }
+    }
+
+    fn push_step(&mut self, step: TraceStep) {
+        self.farthest_observed_boundary =
+            RootNetfilterBoundary::farthest(self.farthest_observed_boundary, step.boundary());
+        self.complete |= step.is_terminal();
+        if self.steps.len() < MAX_STEPS_PER_PACKET {
+            self.steps.push(step);
+        } else {
+            self.truncated = true;
+        }
+    }
+
+    fn readiness_header(
+        &self,
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+    ) -> Option<&TracePacketHeader> {
+        let traces_udp_readiness_rule = self.steps.iter().any(|step| {
+            step.table == "raw"
+                && step.chain == "PREROUTING"
+                && step.rule.as_deref().is_some_and(|rule| {
+                    rule_has_option_value(rule, "-p", "udp")
+                        && rule_has_option_value(rule, "--dport", "53")
+                        && rule_has_option_value(rule, "--length", "67")
+                        && rule_has_option_value(rule, "--comment", namespace)
+                        && rule_has_option_value(rule, "-j", "TRACE")
+                })
+        });
+        self.headers.iter().find(|header| {
+            header.input.as_deref() == Some(host_device)
+                && header.source.as_deref() == Some(peer_ip)
+                && header.destination.as_deref() == Some(READINESS_DNS_IPV4)
+                && header.length == Some(READINESS_PACKET_BYTES)
+                && (header
+                    .protocol
+                    .as_deref()
+                    .is_some_and(|protocol| protocol.eq_ignore_ascii_case("udp"))
+                    || traces_udp_readiness_rule)
+                && header.destination_port == Some(53)
+        })
+    }
+
+    fn report(
+        &self,
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+        dns_port: u16,
+    ) -> Option<TracePacketReport> {
+        let original_header = self
+            .readiness_header(namespace, host_device, peer_ip)?
+            .clone();
+        let dns_port_value = dns_port;
+        let dns_port = dns_port.to_string();
+        let nat_prerouting_reached = self
+            .steps
+            .iter()
+            .any(|step| step.table == "nat" && step.chain == "PREROUTING");
+        let dns_redirect_matched = self.steps.iter().any(|step| {
+            step.table == "nat"
+                && step.chain == "PREROUTING"
+                && step.rule.as_deref().is_some_and(|rule| {
+                    rule_has_option_value(rule, "-p", "udp")
+                        && rule_has_option_value(rule, "--dport", "53")
+                        && rule_has_option_value(rule, "--comment", namespace)
+                        && rule_has_option_value(rule, "-j", "REDIRECT")
+                        && (rule_has_option_value(rule, "--to-port", &dns_port)
+                            || rule_has_option_value(rule, "--to-ports", &dns_port))
+                })
+        });
+        let post_redirect_header = self
+            .headers
+            .iter()
+            .find(|header| {
+                header.input.as_deref() == Some(host_device)
+                    && header.source.as_deref() == Some(peer_ip)
+                    && header.destination.as_deref() != Some(READINESS_DNS_IPV4)
+                    && header.destination_port == Some(dns_port_value)
+            })
+            .cloned();
+        let filter_forward_reached = self
+            .steps
+            .iter()
+            .any(|step| step.table == "filter" && step.chain == "FORWARD");
+        let filter_input_reached = self
+            .steps
+            .iter()
+            .any(|step| step.table == "filter" && step.chain == "INPUT");
+        let pool_input_comment =
+            parse_netns_name(namespace).map(|name| make_pool_dns_filter_comment(name.pool_index));
+        let pool_input_rule_reached = self.steps.iter().any(|step| {
+            step.table == "filter"
+                && step.chain == "INPUT"
+                && step.kind == "rule"
+                && step.verdict == "CONTINUE"
+                && step.rule.as_deref().is_some_and(|rule| {
+                    rule_has_option_value(rule, "-p", "udp")
+                        && rule_has_option_value(rule, "--dport", &dns_port)
+                        && pool_input_comment.as_deref().is_some_and(|comment| {
+                            rule_has_option_value(rule, "--comment", comment)
+                        })
+                        && !rule_has_option_value(rule, "-j", "REJECT")
+                })
+        });
+        let input_policy_accepted = self.steps.iter().any(|step| {
+            step.table == "filter"
+                && step.chain == "INPUT"
+                && step.kind == "policy"
+                && step.verdict == "ACCEPT"
+        });
+        let mut observed = vec![RootNetfilterObservation::RawPreroutingTrace];
+        if nat_prerouting_reached {
+            observed.extend([
+                RootNetfilterObservation::RawPreroutingContinued,
+                RootNetfilterObservation::RootConntrackHookPassed,
+                RootNetfilterObservation::NatPrerouting,
+            ]);
+        }
+        if dns_redirect_matched {
+            observed.push(RootNetfilterObservation::DnsRedirect);
+        }
+        if post_redirect_header.is_some() {
+            observed.push(RootNetfilterObservation::PostRedirectHeader);
+        }
+        if filter_forward_reached {
+            observed.push(RootNetfilterObservation::FilterForward);
+        }
+        if filter_input_reached {
+            observed.push(RootNetfilterObservation::FilterInput);
+        }
+        if pool_input_rule_reached {
+            observed.push(RootNetfilterObservation::PoolDnsInputRule);
+        }
+        if input_policy_accepted {
+            observed.push(RootNetfilterObservation::InputPolicyAccepted);
+        }
+        Some(TracePacketReport {
+            sequence: self.sequence,
+            family: self.family,
+            packet_id: self.packet_id.clone(),
+            source_port: original_header.source_port,
+            post_redirect_destination: post_redirect_header
+                .as_ref()
+                .and_then(|header| header.destination.clone()),
+            observed,
+            farthest_observed_boundary: self.farthest_observed_boundary,
+            truncated: self.truncated,
+            complete: self.complete,
+        })
+    }
+}
+
+fn rule_has_option_value(rule: &str, option: &str, expected: &str) -> bool {
+    let mut tokens = rule.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if token == option {
+            return tokens.next() == Some(expected);
+        }
+    }
+    false
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TracePacketHeader {
+    input: Option<String>,
+    source: Option<String>,
+    destination: Option<String>,
+    length: Option<u64>,
+    protocol: Option<String>,
+    source_port: Option<u16>,
+    destination_port: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RootNetfilterObservation {
+    RawPreroutingTrace,
+    RawPreroutingContinued,
+    RootConntrackHookPassed,
+    NatPrerouting,
+    DnsRedirect,
+    PostRedirectHeader,
+    FilterForward,
+    FilterInput,
+    PoolDnsInputRule,
+    InputPolicyAccepted,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TracePacketReport {
+    sequence: u64,
+    family: u8,
+    packet_id: String,
+    source_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_redirect_destination: Option<String>,
+    observed: Vec<RootNetfilterObservation>,
+    farthest_observed_boundary: Option<RootNetfilterBoundary>,
+    truncated: bool,
+    complete: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TraceStep {
+    table: String,
+    chain: String,
+    kind: String,
+    verdict: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rule: Option<String>,
+}
+
+impl TraceStep {
+    fn boundary(&self) -> Option<RootNetfilterBoundary> {
+        match (self.table.as_str(), self.chain.as_str()) {
+            ("raw", "PREROUTING") => Some(RootNetfilterBoundary::RawPrerouting),
+            ("nat", "PREROUTING") => Some(RootNetfilterBoundary::NatPrerouting),
+            ("filter", "FORWARD") => Some(RootNetfilterBoundary::FilterForward),
+            ("filter", "INPUT") => Some(RootNetfilterBoundary::FilterInput),
+            _ => None,
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(self.verdict.as_str(), "DROP" | "REJECT")
+            || (self.table == "filter" && self.verdict == "ACCEPT")
+            || (self.kind == "policy"
+                && self.table == "filter"
+                && matches!(self.chain.as_str(), "INPUT" | "FORWARD" | "OUTPUT"))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RootNetfilterBoundary {
+    RawPrerouting,
+    NatPrerouting,
+    FilterForward,
+    FilterInput,
+}
+
+impl RootNetfilterBoundary {
+    fn farthest(current: Option<Self>, candidate: Option<Self>) -> Option<RootNetfilterBoundary> {
+        match (current, candidate) {
+            (Some(current), Some(candidate)) => Some(current.max(candidate)),
+            (Some(current), None) => Some(current),
+            (None, Some(candidate)) => Some(candidate),
+            (None, None) => None,
+        }
+    }
+}
+
+enum ParsedMonitorLine {
+    Packet {
+        family: u8,
+        packet_id: String,
+        header: TracePacketHeader,
+    },
+    Trace {
+        family: u8,
+        packet_id: String,
+        step: TraceStep,
+    },
+}
+
+fn parse_monitor_line(line: &str) -> Option<ParsedMonitorLine> {
+    let trimmed = line.trim();
+    if trimmed.starts_with("PACKET:") {
+        parse_packet_line(trimmed)
+    } else if trimmed.starts_with("TRACE:") {
+        parse_trace_line(trimmed)
+    } else {
+        None
+    }
+}
+
+fn parse_packet_line(line: &str) -> Option<ParsedMonitorLine> {
+    let mut tokens = line.split_whitespace();
+    (tokens.next()? == "PACKET:").then_some(())?;
+    let family = tokens.next()?.parse().ok()?;
+    let packet_id = checked_identifier(tokens.next()?)?.to_string();
+    let mut header = TracePacketHeader {
+        input: None,
+        source: None,
+        destination: None,
+        length: None,
+        protocol: None,
+        source_port: None,
+        destination_port: None,
+    };
+    for token in tokens {
+        let Some((key, value)) = token.split_once('=') else {
+            continue;
+        };
+        match key {
+            "IN" => header.input = checked_identifier(value).map(str::to_string),
+            "SRC" => header.source = checked_identifier(value).map(str::to_string),
+            "DST" => header.destination = checked_identifier(value).map(str::to_string),
+            "LEN" => header.length = value.parse().ok(),
+            "PROTO" => header.protocol = checked_identifier(value).map(str::to_string),
+            "SPT" | "SPORT" => header.source_port = value.parse().ok(),
+            "DPT" | "DPORT" => header.destination_port = value.parse().ok(),
+            _ => {}
+        }
+    }
+    Some(ParsedMonitorLine::Packet {
+        family,
+        packet_id,
+        header,
+    })
+}
+
+fn parse_trace_line(line: &str) -> Option<ParsedMonitorLine> {
+    let mut tokens = line.split_whitespace();
+    (tokens.next()? == "TRACE:").then_some(())?;
+    let family = tokens.next()?.parse().ok()?;
+    let packet_id = checked_identifier(tokens.next()?)?.to_string();
+    let descriptor = tokens.next()?;
+    let mut descriptor_parts = descriptor.split(':');
+    let table = checked_identifier(descriptor_parts.next()?)?.to_string();
+    let chain = checked_identifier(descriptor_parts.next()?)?.to_string();
+    let kind = checked_identifier(descriptor_parts.next()?)?.to_string();
+    let verdict = checked_identifier(descriptor_parts.next_back()?)?.to_string();
+    let rule = {
+        let detail = tokens.collect::<Vec<_>>().join(" ");
+        (!detail.is_empty()).then(|| bounded_string(&detail, MAX_RULE_DETAIL_BYTES))
+    };
+    Some(ParsedMonitorLine::Trace {
+        family,
+        packet_id,
+        step: TraceStep {
+            table,
+            chain,
+            kind,
+            verdict,
+            rule,
+        },
+    })
+}
+
+fn checked_identifier(value: &str) -> Option<&str> {
+    (value.len() <= MAX_IDENTIFIER_BYTES).then_some(value)
+}
+
+fn bounded_string(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_string();
+    }
+    let mut end = limit;
+    while !value.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    format!("{} [truncated]", &value[..end])
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TraceReportStatus {
+    Captured,
+    NoMatchingPacket,
+    BufferTruncated,
+    BaselineUnavailable,
+    AttachmentUnavailable,
+    MonitorUnavailable,
+    CursorMismatch,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TraceMonitorSnapshot {
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+impl TraceMonitorSnapshot {
+    fn from_status(status: &TraceMonitorStatus) -> Self {
+        match status {
+            TraceMonitorStatus::Running => Self {
+                state: "running",
+                detail: None,
+            },
+            TraceMonitorStatus::Unavailable(detail) => Self {
+                state: "unavailable",
+                detail: Some(detail.clone()),
+            },
+            TraceMonitorStatus::Stopped => Self {
+                state: "stopped",
+                detail: None,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct GuestDnsNetfilterTraceReport {
+    status: TraceReportStatus,
+    monitor: TraceMonitorSnapshot,
+    matched_packets: usize,
+    evicted_packets: u64,
+    malformed_lines: u64,
+    truncated_lines: u64,
+    packets: Vec<TracePacketReport>,
+}
+
+impl GuestDnsNetfilterTraceReport {
+    fn attachment_unavailable(reason: &str) -> Self {
+        Self {
+            status: TraceReportStatus::AttachmentUnavailable,
+            monitor: TraceMonitorSnapshot {
+                state: "unavailable",
+                detail: Some(reason.to_string()),
+            },
+            matched_packets: 0,
+            evicted_packets: 0,
+            malformed_lines: 0,
+            truncated_lines: 0,
+            packets: Vec::new(),
+        }
+    }
+
+    fn baseline_unavailable() -> Self {
+        Self {
+            status: TraceReportStatus::BaselineUnavailable,
+            monitor: TraceMonitorSnapshot {
+                state: "unknown",
+                detail: None,
+            },
+            matched_packets: 0,
+            evicted_packets: 0,
+            malformed_lines: 0,
+            truncated_lines: 0,
+            packets: Vec::new(),
+        }
+    }
+
+    fn complete_for(&self, expected_packets: usize) -> bool {
+        self.packets.iter().filter(|packet| packet.complete).count() >= expected_packets
+            || matches!(self.status, TraceReportStatus::CursorMismatch)
+    }
+}
+
+impl GuestDnsNetfilterTraceReader {
+    fn cursor(&self) -> GuestDnsNetfilterTraceCursor {
+        let state = lock_state(&self.state);
+        GuestDnsNetfilterTraceCursor {
+            monitor_id: state.monitor_id,
+            sequence: state.next_sequence.saturating_sub(1),
+        }
+    }
+
+    async fn capture(
+        &self,
+        cursor: GuestDnsNetfilterTraceCursor,
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+        dns_port: u16,
+        readiness_attempts: u16,
+    ) -> GuestDnsNetfilterTraceReport {
+        let deadline = Instant::now() + TRACE_CAPTURE_WAIT;
+        let expected_packets = usize::from(readiness_attempts);
+        loop {
+            let notified = self.changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            let report = self.capture_now(cursor, namespace, host_device, peer_ip, dns_port);
+            if expected_packets == 0 || report.complete_for(expected_packets) {
+                return report;
+            }
+            if timeout_at(deadline, &mut notified).await.is_err() {
+                return self.capture_now(cursor, namespace, host_device, peer_ip, dns_port);
+            }
+        }
+    }
+
+    fn capture_now(
+        &self,
+        cursor: GuestDnsNetfilterTraceCursor,
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+        dns_port: u16,
+    ) -> GuestDnsNetfilterTraceReport {
+        let state = lock_state(&self.state);
+        if cursor.monitor_id != state.monitor_id {
+            return GuestDnsNetfilterTraceReport {
+                status: TraceReportStatus::CursorMismatch,
+                monitor: TraceMonitorSnapshot::from_status(&state.status),
+                matched_packets: 0,
+                evicted_packets: state.evicted_packets,
+                malformed_lines: state.malformed_lines,
+                truncated_lines: state.truncated_lines,
+                packets: Vec::new(),
+            };
+        }
+
+        let matches = state
+            .packets
+            .iter()
+            .filter_map(|packet| {
+                (packet.sequence > cursor.sequence)
+                    .then(|| packet.report(namespace, host_device, peer_ip, dns_port))
+                    .flatten()
+            })
+            .collect::<Vec<_>>();
+        let matched_packets = matches.len();
+        let packets = matches
+            .into_iter()
+            .rev()
+            .take(MAX_REPORTED_PACKETS)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>();
+        let buffer_truncated = state
+            .packets
+            .front()
+            .is_some_and(|packet| packet.sequence > cursor.sequence.saturating_add(1));
+        let status = if !packets.is_empty() {
+            TraceReportStatus::Captured
+        } else if buffer_truncated {
+            TraceReportStatus::BufferTruncated
+        } else if matches!(state.status, TraceMonitorStatus::Running) {
+            TraceReportStatus::NoMatchingPacket
+        } else {
+            TraceReportStatus::MonitorUnavailable
+        };
+        GuestDnsNetfilterTraceReport {
+            status,
+            monitor: TraceMonitorSnapshot::from_status(&state.status),
+            matched_packets,
+            evicted_packets: state.evicted_packets,
+            malformed_lines: state.malformed_lines,
+            truncated_lines: state.truncated_lines,
+            packets,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORIGINAL_PACKET: &str =
+        "PACKET: 2 6379008e IN=vm0-ve-00-01 SRC=10.200.0.2 DST=8.8.8.8 LEN=67 SPORT=49152 DPORT=53";
+    const POST_NAT_PACKET: &str = "PACKET: 2 6379008e IN=vm0-ve-00-01 SRC=10.200.0.2 DST=10.200.0.1 LEN=67 SPORT=49152 DPORT=5300";
+    const READINESS_TRACE_RULE: &str = " TRACE: 2 6379008e raw:PREROUTING:rule:0x1:CONTINUE -4 -t raw -A PREROUTING -i vm0-ve-00-01 -s 10.200.0.2/32 -d 8.8.8.8/32 -p udp --dport 53 -m length --length 67 -m comment --comment vm0-ns-00-01 -j TRACE";
+
+    fn reader_and_state() -> (GuestDnsNetfilterTraceReader, Arc<Mutex<TraceState>>) {
+        let state = Arc::new(Mutex::new(TraceState::new(7)));
+        (
+            GuestDnsNetfilterTraceReader {
+                state: Arc::clone(&state),
+                changed: Arc::new(Notify::new()),
+            },
+            state,
+        )
+    }
+
+    fn ingest_verified_fixture(state: &Mutex<TraceState>) {
+        let lines = [
+            ORIGINAL_PACKET,
+            READINESS_TRACE_RULE,
+            " TRACE: 2 6379008e raw:PREROUTING:policy:ACCEPT",
+            " TRACE: 2 6379008e nat:PREROUTING:rule:0x2:ACCEPT -4 -t nat -A PREROUTING -i vm0-ve-00-01 -s 10.200.0.2/32 -p udp --dport 53 -m comment --comment vm0-ns-00-01 -j REDIRECT --to-ports 5300",
+            POST_NAT_PACKET,
+            " TRACE: 2 6379008e filter:INPUT:rule:0x3:CONTINUE -4 -t filter -A INPUT -i vm0-ve-00-+ -p udp --dport 5300 -m comment --comment vm0-ns-00-dns",
+            " TRACE: 2 6379008e filter:INPUT:policy:ACCEPT",
+        ];
+        let mut state = lock_state(state);
+        for line in lines {
+            state.ingest(line);
+        }
+    }
+
+    #[test]
+    fn parses_verified_trace_and_reports_farthest_root_hook() {
+        let (reader, state) = reader_and_state();
+        let cursor = reader.cursor();
+        ingest_verified_fixture(&state);
+
+        let report = reader.capture_now(cursor, "vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2", 5300);
+        let value = serde_json::to_value(report).unwrap();
+
+        assert_eq!(value["status"], "captured");
+        assert_eq!(value["matched_packets"], 1);
+        assert_eq!(
+            value["packets"][0]["farthest_observed_boundary"],
+            "filter_input"
+        );
+        assert_eq!(
+            value["packets"][0]["post_redirect_destination"],
+            "10.200.0.1"
+        );
+        assert_eq!(
+            value["packets"][0]["observed"],
+            serde_json::json!([
+                "raw_prerouting_trace",
+                "raw_prerouting_continued",
+                "root_conntrack_hook_passed",
+                "nat_prerouting",
+                "dns_redirect",
+                "post_redirect_header",
+                "filter_input",
+                "pool_dns_input_rule",
+                "input_policy_accepted"
+            ])
+        );
+    }
+
+    #[test]
+    fn excludes_packets_before_cursor_and_non_readiness_packets() {
+        let (reader, state) = reader_and_state();
+        ingest_verified_fixture(&state);
+        let cursor = reader.cursor();
+        lock_state(&state).ingest(
+            "PACKET: 2 other IN=vm0-ve-00-01 SRC=10.200.0.2 DST=192.0.2.1 LEN=67 PROTO=UDP SPT=1 DPT=53",
+        );
+
+        let report = reader.capture_now(cursor, "vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2", 5300);
+
+        assert!(matches!(report.status, TraceReportStatus::NoMatchingPacket));
+    }
+
+    #[test]
+    fn excludes_interleaved_other_runner_packet() {
+        let (reader, state) = reader_and_state();
+        let cursor = reader.cursor();
+        let mut state = lock_state(&state);
+        for line in [
+            "PACKET: 2 other IN=vm0-ve-01-01 SRC=10.200.4.2 DST=8.8.8.8 LEN=67 SPORT=49152 DPORT=53",
+            "TRACE: 2 other raw:PREROUTING:rule:0x1:CONTINUE -4 -t raw -A PREROUTING -i vm0-ve-01-01 -s 10.200.4.2/32 -d 8.8.8.8/32 -p udp --dport 53 -m length --length 67 -m comment --comment vm0-ns-01-01 -j TRACE",
+            "TRACE: 2 other filter:INPUT:policy:ACCEPT",
+        ] {
+            state.ingest(line);
+        }
+        drop(state);
+
+        let report = reader.capture_now(cursor, "vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2", 5300);
+
+        assert!(matches!(report.status, TraceReportStatus::NoMatchingPacket));
+    }
+
+    #[test]
+    fn reports_forward_drop_without_claiming_redirect_or_input_progress() {
+        let (reader, state) = reader_and_state();
+        let cursor = reader.cursor();
+        let mut state = lock_state(&state);
+        for line in [
+            ORIGINAL_PACKET,
+            READINESS_TRACE_RULE,
+            "TRACE: 2 6379008e raw:PREROUTING:policy:ACCEPT",
+            "TRACE: 2 6379008e nat:PREROUTING:policy:ACCEPT",
+            "TRACE: 2 6379008e filter:FORWARD:rule:0x4:DROP -4 -t filter -A FORWARD -i vm0-ve-00-01 -s 10.200.0.2/32 -p udp --dport 53 -m comment --comment vm0-ns-00-01 -j DROP",
+        ] {
+            state.ingest(line);
+        }
+        drop(state);
+
+        let report = reader.capture_now(cursor, "vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2", 5300);
+        let value = serde_json::to_value(report).unwrap();
+        let observed = value["packets"][0]["observed"].as_array().unwrap();
+
+        assert!(observed.contains(&serde_json::json!("filter_forward")));
+        assert!(!observed.contains(&serde_json::json!("dns_redirect")));
+        assert!(!observed.contains(&serde_json::json!("filter_input")));
+        assert_eq!(
+            value["packets"][0]["farthest_observed_boundary"],
+            "filter_forward"
+        );
+        assert_eq!(value["packets"][0]["complete"], true);
+    }
+
+    #[test]
+    fn completed_packet_id_reuse_keeps_three_attempt_report_bounded() {
+        let (reader, state) = reader_and_state();
+        ingest_verified_fixture(&state);
+        let cursor = reader.cursor();
+        for _ in 0..3 {
+            ingest_verified_fixture(&state);
+        }
+
+        let report = reader.capture_now(cursor, "vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2", 5300);
+        let output = serde_json::to_string(&report).unwrap();
+
+        assert!(matches!(report.status, TraceReportStatus::Captured));
+        assert_eq!(report.matched_packets, 3);
+        assert_eq!(report.packets.len(), 3);
+        assert!(
+            output.len() < 1_536,
+            "trace report was {} bytes",
+            output.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_waits_for_expected_packet_and_keeps_report_bounded() {
+        let (reader, state) = reader_and_state();
+        let cursor = reader.cursor();
+        let ingest_state = Arc::clone(&state);
+        let changed = Arc::clone(&reader.changed);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            ingest_verified_fixture(&ingest_state);
+            changed.notify_waiters();
+        });
+
+        let report = reader
+            .capture(
+                cursor,
+                "vm0-ns-00-01",
+                "vm0-ve-00-01",
+                "10.200.0.2",
+                5300,
+                1,
+            )
+            .await;
+        let output = serde_json::to_string(&report).unwrap();
+
+        assert!(matches!(report.status, TraceReportStatus::Captured));
+        assert_eq!(report.matched_packets, 1);
+        assert!(output.len() < 2 * 1024);
+    }
+
+    #[tokio::test]
+    async fn bounded_line_reader_discards_oversized_lines_and_keeps_following_lines() {
+        let input = format!(
+            "{}\n{ORIGINAL_PACKET}\n",
+            "x".repeat(MAX_TRACE_LINE_BYTES + 10)
+        );
+        let mut observed = Vec::new();
+
+        read_bounded_lines(input.as_bytes(), MAX_TRACE_LINE_BYTES, |line, truncated| {
+            observed.push((line, truncated));
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(observed.len(), 2);
+        assert!(observed.first().is_some_and(|(_, truncated)| *truncated));
+        assert_eq!(observed.get(1), Some(&(ORIGINAL_PACKET.to_string(), false)));
+    }
+
+    #[test]
+    fn packet_and_step_bounds_are_explicit() {
+        let (_, state) = reader_and_state();
+        let mut state = lock_state(&state);
+        state.ingest(ORIGINAL_PACKET);
+        for _ in 0..(MAX_HEADERS_PER_PACKET + 2) {
+            state.ingest(POST_NAT_PACKET);
+        }
+        for _ in 0..(MAX_STEPS_PER_PACKET + 2) {
+            state.ingest("TRACE: 2 6379008e raw:PREROUTING:rule:0x1:CONTINUE");
+        }
+
+        let packet = state.packets.back().unwrap();
+        assert_eq!(packet.headers.len(), MAX_HEADERS_PER_PACKET);
+        assert_eq!(packet.steps.len(), MAX_STEPS_PER_PACKET);
+        assert!(packet.truncated);
+    }
+
+    #[tokio::test]
+    async fn process_exit_marks_monitor_unavailable() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("printf 'monitor failed' >&2; exit 3");
+        let mut monitor = GuestDnsNetfilterTraceMonitor::start_command(command)
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            if matches!(
+                lock_state(&monitor.reader.state).status,
+                TraceMonitorStatus::Unavailable(_)
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        {
+            let state = lock_state(&monitor.reader.state);
+            assert!(matches!(state.status, TraceMonitorStatus::Unavailable(_)));
+        }
+        monitor.shutdown().await;
+    }
+}

--- a/crates/sandbox-fc/src/guest_dns_network_evidence.rs
+++ b/crates/sandbox-fc/src/guest_dns_network_evidence.rs
@@ -6,6 +6,9 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::command::{CommandError, exec_with_timeout};
+use crate::guest_dns_netfilter_trace::{
+    GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceCursor, GuestDnsNetfilterTraceReport,
+};
 
 const BASELINE_COMMAND_TIMEOUT: Duration = Duration::from_millis(250);
 const PEER_DEVICE: &str = "veth0";
@@ -14,32 +17,62 @@ const EXPECTED_NAMESPACE_MASQUERADE_RULE: &str =
 const EXPECTED_READINESS_PACKET_BYTES: u64 = 67;
 const FAILURE_DETAIL_LIMIT_BYTES: usize = 256;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct GuestDnsNetworkEvidenceTarget {
     namespace: String,
     host_device: String,
+    peer_ip: String,
+    dns_port: u16,
+    #[serde(skip)]
+    root_netfilter_trace: GuestDnsNetfilterTraceAttachment,
 }
 
 impl GuestDnsNetworkEvidenceTarget {
-    pub(crate) fn new(namespace: &str, host_device: &str) -> Self {
+    pub(crate) fn new(
+        namespace: &str,
+        host_device: &str,
+        peer_ip: &str,
+        dns_port: u16,
+        root_netfilter_trace: &GuestDnsNetfilterTraceAttachment,
+    ) -> Self {
         Self {
             namespace: namespace.to_string(),
             host_device: host_device.to_string(),
+            peer_ip: peer_ip.to_string(),
+            dns_port,
+            root_netfilter_trace: root_netfilter_trace.clone(),
         }
     }
 }
+
+impl PartialEq for GuestDnsNetworkEvidenceTarget {
+    fn eq(&self, other: &Self) -> bool {
+        self.namespace == other.namespace
+            && self.host_device == other.host_device
+            && self.peer_ip == other.peer_ip
+            && self.dns_port == other.dns_port
+    }
+}
+
+impl Eq for GuestDnsNetworkEvidenceTarget {}
 
 #[derive(Debug)]
 pub(crate) struct GuestDnsNetworkEvidenceBaseline {
     target: GuestDnsNetworkEvidenceTarget,
     capture: NetworkCapture,
+    root_netfilter_trace_cursor: Option<GuestDnsNetfilterTraceCursor>,
 }
 
 pub(crate) async fn capture_guest_dns_network_evidence_baseline(
     target: GuestDnsNetworkEvidenceTarget,
 ) -> Arc<GuestDnsNetworkEvidenceBaseline> {
     let capture = capture_network_evidence(&target, BASELINE_COMMAND_TIMEOUT).await;
-    Arc::new(GuestDnsNetworkEvidenceBaseline { target, capture })
+    let root_netfilter_trace_cursor = target.root_netfilter_trace.cursor();
+    Arc::new(GuestDnsNetworkEvidenceBaseline {
+        target,
+        capture,
+        root_netfilter_trace_cursor,
+    })
 }
 
 pub(crate) async fn capture_guest_dns_network_evidence_report(
@@ -48,8 +81,33 @@ pub(crate) async fn capture_guest_dns_network_evidence_report(
     readiness_attempts: u16,
     command_timeout: Duration,
 ) -> String {
-    let terminal = capture_network_evidence(&target, command_timeout).await;
-    render_report(&target, baseline, &terminal, readiness_attempts)
+    let trace_cursor = baseline
+        .filter(|baseline| baseline.target == target)
+        .and_then(|baseline| baseline.root_netfilter_trace_cursor);
+    let capture_trace = async {
+        target
+            .root_netfilter_trace
+            .capture(
+                trace_cursor,
+                &target.namespace,
+                &target.host_device,
+                &target.peer_ip,
+                target.dns_port,
+                readiness_attempts,
+            )
+            .await
+    };
+    let (terminal, root_netfilter_trace) = tokio::join!(
+        capture_network_evidence(&target, command_timeout),
+        capture_trace,
+    );
+    render_report(
+        &target,
+        baseline,
+        &terminal,
+        readiness_attempts,
+        root_netfilter_trace.as_ref(),
+    )
 }
 
 async fn capture_network_evidence(
@@ -313,6 +371,34 @@ struct EvidenceCorrelation {
     deltas: Option<EvidenceDeltas>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CounterObservationStatus {
+    Observed,
+    NotObserved,
+    ZeroAttempts,
+    BaselineUnavailable,
+    TerminalUnavailable,
+    IdentityMismatch,
+    CounterReset,
+    ErrorOrDrop,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+struct CounterObservations {
+    exact_namespace_masquerade: CounterObservationStatus,
+    aggregate_veth_handoff: CounterObservationStatus,
+}
+
+impl CounterObservations {
+    fn uniform(status: CounterObservationStatus) -> Self {
+        Self {
+            exact_namespace_masquerade: status,
+            aggregate_veth_handoff: status,
+        }
+    }
+}
+
 impl EvidenceCorrelation {
     fn inconclusive(reason: EvidenceReason, deltas: Option<EvidenceDeltas>) -> Self {
         Self {
@@ -439,6 +525,95 @@ fn correlate(
     EvidenceCorrelation::root_veth_rx(deltas)
 }
 
+fn observe_counters(
+    target: &GuestDnsNetworkEvidenceTarget,
+    baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
+    terminal: &NetworkCapture,
+    readiness_attempts: u16,
+) -> CounterObservations {
+    let Some(baseline) = baseline else {
+        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
+    };
+    if baseline.target != *target {
+        return CounterObservations::uniform(CounterObservationStatus::IdentityMismatch);
+    }
+    let CaptureValue::Captured(baseline_namespace_link) = &baseline.capture.namespace_link else {
+        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
+    };
+    let CaptureValue::Captured(baseline_root_link) = &baseline.capture.root_link else {
+        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
+    };
+    let CaptureValue::Captured(baseline_masquerade) = &baseline.capture.namespace_masquerade else {
+        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
+    };
+    let CaptureValue::Captured(terminal_namespace_link) = &terminal.namespace_link else {
+        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
+    };
+    let CaptureValue::Captured(terminal_root_link) = &terminal.root_link else {
+        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
+    };
+    let CaptureValue::Captured(terminal_masquerade) = &terminal.namespace_masquerade else {
+        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
+    };
+    if !reciprocal_identity(baseline_namespace_link, baseline_root_link)
+        || !reciprocal_identity(terminal_namespace_link, terminal_root_link)
+        || !same_identity(baseline_namespace_link, terminal_namespace_link)
+        || !same_identity(baseline_root_link, terminal_root_link)
+    {
+        return CounterObservations::uniform(CounterObservationStatus::IdentityMismatch);
+    }
+
+    let Some(namespace_link_delta) = terminal_namespace_link
+        .stats64
+        .checked_delta(baseline_namespace_link.stats64)
+    else {
+        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
+    };
+    let Some(root_link_delta) = terminal_root_link
+        .stats64
+        .checked_delta(baseline_root_link.stats64)
+    else {
+        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
+    };
+    let Some(namespace_masquerade_delta) = terminal_masquerade.checked_delta(*baseline_masquerade)
+    else {
+        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
+    };
+
+    let exact_namespace_masquerade = if readiness_attempts == 0 {
+        CounterObservationStatus::ZeroAttempts
+    } else {
+        let expected_packets = u64::from(readiness_attempts);
+        if namespace_masquerade_delta.packets == expected_packets
+            && namespace_masquerade_delta.bytes
+                == expected_packets * EXPECTED_READINESS_PACKET_BYTES
+        {
+            CounterObservationStatus::Observed
+        } else {
+            CounterObservationStatus::NotObserved
+        }
+    };
+    let veth_error_or_drop = namespace_link_delta.tx.errors != 0
+        || namespace_link_delta.tx.dropped != 0
+        || root_link_delta.rx.errors != 0
+        || root_link_delta.rx.dropped != 0;
+    let aggregate_veth_handoff = if veth_error_or_drop {
+        CounterObservationStatus::ErrorOrDrop
+    } else if namespace_link_delta.tx.packets > 0
+        && namespace_link_delta.tx.packets == root_link_delta.rx.packets
+        && namespace_link_delta.tx.bytes == root_link_delta.rx.bytes
+    {
+        CounterObservationStatus::Observed
+    } else {
+        CounterObservationStatus::NotObserved
+    };
+
+    CounterObservations {
+        exact_namespace_masquerade,
+        aggregate_veth_handoff,
+    }
+}
+
 fn reciprocal_identity(namespace_link: &LinkSnapshot, root_link: &LinkSnapshot) -> bool {
     namespace_link.ifindex == root_link.link_index && namespace_link.link_index == root_link.ifindex
 }
@@ -456,9 +631,12 @@ struct EvidenceReport<'a> {
     classification: EvidenceClassification,
     reason: EvidenceReason,
     farthest_observed_boundary: Option<EvidenceBoundary>,
+    counter_observations: CounterObservations,
     baseline: Option<&'a NetworkCapture>,
     terminal: &'a NetworkCapture,
     deltas: Option<&'a EvidenceDeltas>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    root_netfilter_trace: Option<&'a GuestDnsNetfilterTraceReport>,
 }
 
 fn render_report(
@@ -466,17 +644,21 @@ fn render_report(
     baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
     terminal: &NetworkCapture,
     readiness_attempts: u16,
+    root_netfilter_trace: Option<&GuestDnsNetfilterTraceReport>,
 ) -> String {
     let correlation = correlate(target, baseline, terminal, readiness_attempts);
+    let counter_observations = observe_counters(target, baseline, terminal, readiness_attempts);
     let report = EvidenceReport {
         target,
         readiness_attempts,
         classification: correlation.classification,
         reason: correlation.reason,
         farthest_observed_boundary: correlation.farthest_observed_boundary,
+        counter_observations,
         baseline: baseline.map(|baseline| &baseline.capture),
         terminal,
         deltas: correlation.deltas.as_ref(),
+        root_netfilter_trace,
     };
     match serde_json::to_string(&report) {
         Ok(output) => output,
@@ -563,13 +745,20 @@ mod tests {
     }
 
     fn target() -> GuestDnsNetworkEvidenceTarget {
-        GuestDnsNetworkEvidenceTarget::new("vm0-ns-00-01", "vm0-ve-00-01")
+        GuestDnsNetworkEvidenceTarget::new(
+            "vm0-ns-00-01",
+            "vm0-ve-00-01",
+            "10.200.0.2",
+            5300,
+            &GuestDnsNetfilterTraceAttachment::Disabled,
+        )
     }
 
     fn baseline(capture: NetworkCapture) -> GuestDnsNetworkEvidenceBaseline {
         GuestDnsNetworkEvidenceBaseline {
             target: target(),
             capture,
+            root_netfilter_trace_cursor: None,
         }
     }
 
@@ -711,6 +900,38 @@ mod tests {
     }
 
     #[test]
+    fn noisy_veth_window_preserves_independent_positive_observations() {
+        let baseline = baseline(exact_capture());
+        let mut terminal = terminal_exact_capture();
+        if let CaptureValue::Captured(namespace_link) = &mut terminal.namespace_link {
+            namespace_link.stats64.tx = counters(14, 1_134);
+        }
+        if let CaptureValue::Captured(root_link) = &mut terminal.root_link {
+            root_link.stats64.rx = counters(14, 1_134);
+        }
+
+        let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
+        let observations = observe_counters(&target(), Some(&baseline), &terminal, 3);
+
+        assert_eq!(
+            correlation.classification,
+            EvidenceClassification::Inconclusive
+        );
+        assert_eq!(
+            correlation.reason,
+            EvidenceReason::NamespaceTxPacketMismatch
+        );
+        assert_eq!(
+            observations.exact_namespace_masquerade,
+            CounterObservationStatus::Observed
+        );
+        assert_eq!(
+            observations.aggregate_veth_handoff,
+            CounterObservationStatus::Observed
+        );
+    }
+
+    #[test]
     fn error_or_drop_progress_is_inconclusive() {
         let baseline = baseline(exact_capture());
         let mut terminal = terminal_exact_capture();
@@ -818,13 +1039,31 @@ mod tests {
     #[test]
     fn report_is_bounded_and_contains_attempt_correlation() {
         let baseline = baseline(exact_capture());
-        let report = render_report(&target(), Some(&baseline), &terminal_exact_capture(), 3);
+        let report = render_report(
+            &target(),
+            Some(&baseline),
+            &terminal_exact_capture(),
+            3,
+            None,
+        );
         let value: serde_json::Value = serde_json::from_str(&report).unwrap();
 
-        assert!(report.len() < 4 * 1024);
+        assert!(
+            report.len() < 2 * 1024,
+            "counter report was {} bytes",
+            report.len()
+        );
         assert_eq!(value["readiness_attempts"], 3);
         assert_eq!(value["classification"], "readiness_correlated_root_veth_rx");
         assert_eq!(value["farthest_observed_boundary"], "root_veth_rx");
         assert_eq!(value["deltas"]["namespace_masquerade"]["packets"], 3);
+        assert_eq!(
+            value["counter_observations"]["exact_namespace_masquerade"],
+            "observed"
+        );
+        assert_eq!(
+            value["counter_observations"]["aggregate_veth_handoff"],
+            "observed"
+        );
     }
 }

--- a/crates/sandbox-fc/src/guest_dns_network_evidence.rs
+++ b/crates/sandbox-fc/src/guest_dns_network_evidence.rs
@@ -9,12 +9,12 @@ use crate::command::{CommandError, exec_with_timeout};
 use crate::guest_dns_netfilter_trace::{
     GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceCursor, GuestDnsNetfilterTraceReport,
 };
+use crate::guest_dns_readiness::GUEST_DNS_READINESS_PACKET_BYTES;
 
 const BASELINE_COMMAND_TIMEOUT: Duration = Duration::from_millis(250);
 const PEER_DEVICE: &str = "veth0";
 const EXPECTED_NAMESPACE_MASQUERADE_RULE: &str =
     "-A POSTROUTING -s 192.168.241.0/29 -o veth0 -j MASQUERADE";
-const EXPECTED_READINESS_PACKET_BYTES: u64 = 67;
 const FAILURE_DETAIL_LIMIT_BYTES: usize = 256;
 
 #[derive(Clone, Debug, Serialize)]
@@ -45,6 +45,8 @@ impl GuestDnsNetworkEvidenceTarget {
     }
 }
 
+// The trace reader is runtime-wide diagnostic capability, not attachment
+// identity. Baseline reuse is keyed by the namespace-facing fields only.
 impl PartialEq for GuestDnsNetworkEvidenceTarget {
     fn eq(&self, other: &Self) -> bool {
         self.namespace == other.namespace
@@ -491,7 +493,7 @@ fn correlate(
             Some(deltas),
         );
     }
-    if deltas.namespace_masquerade.bytes != expected_packets * EXPECTED_READINESS_PACKET_BYTES {
+    if deltas.namespace_masquerade.bytes != expected_packets * GUEST_DNS_READINESS_PACKET_BYTES {
         return EvidenceCorrelation::inconclusive(
             EvidenceReason::MasqueradeByteMismatch,
             Some(deltas),
@@ -526,82 +528,46 @@ fn correlate(
 }
 
 fn observe_counters(
-    target: &GuestDnsNetworkEvidenceTarget,
-    baseline: Option<&GuestDnsNetworkEvidenceBaseline>,
-    terminal: &NetworkCapture,
+    correlation: &EvidenceCorrelation,
     readiness_attempts: u16,
 ) -> CounterObservations {
-    let Some(baseline) = baseline else {
-        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
+    let Some(deltas) = correlation.deltas else {
+        let status = match correlation.reason {
+            EvidenceReason::ZeroAttempts => CounterObservationStatus::ZeroAttempts,
+            EvidenceReason::BaselineUnavailable => CounterObservationStatus::BaselineUnavailable,
+            EvidenceReason::TerminalUnavailable => CounterObservationStatus::TerminalUnavailable,
+            EvidenceReason::IdentityMismatch => CounterObservationStatus::IdentityMismatch,
+            EvidenceReason::CounterReset => CounterObservationStatus::CounterReset,
+            // These reasons normally retain deltas. Missing deltas cannot
+            // support a positive independent observation.
+            EvidenceReason::ExactCorrelation
+            | EvidenceReason::MasqueradePacketMismatch
+            | EvidenceReason::MasqueradeByteMismatch
+            | EvidenceReason::NamespaceTxPacketMismatch
+            | EvidenceReason::RootRxPacketMismatch
+            | EvidenceReason::VethByteMismatch
+            | EvidenceReason::VethErrorOrDrop => CounterObservationStatus::NotObserved,
+        };
+        return CounterObservations::uniform(status);
     };
-    if baseline.target != *target {
-        return CounterObservations::uniform(CounterObservationStatus::IdentityMismatch);
-    }
-    let CaptureValue::Captured(baseline_namespace_link) = &baseline.capture.namespace_link else {
-        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
-    };
-    let CaptureValue::Captured(baseline_root_link) = &baseline.capture.root_link else {
-        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
-    };
-    let CaptureValue::Captured(baseline_masquerade) = &baseline.capture.namespace_masquerade else {
-        return CounterObservations::uniform(CounterObservationStatus::BaselineUnavailable);
-    };
-    let CaptureValue::Captured(terminal_namespace_link) = &terminal.namespace_link else {
-        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
-    };
-    let CaptureValue::Captured(terminal_root_link) = &terminal.root_link else {
-        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
-    };
-    let CaptureValue::Captured(terminal_masquerade) = &terminal.namespace_masquerade else {
-        return CounterObservations::uniform(CounterObservationStatus::TerminalUnavailable);
-    };
-    if !reciprocal_identity(baseline_namespace_link, baseline_root_link)
-        || !reciprocal_identity(terminal_namespace_link, terminal_root_link)
-        || !same_identity(baseline_namespace_link, terminal_namespace_link)
-        || !same_identity(baseline_root_link, terminal_root_link)
+
+    let expected_packets = u64::from(readiness_attempts);
+    let exact_namespace_masquerade = if deltas.namespace_masquerade.packets == expected_packets
+        && deltas.namespace_masquerade.bytes == expected_packets * GUEST_DNS_READINESS_PACKET_BYTES
     {
-        return CounterObservations::uniform(CounterObservationStatus::IdentityMismatch);
-    }
-
-    let Some(namespace_link_delta) = terminal_namespace_link
-        .stats64
-        .checked_delta(baseline_namespace_link.stats64)
-    else {
-        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
-    };
-    let Some(root_link_delta) = terminal_root_link
-        .stats64
-        .checked_delta(baseline_root_link.stats64)
-    else {
-        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
-    };
-    let Some(namespace_masquerade_delta) = terminal_masquerade.checked_delta(*baseline_masquerade)
-    else {
-        return CounterObservations::uniform(CounterObservationStatus::CounterReset);
-    };
-
-    let exact_namespace_masquerade = if readiness_attempts == 0 {
-        CounterObservationStatus::ZeroAttempts
+        CounterObservationStatus::Observed
     } else {
-        let expected_packets = u64::from(readiness_attempts);
-        if namespace_masquerade_delta.packets == expected_packets
-            && namespace_masquerade_delta.bytes
-                == expected_packets * EXPECTED_READINESS_PACKET_BYTES
-        {
-            CounterObservationStatus::Observed
-        } else {
-            CounterObservationStatus::NotObserved
-        }
+        CounterObservationStatus::NotObserved
     };
-    let veth_error_or_drop = namespace_link_delta.tx.errors != 0
-        || namespace_link_delta.tx.dropped != 0
-        || root_link_delta.rx.errors != 0
-        || root_link_delta.rx.dropped != 0;
+    let veth_error_or_drop = deltas.namespace_link.tx.errors != 0
+        || deltas.namespace_link.tx.dropped != 0
+        || deltas.root_link.rx.errors != 0
+        || deltas.root_link.rx.dropped != 0;
     let aggregate_veth_handoff = if veth_error_or_drop {
         CounterObservationStatus::ErrorOrDrop
-    } else if namespace_link_delta.tx.packets > 0
-        && namespace_link_delta.tx.packets == root_link_delta.rx.packets
-        && namespace_link_delta.tx.bytes == root_link_delta.rx.bytes
+    } else if deltas.namespace_link.tx.packets > 0
+        && deltas.namespace_link.tx.packets == deltas.root_link.rx.packets
+        && deltas.namespace_link.tx.bytes == deltas.root_link.rx.bytes
     {
         CounterObservationStatus::Observed
     } else {
@@ -647,7 +613,7 @@ fn render_report(
     root_netfilter_trace: Option<&GuestDnsNetfilterTraceReport>,
 ) -> String {
     let correlation = correlate(target, baseline, terminal, readiness_attempts);
-    let counter_observations = observe_counters(target, baseline, terminal, readiness_attempts);
+    let counter_observations = observe_counters(&correlation, readiness_attempts);
     let report = EvidenceReport {
         target,
         readiness_attempts,
@@ -911,7 +877,7 @@ mod tests {
         }
 
         let correlation = correlate(&target(), Some(&baseline), &terminal, 3);
-        let observations = observe_counters(&target(), Some(&baseline), &terminal, 3);
+        let observations = observe_counters(&correlation, 3);
 
         assert_eq!(
             correlation.classification,

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -19,10 +19,14 @@ const STDOUT_LIMIT_BYTES: u32 = 1_024;
 const STDERR_LIMIT_BYTES: u32 = 512;
 const EXPECTED_TRANSIENT_EXIT_CODES: &[i32] = &[2];
 
+pub(crate) const GUEST_DNS_READINESS_MAX_ATTEMPTS: u16 = 3;
+/// IPv4 packet size of the fixed `vm0-readiness.invalid` UDP A query.
+pub(crate) const GUEST_DNS_READINESS_PACKET_BYTES: u64 = 67;
+
 const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
     total_timeout: Duration::from_secs(7),
     attempt_timeout: OPERATION_WAIT_TIMEOUT,
-    max_attempts: 3,
+    max_attempts: GUEST_DNS_READINESS_MAX_ATTEMPTS,
 };
 
 #[derive(Clone, Copy)]

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -34,6 +34,7 @@ mod duration;
 mod exec_operation_result;
 mod factory;
 mod guest_dns_failure_diagnostics;
+mod guest_dns_netfilter_trace;
 mod guest_dns_network_evidence;
 mod guest_dns_readiness;
 mod guest_operations;

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -5,9 +5,9 @@ mod readiness;
 
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
-pub(crate) use pool::NetnsPoolHandle;
 pub use pool::{
     NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
+pub(crate) use pool::{NetnsPoolHandle, make_pool_dns_filter_comment};
 pub(crate) use readiness::probe_namespace_dns_diagnostic;
 pub use readiness::{DNS_DIAGNOSTIC_HOSTNAME, DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -45,6 +45,7 @@ mod naming;
 mod state;
 mod types;
 
+pub(crate) use naming::make_pool_dns_filter_comment;
 pub use naming::{ParsedNetnsName, parse_netns_name};
 pub use state::NetnsPool;
 pub(crate) use state::NetnsPoolHandle;

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -19,6 +19,7 @@ use crate::command::{
 use crate::guest_dns_netfilter_trace::{
     GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceReader,
 };
+use crate::guest_dns_readiness::GUEST_DNS_READINESS_PACKET_BYTES;
 use crate::paths::LockPaths;
 
 use super::super::error::{NetworkError, Result};
@@ -32,7 +33,6 @@ use super::types::NetnsInfo;
 
 const NETNS_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const GUEST_DNS_READINESS_IPV4: &str = "8.8.8.8/32";
-const GUEST_DNS_READINESS_PACKET_BYTES: u64 = 67;
 
 // Each namespace starts two `ip` children concurrently. A 16-wide window caps
 // that fanout at 32 processes. At the 256-namespace hard limit, sixteen

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -16,6 +16,9 @@ use crate::command::{
     CommandError, IgnoredCommandOutcome, exec_ignore_errors_with_timeout, exec_status_with_timeout,
     exec_with_timeout,
 };
+use crate::guest_dns_netfilter_trace::{
+    GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceReader,
+};
 use crate::paths::LockPaths;
 
 use super::super::error::{NetworkError, Result};
@@ -28,6 +31,8 @@ use super::naming::{
 use super::types::NetnsInfo;
 
 const NETNS_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const GUEST_DNS_READINESS_IPV4: &str = "8.8.8.8/32";
+const GUEST_DNS_READINESS_PACKET_BYTES: u64 = 67;
 
 // Each namespace starts two `ip` children concurrently. A 16-wide window caps
 // that fanout at 32 processes. At the 256-namespace hard limit, sixteen
@@ -428,6 +433,46 @@ fn namespace_firewall_restore_tables(
     ]
 }
 
+fn namespace_guest_dns_trace_restore_tables(
+    name: &str,
+    host_device: &str,
+    peer_ip: &str,
+) -> Vec<FirewallRestoreTable> {
+    let peer = format!("{peer_ip}/32");
+    vec![FirewallRestoreTable {
+        table: "raw",
+        rules: vec![
+            format!(
+                "-I PREROUTING 1 -i {host_device} -s {peer} -d {GUEST_DNS_READINESS_IPV4} -p udp --dport 53 -m length --length {GUEST_DNS_READINESS_PACKET_BYTES} -m comment --comment {name} -j TRACE"
+            ),
+            format!(
+                "-I PREROUTING 1 -i {host_device} -s {peer} -d {GUEST_DNS_READINESS_IPV4} -p tcp --dport 53 -m comment --comment {name} -j TRACE"
+            ),
+        ],
+    }]
+}
+
+async fn apply_namespace_guest_dns_trace_rules(
+    command: &str,
+    name: &str,
+    host_device: &str,
+    peer_ip: &str,
+) -> bool {
+    let firewall = namespace_guest_dns_trace_restore_tables(name, host_device, peer_ip);
+    match apply_firewall_rules_with_restore(command, &firewall).await {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(
+                name,
+                host_device,
+                %error,
+                "root netfilter trace rules unavailable; namespace remains usable"
+            );
+            false
+        }
+    }
+}
+
 pub(super) async fn get_default_interface() -> Result<String> {
     let result =
         exec_with_timeout("ip", &["route", "get", "8.8.8.8"], NETNS_COMMAND_TIMEOUT).await?;
@@ -791,6 +836,8 @@ pub(super) async fn create_single_namespace(
     default_iface: String,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    guest_dns_netfilter_trace_requested: bool,
+    guest_dns_netfilter_trace_reader: Option<GuestDnsNetfilterTraceReader>,
 ) -> Result<NetnsInfo> {
     if ns_index >= MAX_NAMESPACES {
         return Err(NetworkError::NamespaceLimitReached {
@@ -823,8 +870,35 @@ pub(super) async fn create_single_namespace(
 
     match result {
         Ok(()) => {
+            let trace = match (
+                guest_dns_netfilter_trace_requested,
+                guest_dns_netfilter_trace_reader,
+                dns_port,
+            ) {
+                (false, _, _) => GuestDnsNetfilterTraceAttachment::Disabled,
+                (true, None, _) => {
+                    GuestDnsNetfilterTraceAttachment::unavailable("monitor_unavailable")
+                }
+                (true, Some(_), None) => {
+                    GuestDnsNetfilterTraceAttachment::unavailable("dns_proxy_disabled")
+                }
+                (true, Some(reader), Some(_))
+                    if apply_namespace_guest_dns_trace_rules(
+                        "iptables-restore",
+                        &ns_name,
+                        &host_device,
+                        &peer_ip,
+                    )
+                    .await =>
+                {
+                    GuestDnsNetfilterTraceAttachment::enabled(reader)
+                }
+                (true, Some(_), Some(_)) => {
+                    GuestDnsNetfilterTraceAttachment::unavailable("rule_install_failed")
+                }
+            };
             info!(name = %ns_name, "namespace created");
-            Ok(NetnsInfo::new(ns_name, host_device, peer_ip))
+            Ok(NetnsInfo::new(ns_name, host_device, peer_ip).with_guest_dns_netfilter_trace(trace))
         }
         Err(e) => {
             error!(name = %ns_name, error = %e, "failed to create namespace, cleaning up");
@@ -1661,6 +1735,35 @@ COMMIT'
         )
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn guest_dns_trace_rules_match_only_readiness_udp_and_dns_tcp() {
+        let tables =
+            namespace_guest_dns_trace_restore_tables("vm0-ns-00-01", "vm0-ve-00-01", "10.200.0.2");
+
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].table, "raw");
+        assert_eq!(
+            tables[0].rules,
+            vec![
+                "-I PREROUTING 1 -i vm0-ve-00-01 -s 10.200.0.2/32 -d 8.8.8.8/32 -p udp --dport 53 -m length --length 67 -m comment --comment vm0-ns-00-01 -j TRACE",
+                "-I PREROUTING 1 -i vm0-ve-00-01 -s 10.200.0.2/32 -d 8.8.8.8/32 -p tcp --dport 53 -m comment --comment vm0-ns-00-01 -j TRACE",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_dns_trace_rule_failure_is_best_effort() {
+        let applied = apply_namespace_guest_dns_trace_rules(
+            "false",
+            "vm0-ns-00-01",
+            "vm0-ve-00-01",
+            "10.200.0.2",
+        )
+        .await;
+
+        assert!(!applied);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -9,6 +9,7 @@ use futures_util::future::join_all;
 use tokio::sync::watch;
 use tracing::{error, info, warn};
 
+use crate::guest_dns_netfilter_trace::GuestDnsNetfilterTraceReader;
 use crate::paths::LockPaths;
 
 use super::super::error::{NetworkError, Result};
@@ -134,6 +135,8 @@ struct NetnsPoolState {
     pool_index: u32,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    guest_dns_netfilter_trace_requested: bool,
+    guest_dns_netfilter_trace_reader: Option<GuestDnsNetfilterTraceReader>,
     dns_readiness_state: DnsReadinessState,
     dns_readiness_probe: DnsReadinessProbe,
     dns_readiness_timeout: Duration,
@@ -174,6 +177,8 @@ impl NetnsPoolState {
             pool_index: 0,
             proxy_port: None,
             dns_port: None,
+            guest_dns_netfilter_trace_requested: false,
+            guest_dns_netfilter_trace_reader: None,
             dns_readiness_state: DnsReadinessState::NotRequired,
             dns_readiness_probe: production_dns_readiness_probe(),
             dns_readiness_timeout: DNS_READINESS_OPERATION_TIMEOUT,
@@ -200,7 +205,11 @@ impl NetnsPoolState {
     }
 
     async fn create_checked(config: CheckedNetnsPoolConfig) -> Result<Self> {
-        let config = config.inner;
+        let CheckedNetnsPoolConfig {
+            inner: config,
+            guest_dns_netfilter_trace_requested,
+            guest_dns_netfilter_trace_reader,
+        } = config;
         let lock_paths = LockPaths::new();
         let (index, lock) = acquire_pool_lock(&lock_paths)?;
 
@@ -239,6 +248,8 @@ impl NetnsPoolState {
             pool_index: index,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
+            guest_dns_netfilter_trace_requested,
+            guest_dns_netfilter_trace_reader,
             dns_readiness_state: if config.dns_port.is_some() && config.proxy_port.is_some() {
                 DnsReadinessState::Pending
             } else {
@@ -414,6 +425,8 @@ impl NetnsPoolState {
         let ns_index = self.reserve_ns_index()?;
         let pool_index = self.pool_index;
         let default_iface = self.default_iface.clone();
+        let guest_dns_netfilter_trace_requested = self.guest_dns_netfilter_trace_requested;
+        let guest_dns_netfilter_trace_reader = self.guest_dns_netfilter_trace_reader.clone();
         let (proxy_port, dns_port) = match kind {
             NetnsKind::Plain => (None, None),
             NetnsKind::Proxy => {
@@ -443,7 +456,15 @@ impl NetnsPoolState {
             kind,
             self.creation_notifier(),
             create_namespace_with_readiness(
-                create_single_namespace(pool_index, ns_index, default_iface, proxy_port, dns_port),
+                create_single_namespace(
+                    pool_index,
+                    ns_index,
+                    default_iface,
+                    proxy_port,
+                    dns_port,
+                    guest_dns_netfilter_trace_requested,
+                    guest_dns_netfilter_trace_reader,
+                ),
                 readiness,
                 ops,
             ),

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 use sandbox::SandboxError;
 use tracing::warn;
 
+use crate::guest_dns_netfilter_trace::{
+    GuestDnsNetfilterTraceAttachment, GuestDnsNetfilterTraceReader,
+};
 use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceBaseline;
 
 /// Cloneable metadata for a network namespace.
@@ -21,6 +24,8 @@ pub struct NetnsInfo {
     pub(super) peer_ip: String,
     /// Process-local count of successful checkouts for this namespace.
     pub(super) attachment_generation: u64,
+    /// Local/CI-only root netfilter trace availability for this attachment.
+    pub(super) guest_dns_netfilter_trace: GuestDnsNetfilterTraceAttachment,
     /// Last quiescent DNS evidence snapshot retained only in this process.
     dns_network_baseline: Option<Arc<GuestDnsNetworkEvidenceBaseline>>,
 }
@@ -32,8 +37,17 @@ impl NetnsInfo {
             host_device,
             peer_ip,
             attachment_generation: 0,
+            guest_dns_netfilter_trace: GuestDnsNetfilterTraceAttachment::Disabled,
             dns_network_baseline: None,
         }
+    }
+
+    pub(super) fn with_guest_dns_netfilter_trace(
+        mut self,
+        trace: GuestDnsNetfilterTraceAttachment,
+    ) -> Self {
+        self.guest_dns_netfilter_trace = trace;
+        self
     }
 
     /// Returns the host network namespace name.
@@ -54,6 +68,10 @@ impl NetnsInfo {
     /// Returns the process-local checkout generation for this attachment.
     pub(crate) fn attachment_generation(&self) -> u64 {
         self.attachment_generation
+    }
+
+    pub(crate) fn guest_dns_netfilter_trace(&self) -> &GuestDnsNetfilterTraceAttachment {
+        &self.guest_dns_netfilter_trace
     }
 }
 
@@ -177,6 +195,8 @@ pub struct NetnsPoolConfig {
 /// Network pool config after host network prerequisites have been validated.
 pub(crate) struct CheckedNetnsPoolConfig {
     pub(super) inner: NetnsPoolConfig,
+    pub(super) guest_dns_netfilter_trace_requested: bool,
+    pub(super) guest_dns_netfilter_trace_reader: Option<GuestDnsNetfilterTraceReader>,
 }
 
 impl NetnsPoolConfig {
@@ -185,7 +205,23 @@ impl NetnsPoolConfig {
         self,
     ) -> std::result::Result<CheckedNetnsPoolConfig, SandboxError> {
         crate::prerequisites::check_network_prerequisites(self.dns_port.is_some()).await?;
-        Ok(CheckedNetnsPoolConfig { inner: self })
+        Ok(CheckedNetnsPoolConfig {
+            inner: self,
+            guest_dns_netfilter_trace_requested: false,
+            guest_dns_netfilter_trace_reader: None,
+        })
+    }
+}
+
+impl CheckedNetnsPoolConfig {
+    pub(crate) fn with_guest_dns_netfilter_trace(
+        mut self,
+        requested: bool,
+        reader: Option<GuestDnsNetfilterTraceReader>,
+    ) -> Self {
+        self.guest_dns_netfilter_trace_requested = requested;
+        self.guest_dns_netfilter_trace_reader = reader;
+        self
     }
 }
 

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -11,6 +11,7 @@ use nbd_cow::pool::{DevicePoolConfig, DevicePoolHandle};
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::duration::duration_ms;
 use crate::factory::FirecrackerFactory;
+use crate::guest_dns_netfilter_trace::GuestDnsNetfilterTraceMonitor;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::runtime_dirs::checked_runtime_sock_dir;
@@ -24,6 +25,7 @@ pub struct FirecrackerRuntime {
     device_pool: DevicePoolHandle,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    guest_dns_netfilter_trace_monitor: Option<GuestDnsNetfilterTraceMonitor>,
 }
 
 impl FirecrackerRuntime {
@@ -40,12 +42,39 @@ impl FirecrackerRuntime {
         }
         .into_checked()
         .await?;
-        let netns_pool = NetnsPoolHandle::create_checked(netns_config)
-            .await
-            .map_err(|e| SandboxError::Initialization {
-                phase: SandboxInitializationPhase::Runtime,
-                message: format!("netns pool: {e}"),
-            })?;
+        let trace_requested = config.guest_dns_netfilter_trace && config.dns_port.is_some();
+        let mut guest_dns_netfilter_trace_monitor = if trace_requested {
+            match GuestDnsNetfilterTraceMonitor::start().await {
+                Ok(monitor) => Some(monitor),
+                Err(error) => {
+                    warn!(
+                        %error,
+                        "root netfilter trace unavailable; continuing without trace diagnostics"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let netns_config = netns_config.with_guest_dns_netfilter_trace(
+            trace_requested,
+            guest_dns_netfilter_trace_monitor
+                .as_ref()
+                .map(GuestDnsNetfilterTraceMonitor::reader),
+        );
+        let netns_pool = match NetnsPoolHandle::create_checked(netns_config).await {
+            Ok(pool) => pool,
+            Err(e) => {
+                if let Some(monitor) = guest_dns_netfilter_trace_monitor.as_mut() {
+                    monitor.shutdown().await;
+                }
+                return Err(SandboxError::Initialization {
+                    phase: SandboxInitializationPhase::Runtime,
+                    message: format!("netns pool: {e}"),
+                });
+            }
+        };
         info!(
             elapsed_ms = duration_ms(t.elapsed()),
             "runtime netns pool created"
@@ -63,6 +92,7 @@ impl FirecrackerRuntime {
             device_pool,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
+            guest_dns_netfilter_trace_monitor,
         })
     }
 
@@ -145,6 +175,10 @@ impl SandboxRuntime for FirecrackerRuntime {
         // Clean up shared netns pool.
         if let Err(e) = self.netns_pool.cleanup().await {
             warn!(error = %e, "failed to cleanup shared netns pool");
+        }
+
+        if let Some(monitor) = self.guest_dns_netfilter_trace_monitor.as_mut() {
+            monitor.shutdown().await;
         }
 
         // Clean up shared device pool.

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -41,6 +41,7 @@ use crate::factory::InvariantConfig;
 use crate::guest_dns_failure_diagnostics::{
     GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_diagnostics,
 };
+use crate::guest_dns_netfilter_trace::GuestDnsNetfilterTraceAttachment;
 use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceBaseline;
 use crate::guest_dns_network_evidence::GuestDnsNetworkEvidenceTarget;
 use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
@@ -546,6 +547,10 @@ impl SandboxNetwork {
         self.info.attachment_generation()
     }
 
+    fn guest_dns_netfilter_trace(&self) -> &GuestDnsNetfilterTraceAttachment {
+        self.info.guest_dns_netfilter_trace()
+    }
+
     fn reuse_eligible(&self) -> bool {
         self.lease.as_ref().is_some_and(NetnsLease::reuse_eligible)
     }
@@ -645,9 +650,18 @@ impl FirecrackerSandbox {
     pub(crate) fn dns_network_evidence_target_for_reuse(
         &self,
     ) -> Option<GuestDnsNetworkEvidenceTarget> {
-        (self.factory_config.dns_port.is_some() && self.network.reuse_eligible()).then(|| {
-            GuestDnsNetworkEvidenceTarget::new(self.network.name(), self.network.host_device())
-        })
+        self.factory_config
+            .dns_port
+            .filter(|_| self.network.reuse_eligible())
+            .map(|dns_port| {
+                GuestDnsNetworkEvidenceTarget::new(
+                    self.network.name(),
+                    self.network.host_device(),
+                    self.network.peer_ip(),
+                    dns_port,
+                    self.network.guest_dns_netfilter_trace(),
+                )
+            })
     }
 
     fn current_state(&self) -> SandboxState {
@@ -1309,6 +1323,7 @@ impl FirecrackerSandbox {
                             dns_port,
                             attachment_generation: self.network.attachment_generation(),
                             readiness_attempts: error.attempts,
+                            root_netfilter_trace: self.network.guest_dns_netfilter_trace(),
                             network_evidence_baseline: self.guest_dns_network_baseline.as_deref(),
                             startup_mode: if self.factory_config.snapshot.is_some() {
                                 "snapshot_restore"

--- a/crates/sandbox-mock/src/tests/factory_runtime.rs
+++ b/crates/sandbox-mock/src/tests/factory_runtime.rs
@@ -115,6 +115,7 @@ async fn runtime_provider_creates_runtime() {
         .create_runtime(RuntimeConfig {
             proxy_port: None,
             dns_port: None,
+            guest_dns_netfilter_trace: false,
         })
         .await
         .unwrap();

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -178,6 +178,11 @@ pub struct RuntimeConfig {
     pub proxy_port: Option<u16>,
     /// DNS proxy port for DNS query interception. Shared across all factories.
     pub dns_port: Option<u16>,
+    /// Capture root netfilter traversal for guest DNS readiness diagnostics.
+    ///
+    /// This is intended for local and CI runners only. Production runners keep
+    /// it disabled so healthy sandbox traffic has no trace overhead.
+    pub guest_dns_netfilter_trace: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- keep production runners unchanged while enabling one bounded, runtime-owned `xtables-monitor` reader for local and runner-behavior execution
- install best-effort, namespace-owned TRACE rules for the exact UDP readiness packet and TCP DNS validation path without making diagnostics part of namespace admission
- retain generation-local trace cursors and report normalized raw, conntrack, NAT REDIRECT, FORWARD/INPUT, pool INPUT, and INPUT policy progress for up to three readiness attempts
- preserve exact namespace MASQUERADE and aggregate lossless-veth observations independently when unrelated startup traffic makes the conservative classifier inconclusive
- extend privileged runner-behavior coverage for exact trace attribution and cleanup

## Scope

This PR adds diagnostics only. It does not change readiness deadlines, replacement behavior, DNS routing, production packet processing, or the mechanism responsible for the intermittent loss.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-features --no-deps`
- `cargo test -p sandbox --all-targets --all-features`
- `cargo test -p sandbox-fc --all-targets --all-features`
- `cargo test -p sandbox-mock --all-targets --all-features`
- `cargo test -p runner --all-targets --all-features`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- cross-built the runner for `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-musl`
- validated the current binaries on `dev-1.aws.vm3.ai` and `dev-11.gcp.vm3.ai`, including exact UDP/TCP raw → NAT REDIRECT → pool INPUT → INPUT policy attribution and rule/namespace cleanup

Closes #23258

Parent context: #22481
