### PR TITLE
docs(runner): clarify procfs scan safety contract

### DIFF
--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -256,10 +256,14 @@ pub async fn discover_all() -> DiscoveredProcesses {
     discover_all_with_status().await.processes
 }
 
-/// Scan `/proc` once and include whether the top-level process scan completed.
+/// Scan `/proc` once and report Firecracker discovery uncertainty.
 ///
-/// Destructive cleanup code should use this variant so it can fail closed when
-/// `/proc` could not be scanned reliably.
+/// `proc_scan_complete` is false when `/proc` traversal fails, when an
+/// unreadable or unparseable cmdline belongs to a live Firecracker, or when
+/// unavailable or malformed stat facts cannot rule one out. Missing PIDs,
+/// zombie Firecrackers, and known non-Firecracker processes do not make it
+/// false. Destructive cleanup code should use this variant so it can fail
+/// closed; the status is not generic argv completeness for every process.
 pub(crate) async fn discover_all_with_status() -> ProcessDiscovery {
     let proc_scan = scan_proc_cmdlines().await;
 

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -261,9 +261,10 @@ pub async fn discover_all() -> DiscoveredProcesses {
 /// `proc_scan_complete` is false when `/proc` traversal fails, when an
 /// unreadable or unparseable cmdline belongs to a live Firecracker, or when
 /// unavailable or malformed stat facts cannot rule one out. Missing PIDs,
-/// zombie Firecrackers, and known non-Firecracker processes do not make it
-/// false. Destructive cleanup code should use this variant so it can fail
-/// closed; the status is not generic argv completeness for every process.
+/// zombie or otherwise terminal Firecrackers, and known non-Firecracker
+/// processes do not make it false. Destructive cleanup code should use this
+/// variant so it can fail closed; the status is not generic argv completeness
+/// for every process.
 pub(crate) async fn discover_all_with_status() -> ProcessDiscovery {
     let proc_scan = scan_proc_cmdlines().await;
 

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -312,9 +312,9 @@ pub(super) struct ProcCmdlineScan {
     /// unreadable or unparseable cmdline belongs to a live Firecracker, or when
     /// unavailable or malformed `/proc/{pid}/stat` facts cannot rule one out.
     /// Empty and NUL-free cmdlines use this same classification. A disappeared
-    /// PID, zombie Firecracker, or known non-Firecracker process does not make
-    /// the scan incomplete. This is not a guarantee that every non-Firecracker
-    /// cmdline was readable.
+    /// PID, zombie or otherwise terminal Firecracker, or known non-Firecracker
+    /// process does not make the scan incomplete. This is not a guarantee that
+    /// every non-Firecracker cmdline was readable.
     pub(super) complete: bool,
 }
 

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -24,10 +24,8 @@ fn parse_cmdline_bytes(bytes: &[u8]) -> Option<Vec<String>> {
 
 /// Read `/proc/{pid}/cmdline` as the NUL-separated argv.
 ///
-/// Returns `None` for kernel threads (empty cmdline) and for processes whose
-/// cmdline has been rewritten (via `prctl(PR_SET_NAME)` or similar) into a
-/// single NUL-free blob — those aren't the exec-spawned processes we care
-/// about identifying here.
+/// Returns `None` when the file cannot be read, when its contents are empty or
+/// NUL-free, or when every NUL-delimited segment is empty.
 pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
     let path = format!("/proc/{pid}/cmdline");
     let bytes = tokio::fs::read(&path).await.ok()?;
@@ -303,12 +301,20 @@ fn service_unit_from_cgroup_path(path: &str) -> Option<String> {
         })
 }
 
-/// Scan `/proc` for all process argvs.
-///
-/// Returns `(pid, argv)` pairs for every readable process plus whether the
-/// top-level directory scan completed without errors.
+/// Scan `/proc` for process argvs and track Firecracker discovery uncertainty.
 pub(super) struct ProcCmdlineScan {
+    /// Cmdlines that were successfully parsed as NUL-separated argvs.
     pub(super) entries: Vec<(u32, Vec<String>)>,
+    /// Whether the scan encountered no uncertainty that callers must treat as
+    /// a potentially undiscovered live Firecracker.
+    ///
+    /// This is false when opening or iterating `/proc` fails, when an
+    /// unreadable or unparseable cmdline belongs to a live Firecracker, or when
+    /// unavailable or malformed `/proc/{pid}/stat` facts cannot rule one out.
+    /// Empty and NUL-free cmdlines use this same classification. A disappeared
+    /// PID, zombie Firecracker, or known non-Firecracker process does not make
+    /// the scan incomplete. This is not a guarantee that every non-Firecracker
+    /// cmdline was readable.
     pub(super) complete: bool,
 }
 

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -77,10 +77,10 @@ pub(crate) struct ProcessDiscovery {
     /// uncertainty that callers must treat as a potentially undiscovered live
     /// Firecracker.
     ///
-    /// Missing PIDs, zombie Firecrackers, and known non-Firecracker processes
-    /// are intentionally ignored. Traversal failures, unreadable or
-    /// unparseable live Firecracker cmdlines, and unavailable or malformed
-    /// stat facts that cannot rule one out make this false. This is not a
-    /// completeness guarantee for arbitrary process argvs.
+    /// Missing PIDs, zombie or otherwise terminal Firecrackers, and known
+    /// non-Firecracker processes are intentionally ignored. Traversal failures,
+    /// unreadable or unparseable live Firecracker cmdlines, and unavailable or
+    /// malformed stat facts that cannot rule one out make this false. This is
+    /// not a completeness guarantee for arbitrary process argvs.
     pub(crate) proc_scan_complete: bool,
 }

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -70,8 +70,17 @@ pub struct DiscoveredProcesses {
     pub dnsmasqs: Vec<DnsmasqProcessInfo>,
 }
 
-/// Process discovery plus whether the top-level `/proc` scan completed.
+/// Process discovery plus Firecracker cmdline-scan completeness.
 pub(crate) struct ProcessDiscovery {
     pub(crate) processes: DiscoveredProcesses,
+    /// Whether `/proc` traversal and per-process classification left no
+    /// uncertainty that callers must treat as a potentially undiscovered live
+    /// Firecracker.
+    ///
+    /// Missing PIDs, zombie Firecrackers, and known non-Firecracker processes
+    /// are intentionally ignored. Traversal failures, unreadable or
+    /// unparseable live Firecracker cmdlines, and unavailable or malformed
+    /// stat facts that cannot rule one out make this false. This is not a
+    /// completeness guarantee for arbitrary process argvs.
     pub(crate) proc_scan_complete: bool,
 }


### PR DESCRIPTION
## Summary

- correct `read_cmdline` documentation to describe its actual read and parse outcomes without attributing NUL-free cmdlines to `PR_SET_NAME`
- define `ProcCmdlineScan::complete` as the Firecracker-specific fail-closed safety contract used by destructive cleanup
- propagate the same missing-PID, terminal-Firecracker, non-Firecracker, and unclassifiable-process semantics through process discovery

## Scope

Documentation only. Process discovery behavior, logs, APIs, protocols, and persisted state are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (2,854 passed, 0 failed, 14 ignored)
- repository pre-commit hooks

Closes #23399
