### PR TITLE
fix(api): send low-credit alerts from contact@vm0.ai

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -6,6 +6,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi } from "./helpers/api-bdd";
+import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createEmailApi } from "./helpers/api-bdd-email";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
@@ -113,6 +114,70 @@ beforeEach(() => {
   // This route drains a cross-file outbox; Resend pacing is not part of these
   // transactional delivery assertions.
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
+});
+
+describe("low-credit email delivery", () => {
+  it("sends low-credit alerts from contact@vm0.ai", async () => {
+    const actor = bdd.user();
+    const billing = createBillingMediaApi(context);
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    await runs.grantProEntitlement(actor);
+
+    const before = await billing.readBillingStatus(actor);
+    expect(before.credits).toBeGreaterThan(5000);
+
+    const agentName = `bdd-low-credit-${randomUUID().slice(0, 8)}`;
+    const compose = await runs.createCompose(actor, {
+      version: "1.0",
+      agents: {
+        [agentName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    const run = await runs.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "cross the low-credit alert threshold",
+      triggerSource: "web",
+    });
+    await webhooks.requestAgentUsageEvent(
+      {
+        runId: run.runId,
+        events: [
+          {
+            idempotencyKey: randomUUID(),
+            kind: "model",
+            provider: "bdd-model",
+            category: "tokens.output",
+            quantity: 1,
+            grossCredits: before.credits - 4999,
+          },
+        ],
+      },
+      {
+        authorization: `Bearer ${runs.sandboxTokenForRun(actor, run.runId)}`,
+      },
+      [200],
+    );
+
+    // Refresh the current Clerk membership mocks before settlement resolves
+    // the organization's admin recipients.
+    await billing.readBillingStatus(actor);
+    await billing.processOrgUsageEvents(actor);
+    const drain = await email.drainEmailOutboxCron(true);
+
+    expect(drain.status).toBe(200);
+    expect(context.mocks.resend.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "VM0 Team <contact@vm0.ai>",
+        to: actor.email,
+        subject: "Your credit balance is running low",
+      }),
+    );
+  });
 });
 
 describe("POST /api/zero/email/inbound", () => {

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -13,7 +13,6 @@ import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import {
-  buildFromAddress,
   buildOneClickUnsubscribeUrl,
   buildUnsubscribeHeaders,
   buildUnsubscribeUrl,
@@ -31,6 +30,7 @@ export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 
 const L = logger("CreditLowBalanceAlert");
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
+const LOW_CREDIT_EMAIL_FROM_ADDRESS = "VM0 Team <contact@vm0.ai>";
 
 function billingCreditsUrl(): string {
   return `${env("APP_URL").replace(/\/$/, "")}/?settings=billing&billingView=credits`;
@@ -305,7 +305,7 @@ export const enqueueCreditLowBalanceAlert$ = command(
           },
         } satisfies EmailTemplate;
         return {
-          fromAddress: buildFromAddress("vm0"),
+          fromAddress: LOW_CREDIT_EMAIL_FROM_ADDRESS,
           toAddresses: recipient.email,
           ccAddresses: null,
           subject: CREDIT_LOW_BALANCE_EMAIL_SUBJECT,


### PR DESCRIPTION
## Summary

- send low-credit balance alerts from `VM0 Team <contact@vm0.ai>`
- preserve the existing threshold, admin-recipient, unsubscribe, suppression, and outbox behavior
- add API integration coverage from threshold-crossing usage settlement through Resend delivery

## Scope

- only low-credit balance alerts use the fixed sender identity
- no global Resend sender configuration or environment variable changes
- no changes to credit settlement or low-balance triggering logic

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full-workspace Knip and TypeScript checks

Closes #23342
