### PR TITLE
docs(mitm-addon): align usage facade overview

### DIFF
--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -2,10 +2,11 @@
 
 The stable facade covers:
 
-- Observable model-provider responses (SSE streams and non-streaming JSON):
-  extract model token counts and buffer them for aggregate platform webhook
-  upload to billing and/or observation endpoints through a background thread pool — see
-  :mod:`usage.providers.model_provider`.
+- Observable model-provider responses (SSE streams, non-streaming JSON, and
+  inspected WebSocket events): extract model token counts, preserve
+  per-response source identity for WebSocket reporting, and buffer results for
+  aggregate platform webhook upload to billing and/or observation endpoints
+  through a background thread pool — see :mod:`usage.providers.model_provider`.
 - Billable connector responses (flagged by the web layer via
   ``billableFirewalls`` → ``metadata_keys.FIREWALL_BILLABLE``): compute
   per-permission billable resource counts and buffer them for aggregate
@@ -15,13 +16,15 @@ The stable facade covers:
   tracking in-flight flows, and publishing runner-visible pending snapshots
   used by the runner's usage-flush and shutdown protocol.
 
-Current production consumers of this package facade are ``mitm_addon.py``,
-``response_streaming.py``, ``runner_flush_lifecycle.py``, and ``terminal_usage.py``.
+Production consumers use this package facade for proxy hooks and response
+processing, runner flush lifecycle and terminal reporting, and Claude/Codex
+provider-output timing.
 Tests should exercise public hook, provider, and lifecycle paths at their
 observable boundaries: runner-visible pending state and in-flight accounting,
 plus the local HTTP webhook boundary. Avoid patching private transport internals.
 Delivery admission tests may target the production ``usage.webhook`` enqueue
-boundary used by the usage buffer; retry and transport helpers remain private.
+boundary used by buffered usage and provider-output timing; retry and transport
+helpers remain private.
 """
 
 from . import webhook


### PR DESCRIPTION
## Summary

- document model-provider WebSocket event inspection and source-preserving usage reporting in the stable facade overview
- replace the fragile production filename inventory with role-based consumer coverage, including Claude and Codex output timing
- clarify that buffered usage and provider-output timing share the public `usage.webhook` delivery-admission boundary

## Scope

Documentation-only change to the Python `usage` package docstring. No exports, runtime behavior, protocols, tests, dependencies, or deployment configuration change.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4379 passed`)

Closes #23434
