### PR TITLE
fix(runner): classify codex safety policy refusals

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1180,6 +1180,38 @@ mod tests {
     }
 
     #[test]
+    fn failed_turn_completed_preserves_cyber_policy_reason_for_diagnostics() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {
+                        "message": "This request has been flagged for possible cybersecurity risk.",
+                        "codexErrorInfo": "cyberPolicy"
+                    },
+                    "startedAt": 10,
+                    "completedAt": 20,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(event["turn"]["error"]["codex_error_info"], "cyberPolicy");
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(events::CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: "This request has been flagged for possible cybersecurity risk."
+                    .to_string(),
+                failure_reason: Some(FailureReason::SafetyPolicyRefusal),
+            })
+        );
+    }
+
+    #[test]
     fn interrupted_turn_completed_stays_turn_completed() {
         let event = mapped_event(
             "turn/completed",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -363,6 +363,7 @@ fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
     match codex_error_info_variant(error)? {
         "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
         "usageLimitExceeded" => Some(FailureReason::UsageLimit),
+        "cyberPolicy" => Some(FailureReason::SafetyPolicyRefusal),
         _ => None,
     }
 }

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -22,6 +22,12 @@ use std::path::Path;
 const LOG_TAG: &str = "sandbox:guest-agent";
 const MAX_LOGGED_CLI_STDERR_LINES: usize = 20;
 const MAX_LOGGED_CLI_STDERR_LINE_BYTES: usize = 4096;
+const CODEX_SAFETY_POLICY_REFUSAL_MESSAGE: &str = concat!(
+    "This content was flagged for possible cybersecurity risk. ",
+    "If this seems wrong, try rephrasing your request. ",
+    "To get authorized for security work, join the Trusted Access for Cyber program: ",
+    "https://chatgpt.com/cyber",
+);
 
 /// Final message and structured diagnostic for a nonzero CLI result.
 #[derive(Debug)]
@@ -244,6 +250,12 @@ fn classify_cli_failure_reason(
     source: FailureDetailSource,
     failure_message: &str,
 ) -> Option<FailureReason> {
+    if matches!(framework, AgentFramework::Codex)
+        && is_codex_safety_policy_refusal(source, failure_message)
+    {
+        return Some(FailureReason::SafetyPolicyRefusal);
+    }
+
     let normalized = failure_message.to_ascii_lowercase();
     if is_insufficient_credits_error(&normalized) {
         return Some(FailureReason::InsufficientCredits);
@@ -315,6 +327,11 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::UsageLimit);
     }
     None
+}
+
+fn is_codex_safety_policy_refusal(source: FailureDetailSource, failure_message: &str) -> bool {
+    source == FailureDetailSource::CodexJsonl
+        && failure_message.trim() == CODEX_SAFETY_POLICY_REFUSAL_MESSAGE
 }
 
 fn is_insufficient_credits_error(normalized: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1146,6 +1146,33 @@ fn cli_failure_reason_prefers_message_classification_over_carried_reason() {
 }
 
 #[test]
+fn cli_failure_reason_preserves_structured_safety_policy_refusal() {
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("debug failure"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(FailureDetailSource::CodexJsonl);
+    let failure_message = selected_failure_message(
+        "This request was refused by the provider.",
+        FailureDetailSource::CodexJsonl,
+        Some(FailureReason::SafetyPolicyRefusal),
+    );
+    let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
+
+    assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::SafetyPolicyRefusal)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::CodexJsonl)
+    );
+}
+
+#[test]
 fn cli_failure_reason_ignores_non_codex_invalid_api_key_text() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -992,6 +992,52 @@ fn cli_failure_reason_ignores_generic_codex_401() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_exact_codex_safety_policy_refusal() {
+    let reason = super::classify_cli_failure_reason(
+        AgentFramework::Codex,
+        FailureDetailSource::CodexJsonl,
+        CODEX_SAFETY_POLICY_REFUSAL_MESSAGE,
+    );
+
+    assert_eq!(reason, Some(FailureReason::SafetyPolicyRefusal));
+}
+
+#[test]
+fn cli_failure_reason_does_not_broadly_classify_safety_policy_text() {
+    for message in [
+        "policy violation",
+        "security risk",
+        "This content was flagged for possible cybersecurity risk.",
+        "This request was refused by a content policy.",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            message,
+        );
+
+        assert_eq!(reason, None, "message: {message}");
+    }
+
+    assert_eq!(
+        super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            CODEX_SAFETY_POLICY_REFUSAL_MESSAGE,
+        ),
+        None
+    );
+    assert_eq!(
+        super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::CodexJsonl,
+            CODEX_SAFETY_POLICY_REFUSAL_MESSAGE,
+        ),
+        None
+    );
+}
+
+#[test]
 fn cli_failure_reason_classifies_codex_oauth_reconnect_required() {
     let reason = classify_cli_failure_reason(
         AgentFramework::Codex,

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -77,6 +77,32 @@ async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::er
         Some(FailureReason::InvalidApiKey)
     );
 
+    unsafe {
+        std::env::set_var("MOCK_CODEX_FIXTURE", "safety-policy-refusal");
+    }
+
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    let diagnostic = cli_result
+        .failure_diagnostic
+        .as_ref()
+        .expect("safety policy refusal JSONL error should produce a diagnostic");
+    assert_eq!(
+        diagnostic.message,
+        "This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request. To get authorized for security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber"
+    );
+    assert_eq!(diagnostic.source, FailureDetailSource::CodexJsonl);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::SafetyPolicyRefusal)
+    );
+
     Ok(())
 }
 

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -434,6 +434,8 @@ pub enum FailureReason {
     ProviderStreamTimeout,
     /// The provider returned a server error.
     ProviderServerError,
+    /// The provider refused the request under a safety policy.
+    SafetyPolicyRefusal,
     /// The CLI requires reconnecting or re-authentication.
     ReconnectRequired,
     /// The provider reported a usage limit.
@@ -454,6 +456,7 @@ impl FailureReason {
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ProviderStreamTimeout => "provider_stream_timeout",
             Self::ProviderServerError => "provider_server_error",
+            Self::SafetyPolicyRefusal => "safety_policy_refusal",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
         }
@@ -1067,6 +1070,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "provider_server_error");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_safety_policy_refusal_reason() {
+        assert_eq!(
+            FailureReason::SafetyPolicyRefusal.as_str(),
+            "safety_policy_refusal"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::SafetyPolicyRefusal);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "safety_policy_refusal");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/guest-mock-codex/fixtures/safety-policy-refusal.jsonl
+++ b/crates/guest-mock-codex/fixtures/safety-policy-refusal.jsonl
@@ -1,0 +1,2 @@
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-000000000005"}
+{"type":"error","message":"This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request. To get authorized for security work, join the Trusted Access for Cyber program: https://chatgpt.com/cyber","codex_error_info":"cyberPolicy"}

--- a/crates/guest-mock-codex/src/fixtures.rs
+++ b/crates/guest-mock-codex/src/fixtures.rs
@@ -23,6 +23,10 @@ const FIXTURES: &[(&str, &str)] = &[
         "invalid-api-key",
         include_str!("../fixtures/invalid-api-key.jsonl"),
     ),
+    (
+        "safety-policy-refusal",
+        include_str!("../fixtures/safety-policy-refusal.jsonl"),
+    ),
 ];
 
 /// Look up a fixture by name. Returns the fixture's raw JSONL content.

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -916,6 +916,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                     | FailureReason::ProviderOverloaded
                     | FailureReason::ProviderStreamTimeout
                     | FailureReason::ProviderServerError
+                    | FailureReason::SafetyPolicyRefusal
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
             )
@@ -1412,6 +1413,7 @@ mod tests {
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {
@@ -1536,6 +1538,7 @@ mod tests {
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
+            FailureReason::SafetyPolicyRefusal,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {


### PR DESCRIPTION
## Summary

- classify Codex `cyberPolicy` diagnostics and the exact observed legacy refusal message as `safety_policy_refusal`
- reuse the runner's structured expected-failure boundary so only matching CLI nonzero outcomes log at `info`
- cover shared serialization, app-server mapping, JSONL diagnostic preservation, narrow fallback matching, and runner severity

## Behavior

The run still fails with exit code 1 and preserves the provider refusal message for the user. Unclassified failures, non-CLI failures, and generic policy or security text continue to log at `error`.

This does not retry, bypass provider policy, rewrite the request, or convert the run to success.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p guest-mock-codex -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p guest-mock-codex -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::start::job_spawn`

Closes #23383
