### PR TITLE
refactor(mitm-addon): retire original url compatibility wrapper

### DIFF
--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -291,17 +291,6 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
     return TrustedAuthority(host=normalized_sni, port=port, url=trusted_url)
 
 
-def get_original_url(flow: http.HTTPFlow) -> str:
-    """Reconstruct the original target URL from the request.
-
-    Uses the trusted authority for HTTPS firewall/auth decisions. ``pretty_url``
-    is intentionally not used: it takes the port from the Host header, so a
-    request to ``host:8443`` with a plain ``Host: host`` (no port) would lose
-    the ``:8443`` and break firewall rule matching.
-    """
-    return get_trusted_authority(flow).url
-
-
 _QueryPair = tuple[str, str]
 
 

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -30,7 +30,7 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
-from url_utils import get_original_url
+from url_utils import get_trusted_authority
 
 DEFAULT_SANDBOX_TOKEN = "sandbox-token"
 FAR_FUTURE_EXPIRES_AT = 9_999_999_999
@@ -221,7 +221,7 @@ def prepare_firewall_request(
 ) -> None:
     flow.metadata[metadata_keys.VM_RUN_ID] = run_id
     flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        get_original_url(flow) if original_url is None else original_url
+        get_trusted_authority(flow).url if original_url is None else original_url
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -45,7 +45,7 @@ from tests.firewall_auth_helpers import (
 )
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
-from url_utils import get_original_url
+from url_utils import get_trusted_authority
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
 
@@ -1191,7 +1191,7 @@ class TestHandleFirewallRequest:
             ),
         )
         flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
-        flow.metadata[metadata_keys.ORIGINAL_URL] = get_original_url(flow)
+        flow.metadata[metadata_keys.ORIGINAL_URL] = get_trusted_authority(flow).url
         api_entry = _api_entry(
             base="https://sts.amazonaws.com",
             auth_config={

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
@@ -2,10 +2,10 @@
 
 import pytest
 
-from url_utils import get_original_url, get_trusted_authority
+from url_utils import get_trusted_authority
 
 
-class TestGetOriginalUrl:
+class TestTrustedAuthorityUrl:
     @pytest.mark.parametrize(
         ("scheme", "port", "expected_url"),
         [
@@ -19,7 +19,10 @@ class TestGetOriginalUrl:
     )
     def test_omits_only_scheme_default_ports(self, real_flow, scheme, port, expected_url):
         flow = real_flow(host="example.com", port=port, scheme=scheme)
-        assert get_original_url(flow) == expected_url
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "example.com"
+        assert trusted.port == port
+        assert trusted.url == expected_url
 
     def test_https_non_standard_port(self, real_flow):
         # Pins two invariants at once for the #10082 regression:
@@ -31,11 +34,17 @@ class TestGetOriginalUrl:
         #   which is why we don't use it).
         flow = real_flow(host="example.com", port=8443)
         assert flow.request.headers.get("Host") == "example.com"
-        assert get_original_url(flow) == "https://example.com:8443/"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "example.com"
+        assert trusted.port == 8443
+        assert trusted.url == "https://example.com:8443/"
 
     def test_with_path_and_query(self, real_flow):
         flow = real_flow(host="api.example.com", port=443, path="/v1/data?key=val")
-        assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "api.example.com"
+        assert trusted.port == 443
+        assert trusted.url == "https://api.example.com/v1/data?key=val"
 
     @pytest.mark.parametrize(
         ("port", "expected_url"),
@@ -57,7 +66,10 @@ class TestGetOriginalUrl:
             path="*",
         )
 
-        assert get_original_url(flow) == expected_url
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "api.example.com"
+        assert trusted.port == port
+        assert trusted.url == expected_url
         assert flow.request.path == "*"
 
     def test_https_uses_sni_for_transparent_destination(self, real_flow, headers):
@@ -67,7 +79,10 @@ class TestGetOriginalUrl:
             path="/v1/data?key=val",
             request_headers=headers(("Host", "api.example.com")),
         )
-        assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "api.example.com"
+        assert trusted.port == 443
+        assert trusted.url == "https://api.example.com/v1/data?key=val"
 
     def test_https_accepts_trailing_dot_authority_equivalence(self, real_flow, headers):
         flow = real_flow(
@@ -76,7 +91,10 @@ class TestGetOriginalUrl:
             path="/v1/data",
             request_headers=headers(("Host", "API.EXAMPLE.COM.")),
         )
-        assert get_original_url(flow) == "https://api.example.com/v1/data"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "api.example.com"
+        assert trusted.port == 443
+        assert trusted.url == "https://api.example.com/v1/data"
 
     def test_http_uses_request_host_not_host_header(self, real_flow, headers):
         flow = real_flow(
@@ -86,7 +104,10 @@ class TestGetOriginalUrl:
             path="/v1/data",
             request_headers=headers(("Host", "api.example.com")),
         )
-        assert get_original_url(flow) == "http://203.0.113.10/v1/data"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "203.0.113.10"
+        assert trusted.port == 80
+        assert trusted.url == "http://203.0.113.10/v1/data"
 
     def test_http_brackets_ipv6_request_host(self, real_flow, headers):
         flow = real_flow(
@@ -96,7 +117,10 @@ class TestGetOriginalUrl:
             path="/v1/data",
             request_headers=headers(("Host", "api.example.com")),
         )
-        assert get_original_url(flow) == "http://[2001:db8::1]:8080/v1/data"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "2001:db8::1"
+        assert trusted.port == 8080
+        assert trusted.url == "http://[2001:db8::1]:8080/v1/data"
 
     def test_https_brackets_ipv6_sni(self, real_flow, headers):
         flow = real_flow(
@@ -106,7 +130,10 @@ class TestGetOriginalUrl:
             path="/v1/data",
             request_headers=headers(("Host", "[2001:db8::1]")),
         )
-        assert get_original_url(flow) == "https://[2001:db8::1]:8443/v1/data"
+        trusted = get_trusted_authority(flow)
+        assert trusted.host == "2001:db8::1"
+        assert trusted.port == 8443
+        assert trusted.url == "https://[2001:db8::1]:8443/v1/data"
 
 
 class TestTrustedAuthoritySuccess:
@@ -365,4 +392,3 @@ class TestTrustedAuthoritySuccess:
         assert trusted.host == expected_host
         assert trusted.port == 443
         assert trusted.url == expected_url
-        assert get_original_url(flow) == expected_url

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from url_utils import AuthorityValidationError, get_original_url, get_trusted_authority
+from url_utils import AuthorityValidationError, get_trusted_authority
 
 
 def _request_headers(headers, host_header):
@@ -29,19 +29,6 @@ def _assert_authority_error(
 
 
 class TestTrustedAuthorityRejection:
-    def test_get_original_url_propagates_authority_validation_error(self, real_flow, headers):
-        flow = real_flow(
-            host="203.0.113.10",
-            sni="attacker.example.com",
-            path="/v1/data",
-            request_headers=headers(("Host", "api.example.com")),
-        )
-
-        with pytest.raises(AuthorityValidationError) as exc_info:
-            get_original_url(flow)
-
-        assert exc_info.value.reason == "authority_mismatch"
-
     def test_https_rejects_host_sni_mismatch(self, real_flow, headers):
         flow = real_flow(
             host="203.0.113.10",


### PR DESCRIPTION
## Summary

- remove the unused `get_original_url()` compatibility projection
- migrate authority URL coverage and firewall/AWS SigV4 test setup to `get_trusted_authority()`
- preserve typed host, port, URL, and rejection coverage while deleting the redundant wrapper-only rejection test

## Compatibility

- no production authority validation or request-classification behavior changes
- no schema, persisted data, HTTP API, queue payload, or runner protocol changes
- no rollout ordering requirement because each runner embeds its own addon source
- no replacement alias or duplicate URL reconstruction helper

## Validation

- `uv run --no-sync python -m pytest tests/test_url_utils_trusted_authority.py tests/test_url_utils_trusted_authority_rejection.py tests/test_request_handler_authority_validation.py tests/test_firewall_auth.py tests/test_firewall_aws_sigv4_auth.py` (407 passed)
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4295 passed)

Closes #23294
