### PR TITLE
ci: pull pgvector services from ghcr

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -535,7 +535,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/vm0-ai/pgvector@sha256:d229d4e975e7102b7df031cbfcf5c4463ee21c84d0373d7a736191a2603dddfd
         options: >-
           --health-cmd pg_isready
           --health-interval 2s
@@ -581,7 +581,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/vm0-ai/pgvector@sha256:d229d4e975e7102b7df031cbfcf5c4463ee21c84d0373d7a736191a2603dddfd
         options: >-
           --health-cmd pg_isready
           --health-interval 2s
@@ -725,7 +725,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/vm0-ai/pgvector@sha256:d229d4e975e7102b7df031cbfcf5c4463ee21c84d0373d7a736191a2603dddfd
         options: >-
           --health-cmd pg_isready
           --health-interval 2s


### PR DESCRIPTION
## Summary

- replace the Docker Hub `pgvector/pgvector:pg17` service in `bench-api`, `test-migrate`, and `test-api`
- pin all three jobs to the public vm0-owned multi-architecture GHCR manifest
- preserve the existing PostgreSQL 17 service topology, health checks, ports, and environment

## Impact

CI container initialization no longer depends on Docker Hub for pgvector. The immutable digest keeps every shard on the same reviewed image while the `vm0-ai/pgvector` fork remains manually synchronized with upstream.

Image: `ghcr.io/vm0-ai/pgvector@sha256:d229d4e975e7102b7df031cbfcf5c4463ee21c84d0373d7a736191a2603dddfd`

The image was published by [vm0-ai/pgvector#1](https://github.com/vm0-ai/pgvector/pull/1) in [Docker Publish run 30270106645](https://github.com/vm0-ai/pgvector/actions/runs/30270106645).

## Verification

- anonymous GHCR manifest request returned HTTP 200 with the pinned digest
- `actionlint` passed for `.github/workflows/turbo.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml` passed
- exact-reference assertions and `git diff --check` passed
- the PR pipeline will exercise all affected jobs and shards
