### PR TITLE
test(api): drain completion before session retry exhaustion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3331,6 +3331,7 @@ describe("CHAT-02: run-level model overrides", () => {
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     const firstBinding = await readThreadSessionBinding(
       context,
       first.threadId,


### PR DESCRIPTION
## Summary

- drain the first chat run's tracked `waitUntil` completion work before capturing the canonical thread-session binding
- prevent the retry-exhaustion scenario from racing the terminal callback and queue drain, which could advance `agent_session_run_id` before the final invariant assertion
- keep the production retry count, timeout, error behavior, and binding assertions unchanged

## Failure evidence

- failing Turbo run: https://github.com/vm0-ai/vm0/actions/runs/30271662915
- first substantive failure: `test-api (8)` at https://github.com/vm0-ai/vm0/actions/runs/30271662915/job/89995603965
- the same commit and shard passed minutes earlier in the merge group: https://github.com/vm0-ai/vm0/actions/runs/30271254765/job/89994216258
- the next main run also passed the same shard: https://github.com/vm0-ai/vm0/actions/runs/30272055530/job/89996933202

The completion endpoint marks the run terminal synchronously, then dispatches callbacks and drains the chat-thread queue through `waitUntil`. The test immediately read its baseline binding and started the next send without waiting for that owned background work, so scheduling determined whether the final provenance still matched the baseline.

## Verification

- target case passed 5 consecutive runs on current `main`: `fails after every canonical session preparation snapshot changes`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- Lefthook pre-commit: Prettier, Knip, and full workspace type checks
- `git diff --check`

