### PR TITLE
refactor(connectors): narrow auth-provider package exports

### DIFF
--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -44,10 +44,6 @@
       "import": "./src/auth-providers/model-provider-auth.ts",
       "types": "./src/auth-providers/model-provider-auth.ts"
     },
-    "./auth-providers/provider-env": {
-      "import": "./src/auth-providers/provider-env.ts",
-      "types": "./src/auth-providers/provider-env.ts"
-    },
     "./auth-providers/provider-flow-types": {
       "import": "./src/auth-providers/provider-flow-types.ts",
       "types": "./src/auth-providers/provider-flow-types.ts"
@@ -56,21 +52,17 @@
       "import": "./src/auth-providers/provider-error.ts",
       "types": "./src/auth-providers/provider-error.ts"
     },
-    "./auth-providers/types": {
-      "import": "./src/auth-providers/types.ts",
-      "types": "./src/auth-providers/types.ts"
+    "./auth-providers/connectors/github/oauth": {
+      "import": "./src/auth-providers/connectors/github/oauth.ts",
+      "types": "./src/auth-providers/connectors/github/oauth.ts"
     },
-    "./auth-providers/connectors/*": {
-      "import": "./src/auth-providers/connectors/*.ts",
-      "types": "./src/auth-providers/connectors/*.ts"
+    "./auth-providers/model-providers/codex-oauth/oauth": {
+      "import": "./src/auth-providers/model-providers/codex-oauth/oauth.ts",
+      "types": "./src/auth-providers/model-providers/codex-oauth/oauth.ts"
     },
-    "./auth-providers/model-providers/*": {
-      "import": "./src/auth-providers/model-providers/*.ts",
-      "types": "./src/auth-providers/model-providers/*.ts"
-    },
-    "./auth-providers/oauth/*": {
-      "import": "./src/auth-providers/oauth/*.ts",
-      "types": "./src/auth-providers/oauth/*.ts"
+    "./auth-providers/oauth/error": {
+      "import": "./src/auth-providers/oauth/error.ts",
+      "types": "./src/auth-providers/oauth/error.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- replace wildcard auth-provider package exports with exact entries for the three current deep consumers
- remove the unconsumed `provider-env` and `types` package entries
- preserve every retained import string and source-module target

## Scope

This is a manifest-only package-boundary change. It does not change provider implementations,
runtime behavior, API contracts, persisted state, or deployment protocols.

## Validation

- `pnpm format`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test -- --maxWorkers=4 --silent=passed-only` (818 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=4 --silent=passed-only` (90 tests)
- `pnpm knip`
- direct Node package-resolution verification for all seven retained auth-provider entries

Closes #23264

Parent context: https://github.com/vm0-ai/vm0-connectors/issues/1
