### PR TITLE
fix(ci): use immutable pages urls for browser e2e

### DIFF
--- a/.github/scripts/prepare-okou-pages-dist.sh
+++ b/.github/scripts/prepare-okou-pages-dist.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if (( $# != 2 )); then
-  echo "usage: $0 <canonical-dist> <empty-pages-dist>" >&2
+if (( $# < 2 || $# > 3 )); then
+  echo "usage: $0 <canonical-dist> <empty-pages-dist> [preview-api-origin]" >&2
   exit 1
 fi
 
 canonical_dist="$1"
 pages_dist="$2"
+preview_api_origin="${3:-}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pages_config_dir="${script_dir}/../pages/okou-app"
 
@@ -22,6 +23,23 @@ if [[ ! -d "$pages_dist" ]] || [[ -n "$(find "$pages_dist" -mindepth 1 -print -q
 fi
 
 cp -a "${canonical_dist}/." "$pages_dist/"
+
+if [[ -n "$preview_api_origin" ]]; then
+  if [[ ! "$preview_api_origin" =~ ^https://(staging|pr-[0-9]+)-api\.vm6\.ai$ ]]; then
+    echo "invalid preview API origin: ${preview_api_origin}" >&2
+    exit 1
+  fi
+
+  runtime_config_marker='<meta name="vm0-api-origin" content="" />'
+  if ! grep -Fq "$runtime_config_marker" "${pages_dist}/index.html"; then
+    echo "canonical app artifact is missing the API origin marker" >&2
+    exit 1
+  fi
+  sed -i \
+    "s|${runtime_config_marker}|<meta name=\"vm0-api-origin\" content=\"${preview_api_origin}\" />|" \
+    "${pages_dist}/index.html"
+fi
+
 find "$pages_dist" -type f -name '*.map' -delete
 rm -f \
   "${pages_dist}/.gitkeep" \

--- a/.github/scripts/tests/prepare-okou-pages-dist-test.sh
+++ b/.github/scripts/tests/prepare-okou-pages-dist-test.sh
@@ -10,7 +10,11 @@ canonical_dist="${tmp_dir}/canonical"
 pages_dist="${tmp_dir}/pages"
 mkdir -p "${canonical_dist}/assets" "$pages_dist"
 
-printf '<!doctype html>\n' > "${canonical_dist}/index.html"
+printf '%s\n' \
+  '<!doctype html>' \
+  '<head>' \
+  '  <meta name="vm0-api-origin" content="" />' \
+  '</head>' > "${canonical_dist}/index.html"
 printf 'console.log("app");\n' > "${canonical_dist}/assets/app-123.js"
 printf '{"version":3}\n' > "${canonical_dist}/assets/app-123.js.map"
 printf '{"version":1}\n' > "${canonical_dist}/manifest.json"
@@ -32,6 +36,29 @@ grep -Fxq '/assets/*' "${pages_dist}/_headers"
 grep -Fq 'Cache-Control: public, max-age=31536000, immutable' \
   "${pages_dist}/_headers"
 grep -Fq '<title>Not Found</title>' "${pages_dist}/assets/404.html"
+grep -Fq '<meta name="vm0-api-origin" content="" />' \
+  "${pages_dist}/index.html"
+
+preview_pages_dist="${tmp_dir}/preview-pages"
+mkdir -p "$preview_pages_dist"
+bash "$script" \
+  "$canonical_dist" \
+  "$preview_pages_dist" \
+  "https://pr-23364-api.vm6.ai"
+grep -Fq \
+  '<meta name="vm0-api-origin" content="https://pr-23364-api.vm6.ai" />' \
+  "${preview_pages_dist}/index.html"
+
+invalid_origin_dist="${tmp_dir}/invalid-origin"
+mkdir -p "$invalid_origin_dist"
+if bash \
+  "$script" \
+  "$canonical_dist" \
+  "$invalid_origin_dist" \
+  "https://example.com" >/dev/null 2>&1; then
+  echo "expected an invalid preview API origin to be rejected" >&2
+  exit 1
+fi
 
 nonempty_dist="${tmp_dir}/nonempty"
 mkdir -p "$nonempty_dist"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1199,6 +1199,8 @@ jobs:
     needs: [detect-release]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      deployment-url: ${{ steps.pages-deploy.outputs.url }}
     concurrency:
       group: deploy-app-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       cancel-in-progress: false
@@ -1222,6 +1224,7 @@ jobs:
       CF_PAGES_PREVIEW_DOMAIN: ${{ vars.CF_PAGES_PREVIEW_DOMAIN }}
       CF_PAGES_PREVIEW_ZONE_ID: ${{ vars.CF_PAGES_PREVIEW_ZONE_ID }}
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+      PREVIEW_DOMAIN: ${{ vars.PREVIEW_DOMAIN }}
       R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
       R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
     steps:
@@ -1402,18 +1405,22 @@ jobs:
 
           : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
           : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+          : "${PREVIEW_DOMAIN:?PREVIEW_DOMAIN variable is required}"
 
           r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           artifact_uri="s3://${R2_BUCKET_NAME}/${ARTIFACT_PREFIX}"
           canonical_dist="$(mktemp -d)"
           pages_dist="$(mktemp -d)"
+          job_ref="${PAGES_BRANCH%-app}"
+          api_origin="https://${job_ref}-api.${PREVIEW_DOMAIN}"
 
           aws s3 cp "$artifact_uri/" "$canonical_dist/" \
             --endpoint-url "$r2_endpoint" \
             --recursive
           bash .github/scripts/prepare-okou-pages-dist.sh \
             "$canonical_dist" \
-            "$pages_dist"
+            "$pages_dist" \
+            "$api_origin"
 
           {
             echo "dist=$pages_dist"
@@ -1431,11 +1438,13 @@ jobs:
           echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
+        id: pages-deploy
         env:
           ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
+          WRANGLER_OUTPUT_FILE_PATH: /tmp/wrangler-pages-output.ndjson
         working-directory: turbo
         run: |
           set -euo pipefail
@@ -1445,6 +1454,36 @@ jobs:
             --branch "$PAGES_BRANCH" \
             --commit-hash "$ARTIFACT_SHA" \
             --commit-dirty=false
+
+          deployment="$(
+            jq --slurp --compact-output \
+              'map(select(.type == "pages-deploy-detailed")) | last' \
+              "$WRANGLER_OUTPUT_FILE_PATH"
+          )"
+          deployment_url="$(jq -r '.url // empty' <<< "$deployment")"
+          deployment_commit="$(jq -r \
+            '.deployment_trigger.metadata.commit_hash // empty' \
+            <<< "$deployment")"
+
+          if [[ -z "$deployment_url" ]]; then
+            echo "::error::Wrangler did not report a Pages deployment URL"
+            exit 1
+          fi
+          deployment_host="${deployment_url#https://}"
+          deployment_hash="${deployment_host%%.*}"
+          if [[ \
+            ! "$deployment_hash" =~ ^[0-9a-f]{8}$ ||
+            "$deployment_url" != "https://${deployment_hash}.${CF_PAGES_PROJECT_NAME}.pages.dev" \
+          ]]; then
+            echo "::error::Wrangler did not report an immutable Pages deployment URL"
+            exit 1
+          fi
+          if [[ "$deployment_commit" != "$ARTIFACT_SHA" ]]; then
+            echo "::error::Pages deployment commit does not match the app artifact"
+            exit 1
+          fi
+
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
 
       - name: Configure Cloudflare Pages custom preview domain
         if: steps.pages-custom-domain.outputs.domain != ''
@@ -1465,7 +1504,7 @@ jobs:
       - name: Wait for Cloudflare Pages preview assets
         env:
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
-          PAGES_URL: ${{ steps.pages-custom-domain.outputs.url || steps.pages-preview.outputs.url }}
+          PAGES_URL: ${{ steps.pages-deploy.outputs.url }}
         run: |
           set -euo pipefail
 
@@ -1576,9 +1615,11 @@ jobs:
 
       - name: Record Cloudflare Pages preview
         env:
+          PAGES_DEPLOYMENT_URL: ${{ steps.pages-deploy.outputs.url }}
           PAGES_CUSTOM_URL: ${{ steps.pages-custom-domain.outputs.url }}
           PAGES_PREVIEW_URL: ${{ steps.pages-preview.outputs.url }}
         run: |
+          echo "Cloudflare Pages deployment: ${PAGES_DEPLOYMENT_URL}" >> "$GITHUB_STEP_SUMMARY"
           echo "Cloudflare Pages preview: ${PAGES_PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
           if [[ -n "$PAGES_CUSTOM_URL" ]]; then
             echo "Cloudflare Pages custom preview: ${PAGES_CUSTOM_URL}" >> "$GITHUB_STEP_SUMMARY"
@@ -1709,8 +1750,8 @@ jobs:
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
         env:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
-          VM0_AUTH_URL: ${{ needs.prepare.outputs.app-preview-url }}
-          VM0_AUTH_REDIRECT_URL: ${{ needs.prepare.outputs.app-preview-url }}/_/skeleton
+          VM0_AUTH_URL: ${{ needs.deploy-app.outputs.deployment-url }}
+          VM0_AUTH_REDIRECT_URL: ${{ needs.deploy-app.outputs.deployment-url }}/_/skeleton
           VM0_AUTH_DOMAIN: ${{ needs.prepare.outputs.api-preview-url != '' && format('{0}-api.{1}', needs.prepare.outputs.job-ref, vars.PREVIEW_DOMAIN || 'vm6.ai') || '' }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -1807,7 +1848,7 @@ jobs:
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts
         env:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
-          VM0_APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
+          VM0_APP_URL: ${{ needs.deploy-app.outputs.deployment-url }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -808,6 +808,31 @@ describe("createApp", () => {
       );
     });
 
+    it("allows immutable okou Pages deployment origins in preview", async () => {
+      mockEnv("ENV", "preview");
+      const app = createApp({ signal: context.signal });
+      const origin = "https://3508a2f5.okou-app.pages.dev";
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    });
+
+    it("does not allow okou Pages deployment origins in production", async () => {
+      mockEnv("ENV", "production");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://3508a2f5.okou-app.pages.dev" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    });
+
     it("does not allow lookalike okou preview origins", async () => {
       mockEnv("ENV", "preview");
       const app = createApp({ signal: context.signal });

--- a/turbo/apps/api/src/lib/__tests__/billing-redirect.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/billing-redirect.test.ts
@@ -6,6 +6,7 @@ import { mockEnv } from "../env";
 describe("billingRedirectAllowed", () => {
   beforeEach(() => {
     mockEnv("APP_URL", "https://app.vm7.ai:8443");
+    mockEnv("ENV", "preview");
   });
 
   it("accepts the configured app origin", () => {
@@ -19,6 +20,24 @@ describe("billingRedirectAllowed", () => {
   it("rejects a non-App origin", () => {
     expect(
       billingRedirectAllowed("https://example.com/onboarding?billing=success"),
+    ).toBeFalsy();
+  });
+
+  it("accepts an immutable okou Pages deployment in preview", () => {
+    expect(
+      billingRedirectAllowed(
+        "https://3508a2f5.okou-app.pages.dev/onboarding?billing=success",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("rejects an immutable okou Pages deployment in production", () => {
+    mockEnv("ENV", "production");
+
+    expect(
+      billingRedirectAllowed(
+        "https://3508a2f5.okou-app.pages.dev/onboarding?billing=success",
+      ),
     ).toBeFalsy();
   });
 });

--- a/turbo/apps/api/src/lib/billing-redirect.ts
+++ b/turbo/apps/api/src/lib/billing-redirect.ts
@@ -8,6 +8,9 @@ import { env } from "./env";
 //   - any first-party *.vm0.ai production domain (app.vm0.ai, www.vm0.ai, ...),
 //   - okou.ai and its production subdomains,
 //   - *.omby.ai staging and per-branch preview hosts.
+// Preview APIs also accept immutable okou-app.pages.dev deployment hosts used
+// by E2E. Production APIs do not, so checkout session ids cannot be redirected
+// to preview code.
 // User-hosted content lives on a different registrable domain (sites.vm0.io),
 // so the *.vm0.ai wildcard stays first-party. hostname comes from URL parsing,
 // so the suffix checks cannot be spoofed by paths or userinfo.
@@ -22,6 +25,9 @@ export function billingRedirectAllowed(rawUrl: string): boolean {
     host.endsWith(".vm0.ai") ||
     host === "okou.ai" ||
     host.endsWith(".okou.ai") ||
-    host.endsWith(".omby.ai")
+    host.endsWith(".omby.ai") ||
+    (env("ENV") === "preview" &&
+      url.port === "" &&
+      host.endsWith(".okou-app.pages.dev"))
   );
 }

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -17,6 +17,7 @@ const STATIC_ALLOWED_ORIGINS = Object.freeze(
     "https://app.vm7.ai:8443",
   ]),
 );
+const OKOU_PAGES_PREVIEW_HOST_SUFFIX = ".okou-app.pages.dev";
 
 function getAllowedOrigin(origin: string | undefined): string | null {
   if (!origin) {
@@ -51,7 +52,9 @@ function getAllowedOrigin(origin: string | undefined): string | null {
 
   if (
     deployEnv === "preview" &&
-    (hostname.endsWith(".vm7.ai") || hostname.endsWith(".omby.ai"))
+    (hostname.endsWith(".vm7.ai") ||
+      hostname.endsWith(".omby.ai") ||
+      (url.port === "" && hostname.endsWith(OKOU_PAGES_PREVIEW_HOST_SUFFIX)))
   ) {
     return normalizedOrigin;
   }

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Zero</title>
     <meta charset="UTF-8" />
+    <meta name="vm0-api-origin" content="" />
     <style>
       body {
         margin: 0;

--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -18,6 +18,7 @@ const PREVIEW_CLERK_KEY = "pk_test_preview";
 const PRODUCTION_CLERK_KEY = "pk_live_production";
 const PREVIEW_VAPID_KEY = "preview_vapid_key";
 const PRODUCTION_VAPID_KEY = "production_vapid_key";
+const PREVIEW_API_ORIGIN_SELECTOR = 'meta[name="vm0-api-origin"]';
 
 const { posthogInit, sentryInit } = vi.hoisted(() => {
   return {
@@ -53,6 +54,13 @@ const appendedPlausibleScripts: HTMLScriptElement[] = [];
 
 function setBrowserUrl(url: string): void {
   window.location.href = url;
+}
+
+function setPreviewApiOrigin(origin: string): void {
+  const element = document.createElement("meta");
+  element.name = "vm0-api-origin";
+  element.content = origin;
+  document.head.append(element);
 }
 
 function installImmediateIdleCallback(): void {
@@ -124,6 +132,7 @@ function plausibleScriptSources(): string[] {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetModules();
+  document.querySelector(PREVIEW_API_ORIGIN_SELECTOR)?.remove();
   appendedPlausibleScripts.length = 0;
   stubPortableBuildInputs();
   installImmediateIdleCallback();
@@ -133,6 +142,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  document.querySelector(PREVIEW_API_ORIGIN_SELECTOR)?.remove();
   Reflect.deleteProperty(window, "plausible");
   Reflect.deleteProperty(window, "__vm0PlausibleLoadScheduled");
 });
@@ -264,8 +274,32 @@ describe("portable platform runtime environment", () => {
     });
   });
 
+  it("uses the configured API for an immutable Pages deployment", async () => {
+    setBrowserUrl("https://3508a2f5.okou-app.pages.dev/agents");
+    setPreviewApiOrigin("https://pr-23364-api.vm6.ai");
+    const runtime = await loadRuntimeSurfaces();
+
+    expect(runtime.apiBase.resolveApiBase()).toBe(
+      "https://pr-23364-api.vm6.ai",
+    );
+    expect(runtime.apiBase.resolveOAuthApiBase()).toBe(
+      "https://pr-23364-api.vm6.ai",
+    );
+  });
+
+  it("rejects an invalid API origin on an immutable Pages deployment", async () => {
+    setBrowserUrl("https://3508a2f5.okou-app.pages.dev/agents");
+    setPreviewApiOrigin("https://example.com");
+    const runtime = await loadRuntimeSurfaces();
+
+    expect(() => runtime.apiBase.resolveApiBase()).toThrow(
+      "Invalid Cloudflare Pages preview API origin",
+    );
+  });
+
   it("keeps unrecognized provider hosts on the same origin", async () => {
     setBrowserUrl("https://deployment.pages.dev/agents");
+    setPreviewApiOrigin("https://pr-23364-api.vm6.ai");
     const runtime = await loadRuntimeSurfaces();
 
     expect(runtime.apiBase.resolveApiBase()).toBe(

--- a/turbo/apps/platform/src/signals/api-base.ts
+++ b/turbo/apps/platform/src/signals/api-base.ts
@@ -8,6 +8,10 @@ import {
 type PlatformHostTarget = PlatformService;
 export { rewritePlatformHostname };
 
+const OKOU_PAGES_PREVIEW_HOST_SUFFIX = ".okou-app.pages.dev";
+const PREVIEW_API_HOSTNAME_PATTERN = /^(?:staging|pr-[0-9]+)-api\.vm6\.ai$/u;
+const PREVIEW_API_ORIGIN_SELECTOR = 'meta[name="vm0-api-origin"]';
+
 function trimTrailingSlash(base: string): string {
   return base.endsWith("/") ? base.slice(0, -1) : base;
 }
@@ -19,10 +23,53 @@ function browserOrigin(): string | null {
   return location.origin;
 }
 
+function configuredPreviewApiOrigin(currentOrigin: string): string | null {
+  const currentUrl = new URL(currentOrigin);
+  if (
+    currentUrl.protocol !== "https:" ||
+    !currentUrl.hostname.endsWith(OKOU_PAGES_PREVIEW_HOST_SUFFIX) ||
+    typeof document === "undefined"
+  ) {
+    return null;
+  }
+
+  const element = document.querySelector(PREVIEW_API_ORIGIN_SELECTOR);
+  if (!(element instanceof HTMLMetaElement)) {
+    return null;
+  }
+
+  const configuredOrigin = element.content.trim();
+  if (!configuredOrigin) {
+    return null;
+  }
+
+  const configuredUrl = new URL(configuredOrigin);
+  if (
+    configuredUrl.protocol !== "https:" ||
+    configuredUrl.port !== "" ||
+    configuredUrl.username !== "" ||
+    configuredUrl.password !== "" ||
+    configuredUrl.pathname !== "/" ||
+    configuredUrl.search !== "" ||
+    configuredUrl.hash !== "" ||
+    !PREVIEW_API_HOSTNAME_PATTERN.test(configuredUrl.hostname)
+  ) {
+    throw new Error("Invalid Cloudflare Pages preview API origin");
+  }
+
+  return configuredUrl.origin;
+}
+
 function platformOriginForTarget(
   origin: string,
   target: PlatformHostTarget,
 ): string {
+  if (target === "api") {
+    const configuredOrigin = configuredPreviewApiOrigin(origin);
+    if (configuredOrigin) {
+      return configuredOrigin;
+    }
+  }
   return derivePlatformServiceOrigin(origin, target);
 }
 


### PR DESCRIPTION
## Summary

- capture and validate Wrangler's immutable Cloudflare Pages deployment URL
- run Browser and Playwright E2E against that deployment URL instead of the mutable preview alias
- inject the matching preview API origin into the Pages artifact and allow the owned Pages project origin only in preview CORS and billing redirects
- keep the existing custom preview domain for human access and deployment summaries

## Why

The mutable per-PR app hostname can briefly resolve to different asset generations across Cloudflare edge locations. Clerk then remains on the authentication loading skeleton when an HTML document references JavaScript that is not yet available at the selected edge. A deployment hash URL is immutable and atomically identifies one Pages deployment, removing alias propagation from the E2E path.

## Testing

- `bash .github/scripts/tests/prepare-okou-pages-dist-test.sh`
- `pnpm -F @vm0/app exec vitest run src/__tests__/platform-runtime-environment.test.ts`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts src/lib/__tests__/billing-redirect.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/app --workspace api`
- `actionlint .github/workflows/turbo.yml`
- pre-commit hook: full Turbo type check (12/12 packages) and full Knip
