### PR TITLE
fix(platform): remove standalone connector hint

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -758,7 +758,7 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("moves reconnect into the connector options menu", async () => {
+  it("omits standalone instructions from reconnect progress", async () => {
     mockConnectors([
       {
         type: "meta-ads",
@@ -767,6 +767,7 @@ describe("connectors page", () => {
     ]);
     const authWindow = createMockAuthWindow();
     context.mocks.browser.open(authWindow);
+    context.mocks.browser.standaloneDisplayMode(true);
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
@@ -804,6 +805,14 @@ describe("connectors page", () => {
         "https://oauth.test/meta-ads/authorize",
       );
     });
+    expect(
+      within(connectorCardByLabel("Meta Ads")).getByText("Connecting…"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectorCardByLabel("Meta Ads")).queryByText(
+        "Switch back here after completing sign-in.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("disconnects a connected catalog connector from the options menu", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -51,7 +51,6 @@ import {
   clearManualGrantForm$,
   manualGrantFormValuesFor$,
   selectedConnectorRef$,
-  isStandaloneMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
   hasConnectorStatusBrowserAuthGrant,
@@ -354,12 +353,7 @@ function getOAuthAuthCodeProgressContent({
 }) {
   // While browser authorization is in progress, only show connecting state.
   if (isPolling) {
-    const standaloneHint = isStandaloneMode()
-      ? " Switch back here after completing sign-in."
-      : "";
-    return (
-      <p className="text-sm text-muted-foreground">{`Connecting...${standaloneHint}`}</p>
-    );
+    return <p className="text-sm text-muted-foreground">Connecting...</p>;
   }
 
   if (settling) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -23,7 +23,6 @@ import {
 import {
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
-  isStandaloneMode,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { DropdownMenuModalItem } from "../../../components/dropdown-menu-modal-item.tsx";
 import { LoadingSwitch } from "../../../components/loading-switch.tsx";
@@ -178,13 +177,10 @@ function ConnectorConnectionStatus({
 }) {
   const connectionStatus = connectorCurrentConnectionStatus(connector);
   if (busy) {
-    const standaloneHint = isStandaloneMode()
-      ? " Switch back here after completing sign-in."
-      : "";
     return (
       <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
-        {`Connecting…${standaloneHint}`}
+        Connecting…
       </span>
     );
   }


### PR DESCRIPTION
## Summary

- remove the standalone-only return guidance from connector connection progress
- show the same concise Connecting status in browser and installed PWA flows
- cover standalone reconnect progress in the connectors page integration test

## User impact

Installed PWA connector cards no longer append the long Switch back here after completing sign-in message while OAuth is in progress. The concise status avoids the overflow reported in #22466 without changing the OAuth flow.

## Verification

- pnpm exec prettier --write on the three changed platform files
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- targeted zero-connectors-page Vitest passed
- pre-commit Knip and repository type checks passed

Closes #22466