### PR TITLE
fix(platform): keep chat sidebar resize events above iframes

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-sidebar-layout.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-sidebar-layout.ts
@@ -1,0 +1,101 @@
+import { command, computed, state } from "ccstate";
+
+import { localStorageSignals } from "../external/local-storage.ts";
+import { resetSignal } from "../utils.ts";
+
+// Smallest the sidebar may shrink to before its content stops being usable.
+export const CHAT_THREAD_SIDEBAR_MIN_WIDTH = 400;
+// Width the chat thread keeps so its composer never collapses.
+export const CHAT_THREAD_SIDEBAR_MIN_THREAD_WIDTH = 600;
+
+// Keep the existing storage key so previously saved artifact panel widths
+// continue to apply to the unified chat thread sidebar.
+const {
+  get$: chatThreadSidebarWidthRaw$,
+  set$: setChatThreadSidebarWidthRaw$,
+} = localStorageSignals("artifactPanelWidth");
+
+export const chatThreadSidebarWidth$ = computed<number | null>((get) => {
+  const raw = get(chatThreadSidebarWidthRaw$);
+  if (raw === null) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+});
+
+const setChatThreadSidebarWidth$ = command(({ set }, width: number) => {
+  set(setChatThreadSidebarWidthRaw$, String(Math.round(width)));
+});
+
+const internalChatThreadSidebarResizing$ = state(false);
+export const chatThreadSidebarResizing$ = computed((get) => {
+  return get(internalChatThreadSidebarResizing$);
+});
+
+const resetChatThreadSidebarResize$ = resetSignal();
+
+const chatThreadSidebarDragMaskEl$ = computed(() => {
+  const element = document.createElement("div");
+  element.dataset.chatThreadSidebarResizeMask = "";
+  element.setAttribute("aria-hidden", "true");
+  Object.assign(element.style, {
+    background: "transparent",
+    cursor: "col-resize",
+    inset: "0",
+    position: "fixed",
+    touchAction: "none",
+    userSelect: "none",
+    zIndex: "2147483647",
+  });
+  return element;
+});
+
+export const startChatThreadSidebarResize$ = command(
+  ({ get, set }, container: HTMLElement, pageSignal: AbortSignal): void => {
+    pageSignal.throwIfAborted();
+
+    const rect = container.getBoundingClientRect();
+    const maxWidth = Math.max(
+      CHAT_THREAD_SIDEBAR_MIN_WIDTH,
+      rect.width - CHAT_THREAD_SIDEBAR_MIN_THREAD_WIDTH,
+    );
+    const dragSignal = set(resetChatThreadSidebarResize$, pageSignal);
+    const dragMaskEl = get(chatThreadSidebarDragMaskEl$);
+
+    function resetResize(): void {
+      set(resetChatThreadSidebarResize$);
+    }
+
+    dragMaskEl.addEventListener(
+      "pointermove",
+      (event) => {
+        const nextWidth = Math.min(
+          Math.max(rect.right - event.clientX, CHAT_THREAD_SIDEBAR_MIN_WIDTH),
+          maxWidth,
+        );
+        set(setChatThreadSidebarWidth$, nextWidth);
+      },
+      { signal: dragSignal },
+    );
+    dragMaskEl.addEventListener("pointerup", resetResize, {
+      signal: dragSignal,
+    });
+    dragMaskEl.addEventListener("pointercancel", resetResize, {
+      signal: dragSignal,
+    });
+    window.addEventListener("blur", resetResize, { signal: dragSignal });
+
+    dragSignal.addEventListener(
+      "abort",
+      () => {
+        dragMaskEl.remove();
+        set(internalChatThreadSidebarResizing$, false);
+      },
+      { once: true },
+    );
+
+    document.body.append(dragMaskEl);
+    set(internalChatThreadSidebarResizing$, true);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -4,7 +4,6 @@ import {
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
-import { localStorageSignals } from "../external/local-storage.ts";
 import {
   classifyChatAttachment,
   previewAttachmentFromUrl,
@@ -304,45 +303,5 @@ export const openAudioLightboxOrArtifact$ = command(
 export const openDocumentLightboxOrArtifact$ = command(
   ({ set }, value: AttachmentDocumentLightboxInput) => {
     set(openDocumentLightboxModal$, value);
-  },
-);
-
-// ---------------------------------------------------------------------------
-// Artifact panel width — user-resizable split between the chat thread and the
-// artifact preview at xl+ breakpoints. Persisted in localStorage as a pixel
-// width; clamping against the live viewport happens at render via CSS clamp().
-// `null` means "never resized" and falls back to the responsive default.
-// ---------------------------------------------------------------------------
-
-// Smallest the preview may shrink to before content stops being usable.
-export const ARTIFACT_PANEL_MIN_WIDTH = 400;
-// Width the chat thread is guaranteed to keep so its composer never collapses.
-export const ARTIFACT_PANEL_MIN_THREAD_WIDTH = 600;
-
-const { get$: artifactPanelWidthRaw$, set$: setArtifactPanelWidthRaw$ } =
-  localStorageSignals("artifactPanelWidth");
-
-export const artifactPanelWidth$ = computed<number | null>((get) => {
-  const raw = get(artifactPanelWidthRaw$);
-  if (raw === null) {
-    return null;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isNaN(parsed) ? null : parsed;
-});
-
-export const setArtifactPanelWidth$ = command(({ set }, width: number) => {
-  set(setArtifactPanelWidthRaw$, String(Math.round(width)));
-});
-
-// True while the user is dragging the divider, so the panels can drop their
-// width transition and track the pointer without lag.
-const internalArtifactPanelResizing$ = state(false);
-export const artifactPanelResizing$ = computed((get) => {
-  return get(internalArtifactPanelResizing$);
-});
-export const setArtifactPanelResizing$ = command(
-  ({ set }, resizing: boolean) => {
-    set(internalArtifactPanelResizing$, resizing);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -25,9 +25,12 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import type { ZeroClientFactory } from "../../../signals/api-client.ts";
 import { syncArtifactFileToGoogleDrive } from "../../../signals/chat-page/artifact-google-drive-sync.ts";
+import {
+  chatThreadSidebarResizing$,
+  chatThreadSidebarWidth$,
+} from "../../../signals/chat-page/chat-thread-sidebar-layout.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { resetSignal } from "../../../signals/utils.ts";
-import { artifactPanelWidth$ } from "../../../signals/zero-page/zero-artifact-sidebar.ts";
 
 const context = testContext();
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
@@ -359,7 +362,7 @@ describe("zero artifact sidebar", () => {
     });
   });
 
-  it("resizes the artifact preview pane and persists the width", async () => {
+  it("resizes the sidebar through a document drag mask and resets each drag endpoint", async () => {
     const markdownUrl =
       "https://cdn.vm7.io/artifacts/test/run-1/release-notes.md";
     context.mocks.http.get(markdownUrl, () => {
@@ -378,7 +381,7 @@ describe("zero artifact sidebar", () => {
     });
 
     const resizeHandle = screen.getByRole("separator", {
-      name: "Resize preview panel",
+      name: "Resize sidebar",
     });
     const splitContainer = resizeHandle.parentElement;
     if (!splitContainer) {
@@ -402,33 +405,73 @@ describe("zero artifact sidebar", () => {
     };
 
     expect(
-      splitContainer.style.getPropertyValue("--artifact-panel-width"),
+      splitContainer.style.getPropertyValue("--chat-thread-sidebar-width"),
     ).toBe("min(760px, 48vw)");
 
     fireEvent.pointerDown(resizeHandle, { clientX: 760 });
 
-    const chatThread = screen.getByLabelText("Chat thread");
-    chatThread.focus();
-    chatThread.blur();
-    expect(document.body).toHaveFocus();
+    const dragMask = document.querySelector<HTMLElement>(
+      "[data-chat-thread-sidebar-resize-mask]",
+    );
+    expect(dragMask).not.toBeNull();
+    if (!dragMask) {
+      throw new Error("Chat thread sidebar drag mask not found");
+    }
+    expect(dragMask.parentElement).toBe(document.body);
+    expect(dragMask.style.position).toBe("fixed");
+    expect(dragMask.style.inset).toBe("0");
+    expect(dragMask.style.zIndex).toBe("2147483647");
+    expect(dragMask.style.cursor).toBe("col-resize");
+    expect(dragMask.style.userSelect).toBe("none");
+    expect(dragMask.style.touchAction).toBe("none");
+    expect(context.store.get(chatThreadSidebarResizing$)).toBeTruthy();
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
 
-    fireEvent.pointerMove(window, { clientX: 700 });
+    fireEvent.pointerMove(dragMask, { clientX: 700 });
 
     await waitFor(() => {
       expect(
-        splitContainer.style.getPropertyValue("--artifact-panel-width"),
+        splitContainer.style.getPropertyValue("--chat-thread-sidebar-width"),
       ).toBe("clamp(400px, 700px, calc(100% - 600px))");
-      expect(context.store.get(artifactPanelWidth$)).toBe(700);
+      expect(context.store.get(chatThreadSidebarWidth$)).toBe(700);
     });
-    expect(document.body).toHaveFocus();
-    expect(document.body.style.cursor).toBe("col-resize");
-    expect(document.body.style.userSelect).toBe("none");
 
-    fireEvent.pointerUp(window);
+    fireEvent.pointerUp(dragMask);
 
     await waitFor(() => {
-      expect(document.body.style.cursor).toBe("");
-      expect(document.body.style.userSelect).toBe("");
+      expect(
+        document.querySelector("[data-chat-thread-sidebar-resize-mask]"),
+      ).not.toBeInTheDocument();
+      expect(context.store.get(chatThreadSidebarResizing$)).toBeFalsy();
+    });
+
+    fireEvent.pointerDown(resizeHandle, { clientX: 700 });
+    const cancelMask = document.querySelector<HTMLElement>(
+      "[data-chat-thread-sidebar-resize-mask]",
+    );
+    if (!cancelMask) {
+      throw new Error("Chat thread sidebar cancel mask not found");
+    }
+    fireEvent.pointerCancel(cancelMask);
+
+    await waitFor(() => {
+      expect(cancelMask).not.toBeInTheDocument();
+      expect(context.store.get(chatThreadSidebarResizing$)).toBeFalsy();
+    });
+
+    fireEvent.pointerDown(resizeHandle, { clientX: 700 });
+    const blurMask = document.querySelector<HTMLElement>(
+      "[data-chat-thread-sidebar-resize-mask]",
+    );
+    if (!blurMask) {
+      throw new Error("Chat thread sidebar blur mask not found");
+    }
+    fireEvent(window, new Event("blur"));
+
+    await waitFor(() => {
+      expect(blurMask).not.toBeInTheDocument();
+      expect(context.store.get(chatThreadSidebarResizing$)).toBeFalsy();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
@@ -31,7 +31,7 @@ function chatThreadSidebarLayout(
   };
 }
 
-export function ChatThreadSidebarResizeHandle() {
+function ChatThreadSidebarResizeHandle() {
   const startResize = useSet(startChatThreadSidebarResize$);
   const pageSignal = useGet(pageSignal$);
 

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
@@ -1,0 +1,105 @@
+import type {
+  CSSProperties,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from "react";
+import { useGet, useSet } from "ccstate-react";
+import { cn } from "@vm0/ui";
+
+import {
+  CHAT_THREAD_SIDEBAR_MIN_THREAD_WIDTH,
+  CHAT_THREAD_SIDEBAR_MIN_WIDTH,
+  chatThreadSidebarResizing$,
+  chatThreadSidebarWidth$,
+  startChatThreadSidebarResize$,
+} from "../../signals/chat-page/chat-thread-sidebar-layout.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+
+function chatThreadSidebarLayout(
+  width: number | null,
+  resizing: boolean,
+): { style: CSSProperties; transition: string } {
+  const widthValue =
+    width === null
+      ? "min(760px, 48vw)"
+      : `clamp(${CHAT_THREAD_SIDEBAR_MIN_WIDTH}px, ${width}px, calc(100% - ${CHAT_THREAD_SIDEBAR_MIN_THREAD_WIDTH}px))`;
+  return {
+    style: { "--chat-thread-sidebar-width": widthValue } as CSSProperties,
+    transition: resizing
+      ? ""
+      : "transition-[flex-basis,width] duration-[240ms] ease",
+  };
+}
+
+export function ChatThreadSidebarResizeHandle() {
+  const startResize = useSet(startChatThreadSidebarResize$);
+  const pageSignal = useGet(pageSignal$);
+
+  function handlePointerDown(event: ReactPointerEvent<HTMLDivElement>): void {
+    const container = event.currentTarget.parentElement;
+    if (!container) {
+      return;
+    }
+    event.preventDefault();
+    startResize(container, pageSignal);
+  }
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      className="group relative hidden w-1 shrink-0 cursor-col-resize items-stretch justify-center xl:flex"
+      onPointerDown={handlePointerDown}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/60 transition-colors group-hover:bg-border"
+      />
+    </div>
+  );
+}
+
+export function ChatThreadSidebarShell({
+  children,
+  open,
+  sidebar,
+}: {
+  readonly children: ReactNode;
+  readonly open: boolean;
+  readonly sidebar: ReactNode;
+}) {
+  const { style, transition } = chatThreadSidebarLayout(
+    useGet(chatThreadSidebarWidth$),
+    useGet(chatThreadSidebarResizing$),
+  );
+
+  return (
+    // Keep this structure stable across sidebar open/close so the chat thread
+    // subtree and its scroll and keyboard state never unmount.
+    <div className="flex flex-1 min-h-0 bg-transparent" style={style}>
+      <div
+        className={cn(
+          "min-w-0 min-h-0",
+          transition,
+          open ? "hidden xl:flex flex-1 basis-0" : "flex flex-1",
+        )}
+      >
+        {children}
+      </div>
+      {open && <ChatThreadSidebarResizeHandle />}
+      <div
+        className={cn(
+          "flex min-h-0 min-w-0 overflow-hidden",
+          transition,
+          open
+            ? "flex-1 basis-0 xl:w-[var(--chat-thread-sidebar-width)] xl:flex-none xl:basis-[var(--chat-thread-sidebar-width)]"
+            : "pointer-events-none w-0 flex-none basis-0",
+        )}
+        aria-hidden={!open}
+      >
+        {sidebar}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -35,12 +35,12 @@ import { MailDraftSidebar } from "./mail-draft-sidebar.tsx";
 import { ArtifactSidebar } from "./zero-artifact-sidebar.tsx";
 
 // ---------------------------------------------------------------------------
-// Thread-owned utility sidebar shell (NewChatThreadSidebar feature switch).
+// Thread-owned utility sidebar content (NewChatThreadSidebar feature switch).
 //
-// One shell hosts the five mutually exclusive targets. The page wrapper in
-// ZeroChatThreadPage still owns width, resize, and the responsive split; this
-// module owns which body renders and routes Close/Back/fullscreen into the
-// owning thread's `sidebar` signals instead of legacy search params.
+// The outer ChatThreadSidebarShell owns width, resize, and the responsive
+// split. This module chooses among the five mutually exclusive bodies and
+// routes Close/Back/fullscreen into the owning thread's `sidebar` signals
+// instead of legacy search params.
 // ---------------------------------------------------------------------------
 
 const ARTIFACT_AUTO_LOAD_THRESHOLD_PX = 800;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2,7 +2,6 @@ import type {
   CSSProperties,
   FormEvent,
   MouseEvent as ReactMouseEvent,
-  PointerEvent as ReactPointerEvent,
   ReactNode,
   UIEvent as ReactUIEvent,
 } from "react";
@@ -210,10 +209,6 @@ import {
   artifactInboxQuery$,
   artifactInboxSearchOpen$,
   artifactInboxSection$,
-  ARTIFACT_PANEL_MIN_THREAD_WIDTH,
-  ARTIFACT_PANEL_MIN_WIDTH,
-  artifactPanelResizing$,
-  artifactPanelWidth$,
   backToArtifactInbox$,
   type ArtifactInboxSection,
   type ArtifactRef,
@@ -223,8 +218,6 @@ import {
   openArtifactFromInbox$,
   setArtifactInboxQuery$,
   setArtifactInboxSection$,
-  setArtifactPanelResizing$,
-  setArtifactPanelWidth$,
   openImageLightboxOrArtifact$ as openAttachmentImageLightbox$,
   openVideoLightboxOrArtifact$ as openAttachmentVideoLightbox$,
   toggleArtifactFullscreen$,
@@ -251,6 +244,7 @@ import {
   ThreadSidebarSlot,
   useOpenThreadArtifacts,
 } from "./thread-sidebar.tsx";
+import { ChatThreadSidebarShell } from "./chat-thread-sidebar-shell.tsx";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import { currentMailDraftId$ } from "../../signals/zero-page/mail-draft-sidebar.ts";
 import { currentBrowserSessionId$ } from "../../signals/zero-page/browser-session-sidebar.ts";
@@ -2517,88 +2511,6 @@ function ChatThread({
   );
 }
 
-// Drag the divider to resize the artifact preview against the chat thread.
-// The preview panel is the right-most child, so its right edge coincides with
-// the container's right edge; the width is the gap from the pointer to it.
-function startArtifactPanelResize(
-  event: ReactPointerEvent<HTMLDivElement>,
-  setWidth: (width: number) => void,
-  setResizing: (resizing: boolean) => void,
-): void {
-  const container = event.currentTarget.parentElement;
-  if (!container) {
-    return;
-  }
-  event.preventDefault();
-  const rect = container.getBoundingClientRect();
-  const maxWidth = Math.max(
-    ARTIFACT_PANEL_MIN_WIDTH,
-    rect.width - ARTIFACT_PANEL_MIN_THREAD_WIDTH,
-  );
-  setResizing(true);
-  document.body.style.cursor = "col-resize";
-  document.body.style.userSelect = "none";
-
-  function onMove(moveEvent: PointerEvent): void {
-    const next = Math.min(
-      Math.max(rect.right - moveEvent.clientX, ARTIFACT_PANEL_MIN_WIDTH),
-      maxWidth,
-    );
-    setWidth(next);
-  }
-  function onUp(): void {
-    window.removeEventListener("pointermove", onMove);
-    window.removeEventListener("pointerup", onUp);
-    document.body.style.removeProperty("cursor");
-    document.body.style.removeProperty("user-select");
-    setResizing(false);
-  }
-  window.addEventListener("pointermove", onMove);
-  window.addEventListener("pointerup", onUp);
-}
-
-// Resolve the artifact panel's CSS width and transition from the persisted
-// width and the live drag state. A null width means "never resized" -> keep
-// the responsive default; once resized, the stored px is clamped against the
-// live container so the chat thread always keeps ARTIFACT_PANEL_MIN_THREAD_WIDTH.
-// The transition is dropped mid-drag so the panel tracks the pointer 1:1.
-function artifactPanelLayout(
-  width: number | null,
-  resizing: boolean,
-): { style: CSSProperties; transition: string } {
-  const widthValue =
-    width === null
-      ? "min(760px, 48vw)"
-      : `clamp(${ARTIFACT_PANEL_MIN_WIDTH}px, ${width}px, calc(100% - ${ARTIFACT_PANEL_MIN_THREAD_WIDTH}px))`;
-  return {
-    style: { "--artifact-panel-width": widthValue } as CSSProperties,
-    transition: resizing
-      ? ""
-      : "transition-[flex-basis,width] duration-[240ms] ease",
-  };
-}
-
-function ArtifactResizeHandle() {
-  const setWidth = useSet(setArtifactPanelWidth$);
-  const setResizing = useSet(setArtifactPanelResizing$);
-  return (
-    <div
-      role="separator"
-      aria-orientation="vertical"
-      aria-label="Resize preview panel"
-      className="group relative hidden xl:flex w-1 shrink-0 cursor-col-resize items-stretch justify-center"
-      onPointerDown={(event) => {
-        startArtifactPanelResize(event, setWidth, setResizing);
-      }}
-    >
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/60 transition-colors group-hover:bg-border"
-      />
-    </div>
-  );
-}
-
 function ChatThreadArea({
   leftThread,
   rightThread,
@@ -2706,45 +2618,12 @@ export function ZeroChatThreadPage() {
       automationPanelOpen ||
       mailDraftPanelOpen ||
       browserPanelOpen;
-  const { style: artifactPanelStyle, transition: artifactTransition } =
-    artifactPanelLayout(
-      useGet(artifactPanelWidth$),
-      useGet(artifactPanelResizing$),
-    );
   return (
     <>
-      {/* Keep the wrapper structure stable across right panel open/close so the
-          thread area's React subtree (and its scroll/keyboard state) never
-          unmounts when the sidebar appears. Only the wrapper className and
-          the optional sidebar sibling change with state. Below xl: the
-          thread half hides so the sidebar fills the pane (no toggle, the
-          50/50 split needs each half ~640px to clear the composer's sm:
-          breakpoint, below which the model picker collapses to icons). */}
-      <div
-        className="flex flex-1 min-h-0 bg-transparent"
-        style={artifactPanelStyle}
-      >
-        <div
-          className={cn(
-            "min-w-0 min-h-0",
-            artifactTransition,
-            rightPanelOpen ? "hidden xl:flex flex-1 basis-0" : "flex flex-1",
-          )}
-        >
-          <ChatThreadArea leftThread={leftThread} rightThread={rightThread} />
-        </div>
-        {rightPanelOpen && <ArtifactResizeHandle />}
-        <div
-          className={cn(
-            "flex min-h-0 min-w-0 overflow-hidden",
-            artifactTransition,
-            rightPanelOpen
-              ? "flex-1 basis-0 xl:w-[var(--artifact-panel-width)] xl:flex-none xl:basis-[var(--artifact-panel-width)]"
-              : "pointer-events-none w-0 flex-none basis-0",
-          )}
-          aria-hidden={!rightPanelOpen}
-        >
-          {newSidebarEnabled ? (
+      <ChatThreadSidebarShell
+        open={rightPanelOpen}
+        sidebar={
+          newSidebarEnabled ? (
             activeThreadSidebar ? (
               activeThreadSidebar.target.type === "automations" ? (
                 <ThreadAutomationsSidebarSlot
@@ -2773,9 +2652,11 @@ export function ZeroChatThreadPage() {
               leftThread={leftThread}
               rightThread={rightThread}
             />
-          ) : null}
-        </div>
-      </div>
+          ) : null
+        }
+      >
+        <ChatThreadArea leftThread={leftThread} rightThread={rightThread} />
+      </ChatThreadSidebarShell>
       {lightboxUrl && <AttachmentLightbox />}
       <ChatConnectorActionConnectModal />
     </>


### PR DESCRIPTION
## Summary

- move the shared chat thread sidebar split, width preference, transition state, and `ChatThreadSidebarResizeHandle` out of the artifact-specific page implementation
- insert a transparent fixed drag mask at the maximum z-index while resizing so embedded iframes cannot intercept pointer move or release events
- make a `resetSignal`-derived `dragSignal` own all drag listeners and cleanup, with pointer up, pointer cancel, window blur, and page abort converging on the same reset path
- preserve the existing width transition outside active drags and retain the existing localStorage key for saved widths

## User impact

Chat sidebar resizing now remains responsive when the pointer crosses embedded content, and interrupted gestures no longer leave stale resize state behind. The same outer shell applies this behavior to both the unified sidebar targets and the legacy sidebar path.

## Verification

- `pnpm exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx` (21 tests passed)
- `pnpm --filter @vm0/app check-types`
- Prettier 3.8.1 check on changed files
- Oxlint, type-aware Oxlint, and ESLint on changed files
