### PR TITLE
test(e2e): poll browser targets below ipc timeout

### DIFF
--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -42,9 +42,6 @@ browser_setup() {
   fi
 
   export NODE_TLS_REJECT_UNAUTHORIZED=0
-  # The daemon reads this once when the first command starts it. Per-command
-  # environment overrides do not change an already-running daemon.
-  export AGENT_BROWSER_DEFAULT_TIMEOUT=60000
   export AGENT_BROWSER_SESSION="${AGENT_BROWSER_SESSION:-${JOB_REF:-local}-sign-up}"
 
   export OTP="424242"
@@ -70,25 +67,49 @@ generate_test_email() {
 
 # ---------------------------------------------------------------------------
 # wait_for_browser_target — Wait for a browser target across navigation
-# agent-browser may surface a transient CDP context error when Clerk replaces
-# the document while a selector wait is active. Retry that transition without
-# adding a fixed delay; preserve real selector timeouts as failures.
-# Usage: wait_for_browser_target <agent-browser wait arguments...>
+# Poll the target so no individual agent-browser command reaches its
+# 30-second IPC read timeout. Supports the wait forms used by browser E2E:
+# selectors, --fn expressions, and --text values.
+# Usage: wait_for_browser_target <selector>|--fn <expression>|--text <text>
 # ---------------------------------------------------------------------------
 wait_for_browser_target() {
-  local navigation_attempt wait_output
+  local condition description value_json
+  case "${1:-}" in
+    --fn)
+      condition="Boolean(${2:?wait expression is required})"
+      description="JavaScript condition"
+      ;;
+    --text)
+      value_json=$(node -e \
+        'process.stdout.write(JSON.stringify(process.argv[1]))' \
+        "${2:?wait text is required}")
+      condition="(document.body?.innerText ?? '').toLowerCase().includes(${value_json}.toLowerCase())"
+      description="text ${2}"
+      ;;
+    *)
+      value_json=$(node -e \
+        'process.stdout.write(JSON.stringify(process.argv[1]))' \
+        "${1:?wait selector is required}")
+      condition="Boolean(document.querySelector(${value_json}))"
+      description="selector ${1}"
+      ;;
+  esac
 
-  for navigation_attempt in 1 2 3; do
-    if wait_output=$(agent-browser wait "$@" 2>&1); then
-      return 0
-    fi
-    if [[ "$wait_output" != *"Inspected target navigated or closed"* ]]; then
+  local wait_started="$SECONDS"
+  local wait_output
+  while (( SECONDS - wait_started < 60 )); do
+    if wait_output=$(agent-browser eval "$condition" 2>&1); then
+      if [[ "$wait_output" == "true" ]]; then
+        return 0
+      fi
+    elif [[ "$wait_output" != *"Inspected target navigated or closed"* ]]; then
       echo "$wait_output" >&2
       return 1
     fi
+    sleep 0.25
   done
 
-  echo "$wait_output" >&2
+  echo "Wait timed out after 60000ms: ${description}" >&2
   return 1
 }
 

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -70,9 +70,16 @@ generate_test_email() {
 # Poll the target so no individual agent-browser command reaches its
 # 30-second IPC read timeout. Supports the wait forms used by browser E2E:
 # selectors, --fn expressions, and --text values.
-# Usage: wait_for_browser_target <selector>|--fn <expression>|--text <text>
+# Usage: wait_for_browser_target [--timeout-seconds <seconds>]
+#          <selector>|--fn <expression>|--text <text>
 # ---------------------------------------------------------------------------
 wait_for_browser_target() {
+  local wait_timeout_seconds=60
+  if [[ "${1:-}" == "--timeout-seconds" ]]; then
+    wait_timeout_seconds="${2:?wait timeout is required}"
+    shift 2
+  fi
+
   local condition description value_json
   case "${1:-}" in
     --fn)
@@ -97,7 +104,7 @@ wait_for_browser_target() {
 
   local wait_started="$SECONDS"
   local wait_output
-  while (( SECONDS - wait_started < 60 )); do
+  while (( SECONDS - wait_started < wait_timeout_seconds )); do
     if wait_output=$(agent-browser eval "$condition" 2>&1); then
       if [[ "$wait_output" == "true" ]]; then
         return 0
@@ -109,7 +116,7 @@ wait_for_browser_target() {
     sleep 0.25
   done
 
-  echo "Wait timed out after 60000ms: ${description}" >&2
+  echo "Wait timed out after $((wait_timeout_seconds * 1000))ms: ${description}" >&2
   return 1
 }
 

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -86,6 +86,24 @@ wait_for_auth_completion() {
     "!window.location.pathname.includes('/${auth_path}')"
 }
 
+open_auth_form() {
+  local url="$1"
+  local auth_path="$2"
+  shift 2
+
+  agent-browser open "$url"
+  if wait_for_browser_target --timeout-seconds 30 "$@" 2>/dev/null; then
+    return
+  fi
+
+  echo "# Clerk ${auth_path} form did not mount in 30s; retrying in a fresh session" >&3
+  agent-browser close 2>/dev/null || true
+  export AGENT_BROWSER_SESSION="${JOB_REF:-local}-${auth_path}-retry"
+  browser_setup
+  agent-browser open "$url"
+  wait_for_browser_target --timeout-seconds 30 "$@"
+}
+
 # ===========================================================================
 # Phase 1: Sign up
 # ===========================================================================
@@ -94,8 +112,7 @@ wait_for_auth_completion() {
   local sign_up_url
   sign_up_url="$(auth_url "/sign-up")"
   echo "# Navigating to $sign_up_url" >&3
-  agent-browser open "$sign_up_url"
-  wait_for_browser_target --fn \
+  open_auth_form "$sign_up_url" "sign-up" --fn \
     "Boolean(
       document.querySelector('input[name=\"emailAddress\"]')
       && document.querySelector('input[name=\"password\"]')
@@ -138,7 +155,9 @@ wait_for_auth_completion() {
   local sign_in_url
   sign_in_url="$(auth_url "/sign-in")"
   echo "# Navigating to $sign_in_url" >&3
-  agent-browser open "$sign_in_url"
+  open_auth_form "$sign_in_url" "sign-in" --fn \
+    "!window.location.pathname.includes('/sign-in')
+      || Boolean(document.querySelector('input[name=\"identifier\"]'))"
 
   # Check if already signed in (redirected away from /sign-in)
   local current_url
@@ -148,7 +167,6 @@ wait_for_auth_completion() {
     return 0
   fi
 
-  wait_for_browser_target 'input[name="identifier"]'
   dismiss_cookie_banner
 
   # Enter email and click Continue


### PR DESCRIPTION
## Summary

- poll browser targets with short `agent-browser eval` calls so no command reaches the 30-second IPC read timeout
- give initial Clerk sign-up and sign-in forms one bounded retry in a fresh browser context
- keep both attempts on the real Clerk UI and fail when the second 30-second target wait also stalls

## Root cause

PR #23334 reproduced the sign-up `FORM_STALL`: the helper exported a 60-second action timeout, but agent-browser 0.22 terminated long wait commands at its 30-second IPC deadline. Polling removed that client limit, but the first merge-group validation then showed a genuine preview mount stall lasting the full 60 seconds. Waiting longer in the same document did not recover it, so the test now performs one fresh cold navigation instead.

## Validation

- `bash -n e2e/helpers/browser.bash`
- BATS discovery: 2 cases
- delayed target probe: a target appearing after 35 seconds succeeds instead of being cut off at 30 seconds
- fault-injection probe: first context stays on a loading skeleton for 30 seconds; the fresh context mounts the form and the test succeeds in 31 seconds
- 5/5 independent local Clerk UI rounds passed after the retry change (sign-up plus fresh sign-in)
- pre-commit file-size check and commitlint passed

Vitest was not run because this change is isolated to the Bash browser E2E path.