### PR TITLE
fix(api): use support address for low-credit alerts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -117,7 +117,7 @@ beforeEach(() => {
 });
 
 describe("low-credit email delivery", () => {
-  it("sends low-credit alerts from contact@vm0.ai", async () => {
+  it("sends low-credit alerts from support@vm0.ai", async () => {
     const actor = bdd.user();
     const billing = createBillingMediaApi(context);
     bdd.acceptAgentStorageWrites();
@@ -172,7 +172,7 @@ describe("low-credit email delivery", () => {
     expect(drain.status).toBe(200);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "VM0 Team <contact@vm0.ai>",
+        from: "VM0 Team <support@vm0.ai>",
         to: actor.email,
         subject: "Your credit balance is running low",
       }),

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -30,7 +30,7 @@ export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 
 const L = logger("CreditLowBalanceAlert");
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
-const LOW_CREDIT_EMAIL_FROM_ADDRESS = "VM0 Team <contact@vm0.ai>";
+const LOW_CREDIT_EMAIL_FROM_ADDRESS = "VM0 Team <support@vm0.ai>";
 
 function billingCreditsUrl(): string {
   return `${env("APP_URL").replace(/\/$/, "")}/?settings=billing&billingView=credits`;


### PR DESCRIPTION
## Summary

- send low-credit balance alerts from `VM0 Team <support@vm0.ai>`
- update the existing API integration test to enforce the sender identity
- leave every other `contact@vm0.ai` use unchanged

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts apps/api/src/signals/routes/__tests__/zero-email.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts --silent=passed-only`
- pre-commit full-workspace Knip and TypeScript checks

Follow-up to #23390.
