### PR TITLE
docs(python): specify query-free x billing path input

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -238,8 +238,15 @@ def classify_bucket(permission: str, method: str, path: str) -> str | None:
     """Return the X billing bucket for a matched firewall request.
 
     ``permission`` is the firewall permission name set on
-    ``metadata_keys.FIREWALL_PERMISSION``.  ``method`` and ``path`` come from
-    ``flow.request``.
+    ``metadata_keys.FIREWALL_PERMISSION``.  ``method`` comes from
+    ``flow.request.method``.  ``path`` must be the URL path with its query
+    removed, not mitmproxy's raw ``flow.request.path``.  The production caller
+    applies ``_strip_request_target_query()`` in ``_response_usage_context()``
+    before calling this function.
+
+    Compiled path overrides match this normalized path.  Passing a raw,
+    query-bearing request target can miss an override and fall back to the
+    permission's default billing bucket.
 
     Returns ``None`` for permissions that are not billable (e.g. the
     ``"app-only"`` scope).  The caller should skip emission in that


### PR DESCRIPTION
## Summary

- clarify that X billing bucket classification requires a query-free URL path
- identify `_strip_request_target_query()` and `_response_usage_context()` as the production normalization boundary
- document that raw query-bearing request targets can miss path overrides and fall back to the permission-default bucket

## Scope

- documentation-only Python source change
- no runtime behavior, API, data, migration, protocol, or deployment change
- no new test added because the existing connector integration regression already exercises the documented query-string behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_reads.py -k query_string_does_not_break_literal_suffix_override` (`1 passed`)
- `uv run --no-sync python -m pytest tests/` (`4379 passed`)
- `git diff --check`

Closes #23436
