### PR TITLE
test(e2e): temporarily skip clerk-dependent auth tests

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -74,6 +74,8 @@ export default defineConfig({
     },
     {
       name: "features",
+      // TODO: Re-enable with smoke.spec.ts, which produces this project's storage state.
+      testIgnore: /.*/,
       testMatch: [
         "agents.spec.ts",
         "chat.spec.ts",

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -13,7 +13,8 @@ import {
 import { fillStripeCheckout } from "../lib/stripe-checkout";
 import { deriveAppUrl } from "../playwright.config";
 
-test("paid onboarding completes through the video workflow", async ({
+// TODO: Re-enable after the recurring Clerk auth initialization failures are resolved.
+test.skip("paid onboarding completes through the video workflow", async ({
   page,
 }) => {
   test.setTimeout(240_000);

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -4,7 +4,8 @@ import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
 import { completeExploreOnboarding } from "../lib/onboarding";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
-test("complete app onboarding to chat page", async ({ browser, page }) => {
+// TODO: Re-enable after the recurring Clerk auth initialization failures are resolved.
+test.skip("complete app onboarding to chat page", async ({ browser, page }) => {
   test.setTimeout(240_000);
 
   const email = process.env.E2E_CLERK_USER_EMAIL!;

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -95,6 +95,8 @@ wait_for_auth_completion() {
 # ===========================================================================
 
 @test "sign up a new test account" {
+  skip "Temporarily disabled after recurring Clerk auth initialization failures"
+
   local sign_up_url
   sign_up_url="$(auth_url "/sign-up")"
   echo "# Navigating to $sign_up_url" >&3
@@ -152,6 +154,8 @@ wait_for_auth_completion() {
 # ===========================================================================
 
 @test "sign out and sign in with same account" {
+  skip "Temporarily disabled after recurring Clerk auth initialization failures"
+
   # Close browser session to clear auth state
   echo "# Closing browser to clear session..." >&3
   agent-browser close 2>/dev/null || true


### PR DESCRIPTION
## Summary

- temporarily skip the two browser BATS cases that exercise Clerk's hosted sign-up and sign-in forms
- temporarily skip the Playwright smoke and paid-onboarding tests that time out waiting for the hosted `/sign-in` handoff
- ignore the downstream Playwright feature project while the smoke setup is disabled, because that setup is the sole producer of its authenticated storage state

## User-visible impact

Recurring Clerk initialization failures no longer block otherwise healthy PR and merge-group runs. The affected hosted-auth and onboarding coverage remains present in the repository with explicit re-enable markers.

## Context

- representative failure: https://github.com/vm0-ai/vm0/actions/runs/30255478435
- browser failures report `form_appeared=false` or never reach password, OTP, or redirect state
- Playwright failures time out in `e2e/playwright/lib/auth.ts:42` while waiting for `/sign-in`

## Verification

- `cd e2e && pnpm check-types`
- Playwright discovery confirms both target tests have `expectedStatus=skipped` and no downstream feature tests are selected
- `npx -y prettier@3.8.1 --check e2e/playwright/playwright.config.ts e2e/playwright/tests/smoke.spec.ts e2e/playwright/tests/paid-onboarding.spec.ts`
- `./e2e/test/libs/bats/bin/bats --count e2e/tests/02-browser/brw-t01-platform-e2e.bats` (`2` tests discovered)
- `git diff --check`

Full browser E2E execution was not run locally because it requires the deployed preview and Clerk environment.
