### PR TITLE
test: wait for namespace pool capacity in runner cancel ci

### DIFF
--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -39,11 +39,16 @@ RECONCILE_TEST_DIR=$(mktemp -d "/tmp/vm0-${SVC}-reconcile.XXXXXX")
 RECONCILE_BIN_DIR="$RECONCILE_TEST_DIR/bin"
 RECONCILE_COUNT_DIR="$RECONCILE_TEST_DIR/counts"
 RECONCILE_LOCK_INFO="$RECONCILE_TEST_DIR/pool-indexes"
+RECONCILE_CAPACITY_RELEASE="$RECONCILE_TEST_DIR/release-capacity"
+RECONCILE_CAPACITY_RELEASED="$RECONCILE_TEST_DIR/capacity-released"
 RECONCILE_IDLE_RELEASE="$RECONCILE_TEST_DIR/release-idle"
 RECONCILE_IDLE_RELEASED="$RECONCILE_TEST_DIR/idle-released"
 RECONCILE_ACTIVE_RELEASE="$RECONCILE_TEST_DIR/release-active"
 RECONCILE_FIREWALL_DELETE_STARTED="$RECONCILE_TEST_DIR/firewall-delete-started"
 RECONCILE_FIREWALL_DELETE_RELEASE="$RECONCILE_TEST_DIR/release-firewall-delete"
+RECONCILE_LOCK_HOLDER_ERROR="$RECONCILE_TEST_DIR/lock-holder-error"
+RECONCILE_REQUIRED_POOL_INDEXES=5
+RECONCILE_CAPACITY_TIMEOUT_SECONDS=60
 RECONCILE_LOCK_HOLDER_PID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
@@ -67,6 +72,7 @@ cleanup() {
     print_service_logs
   fi
   sudo touch \
+    "$RECONCILE_CAPACITY_RELEASE" \
     "$RECONCILE_IDLE_RELEASE" \
     "$RECONCILE_ACTIVE_RELEASE" \
     "$RECONCILE_FIREWALL_DELETE_RELEASE"
@@ -91,21 +97,28 @@ REAL_IPTABLES_RESTORE=$(command -v iptables-restore)
 REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
 REAL_IP6TABLES_RESTORE=$(command -v ip6tables-restore)
 
-# Reserve four pool indexes before the runner starts. Two become clean
-# historical indexes, one owns a synthetic firewall-only orphan, and one
-# remains active throughout reconciliation. The first three locks are released
-# during own-index cleanup, after the runner has captured their resources and
-# acquired a different index.
+# Reserve five pool indexes before the runner starts. Four back the existing
+# reconciliation fixture, while the fifth guarantees admission capacity for
+# the runner. Incomplete attempts release every lock before retrying.
 sudo bash -s -- \
   "$RECONCILE_LOCK_INFO" \
+  "$RECONCILE_CAPACITY_RELEASE" \
+  "$RECONCILE_CAPACITY_RELEASED" \
   "$RECONCILE_IDLE_RELEASE" \
   "$RECONCILE_IDLE_RELEASED" \
-  "$RECONCILE_ACTIVE_RELEASE" <<'LOCK_HOLDER' &
+  "$RECONCILE_ACTIVE_RELEASE" \
+  "$RECONCILE_REQUIRED_POOL_INDEXES" \
+  "$RECONCILE_CAPACITY_TIMEOUT_SECONDS" \
+  >"$RECONCILE_LOCK_HOLDER_ERROR" 2>&1 <<'LOCK_HOLDER' &
 set -euo pipefail
 LOCK_INFO=$1
-IDLE_RELEASE=$2
-IDLE_RELEASED=$3
-ACTIVE_RELEASE=$4
+CAPACITY_RELEASE=$2
+CAPACITY_RELEASED=$3
+IDLE_RELEASE=$4
+IDLE_RELEASED=$5
+ACTIVE_RELEASE=$6
+REQUIRED_POOL_INDEXES=$7
+CAPACITY_TIMEOUT_SECONDS=$8
 declare -a RESERVED_FDS=()
 declare -a RESERVED_INDEXES=()
 
@@ -122,22 +135,55 @@ reserve_index() {
   fi
 }
 
-# Prefer existing persistent lock files. Create new files only if the host has
-# fewer than four idle indexes available.
-for index in $(seq 63 -1 0); do
-  [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] || continue
-  reserve_index "$index"
-  [ "${#RESERVED_INDEXES[@]}" -eq 4 ] && break
-done
-if [ "${#RESERVED_INDEXES[@]}" -lt 4 ]; then
-  for index in $(seq 63 -1 0); do
-    [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] && continue
-    reserve_index "$index"
-    [ "${#RESERVED_INDEXES[@]}" -eq 4 ] && break
+release_reserved_indexes() {
+  local fd
+  for fd in "${RESERVED_FDS[@]}"; do
+    exec {fd}>&-
   done
-fi
-[ "${#RESERVED_INDEXES[@]}" -eq 4 ] || exit 1
-printf '%s\n' "${RESERVED_INDEXES[@]}" >"$LOCK_INFO"
+  RESERVED_FDS=()
+  RESERVED_INDEXES=()
+}
+
+CAPACITY_DEADLINE=$((SECONDS + CAPACITY_TIMEOUT_SECONDS))
+LAST_ACQUIRED=0
+while true; do
+  # Prefer existing persistent lock files. Create new files only if the host
+  # has fewer than five idle indexes available.
+  for index in $(seq 63 -1 0); do
+    [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] || continue
+    reserve_index "$index"
+    [ "${#RESERVED_INDEXES[@]}" -eq "$REQUIRED_POOL_INDEXES" ] && break
+  done
+  if [ "${#RESERVED_INDEXES[@]}" -lt "$REQUIRED_POOL_INDEXES" ]; then
+    for index in $(seq 63 -1 0); do
+      [ -e "/var/lock/vm0-netns-pool-${index}.lock" ] && continue
+      reserve_index "$index"
+      [ "${#RESERVED_INDEXES[@]}" -eq "$REQUIRED_POOL_INDEXES" ] && break
+    done
+  fi
+  LAST_ACQUIRED=${#RESERVED_INDEXES[@]}
+  if [ "$LAST_ACQUIRED" -eq "$REQUIRED_POOL_INDEXES" ]; then
+    break
+  fi
+
+  release_reserved_indexes
+  [ ! -e "$CAPACITY_RELEASE" ] || exit 0
+  if [ "$SECONDS" -ge "$CAPACITY_DEADLINE" ]; then
+    echo "timed out after ${CAPACITY_TIMEOUT_SECONDS}s waiting for namespace pool capacity: required ${REQUIRED_POOL_INDEXES} indexes, acquired ${LAST_ACQUIRED} on last attempt" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# Only the first four indexes belong to the reconciliation fixture. Retain the
+# fifth lock until the parent has created the transient runner service.
+printf '%s\n' "${RESERVED_INDEXES[@]:0:4}" >"$LOCK_INFO"
+
+while [ ! -e "$CAPACITY_RELEASE" ]; do sleep 0.05; done
+CAPACITY_FD=${RESERVED_FDS[4]}
+flock -u "$CAPACITY_FD"
+exec {CAPACITY_FD}>&-
+touch "$CAPACITY_RELEASED"
 
 while [ ! -e "$IDLE_RELEASE" ]; do sleep 0.05; done
 for position in 0 1 2; do
@@ -149,13 +195,21 @@ while [ ! -e "$ACTIVE_RELEASE" ]; do sleep 0.05; done
 LOCK_HOLDER
 RECONCILE_LOCK_HOLDER_PID=$!
 
-for _ in $(seq 1 200); do
+RECONCILE_LOCK_READY_DEADLINE=$((SECONDS + RECONCILE_CAPACITY_TIMEOUT_SECONDS + 5))
+while [ "$SECONDS" -lt "$RECONCILE_LOCK_READY_DEADLINE" ]; do
   [ -s "$RECONCILE_LOCK_INFO" ] && break
-  kill -0 "$RECONCILE_LOCK_HOLDER_PID" 2>/dev/null \
-    || fail "failed to reserve namespace pool indexes"
+  if ! kill -0 "$RECONCILE_LOCK_HOLDER_PID" 2>/dev/null; then
+    [ ! -s "$RECONCILE_LOCK_HOLDER_ERROR" ] \
+      || cat "$RECONCILE_LOCK_HOLDER_ERROR"
+    fail "namespace pool reservation helper exited"
+  fi
   sleep 0.05
 done
-[ -s "$RECONCILE_LOCK_INFO" ] || fail "timed out reserving namespace pool indexes"
+if [ ! -s "$RECONCILE_LOCK_INFO" ]; then
+  [ ! -s "$RECONCILE_LOCK_HOLDER_ERROR" ] \
+    || cat "$RECONCILE_LOCK_HOLDER_ERROR"
+  fail "timed out waiting for namespace pool reservation helper"
+fi
 mapfile -t RECONCILE_POOL_INDEXES <"$RECONCILE_LOCK_INFO"
 printf -v RECONCILE_FIREWALL_POOL_HEX '%02x' "${RECONCILE_POOL_INDEXES[2]}"
 printf -v RECONCILE_ACTIVE_POOL_HEX '%02x' "${RECONCILE_POOL_INDEXES[3]}"
@@ -368,6 +422,16 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
   --env "VM0_RECONCILE_ACTIVE_POOL_HEX=$RECONCILE_ACTIVE_POOL_HEX" \
   --env "VM0_RECONCILE_IDLE_RELEASE=$RECONCILE_IDLE_RELEASE" \
   --env "VM0_RECONCILE_IDLE_RELEASED=$RECONCILE_IDLE_RELEASED"
+
+sudo touch "$RECONCILE_CAPACITY_RELEASE"
+for _ in $(seq 1 200); do
+  [ -e "$RECONCILE_CAPACITY_RELEASED" ] && break
+  kill -0 "$RECONCILE_LOCK_HOLDER_PID" 2>/dev/null \
+    || fail "namespace pool reservation helper exited before capacity release"
+  sleep 0.05
+done
+[ -e "$RECONCILE_CAPACITY_RELEASED" ] \
+  || fail "timed out releasing runner namespace pool capacity"
 
 assert_reconcile_count() {
   local name=$1 expected=$2 path="$RECONCILE_COUNT_DIR/$1" actual=0

--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -98,8 +98,8 @@ REAL_IP6TABLES_SAVE=$(command -v ip6tables-save)
 REAL_IP6TABLES_RESTORE=$(command -v ip6tables-restore)
 
 # Reserve five pool indexes before the runner starts. Four back the existing
-# reconciliation fixture, while the fifth guarantees admission capacity for
-# the runner. Incomplete attempts release every lock before retrying.
+# reconciliation fixture, while the fifth holds capacity for the runner
+# startup handoff. Incomplete attempts release every lock before retrying.
 sudo bash -s -- \
   "$RECONCILE_LOCK_INFO" \
   "$RECONCILE_CAPACITY_RELEASE" \


### PR DESCRIPTION
## Summary

- wait up to 60 seconds for five namespace pool indexes before starting the runner cancel scenario
- release every partial reservation before retrying so concurrent tests do not hoard capacity
- retain a fifth capacity token through transient service creation, then release it with a bounded handshake
- surface the required and last-acquired index counts when capacity admission times out

## Scope

This changes only the runner cancel behavior test. It does not change the production namespace allocator, pool size, runner protocol, service restart policy, workflow timeout, or existing reconciliation and cancellation assertions.

## Validation

- `bash -n .github/scripts/runner-behavior-cancel.sh`
- `shellcheck .github/scripts/runner-behavior-cancel.sh`
- `./scripts/check-file-size.sh .github/scripts/runner-behavior-cancel.sh`
- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `shellcheck .github/scripts/check-release-please-component-releases.sh .github/scripts/check-workflow-shell-compatibility.sh .github/scripts/runner-behavior-*.sh .github/scripts/tests/check-release-please-component-releases-test.sh .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `git diff --check`

The privileged runner behavior lane remains the authoritative integration check for shared-host namespace lock contention.

Closes #23328
