### PR TITLE
fix: show website template previews in a single dialog

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -61,14 +61,20 @@ export const setModelPickerOpen$ = command(({ set }, open: boolean) => {
 // -- Template picker open/category state ------------------------------------
 
 const internalWebsiteTemplatePreviewId$ = state<string | null>(null);
+const internalWebsiteTemplatePreviewLoaded$ = state(false);
 const internalTemplatePickerOpen$ = state(false);
+const internalTemplatePickerSkipEnterAnimation$ = state(false);
 export const templatePickerOpen$ = computed((get) => {
   return (
     get(internalTemplatePickerOpen$) &&
     get(internalWebsiteTemplatePreviewId$) === null
   );
 });
+export const templatePickerSkipEnterAnimation$ = computed((get) => {
+  return get(internalTemplatePickerSkipEnterAnimation$);
+});
 export const setTemplatePickerOpen$ = command(({ set }, open: boolean) => {
+  set(internalTemplatePickerSkipEnterAnimation$, false);
   set(internalTemplatePickerOpen$, open);
 });
 
@@ -86,12 +92,22 @@ export const setTemplatePickerReferenceValue$ = command(
 export const websiteTemplatePreviewId$ = computed((get) => {
   return get(internalWebsiteTemplatePreviewId$);
 });
+export const websiteTemplatePreviewLoaded$ = computed((get) => {
+  return get(internalWebsiteTemplatePreviewLoaded$);
+});
+export const markWebsiteTemplatePreviewLoaded$ = command(({ set }) => {
+  set(internalWebsiteTemplatePreviewLoaded$, true);
+});
 export const openWebsiteTemplatePreview$ = command(
   ({ set }, templateId: string) => {
+    set(internalTemplatePickerSkipEnterAnimation$, false);
+    set(internalWebsiteTemplatePreviewLoaded$, false);
     set(internalWebsiteTemplatePreviewId$, templateId);
   },
 );
 export const closeWebsiteTemplatePreview$ = command(({ set }) => {
+  set(internalTemplatePickerSkipEnterAnimation$, true);
+  set(internalWebsiteTemplatePreviewLoaded$, false);
   set(internalWebsiteTemplatePreviewId$, null);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -60,9 +60,13 @@ export const setModelPickerOpen$ = command(({ set }, open: boolean) => {
 
 // -- Template picker open/category state ------------------------------------
 
+const internalWebsiteTemplatePreviewId$ = state<string | null>(null);
 const internalTemplatePickerOpen$ = state(false);
 export const templatePickerOpen$ = computed((get) => {
-  return get(internalTemplatePickerOpen$);
+  return (
+    get(internalTemplatePickerOpen$) &&
+    get(internalWebsiteTemplatePreviewId$) === null
+  );
 });
 export const setTemplatePickerOpen$ = command(({ set }, open: boolean) => {
   set(internalTemplatePickerOpen$, open);
@@ -79,7 +83,6 @@ export const setTemplatePickerReferenceValue$ = command(
   },
 );
 
-const internalWebsiteTemplatePreviewId$ = state<string | null>(null);
 export const websiteTemplatePreviewId$ = computed((get) => {
   return get(internalWebsiteTemplatePreviewId$);
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -2481,10 +2481,7 @@ describe("chat composer templates", () => {
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`),
       ).toHaveAttribute("src", websiteTemplatePreviewImageUrl);
-      expect(
-        screen.getByTitle(`${websiteTemplate.title} website template preview`)
-          .tagName,
-      ).toBe("IMG");
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
     });
 
     click(
@@ -2496,13 +2493,45 @@ describe("chat composer templates", () => {
       expect(
         screen.getByTitle(`${websiteTemplate.title} website full preview`),
       ).toHaveAttribute("src", websiteTemplate.previewUrl);
+      expect(
+        screen.queryByTitle(
+          `${websiteTemplate.title} website template preview`,
+        ),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
     });
     const websitePreviewDialog = screen.getByRole("dialog", {
       name: `Website / ${websiteTemplate.title}`,
     });
+    click(within(websitePreviewDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByTitle(`${websiteTemplate.title} website full preview`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${websiteTemplate.title} website template preview`),
+      ).toHaveAttribute("src", websiteTemplatePreviewImageUrl);
+      expect(tabByText("Website")).toHaveAttribute("aria-selected", "true");
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    });
+
+    click(
+      within(screen.getByRole("dialog")).getByLabelText(
+        `Preview website template ${websiteTemplate.title}`,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTitle(`${websiteTemplate.title} website full preview`),
+      ).toHaveAttribute("src", websiteTemplate.previewUrl);
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    });
+    const reopenedWebsitePreviewDialog = screen.getByRole("dialog", {
+      name: `Website / ${websiteTemplate.title}`,
+    });
     const websiteBackButton = queryAllByRoleFast(
       "button",
-      websitePreviewDialog,
+      reopenedWebsitePreviewDialog,
     ).find((candidate) => {
       return candidate.textContent?.replace(/\s+/g, " ").trim() === "Website";
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -2494,6 +2494,11 @@ describe("chat composer templates", () => {
         screen.getByTitle(`${websiteTemplate.title} website full preview`),
       ).toHaveAttribute("src", websiteTemplate.previewUrl);
       expect(
+        screen.getByTitle(
+          `${websiteTemplate.title} website preview placeholder`,
+        ),
+      ).toHaveAttribute("src", websiteTemplatePreviewImageUrl);
+      expect(
         screen.queryByTitle(
           `${websiteTemplate.title} website template preview`,
         ),
@@ -2502,6 +2507,20 @@ describe("chat composer templates", () => {
     });
     const websitePreviewDialog = screen.getByRole("dialog", {
       name: `Website / ${websiteTemplate.title}`,
+    });
+    const websitePreviewPlaceholder = screen.getByTitle(
+      `${websiteTemplate.title} website preview placeholder`,
+    );
+    expect(websitePreviewDialog).toHaveClass("data-[state=open]:!animate-none");
+    expect(document.querySelector(".zero-dialog-overlay")).toHaveClass(
+      "data-[state=open]:!animate-none",
+    );
+    expect(websitePreviewPlaceholder).toHaveClass("block");
+    fireEvent.load(
+      screen.getByTitle(`${websiteTemplate.title} website full preview`),
+    );
+    await waitFor(() => {
+      expect(websitePreviewPlaceholder).toHaveClass("hidden");
     });
     click(within(websitePreviewDialog).getByLabelText("Close"));
     await waitFor(() => {
@@ -2545,6 +2564,14 @@ describe("chat composer templates", () => {
       ).not.toBeInTheDocument();
       expect(tabByText("Website")).toHaveAttribute("aria-selected", "true");
     });
+    expect(
+      screen.getByRole("dialog", {
+        name: "Template",
+      }),
+    ).toHaveClass("data-[state=open]:!animate-none");
+    expect(document.querySelector(".zero-dialog-overlay")).toHaveClass(
+      "data-[state=open]:!animate-none",
+    );
     click(screen.getByLabelText("Close"));
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/website-template-preview-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/website-template-preview-dialog.tsx
@@ -5,10 +5,16 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import { useGet, useSet } from "ccstate-react";
-import { findWebsiteTemplateItem, type WebsiteTemplateItem } from "@vm0/core";
+import {
+  findWebsiteTemplateItem,
+  r2ImageTransformUrl,
+  type WebsiteTemplateItem,
+} from "@vm0/core";
 import {
   closeWebsiteTemplatePreview$,
+  markWebsiteTemplatePreviewLoaded$,
   websiteTemplatePreviewId$,
+  websiteTemplatePreviewLoaded$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 
 function WebsiteTemplatePreviewDialog({
@@ -16,19 +22,23 @@ function WebsiteTemplatePreviewDialog({
   open,
   onOpenChange,
 }: {
-  item: WebsiteTemplateItem | null;
+  item: WebsiteTemplateItem;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  if (item === null) {
-    return null;
-  }
+  const previewLoaded = useGet(websiteTemplatePreviewLoaded$);
+  const markPreviewLoaded = useSet(markWebsiteTemplatePreviewLoaded$);
+  const placeholderUrl = r2ImageTransformUrl(item.previewImageUrl, {
+    width: 480,
+    height: 270,
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         aria-describedby={undefined}
-        className="flex h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 [&>button[aria-label=Close]]:top-[7px] sm:h-[min(760px,calc(100dvh-4rem))]"
+        className="flex h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 data-[state=open]:!animate-none [&>button[aria-label=Close]]:top-[7px] sm:h-[min(760px,calc(100dvh-4rem))]"
+        overlayClassName="data-[state=open]:!animate-none"
       >
         <DialogHeader className="shrink-0 border-b border-border px-5 py-4 pr-14 text-left sm:pr-16">
           <DialogTitle className="flex min-w-0 max-w-full items-center justify-start gap-1.5 text-left text-base leading-none">
@@ -48,12 +58,22 @@ function WebsiteTemplatePreviewDialog({
           </DialogTitle>
         </DialogHeader>
         <div className="min-h-0 flex-1 bg-muted/20 p-3 sm:p-5">
-          <div className="h-full overflow-hidden rounded-lg border border-border bg-background">
+          <div className="relative h-full overflow-hidden rounded-lg border border-border bg-background">
+            <img
+              src={placeholderUrl}
+              alt=""
+              aria-hidden="true"
+              title={`${item.title} website preview placeholder`}
+              className={`pointer-events-none absolute inset-0 z-10 h-full w-full bg-background object-contain object-top ${
+                previewLoaded ? "hidden" : "block"
+              }`}
+            />
             <iframe
               title={`${item.title} website full preview`}
               src={item.previewUrl}
               sandbox="allow-same-origin allow-scripts"
               className="h-full w-full border-0 bg-background"
+              onLoad={markPreviewLoaded}
             />
           </div>
         </div>
@@ -68,10 +88,14 @@ export function WebsiteTemplatePreviewDialogSlot() {
   const item =
     previewId === null ? null : (findWebsiteTemplateItem(previewId) ?? null);
 
+  if (item === null) {
+    return null;
+  }
+
   return (
     <WebsiteTemplatePreviewDialog
       item={item}
-      open={item !== null}
+      open
       onOpenChange={(open) => {
         if (!open) {
           closePreview();

--- a/turbo/apps/platform/src/views/zero-page/website-template-preview-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/website-template-preview-dialog.tsx
@@ -28,7 +28,7 @@ function WebsiteTemplatePreviewDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         aria-describedby={undefined}
-        className="flex h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 sm:h-[min(760px,calc(100dvh-4rem))]"
+        className="flex h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 [&>button[aria-label=Close]]:top-[7px] sm:h-[min(760px,calc(100dvh-4rem))]"
       >
         <DialogHeader className="shrink-0 border-b border-border px-5 py-4 pr-14 text-left sm:pr-16">
           <DialogTitle className="flex min-w-0 max-w-full items-center justify-start gap-1.5 text-left text-base leading-none">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -189,6 +189,7 @@ import {
   uploadPopoverOpen$,
   setUploadPopoverOpen$,
   templatePickerOpen$,
+  templatePickerSkipEnterAnimation$,
   setTemplatePickerOpen$,
   templatePickerReferenceValue$,
   setTemplatePickerReferenceValue$,
@@ -4383,6 +4384,7 @@ function TemplatePickerDialog({
   value,
   onChange,
   onClose,
+  skipEnterAnimation,
   hasPptTab,
   presentationItems,
   hasIllustrationTab,
@@ -4393,6 +4395,7 @@ function TemplatePickerDialog({
   value: GenerationTemplateRequest | undefined;
   onChange: (value: GenerationTemplateRequest | undefined) => void;
   onClose: () => void;
+  skipEnterAnimation: boolean;
   hasPptTab: boolean;
   presentationItems: readonly PresentationTemplateItem[];
   hasIllustrationTab: boolean;
@@ -4429,6 +4432,7 @@ function TemplatePickerDialog({
   const isPreviewing = Boolean(previewItem);
   const dialogContentClassName = cn(
     "gap-0 overflow-hidden p-0 focus:outline-none focus-visible:outline-none focus-visible:ring-0",
+    skipEnterAnimation && "data-[state=open]:!animate-none",
     isPreviewing
       ? "flex h-[min(90dvh,760px)] max-w-6xl flex-col sm:h-auto [&>button[aria-label=Close]]:top-[7px]"
       : "flex h-[min(82vh,760px)] max-w-6xl flex-col [&>button[aria-label=Close]]:top-[7px] sm:[&>button[aria-label=Close]]:top-[19px]",
@@ -4645,6 +4649,9 @@ function TemplatePickerDialog({
     >
       <DialogContent
         className={dialogContentClassName}
+        overlayClassName={
+          skipEnterAnimation ? "data-[state=open]:!animate-none" : undefined
+        }
         aria-describedby={undefined}
         onKeyDown={handleDialogKeyDown}
         onKeyDownCapture={
@@ -5113,6 +5120,7 @@ function TemplatePickerButton({
   runtime: TemplatePreviewRuntime;
 }) {
   const open = useGet(templatePickerOpen$);
+  const skipEnterAnimation = useGet(templatePickerSkipEnterAnimation$);
   const category = useGet(templatePickerCategory$);
   const referenceValue = useGet(templatePickerReferenceValue$);
   const setOpen = useSet(setTemplatePickerOpen$);
@@ -5184,6 +5192,7 @@ function TemplatePickerButton({
             setReferenceValue(null);
             setOpen(false);
           }}
+          skipEnterAnimation={skipEnterAnimation}
           hasPptTab={hasPptTab}
           presentationItems={presentationItems}
           hasIllustrationTab={hasIllustrationTab}


### PR DESCRIPTION
## Summary

- Close the website template picker while a full preview is open so only one dialog is visible.
- Restore the Website picker when the preview is closed with the close button or the Website breadcrumb.
- Extend the platform integration test to cover the single-dialog transition and both close paths.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/zero-page/zero-chat-composer.ts apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx --maxWorkers=1 --silent=passed-only` (31 passed)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint` (passes with existing warnings)
- Browser verification was attempted; local Clerk configuration is missing `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW`, so the app remained on its loading screen.
