### PR TITLE
refactor(python): require typed network log targets

### DIFF
--- a/crates/runner/mitm-addon/src/http_network_log.py
+++ b/crates/runner/mitm-addon/src/http_network_log.py
@@ -40,15 +40,13 @@ def set_target_from_url(flow: http.HTTPFlow, url: str) -> None:
     set_target(flow, url=url, host=host, port=port)
 
 
-def target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
-    target_metadata = flow.metadata.get(metadata_keys.NETWORK_LOG_TARGET)
-    if target_metadata is not None:
-        typed_target = cast(dict[str, object], target_metadata)
-        return (
-            cast(str, typed_target["url"]),
-            cast(str, typed_target["host"]),
-            cast(int, typed_target["port"]),
-        )
-
-    host, port = fallback_host_port(flow, original_url)
-    return original_url, host, port
+def target(flow: http.HTTPFlow) -> tuple[str, str, int]:
+    typed_target = cast(
+        dict[str, object],
+        flow.metadata[metadata_keys.NETWORK_LOG_TARGET],
+    )
+    return (
+        cast(str, typed_target["url"]),
+        cast(str, typed_target["host"]),
+        cast(int, typed_target["port"]),
+    )

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -500,13 +500,12 @@ def _http_network_log_entry(
     flow: http.HTTPFlow,
     *,
     action: str,
-    original_url: str,
     status_code: int,
     latency_ms: int,
     request_size: int,
     response_size: int,
 ) -> dict:
-    url, host, port = http_network_log.target(flow, original_url)
+    url, host, port = http_network_log.target(flow)
     entry = {
         "type": "http",
         "action": action,
@@ -1357,7 +1356,6 @@ def _handle_response(flow: http.HTTPFlow) -> None:
         log_entry = _http_network_log_entry(
             flow,
             action=firewall_action,
-            original_url=original_url,
             status_code=status_code,
             latency_ms=latency_ms,
             request_size=request_size,
@@ -1472,7 +1470,6 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     log_entry = _http_network_log_entry(
         flow,
         action=firewall_action,
-        original_url=original_url,
         status_code=0,
         latency_ms=latency_ms,
         request_size=request_size,

--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -12,6 +12,7 @@ from mitmproxy import http
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 from tests.flow_helpers import header_map
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
@@ -132,6 +133,12 @@ def make_model_provider_flow(
     )
     flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
     flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    http_network_log.set_target(
+        flow,
+        url=original_url,
+        host=host,
+        port=flow.request.port,
+    )
     flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
     flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = (

--- a/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
@@ -11,6 +11,7 @@ import brotli
 import zstandard
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import usage
 
@@ -358,6 +359,12 @@ def set_model_provider_metadata(
         run_id=run_id,
     )
     flow.metadata[metadata_keys.ORIGINAL_URL] = provider_case.original_url
+    http_network_log.set_target(
+        flow,
+        url=provider_case.original_url,
+        host=provider_case.host,
+        port=flow.request.port,
+    )
     flow.metadata[metadata_keys.FIREWALL_NAME] = provider_case.firewall_name
     if observable:
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = provider_case.model

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache.py
@@ -13,6 +13,7 @@ from mitmproxy.test import tutils
 
 import codex_model_catalog_cache as catalog_cache
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
@@ -62,8 +63,13 @@ def _catalog_flow(
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-catalog-cache"
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        f"https://chatgpt.com/backend-api/codex/models?client_version={version}"
+    original_url = f"https://chatgpt.com/backend-api/codex/models?client_version={version}"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    http_network_log.set_target(
+        flow,
+        url=original_url,
+        host="chatgpt.com",
+        port=flow.request.port,
     )
     return flow
 
@@ -99,6 +105,12 @@ def _responses_flow(
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://chatgpt.com/backend-api/codex/responses"
+    http_network_log.set_target(
+        flow,
+        url="https://chatgpt.com/backend-api/codex/responses",
+        host="chatgpt.com",
+        port=flow.request.port,
+    )
     return flow
 
 

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -556,11 +556,14 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
         flow.error = Error("connection reset by peer")
+        request_streaming.configure_request_stream(flow)
 
         with mitm_ctx(), pytest.raises(KeyError, match=metadata_keys.NETWORK_LOG_TARGET):
             mitm_addon.error(flow)
 
         assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert flow.request.stream is False
         assert not Path(log_path).exists()
 
     def test_error_request_size_tracks_streamed_bytes_and_releases_request_stream_state(

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -5,11 +5,13 @@ import time
 import uuid
 from pathlib import Path
 
+import pytest
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
 import auth_base_forwarder
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import request_classification
 import request_streaming
@@ -324,6 +326,12 @@ class TestErrorHandler:
         # Matches the request handler's invariant: original_url is set
         # alongside vm_run_id.
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://example.com/"
+        http_network_log.set_target(
+            flow,
+            url="https://example.com/",
+            host="example.com",
+            port=443,
+        )
         flow.error = Error("connection reset")
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
@@ -340,6 +348,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        http_network_log.set_target(
+            flow,
+            url="https://api.anthropic.com/v1/messages",
+            host="api.anthropic.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.response = tutils.tresp(
@@ -411,6 +425,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "test-token"
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.x.com/2/tweets?ids=1,2,3"
+        http_network_log.set_target(
+            flow,
+            url="https://api.x.com/2/tweets?ids=1,2,3",
+            host="api.x.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "x"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.FIREWALL_PERMISSION] = "tweet.read"
@@ -447,6 +467,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+        http_network_log.set_target(
+            flow,
+            url=raw_url,
+            host="slack.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic() - 1.5
@@ -497,12 +523,18 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
-    def test_error_logs_explicit_zero_original_url_port(self, tmp_path, real_flow, mitm_ctx):
+    def test_error_logs_typed_target_port_zero(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="request.example.com", port=9443)
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://target.example.com:0/path"
+        http_network_log.set_target(
+            flow,
+            url="https://target.example.com:0/path",
+            host="target.example.com",
+            port=0,
+        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
 
@@ -515,25 +547,21 @@ class TestErrorHandler:
         assert entry["url"] == "https://target.example.com:0/path"
         assert entry["error"] == "connection reset by peer"
 
-    def test_error_logs_legacy_target_when_original_url_port_is_invalid(
-        self, tmp_path, real_flow, mitm_ctx
-    ):
+    def test_missing_network_log_target_fails_error(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://invalid.example.com:bad/path"
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
         flow.error = Error("connection reset by peer")
 
-        with mitm_ctx():
+        with mitm_ctx(), pytest.raises(KeyError, match=metadata_keys.NETWORK_LOG_TARGET):
             mitm_addon.error(flow)
 
-        [entry] = read_jsonl_entries_after_flush(Path(log_path))
-        assert entry["host"] == "fallback.example.com"
-        assert entry["port"] == 9443
-        assert entry["url"] == "https://invalid.example.com:bad/path"
-        assert entry["error"] == "connection reset by peer"
+        assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+        assert not Path(log_path).exists()
 
     def test_error_request_size_tracks_streamed_bytes_and_releases_request_stream_state(
         self, tmp_path, real_flow, mitm_ctx
@@ -550,6 +578,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+        http_network_log.set_target(
+            flow,
+            url="https://api.example.com/",
+            host="api.example.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
 
@@ -575,6 +609,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://slack.com/api/chat.postMessage"
+        http_network_log.set_target(
+            flow,
+            url="https://slack.com/api/chat.postMessage",
+            host="slack.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.FIREWALL_BASE] = "https://slack.com/api"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "slack"
@@ -601,6 +641,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://slack.com/api/test?api_key=secret#frag"
+        http_network_log.set_target(
+            flow,
+            url="https://slack.com/api/test?api_key=secret#frag",
+            host="slack.com",
+            port=443,
+        )
         flow.error = Error("connection reset by peer")
 
         mitm_addon.error(flow)
@@ -623,6 +669,12 @@ class TestErrorHandler:
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-002"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        http_network_log.set_target(
+            flow,
+            url="https://api.anthropic.com/v1/messages",
+            host="api.anthropic.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -10,6 +10,7 @@ import zstandard
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import logging_utils
 from tests.flow_helpers import header_map
 from tests.jsonl_log_helpers import (
@@ -603,6 +604,12 @@ class TestModelProviderJsonFallback:
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
+        http_network_log.set_target(
+            flow,
+            url="https://api.github.com/repos",
+            host="api.github.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
         body = b'{"incomplete":'
         set_response_stream_buffer(flow, body)
@@ -622,6 +629,12 @@ class TestModelProviderJsonFallback:
         flow = real_flow(with_response=False, host="api.anthropic.com")
         set_common_model_metadata(flow, tmp_path)
         flow.metadata[metadata_keys.ORIGINAL_URL] = ANTHROPIC_JSON_CASE.original_url
+        http_network_log.set_target(
+            flow,
+            url=ANTHROPIC_JSON_CASE.original_url,
+            host=ANTHROPIC_JSON_CASE.host,
+            port=flow.request.port,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
         body = standard_success_payload(ANTHROPIC_JSON_CASE)
         set_response_stream_buffer(flow, body)

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -6,6 +6,7 @@ import pytest
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map
@@ -758,6 +759,12 @@ class TestModelProviderResponseHookUsage:
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        http_network_log.set_target(
+            flow,
+            url="https://api.anthropic.com/v1/messages",
+            host="api.anthropic.com",
+            port=443,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"

--- a/crates/runner/mitm-addon/tests/test_response_handler_auth_recovery.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_auth_recovery.py
@@ -9,6 +9,7 @@ from mitmproxy.test import tutils
 
 import firewall_auth_cache as auth_cache
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 from tests.auth_state_helpers import (
     auth_cache_key,
@@ -96,6 +97,12 @@ def test_invalid_content_length_with_network_log_does_not_block_401_cache_invali
     flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
     flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-invalid-length-log:0"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
+    http_network_log.set_target(
+        flow,
+        url="https://api.github.com/repos",
+        host="api.github.com",
+        port=443,
+    )
 
     flow.response = tutils.tresp(
         status_code=401,

--- a/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
@@ -5,6 +5,7 @@ import time
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import request_streaming
 from tests.flow_helpers import header_map, response_stream
@@ -30,6 +31,12 @@ def test_response_releases_streaming_state(tmp_path, real_flow, mitm_ctx):
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+    http_network_log.set_target(
+        flow,
+        url="https://api.anthropic.com/v1/messages",
+        host="api.anthropic.com",
+        port=443,
+    )
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
     flow.response = tutils.tresp(
@@ -148,6 +155,12 @@ def test_response_does_not_clear_external_stream_callback(tmp_path, real_flow, m
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(status_code=200)
     flow.response.stream = external_stream
 
@@ -169,6 +182,12 @@ def test_response_does_not_clear_replaced_stream_callback(tmp_path, real_flow, m
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+    http_network_log.set_target(
+        flow,
+        url="https://api.anthropic.com/v1/messages",
+        host="api.anthropic.com",
+        port=443,
+    )
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
     flow.response = tutils.tresp(

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -327,11 +327,14 @@ def test_missing_network_log_target_fails_response(tmp_path, real_flow, mitm_ctx
     )
     flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
     flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+    request_streaming.configure_request_stream(flow)
 
     with mitm_ctx(), pytest.raises(KeyError, match=metadata_keys.NETWORK_LOG_TARGET):
         mitm_addon.response(flow)
 
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+    assert flow.request.stream is False
     assert not Path(log_path).exists()
 
 

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -8,6 +8,7 @@ from mitmproxy import http
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 import mitm_addon
 import request_classification
 import request_streaming
@@ -36,6 +37,12 @@ def test_calculates_latency_and_logs(registry_file, tmp_path, real_flow, mitm_ct
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.anthropic.com/",
+        host="api.anthropic.com",
+        port=443,
+    )
 
     # Add response
     flow.response = tutils.tresp(
@@ -116,6 +123,12 @@ def test_response_log_includes_firewall_auth_metadata(tmp_path, real_flow, mitm_
             metadata_keys.AUTH_URL_REWRITE: True,
         }
     )
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/items",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
 
     with mitm_ctx():
@@ -168,6 +181,12 @@ def test_response_log_serializes_common_metadata_independent_of_firewall_context
             metadata_keys.FIREWALL_ERROR: "ambiguous_connector_route",
             metadata_keys.CONNECTOR_ROUTE_REASON: "connector_intent_required",
         }
+    )
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/items",
+        host="api.example.com",
+        port=443,
     )
     if route_candidates is not None:
         flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] = route_candidates
@@ -271,9 +290,7 @@ def test_network_log_target_url_strips_query_and_fragment(
         ("https://target.example.com/path", 443),
     ],
 )
-def test_logs_explicit_or_default_original_url_port(
-    tmp_path, real_flow, mitm_ctx, original_url, expected_port
-):
+def test_logs_typed_target_port(tmp_path, real_flow, mitm_ctx, original_url, expected_port):
     flow = real_flow(with_response=False, host="request.example.com", port=9443)
     log_path = str(tmp_path / "network.jsonl")
 
@@ -281,6 +298,12 @@ def test_logs_explicit_or_default_original_url_port(
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    http_network_log.set_target(
+        flow,
+        url=original_url,
+        host="target.example.com",
+        port=expected_port,
+    )
     flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
 
     with mitm_ctx():
@@ -292,7 +315,7 @@ def test_logs_explicit_or_default_original_url_port(
     assert entry["url"] == original_url
 
 
-def test_logs_legacy_target_when_original_url_port_is_invalid(tmp_path, real_flow, mitm_ctx):
+def test_missing_network_log_target_fails_response(tmp_path, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
     log_path = str(tmp_path / "network.jsonl")
 
@@ -302,15 +325,14 @@ def test_logs_legacy_target_when_original_url_port_is_invalid(tmp_path, real_flo
     flow.metadata[metadata_keys.ORIGINAL_URL] = (
         "https://invalid.example.com:bad/path?secret=value#frag"
     )
+    flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
     flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
 
-    with mitm_ctx():
+    with mitm_ctx(), pytest.raises(KeyError, match=metadata_keys.NETWORK_LOG_TARGET):
         mitm_addon.response(flow)
 
-    [entry] = read_jsonl_entries_after_flush(Path(log_path))
-    assert entry["host"] == "fallback.example.com"
-    assert entry["port"] == 9443
-    assert entry["url"] == "https://invalid.example.com:bad/path"
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+    assert not Path(log_path).exists()
 
 
 def test_response_size_tracks_streamed_bytes(tmp_path, real_flow, mitm_ctx):
@@ -322,6 +344,12 @@ def test_response_size_tracks_streamed_bytes(tmp_path, real_flow, mitm_ctx):
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=header_map({"content-length": "999", "content-type": "application/json"}),
@@ -348,6 +376,12 @@ def test_response_size_tracks_large_stream_without_body_buffer(tmp_path, real_fl
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=header_map({"content-length": "12", "content-type": "application/json"}),
@@ -381,6 +415,12 @@ def test_request_size_tracks_streamed_bytes_and_captures_stream_body(tmp_path, r
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.metadata[metadata_keys.CAPTURE_BODY] = True
     flow.response = tutils.tresp(
         status_code=200,
@@ -629,6 +669,12 @@ def test_response_size_uses_content_length_without_stream_state(
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200, headers=header_map({"content-length": content_length})
     )
@@ -649,6 +695,12 @@ def test_response_size_accepts_max_safe_content_length(tmp_path, real_flow, mitm
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200, headers=header_map({"content-length": "9007199254740991"})
     )
@@ -671,6 +723,12 @@ def test_response_size_is_zero_without_stream_state_or_content_length(
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200, headers=header_map({"content-type": "application/json"})
     )
@@ -716,6 +774,12 @@ def test_response_size_is_zero_for_invalid_content_length(
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200, headers=header_map({"content-length": content_length})
     )
@@ -736,6 +800,12 @@ def test_response_size_accepts_matching_repeated_content_length(tmp_path, real_f
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50000")]),
@@ -757,6 +827,12 @@ def test_response_size_rejects_conflicting_repeated_content_length(tmp_path, rea
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50001")]),
@@ -778,6 +854,12 @@ def test_response_size_keeps_zero_streamed_bytes(tmp_path, real_flow, mitm_ctx):
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=header_map({"content-length": "50000", "content-type": "application/json"}),
@@ -802,6 +884,12 @@ def test_response_size_tracks_large_unbounded_stream_without_length(tmp_path, re
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+    http_network_log.set_target(
+        flow,
+        url="https://api.example.com/",
+        host="api.example.com",
+        port=443,
+    )
     flow.response = tutils.tresp(
         status_code=200,
         headers=header_map({"content-type": "application/json"}),

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -7,6 +7,7 @@ from mitmproxy import http
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
+import http_network_log
 from tests.flow_helpers import header_map
 from tests.stream_buffer_helpers import set_response_stream_buffer
 
@@ -115,10 +116,13 @@ def make_x_pipeline_flow(
     content_type: str = "application/json",
     content_encoding: str = "",
 ) -> http.HTTPFlow:
+    resolved_original_url = (
+        original_url if original_url is not None else x_original_url(path, query)
+    )
     flow = make_x_response_flow(
         real_flow,
         path=path,
-        original_url=original_url if original_url is not None else x_original_url(path, query),
+        original_url=resolved_original_url,
         response_status=response_status,
         content_type=content_type,
         content_encoding=content_encoding,
@@ -128,6 +132,12 @@ def make_x_pipeline_flow(
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
     flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = sandbox_value
     flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
+    http_network_log.set_target(
+        flow,
+        url=resolved_original_url,
+        host="api.x.com",
+        port=flow.request.port,
+    )
     flow.metadata[metadata_keys.FIREWALL_PERMISSION] = permission
     flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = rule
     return flow

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -229,6 +229,7 @@ phases:
 
 ```python
 import flow_metadata_keys as metadata_keys
+import http_network_log
 
 
 def test_firewall_response_logs_context(tmp_path, real_flow, mitm_ctx):
@@ -241,10 +242,20 @@ def test_firewall_response_logs_context(tmp_path, real_flow, mitm_ctx):
             metadata_keys.FIREWALL_ACTION: "ALLOW",
         }
     )
+    http_network_log.set_target(
+        flow,
+        url="https://api.github.com/repos",
+        host="api.github.com",
+        port=443,
+    )
 
     with mitm_ctx():
         mitm_addon.response(flow)
 ```
+
+Tests that enter `response()` or `error()` directly with a nonempty network log
+path must seed the typed network-log target established by request
+classification. Missing target metadata is an invariant violation.
 
 Do not hand-build `MagicMock` HTTP flows for addon hook tests. Mocks and stubs
 are still appropriate at real external boundaries such as `mitmproxy.ctx`,


### PR DESCRIPTION
## Summary

- Require HTTP response and error network-log entries to consume the typed target established during request classification.
- Remove the legacy target reconstruction from `ORIGINAL_URL`.
- Update direct-hook integration fixtures and testing guidance to model the request-phase invariant explicitly.
- Verify that a missing target fails fast instead of silently logging a reconstructed destination.

## Explicit exclusions

- Keep `fallback_host_port()` and `set_target_from_url()` for authority-validation denial responses, where no trusted classified target exists.
- Do not change the persisted network-log schema or emitted field values.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4373 passed)

Closes #23415
