### PR TITLE
test(python): cover invalid utf-8 authority escapes

### DIFF
--- a/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
@@ -1,4 +1,4 @@
-"""Cross-stage contracts for malformed builtin host policies."""
+"""Validation contracts for credentialed builtin bases and host policies."""
 
 import pytest
 
@@ -7,6 +7,19 @@ import builtin_host_policy
 _AUTH_CONFIG: dict[str, object] = {
     "headers": {"Authorization": "Bearer x"},
 }
+
+
+def test_invalid_utf8_credentialed_base_host_is_rejected() -> None:
+    with pytest.raises(
+        builtin_host_policy.BuiltinHostPolicyError,
+        match="resolved base URL is invalid",
+    ):
+        builtin_host_policy.validate_credentialed_builtin_base(
+            firewall_name="contract-test",
+            base="https://api%FF.example.com/v1",
+            auth_config=_AUTH_CONFIG,
+            host_policy={"kind": "providerOwned", "suffixes": ["example.com"]},
+        )
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
@@ -41,6 +41,18 @@ def test_empty_port_base_authority_is_invalid():
 
 
 @pytest.mark.parametrize(
+    "host",
+    [
+        pytest.param("api%FF.example.com", id="lone-invalid-byte"),
+        pytest.param("api%E2%82.example.com", id="truncated-multibyte"),
+        pytest.param("api%C0%AF.example.com", id="overlong-sequence"),
+    ],
+)
+def test_invalid_utf8_percent_encoded_base_authority_is_invalid(host: str) -> None:
+    assert not matching.firewall_base_config_is_valid(f"https://{host}")
+
+
+@pytest.mark.parametrize(
     "base",
     [
         "https://*.example.com",

--- a/crates/runner/mitm-addon/tests/test_url_utils.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils.py
@@ -145,6 +145,7 @@ class TestBuildRewriteUrl:
             ("https://example.com/hook/%255csecret", "unsafe path"),
             ("https://%7bparam%7d.example/hook", "unsafe percent encoding"),
             ("https://example%zz.com/hook", "invalid percent encoding"),
+            ("https://api%FF.example.com/hook", "host has invalid percent encoding"),
             ("https://0177.0.0.1/hook", "invalid host"),
             ("https://0177.0.0.1?token=static", "invalid host"),
             ("https://0x7f.0.0.1/hook", "invalid host"),


### PR DESCRIPTION
## Summary

- cover lone, truncated, and overlong invalid UTF-8 percent escapes at firewall base validation
- pin the stable `auth.base` validation error instead of accepting a leaked Unicode decoder exception
- pin credentialed built-in base rejection with its domain error

## Scope

This is a test-only change. It does not change URL decoding, normalization, forwarding, APIs, schemas, protocols, persisted state, dependencies, or deployment behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_malformed_base.py tests/test_url_utils.py tests/test_builtin_host_policy_contract.py` (212 passed)
- `uv run --no-sync python -m pytest tests/` (4,378 passed)
- `git diff --check`

Closes #23416
