### PR TITLE
fix: improve feishu setup guidance and oauth callback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1,6 +1,7 @@
 import {
   createCipheriv,
   createHash,
+  createHmac,
   randomBytes,
   randomUUID,
 } from "node:crypto";
@@ -18,7 +19,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createAppWithRoutes } from "../../../app-factory-core";
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
@@ -108,6 +109,24 @@ function feishuConnectBody(connectUrl: string) {
       "Expected signature in Feishu connect URL",
     ),
   };
+}
+
+function legacyFeishuAppOAuthState(args: {
+  readonly installationId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}): string {
+  const encodedPayload = Buffer.from(
+    JSON.stringify({
+      ...args,
+      callbackTarget: "app",
+      timestamp: Math.floor(now() / 1000),
+    }),
+  ).toString("base64url");
+  const signature = createHmac("sha256", env("SECRETS_ENCRYPTION_KEY"))
+    .update(encodedPayload)
+    .digest("base64url");
+  return `${encodedPayload}.${signature}`;
 }
 
 function encryptPayload(payload: unknown): string {
@@ -330,12 +349,6 @@ beforeEach(() => {
         },
       });
     }),
-    http.post("https://open.feishu.cn/open-apis/authen/v2/oauth/token", () => {
-      return HttpResponse.json({
-        code: 0,
-        access_token: "feishu-user-access-token",
-      });
-    }),
     http.get("https://open.feishu.cn/open-apis/authen/v1/user_info", () => {
       return HttpResponse.json({
         code: 0,
@@ -355,6 +368,7 @@ describe("Feishu integration", () => {
   let removedReactions: string[];
   let historyMessages: readonly Readonly<Record<string, unknown>>[];
   let failedSendTargets: string[];
+  let oauthTokenRedirectUris: string[];
 
   beforeEach(() => {
     outboundMessages = [];
@@ -362,7 +376,27 @@ describe("Feishu integration", () => {
     removedReactions = [];
     historyMessages = [];
     failedSendTargets = [];
+    oauthTokenRedirectUris = [];
     server.use(
+      http.post(
+        "https://open.feishu.cn/open-apis/authen/v2/oauth/token",
+        async ({ request }) => {
+          const body: unknown = await request.json();
+          if (
+            typeof body !== "object" ||
+            body === null ||
+            !("redirect_uri" in body) ||
+            typeof body.redirect_uri !== "string"
+          ) {
+            throw new Error("Expected Feishu OAuth redirect URI");
+          }
+          oauthTokenRedirectUris.push(body.redirect_uri);
+          return HttpResponse.json({
+            code: 0,
+            access_token: "feishu-user-access-token",
+          });
+        },
+      ),
       http.post(
         "https://open.feishu.cn/open-apis/im/v1/messages/:messageId/reply",
         async ({ params, request }) => {
@@ -1025,7 +1059,7 @@ describe("Feishu integration", () => {
     const connectUrl = status.body.installations?.[0]?.connectUrl;
     expect(connectUrl).toBeDefined();
     expect(status.body.oauthRedirectUrl).toBe(
-      "https://www.vm0.test/api/zero/feishu/oauth/callback",
+      `${APP_ORIGIN}/connectors/feishu/callback`,
     );
     if (!connectUrl) {
       throw new Error("Expected Feishu status to return an OAuth connect URL");
@@ -1057,7 +1091,7 @@ describe("Feishu integration", () => {
     expect(authorizationUrl.origin).toBe("https://accounts.feishu.cn");
     expect(authorizationUrl.searchParams.get("client_id")).toBe(appId);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://www.vm0.test/api/zero/feishu/oauth/callback",
+      `${APP_ORIGIN}/connectors/feishu/callback`,
     );
     const state = authorizationUrl.searchParams.get("state");
     if (!state) {
@@ -1088,6 +1122,26 @@ describe("Feishu integration", () => {
     await expect(callbackResponse.json()).resolves.toStrictEqual({
       redirectUrl: `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
     });
+    expect(oauthTokenRedirectUris).toStrictEqual([
+      `${APP_ORIGIN}/connectors/feishu/callback`,
+    ]);
+
+    const legacyCallbackResponse = await oauthApp.request(
+      `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
+        code: "legacy-feishu-oauth-code",
+        responseMode: "json",
+        state: legacyFeishuAppOAuthState({
+          installationId,
+          orgId: requireValue(actor.orgId, "Expected an organization"),
+          userId: actor.userId,
+        }),
+      })}`,
+    );
+    expect(legacyCallbackResponse.status).toBe(200);
+    expect(oauthTokenRedirectUris).toStrictEqual([
+      `${APP_ORIGIN}/connectors/feishu/callback`,
+      "https://www.vm0.test/api/zero/feishu/oauth/callback",
+    ]);
     await flushWaitUntilForTest();
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -80,6 +80,12 @@ function appCallbackUrl(query: FeishuOAuthCallbackQuery): string {
   return url.toString();
 }
 
+function oauthRedirectUri(target: "app" | undefined): string {
+  return target === "app"
+    ? feishuOAuthAppCallbackUrl()
+    : feishuOAuthCallbackUrl();
+}
+
 function resolveCallbackState(
   query: FeishuOAuthCallbackQuery,
 ): FeishuOAuthState | Response {
@@ -259,7 +265,10 @@ const connect$ = command(async ({ get }, signal: AbortSignal) => {
     query.callbackTarget,
   );
   authorizationUrl.searchParams.set("client_id", installation.appId);
-  authorizationUrl.searchParams.set("redirect_uri", feishuOAuthCallbackUrl());
+  authorizationUrl.searchParams.set(
+    "redirect_uri",
+    oauthRedirectUri(query.callbackTarget),
+  );
   authorizationUrl.searchParams.set("response_type", "code");
   authorizationUrl.searchParams.set("state", oauthState);
   return redirectResponse(authorizationUrl.toString());
@@ -314,7 +323,7 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
     appId: config.appId,
     appSecret: config.appSecret,
     code: query.code,
-    redirectUri: feishuOAuthCallbackUrl(),
+    redirectUri: oauthRedirectUri(state.oauthRedirectTarget),
     installationId: state.installationId,
     signal,
   });

--- a/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
+++ b/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
@@ -14,6 +14,7 @@ const feishuOAuthStateSchema = z.object({
   orgId: z.string().min(1),
   userId: z.string().min(1),
   callbackTarget: z.literal("app").optional(),
+  oauthRedirectTarget: z.literal("app").optional(),
   timestamp: z.number().int(),
 });
 
@@ -30,6 +31,7 @@ function createFeishuOAuthState(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly callbackTarget?: "app";
+  readonly oauthRedirectTarget?: "app";
   readonly timestamp?: number;
 }): string {
   const encodedPayload = Buffer.from(
@@ -86,6 +88,7 @@ export function createFeishuOAuthAuthorizationState(
     orgId: state.orgId,
     userId: state.userId,
     callbackTarget,
+    oauthRedirectTarget: callbackTarget,
     timestamp: state.timestamp,
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
@@ -18,7 +18,7 @@ import {
 } from "../external/feishu-client";
 import { tapError } from "../utils";
 import { encryptPersistentSecretValue } from "./crypto.utils";
-import { feishuCallbackUrl, feishuOAuthCallbackUrl } from "./feishu-config";
+import { feishuCallbackUrl, feishuOAuthAppCallbackUrl } from "./feishu-config";
 import { buildFeishuOAuthConnectUrl } from "./feishu-oauth-state";
 
 const L = logger("ZeroFeishuConnect");
@@ -103,7 +103,7 @@ function toFeishuInstallationStatus(
     botName: installation.botName,
     botAvatarUrl: installation.botAvatarUrl,
     callbackUrl: feishuCallbackUrl(installation.id),
-    oauthRedirectUrl: feishuOAuthCallbackUrl(),
+    oauthRedirectUrl: feishuOAuthAppCallbackUrl(),
     connectUrl: installation.setupCompletedAt
       ? buildFeishuOAuthConnectUrl({
           installationId: installation.id,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -155,6 +155,34 @@ describe("works page", () => {
     expect(screen.queryByTestId("feishu-settings-loading")).toBeNull();
   });
 
+  it("shows Feishu setup troubleshooting guidance", async () => {
+    mockFeishuAPI();
+
+    detachedSetupPage({
+      context,
+      path: "/settings/feishu",
+      featureSwitches: {
+        [FeatureSwitchKey.FeishuIntegration]: true,
+      },
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Setup FAQ" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Why does Feishu show "Challenge code didn't get a response"\?/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Return to the Tokens step/)).toBeInTheDocument();
+    expect(
+      screen.getByText("Why is publishing the app waiting for approval?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Feishu sends the approval request/),
+    ).toBeInTheDocument();
+  });
+
   it("shows integration cards with current connection status and realtime refreshes", async () => {
     mockSlackAPI({
       isConnected: true,
@@ -340,7 +368,7 @@ describe("works page", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides the Feishu setup guide after setup completes", async () => {
+  it("lets a bot owner use the completed review guide without editing", async () => {
     const installationId = "00000000-0000-4000-8000-000000000001";
     const agentId = "00000000-0000-4000-8000-000000000002";
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
@@ -380,10 +408,48 @@ describe("works page", () => {
     await expect(screen.findByText("Feishu bots")).resolves.toBeInTheDocument();
 
     click(getRole("button", "More options for Completed owner bot"));
-    expect(queryRole("button", "Setup guide")).toBeNull();
     expect(queryRole("button", "Manage")).toBeNull();
     expect(getRole("button", "Uninstall")).toBeInTheDocument();
     expect(getRole("button", "Disconnect")).toBeInTheDocument();
+    click(getRole("button", "Review guide"));
+
+    expect(
+      screen.getByRole("heading", { name: "Feishu review guide" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Create an enterprise custom app"),
+    ).toBeInTheDocument();
+
+    click(getRole("button", "Next"));
+    expect(screen.getByLabelText("App ID")).toHaveValue("cli_completed_owner");
+    expect(screen.getByLabelText("App ID")).toBeDisabled();
+    expect(screen.getByLabelText("App Secret")).toBeDisabled();
+    expect(screen.getByLabelText("App Secret")).toHaveAttribute(
+      "placeholder",
+      "Configured",
+    );
+
+    click(getRole("button", "Next"));
+    expect(screen.getByLabelText("Encrypt Key")).toBeDisabled();
+    expect(screen.getByLabelText("Verification Token")).toBeDisabled();
+    expect(getRole("button", "Next")).toBeEnabled();
+
+    click(getRole("button", "Next"));
+    expect(screen.getByText("Configure event delivery")).toBeInTheDocument();
+
+    click(getRole("button", "Next"));
+    expect(
+      screen.getByText("Configure the OAuth redirect URL"),
+    ).toBeInTheDocument();
+
+    click(getRole("button", "Next"));
+    expect(screen.getByText("Publish the app")).toBeInTheDocument();
+    expect(screen.getByLabelText("Default agent")).toBeDisabled();
+
+    click(getRole("button", "Done"));
+    expect(
+      screen.queryByRole("heading", { name: "Feishu review guide" }),
+    ).toBeNull();
   });
 
   it("only lets a connected non-owner disconnect their own account", async () => {
@@ -426,6 +492,7 @@ describe("works page", () => {
 
     click(getRole("button", "More options for Member bot"));
     expect(getRole("button", "Disconnect")).toBeInTheDocument();
+    expect(queryRole("button", "Review guide")).toBeNull();
     expect(queryRole("button", "Manage")).toBeNull();
     expect(queryRole("button", "Uninstall")).toBeNull();
   });
@@ -496,7 +563,7 @@ describe("works page", () => {
         isConnected,
         appId: "cli_feishu",
         callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
-        oauthRedirectUrl: "https://api.vm0.test/api/zero/feishu/oauth/callback",
+        oauthRedirectUrl: "https://app.vm0.test/connectors/feishu/callback",
         callbackVerified,
         messageReceived: false,
         tenantKey: null,
@@ -562,7 +629,7 @@ describe("works page", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByDisplayValue(
-        "https://api.vm0.test/api/zero/feishu/oauth/callback",
+        "https://app.vm0.test/connectors/feishu/callback",
       ),
     ).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -296,12 +296,14 @@ function FeishuCredentialInput({
   label,
   form,
   saving,
+  readOnly,
   placeholder,
 }: {
   field: FeishuCredentialField;
   label: string;
   form: FeishuSetupInput;
   saving: boolean;
+  readOnly: boolean;
   placeholder?: string;
 }) {
   const updateForm = useSet(updateFeishuSetupForm$);
@@ -315,10 +317,10 @@ function FeishuCredentialInput({
         id={id}
         type={field === "appId" ? "text" : "password"}
         value={form[field]}
-        disabled={saving}
+        disabled={saving || readOnly}
         required
         autoComplete="off"
-        placeholder={placeholder}
+        placeholder={readOnly && field !== "appId" ? "Configured" : placeholder}
         onChange={(event) => {
           updateForm({ [field]: event.target.value });
         }}
@@ -330,9 +332,11 @@ function FeishuCredentialInput({
 function FeishuAppCredentialFields({
   form,
   saving,
+  readOnly,
 }: {
   form: FeishuSetupInput;
   saving: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
@@ -341,6 +345,7 @@ function FeishuAppCredentialFields({
         label="App ID"
         form={form}
         saving={saving}
+        readOnly={readOnly}
         placeholder="cli_..."
       />
       <FeishuCredentialInput
@@ -348,6 +353,7 @@ function FeishuAppCredentialFields({
         label="App Secret"
         form={form}
         saving={saving}
+        readOnly={readOnly}
       />
     </div>
   );
@@ -356,9 +362,11 @@ function FeishuAppCredentialFields({
 function FeishuEventCredentialFields({
   form,
   saving,
+  readOnly,
 }: {
   form: FeishuSetupInput;
   saving: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
@@ -367,12 +375,14 @@ function FeishuEventCredentialFields({
         label="Encrypt Key"
         form={form}
         saving={saving}
+        readOnly={readOnly}
       />
       <FeishuCredentialInput
         field="verificationToken"
         label="Verification Token"
         form={form}
         saving={saving}
+        readOnly={readOnly}
       />
     </div>
   );
@@ -384,6 +394,7 @@ function FeishuAgentSelect({
   orgDefaultAgentId,
   orgDefaultAgentName,
   saving,
+  readOnly,
   onAgentChange,
 }: {
   form: FeishuSetupInput;
@@ -391,6 +402,7 @@ function FeishuAgentSelect({
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
   saving: boolean;
+  readOnly: boolean;
   onAgentChange?: (defaultAgentId: string) => void;
 }) {
   const updateForm = useSet(updateFeishuSetupForm$);
@@ -401,7 +413,7 @@ function FeishuAgentSelect({
       </label>
       <Select
         value={form.defaultAgentId}
-        disabled={saving}
+        disabled={saving || readOnly}
         onValueChange={(defaultAgentId) => {
           updateForm({ defaultAgentId });
           onAgentChange?.(defaultAgentId);
@@ -494,9 +506,11 @@ function FeishuCreateStep() {
 function FeishuCredentialsStep({
   form,
   saving,
+  readOnly,
 }: {
   form: FeishuSetupInput;
   saving: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -515,7 +529,11 @@ function FeishuCredentialsStep({
           />
         </div>
       </div>
-      <FeishuAppCredentialFields form={form} saving={saving} />
+      <FeishuAppCredentialFields
+        form={form}
+        saving={saving}
+        readOnly={readOnly}
+      />
     </div>
   );
 }
@@ -523,9 +541,11 @@ function FeishuCredentialsStep({
 function FeishuTokensStep({
   form,
   saving,
+  readOnly,
 }: {
   form: FeishuSetupInput;
   saving: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -554,7 +574,11 @@ function FeishuTokensStep({
           />
         </div>
       </div>
-      <FeishuEventCredentialFields form={form} saving={saving} />
+      <FeishuEventCredentialFields
+        form={form}
+        saving={saving}
+        readOnly={readOnly}
+      />
     </div>
   );
 }
@@ -661,12 +685,14 @@ function FeishuPublishStep({
   agents,
   orgDefaultAgentId,
   orgDefaultAgentName,
+  readOnly,
 }: {
   data: FeishuDialogData | null;
   form: FeishuSetupInput;
   agents: TeamComposeItem[];
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
+  readOnly: boolean;
 }) {
   const [updateLoadable, updateAgent] = useLoadableSet(
     updateFeishuInstallationAgent$,
@@ -718,6 +744,7 @@ function FeishuPublishStep({
           orgDefaultAgentId={orgDefaultAgentId}
           orgDefaultAgentName={orgDefaultAgentName}
           saving={!data?.id || updateLoadable.state === "loading"}
+          readOnly={readOnly}
           onAgentChange={(defaultAgentId) => {
             if (!data?.id) {
               return;
@@ -741,6 +768,7 @@ function FeishuSetupStepContent({
   orgDefaultAgentId,
   orgDefaultAgentName,
   saving,
+  readOnly,
 }: {
   step: FeishuSetupStep;
   data: FeishuDialogData | null;
@@ -749,16 +777,25 @@ function FeishuSetupStepContent({
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
   saving: boolean;
+  readOnly: boolean;
 }) {
   switch (step) {
     case "create": {
       return <FeishuCreateStep />;
     }
     case "credentials": {
-      return <FeishuCredentialsStep form={form} saving={saving} />;
+      return (
+        <FeishuCredentialsStep
+          form={form}
+          saving={saving}
+          readOnly={readOnly}
+        />
+      );
     }
     case "tokens": {
-      return <FeishuTokensStep form={form} saving={saving} />;
+      return (
+        <FeishuTokensStep form={form} saving={saving} readOnly={readOnly} />
+      );
     }
     case "redirect": {
       return <FeishuRedirectStep data={data} />;
@@ -774,6 +811,7 @@ function FeishuSetupStepContent({
           agents={agents}
           orgDefaultAgentId={orgDefaultAgentId}
           orgDefaultAgentName={orgDefaultAgentName}
+          readOnly={readOnly}
         />
       );
     }
@@ -839,7 +877,11 @@ function feishuSetupContinueLabel(args: {
   readonly saving: boolean;
   readonly checkingAppId: boolean;
   readonly callbackVerified: boolean;
+  readonly readOnly: boolean;
 }): string {
+  if (args.readOnly) {
+    return args.step === "publish" ? "Done" : "Next";
+  }
   if (args.step === "tokens") {
     return args.saving ? "Verifying…" : "Verify and continue";
   }
@@ -858,6 +900,7 @@ function FeishuSetupWizardFooter({
   saving,
   checkingAppId,
   canContinue,
+  readOnly,
   onClose,
   onBack,
   onContinue,
@@ -867,16 +910,19 @@ function FeishuSetupWizardFooter({
   saving: boolean;
   checkingAppId: boolean;
   canContinue: boolean;
+  readOnly: boolean;
   onClose: () => void;
   onBack: () => void;
   onContinue: () => void;
 }) {
   const isFirstStep = step === "create";
+  const firstStepLabel = readOnly ? "Close" : "Cancel";
   const continueLabel = feishuSetupContinueLabel({
     step,
     saving,
     checkingAppId,
     callbackVerified: data?.callbackVerified ?? false,
+    readOnly,
   });
   return (
     <DialogFooter>
@@ -887,7 +933,7 @@ function FeishuSetupWizardFooter({
         onClick={isFirstStep ? onClose : onBack}
       >
         {isFirstStep ? (
-          "Cancel"
+          firstStepLabel
         ) : (
           <span className="inline-flex items-center gap-2">
             <IconArrowLeft size={16} />
@@ -896,13 +942,13 @@ function FeishuSetupWizardFooter({
         )}
       </Button>
       <Button
-        type={step === "tokens" ? "submit" : "button"}
+        type={step === "tokens" && !readOnly ? "submit" : "button"}
         disabled={!canContinue}
-        onClick={step === "tokens" ? undefined : onContinue}
+        onClick={step === "tokens" && !readOnly ? undefined : onContinue}
       >
         {saving ? <IconLoader2 size={16} className="animate-spin" /> : null}
         {continueLabel}
-        {step !== "tokens" && step !== "publish" ? (
+        {(step !== "tokens" || readOnly) && step !== "publish" ? (
           <IconArrowRight size={16} />
         ) : null}
       </Button>
@@ -915,12 +961,14 @@ function FeishuSetupWizard({
   agents,
   orgDefaultAgentId,
   orgDefaultAgentName,
+  readOnly,
   onClose,
 }: {
   data: FeishuDialogData | null;
   agents: TeamComposeItem[];
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
+  readOnly: boolean;
   onClose: () => void;
 }) {
   const step = useGet(feishuSetupStep$);
@@ -940,11 +988,12 @@ function FeishuSetupWizard({
     setupLoadable.state === "loading" ||
     completionLoadable.state === "loading";
   const canSave = canSubmitFeishuSetup(form, saving);
-  const canContinue = canContinueFeishuSetup({ step, data, form, saving });
+  const canContinue =
+    readOnly || canContinueFeishuSetup({ step, data, form, saving });
 
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (step !== "tokens" || !canSave) {
+    if (readOnly || step !== "tokens" || !canSave) {
       return;
     }
     detach(
@@ -961,6 +1010,10 @@ function FeishuSetupWizard({
       return;
     }
     if (step === "publish") {
+      if (readOnly) {
+        onClose();
+        return;
+      }
       const installationId = data?.id;
       if (!installationId) {
         return;
@@ -998,6 +1051,7 @@ function FeishuSetupWizard({
         orgDefaultAgentId={orgDefaultAgentId}
         orgDefaultAgentName={orgDefaultAgentName}
         saving={saving}
+        readOnly={readOnly}
       />
       <FeishuSetupWizardFooter
         step={step}
@@ -1005,6 +1059,7 @@ function FeishuSetupWizard({
         saving={saving}
         checkingAppId={appIdCheckLoadable.state === "loading"}
         canContinue={canContinue}
+        readOnly={readOnly}
         onClose={onClose}
         onBack={goBack}
         onContinue={continueFlow}
@@ -1132,22 +1187,20 @@ function FeishuBotMenu({
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
         {bot.canManage ? (
           <>
-            {!bot.setupCompleted ? (
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-                onClick={() => {
-                  open({
-                    appId: bot.appId,
-                    defaultAgentId: bot.defaultAgentId,
-                    step: "events",
-                    installationId: bot.id,
-                  });
-                }}
-              >
-                Manage
-              </button>
-            ) : null}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+              onClick={() => {
+                open({
+                  appId: bot.appId,
+                  defaultAgentId: bot.defaultAgentId,
+                  step: bot.setupCompleted ? "create" : "events",
+                  installationId: bot.id,
+                });
+              }}
+            >
+              {bot.setupCompleted ? "Review guide" : "Manage"}
+            </button>
             <button
               type="button"
               disabled={!bot.id}
@@ -1322,6 +1375,61 @@ function FeishuBotsCard({
   );
 }
 
+function FeishuSetupFaq() {
+  return (
+    <section
+      className="zero-card overflow-hidden"
+      aria-labelledby="feishu-setup-faq-title"
+    >
+      <div className="border-b border-border/50 px-4 py-3">
+        <h2
+          id="feishu-setup-faq-title"
+          className="text-sm font-medium text-foreground"
+        >
+          Setup FAQ
+        </h2>
+      </div>
+      <div className="divide-y divide-border/50">
+        <details className="group px-4 py-4 sm:px-5">
+          <summary className="flex cursor-pointer list-none items-start gap-2 text-sm font-medium text-foreground">
+            <IconChevronRight
+              size={17}
+              aria-hidden="true"
+              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+            />
+            <span>
+              Why does Feishu show &quot;Challenge code didn&apos;t get a
+              response&quot;?
+            </span>
+          </summary>
+          <p className="mt-2 pl-[25px] text-sm leading-relaxed text-muted-foreground">
+            This usually means the Encrypt Key or Verification Token saved
+            during the Tokens step is incorrect. Return to the Tokens step,
+            enter both values from Event Configuration → Encryption Strategy
+            again, save them, and retry the Request URL.
+          </p>
+        </details>
+        <details className="group px-4 py-4 sm:px-5">
+          <summary className="flex cursor-pointer list-none items-start gap-2 text-sm font-medium text-foreground">
+            <IconChevronRight
+              size={17}
+              aria-hidden="true"
+              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+            />
+            <span>Why is publishing the app waiting for approval?</span>
+          </summary>
+          <p className="mt-2 pl-[25px] text-sm leading-relaxed text-muted-foreground">
+            If availability is set to All members, a Feishu administrator must
+            approve the release. Feishu sends the approval request to an
+            administrator in a direct message, and the app remains pending until
+            an administrator completes the review.
+          </p>
+        </details>
+      </div>
+    </section>
+  );
+}
+
 function FeishuSettingsSkeleton() {
   return (
     <section
@@ -1382,12 +1490,14 @@ function FeishuDialogBody({
       </p>
     );
   }
+  const readOnly = data?.setupCompleted ?? false;
   return (
     <FeishuSetupWizard
       data={data}
       agents={agents}
       orgDefaultAgentId={orgDefaultAgentId}
       orgDefaultAgentName={orgDefaultAgentName}
+      readOnly={readOnly}
       onClose={onClose}
     />
   );
@@ -1409,6 +1519,14 @@ function FeishuSetupDialog({
   const open = useGet(feishuDialogOpen$);
   const existing = useGet(feishuDialogExisting$);
   const close = useSet(closeFeishuDialog$);
+  const readOnly = data?.setupCompleted ?? false;
+  let title = existing ? "Manage Feishu bot" : "Add a Feishu bot";
+  let description =
+    "Create an enterprise custom app, enable its bot, and complete these steps in the Feishu developer console.";
+  if (readOnly) {
+    title = "Feishu review guide";
+    description = "Review the completed setup steps for this Feishu bot.";
+  }
   return (
     <Dialog
       open={open}
@@ -1425,13 +1543,8 @@ function FeishuSetupDialog({
         }}
       >
         <DialogHeader>
-          <DialogTitle>
-            {existing ? "Manage Feishu bot" : "Add a Feishu bot"}
-          </DialogTitle>
-          <DialogDescription>
-            Create an enterprise custom app, enable its bot, and complete these
-            steps in the Feishu developer console.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <FeishuDialogBody
           data={data}
@@ -1682,6 +1795,7 @@ export function ZeroFeishuSettingsPage() {
               <FeishuUninstallDialog bot={uninstallBot} />
             </>
           )}
+          <FeishuSetupFaq />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary

- add a Feishu setup FAQ and a read-only Review guide for completed bot installations
- use the app callback URL for app-targeted Feishu OAuth while preserving the legacy API callback for in-flight states
- cover setup guidance, permissions, callback selection, and deployment compatibility with integration tests

## Testing

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/app`