### PR TITLE
fix(ci): handle cloudflare ssh banner timeouts

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -63,12 +63,13 @@ runs:
 
         install -m 755 "$GITHUB_WORKSPACE/.github/scripts/cloudflare-ssh-proxy.sh" "$HOME/.ssh/cf-proxy.sh"
 
+        # Cloudflare Access setup and the origin SSH banner share this timeout.
+        # ConnectionAttempts does not restart an active ProxyCommand.
         SSH_CONFIG="$(printf '%s\n' \
           "Host *.vm3.ai" \
           "  StrictHostKeyChecking no" \
           "  UserKnownHostsFile /dev/null" \
-          "  ConnectTimeout 10" \
-          "  ConnectionAttempts 3" \
+          "  ConnectTimeout 30" \
           "  ServerAliveInterval 15" \
           "  ServerAliveCountMax 4" \
           "  TCPKeepAlive yes" \

--- a/.github/scripts/cloudflare-ssh-proxy.sh
+++ b/.github/scripts/cloudflare-ssh-proxy.sh
@@ -80,11 +80,11 @@ failure_message() {
   esac
 }
 
-emit_failure_marker() {
+emit_failure_report() {
   local status="$1"
-  local title message escaped_title escaped_message
-  title=$(failure_title)
-  message=$(failure_message "$status" "$title")
+  local title="$2"
+  local message="$3"
+  local escaped_title escaped_message
   escaped_title=$(github_escape "$title")
   escaped_message=$(github_escape "$message")
 
@@ -96,7 +96,7 @@ emit_failure_marker() {
       echo ""
       echo "- Host: \`${HOST}\`"
       echo "- Tunnel: \`${TUNNEL_HOST}\`"
-      echo "- cloudflared exit: \`${status}\`"
+      echo "- Exit status: \`${status}\`"
       echo "- Diagnosis: ${message}"
       echo ""
     } >> "$GITHUB_STEP_SUMMARY"
@@ -108,16 +108,67 @@ emit_failure_marker() {
   fi
 }
 
+emit_failure_marker() {
+  local status="$1"
+  local title message
+  title=$(failure_title)
+  message=$(failure_message "$status" "$title")
+  emit_failure_report "$status" "$title" "$message"
+}
+
+emit_interrupted_marker() {
+  local signal="$1"
+  local status="$2"
+  local title="Cloudflare SSH proxy interrupted"
+  local message
+  message="Cloudflare Access SSH to ${HOST} (${TUNNEL_HOST}) was interrupted by signal ${signal}. If SSH reported a banner timeout, cloudflared did not deliver the origin SSH banner before ConnectTimeout; inspect the redacted stderr below."
+  emit_failure_report "$status" "$title" "$message"
+}
+
+cloudflared_pid=""
+
+terminate_cloudflared() {
+  if [ -n "$cloudflared_pid" ]; then
+    kill -TERM "$cloudflared_pid" 2>/dev/null || true
+    wait "$cloudflared_pid" 2>/dev/null || true
+    cloudflared_pid=""
+  fi
+}
+
+cleanup() {
+  local status="$1"
+  trap - EXIT
+  terminate_cloudflared
+  rm -f "$LOG_FILE"
+  exit "$status"
+}
+
+handle_signal() {
+  local signal="$1"
+  local status="$2"
+  trap - HUP INT TERM
+  terminate_cloudflared
+  emit_interrupted_marker "$signal" "$status"
+  exit "$status"
+}
+
+trap 'cleanup $?' EXIT
+trap 'handle_signal HUP 129' HUP
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
+
 status=0
 "$CLOUDFLARED_BIN" access ssh \
   --hostname "$TUNNEL_HOST" \
   --id "$CF_ACCESS_CLIENT_ID" \
   --secret "$CF_ACCESS_CLIENT_SECRET" \
-  2> "$LOG_FILE" || status=$?
+  <&0 2> "$LOG_FILE" &
+cloudflared_pid=$!
+wait "$cloudflared_pid" || status=$?
+cloudflared_pid=""
 
 if [ "$status" -ne 0 ]; then
   emit_failure_marker "$status"
 fi
 
-rm -f "$LOG_FILE"
 exit "$status"

--- a/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
@@ -37,7 +37,17 @@ EOF
 }
 
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+proxy_pid=""
+
+cleanup() {
+  if [ -n "$proxy_pid" ]; then
+    kill -TERM "$proxy_pid" 2>/dev/null || true
+    wait "$proxy_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp"
+}
+
+trap cleanup EXIT
 
 home_success="$tmp/home-success"
 make_home "$home_success"
@@ -46,6 +56,8 @@ success_cloudflared="$tmp/cloudflared-success"
 cat > "$success_cloudflared" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$FAKE_ARGS_FILE"
+IFS= read -r input
+printf 'proxied: %s\n' "$input"
 exit 0
 EOF
 chmod +x "$success_cloudflared"
@@ -53,11 +65,12 @@ chmod +x "$success_cloudflared"
 HOME="$home_success" \
 CLOUDFLARED_BIN="$success_cloudflared" \
 FAKE_ARGS_FILE="$args_file" \
-"$PROXY" dev-1.aws.vm3.ai > "$tmp/success.out" 2> "$tmp/success.err"
+"$PROXY" dev-1.aws.vm3.ai <<< "SSH-2.0-test-client" > "$tmp/success.out" 2> "$tmp/success.err"
 
 assert_contains "$args_file" "--hostname dev-1-aws-ssh.vm3.ai"
 assert_contains "$args_file" "--id client-id"
 assert_contains "$args_file" "--secret super-secret"
+assert_contains "$tmp/success.out" "proxied: SSH-2.0-test-client"
 assert_not_contains "$tmp/success.err" "::error"
 
 home_failure="$tmp/home-failure"
@@ -88,8 +101,76 @@ assert_contains "$tmp/failure.err" "dev-1.aws.vm3.ai"
 assert_contains "$tmp/failure.err" "dev-1-aws-ssh.vm3.ai"
 assert_contains "$tmp/failure.err" "----- cloudflared stderr (last 20 lines, redacted) -----"
 assert_contains "$summary" "### Metal Cloudflare tunnel unavailable"
-assert_contains "$summary" "cloudflared exit: \`255\`"
+assert_contains "$summary" "Exit status: \`255\`"
 assert_not_contains "$tmp/failure.err" "super-secret"
 assert_not_contains "$summary" "super-secret"
+
+home_interrupted="$tmp/home-interrupted"
+make_home "$home_interrupted"
+interrupted_summary="$tmp/interrupted-summary.md"
+interrupted_logs="$tmp/interrupted-logs"
+interrupted_pid_file="$tmp/interrupted.pid"
+interrupted_signal_file="$tmp/interrupted.signal"
+mkdir -p "$interrupted_logs"
+interrupted_cloudflared="$tmp/cloudflared-interrupted"
+cat > "$interrupted_cloudflared" <<'EOF'
+#!/usr/bin/env bash
+trap 'printf "terminated\n" > "$FAKE_SIGNAL_FILE"; exit 143' TERM
+printf '%s\n' "$$" > "$FAKE_PID_FILE"
+printf 'websocket handshake still pending: %s\n' "$*" >&2
+while :; do
+  :
+done
+EOF
+chmod +x "$interrupted_cloudflared"
+
+HOME="$home_interrupted" \
+CLOUDFLARED_BIN="$interrupted_cloudflared" \
+FAKE_PID_FILE="$interrupted_pid_file" \
+FAKE_SIGNAL_FILE="$interrupted_signal_file" \
+GITHUB_STEP_SUMMARY="$interrupted_summary" \
+RUNNER_TEMP="$interrupted_logs" \
+"$PROXY" dev-1.aws.vm3.ai < /dev/null > "$tmp/interrupted.out" 2> "$tmp/interrupted.err" &
+proxy_pid=$!
+
+deadline=$((SECONDS + 5))
+while [ ! -s "$interrupted_pid_file" ]; do
+  if ! kill -0 "$proxy_pid" 2>/dev/null; then
+    echo "proxy exited before starting cloudflared" >&2
+    exit 1
+  fi
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "timed out waiting for cloudflared to start" >&2
+    exit 1
+  fi
+done
+
+interrupted_pid=$(cat "$interrupted_pid_file")
+kill -HUP "$proxy_pid"
+status=0
+wait "$proxy_pid" || status=$?
+proxy_pid=""
+
+if [ "$status" -ne 129 ]; then
+  echo "expected interrupted status 129, got ${status}" >&2
+  exit 1
+fi
+
+assert_contains "$interrupted_signal_file" "terminated"
+assert_contains "$tmp/interrupted.err" "::error title=Cloudflare SSH proxy interrupted::"
+assert_contains "$tmp/interrupted.err" "interrupted by signal HUP"
+assert_contains "$tmp/interrupted.err" "websocket handshake still pending"
+assert_contains "$interrupted_summary" "### Cloudflare SSH proxy interrupted"
+assert_contains "$interrupted_summary" "Exit status: \`129\`"
+assert_not_contains "$tmp/interrupted.err" "super-secret"
+assert_not_contains "$interrupted_summary" "super-secret"
+if kill -0 "$interrupted_pid" 2>/dev/null; then
+  echo "expected interrupted cloudflared process ${interrupted_pid} to be reaped" >&2
+  exit 1
+fi
+if compgen -G "$interrupted_logs/cloudflared-ssh-*.log" > /dev/null; then
+  echo "expected interrupted cloudflared logs to be removed" >&2
+  exit 1
+fi
 
 echo "cloudflare-ssh-proxy-test: ok"


### PR DESCRIPTION
## Summary

- increase the SSH handshake budget from 10 to 30 seconds and remove `ConnectionAttempts`, which does not restart an active `ProxyCommand`
- make the proxy wrapper own the `cloudflared` child lifecycle so OpenSSH interruption signals terminate and reap it instead of leaving an orphan
- preserve redacted Cloudflare stderr and a GitHub step-summary diagnosis when the proxy is interrupted
- cover stdin forwarding, interruption reporting, secret redaction, child reaping, and temporary-log cleanup

## User impact

Transient Cloudflare Access stalls now have more time to recover. If the SSH banner still times out, CI retains actionable diagnostics and does not leave a `cloudflared` process for runner cleanup. This addresses the failure shape seen in [this CI job](https://github.com/vm0-ai/vm0/actions/runs/30323105738/job/90163529005).

## Verification

- `bash .github/scripts/tests/cloudflare-ssh-proxy-test.sh`
- signal cleanup test repeated 50 times successfully
- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `pnpm dlx prettier@3.8.1 --check .github/actions/setup-ssh-tunnel/action.yml`
- action YAML parsed successfully with Ruby Psych

## Scope

This PR intentionally does not change the `cloudflared` version, credential transport, host-key policy, or server deployment management.