### PR TITLE
refactor(runner): canonicalize profile discovery contract

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -508,8 +508,6 @@ impl JobProvider for ApiProvider {
                     if self.cancel.is_cancelled() {
                         return None;
                     }
-                    // Fall back to default profile when server doesn't send one
-                    // (backwards compat with pre-profile API).
                     let run_id = job.run_id;
                     let cli_agent_session_id = job.cli_agent_session_id;
                     let history_generation_run_id = job.history_generation_run_id;
@@ -517,9 +515,7 @@ impl JobProvider for ApiProvider {
                         job.history_generation_affinity_protected_until;
                     let affinity_protected_until = job.affinity_protected_until;
                     let session_affinity_resource = job.session_affinity_resource;
-                    let profile = job
-                        .experimental_profile
-                        .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                    let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_affinity_metadata(cli_agent_session_id, affinity_protected_until)
@@ -1609,10 +1605,26 @@ mod tests {
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
     ) -> Arc<ApiProvider> {
-        api_provider_for_test_with_claim_cooldown_capacity(
+        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
             api_url,
             cancel,
             poll_wakeups,
+            vec![crate::profile::DEFAULT_PROFILE.to_string()],
+            CLAIM_COOLDOWN_CAPACITY,
+        )
+    }
+
+    fn api_provider_for_test_with_supported_profiles(
+        api_url: String,
+        cancel: CancellationToken,
+        poll_wakeups: Arc<PollWakeups>,
+        supported_profiles: Vec<String>,
+    ) -> Arc<ApiProvider> {
+        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
+            api_url,
+            cancel,
+            poll_wakeups,
+            supported_profiles,
             CLAIM_COOLDOWN_CAPACITY,
         )
     }
@@ -1621,6 +1633,22 @@ mod tests {
         api_url: String,
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
+        claim_cooldown_capacity: usize,
+    ) -> Arc<ApiProvider> {
+        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
+            api_url,
+            cancel,
+            poll_wakeups,
+            vec![crate::profile::DEFAULT_PROFILE.to_string()],
+            claim_cooldown_capacity,
+        )
+    }
+
+    fn api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
+        api_url: String,
+        cancel: CancellationToken,
+        poll_wakeups: Arc<PollWakeups>,
+        supported_profiles: Vec<String>,
         claim_cooldown_capacity: usize,
     ) -> Arc<ApiProvider> {
         let api = ApiClient::new(
@@ -1638,7 +1666,7 @@ mod tests {
             api,
             runner_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
             group: "default".to_string(),
-            supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
+            supported_profiles,
             poll_wakeups,
             direct_candidates: DirectCandidateInbox::new(
                 DIRECT_CANDIDATE_INBOX_CAPACITY,
@@ -2169,7 +2197,7 @@ mod tests {
                 then.status(200).json_body(serde_json::json!({
                     "job": {
                         "runId": run_id,
-                        "experimentalProfile": "vm0/default",
+                        "experimentalProfile": "vm0/large",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
                         "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
@@ -2179,10 +2207,11 @@ mod tests {
                 }));
             })
             .await;
-        let provider = api_provider_for_test(
+        let provider = api_provider_for_test_with_supported_profiles(
             server.base_url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
+            vec!["vm0/large".to_string()],
         );
 
         let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
@@ -2191,7 +2220,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(discovered.run_id(), run_id);
-        assert_eq!(discovered.profile_name(), "vm0/default");
+        assert_eq!(discovered.profile_name(), "vm0/large");
         assert_eq!(discovered.cli_agent_session_id(), Some("sess-poll"));
         assert_eq!(
             discovered.history_generation_run_id(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1605,11 +1605,10 @@ mod tests {
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
     ) -> Arc<ApiProvider> {
-        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
+        api_provider_for_test_with_claim_cooldown_capacity(
             api_url,
             cancel,
             poll_wakeups,
-            vec![crate::profile::DEFAULT_PROFILE.to_string()],
             CLAIM_COOLDOWN_CAPACITY,
         )
     }
@@ -1620,35 +1619,17 @@ mod tests {
         poll_wakeups: Arc<PollWakeups>,
         supported_profiles: Vec<String>,
     ) -> Arc<ApiProvider> {
-        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
-            api_url,
-            cancel,
-            poll_wakeups,
-            supported_profiles,
-            CLAIM_COOLDOWN_CAPACITY,
-        )
+        let mut provider = api_provider_for_test(api_url, cancel, poll_wakeups);
+        Arc::get_mut(&mut provider)
+            .expect("fresh test provider should not be shared")
+            .supported_profiles = supported_profiles;
+        provider
     }
 
     fn api_provider_for_test_with_claim_cooldown_capacity(
         api_url: String,
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
-        claim_cooldown_capacity: usize,
-    ) -> Arc<ApiProvider> {
-        api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
-            api_url,
-            cancel,
-            poll_wakeups,
-            vec![crate::profile::DEFAULT_PROFILE.to_string()],
-            claim_cooldown_capacity,
-        )
-    }
-
-    fn api_provider_for_test_with_supported_profiles_and_claim_cooldown_capacity(
-        api_url: String,
-        cancel: CancellationToken,
-        poll_wakeups: Arc<PollWakeups>,
-        supported_profiles: Vec<String>,
         claim_cooldown_capacity: usize,
     ) -> Arc<ApiProvider> {
         let api = ApiClient::new(
@@ -1666,7 +1647,7 @@ mod tests {
             api,
             runner_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
             group: "default".to_string(),
-            supported_profiles,
+            supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
             direct_candidates: DirectCandidateInbox::new(
                 DIRECT_CANDIDATE_INBOX_CAPACITY,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -35,8 +35,7 @@ pub struct PollResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Job {
     pub run_id: RunId,
-    #[serde(default)]
-    pub experimental_profile: Option<String>,
+    pub experimental_profile: String,
     #[serde(default)]
     pub cli_agent_session_id: Option<String>,
     #[serde(default)]
@@ -1538,7 +1537,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap()
         );
-        assert_eq!(job.experimental_profile.as_deref(), Some("browser"));
+        assert_eq!(job.experimental_profile, "browser");
         assert_eq!(
             job.session_affinity_resource,
             Some(SessionAffinityResource::WorkspaceCache)
@@ -1553,13 +1552,11 @@ mod tests {
     }
 
     #[test]
-    fn job_optional_profile_defaults_to_none() {
+    fn job_requires_profile() {
         let json = json!({
             "runId": "550e8400-e29b-41d4-a716-446655440000"
         });
-        let job: Job = serde_json::from_value(json).unwrap();
-        assert!(job.experimental_profile.is_none());
-        assert!(job.session_affinity_resource.is_none());
+        assert!(serde_json::from_value::<Job>(json).is_err());
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -108,6 +108,18 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
   });
 }
 
+export async function setRunnerJobContextProfileAsPreviousApi(
+  context: TestContext,
+  runId: string,
+  profile: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "set-runner-job-context-profile-as-previous-api",
+    run_id: runId,
+    profile,
+  });
+}
+
 export async function removeRunCanonicalStorageState(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -87,6 +87,7 @@ import {
   resetFakeKms,
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
+  setRunnerJobContextProfileAsPreviousApi,
 } from "./helpers/runtime-state";
 import {
   setSecretKmsClientForTests,
@@ -2689,9 +2690,37 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("filters runner polls by supported profiles without widening malformed polls", async () => {
+  it("polls and claims context written by the previous profile API", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt: "claim previous profile context",
+      modelProvider: "anthropic-api-key",
+    });
+    await setRunnerJobContextProfileAsPreviousApi(
+      context,
+      created.runId,
+      "vm0/large",
+    );
+
+    const poll = await api.pollRunner(runnerGroup);
+    expect(poll.body.job).toMatchObject({
+      runId: created.runId,
+      experimentalProfile: "vm0/default",
+    });
+
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.prompt).toBe("claim previous profile context");
+    expect(claim).not.toHaveProperty("experimentalProfile");
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
+  it("filters runner polls by supported profiles without widening malformed polls", async () => {
+    const api = createRunsApi(context);
+    const { actor, runnerGroup } = await entitledRunActor();
 
     const missingSupport = await api.requestRawPollRunner(
       true,
@@ -2706,17 +2735,27 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expectApiError(emptySupport.body);
 
-    const created = await api.createRun(actor, {
-      agentId,
+    const composeName = `bdd-runner-profile-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          experimental_profile: "vm0/large",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    const created = await api.createDirectRun(actor, {
+      agentComposeVersionId: compose.versionId,
       prompt: "poll with explicit support list",
-      modelProvider: "anthropic-api-key",
     });
 
     const incompatiblePoll = await api.requestPollRunner(
       true,
       {
         group: runnerGroup,
-        supportedProfiles: ["vm0/large"],
+        supportedProfiles: ["vm0/default"],
       },
       [200],
     );
@@ -2731,7 +2770,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       true,
       {
         group: runnerGroup,
-        supportedProfiles: ["vm0/default"],
+        supportedProfiles: ["vm0/large"],
       },
       [200],
     );
@@ -2741,6 +2780,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       );
     }
     expect(compatiblePoll.body.job?.runId).toBe(created.runId);
+    expect(compatiblePoll.body.job?.experimentalProfile).toBe("vm0/large");
 
     await api.requestCancelRun(actor, created.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -599,6 +599,37 @@ async function setComputerUseHostAsPreviousApi(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
+type PreviousApiRunnerJobContextProfileAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "set-runner-job-context-profile-as-previous-api" }
+>;
+
+async function setRunnerJobContextProfileAsPreviousApi(
+  db: Db,
+  body: PreviousApiRunnerJobContextProfileAction,
+  signal: AbortSignal,
+) {
+  // The previous API stored the routing profile in both the dedicated queue
+  // column and execution-context JSON.
+  const [updated] = await db
+    .update(runnerJobQueue)
+    .set({
+      executionContext: sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{experimentalProfile}',
+        to_jsonb(${body.profile}::text),
+        true
+      )`,
+    })
+    .where(eq(runnerJobQueue.runId, body.run_id))
+    .returning({ runId: runnerJobQueue.runId });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected a runner job for previous API profile update");
+  }
+  return { status: 200 as const, body: { ok: true as const } };
+}
+
 type PreviousApiBrowserProfileAction = Extract<
   TestRuntimeStateActionBody,
   { action: "read-browser-profile-as-previous-api" }
@@ -659,6 +690,7 @@ async function readBrowserProfileAsPreviousApi(
 type CompatibilityFixtureAction =
   | LegacyArtifactCatalogFileAction
   | PreviousApiComputerAccessAction
+  | PreviousApiRunnerJobContextProfileAction
   | PreviousApiBrowserProfileAction;
 
 function isCompatibilityFixtureAction(
@@ -667,6 +699,7 @@ function isCompatibilityFixtureAction(
   return [
     "insert-legacy-artifact-catalog-file",
     "set-computer-use-host-as-previous-api",
+    "set-runner-job-context-profile-as-previous-api",
     "read-browser-profile-as-previous-api",
   ].includes(body.action);
 }
@@ -682,6 +715,9 @@ async function compatibilityFixtureActionResponse(
     }
     case "set-computer-use-host-as-previous-api": {
       return await setComputerUseHostAsPreviousApi(db, body, signal);
+    }
+    case "set-runner-job-context-profile-as-previous-api": {
+      return await setRunnerJobContextProfileAsPreviousApi(db, body, signal);
     }
     case "read-browser-profile-as-previous-api": {
       return await readBrowserProfileAsPreviousApi(db, body, signal);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4756,7 +4756,6 @@ async function buildStoredExecutionContextDraft(args: {
       disallowedTools: args.body.disallowedTools,
       tools: args.body.tools,
       settings: args.body.settings,
-      experimentalProfile: runnerProfile(args.resolved.content),
       featureFlags: getAllFeatureStates(args.featureSwitchContext),
       billableFirewalls: [...args.billableFirewalls],
       modelUsageProvider: args.modelUsageProvider,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
@@ -77,7 +77,6 @@
   "disallowedTools": ["FixtureDangerousTool"],
   "tools": ["Bash", "Read"],
   "settings": "{\"fixture\":true}",
-  "experimentalProfile": "vm0/default",
   "featureFlags": {
     "fixtureFlag": true
   },

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -42,9 +42,32 @@ describe("runner claim response contract", () => {
       runId: "00000000-0000-4000-8000-000000020985",
       agentComposeVersionId:
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      experimentalProfile: "vm0/default",
       modelUsageProvider: "fixture-model",
     });
+    expect(context).not.toHaveProperty("experimentalProfile");
+  });
+});
+
+describe("runner poll response contract", () => {
+  const job = {
+    runId: "22222222-2222-4222-8222-222222222222",
+    prompt: "continue",
+    appendSystemPrompt: null,
+    agentComposeVersionId: null,
+    vars: null,
+  };
+
+  it.each(["vm0/default", "vm0/large"])(
+    "requires and preserves profile %s",
+    (experimentalProfile) => {
+      expect(jobSchema.parse({ ...job, experimentalProfile })).toMatchObject({
+        experimentalProfile,
+      });
+    },
+  );
+
+  it("rejects a missing profile", () => {
+    expect(jobSchema.safeParse(job).success).toBe(false);
   });
 });
 
@@ -477,6 +500,7 @@ describe("runner resume session contract", () => {
       appendSystemPrompt: null,
       agentComposeVersionId: null,
       vars: null,
+      experimentalProfile: "vm0/default",
       historyGenerationRunId,
       historyGenerationAffinityProtectedUntil,
       sessionAffinityResource: "reusableSandbox",
@@ -521,6 +545,7 @@ describe("runner resume session contract", () => {
       appendSystemPrompt: null,
       agentComposeVersionId: null,
       vars: null,
+      experimentalProfile: "vm0/default",
       historyGenerationAffinityProtectedUntil: null,
     });
     expect(job.historyGenerationAffinityProtectedUntil).toBeNull();

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -177,7 +177,7 @@ export const jobSchema = z.object({
   appendSystemPrompt: z.string().nullable(),
   agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
-  experimentalProfile: z.string().optional(),
+  experimentalProfile: z.string(),
   cliAgentSessionId: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
   historyGenerationAffinityProtectedUntil: z
@@ -569,8 +569,6 @@ export const storedExecutionContextSchema = z.object({
   tools: z.array(z.string()).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
-  // VM profile for resource allocation (e.g., "vm0/default")
-  experimentalProfile: z.string().optional(),
   // Feature flags evaluated at job creation time (all switch states for user/org)
   featureFlags: z.record(z.string(), z.boolean()).optional(),
   billableFirewalls: z.array(z.string()).optional(),
@@ -642,8 +640,6 @@ export const executionContextSchema = z.object({
   tools: z.array(z.string()).optional(),
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings: z.string().optional(),
-  // VM profile for resource allocation (e.g., "vm0/default")
-  experimentalProfile: z.string().optional(),
   // Feature flags evaluated at job creation time (all switch states for user/org)
   featureFlags: z.record(z.string(), z.boolean()).optional(),
   billableFirewalls: z.array(z.string()).optional(),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -91,6 +91,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     computer_use_host_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("set-runner-job-context-profile-as-previous-api"),
+    run_id: z.uuid(),
+    profile: z.string(),
+  }),
+  z.object({
     action: z.literal("read-browser-profile-as-previous-api"),
     browser_id: z.uuid(),
     user_id: z.string(),


### PR DESCRIPTION
## Summary

- require runner poll jobs to carry their queued profile and remove the Rust
  `vm0/default` fallback
- remove the unused profile copy from stored execution context and claim
  responses, leaving `runner_job_queue.profile` as the canonical routing source
- cover exact non-default profile propagation and prove previous-API queue JSON
  remains pollable and claimable

## Compatibility

- no database schema change, migration, backfill, or persisted-data rewrite
- compose `experimental_profile` defaulting and optional affinity/session fields
  are unchanged
- previous-API execution-context JSON with `experimentalProfile` is accepted and
  stripped, while polling continues to use the dedicated queue column
- current and recent API versions already emit the required poll field; a
  pre-profile poll producer is intentionally no longer supported

## Validation

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm knip`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit hooks, including full Turbo type checking

Closes #23373
