### PR TITLE
fix(platform): default artifacts to presentations

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-page-setup.ts
@@ -27,7 +27,7 @@ export const setupArtifactsPage$ = command(
 
     // Entering the page always starts a fresh first page. Later pages are
     // fetched on scroll and never cached across visits.
-    set(setArtifactCatalogKind$, null);
+    set(setArtifactCatalogKind$, "presentation");
     set(reloadArtifactCatalog$);
     set(updatePage$, createElement(ArtifactCatalogPage), "sidebar");
     set(updateDocumentTitle$, "Artifacts");

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -96,15 +96,16 @@ describe("artifact catalog page", () => {
     );
   });
 
-  it("asks the server for one kind when a filter is selected", async () => {
+  it("defaults to presentations and uses the requested filter order", async () => {
     const requestedKinds: (string | undefined)[] = [];
     context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {
       requestedKinds.push(query.kind);
+      const imageSelected = query.kind === "image";
       return respond(200, {
         artifacts: [
           artifact({
-            kind: query.kind === "image" ? "image" : "file",
-            title: query.kind === "image" ? "generated.png" : "notes.txt",
+            kind: imageSelected ? "image" : "presentation",
+            title: imageSelected ? "generated.png" : "launch-deck",
           }),
         ],
         nextCursor: null,
@@ -112,7 +113,26 @@ describe("artifact catalog page", () => {
     });
 
     setupArtifactCatalogPage();
-    await findCard("notes.txt");
+    await findCard("launch-deck");
+
+    const kindFilterGroup = document.querySelector<HTMLElement>(
+      '[aria-label="Artifact kind filters"]',
+    );
+    if (!kindFilterGroup) {
+      throw new Error("Expected artifact kind filters");
+    }
+    const kindFilters = queryAllByRoleFast("button", kindFilterGroup);
+    expect(
+      kindFilters.map((button) => {
+        return button.textContent;
+      }),
+    ).toStrictEqual(["Presentations", "Websites", "Images", "Videos", "Files"]);
+    expect(buttonByLabel("Show all artifacts")).toBeUndefined();
+    expect(buttonByLabel("Show presentation artifacts")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(requestedKinds).toStrictEqual(["presentation"]);
 
     const imageFilter = buttonByLabel("Show image artifacts");
     if (!imageFilter) {
@@ -121,7 +141,7 @@ describe("artifact catalog page", () => {
     await click(imageFilter);
 
     await findCard("generated.png");
-    expect(requestedKinds).toStrictEqual([undefined, "image"]);
+    expect(requestedKinds).toStrictEqual(["presentation", "image"]);
   });
 
   it("renders generic file artwork when a card has no thumbnail", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -44,19 +44,18 @@ const ARTIFACT_KIND_OPTIONS: readonly {
   readonly label: string;
   readonly value: ArtifactCatalogKind | null;
 }[] = [
-  { ariaLabel: "Show all artifacts", label: "All", value: null },
-  { ariaLabel: "Show image artifacts", label: "Images", value: "image" },
-  { ariaLabel: "Show video artifacts", label: "Videos", value: "video" },
-  {
-    ariaLabel: "Show website artifacts",
-    label: "Websites",
-    value: "hosted-site",
-  },
   {
     ariaLabel: "Show presentation artifacts",
     label: "Presentations",
     value: "presentation",
   },
+  {
+    ariaLabel: "Show website artifacts",
+    label: "Websites",
+    value: "hosted-site",
+  },
+  { ariaLabel: "Show image artifacts", label: "Images", value: "image" },
+  { ariaLabel: "Show video artifacts", label: "Videos", value: "video" },
   { ariaLabel: "Show file artifacts", label: "Files", value: "file" },
 ];
 


### PR DESCRIPTION
## Summary

- remove the All filter from /artifacts
- order filters as Presentations, Websites, Images, Videos, and Files
- initialize the page with Presentations selected so the first catalog request is presentation-only
- cover the default selection, filter order, absence of All, and category switching in the page test

## Verification

- pnpm exec prettier --write on the three changed files
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx (12 tests passed)

Browser verification was not run, following the repository preference to rely on the PR pipeline for vm0 PRs.