### PR TITLE
refactor(sandbox-mock): retire legacy lifecycle gates

### DIFF
--- a/crates/sandbox-mock/src/factory_runtime.rs
+++ b/crates/sandbox-mock/src/factory_runtime.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use ::sandbox::*;
 use async_trait::async_trait;
 
-use crate::lifecycle::{DestroyBehavior, wait_blocking_gate};
+use crate::lifecycle::{DestroyBehavior, wait_lifecycle_gate};
 use crate::overrides::MockSandboxOverrides;
 use crate::sandbox::MockSandbox;
 use crate::support::LockIgnoringPoison;
@@ -100,7 +100,7 @@ impl SandboxFactory for MockSandboxFactory {
     async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {
         if let Some(o) = &self.overrides {
             *o.lifecycle.destroy_calls.lock_ignoring_poison() += 1;
-            wait_blocking_gate(&o.lifecycle.destroy_gate).await;
+            wait_lifecycle_gate(&o.lifecycle.destroy_gate).await;
             match o
                 .lifecycle
                 .destroy_behaviors

--- a/crates/sandbox-mock/src/lifecycle.rs
+++ b/crates/sandbox-mock/src/lifecycle.rs
@@ -228,24 +228,9 @@ impl Default for MockLifecycleGate {
     }
 }
 
-#[derive(Clone)]
-pub(crate) enum BlockingGate {
-    LegacyNotify {
-        entered: Arc<tokio::sync::Notify>,
-        release: Arc<tokio::sync::Notify>,
-    },
-    Lifecycle(MockLifecycleGate),
-}
-
-pub(crate) async fn wait_blocking_gate(gate: &Mutex<Option<BlockingGate>>) {
+pub(crate) async fn wait_lifecycle_gate(gate: &Mutex<Option<MockLifecycleGate>>) {
     let gate = gate.lock_ignoring_poison().clone();
     if let Some(gate) = gate {
-        match gate {
-            BlockingGate::LegacyNotify { entered, release } => {
-                entered.notify_waiters();
-                release.notified().await;
-            }
-            BlockingGate::Lifecycle(gate) => gate.enter_and_wait().await,
-        }
+        gate.enter_and_wait().await;
     }
 }

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -8,7 +8,7 @@ use crate::call_records::{
     CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, StartProcessCall,
     WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
-use crate::lifecycle::{BlockingGate, DestroyBehavior, LifecycleBehaviors, MockLifecycleGate};
+use crate::lifecycle::{DestroyBehavior, LifecycleBehaviors, MockLifecycleGate};
 use crate::support::LockIgnoringPoison;
 
 pub(crate) struct ExecMatcherResult {
@@ -57,13 +57,13 @@ pub(crate) struct LifecycleOverrideState {
     /// these overrides. Empty queue → default reusable outcome.
     pub(crate) park_behaviors: LifecycleBehaviors<SandboxParkOutcome>,
     /// Optional gate that records and blocks every `park()` entry until released.
-    pub(crate) park_gate: Mutex<Option<BlockingGate>>,
+    pub(crate) park_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) unpark_behaviors: LifecycleBehaviors<()>,
     /// Optional gate that records and blocks every factory `destroy()` entry
     /// until released.
-    pub(crate) destroy_gate: Mutex<Option<BlockingGate>>,
+    pub(crate) destroy_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of destroy behaviours consumed by every factory built with
     /// these overrides. Empty queue → default successful destroy.
     pub(crate) destroy_behaviors: Mutex<VecDeque<DestroyBehavior>>,
@@ -399,25 +399,8 @@ impl MockSandboxOverrides {
     }
 
     /// Block every `park()` call with a durable lifecycle gate.
-    ///
-    /// Prefer this over [`Self::set_park_gate`]: entries and releases are
-    /// durable, so tests do not need to pre-arm `Notify` futures.
     pub fn set_park_lifecycle_gate(&self, gate: MockLifecycleGate) {
-        *self.lifecycle.park_gate.lock_ignoring_poison() = Some(BlockingGate::Lifecycle(gate));
-    }
-
-    /// Legacy `Notify`-pair park gate.
-    ///
-    /// New tests should use [`Self::set_park_lifecycle_gate`] because this
-    /// edge-triggered API can lose entry or release notifications if the test
-    /// does not pre-arm the corresponding `notified()` future.
-    pub fn set_park_gate(
-        &self,
-        entered: Arc<tokio::sync::Notify>,
-        release: Arc<tokio::sync::Notify>,
-    ) {
-        *self.lifecycle.park_gate.lock_ignoring_poison() =
-            Some(BlockingGate::LegacyNotify { entered, release });
+        *self.lifecycle.park_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Queue an `unpark()` result applied to the next factory-created sandbox.
@@ -433,25 +416,8 @@ impl MockSandboxOverrides {
     }
 
     /// Block every factory `destroy()` call with a durable lifecycle gate.
-    ///
-    /// Prefer this over [`Self::set_destroy_gate`]: entries and releases are
-    /// durable, so tests do not need to pre-arm `Notify` futures.
     pub fn set_destroy_lifecycle_gate(&self, gate: MockLifecycleGate) {
-        *self.lifecycle.destroy_gate.lock_ignoring_poison() = Some(BlockingGate::Lifecycle(gate));
-    }
-
-    /// Legacy `Notify`-pair destroy gate.
-    ///
-    /// New tests should use [`Self::set_destroy_lifecycle_gate`] because this
-    /// edge-triggered API can lose entry or release notifications if the test
-    /// does not pre-arm the corresponding `notified()` future.
-    pub fn set_destroy_gate(
-        &self,
-        entered: Arc<tokio::sync::Notify>,
-        release: Arc<tokio::sync::Notify>,
-    ) {
-        *self.lifecycle.destroy_gate.lock_ignoring_poison() =
-            Some(BlockingGate::LegacyNotify { entered, release });
+        *self.lifecycle.destroy_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Queue a factory `destroy()` panic applied to the next destroy call made

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -13,7 +13,7 @@ use crate::call_records::{
     CopyFileCall, ExecCall, ProcessCancelCall, ProcessControlCall, ReadFileCall, StartProcessCall,
     WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
-use crate::lifecycle::{MockLifecycleGate, wait_blocking_gate};
+use crate::lifecycle::{MockLifecycleGate, wait_lifecycle_gate};
 use crate::overrides::MockSandboxOverrides;
 use crate::support::{
     LockIgnoringPoison, MOCK_COPY_FILE_MAX_BYTES, validate_mock_copy_host_path,
@@ -313,7 +313,7 @@ impl Sandbox for MockSandbox {
             return Ok(SandboxParkOutcome::Reusable);
         };
         *o.lifecycle.park_calls.lock_ignoring_poison() += 1;
-        wait_blocking_gate(&o.lifecycle.park_gate).await;
+        wait_lifecycle_gate(&o.lifecycle.park_gate).await;
         o.lifecycle
             .park_behaviors
             .next_result(SandboxParkOutcome::Reusable)

--- a/crates/sandbox-mock/src/tests/lifecycle.rs
+++ b/crates/sandbox-mock/src/tests/lifecycle.rs
@@ -86,54 +86,6 @@ async fn lifecycle_behaviors_are_consumed_fifo_and_default_to_success() {
 }
 
 #[tokio::test]
-async fn legacy_notify_gates_still_block_lifecycle_until_released() {
-    let overrides = Arc::new(MockSandboxOverrides::new());
-    let park_entered = Arc::new(tokio::sync::Notify::new());
-    let park_release = Arc::new(tokio::sync::Notify::new());
-    let destroy_entered = Arc::new(tokio::sync::Notify::new());
-    let destroy_release = Arc::new(tokio::sync::Notify::new());
-    overrides.set_park_gate(Arc::clone(&park_entered), Arc::clone(&park_release));
-    overrides.set_destroy_gate(Arc::clone(&destroy_entered), Arc::clone(&destroy_release));
-    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
-
-    let mut sandbox = factory.create(test_sandbox_config()).await.unwrap();
-    let park_entered_wait = park_entered.notified();
-    tokio::pin!(park_entered_wait);
-    park_entered_wait.as_mut().enable();
-    let park_task = tokio::spawn(async move { sandbox.park().await });
-
-    tokio::time::timeout(test_timeout(), park_entered_wait)
-        .await
-        .expect("legacy park gate should report entry");
-    assert_eq!(overrides.park_call_count(), 1);
-    assert!(
-        !park_task.is_finished(),
-        "legacy park gate should block until release is notified"
-    );
-    park_release.notify_one();
-    park_task.await.unwrap().unwrap();
-
-    let sandbox = factory.create(test_sandbox_config()).await.unwrap();
-    let destroy_entered_wait = destroy_entered.notified();
-    tokio::pin!(destroy_entered_wait);
-    destroy_entered_wait.as_mut().enable();
-    let destroy_task = tokio::spawn(async move {
-        factory.destroy(sandbox).await;
-    });
-
-    tokio::time::timeout(test_timeout(), destroy_entered_wait)
-        .await
-        .expect("legacy destroy gate should report entry");
-    assert_eq!(overrides.destroy_call_count(), 1);
-    assert!(
-        !destroy_task.is_finished(),
-        "legacy destroy gate should block until release is notified"
-    );
-    destroy_release.notify_one();
-    destroy_task.await.unwrap();
-}
-
-#[tokio::test]
 async fn lifecycle_gate_observes_park_entry_after_it_already_happened() {
     let gate = MockLifecycleGate::new();
     let overrides = Arc::new(MockSandboxOverrides::new());


### PR DESCRIPTION
## Summary

- remove the unused raw-`Notify` park and destroy gate setters and their compatibility-only test
- store `MockLifecycleGate` directly and remove the obsolete `BlockingGate` dispatch abstraction
- preserve the separately used wait-process `Notify` gate unchanged

## Scope

This changes only `sandbox-mock` test infrastructure. It does not change runner production behavior, persisted state, protocols, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-mock --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-mock --no-deps`
- repository pre-commit hooks, including workspace Rust formatting, Clippy, and documentation checks

Closes #23405
