### PR TITLE
fix(platform): preserve native fetch error messages

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -199,6 +199,7 @@ describe("portable platform runtime environment", () => {
       expect.objectContaining({
         dsn: SENTRY_DSN,
         enabled: true,
+        enhanceFetchErrorMessages: false,
         environment: "production",
       }),
     );

--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -27,6 +27,9 @@ export function initSentry(): void {
     // Disable tracing - only error tracking is needed
     tracesSampleRate: 0,
 
+    // Preserve native fetch errors for application-level error handling.
+    enhanceFetchErrorMessages: false,
+
     // Filter out expected errors
     beforeSend(event, hint) {
       // Filter out 4xx client errors that are expected


### PR DESCRIPTION
## Summary

- disable Sentry's fetch error message enhancement so browser transport errors retain their native messages
- prevent telemetry instrumentation from appending request hostnames before application-level error handling
- cover the Sentry runtime setting in the platform environment test

## User impact

Existing network-error handling can recognize the browser-native `Failed to fetch` message again, so users no longer see Sentry-decorated transport toasts such as `Failed to fetch (api.vm0.ai)`.

## Verification

- `pnpm exec prettier --write apps/platform/src/lib/sentry.ts apps/platform/src/__tests__/platform-runtime-environment.test.ts`
- `pnpm -F @vm0/app exec vitest run src/__tests__/platform-runtime-environment.test.ts` (5 tests passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
