### PR TITLE
chore(rust): update event-listener to 5.4.2

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -856,15 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,11 +1054,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary

- Update `event-listener` from 5.4.1 to 5.4.2.
- Remove the no-longer-used transitive `concurrent-queue` 2.5.0 package from the lockfile.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`.

## Manual version bumps

- None.

## Validation

- `cargo test --workspace --exclude runner`
- `cargo test -p runner`
