### PR TITLE
fix(ci): read pull request titles from the api so title fixes pass on rerun

### DIFF
--- a/.github/scripts/check-pr-title.sh
+++ b/.github/scripts/check-pr-title.sh
@@ -49,6 +49,10 @@ fi
 if [ "$failed" -ne 0 ]; then
   cat >&2 <<EOF
 
+How to fix:
+  Edit the pull request title, then re-run this check.
+  This check reads the current title, so no new commit is needed.
+
 Expected examples:
   feat(api): compact chat thread snapshots hourly
   fix: remove stale runner cleanup

--- a/.github/scripts/resolve-pr-title.sh
+++ b/.github/scripts/resolve-pr-title.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the pull request title for the current CI event and print it.
+#
+# The title is always read from the API, never from the pull_request event
+# payload: a re-run replays the original payload, so a payload read would keep
+# validating the pre-edit title and force an empty commit just to refresh it.
+#
+# Prints nothing and exits 0 for events that have no pull request to validate.
+
+EVENT_NAME="${EVENT_NAME:-}"
+MQ_HEAD_REF="${MQ_HEAD_REF:-}"
+PR_NUMBER="${PR_NUMBER:-}"
+REPO="${REPO:-}"
+
+case "$EVENT_NAME" in
+  pull_request)
+    pr_number="$PR_NUMBER"
+    if [ -z "$pr_number" ]; then
+      echo "::error::Could not resolve pull request number from the pull_request event" >&2
+      exit 1
+    fi
+    ;;
+  merge_group)
+    pr_number="$(printf '%s\n' "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//' || true)"
+    if [ -z "$pr_number" ]; then
+      echo "::error::Could not resolve pull request number from merge queue ref: $MQ_HEAD_REF" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+title="$(gh pr view "$pr_number" --repo "$REPO" --json title --jq .title)"
+
+# Callers treat empty output as "no pull request to validate", so an empty
+# resolved title must fail here instead of silently skipping validation.
+if [ -z "$title" ]; then
+  echo "::error::Resolved an empty title for pull request #${pr_number}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$title"

--- a/.github/scripts/tests/check-pr-title-test.sh
+++ b/.github/scripts/tests/check-pr-title-test.sh
@@ -17,6 +17,21 @@ expect_fail() {
   fi
 }
 
+expect_fail_output_contains() {
+  local title="$1"
+  local expected="$2"
+  local output
+  output="$(bash "$CHECK_PR_TITLE" "$title" 2>&1 || true)"
+  case "$output" in
+    *"$expected"*) ;;
+    *)
+      echo "Expected failure output for '$title' to contain: $expected" >&2
+      echo "Actual output: $output" >&2
+      exit 1
+      ;;
+  esac
+}
+
 expect_pass "feat(api): compact chat thread snapshots hourly"
 expect_pass "fix: remove stale runner cleanup"
 expect_pass "feat(api)!: change runner contract"
@@ -28,5 +43,10 @@ expect_fail "feat(api): compact chat thread snapshots hourly."
 expect_fail "feature: compact chat thread snapshots hourly"
 expect_fail "fix: "
 expect_fail "fix: $(printf 'a%.0s' {1..100})"
+
+expect_fail_output_contains "Compact chat thread snapshots hourly" \
+  "Edit the pull request title, then re-run this check"
+expect_fail_output_contains "Compact chat thread snapshots hourly" \
+  "no new commit is needed"
 
 echo "check-pr-title tests passed"

--- a/.github/scripts/tests/resolve-pr-title-test.sh
+++ b/.github/scripts/tests/resolve-pr-title-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/resolve-pr-title.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+fake_bin="${tmp_dir}/bin"
+mkdir -p "$fake_bin"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+cat >"${fake_bin}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$MOCK_GH_LOG"
+
+pr_number=""
+previous=""
+for argument in "$@"; do
+  case "$previous" in
+    view) pr_number=$argument ;;
+  esac
+  previous=$argument
+done
+
+case "$pr_number" in
+  7) printf '\n' ;;
+  *) printf 'feat(api): title from the api for pr %s\n' "$pr_number" ;;
+esac
+SH
+chmod +x "${fake_bin}/gh"
+
+run_resolve() {
+  MOCK_GH_LOG="${tmp_dir}/gh.log" PATH="${fake_bin}:$PATH" "$@" bash "$script"
+}
+
+reset_log() {
+  : >"${tmp_dir}/gh.log"
+}
+
+# pull_request resolves through the API using the event's PR number.
+reset_log
+output="$(run_resolve env EVENT_NAME=pull_request PR_NUMBER=42 REPO=vm0-ai/vm0)"
+[ "$output" = "feat(api): title from the api for pr 42" ] ||
+  fail "pull_request should resolve the title from the api, got: $output"
+grep -q 'pr view 42 --repo vm0-ai/vm0 --json title --jq .title' "${tmp_dir}/gh.log" ||
+  fail "pull_request should call gh pr view with the event pr number"
+
+# Regression guard: a stale payload title must never win over the live title.
+# This is the whole point of the check; a revert to a payload read fails here.
+reset_log
+output="$(run_resolve env EVENT_NAME=pull_request PR_NUMBER=42 REPO=vm0-ai/vm0 \
+  PR_TITLE="feat(api): Stale Title From The Event Payload")"
+[ "$output" = "feat(api): title from the api for pr 42" ] ||
+  fail "pull_request must ignore a payload title, got: $output"
+
+# merge_group resolves the pr number out of the queue ref.
+reset_log
+output="$(run_resolve env EVENT_NAME=merge_group REPO=vm0-ai/vm0 \
+  MQ_HEAD_REF=gh-readonly-queue/main/pr-99-0123456789abcdef)"
+[ "$output" = "feat(api): title from the api for pr 99" ] ||
+  fail "merge_group should resolve the title for the queued pr, got: $output"
+grep -q 'pr view 99 ' "${tmp_dir}/gh.log" ||
+  fail "merge_group should call gh pr view with the queued pr number"
+
+# Events without a pull request produce no title and no api call.
+reset_log
+output="$(run_resolve env EVENT_NAME=push REPO=vm0-ai/vm0)"
+[ -z "$output" ] || fail "push should resolve no title, got: $output"
+[ ! -s "${tmp_dir}/gh.log" ] || fail "push should not call gh"
+
+# A pull_request event without a number fails instead of validating nothing.
+reset_log
+if run_resolve env EVENT_NAME=pull_request PR_NUMBER= REPO=vm0-ai/vm0 >/dev/null 2>&1; then
+  fail "pull_request without a pr number should fail"
+fi
+
+# An unparseable merge queue ref fails instead of validating nothing.
+reset_log
+if run_resolve env EVENT_NAME=merge_group REPO=vm0-ai/vm0 \
+  MQ_HEAD_REF=refs/heads/main >/dev/null 2>&1; then
+  fail "merge_group with an unparseable ref should fail"
+fi
+
+# An empty resolved title fails instead of being read as "nothing to validate".
+reset_log
+if run_resolve env EVENT_NAME=pull_request PR_NUMBER=7 REPO=vm0-ai/vm0 >/dev/null 2>&1; then
+  fail "an empty resolved title should fail"
+fi
+
+echo "resolve-pr-title tests passed"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,30 +73,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          case "$EVENT_NAME" in
-            pull_request)
-              if [ -z "$PR_NUMBER" ]; then
-                echo "::error::Could not resolve pull request number from the pull_request event"
-                exit 1
-              fi
-              # Read the title from the API rather than the event payload: a
-              # re-run replays the original payload, so a payload read would keep
-              # failing on the pre-edit title and force an empty commit instead.
-              title="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq .title)"
-              ;;
-            merge_group)
-              pr_number="$(printf '%s\n' "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//' || true)"
-              if [ -z "$pr_number" ]; then
-                echo "::error::Could not resolve pull request number from merge queue ref: $MQ_HEAD_REF"
-                exit 1
-              fi
-              title="$(gh pr view "$pr_number" --repo "$REPO" --json title --jq .title)"
-              ;;
-            *)
-              echo "No pull request title to validate for $EVENT_NAME"
-              exit 0
-              ;;
-          esac
+          title="$(.github/scripts/resolve-pr-title.sh)"
+
+          if [ -z "$title" ]; then
+            echo "No pull request title to validate for $EVENT_NAME"
+            exit 0
+          fi
 
           .github/scripts/check-pr-title.sh "$title"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,14 +68,21 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
           MQ_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
-          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           case "$EVENT_NAME" in
             pull_request)
-              title="$PR_TITLE"
+              if [ -z "$PR_NUMBER" ]; then
+                echo "::error::Could not resolve pull request number from the pull_request event"
+                exit 1
+              fi
+              # Read the title from the API rather than the event payload: a
+              # re-run replays the original payload, so a payload read would keep
+              # failing on the pre-edit title and force an empty commit instead.
+              title="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq .title)"
               ;;
             merge_group)
               pr_number="$(printf '%s\n' "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//' || true)"


### PR DESCRIPTION
## Summary

- Resolve the PR title in the `Pull Request Title` check from the GitHub API instead of the `pull_request` event payload, so re-running the check picks up an edited title.
- Tell contributors in the failure output that editing the title and re-running is enough, and that no new commit is required.
- Cover the new guidance text with the existing `check-pr-title` script test.

## Problem

`pr-title` read the title from `${{ github.event.pull_request.title }}`. The workflow triggers on `on: pull_request:` with no `types:`, which defaults to `opened, synchronize, reopened` and excludes `edited`, so renaming a PR never started a fresh run. Re-running did not help either: a re-run replays the original event payload, so the job kept validating the pre-edit title.

Observed on #23362 — after the title was corrected, `gh run rerun --failed` still logged the old value and failed again:

```
PR_TITLE: feat(connectors): route configured OAuth providers through App callbacks
##[error]Pull request title subject must be lower-case
```

The only remaining workaround was pushing an empty commit to produce a `synchronize` event. That adds a junk commit, restarts the entire pipeline, and moves HEAD, which also invalidates any existing PR review.

## User impact

Fixing a bad PR title is now: edit the title, then re-run the failed check. No empty commit, no full pipeline restart, and HEAD stays put so existing reviews remain valid. `ci-gate-security` depends on `pr-title` via `needs`, so `gh run rerun --failed` re-runs both and the gate turns green with it.

## Implementation notes

- The `merge_group` branch of this same step already resolved the title through `gh pr view`. This change makes the `pull_request` branch consistent with it rather than introducing a new mechanism.
- `PR_TITLE` is replaced by `PR_NUMBER`, with a fail-fast guard when the number cannot be resolved, matching the existing `merge_group` error handling.
- The workflow already declares `pull-requests: read`, which is what `gh pr view --json title` needs, so this also works for fork PRs using the default `github.token`.
- Adding `edited` to the trigger types was considered and rejected: `edited` also fires on description edits, so every body tweak would re-run the whole Security Scanning workflow, including CodeQL (~4 min) and Semgrep SAST (~5 min).
- This check only validates the title. Editing the PR description has no effect on it either way.

## Verification

- `bash .github/scripts/tests/check-pr-title-test.sh` — passes, including the two new assertions on the guidance text. This suite is already executed in CI by the loop over `.github/scripts/tests/*.sh`.
- `shellcheck .github/scripts/check-pr-title.sh .github/scripts/tests/check-pr-title-test.sh` — clean.
- `security.yml` parses as valid YAML; `actionlint` runs in CI via `Workflow Lint`.
- `.github/scripts/check-workflow-shell-compatibility.sh` needs `shellcheck` and `yq`, which are unavailable in this sandbox; it runs in CI.
