### PR TITLE
feat(connectors): default oauth callbacks to app

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -413,7 +413,26 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("keeps API-origin callbacks on the API when the app target is requested", async () => {
+  it("uses App callbacks by default outside the legacy callback list", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("test-oauth", {
+      headers: authHeaders(),
+      origin: API_ORIGIN,
+      callbackTarget: "app",
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.test/connectors/test-oauth/callback",
+    );
+    expectOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps denylisted API-origin callbacks on the API", async () => {
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("cloudflare", {

--- a/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
@@ -45,8 +45,7 @@ export function getConnectorOAuthCallbackUrlForMethod(args: {
   );
   if (
     args.callbackTarget === "app" &&
-    isConnectorAppOauthCallbackEnabled(args.connectorRef) &&
-    callbackOrigin === "web"
+    isConnectorAppOauthCallbackEnabled(args.connectorRef)
   ) {
     return new URL(
       `/connectors/${encodeURIComponent(args.connectorRef)}/callback`,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1472,6 +1472,7 @@ describe("connectors page", () => {
     ["mercury", "Mercury"],
     ["notion", "Notion"],
     ["sentry", "Sentry"],
+    ["server-authored-oauth", "Server-authored OAuth"],
     ["vercel", "Vercel"],
   ] as const)(
     "starts %s OAuth with the app callback",
@@ -1518,6 +1519,49 @@ describe("connectors page", () => {
       });
     },
   );
+
+  it("keeps denylisted OAuth connectors on their legacy callback", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "cloudflare",
+        label: "Cloudflare",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    ]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("cloudflare");
+        expect(body.callbackTarget).toBeUndefined();
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/cloudflare/authorize",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    click(await screen.findByLabelText("Connect Cloudflare"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/cloudflare/authorize",
+      );
+    });
+  });
 
   it("routes a server-authored connector from its catalog grant metadata", async () => {
     const connectorRef = "server-authored-steam";

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -1,37 +1,24 @@
-// Add a connector only after its OAuth app accepts the App callback URL.
+// Keep a connector here until its OAuth app accepts the App callback URL.
 export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
   "vm0.connector.appOauthCallbackMetadata";
 
-const ENABLED_CONNECTOR_REFS: ReadonlySet<string> = new Set([
-  "github",
-  "gmail",
-  "google-ads",
-  "google-analytics",
-  "google-calendar",
-  "google-cloud",
-  "google-contacts",
-  "google-docs",
-  "google-drive",
-  "google-forms",
-  "google-maps",
-  "google-meet",
-  "google-search-console",
-  "google-sheets",
-  "hubspot",
-  "intervals-icu",
-  "linear",
-  "meta-ads",
-  "mercury",
-  "notion",
-  "sentry",
-  "stripe",
-  "vercel",
-  "x",
-  "youtube",
+const LEGACY_CALLBACK_CONNECTOR_REFS: ReadonlySet<string> = new Set([
+  "airtable",
+  "asana",
+  "cloudflare",
+  "gumroad",
+  "microsoft-365",
+  "monday",
+  "outlook-calendar",
+  "outlook-mail",
+  "slack",
+  "strava",
+  "todoist",
+  "xero",
 ]);
 
 export function isConnectorAppOauthCallbackEnabled(
   connectorRef: string,
 ): boolean {
-  return ENABLED_CONNECTOR_REFS.has(connectorRef);
+  return !LEGACY_CALLBACK_CONNECTOR_REFS.has(connectorRef);
 }


### PR DESCRIPTION
## Summary

- replace the App OAuth callback allowlist with a legacy callback denylist
- default existing and future OAuth connectors outside the denylist to the App callback
- keep Airtable, Asana, Cloudflare, Gumroad, Microsoft 365, Monday, Outlook Calendar, Outlook Mail, Slack, Strava, Todoist, and Xero on their existing callback behavior
- allow an explicit App callback target to override a catalog method default while preserving old callers that omit the target

## Testing

- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- scoped Knip checks for `@vm0/connectors`, `api`, and `@vm0/app`

Part of #22564