### PR TITLE
perf(mitm-addon): reuse trusted authority during prebind

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -94,7 +94,7 @@ from logging_utils import (
     log_proxy_entry,
     shutdown_log_writer,
 )
-from url_utils import AuthorityValidationError, get_trusted_authority
+from url_utils import AuthorityValidationError, TrustedAuthority, get_trusted_authority
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
@@ -245,6 +245,22 @@ def _classify_request_for_flow(
     )
 
 
+def _classify_request_for_flow_with_trusted_authority(
+    flow: http.HTTPFlow,
+    *,
+    trusted_authority: TrustedAuthority,
+    defer_unresolved_public_destination: bool = False,
+) -> request_classification.RequestClassification:
+    return request_classification.classify_request_with_trusted_authority(
+        flow,
+        registry_path=get_registry_path(),
+        api_url=get_api_url(),
+        tls_admission=upstream_admission.tls_admission_for_client(flow.client_conn),
+        trusted_authority=trusted_authority,
+        defer_unresolved_public_destination=defer_unresolved_public_destination,
+    )
+
+
 def _request_classification_for_flow(
     flow: http.HTTPFlow,
 ) -> request_classification.RequestClassification:
@@ -300,8 +316,9 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
             trusted_authority.host,
             trusted_authority.port,
         ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
-            classification = _classify_request_for_flow(
+            classification = _classify_request_for_flow_with_trusted_authority(
                 flow,
+                trusted_authority=trusted_authority,
                 defer_unresolved_public_destination=True,
             )
             if classification.kind == "api_allow":
@@ -318,8 +335,9 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
             return
         _prebind_requestheaders_upstream_destination(
             flow,
-            _classify_request_for_flow(
+            _classify_request_for_flow_with_trusted_authority(
                 flow,
+                trusted_authority=trusted_authority,
                 defer_unresolved_public_destination=True,
             ),
         )

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -29,7 +29,7 @@ import registry
 import registry_firewalls
 import upstream_admission
 import upstream_destination_binding
-from url_utils import AuthorityValidationError, get_trusted_authority
+from url_utils import AuthorityValidationError, TrustedAuthority, get_trusted_authority
 
 REQUEST_CLASSIFICATION_METADATA_KEY = "_request_classification"
 # Metadata that the requestheaders probe path may write while using this
@@ -283,6 +283,46 @@ def classify_request(
     tls_admission: TlsAdmissionView | None,
     defer_unresolved_public_destination: bool = False,
 ) -> RequestClassification:
+    """Classify the current flow after validating its authority."""
+    return _classify_request(
+        flow,
+        registry_path=registry_path,
+        api_url=api_url,
+        tls_admission=tls_admission,
+        trusted_authority=None,
+        defer_unresolved_public_destination=defer_unresolved_public_destination,
+    )
+
+
+def classify_request_with_trusted_authority(
+    flow: http.HTTPFlow,
+    *,
+    registry_path: str,
+    api_url: str,
+    tls_admission: TlsAdmissionView | None,
+    trusted_authority: TrustedAuthority,
+    defer_unresolved_public_destination: bool = False,
+) -> RequestClassification:
+    """Classify using authority validated from this unchanged synchronous flow."""
+    return _classify_request(
+        flow,
+        registry_path=registry_path,
+        api_url=api_url,
+        tls_admission=tls_admission,
+        trusted_authority=trusted_authority,
+        defer_unresolved_public_destination=defer_unresolved_public_destination,
+    )
+
+
+def _classify_request(
+    flow: http.HTTPFlow,
+    *,
+    registry_path: str,
+    api_url: str,
+    tls_admission: TlsAdmissionView | None,
+    trusted_authority: TrustedAuthority | None,
+    defer_unresolved_public_destination: bool,
+) -> RequestClassification:
     """Classify a flow and write metadata needed by downstream hook handling.
 
     The decision order is registry/TLS admission, registered VM resolution,
@@ -351,13 +391,14 @@ def classify_request(
     if is_browser_passthrough_heuristic(flow):
         flow.metadata[metadata_keys.BROWSER_USER_AGENT] = True
 
-    try:
-        trusted_authority = get_trusted_authority(flow)
-    except AuthorityValidationError as e:
-        return AuthorityDenied(
-            vm_info=vm_info,
-            authority_error=e,
-        )
+    if trusted_authority is None:
+        try:
+            trusted_authority = get_trusted_authority(flow)
+        except AuthorityValidationError as e:
+            return AuthorityDenied(
+                vm_info=vm_info,
+                authority_error=e,
+            )
 
     original_url = trusted_authority.url
     _store_trusted_authority_metadata(

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -283,46 +283,6 @@ def classify_request(
     tls_admission: TlsAdmissionView | None,
     defer_unresolved_public_destination: bool = False,
 ) -> RequestClassification:
-    """Classify the current flow after validating its authority."""
-    return _classify_request(
-        flow,
-        registry_path=registry_path,
-        api_url=api_url,
-        tls_admission=tls_admission,
-        trusted_authority=None,
-        defer_unresolved_public_destination=defer_unresolved_public_destination,
-    )
-
-
-def classify_request_with_trusted_authority(
-    flow: http.HTTPFlow,
-    *,
-    registry_path: str,
-    api_url: str,
-    tls_admission: TlsAdmissionView | None,
-    trusted_authority: TrustedAuthority,
-    defer_unresolved_public_destination: bool = False,
-) -> RequestClassification:
-    """Classify using authority validated from this unchanged synchronous flow."""
-    return _classify_request(
-        flow,
-        registry_path=registry_path,
-        api_url=api_url,
-        tls_admission=tls_admission,
-        trusted_authority=trusted_authority,
-        defer_unresolved_public_destination=defer_unresolved_public_destination,
-    )
-
-
-def _classify_request(
-    flow: http.HTTPFlow,
-    *,
-    registry_path: str,
-    api_url: str,
-    tls_admission: TlsAdmissionView | None,
-    trusted_authority: TrustedAuthority | None,
-    defer_unresolved_public_destination: bool,
-) -> RequestClassification:
     """Classify a flow and write metadata needed by downstream hook handling.
 
     The decision order is registry/TLS admission, registered VM resolution,
@@ -342,7 +302,50 @@ def _classify_request(
     still requires request-phase publicDestination revalidation before the flow
     is allowed to proceed.
     """
+    return _classify_request(
+        flow,
+        registry_path=registry_path,
+        api_url=api_url,
+        tls_admission=tls_admission,
+        trusted_authority=None,
+        defer_unresolved_public_destination=defer_unresolved_public_destination,
+    )
 
+
+def classify_request_with_trusted_authority(
+    flow: http.HTTPFlow,
+    *,
+    registry_path: str,
+    api_url: str,
+    tls_admission: TlsAdmissionView | None,
+    trusted_authority: TrustedAuthority,
+    defer_unresolved_public_destination: bool = False,
+) -> RequestClassification:
+    """Classify using authority validated from this unchanged synchronous flow.
+
+    Call this only immediately after `get_trusted_authority(flow)`, without
+    yielding or mutating request or SNI state. All other callers must use
+    `classify_request()`.
+    """
+    return _classify_request(
+        flow,
+        registry_path=registry_path,
+        api_url=api_url,
+        tls_admission=tls_admission,
+        trusted_authority=trusted_authority,
+        defer_unresolved_public_destination=defer_unresolved_public_destination,
+    )
+
+
+def _classify_request(
+    flow: http.HTTPFlow,
+    *,
+    registry_path: str,
+    api_url: str,
+    tls_admission: TlsAdmissionView | None,
+    trusted_authority: TrustedAuthority | None,
+    defer_unresolved_public_destination: bool,
+) -> RequestClassification:
     client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
 
     if not client_ip:

--- a/crates/runner/mitm-addon/tests/requestheaders_helpers.py
+++ b/crates/runner/mitm-addon/tests/requestheaders_helpers.py
@@ -4,10 +4,13 @@ import inspect
 from collections.abc import Awaitable
 from typing import cast
 
+import pytest
 from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
+import mitm_addon
 import request_classification
+from url_utils import TrustedAuthority, get_trusted_authority
 
 
 async def await_requestheaders_result(result: object) -> None:
@@ -23,3 +26,18 @@ def _assert_no_request_stream(flow: http.HTTPFlow) -> None:
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
     assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
+
+
+def track_trusted_authority_validations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[http.HTTPFlow]:
+    """Wrap both hook-owned validator bindings and return validated flows."""
+    validated_flows: list[http.HTTPFlow] = []
+
+    def track(flow: http.HTTPFlow) -> TrustedAuthority:
+        validated_flows.append(flow)
+        return get_trusted_authority(flow)
+
+    monkeypatch.setattr(mitm_addon, "get_trusted_authority", track)
+    monkeypatch.setattr(request_classification, "get_trusted_authority", track)
+    return validated_flows

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -11,7 +11,10 @@ import upstream_admission
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
-from tests.requestheaders_helpers import _assert_no_request_stream
+from tests.requestheaders_helpers import (
+    _assert_no_request_stream,
+    track_trusted_authority_validations,
+)
 from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 
@@ -307,7 +310,7 @@ async def test_api_allow_current_server_binding_mismatch_blocks_even_with_prior_
 
 
 async def test_api_allow_small_bounded_body_retargets_unconnected_upstream(
-    tmp_path, real_flow, mitm_ctx, headers
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
 ):
     reg_path = _write_api_registry(tmp_path, capture_network_bodies=False)
     flow = real_flow(
@@ -322,10 +325,12 @@ async def test_api_allow_small_bounded_body_retargets_unconnected_upstream(
             ("Content-Length", "4"),
         ),
     )
+    validated_flows = track_trusted_authority_validations(monkeypatch)
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         assert mitm_addon.requestheaders(flow) is None
 
+        assert validated_flows == [flow]
         _assert_no_request_stream(flow)
         assert metadata_keys.VM_RUN_ID not in flow.metadata
         assert metadata_keys.ORIGINAL_URL not in flow.metadata
@@ -333,6 +338,7 @@ async def test_api_allow_small_bounded_body_retargets_unconnected_upstream(
 
         await mitm_addon.request(flow)
 
+    assert validated_flows == [flow, flow]
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -10,6 +10,7 @@ from mitmproxy import connection
 import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import registry
 import request_classification
 import upstream_admission
 import upstream_destination_binding
@@ -23,6 +24,7 @@ from tests.request_handler_helpers import (
 from tests.requestheaders_helpers import (
     _assert_no_request_stream,
     await_requestheaders_result,
+    track_trusted_authority_validations,
 )
 from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
@@ -578,7 +580,7 @@ async def test_firewall_allow_header_auth_requestheaders_retargets_unconnected_u
 
 
 async def test_firewall_allow_small_bounded_body_retargets_unconnected_upstream(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
     reg_path = _write_github_firewall_registry(
         tmp_path,
@@ -593,12 +595,14 @@ async def test_firewall_allow_small_bounded_body_retargets_unconnected_upstream(
         path="/repos/octocat/hello",
         request_headers=headers(("Host", "api.github.com"), ("Content-Length", "4")),
     )
+    validated_flows = track_trusted_authority_validations(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
     ):
         assert mitm_addon.requestheaders(flow) is None
+        assert validated_flows == [flow]
         _assert_no_request_stream(flow)
         assert metadata_keys.VM_RUN_ID not in flow.metadata
         assert metadata_keys.ORIGINAL_URL not in flow.metadata
@@ -606,6 +610,7 @@ async def test_firewall_allow_small_bounded_body_retargets_unconnected_upstream(
 
         await mitm_addon.request(flow)
 
+    assert validated_flows == [flow, flow]
     auth_fetch.assert_awaited_once()
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer resolved"
@@ -613,6 +618,49 @@ async def test_firewall_allow_small_bounded_body_retargets_unconnected_upstream(
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("203.0.113.10", 443)
+
+
+def test_bounded_requestheaders_keeps_matching_connector_binding_without_classification(
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(("Host", "api.github.com"), ("Content-Length", "4")),
+    )
+    upstream_destination_binding.record_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("203.0.113.10", 443),
+    )
+    flow.server_conn.address = ("api.github.com", 443)
+    validated_flows = track_trusted_authority_validations(monkeypatch)
+    registry_loads: list[str] = []
+    load_registry_state = registry.load_registry_state
+
+    def track_registry_load(registry_path: str) -> registry.RegistryState:
+        registry_loads.append(registry_path)
+        return load_registry_state(registry_path)
+
+    monkeypatch.setattr(registry, "load_registry_state", track_registry_load)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        assert mitm_addon.requestheaders(flow) is None
+
+    assert validated_flows == [flow]
+    assert registry_loads == []
+    _assert_no_request_stream(flow)
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("connector_auth",))
 
 
 async def test_firewall_allow_small_bounded_body_uses_connected_upstream_when_tls_verified(


### PR DESCRIPTION
## Summary

- add an explicit same-flow classifier entry point for an already validated `TrustedAuthority`
- reuse that authority during bounded platform API and connector-auth prebinding
- verify one header-phase validation, independent request-phase revalidation, and the existing bound-destination fast path

## Scope

This does not cache authority approval on the flow or across hooks or requests. Canonical request classification remains self-validating, and `request()` continues to validate current authority state independently.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_headers_api_admission.py tests/test_request_headers_connector_admission.py`
- `uv run --no-sync python -m pytest tests/test_request_handler_authority_validation.py tests/test_url_utils_trusted_authority.py tests/test_url_utils_trusted_authority_rejection.py`
- `uv run --no-sync python -m pytest tests/test_request_headers_streaming.py tests/test_request_handler_public_destination.py`
- `uv run --no-sync python -m pytest tests/` — 4,374 passed

Closes #23419
