### PR TITLE
refactor: reduce fallback slop in organization member ids

### DIFF
--- a/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
+++ b/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
@@ -6,7 +6,7 @@ const CLERK_API_BASE = "https://api.clerk.com/v1";
 
 const membershipRequestDataSchema = z.object({
   id: z.string(),
-  public_user_data: z.object({ user_id: z.string().optional() }).optional(),
+  public_user_data: z.object({ user_id: z.string().min(1) }),
   created_at: z.number(),
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -1000,6 +1000,19 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       return response.body;
     },
 
+    async requestListMembers<S extends 200 | 400 | 401 | 403 | 404 | 500>(
+      actor: ApiTestUser,
+      statuses: readonly S[],
+    ) {
+      const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
+        zeroOrgMembersContract,
+      );
+      return await accept(
+        client.members({ headers: authenticate(actor) }),
+        statuses,
+      );
+    },
+
     async requestReadOrgWithBearer(
       token: string,
       statuses: readonly (200 | 401 | 403 | 404)[],

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
+import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   createAuthOrgAgentsBddApi,
@@ -421,7 +422,7 @@ describe("ORG-02: membership admin matrix", () => {
           {
             role: "org:admin",
             publicUserData: {},
-            createdAt: Date.now(),
+            createdAt: now(),
           },
         ],
       },
@@ -441,7 +442,7 @@ describe("ORG-02: membership admin matrix", () => {
               {
                 id: `request-${shortId()}`,
                 public_user_data: {},
-                created_at: Date.now(),
+                created_at: now(),
               },
             ],
           });

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 
+import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
+import { server } from "../../../mocks/server";
 import {
   createAuthOrgAgentsBddApi,
   type ApiTestUser,
@@ -408,6 +410,48 @@ describe("ORG-01: org update and delete error matrix", () => {
 });
 
 describe("ORG-02: membership admin matrix", () => {
+  it("rejects Clerk member records without required user identifiers", async () => {
+    const admin = api.user();
+    const orgId = orgIdOf(admin);
+    api.mockClerkOrg(admin);
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValueOnce(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: {},
+            createdAt: Date.now(),
+          },
+        ],
+      },
+    );
+    const missingMemberId = await api.requestListMembers(admin, [500]);
+    expect(missingMemberId.status).toBe(500);
+
+    server.use(
+      http.get(
+        "https://api.clerk.com/v1/organizations/:orgId/membership_requests",
+        ({ params }) => {
+          if (params.orgId !== orgId) {
+            return HttpResponse.json({ data: [] });
+          }
+          return HttpResponse.json({
+            data: [
+              {
+                id: `request-${shortId()}`,
+                public_user_data: {},
+                created_at: Date.now(),
+              },
+            ],
+          });
+        },
+      ),
+    );
+    const missingRequestUserId = await api.requestListMembers(admin, [500]);
+    expect(missingRequestUserId.status).toBe(500);
+  });
+
   it("enforces role, self, unknown-target, invalid-body, and clerk-failure arms across member routes [ORG-MEMBERS-C]", async () => {
     const admin = api.user();
     const orgId = orgIdOf(admin);

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -682,6 +682,15 @@ function mapClerkOrgRole(clerkRole: string): OrgRole {
   return clerkRole === "org:admin" ? "admin" : "member";
 }
 
+function requiredClerkMembershipUserId(
+  userId: string | null | undefined,
+): string {
+  if (!userId) {
+    throw new Error("Clerk organization membership is missing its user ID");
+  }
+  return userId;
+}
+
 function userPrimaryEmail(user: User): string {
   const primary = user.emailAddresses.find((e) => {
     return e.id === user.primaryEmailAddressId;
@@ -785,27 +794,33 @@ export function zeroOrgMembersList(
       }),
     ]);
 
-    const memberUserIds = memberships.data
-      .map((m) => {
-        return m.publicUserData?.userId;
-      })
-      .filter((id): id is string => {
-        return Boolean(id);
-      });
-    const memberProfiles = await fetchUserProfileMap(db, client, memberUserIds);
-
-    const memberList: OrgMember[] = memberships.data.map((membership) => {
-      const uid = membership.publicUserData?.userId ?? "";
-      const profile = memberProfiles.get(uid);
+    const membersWithUserIds = memberships.data.map((membership) => {
       return {
-        userId: uid,
+        membership,
+        userId: requiredClerkMembershipUserId(
+          membership.publicUserData?.userId,
+        ),
+      };
+    });
+    const memberProfiles = await fetchUserProfileMap(
+      db,
+      client,
+      membersWithUserIds.map((member) => {
+        return member.userId;
+      }),
+    );
+
+    const memberList: OrgMember[] = membersWithUserIds.map((member) => {
+      const profile = memberProfiles.get(member.userId);
+      return {
+        userId: member.userId,
         email: profile?.email ?? "",
         firstName: profile?.firstName ?? null,
         lastName: profile?.lastName ?? null,
         imageUrl: profile?.imageUrl ?? "",
-        role: mapClerkOrgRole(membership.role),
-        joinedAt: membership.createdAt
-          ? new Date(membership.createdAt).toISOString()
+        role: mapClerkOrgRole(member.membership.role),
+        joinedAt: member.membership.createdAt
+          ? new Date(member.membership.createdAt).toISOString()
           : "",
       };
     });
@@ -827,20 +842,16 @@ export function zeroOrgMembersList(
     > = [];
     if (args.callerRole === "admin") {
       const requestsData = await fetchClerkMembershipRequests(args.orgId);
-      const requestUserIds = requestsData
-        .map((r) => {
-          return r.public_user_data?.user_id;
-        })
-        .filter((id): id is string => {
-          return Boolean(id);
-        });
+      const requestUserIds = requestsData.map((request) => {
+        return request.public_user_data.user_id;
+      });
       const requestProfiles = await fetchUserProfileMap(
         db,
         client,
         requestUserIds,
       );
       membershipRequests = requestsData.map((req) => {
-        const uid = req.public_user_data?.user_id ?? "";
+        const uid = req.public_user_data.user_id;
         const profile = requestProfiles.get(uid);
         return {
           id: req.id,


### PR DESCRIPTION
## Summary

- Reject Clerk organization membership rows that omit their required user ID instead of returning `userId: ""`.
- Require pending membership-request payloads to include a non-empty `public_user_data.user_id` before they enter the organization member response.
- Cover both the Clerk SDK membership path and the Clerk REST membership-request path with a focused regression test.

User-visible impact: organization member reads now fail clearly on malformed Clerk identity data instead of manufacturing empty member identifiers.

## Repository scan

- Scan timestamp: `2026-07-27T20:02:18.284Z`
- Base commit: `ae28bdda4f94c2ea12f0fec5f26017cc62fd4abb`
- Files scanned: 3,741
- Raw matches: 19,353
- Scanner initial high-confidence production total: 227
- `actionable_total`: 1 after manual review removed duplicate, external-adapter, display-only, test-only, and intentionally compatible fallbacks
- `edit_budget`: 1 (`max(1, ceil(1 * 0.05))`)
- Candidates changed: 1 organization-member identity invariant, covering both SDK and REST sources

Matches by category:

- `nullish`: 5,907
- `nullish-chain`: 133
- `field-fallback-chain`: 104
- `optional-prop`: 5,844
- `zod-optional`: 2,607
- `zod-loose-optional`: 3
- `loose-record`: 1,064
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 30
- `empty-fallback`: 587
- `string-fallback`: 663
- `null-undefined-fallback`: 1,589
- `empty-catch`: 3
- `promise-catch-swallow`: 16
- `rust-unwrap-or`: 648
- `rust-ok-discard`: 152

## Files changed

- `turbo/apps/api/src/signals/external/clerk-membership-requests.ts`: makes the downstream-required Clerk request user ID explicit in the validated REST contract.
- `turbo/apps/api/src/signals/services/zero-org-data.service.ts`: validates SDK membership IDs before profile lookup and removes both empty-ID fallbacks.
- `turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts`: adds a status-aware member-list request helper for failure coverage.
- `turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts`: verifies malformed SDK and REST member records are rejected rather than serialized with empty IDs.

This is safe because both public response variants already require a string `userId`; there is no valid downstream behavior for an absent identity.

## Verification

- Scoped Prettier: passed.
- Scoped type-aware Oxlint and ESLint on all four changed files: passed.
- Targeted regression: `pnpm --filter api exec vitest run src/signals/routes/__tests__/org-team.bdd.test.ts -t "rejects Clerk member records without required user identifiers"` — 1 passed, 6 skipped.
- `git diff --check`: passed.
- Package-wide API lint reached an unrelated current-main numeric-separator error in `zero-maps-osm.service.ts`.
- Final API type-check reached unrelated current-main `archiver` type errors in `diagnostic-bundle.service.ts`, `google-drive-artifact-sync.service.ts`, and `user-export.service.ts`; the changed files passed type-aware lint.
- The normal pre-commit hook passed file-size and formatting, then `knip` stopped on 862 unrelated generated connector files that became untracked after updating to the latest `main`; those files were preserved and excluded from this commit.

This workflow intentionally leaves all remaining scan candidates for later daily runs.
