### PR TITLE
test(rust): retain child cleanup after timeout

### DIFF
--- a/crates/guest-mock-claude/tests/stream_json_shell.rs
+++ b/crates/guest-mock-claude/tests/stream_json_shell.rs
@@ -4,9 +4,25 @@ use std::collections::HashSet;
 use std::fs;
 use std::process::Stdio;
 
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use std::sync::mpsc;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use guest_mock_claude::process_group_child::observe_child_exit_without_reaping;
 use serde_json::Value;
 #[cfg(target_os = "linux")]
 use support::kill_pid_file;
+#[cfg(unix)]
+use support::{
+    ChildWaitOutcome, continue_cleanup_in_background,
+    wait_child_status_and_cleanup_group_with_observer,
+};
 use support::{
     LARGE_MOCK_OUTPUT_BYTES, MOCK_CAPTURE_LIMIT_BYTES, STDERR_TRUNCATION_MARKER,
     STDOUT_TRUNCATION_MARKER, event_kind, expected_history_path, init_session_id, mock_claude,
@@ -486,5 +502,148 @@ fn orphan_pipe_does_not_block_output_wait() -> Result<(), Box<dyn std::error::Er
         events.iter().map(event_kind).collect::<Vec<_>>(),
         ["system/init", "result/success"]
     );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn post_sigkill_timeout_transfers_child_and_pipe_cleanup() -> Result<(), Box<dyn std::error::Error>>
+{
+    const STDOUT_PREFIX: &[u8] = b"stdout-ready";
+    const STDERR_PREFIX: &[u8] = b"stderr-ready";
+    const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+    let mut command = Command::new("sh");
+    command
+        .args([
+            "-c",
+            "printf stdout-ready; printf stderr-ready >&2; exec sleep 30",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = spawn_managed_mock_child(&mut command)?;
+    let child_pid = child.id();
+    let Some(mut child_stdout) = child.take_stdout() else {
+        child.terminate();
+        return Err(std::io::Error::other("missing test child stdout").into());
+    };
+    let Some(mut child_stderr) = child.take_stderr() else {
+        child.terminate();
+        return Err(std::io::Error::other("missing test child stderr").into());
+    };
+
+    let (stdout_ready_tx, stdout_ready_rx) = mpsc::channel();
+    let (stdout_result_tx, stdout_result_rx) = mpsc::channel();
+    let stdout_thread = std::thread::spawn(move || {
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            let mut output = vec![0; STDOUT_PREFIX.len()];
+            child_stdout.read_exact(&mut output)?;
+            stdout_ready_tx
+                .send(())
+                .map_err(|_| std::io::Error::other("stdout readiness receiver dropped"))?;
+            child_stdout.read_to_end(&mut output)?;
+            Ok(output)
+        })();
+        let _ = stdout_result_tx.send(result);
+    });
+
+    let (stderr_ready_tx, stderr_ready_rx) = mpsc::channel();
+    let (stderr_result_tx, stderr_result_rx) = mpsc::channel();
+    let stderr_thread = std::thread::spawn(move || {
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            let mut output = vec![0; STDERR_PREFIX.len()];
+            child_stderr.read_exact(&mut output)?;
+            stderr_ready_tx
+                .send(())
+                .map_err(|_| std::io::Error::other("stderr readiness receiver dropped"))?;
+            child_stderr.read_to_end(&mut output)?;
+            Ok(output)
+        })();
+        let _ = stderr_result_tx.send(result);
+    });
+
+    for (stream, ready_rx) in [("stdout", &stdout_ready_rx), ("stderr", &stderr_ready_rx)] {
+        if let Err(error) = ready_rx.recv_timeout(CLEANUP_TIMEOUT) {
+            child.terminate();
+            let _ = stdout_thread.join();
+            let _ = stderr_thread.join();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("{stream} reader did not become ready: {error}"),
+            )
+            .into());
+        }
+    }
+
+    let (observer_ready_tx, observer_ready_rx) = mpsc::channel();
+    let (release_observer_tx, release_observer_rx) = mpsc::channel();
+    let started = Instant::now();
+    let outcome = wait_child_status_and_cleanup_group_with_observer(
+        child,
+        Duration::ZERO,
+        Duration::from_millis(20),
+        move |pid| {
+            observe_child_exit_without_reaping(pid)?;
+            observer_ready_tx
+                .send(())
+                .map_err(|_| std::io::Error::other("observer readiness receiver dropped"))?;
+            let _ = release_observer_rx.recv();
+            Ok(())
+        },
+    );
+    let elapsed = started.elapsed();
+
+    let (cleanup, error) = match outcome {
+        ChildWaitOutcome::CleanupPending { cleanup, error } => (cleanup, error),
+        ChildWaitOutcome::Complete(result) => {
+            let _ = stdout_thread.join();
+            let _ = stderr_thread.join();
+            return Err(std::io::Error::other(format!(
+                "expected pending child cleanup, got {result:?}"
+            ))
+            .into());
+        }
+    };
+    let (cleanup_complete_tx, cleanup_complete_rx) = mpsc::channel();
+    continue_cleanup_in_background(
+        cleanup,
+        stdout_thread,
+        stderr_thread,
+        Some(cleanup_complete_tx),
+    );
+
+    assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+    assert!(
+        error
+            .to_string()
+            .starts_with("mock child did not exit after SIGKILL:"),
+        "unexpected timeout diagnostic: {error}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "foreground timeout should remain bounded, elapsed: {elapsed:?}"
+    );
+
+    observer_ready_rx.recv_timeout(CLEANUP_TIMEOUT)?;
+    release_observer_tx.send(())?;
+    cleanup_complete_rx.recv_timeout(CLEANUP_TIMEOUT)?;
+
+    let stdout = stdout_result_rx.recv_timeout(CLEANUP_TIMEOUT)??;
+    let stderr = stderr_result_rx.recv_timeout(CLEANUP_TIMEOUT)??;
+    assert_eq!(stdout, STDOUT_PREFIX);
+    assert_eq!(stderr, STDERR_PREFIX);
+
+    let child_pid = libc::pid_t::try_from(child_pid)?;
+    let mut status = 0;
+    // SAFETY: cleanup completion reports that the owned direct child has
+    // already been waited; WNOHANG only verifies that no waitable child remains.
+    let wait_result = unsafe { libc::waitpid(child_pid, &mut status, libc::WNOHANG) };
+    assert_eq!(wait_result, -1);
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ECHILD)
+    );
+
     Ok(())
 }

--- a/crates/guest-mock-claude/tests/support/mod.rs
+++ b/crates/guest-mock-claude/tests/support/mod.rs
@@ -22,6 +22,25 @@ pub const LARGE_MOCK_OUTPUT_BYTES: usize = MOCK_CAPTURE_LIMIT_BYTES + 1024;
 pub const STDOUT_TRUNCATION_MARKER: &str = "[stdout truncated after 1048576 bytes]";
 pub const STDERR_TRUNCATION_MARKER: &str = "[stderr truncated after 1048576 bytes]";
 
+pub(super) enum ChildWaitOutcome {
+    Complete(std::io::Result<ExitStatus>),
+    CleanupPending {
+        cleanup: PendingChildCleanup,
+        error: std::io::Error,
+    },
+}
+
+#[cfg(unix)]
+pub(super) struct PendingChildCleanup {
+    child: ProcessGroupChild,
+    wait_thread: JoinHandle<std::io::Result<()>>,
+}
+
+#[cfg(not(unix))]
+pub(super) struct PendingChildCleanup {
+    wait_thread: JoinHandle<std::io::Result<ExitStatus>>,
+}
+
 pub struct StreamJsonChild {
     child: Option<ProcessGroupChild>,
     stdin: Option<ChildStdin>,
@@ -76,12 +95,6 @@ pub fn spawn_managed_mock_child(command: &mut Command) -> std::io::Result<Proces
 
 fn missing_child_pipe(pipe_name: &str) -> std::io::Error {
     std::io::Error::other(format!("mock child missing {pipe_name} pipe"))
-}
-
-fn child_exit_timed_out(error: &(dyn std::error::Error + 'static)) -> bool {
-    error
-        .downcast_ref::<std::io::Error>()
-        .is_some_and(|error| error.kind() == std::io::ErrorKind::TimedOut)
 }
 
 pub fn run_mock_output(command: &mut Command) -> Result<Output, Box<dyn std::error::Error>> {
@@ -288,8 +301,11 @@ fn wait_child(
     });
 
     let status = match wait_child_status_and_cleanup_group(child) {
-        Err(error) if child_exit_timed_out(error.as_ref()) => return Err(error),
-        result => result,
+        ChildWaitOutcome::Complete(result) => result,
+        ChildWaitOutcome::CleanupPending { cleanup, error } => {
+            continue_cleanup_in_background(cleanup, stdout_thread, stderr_thread, None);
+            return Err(error.into());
+        }
     };
     let stdout_result = stdout_thread
         .join()
@@ -305,79 +321,141 @@ fn wait_child(
 }
 
 #[cfg(unix)]
-fn wait_child_status_and_cleanup_group(
+fn wait_child_status_and_cleanup_group(child: ProcessGroupChild) -> ChildWaitOutcome {
+    wait_child_status_and_cleanup_group_with_observer(
+        child,
+        CHILD_EXIT_TIMEOUT,
+        CHILD_EXIT_TIMEOUT,
+        observe_child_exit_without_reaping,
+    )
+}
+
+#[cfg(unix)]
+pub(super) fn wait_child_status_and_cleanup_group_with_observer(
     child: ProcessGroupChild,
-) -> Result<ExitStatus, Box<dyn std::error::Error>> {
+    exit_timeout: Duration,
+    kill_timeout: Duration,
+    observe_child_exit: impl FnOnce(u32) -> std::io::Result<()> + Send + 'static,
+) -> ChildWaitOutcome {
     let pid = child.id();
     let (tx, rx) = mpsc::channel();
     let wait_thread = std::thread::spawn(move || {
-        let result = observe_child_exit_without_reaping(pid);
-        let _ = tx.send(result);
+        let result = observe_child_exit(pid);
+        let _ = tx.send(());
+        result
     });
 
-    let child_observed = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
-        Ok(result) => result,
+    match rx.recv_timeout(exit_timeout) {
+        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+            ChildWaitOutcome::Complete(finish_observed_child(child, wait_thread))
+        }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             process_group_child::terminate_child_by_pid(pid);
-            rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
-                std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!("mock child did not exit after SIGKILL: {error}"),
-                )
-            })?
+            match rx.recv_timeout(kill_timeout) {
+                Ok(()) => ChildWaitOutcome::Complete(finish_observed_child(child, wait_thread)),
+                Err(error) => ChildWaitOutcome::CleanupPending {
+                    cleanup: PendingChildCleanup { child, wait_thread },
+                    error: std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("mock child did not exit after SIGKILL: {error}"),
+                    ),
+                },
+            }
         }
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
-            "mock child wait thread exited without observing status",
-        )),
-    };
+    }
+}
 
-    wait_thread
-        .join()
-        .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
+#[cfg(unix)]
+fn finish_observed_child(
+    child: ProcessGroupChild,
+    wait_thread: JoinHandle<std::io::Result<()>>,
+) -> std::io::Result<ExitStatus> {
+    let child_observed = match wait_thread.join() {
+        Ok(result) => result,
+        Err(_) => {
+            child.terminate();
+            return Err(std::io::Error::other("child wait thread panicked"));
+        }
+    };
     if let Err(error) = child_observed {
         child.terminate();
-        return Err(error.into());
+        return Err(error);
     }
+    let pid = child.id();
     process_group_child::terminate_process_group(pid);
-    Ok(child.wait_direct_child()?)
+    child.wait_direct_child()
 }
 
 #[cfg(not(unix))]
-fn wait_child_status_and_cleanup_group(
-    child: ProcessGroupChild,
-) -> Result<ExitStatus, Box<dyn std::error::Error>> {
-    wait_child_status(child)
-}
-
-#[cfg(not(unix))]
-fn wait_child_status(child: ProcessGroupChild) -> Result<ExitStatus, Box<dyn std::error::Error>> {
+fn wait_child_status_and_cleanup_group(child: ProcessGroupChild) -> ChildWaitOutcome {
     let pid = child.id();
     let (tx, rx) = mpsc::channel();
     let wait_thread = std::thread::spawn(move || {
         let result = child.wait_direct_child();
-        let _ = tx.send(result);
+        let _ = tx.send(());
+        result
     });
 
-    let child_result = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
-        Ok(result) => result,
+    match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
+        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+            ChildWaitOutcome::Complete(join_child_waiter(wait_thread))
+        }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             process_group_child::terminate_child_by_pid(pid);
-            rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
-                std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!("mock child did not exit after SIGKILL: {error}"),
-                )
-            })?
+            match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
+                Ok(()) => ChildWaitOutcome::Complete(join_child_waiter(wait_thread)),
+                Err(error) => ChildWaitOutcome::CleanupPending {
+                    cleanup: PendingChildCleanup { wait_thread },
+                    error: std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("mock child did not exit after SIGKILL: {error}"),
+                    ),
+                },
+            }
         }
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
-            "mock child wait thread exited without status",
-        )),
-    };
+    }
+}
 
+#[cfg(not(unix))]
+fn join_child_waiter(
+    wait_thread: JoinHandle<std::io::Result<ExitStatus>>,
+) -> std::io::Result<ExitStatus> {
     wait_thread
         .join()
-        .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
-    Ok(child_result?)
+        .map_err(|_| std::io::Error::other("child wait thread panicked"))?
+}
+
+#[cfg(unix)]
+impl PendingChildCleanup {
+    fn finish(self) -> std::io::Result<()> {
+        finish_observed_child(self.child, self.wait_thread).map(|_| ())
+    }
+}
+
+#[cfg(not(unix))]
+impl PendingChildCleanup {
+    fn finish(self) -> std::io::Result<()> {
+        join_child_waiter(self.wait_thread).map(|_| ())
+    }
+}
+
+pub(super) fn continue_cleanup_in_background<StdoutResult, StderrResult>(
+    cleanup: PendingChildCleanup,
+    stdout_thread: JoinHandle<StdoutResult>,
+    stderr_thread: JoinHandle<StderrResult>,
+    cleanup_complete: Option<mpsc::Sender<()>>,
+) where
+    StdoutResult: Send + 'static,
+    StderrResult: Send + 'static,
+{
+    let _ = std::thread::spawn(move || {
+        let _ = cleanup.finish();
+        let _ = stdout_thread.join();
+        let _ = stderr_thread.join();
+        if let Some(cleanup_complete) = cleanup_complete {
+            let _ = cleanup_complete.send(());
+        }
+    });
 }
 
 pub fn wait_child_output(
@@ -403,8 +481,11 @@ pub fn wait_child_output(
     });
 
     let status = match wait_child_status_and_cleanup_group(child) {
-        Err(error) if child_exit_timed_out(error.as_ref()) => return Err(error),
-        result => result,
+        ChildWaitOutcome::Complete(result) => result,
+        ChildWaitOutcome::CleanupPending { cleanup, error } => {
+            continue_cleanup_in_background(cleanup, stdout_thread, stderr_thread, None);
+            return Err(error.into());
+        }
     };
     let stdout_result = stdout_thread
         .join()


### PR DESCRIPTION
## Summary

- retain ownership of timed-out mock children, exit observers, and pipe readers in a detached cleanup coordinator
- preserve the existing `WNOWAIT` observation and process-group cleanup ordering on the normal path
- add a deterministic real-process regression test that forces the post-`SIGKILL` timeout and verifies pipe EOF plus direct-child reaping

## Scope

- changes are limited to the `guest-mock-claude` integration-test harness and its regression coverage
- no production child-process implementation, dependency, CI, or documentation changes

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p guest-mock-claude --all-features --no-deps`
- `cd crates && cargo test -p guest-mock-claude --all-targets --all-features`
- focused regression test repeated 20 times

Closes #23403
