### PR TITLE
refactor(api): require public connector form field ids

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -28,7 +28,7 @@ setup_file() {
     # connector-aware path as the frontend's "Add Connection" dialog.
     connect_e2e_connector \
         "discord-webhook" \
-        '{"DISCORD_WEBHOOK_URL":"https://discord.com/api/webhooks/1234567890/fake-token-for-e2e"}'
+        '{"url":"https://discord.com/api/webhooks/1234567890/fake-token-for-e2e"}'
 }
 
 teardown_file() {

--- a/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
+++ b/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
@@ -28,9 +28,9 @@ setup_file() {
         "$(jq -nc \
             --arg subdomain "$TEST_SUBDOMAIN" \
             '{
-                ZENDESK_API_TOKEN: "fake-zendesk-token-for-e2e",
-                ZENDESK_SUBDOMAIN: $subdomain,
-                ZENDESK_EMAIL: "e2e@test.vm0.ai"
+                apiToken: "fake-zendesk-token-for-e2e",
+                subdomain: $subdomain,
+                email: "e2e@test.vm0.ai"
             }')"
 
     # Create artifact

--- a/e2e/tests/03-runner/t51-firewall-auth-query.bats
+++ b/e2e/tests/03-runner/t51-firewall-auth-query.bats
@@ -26,7 +26,7 @@ setup_file() {
     # Set up serpapi connector — api-token auth, single secret.
     connect_e2e_connector \
         "serpapi" \
-        '{"SERPAPI_TOKEN":"fake-serpapi-token-for-e2e"}'
+        '{"apiKey":"fake-serpapi-token-for-e2e"}'
 
     # Create artifact
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -122,7 +122,7 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
       actor,
       "openai",
       "api-token",
-      { OPENAI_TOKEN: "manual-agent-token" },
+      { apiKey: "manual-agent-token" },
       agent.agentId,
     );
 
@@ -140,33 +140,12 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
     });
 
     await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
-      OPENAI_TOKEN: "default-agent-token",
+      apiKey: "default-agent-token",
     });
 
     await expect(
       authOrgApi.readEnabledConnectorTypes(actor, body.agentId),
     ).resolves.toContain("openai");
-  });
-
-  it("keeps the previous manual-grant request shape connection-only during rollout", async () => {
-    const bdd = createBddApi(context);
-    const actor = bdd.user();
-    authOrgApi.acceptAgentStorageWrites();
-    const { body } = await authOrgApi.bootstrapLimitedFreeOnboarding(actor, {
-      displayName: "Legacy Connector Agent",
-    });
-
-    const response = await connectorsApi.requestManualGrant(
-      actor,
-      "openai",
-      "api-token",
-      { OPENAI_TOKEN: "legacy-client-token" },
-      { statuses: [200] },
-    );
-    expect(response.status).toBe(200);
-    await expect(
-      authOrgApi.readEnabledConnectorTypes(actor, body.agentId),
-    ).resolves.not.toContain("openai");
   });
 
   it("discovers, connects, reads, computes scope diff, and deletes a manual connector through APIs", async () => {
@@ -212,20 +191,21 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
       "openai",
       "api-token",
       {
-        OPENAI_TOKEN: "sk-bdd-manual-secret",
-        EXTRA_TOKEN: "secret-value-should-not-echo",
+        apiKey: "sk-bdd-manual-secret",
+        unknownField: "secret-value-should-not-echo",
       },
       { statuses: [400] },
     );
     expectApiError(badGrant.body);
-    expect(badGrant.body.error.message).toContain("EXTRA_TOKEN");
+    expect(badGrant.body.error.message).toContain("apiKey");
+    expect(badGrant.body.error.message).not.toContain("unknownField");
     expectNoVisibleSecret(badGrant.body, "secret-value-should-not-echo");
 
     const connected = await connectorsApi.connectManualGrant(
       actor,
       "openai",
       "api-token",
-      { OPENAI_TOKEN: " sk-bdd-manual-secret\n" },
+      { apiKey: " sk-bdd-manual-secret\n" },
     );
     expect(typeof connected.id).toBe("string");
     expectNoVisibleSecret(connected, "sk-bdd-manual-secret");
@@ -783,24 +763,24 @@ describe("CONN-02: OAuth device authorization", () => {
       actor,
       "test-oauth-device",
       "api",
-      { mode: "production" },
+      { environment: "production" },
       [400],
     );
     expectApiError(invalidOptionValue.body);
     expect(invalidOptionValue.body.error.message).toBe(
-      "test-oauth-device api device-auth start option mode must be one of: test, live",
+      "test-oauth-device api device-auth start option environment must be one of: test, live",
     );
 
-    const unexpectedOptionKey = await connectorsApi.requestDeviceAuthStart(
+    const privateOptionKey = await connectorsApi.requestDeviceAuthStart(
       actor,
       "test-oauth-device",
       "api",
-      { region: "us" },
+      { mode: "live" },
       [400],
     );
-    expectApiError(unexpectedOptionKey.body);
-    expect(unexpectedOptionKey.body.error.message).toBe(
-      "test-oauth-device api device-auth start option region is not supported",
+    expectApiError(privateOptionKey.body);
+    expect(privateOptionKey.body.error.message).toBe(
+      "test-oauth-device api device-auth start option(s) must use public IDs: environment",
     );
 
     const prototypeOptionKey = await connectorsApi.requestDeviceAuthStart(
@@ -812,7 +792,7 @@ describe("CONN-02: OAuth device authorization", () => {
     );
     expectApiError(prototypeOptionKey.body);
     expect(prototypeOptionKey.body.error.message).toBe(
-      "test-oauth-device api device-auth start option toString is not supported",
+      "test-oauth-device api device-auth start option(s) must use public IDs: environment",
     );
 
     const stripeDeviceAuth = await connectorsApi.requestDeviceAuthStart(
@@ -867,7 +847,7 @@ describe("CONN-02: OAuth device authorization", () => {
     });
 
     await connectorsApi.startDeviceAuth(actor, "test-oauth-device", "api", {
-      mode: "live",
+      environment: "live",
     });
     expect(provider.deviceCodeBodies[0]?.get("client_id")).toBe(
       "test-oauth-device-api-client",
@@ -2609,9 +2589,9 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     const state = stateFromAuthorizationUrl(start.authorizationUrl);
 
     await connectorsApi.connectManualGrant(actor, "test-oauth", "api-token", {
-      TEST_OAUTH_TOKEN: "bdd-manual-test-oauth-token",
-      TEST_OAUTH_API_TOKEN_INPUT_VAR: "bdd-input-variable",
-      TEST_OAUTH_API_TENANT_ID: "bdd-manual-tenant",
+      apiToken: "bdd-manual-test-oauth-token",
+      inputVariable: "bdd-input-variable",
+      tenantId: "bdd-manual-tenant",
     });
     const manual = await connectorsApi.readConnectorByType(actor, "test-oauth");
     expect(manual.authMethod).toBe("api-token");

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -3036,7 +3036,7 @@ describe("connector catalog valid lifecycle", () => {
   }, 30_000);
 
   it("executes an external device grant with catalog-owned storage", async () => {
-    mockTestOAuthDeviceConnectorProvider();
+    const provider = mockTestOAuthDeviceConnectorProvider();
     configureSource();
     const release = buildRelease({
       version: "2026-07-15.external-device-grant",
@@ -3044,20 +3044,36 @@ describe("connector catalog valid lifecycle", () => {
       label: "Catalog Device OAuth",
       mutateCatalog: (artifact) => {
         const method = publicAuthMethod({
-          id: "oauth",
+          id: "api",
           grantKind: "device-auth",
         });
         method.featureSwitch = "testOauthConnector";
+        method.startOptions = [
+          {
+            id: "environment",
+            kind: "select",
+            label: "Environment",
+            required: true,
+            defaultValue: null,
+            options: [
+              { value: "test", label: "Test" },
+              { value: "live", label: "Live" },
+            ],
+          },
+        ];
         setArtifactAuthMethods(artifact, [method]);
       },
       mutateRuntime: (artifact) => {
-        setArtifactAuthMethods(artifact, [
-          devicePrivateAuthMethod({
-            accessTokenName: "CATALOG_DEVICE_ACCESS_TOKEN",
-            clientId: "test-oauth-device-client",
-            scopes: ["read"],
-          }),
-        ]);
+        const method = devicePrivateAuthMethod({
+          accessTokenName: "CATALOG_DEVICE_ACCESS_TOKEN",
+          clientId: "test-oauth-device-api-client",
+          scopes: ["read"],
+        });
+        method.id = "api";
+        recordValue(method.grant, "device grant").startOptionMappings = [
+          { privateName: "mode", publicId: "environment" },
+        ];
+        setArtifactAuthMethods(artifact, [method]);
       },
     });
     serveObjects(catalogObjects([release], release));
@@ -3073,11 +3089,25 @@ describe("connector catalog valid lifecycle", () => {
       await connectorsApi.deleteFeatureSwitches(actor);
     });
     const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const missingOption = await connectorsApi.requestDeviceAuthStart(
+      actor,
+      "test-oauth-device",
+      "api",
+      undefined,
+      [400],
+    );
+    expectApiError(missingOption.body);
+    expect(missingOption.body.error.message).toBe(
+      "test-oauth-device api device-auth start option environment is required",
+    );
+
     const session = await connectorsApi.startDeviceAuth(
       actor,
       "test-oauth-device",
-      "oauth",
+      "api",
+      { environment: "live" },
     );
+    expect(provider.deviceCodeBodies[0]?.get("mode")).toBe("live");
     await connectorsApi.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.TestOauthConnector]: false,
     });
@@ -3095,7 +3125,7 @@ describe("connector catalog valid lifecycle", () => {
     }
     expect(completed.connector).toMatchObject({
       type: "test-oauth-device",
-      authMethod: "oauth",
+      authMethod: "api",
       oauthScopes: ["read"],
     });
     zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5705,8 +5705,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.grantProEntitlement(actor);
 
     await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      GITLAB_TOKEN: "glpat-stored-token",
-      GITLAB_HOST: "gitlab.example.com",
+      accessToken: "glpat-stored-token",
+      host: "gitlab.example.com",
     });
     const composeName = `bdd-compose-overrides-connector-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
@@ -5956,7 +5956,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      GITLAB_TOKEN: "glpat-bdd",
+      accessToken: "glpat-bdd",
     });
     await api.enableAgentConnectors(actor, agentId, ["gitlab"]);
 
@@ -5977,8 +5977,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 
     // Reconnecting with the optional variable threads it into the next run.
     await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      GITLAB_TOKEN: "glpat-bdd",
-      GITLAB_HOST: "gitlab.example.com",
+      accessToken: "glpat-bdd",
+      host: "gitlab.example.com",
     });
     const withHost = await api.createRun(actor, {
       agentId,
@@ -6018,10 +6018,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       refreshToken: "x-bdd-lazy-refresh",
     });
     await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      GITLAB_TOKEN: "glpat-bdd-parallel",
+      accessToken: "glpat-bdd-parallel",
     });
     await connectors.connectManualGrant(actor, "figma", "api-token", {
-      FIGMA_TOKEN: "figd_bdd-parallel",
+      accessToken: "figd_bdd-parallel",
     });
     await api.enableAgentConnectors(actor, agentId, ["x", "gitlab", "figma"]);
 
@@ -6049,7 +6049,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await connectors.connectManualGrant(actor, "figma", "api-token", {
-      FIGMA_TOKEN: "figd_bdd",
+      accessToken: "figd_bdd",
     });
     await api.enableAgentConnectors(actor, agentId, ["figma"]);
 
@@ -6109,8 +6109,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await connectors.connectManualGrant(actor, "lark", "api-token", {
-      LARK_APP_ID: "lark-app-id",
-      LARK_APP_SECRET: "lark-app-secret",
+      appId: "lark-app-id",
+      appSecret: "lark-app-secret",
     });
     await api.enableAgentConnectors(actor, agentId, ["lark"]);
 
@@ -7108,9 +7108,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await connectors.connectManualGrant(actor, "zendesk", "api-token", {
-      ZENDESK_API_TOKEN: "zendesk-token-bdd",
-      ZENDESK_EMAIL: "connector@example.com",
-      ZENDESK_SUBDOMAIN: "münich",
+      apiToken: "zendesk-token-bdd",
+      email: "connector@example.com",
+      subdomain: "münich",
     });
     await api.enableAgentConnectors(actor, agentId, ["zendesk"]);
     await authOrg.setVariable(actor, {
@@ -7163,9 +7163,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const { actor, agentId } = await entitledRunActor();
 
     await connectors.connectManualGrant(actor, "jira", "api-token", {
-      JIRA_API_TOKEN: "jira-token-bdd",
-      JIRA_DOMAIN: "attacker.example",
-      JIRA_EMAIL: "connector@example.com",
+      apiToken: "jira-token-bdd",
+      domain: "attacker.example",
+      email: "connector@example.com",
     });
     await api.enableAgentConnectors(actor, agentId, ["jira"]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -1322,8 +1322,8 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const connectorsApi = createConnectorBddApi(context);
     const { actor, headers } = await firewallRun();
     await connectorsApi.connectManualGrant(actor, "lark", "api-token", {
-      LARK_APP_ID: "lark-app-id",
-      LARK_APP_SECRET: "lark-app-secret",
+      appId: "lark-app-id",
+      appSecret: "lark-app-secret",
     });
     server.use(
       http.post(
@@ -1424,9 +1424,9 @@ describe("FW-6: manual-grant api-token refresh without a provider client", () =>
       [FeatureSwitchKey.TestOauthConnector]: true,
     });
     await connectorsApi.connectManualGrant(actor, "test-oauth", "api-token", {
-      TEST_OAUTH_TOKEN: "manual-secret",
-      TEST_OAUTH_API_TOKEN_INPUT_VAR: "manual-var",
-      TEST_OAUTH_API_TENANT_ID: "tenant-x",
+      apiToken: "manual-secret",
+      inputVariable: "manual-var",
+      tenantId: "tenant-x",
     });
 
     const before = Math.floor(now() / 1000);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -4428,7 +4428,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const granted = await runs.grantProEntitlement(actor);
     await runs.ensureOrgModelProvider(actor);
     await connectors.connectManualGrant(actor, "openai", "api-token", {
-      OPENAI_TOKEN: "org-teardown-connector-token",
+      apiKey: "org-teardown-connector-token",
     });
     const agent = await bdd.createAgent(actor, {
       displayName: "BDD Org Teardown Agent",
@@ -4785,7 +4785,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     await runs.grantProEntitlement(doomed);
     await runs.ensureOrgModelProvider(doomed);
     await connectors.connectManualGrant(doomed, "openai", "api-token", {
-      OPENAI_TOKEN: "user-teardown-connector-token",
+      apiKey: "user-teardown-connector-token",
     });
     const peer = bdd.user({ orgId: doomed.orgId, orgRole: "org:member" });
     const sharedAgent = await bdd.createAgent(peer, {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -844,7 +844,7 @@ describe("GET /api/zero/connector-catalog", () => {
     });
     expect(apiMethod?.startOptions).toStrictEqual([
       {
-        id: "mode",
+        id: "environment",
         kind: "select",
         label: "Mode",
         required: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-delete.test.ts
@@ -46,7 +46,7 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
       params: { type: "openai" },
       body: {
         authMethod: "api-token",
-        values: { OPENAI_TOKEN: "sk-test-token" },
+        values: { apiKey: "sk-test-token" },
       },
       headers: authHeaders(),
     }),
@@ -62,8 +62,8 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
       body: {
         authMethod: "api-token",
         values: {
-          GITLAB_TOKEN: "gl-test-token",
-          GITLAB_HOST: "gitlab.example.com",
+          accessToken: "gl-test-token",
+          host: "gitlab.example.com",
         },
       },
       headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-type-get.test.ts
@@ -56,7 +56,7 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
       params: { type: "openai" },
       body: {
         authMethod: "api-token",
-        values: { OPENAI_TOKEN: "sk-test-token" },
+        values: { apiKey: "sk-test-token" },
       },
       headers: authHeaders(),
     }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -40,8 +40,8 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
       body: {
         authMethod: "api-token",
         values: {
-          GITLAB_TOKEN: "gl-test-token",
-          GITLAB_HOST: "gitlab.example.com",
+          accessToken: "gl-test-token",
+          host: "gitlab.example.com",
         },
       },
       headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
@@ -136,7 +136,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { type: "openai" },
-        body: { authMethod: "api-token", values: { OPENAI_TOKEN: "sk-test" } },
+        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: {},
       }),
       [401],
@@ -152,7 +152,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { type: "openai" },
-        body: { authMethod: "api-token", values: { OPENAI_TOKEN: "sk-test" } },
+        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [401],
@@ -173,7 +173,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
           authorization: "Bearer clerk-session",
           "content-type": "application/json",
         },
-        body: JSON.stringify({ values: { OPENAI_TOKEN: "sk-test" } }),
+        body: JSON.stringify({ values: { apiKey: "sk-test" } }),
       },
     );
 
@@ -238,7 +238,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         params: { type: "openai" },
         body: {
           authMethod: "api-token",
-          values: { OPENAI_TOKEN: " sk-test\n" },
+          values: { apiKey: " sk-test\n" },
         },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -260,35 +260,6 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     });
   });
 
-  it("connects a first-time manual grant connector using public field ids", async () => {
-    const fixture = await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "openai" },
-        body: {
-          authMethod: "api-token",
-          values: { apiKey: " sk-test\n" },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toMatchObject({
-      type: "openai",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-    });
-    const stored = await readConnector(fixture, "openai");
-    expect(stored.body).toMatchObject({
-      type: "openai",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-    });
-  });
-
   it("connects Zendesk manual grant fields through the API", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
@@ -299,9 +270,9 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            ZENDESK_API_TOKEN: " zendesk\n-token ",
-            ZENDESK_EMAIL: " support@example.com ",
-            ZENDESK_SUBDOMAIN: " example ",
+            apiToken: " zendesk\n-token ",
+            email: " support@example.com ",
+            subdomain: " example ",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -350,9 +321,9 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            ZENDESK_API_TOKEN: "zendesk-token",
-            ZENDESK_EMAIL: "support@example.com",
-            ZENDESK_SUBDOMAIN: "example",
+            apiToken: "zendesk-token",
+            email: "support@example.com",
+            subdomain: "example",
           },
         },
         headers: authHeaders(),
@@ -404,7 +375,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         },
         body: JSON.stringify({
           authMethod: "api-token",
-          values: { OPENAI_TOKEN: "replacement" },
+          values: { apiKey: "replacement" },
         }),
       },
     );
@@ -442,64 +413,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     });
   });
 
-  it("connects Zendesk manual grant fields using public field ids", async () => {
-    const fixture = await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "zendesk" },
-        body: {
-          authMethod: "api-token",
-          values: {
-            apiToken: " zendesk\n-token ",
-            email: " support@example.com ",
-            subdomain: " example ",
-          },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toMatchObject({
-      type: "zendesk",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-    });
-    const stored = await readConnector(fixture, "zendesk");
-    expect(stored.body.authMethod).toBe("api-token");
-  });
-
-  it("accepts a full URL host field for manual grant connectors", async () => {
-    const fixture = await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "insforge" },
-        body: {
-          authMethod: "api-token",
-          values: {
-            INSFORGE_API_KEY: "ik_test-key",
-            INSFORGE_DOMAIN: "https://9ksx253h.us-west.insforge.app/api/",
-          },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toMatchObject({
-      type: "insforge",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-    });
-    const stored = await readConnector(fixture, "insforge");
-    expect(stored.body.authMethod).toBe("api-token");
-  });
-
-  it("normalizes host fields submitted with public field ids", async () => {
+  it("normalizes a full URL host field for manual grant connectors", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
@@ -528,36 +442,6 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
   });
 
   it("connects Lark app credentials through the API", async () => {
-    const fixture = await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "lark" },
-        body: {
-          authMethod: "api-token",
-          values: {
-            LARK_APP_ID: " cli_a123 ",
-            LARK_APP_SECRET: " lark-app-secret\n",
-          },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toMatchObject({
-      type: "lark",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-      reconnectReason: null,
-      tokenExpiresAt: null,
-    });
-    const stored = await readConnector(fixture, "lark");
-    expect(stored.body.connectionStatus).toBe("connected");
-  });
-
-  it("connects Lark secret and variable fields using public field ids", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
@@ -596,8 +480,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            LARK_APP_ID: "cli_old",
-            LARK_APP_SECRET: "old-lark-app-secret",
+            appId: "cli_old",
+            appSecret: "old-lark-app-secret",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -611,8 +495,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            LARK_APP_ID: "cli_new",
-            LARK_APP_SECRET: "new-lark-app-secret",
+            appId: "cli_new",
+            appSecret: "new-lark-app-secret",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -641,9 +525,9 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            TEST_OAUTH_TOKEN: "old-manual-test-oauth-token",
-            TEST_OAUTH_API_TOKEN_INPUT_VAR: "old-input-variable",
-            TEST_OAUTH_API_TENANT_ID: "old-tenant",
+            apiToken: "old-manual-test-oauth-token",
+            inputVariable: "old-input-variable",
+            tenantId: "old-tenant",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -657,9 +541,9 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            TEST_OAUTH_TOKEN: "manual-test-oauth-token",
-            TEST_OAUTH_API_TOKEN_INPUT_VAR: "manual-input-variable",
-            TEST_OAUTH_API_TENANT_ID: "manual-tenant",
+            apiToken: "manual-test-oauth-token",
+            inputVariable: "manual-input-variable",
+            tenantId: "manual-tenant",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -672,44 +556,6 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
   });
 
   it("replaces GitLab manual grant when optional fields are omitted", async () => {
-    const fixture = await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-    await accept(
-      client.connect({
-        params: { type: "gitlab" },
-        body: {
-          authMethod: "api-token",
-          values: {
-            GITLAB_TOKEN: "old-token",
-            GITLAB_HOST: "gitlab.example.com",
-          },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    await accept(
-      client.connect({
-        params: { type: "gitlab" },
-        body: {
-          authMethod: "api-token",
-          values: { GITLAB_TOKEN: "new-token" },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    const stored = await readConnector(fixture, "gitlab");
-    expect(stored.body).toMatchObject({
-      type: "gitlab",
-      authMethod: "api-token",
-      connectionStatus: "connected",
-    });
-  });
-
-  it("replaces GitLab manual grant using public field ids when optional fields are omitted", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     await accept(
@@ -747,7 +593,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     });
   });
 
-  it("rejects ambiguous public and legacy keys for the same field", async () => {
+  it("rejects private field names and identifies the public field id", async () => {
     await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
@@ -756,10 +602,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         params: { type: "openai" },
         body: {
           authMethod: "api-token",
-          values: {
-            apiKey: "sk-public",
-            OPENAI_TOKEN: "sk-legacy",
-          },
+          values: { OPENAI_TOKEN: "sk-private" },
         },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -767,33 +610,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     );
 
     expect(response.body.error.message).toContain("apiKey");
-    expect(response.body.error.message).not.toContain("sk-public");
-    expect(response.body.error.message).not.toContain("sk-legacy");
-  });
-
-  it("rejects unknown fields without echoing submitted values", async () => {
-    await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "openai" },
-        body: {
-          authMethod: "api-token",
-          values: {
-            OPENAI_TOKEN: "sk-test",
-            EXTRA_TOKEN: "secret-value-should-not-echo",
-          },
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [400],
-    );
-
-    expect(response.body.error.message).toContain("EXTRA_TOKEN");
-    expect(response.body.error.message).not.toContain(
-      "secret-value-should-not-echo",
-    );
+    expect(response.body.error.message).not.toContain("OPENAI_TOKEN");
+    expect(response.body.error.message).not.toContain("sk-private");
   });
 
   it("rejects unknown public fields without echoing submitted values", async () => {
@@ -815,7 +633,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
       [400],
     );
 
-    expect(response.body.error.message).toContain("unknownField");
+    expect(response.body.error.message).toContain("apiKey");
+    expect(response.body.error.message).not.toContain("unknownField");
     expect(response.body.error.message).not.toContain(
       "secret-value-should-not-echo",
     );
@@ -834,26 +653,11 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
       [400],
     );
 
-    expect(response.body.error.message).toContain("OPENAI_TOKEN");
+    expect(response.body.error.message).toContain("apiKey");
+    expect(response.body.error.message).not.toContain("OPENAI_TOKEN");
   });
 
-  it("rejects required fields that sanitize to empty", async () => {
-    await seedFixture();
-    const client = setupApp({ context })(zeroConnectorManualGrantContract);
-
-    const response = await accept(
-      client.connect({
-        params: { type: "openai" },
-        body: { authMethod: "api-token", values: { OPENAI_TOKEN: " \n\t " } },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [400],
-    );
-
-    expect(response.body.error.message).toContain("OPENAI_TOKEN");
-  });
-
-  it("rejects public required fields that sanitize to empty without private field names", async () => {
+  it("rejects required fields that sanitize to empty without private field names", async () => {
     await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
@@ -895,7 +699,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { type: "stripe" },
-        body: { authMethod: "oauth", values: { STRIPE_TOKEN: "sk_test_key" } },
+        body: { authMethod: "oauth", values: { apiKey: "sk_test_key" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -916,8 +720,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            BENTO_CLOUD_API_KEY: "bento-token",
-            BENTO_CLOUD_API_ENDPOINT: "https://example.bentoml.test",
+            apiToken: "bento-token",
+            endpoint: "https://example.bentoml.test",
           },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -959,7 +763,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     await accept(
       client.connect({
         params: { type: "openai" },
-        body: { authMethod: "api-token", values: { OPENAI_TOKEN: "sk-test" } },
+        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -985,8 +789,8 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         body: {
           authMethod: "api-token",
           values: {
-            BENTO_CLOUD_API_KEY: "bento-token",
-            BENTO_CLOUD_API_ENDPOINT: "https://example.bentoml.test",
+            apiToken: "bento-token",
+            endpoint: "https://example.bentoml.test",
           },
         },
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -126,7 +126,7 @@ describe("GET /api/zero/connectors/:type/scope-diff", () => {
   it("returns an empty diff for manual auth connectors", async () => {
     const actor = bdd.user();
     await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
-      OPENAI_TOKEN: "sk-bdd-scope-diff",
+      apiKey: "sk-bdd-scope-diff",
     });
 
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -290,10 +290,10 @@ describe("zero workflows", () => {
     });
 
     await connectManualGrant(viewer, "runtime", "api-token", {
-      RUNTIME_API_KEY: "runtime-readiness-test",
+      apiKey: "runtime-readiness-test",
     });
     await connectManualGrant(viewer, "gitlab", "api-token", {
-      GITLAB_TOKEN: "gitlab-readiness-test",
+      accessToken: "gitlab-readiness-test",
     });
     await api.enableAgentConnectors(viewer, agent.agentId, ["gitlab"]);
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -3,14 +3,12 @@ import type {
   ConnectorDeviceAuthStartOptionConfig,
   ConnectorDeviceAuthStartOptions,
   ConnectorDeviceAuthStartOptionsConfig,
-  ConnectorManualGrantFieldConfig,
 } from "@vm0/connectors/connector-config";
 import { parseConnectorDeviceAuthStartOptionsConfig } from "@vm0/connectors/connector-auth-method";
 
 interface PublicManualGrantFieldDescriptor {
   readonly publicId: string;
   readonly privateName: string;
-  readonly config: ConnectorManualGrantFieldConfig;
 }
 
 interface PublicDeviceAuthStartOptionDescriptor {
@@ -23,7 +21,7 @@ type ManualGrantSubmittedValuesNormalizationResult =
   | {
       readonly ok: true;
       readonly values: Readonly<Record<string, string>>;
-      readonly errorNamesByPrivateName: Readonly<Record<string, string>>;
+      readonly publicIdsByPrivateName: Readonly<Record<string, string>>;
     }
   | { readonly ok: false; readonly message: string };
 
@@ -34,7 +32,7 @@ type DeviceAuthStartOptionsNormalizationResult =
     }
   | { readonly ok: false; readonly message: string };
 
-function formatPublicFieldList(names: readonly string[]): string {
+function formatFieldList(names: readonly string[]): string {
   return [...names].sort().join(", ");
 }
 
@@ -48,7 +46,6 @@ function publicManualGrantFieldDescriptors(
     return {
       publicId: config.publicId,
       privateName,
-      config,
     };
   });
 }
@@ -107,64 +104,26 @@ function normalizeManualGrantSubmittedValuesFromDescriptors(args: {
       return [descriptor.publicId, descriptor];
     }),
   );
-  const descriptorByPrivateName = new Map(
-    descriptors.map((descriptor) => {
-      return [descriptor.privateName, descriptor];
-    }),
-  );
   const normalizedValues = new Map<string, string>();
-  const seenPrivateNames = new Set<string>();
   const unknownNames: string[] = [];
-  const ambiguousPublicNames: string[] = [];
-  let usesPublicIds = false;
 
   for (const [submittedName, value] of Object.entries(args.values)) {
-    const publicDescriptor = descriptorByPublicId.get(submittedName);
-    const legacyDescriptor = descriptorByPrivateName.get(submittedName);
-    const descriptor = publicDescriptor ?? legacyDescriptor;
-
+    const descriptor = descriptorByPublicId.get(submittedName);
     if (!descriptor) {
       unknownNames.push(submittedName);
       continue;
     }
 
-    if (
-      publicDescriptor &&
-      legacyDescriptor &&
-      publicDescriptor.privateName !== legacyDescriptor.privateName
-    ) {
-      usesPublicIds = true;
-      ambiguousPublicNames.push(publicDescriptor.publicId);
-      continue;
-    }
-
-    if (publicDescriptor) {
-      usesPublicIds = true;
-    }
-
-    if (seenPrivateNames.has(descriptor.privateName)) {
-      ambiguousPublicNames.push(descriptor.publicId);
-      continue;
-    }
-
-    seenPrivateNames.add(descriptor.privateName);
     normalizedValues.set(descriptor.privateName, value);
   }
 
   if (unknownNames.length > 0) {
     return {
       ok: false,
-      message: `Unknown manual grant field(s): ${formatPublicFieldList(
-        unknownNames,
-      )}`,
-    };
-  }
-
-  if (ambiguousPublicNames.length > 0) {
-    return {
-      ok: false,
-      message: `Ambiguous manual grant field(s): ${formatPublicFieldList(
-        ambiguousPublicNames,
+      message: `Unknown manual grant field(s). Expected: ${formatFieldList(
+        descriptors.map((descriptor) => {
+          return descriptor.publicId;
+        }),
       )}`,
     };
   }
@@ -172,12 +131,9 @@ function normalizeManualGrantSubmittedValuesFromDescriptors(args: {
   return {
     ok: true,
     values: Object.fromEntries(normalizedValues),
-    errorNamesByPrivateName: Object.fromEntries(
+    publicIdsByPrivateName: Object.fromEntries(
       descriptors.map((descriptor) => {
-        return [
-          descriptor.privateName,
-          usesPublicIds ? descriptor.publicId : descriptor.privateName,
-        ];
+        return [descriptor.privateName, descriptor.publicId];
       }),
     ),
   };
@@ -189,9 +145,6 @@ export function normalizeDeviceAuthStartOptionsWithMethod(args: {
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly options: ConnectorDeviceAuthStartOptions | undefined;
 }): DeviceAuthStartOptionsNormalizationResult {
-  if (!args.options) {
-    return { ok: true, options: undefined };
-  }
   const descriptors =
     args.method.grant.kind === "device-auth"
       ? publicDeviceAuthStartOptionDescriptors(args.method.grant)
@@ -200,10 +153,6 @@ export function normalizeDeviceAuthStartOptionsWithMethod(args: {
     authMethodId: args.authMethodId,
     connectorRef: args.connectorRef,
     descriptors,
-    startOptions:
-      args.method.grant.kind === "device-auth"
-        ? args.method.grant.startOptions
-        : undefined,
     options: args.options,
   });
 }
@@ -213,7 +162,6 @@ function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
   readonly connectorRef: string;
   readonly descriptors: readonly PublicDeviceAuthStartOptionDescriptor[] | null;
   readonly options: ConnectorDeviceAuthStartOptions | undefined;
-  readonly startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined;
 }): DeviceAuthStartOptionsNormalizationResult {
   if (!args.options) {
     return { ok: true, options: undefined };
@@ -226,53 +174,22 @@ function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
     };
   }
 
-  const descriptorByPublicId = new Map(
-    descriptors.map((descriptor) => {
-      return [descriptor.publicId, descriptor];
-    }),
-  );
-  const descriptorByPrivateName = new Map(
-    descriptors.map((descriptor) => {
-      return [descriptor.privateName, descriptor];
-    }),
-  );
-  const normalizedOptions = new Map<string, string>();
-  const seenPrivateNames = new Set<string>();
-  const ambiguousPublicNames: string[] = [];
-
-  for (const [submittedName, value] of Object.entries(args.options)) {
-    const publicDescriptor = descriptorByPublicId.get(submittedName);
-    const legacyDescriptor = descriptorByPrivateName.get(submittedName);
-    const descriptor = publicDescriptor ?? legacyDescriptor;
-
-    if (!descriptor) {
-      normalizedOptions.set(submittedName, value);
-      continue;
-    }
-
-    if (
-      publicDescriptor &&
-      legacyDescriptor &&
-      publicDescriptor.privateName !== legacyDescriptor.privateName
-    ) {
-      ambiguousPublicNames.push(publicDescriptor.publicId);
-      continue;
-    }
-
-    if (seenPrivateNames.has(descriptor.privateName)) {
-      ambiguousPublicNames.push(descriptor.publicId);
-      continue;
-    }
-
-    seenPrivateNames.add(descriptor.privateName);
-    normalizedOptions.set(descriptor.privateName, value);
-  }
-
-  if (ambiguousPublicNames.length > 0) {
+  const startOptionsByPublicId: ConnectorDeviceAuthStartOptionsConfig =
+    Object.fromEntries(
+      descriptors.map((descriptor) => {
+        return [descriptor.publicId, descriptor.config];
+      }),
+    );
+  const hasUnknownName = Object.keys(args.options).some((name) => {
+    return !Object.hasOwn(startOptionsByPublicId, name);
+  });
+  if (hasUnknownName && descriptors.length > 0) {
     return {
       ok: false,
-      message: `Ambiguous device-auth start option(s): ${formatPublicFieldList(
-        ambiguousPublicNames,
+      message: `${args.connectorRef} ${args.authMethodId} device-auth start option(s) must use public IDs: ${formatFieldList(
+        descriptors.map((descriptor) => {
+          return descriptor.publicId;
+        }),
       )}`,
     };
   }
@@ -280,10 +197,19 @@ function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
   const parsed = parseConnectorDeviceAuthStartOptionsConfig({
     connectorRef: args.connectorRef,
     authMethodId: args.authMethodId,
-    startOptions: args.startOptions,
-    options: Object.fromEntries(normalizedOptions),
+    startOptions: startOptionsByPublicId,
+    options: args.options,
   });
-  return parsed.success
-    ? { ok: true, options: parsed.options }
-    : { ok: false, message: parsed.message };
+  if (!parsed.success) {
+    return { ok: false, message: parsed.message };
+  }
+
+  const normalizedOptions: Record<string, string> = {};
+  for (const descriptor of descriptors) {
+    const value = parsed.options[descriptor.publicId];
+    if (value !== undefined) {
+      normalizedOptions[descriptor.privateName] = value;
+    }
+  }
+  return { ok: true, options: normalizedOptions };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -27,7 +27,7 @@ type ManualGrantSubmittedValuesNormalizationResult =
 type DeviceAuthStartOptionsNormalizationResult =
   | {
       readonly ok: true;
-      readonly options: ConnectorDeviceAuthStartOptions | undefined;
+      readonly options: ConnectorDeviceAuthStartOptions;
     }
   | { readonly ok: false; readonly message: string };
 
@@ -157,9 +157,6 @@ function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
   readonly descriptors: readonly PublicDeviceAuthStartOptionDescriptor[] | null;
   readonly options: ConnectorDeviceAuthStartOptions | undefined;
 }): DeviceAuthStartOptionsNormalizationResult {
-  if (!args.options) {
-    return { ok: true, options: undefined };
-  }
   const descriptors = args.descriptors;
   if (!descriptors) {
     return {
@@ -174,7 +171,7 @@ function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
         return [descriptor.publicId, descriptor.config];
       }),
     );
-  const hasUnknownName = Object.keys(args.options).some((name) => {
+  const hasUnknownName = Object.keys(args.options ?? {}).some((name) => {
     return !Object.hasOwn(startOptionsByPublicId, name);
   });
   if (hasUnknownName && descriptors.length > 0) {

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -104,19 +104,19 @@ function normalizeManualGrantSubmittedValuesFromDescriptors(args: {
     }),
   );
   const normalizedValues = new Map<string, string>();
-  const unknownNames: string[] = [];
+  let hasUnknownName = false;
 
   for (const [submittedName, value] of Object.entries(args.values)) {
     const descriptor = descriptorByPublicId.get(submittedName);
     if (!descriptor) {
-      unknownNames.push(submittedName);
+      hasUnknownName = true;
       continue;
     }
 
     normalizedValues.set(descriptor.privateName, value);
   }
 
-  if (unknownNames.length > 0) {
+  if (hasUnknownName) {
     return {
       ok: false,
       message: `Unknown manual grant field(s). Expected: ${formatFieldList(

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -21,7 +21,6 @@ type ManualGrantSubmittedValuesNormalizationResult =
   | {
       readonly ok: true;
       readonly values: Readonly<Record<string, string>>;
-      readonly publicIdsByPrivateName: Readonly<Record<string, string>>;
     }
   | { readonly ok: false; readonly message: string };
 
@@ -131,11 +130,6 @@ function normalizeManualGrantSubmittedValuesFromDescriptors(args: {
   return {
     ok: true,
     values: Object.fromEntries(normalizedValues),
-    publicIdsByPrivateName: Object.fromEntries(
-      descriptors.map((descriptor) => {
-        return [descriptor.privateName, descriptor.publicId];
-      }),
-    ),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -932,7 +932,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       authMethodId: resolvedMethod.authMethodId,
       method: resolvedMethod.method,
       authClient: resolvedClient.authClient,
-      options: normalizedStartOptions.options ?? {},
+      options: normalizedStartOptions.options,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -343,9 +343,7 @@ function prepareManualGrantConnect(
         : sanitized;
     if (!value) {
       if (config.required) {
-        missingRequiredNames.push(
-          normalizedValuesResult.publicIdsByPrivateName[name] ?? name,
-        );
+        missingRequiredNames.push(config.publicId);
       }
       continue;
     }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -344,7 +344,7 @@ function prepareManualGrantConnect(
     if (!value) {
       if (config.required) {
         missingRequiredNames.push(
-          normalizedValuesResult.errorNamesByPrivateName[name] ?? name,
+          normalizedValuesResult.publicIdsByPrivateName[name] ?? name,
         );
       }
       continue;

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -431,10 +431,10 @@ function manualField(args: {
   };
 }
 
-function selectStartOption(): DeviceStartOption {
+function selectStartOption(publicId = "mode"): DeviceStartOption {
   return {
     privateName: "mode",
-    publicId: "mode",
+    publicId,
     kind: "select",
     label: "Mode",
     required: true,
@@ -1648,7 +1648,7 @@ const connectors = [
             "TEST_OAUTH_DEVICE_API_ACCESS_TOKEN",
           ),
         },
-        startOptions: [selectStartOption()],
+        startOptions: [selectStartOption("environment")],
       }),
     ],
   }),


### PR DESCRIPTION
## Summary

- accept only catalog-authored public IDs for manual-grant fields and device-auth start options
- map validated public IDs to the existing private credential and provider names inside the API
- remove private-name fallback, mixed-mode ambiguity handling, and legacy request-shape tests
- update API integration and runner E2E callers to use the final public request contract

## Compatibility

Current platform and CLI clients already submit public IDs. Persisted credentials and provider-facing
private names are unchanged. This PR does not change the connector catalog schema, database schema,
credential storage contract, provider contract, or client source.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run ...` (14 affected/shared-fixture files, 470 tests)
- focused self-review runs: manual grant (24 tests), device auth and catalog sync (130 tests)
- `pnpm knip`
- pre-commit workspace formatting, Knip, and type checking
- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t42-firewall-placeholder.bats e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats e2e/tests/03-runner/t51-firewall-auth-query.bats`
- `git diff --check`

Closes #23265

Parent context: vm0-ai/vm0-connectors#1
