### PR TITLE
fix(runner): discover first-run session ids after failures

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1625,6 +1625,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finalizer_promotes_failed_first_run_workspace_with_discovered_session() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-discovered-after-failure";
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: None,
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(
+            workspace_image.result(),
+            crate::workspace_image_cache::WorkspaceCacheCheckoutResult::NoSession
+        );
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let (factory, sandbox) = sandbox_with_overrides(sandbox_id, Arc::clone(&overrides)).await;
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "unused-context-session",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.factory = factory;
+        context.cli_agent_session_id = None;
+        context.discovered_cli_agent_session_id = Some(session_id.into());
+        context.exit_code = 1;
+        context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64;
+        let held_session_snapshot = context.held_session_snapshot.clone();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(sandbox),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                1,
+                Some("simulated agent failure".into()),
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(overrides.park_call_count(), 0);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(fixture.idle_pool.lock().await.len(), 0);
+        let cache_states = cache.held_session_states().await;
+        assert_eq!(cache_states.len(), 1);
+        assert_eq!(cache_states[0].session_id, session_id);
+        let inspection = cache.inspect().await.unwrap();
+        assert_eq!(inspection.entries.len(), 1);
+        assert_eq!(
+            inspection.entries[0].last_terminal_status,
+            Some(WorkspaceCacheTerminalStatus::NonzeroExit)
+        );
+        let active_sessions = super::super::active_sessions::new_active_cli_agent_sessions();
+        let snapshot_states =
+            held_session_snapshot.current_held_session_states(Vec::new(), &active_sessions, None);
+        assert_eq!(snapshot_states.len(), 1);
+        assert_eq!(snapshot_states[0].session_id, session_id);
+        assert_eq!(snapshot_states[0].workspace_caches.len(), 1);
+    }
+
+    #[tokio::test]
     async fn finalizer_stop_error_abandons_frozen_workspace_cache_before_destroy() {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -734,10 +734,6 @@ impl AgentExecutionResult {
         }
     }
 
-    pub(super) fn exit_code(&self) -> i32 {
-        self.failure.as_ref().map_or(0, |failure| failure.exit_code)
-    }
-
     pub(super) fn with_stdout_stream_diagnostics(
         mut self,
         diagnostics: AgentStdoutStreamDiagnostics,

--- a/crates/runner/src/executor/diagnostics/guest_files.rs
+++ b/crates/runner/src/executor/diagnostics/guest_files.rs
@@ -84,7 +84,8 @@ pub(in crate::executor) async fn read_guest_failure_diagnostic_file(
 ///
 /// The guest-agent writes the session ID to the guest runtime directory
 /// after the CLI emits its `system/init` event. On first runs (no
-/// `resume_session`), the runner uses this to park the VM for keep-alive.
+/// `resume_session`), the runner uses this as the late-discovered identity
+/// for session tracking and finalization.
 pub(in crate::executor) async fn read_guest_cli_agent_session_id(
     sandbox: &dyn Sandbox,
     run_id: RunId,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -231,7 +231,8 @@ pub struct ExecuteOutcome {
     pub network_log_session: Option<NetworkLogSession>,
     pub workspace_image: Option<WorkspaceImageLease>,
     /// CLI-generated session ID read from the guest after execution.
-    /// Used for first-run VM parking when `resume_session` is absent.
+    /// Used for late session tracking and finalization when `resume_session`
+    /// is absent.
     pub discovered_cli_agent_session_id: Option<String>,
     pub restored_session_identity: Option<RestoredSessionIdentity>,
 }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1330,23 +1330,22 @@ pub(super) async fn execute_prepared_sandbox_run(
         }
     }
 
-    // Read CLI-generated session ID for first-run parking.
-    let discovered_cli_agent_session_id =
-        if agent_result.exit_code() == 0 && context.cli_agent_session_id().is_none() {
-            let id = read_guest_cli_agent_session_id(sandbox.as_ref(), context.run_id)
-                .await
-                .and_then(|id| normalize_guest_cli_agent_session_id_for_parking(context, id));
-            if let Some(ref sid) = id {
-                info!(
-                    run_id = %context.run_id,
-                    session_id = %sid,
-                    "read guest session ID for parking"
-                );
-            }
-            id
-        } else {
-            None
-        };
+    // Read the CLI-generated session ID after a first-run execution.
+    let discovered_cli_agent_session_id = if context.cli_agent_session_id().is_none() {
+        let id = read_guest_cli_agent_session_id(sandbox.as_ref(), context.run_id)
+            .await
+            .and_then(|id| normalize_guest_cli_agent_session_id(context, id));
+        if let Some(ref sid) = id {
+            info!(
+                run_id = %context.run_id,
+                session_id = %sid,
+                "read guest CLI agent session ID after execution"
+            );
+        }
+        id
+    } else {
+        None
+    };
 
     ExecuteOutcome {
         failure: agent_result.failure,
@@ -1359,7 +1358,7 @@ pub(super) async fn execute_prepared_sandbox_run(
     }
 }
 
-fn normalize_guest_cli_agent_session_id_for_parking(
+fn normalize_guest_cli_agent_session_id(
     context: &ExecutionContext,
     session_id: String,
 ) -> Option<String> {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -175,7 +175,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn execute_prepared_sandbox_run_logs_guest_session_id() {
+async fn execute_prepared_sandbox_run_logs_discovered_guest_session_id() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -212,7 +212,7 @@ async fn execute_prepared_sandbox_run_logs_guest_session_id() {
         outcome.discovered_cli_agent_session_id.as_deref(),
         Some(raw_session_id)
     );
-    let event = captured_event(&events, "read guest session ID for parking");
+    let event = captured_event(&events, "read guest CLI agent session ID after execution");
     assert_eq!(
         event.fields.get("session_id").map(String::as_str),
         Some(raw_session_id)
@@ -220,8 +220,54 @@ async fn execute_prepared_sandbox_run_logs_guest_session_id() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_session_id_for_parking()
- {
+async fn execute_prepared_sandbox_run_discovers_guest_session_id_after_nonzero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let raw_session_id = "sess-failed-first-run";
+    overrides.push_wait_process_exit(ProcessExit::new(1, 7, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(None));
+    overrides.push_read_file_result(Ok(None));
+    overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let source_ip = sandbox.source_ip().to_string();
+    let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let (outcome, events) = capture_async_events(execute_prepared_sandbox_run(
+        PreparedSandboxRun {
+            sandbox,
+            source_ip,
+            network_log_session,
+        },
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    ))
+    .await;
+
+    assert_eq!(outcome.exit_code(), 7);
+    assert_eq!(outcome.error(), Some("Agent exited with code 7"));
+    assert_eq!(
+        outcome.discovered_cli_agent_session_id.as_deref(),
+        Some(raw_session_id)
+    );
+    let event = captured_event(&events, "read guest CLI agent session ID after execution");
+    assert_eq!(
+        event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_session_id() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -260,7 +306,7 @@ async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_s
         outcome.discovered_cli_agent_session_id.as_deref(),
         Some(canonical_session_id)
     );
-    let event = captured_event(&events, "read guest session ID for parking");
+    let event = captured_event(&events, "read guest CLI agent session ID after execution");
     assert_eq!(
         event.fields.get("session_id").map(String::as_str),
         Some(canonical_session_id)


### PR DESCRIPTION
## Summary

- discover a valid guest-generated CLI agent session ID after first-run execution regardless of the agent exit code
- keep failed and cancelled sandboxes ineligible for parking while allowing existing nonzero workspace-cache finalization to use the late ID
- generalize parking-specific identity comments and diagnostics, and remove the now-unused execution-result exit-code helper
- cover failed first-run discovery and `NoSession` workspace promotion with lifecycle tests

## Scope

- no runner/backend API or queue payload changes
- no runner/guest contract changes
- no schema, migration, or persisted metadata format changes
- no change to sandbox parking or workspace terminal-status policy

## Validation

- `cargo test -p runner execute_prepared_sandbox_run_discovers_guest_session_id_after_nonzero_exit -- --nocapture`
- `cargo test -p runner finalizer_promotes_failed_first_run_workspace_with_discovered_session -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2855 passed, 14 ignored; guest inventory passed)

Closes #23398
