### PR TITLE
fix(ci): bind release checkouts to created release sha

### DIFF
--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -262,6 +262,26 @@ ruby -e '
   raise "release workflow must not use the triggering workflow SHA as a release target" if File.read(ARGV[1]).include?("github.event.workflow_run.head_sha")
 
   expected_target = "$" + "{{ needs.release-please.outputs.release_target }}"
+  desktop_target = "desktop-v" + "$" + "{{ needs.release-please.outputs.desktop_version }}"
+  checkout_ref_exceptions = {
+    "queue-production-deploy" => "main",
+    "build-desktop-release" => desktop_target,
+    "publish-desktop-update-manifest" => desktop_target,
+    "update-rollback-dashboard" => "main",
+  }
+  release.each do |job_name, job|
+    checkout_steps = job.fetch("steps", []).select do |step|
+      step["uses"].to_s.start_with?("actions/checkout@")
+    end
+    checkout_steps.each do |checkout_step|
+      expected_ref = checkout_ref_exceptions.fetch(job_name, expected_target)
+      actual_ref = checkout_step.fetch("with", {})["ref"]
+      unless actual_ref == expected_ref
+        raise "#{job_name} checkout must use #{expected_ref.inspect}, got #{actual_ref.inspect}"
+      end
+    end
+  end
+
   host_worker_step = release.fetch("detect-host-worker-deploy-inputs").fetch("steps").find { |step| step["id"] == "detect" }
   raise "Host Worker detection must use the resolved release target" unless host_worker_step.fetch("run").include?("HEAD_SHA=\"#{expected_target}\"")
   schema_step = release.fetch("deploy-api-schema").fetch("steps").find { |step| step["name"] == "Publish Runtime API Schema" }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -616,6 +616,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - uses: ./.github/actions/toolchain-init
 
@@ -817,6 +819,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Build Runtime API Schema
@@ -959,6 +963,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
+          ref: ${{ needs.release-please.outputs.release_target }}
           fetch-depth: 0
 
       - name: Detect Host Worker deploy input changes
@@ -1012,6 +1017,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting
@@ -1167,6 +1174,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Start GitHub Deployment
@@ -1357,6 +1366,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Start GitHub Deployment
@@ -1653,6 +1664,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -1801,6 +1814,8 @@ jobs:
           - x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Resolve runner target metadata
         id: target-metadata
@@ -1990,6 +2005,8 @@ jobs:
       matrix: ${{ steps.groups.outputs.matrix }}
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -2046,6 +2063,8 @@ jobs:
         include: ${{ fromJSON(needs.runner-production-host-groups.outputs.matrix || '[]') }}
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -2292,6 +2311,8 @@ jobs:
         include: ${{ fromJSON(needs.runner-production-host-groups.outputs.matrix || '[]') }}
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -2454,6 +2475,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Build E2B templates
@@ -2477,6 +2500,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.release_target }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Generate Node.js SBOM


### PR DESCRIPTION
## Summary

- Check out `needs.release-please.outputs.release_target` in every release job that consumes the created release.
- Keep the control-plane `main` checkouts and desktop tag checkouts explicit.
- Extend the release workflow regression test to enforce the checkout-ref invariant for current and future jobs.

## Validation

- `bash -n .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint .github/workflows/release-please.yml`
- `pnpm -F api exec vitest run src/__tests__/release-please-config.test.ts`
- `shellcheck .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `git diff --check`

## Scope

- Does not republish or backfill the already-failed CLI version.
- Does not change schemas, persisted data, APIs, OIDC permissions, or release version selection.

Closes #23421
