### PR TITLE
perf(api): lazily materialize connector server firewalls

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6960,6 +6960,53 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 });
 
 describe("RUN-02: custom connectors, grants, and network policies", () => {
+  it("preserves global fixed-host ownership after selected firewall metadata is used", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.connectManualGrant(
+      actor,
+      "figma",
+      "api-token",
+      {
+        accessToken: "selected-figma-token",
+      },
+      agentId,
+    );
+    await api.enableAgentConnectors(actor, agentId, ["figma"]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use selected connector metadata before a global lookup",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    expect(findFirewallEntry(claim.firewalls, "figma")).toMatchObject({
+      kind: "builtin",
+      name: "figma",
+    });
+
+    const collision = await connectors.requestCreateCustomConnector(
+      actor,
+      {
+        slug: `lazy-global-${randomUUID().slice(0, 8)}`,
+        displayName: "Lazy Global Collision",
+        prefixes: ["https://api.github.com/v3/"],
+        headerName: "Authorization",
+        headerTemplate: "Bearer {{secret}}",
+      },
+      [400],
+    );
+    expectApiError(collision.body);
+    expect(collision.body.error.message).toContain("api.github.com");
+    expect(collision.body.error.message).toContain("GitHub");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
+  });
+
   it("injects enabled custom connector firewalls with resolvable org secrets", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -48,7 +48,6 @@ interface AcceptedServerFirewall {
   readonly label: string;
   readonly billable: boolean;
   readonly firewall: AcceptedFirewallConfig;
-  readonly routing: ConnectorCatalogFirewallRouting;
   readonly defaultAllowed: AcceptedGeneratedFirewall["defaultAllowed"];
   readonly defaultUnknownPolicy: AcceptedGeneratedFirewall["defaultUnknownPolicy"];
 }
@@ -116,10 +115,14 @@ export interface ConnectorServerFirewallCatalog {
 }
 
 interface AcceptedConnectorServerFirewallEntry {
-  readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
-  readonly executionMetadata: ConnectorServerFirewallExecutionMetadata;
-  readonly routingIndexMetadata: ConnectorServerFirewallRoutingIndexMetadata;
-  readonly routingMetadata: ConnectorServerFirewallRoutingMetadata;
+  readonly connector: ConnectorCatalogArtifactConnector;
+  readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
+  firewall: AcceptedServerFirewall | undefined;
+  routing: ConnectorCatalogFirewallRouting | undefined;
+  permissionIndex: ConnectorServerFirewallPermissionIndex | undefined;
+  executionMetadata: ConnectorServerFirewallExecutionMetadata | undefined;
+  routingIndexMetadata: ConnectorServerFirewallRoutingIndexMetadata | undefined;
+  routingMetadata: ConnectorServerFirewallRoutingMetadata | undefined;
 }
 
 export interface FirewallRoutingRouteMetadata {
@@ -324,21 +327,22 @@ function acceptedPlaceholderValues(args: {
   return sortedStringRecord(Object.entries(placeholderValues));
 }
 
-function acceptedBaseUrlTemplates(
-  firewall: AcceptedServerFirewall,
-): readonly ConnectorServerFirewallExecutionBaseUrlTemplate[] {
+function acceptedBaseUrlTemplates(args: {
+  readonly firewall: AcceptedServerFirewall;
+  readonly routing: ConnectorCatalogFirewallRouting;
+}): readonly ConnectorServerFirewallExecutionBaseUrlTemplate[] {
   const templates = new Map<
     string,
     ConnectorServerFirewallExecutionBaseUrlTemplate
   >();
-  for (const template of firewall.routing.baseUrlTemplates) {
+  for (const template of args.routing.baseUrlTemplates) {
     const existing = templates.get(template.base);
     if (
       existing &&
       !isDeepStrictEqual(existing.hostPolicy, template.hostPolicy)
     ) {
       throw new Error(
-        `Accepted connector server firewall base URL host policies conflict: ${firewall.connectorRef} (${template.base})`,
+        `Accepted connector server firewall base URL host policies conflict: ${args.firewall.connectorRef} (${template.base})`,
       );
     }
     templates.set(template.base, {
@@ -356,6 +360,7 @@ function acceptedBaseUrlTemplates(
 
 function acceptedExecutionMetadata(args: {
   readonly firewall: AcceptedServerFirewall;
+  readonly routing: ConnectorCatalogFirewallRouting;
   readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
 }): ConnectorServerFirewallExecutionMetadata {
   const placeholderValues = acceptedPlaceholderValues({
@@ -365,32 +370,37 @@ function acceptedExecutionMetadata(args: {
   return {
     connectorRef: args.firewall.connectorRef,
     billable: args.firewall.billable,
-    baseUrlVarNames: args.firewall.routing.baseUrlVarNames,
-    baseUrlTemplates: acceptedBaseUrlTemplates(args.firewall),
+    baseUrlVarNames: args.routing.baseUrlVarNames,
+    baseUrlTemplates: acceptedBaseUrlTemplates({
+      firewall: args.firewall,
+      routing: args.routing,
+    }),
     secretPlaceholderNames: Object.keys(placeholderValues),
     placeholderValues,
   };
 }
 
-function acceptedRoutingIndexMetadata(
-  firewall: AcceptedServerFirewall,
-): ConnectorServerFirewallRoutingIndexMetadata {
+function acceptedRoutingIndexMetadata(args: {
+  readonly firewall: AcceptedServerFirewall;
+  readonly routing: ConnectorCatalogFirewallRouting;
+}): ConnectorServerFirewallRoutingIndexMetadata {
   return {
-    connectorRef: firewall.connectorRef,
-    label: firewall.label,
-    apis: firewall.routing.apis.map((api) => {
+    connectorRef: args.firewall.connectorRef,
+    label: args.firewall.label,
+    apis: args.routing.apis.map((api) => {
       return { base: api.base };
     }),
   };
 }
 
-function acceptedRoutingMetadata(
-  firewall: AcceptedServerFirewall,
-): ConnectorServerFirewallRoutingMetadata {
+function acceptedRoutingMetadata(args: {
+  readonly firewall: AcceptedServerFirewall;
+  readonly routing: ConnectorCatalogFirewallRouting;
+}): ConnectorServerFirewallRoutingMetadata {
   return {
-    connectorRef: firewall.connectorRef,
-    label: firewall.label,
-    apis: firewall.routing.apis.map((api) => {
+    connectorRef: args.firewall.connectorRef,
+    label: args.firewall.label,
+    apis: args.routing.apis.map((api) => {
       return {
         base: api.base,
         environmentNames: api.environmentNames,
@@ -400,76 +410,143 @@ function acceptedRoutingMetadata(
   };
 }
 
-function acceptedServerFirewalls(
-  artifact: ConnectorCatalogArtifact,
-): readonly AcceptedServerFirewall[] {
-  return artifact.connectors.flatMap((connector) => {
-    if (connector.firewall.kind === "none") {
-      return [];
-    }
-    const firewall = connectorCatalogFirewallConfig(connector);
-    if (firewall === null) {
-      throw new Error(
-        `Accepted connector server firewall is missing: ${connector.connectorRef}`,
-      );
-    }
-    return [
-      {
-        connectorRef: connector.connectorRef,
-        label: connector.label,
-        billable: connector.firewall.billable,
-        firewall,
-        routing: deriveConnectorCatalogFirewallRouting(firewall),
-        defaultAllowed: connector.firewall.defaultAllowed,
-        defaultUnknownPolicy: connector.firewall.defaultUnknownPolicy,
-      },
-    ];
-  });
-}
-
 function acceptedEntries(args: {
-  readonly firewalls: readonly AcceptedServerFirewall[];
+  readonly artifact: ConnectorCatalogArtifact;
   readonly runtimeMethodsByRef: ReadonlyMap<
     ConnectorRef,
     readonly ConnectorAuthMethodRuntimeConfig[]
   >;
 }): ReadonlyMap<ConnectorRef, AcceptedConnectorServerFirewallEntry> {
   const entries = new Map<ConnectorRef, AcceptedConnectorServerFirewallEntry>();
-  for (const firewall of args.firewalls) {
-    if (entries.has(firewall.connectorRef)) {
+  for (const connector of args.artifact.connectors) {
+    if (connector.firewall.kind === "none") {
+      continue;
+    }
+    if (entries.has(connector.connectorRef)) {
       throw new Error(
-        `Duplicate accepted connector server firewall: ${firewall.connectorRef}`,
+        `Duplicate accepted connector server firewall: ${connector.connectorRef}`,
       );
     }
-    const methods = args.runtimeMethodsByRef.get(firewall.connectorRef);
+    const methods = args.runtimeMethodsByRef.get(connector.connectorRef);
     if (!methods) {
       throw new Error(
-        `Accepted connector server firewall runtime is missing: ${firewall.connectorRef}`,
+        `Accepted connector server firewall runtime is missing: ${connector.connectorRef}`,
       );
     }
-    const permissionIndex = acceptedPermissionIndex(firewall);
-    const executionMetadata = acceptedExecutionMetadata({
-      firewall,
+    entries.set(connector.connectorRef, {
+      connector,
       methods,
-    });
-    const routingIndexMetadata = acceptedRoutingIndexMetadata(firewall);
-    const routingMetadata = acceptedRoutingMetadata(firewall);
-    entries.set(firewall.connectorRef, {
-      permissionIndex,
-      executionMetadata,
-      routingIndexMetadata,
-      routingMetadata,
+      firewall: undefined,
+      routing: undefined,
+      permissionIndex: undefined,
+      executionMetadata: undefined,
+      routingIndexMetadata: undefined,
+      routingMetadata: undefined,
     });
   }
   return entries;
 }
 
+function acceptedEntryFirewall(
+  entry: AcceptedConnectorServerFirewallEntry,
+): AcceptedServerFirewall {
+  if (entry.firewall !== undefined) {
+    return entry.firewall;
+  }
+  const connector = entry.connector;
+  const firewall = connectorCatalogFirewallConfig(connector);
+  if (firewall === null || connector.firewall.kind === "none") {
+    throw new Error(
+      `Accepted connector server firewall is missing: ${connector.connectorRef}`,
+    );
+  }
+  const accepted = {
+    connectorRef: connector.connectorRef,
+    label: connector.label,
+    billable: connector.firewall.billable,
+    firewall,
+    defaultAllowed: connector.firewall.defaultAllowed,
+    defaultUnknownPolicy: connector.firewall.defaultUnknownPolicy,
+  };
+  entry.firewall = accepted;
+  return accepted;
+}
+
+function acceptedEntryRouting(
+  entry: AcceptedConnectorServerFirewallEntry,
+): ConnectorCatalogFirewallRouting {
+  if (entry.routing !== undefined) {
+    return entry.routing;
+  }
+  const routing = deriveConnectorCatalogFirewallRouting(
+    acceptedEntryFirewall(entry).firewall,
+  );
+  entry.routing = routing;
+  return routing;
+}
+
+function acceptedEntryPermissionIndex(
+  entry: AcceptedConnectorServerFirewallEntry,
+): ConnectorServerFirewallPermissionIndex {
+  if (entry.permissionIndex !== undefined) {
+    return entry.permissionIndex;
+  }
+  const permissionIndex = acceptedPermissionIndex(acceptedEntryFirewall(entry));
+  entry.permissionIndex = permissionIndex;
+  return permissionIndex;
+}
+
+function acceptedEntryExecutionMetadata(
+  entry: AcceptedConnectorServerFirewallEntry,
+): ConnectorServerFirewallExecutionMetadata {
+  if (entry.executionMetadata !== undefined) {
+    return entry.executionMetadata;
+  }
+  const executionMetadata = acceptedExecutionMetadata({
+    firewall: acceptedEntryFirewall(entry),
+    routing: acceptedEntryRouting(entry),
+    methods: entry.methods,
+  });
+  entry.executionMetadata = executionMetadata;
+  return executionMetadata;
+}
+
+function acceptedEntryRoutingIndexMetadata(
+  entry: AcceptedConnectorServerFirewallEntry,
+): ConnectorServerFirewallRoutingIndexMetadata {
+  if (entry.routingIndexMetadata !== undefined) {
+    return entry.routingIndexMetadata;
+  }
+  const routingIndexMetadata = acceptedRoutingIndexMetadata({
+    firewall: acceptedEntryFirewall(entry),
+    routing: acceptedEntryRouting(entry),
+  });
+  entry.routingIndexMetadata = routingIndexMetadata;
+  return routingIndexMetadata;
+}
+
+function acceptedEntryRoutingMetadata(
+  entry: AcceptedConnectorServerFirewallEntry,
+): ConnectorServerFirewallRoutingMetadata {
+  if (entry.routingMetadata !== undefined) {
+    return entry.routingMetadata;
+  }
+  const routingMetadata = acceptedRoutingMetadata({
+    firewall: acceptedEntryFirewall(entry),
+    routing: acceptedEntryRouting(entry),
+  });
+  entry.routingMetadata = routingMetadata;
+  return routingMetadata;
+}
+
 function acceptedFixedHostOwners(
-  firewalls: readonly AcceptedServerFirewall[],
+  entries: Iterable<AcceptedConnectorServerFirewallEntry>,
 ): ReadonlyMap<string, ConnectorServerFirewallHostOwner> {
   const owners = new Map<string, ConnectorServerFirewallHostOwner>();
-  for (const firewall of firewalls) {
-    for (const rawHost of firewall.routing.fixedHosts) {
+  for (const entry of entries) {
+    const firewall = acceptedEntryFirewall(entry);
+    const routing = acceptedEntryRouting(entry);
+    for (const rawHost of routing.fixedHosts) {
       const host = normalizeFirewallFixedHost(rawHost);
       if (!host) {
         throw new Error(
@@ -499,37 +576,46 @@ export function createAcceptedConnectorServerFirewallCatalog(args: {
     readonly ConnectorAuthMethodRuntimeConfig[]
   >;
 }): ConnectorServerFirewallCatalog {
-  const firewalls = acceptedServerFirewalls(args.artifact);
   const entries = acceptedEntries({
-    firewalls,
+    artifact: args.artifact,
     runtimeMethodsByRef: args.runtimeMethodsByRef,
   });
   const connectorRefs = [...entries.keys()].sort(compareStrings);
-  const fixedHostOwners = acceptedFixedHostOwners(firewalls);
+  let fixedHostOwners:
+    | ReadonlyMap<string, ConnectorServerFirewallHostOwner>
+    | undefined;
   return {
     connectorRefs,
     has: (connectorRef) => {
       return entries.has(connectorRef);
     },
     getExecutionMetadata: (connectorRef) => {
-      return entries.get(connectorRef)?.executionMetadata ?? null;
+      const entry = entries.get(connectorRef);
+      return entry ? acceptedEntryExecutionMetadata(entry) : null;
     },
     loadPermissionIndex: (connectorRef) => {
+      const entry = entries.get(connectorRef);
       return Promise.resolve(
-        entries.get(connectorRef)?.permissionIndex ?? null,
+        entry ? acceptedEntryPermissionIndex(entry) : null,
       );
     },
     getRoutingIndexMetadata: (connectorRef) => {
-      return entries.get(connectorRef)?.routingIndexMetadata ?? null;
+      const entry = entries.get(connectorRef);
+      return entry ? acceptedEntryRoutingIndexMetadata(entry) : null;
     },
     loadRoutingMetadata: (connectorRef) => {
+      const entry = entries.get(connectorRef);
       return Promise.resolve(
-        entries.get(connectorRef)?.routingMetadata ?? null,
+        entry ? acceptedEntryRoutingMetadata(entry) : null,
       );
     },
     getFixedHostOwner: (host) => {
       const normalized = normalizeFirewallFixedHost(host);
-      return normalized ? (fixedHostOwners.get(normalized) ?? null) : null;
+      if (!normalized) {
+        return null;
+      }
+      fixedHostOwners ??= acceptedFixedHostOwners(entries.values());
+      return fixedHostOwners.get(normalized) ?? null;
     },
   };
 }


### PR DESCRIPTION
## Summary

- replace eager complete connector server-firewall materialization with
  per-connector staged lazy memoization
- derive permission, execution, and routing metadata only when the matching
  catalog getter is used
- preserve complete global fixed-host ownership and connector diagnostics
  without introducing a new cache or persisted representation
- add an API integration scenario that warms a selected Figma firewall before
  verifying GitHub's global fixed-host ownership

## Behavior

Runtime snapshot creation now builds only the accepted firewall source index
and validates duplicate refs plus matching runtime methods. Successful derived
values remain scoped to the existing identity-keyed runtime snapshot.

Permission-only consumers no longer parse routing. Connector diagnostics do not
construct permission policy objects. The first fixed-host lookup still derives
routing for every accepted firewall and preserves normalized host ownership and
the lexicographically earliest owner rule.

The existing
`api_dispatch_connector_catalog_materialize_server_firewalls` phase now
measures source indexing. Production validation should compare cold attested
catalog load, pre-create, claim assembly, queue, and `api_to_spawn`; the
previous complete phase was about 139 ms p50, while accessed connectors still
retain their own derivation cost.

## Compatibility

No database schema, persisted data, HTTP API, queue payload, runner protocol,
connector credential, or run/session state changes.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "preserves global fixed-host ownership after selected firewall metadata is used"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/zero-connector-check.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts` — 266 passed
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hook: Prettier, full Knip, full Turbo type checks, and file-size check
- `git diff --check`

Closes #23345

Parent context: #23341
