### PR TITLE
fix(chat): preserve full recommended follow-up prompts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -717,6 +717,8 @@ describe("CHAT-02: completed chat callback", () => {
     const titlePrompts: string[] = [];
     const followupSystemPrompts: string[] = [];
     const followupPrompts: string[] = [];
+    const longFollowupPrompt =
+      "Can you draft a new 90-minute workshop outline that focuses on the event-driven workflow of an AI Lead Operations Team and includes hands-on exercises?";
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
       const systemContent = body.messages[0]?.content ?? "";
@@ -728,7 +730,7 @@ describe("CHAT-02: completed chat callback", () => {
         followupSystemPrompts.push(systemContent);
         followupPrompts.push(body.messages[1]?.content ?? "");
         return JSON.stringify([
-          { prompt: "Turn this into a checklist", kind: "talk" },
+          { prompt: longFollowupPrompt, kind: "talk" },
           {
             prompt: "Generate a landing page for this plan",
             kind: "generate",
@@ -831,7 +833,7 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected a recommended follow-up message");
     }
     expect(recommender.recommendedFollowups).toStrictEqual([
-      { prompt: "Turn this into a checklist", kind: "talk" },
+      { prompt: longFollowupPrompt, kind: "talk" },
       {
         prompt: "Generate a landing page for this plan",
         kind: "generate",

--- a/turbo/apps/api/src/signals/services/zero-chat-recommended-followups.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-recommended-followups.service.ts
@@ -17,7 +17,7 @@ function sanitizeFollowupPrompt(raw: string): string | null {
   if (text.length === 0) {
     return null;
   }
-  return text.length > 120 ? `${text.slice(0, 117).trim()}...` : text;
+  return text;
 }
 
 function isRecommendedFollowupGenerationType(


### PR DESCRIPTION
## Summary

- preserve the complete recommended follow-up prompt instead of replacing content beyond 120 characters with a literal ellipsis
- retain the existing cleanup for list markers, surrounding quotes, empty prompts, malformed JSON fragments, and duplicates
- cover the callback persistence and read path with a 151-character follow-up prompt

Fixes #23359

## User impact

Long recommended follow-ups remain fully readable after they are selected into the Web/PWA chat composer. Prompts that were already persisted with a literal ellipsis cannot be recovered retroactively.

## Verification

- `corepack pnpm exec prettier --write apps/api/src/signals/services/zero-chat-recommended-followups.service.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `corepack pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm -F api check-types`
- `corepack pnpm knip --workspace api`
- direct normalization check confirmed all 151 characters are preserved
- targeted Vitest was attempted twice, but the local runner job claim returned `404` before reaching the changed follow-up assertion; the PR pipeline will run the integration coverage
