### PR TITLE
fix(sandbox-fc): propagate firecracker transition errors

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -25,7 +25,7 @@ use vsock_host::{
 };
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
 
-use crate::api::{ApiError, BalloonStatistics};
+use crate::api::BalloonStatistics;
 use crate::duration::duration_ms;
 use nbd_cow::PooledNbdCowDevice;
 
@@ -1938,9 +1938,8 @@ impl Sandbox for FirecrackerSandbox {
     // gate. Both methods propagate guest lifecycle, operation-gate, fence, and
     // Firecracker PATCH failures as `IdleTransition(Park|Unpark)` errors. On
     // failure the caller (runner) destroys the sandbox and falls through to
-    // fresh-create. Firecracker's pause/resume returns 400 when the VM is
-    // already in the target state; within park/unpark this only happens after
-    // a partial retry, so 400 is treated as success (idempotent).
+    // fresh-create. Firecracker accepts repeated target-state requests, so
+    // partial retries do not require suppressing API errors.
     //
     // For profiles where `memory_mb <= MIN_GUEST_MIB` there is no memory
     // to reclaim (balloon is skipped), but vCPUs are still paused — timer
@@ -3439,23 +3438,13 @@ async fn park_inner(
     // Pause vCPUs to eliminate idle CPU overhead (timer ticks, kernel
     // scheduling). For small VMs (target == 0) we skip the balloon but
     // still pause — timer ticks waste CPU regardless of memory size.
-    //
-    // Idempotent 400 handling: Firecracker returns 400 if the VM is
-    // already paused. Within park_inner this only happens if a prior
-    // partial park (balloon OK, pause failed on transient error) already
-    // paused the VM. Treat as success to preserve retry semantics.
-    match client.pause().await {
-        Ok(()) => {}
-        Err(ApiError::Http { status: 400, .. }) => {
-            info!(id = %log_id, "vm already paused, continuing park");
-        }
-        Err(e) => {
-            return Err(SandboxError::IdleTransition {
-                transition: SandboxIdleTransition::Park,
-                message: format!("vm pause: {e}"),
-            });
-        }
-    }
+    client
+        .pause()
+        .await
+        .map_err(|e| SandboxError::IdleTransition {
+            transition: SandboxIdleTransition::Park,
+            message: format!("vm pause: {e}"),
+        })?;
 
     *is_parked = true;
     if target > 0 {
@@ -3489,27 +3478,17 @@ async fn unpark_inner(
 
     // Resume vCPUs before any balloon work — the guest needs running
     // vCPUs to process the deflate PATCH.
-    //
-    // Idempotent 400 handling: Firecracker returns 400 if the VM is
-    // already running. Within unpark_inner this only happens if a prior
-    // partial unpark (resume OK, deflate failed) already resumed the VM.
-    // Treat as success to preserve the trait's retry contract.
     let client = ApiClient::new(api_sock).map_err(|e| SandboxError::IdleTransition {
         transition: SandboxIdleTransition::Unpark,
         message: format!("create API client: {e}"),
     })?;
-    match client.resume().await {
-        Ok(()) => {}
-        Err(ApiError::Http { status: 400, .. }) => {
-            info!(id = %log_id, "vm already running, continuing unpark");
-        }
-        Err(e) => {
-            return Err(SandboxError::IdleTransition {
-                transition: SandboxIdleTransition::Unpark,
-                message: format!("vm resume: {e}"),
-            });
-        }
-    }
+    client
+        .resume()
+        .await
+        .map_err(|e| SandboxError::IdleTransition {
+            transition: SandboxIdleTransition::Unpark,
+            message: format!("vm resume: {e}"),
+        })?;
 
     let park_touched_controller = memory_mb > balloon::MIN_GUEST_MIB;
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -662,6 +662,26 @@ fn assert_idle_transition<T: std::fmt::Debug>(
     }
 }
 
+fn assert_idle_transition_message<T: std::fmt::Debug>(
+    result: sandbox::Result<T>,
+    expected_transition: SandboxIdleTransition,
+    expected_message: &str,
+) {
+    match result {
+        Err(SandboxError::IdleTransition {
+            transition,
+            message,
+        }) => {
+            assert_eq!(transition, expected_transition);
+            assert_eq!(message, expected_message);
+        }
+        other => panic!(
+            "expected {expected_transition} idle transition error with message \
+             {expected_message:?}, got {other:?}"
+        ),
+    }
+}
+
 fn assert_operation_error(
     error: SandboxError,
     expected_operation: SandboxOperation,
@@ -4853,13 +4873,14 @@ async fn unpark_retry_after_failure_succeeds() {
 // -- new tests for vCPU pause/resume --
 
 #[tokio::test]
-async fn park_pause_failure_propagates_as_idle_transition() {
+async fn park_pause_http_400_propagates_as_idle_transition() {
     // Balloon inflate succeeds and observes a severe deficit. The next stats
     // request fails, terminating settle with that severe classification, but
-    // the final VM pause still fails and must remain an operational error.
+    // the final VM pause returns a Firecracker fault and must remain an
+    // operational error.
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let mut api = MockLifecycleApi::with_stats(
-        std::collections::VecDeque::from(vec![204, 500]),
+        std::collections::VecDeque::from(vec![204, 400]),
         std::collections::VecDeque::from([
             MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, 0)),
             MockBalloonStatsReply::Status(500),
@@ -4878,7 +4899,11 @@ async fn park_pause_failure_propagates_as_idle_transition() {
     )
     .await;
 
-    assert_idle_transition(result, SandboxIdleTransition::Park);
+    assert_idle_transition_message(
+        result,
+        SandboxIdleTransition::Park,
+        "vm pause: HTTP 400: test",
+    );
     assert!(!is_parked, "flag must stay false on failure");
     // Controller was aborted before balloon PATCH.
     assert!(controller.is_none());
@@ -4891,9 +4916,10 @@ async fn park_pause_failure_propagates_as_idle_transition() {
 }
 
 #[tokio::test]
-async fn unpark_resume_failure_propagates_as_idle_transition() {
-    // Resume fails with 500 (genuine error). No deflate should be attempted.
-    let mut api = MockLifecycleApi::new(std::collections::VecDeque::from(vec![500]), None);
+async fn unpark_resume_http_400_propagates_as_idle_transition() {
+    // A Firecracker resume fault must not be mistaken for an already-running
+    // VM. No deflate should be attempted.
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::from(vec![400]), None);
 
     let mut is_parked = true;
     let mut controller: Option<balloon::ControllerHandle> = None;
@@ -4909,7 +4935,11 @@ async fn unpark_resume_failure_propagates_as_idle_transition() {
     )
     .await;
 
-    assert_idle_transition(result, SandboxIdleTransition::Unpark);
+    assert_idle_transition_message(
+        result,
+        SandboxIdleTransition::Unpark,
+        "vm resume: HTTP 400: test",
+    );
     assert!(is_parked, "flag must stay true on failure");
     assert!(controller.is_none(), "controller must not be respawned");
 
@@ -4923,9 +4953,9 @@ async fn unpark_resume_failure_propagates_as_idle_transition() {
 #[tokio::test]
 async fn unpark_retry_after_partial_failure_resumes_idempotently() {
     // First unpark: resume OK (204), deflate fails (400).
-    // Second unpark: resume 400 (already running — treated as OK), deflate OK (204).
+    // Second unpark: repeated resume OK (204), deflate OK (204).
     let api = MockLifecycleApi::new(
-        std::collections::VecDeque::from(vec![204, 400, 400, 204]),
+        std::collections::VecDeque::from(vec![204, 400, 204, 204]),
         None,
     );
 
@@ -4946,7 +4976,7 @@ async fn unpark_retry_after_partial_failure_resumes_idempotently() {
     assert_idle_transition(first, SandboxIdleTransition::Unpark);
     assert!(is_parked, "flag must stay true after partial failure");
 
-    // Second attempt: resume 400 (idempotent), deflate OK.
+    // Firecracker accepts the repeated target-state request.
     unpark_inner(
         &mut is_parked,
         2048,


### PR DESCRIPTION
## Summary

- propagate every Firecracker pause and resume HTTP failure as `SandboxError::IdleTransition`
- keep park and unpark state changes behind confirmed vCPU transitions
- align partial-unpark retry coverage with Firecracker v1.15.1 target-state idempotency

## Scope

- no API, schema, guest protocol, queue payload, persisted-state, or deployment configuration changes
- no Firecracker fault-string parsing, follow-up state probe, or new lifecycle state

## Validation

- `cargo test -p sandbox-fc park_pause_http_400_propagates_as_idle_transition`
- `cargo test -p sandbox-fc unpark_resume_http_400_propagates_as_idle_transition`
- `cargo test -p sandbox-fc unpark_retry_after_partial_failure_resumes_idempotently`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc` (786 passed)
- `git diff --check`

Closes #23404
