### PR TITLE
feat(platform): show chat skeletons while loading older messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2493,7 +2493,7 @@ function createHistoryBackfillProgress(
   // Approximate backfill progress from the loaded seqId range. The thread's
   // true max seqId is not exposed to the client, so the newest loaded message
   // stands in for it. The reached-oldest computed hides progress once the
-  // first persistent seqId is 1. Null hides the progress bar.
+  // first persistent seqId is 1. Null hides the loading skeleton.
   return computed((get): Promise<number | null> => {
     if (get(hasReachedOldestMessage$)) {
       return Promise.resolve(null);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -20,6 +20,19 @@ const PAGE_SIZE = 50;
 const GATED_BEFORE_SEQ_ID = 51;
 
 function eventForSeq(seqId: number): ChatEventResponse {
+  if (seqId === TOTAL_MESSAGES) {
+    return {
+      id: `00000000-0000-4000-8000-${String(seqId).padStart(12, "0")}`,
+      threadId: THREAD_ID,
+      eventType: "output.message",
+      role: "assistant",
+      content: "Latest visible message",
+      seqId,
+      createdAt: new Date(
+        Date.parse("2026-03-10T00:00:00.000Z") + seqId * 1000,
+      ).toISOString(),
+    };
+  }
   return {
     id: `00000000-0000-4000-8000-${String(seqId).padStart(12, "0")}`,
     threadId: THREAD_ID,
@@ -81,8 +94,8 @@ function mockPagedHistory(): {
   return { finalHistoryPage, beforeSeqIds };
 }
 
-describe("chat history backfill progress", () => {
-  it("shows incremental progress during backfill and hides it once history completes", async () => {
+describe("chat history backfill loading", () => {
+  it("shows a message skeleton pair above the first message and hides it once history completes", async () => {
     const { finalHistoryPage, beforeSeqIds } = mockPagedHistory();
 
     detachedSetupPage({
@@ -95,19 +108,34 @@ describe("chat history backfill progress", () => {
 
     await waitFor(() => {
       expect(beforeSeqIds).toContain(GATED_BEFORE_SEQ_ID);
-      const progressBar = document.querySelector(
-        "[data-history-backfill-progress]",
+      const messageContainer = document.querySelector(
+        "[data-message-container]",
       );
-      expect(progressBar).toBeInstanceOf(HTMLElement);
-      // Six pages flushed mid-backfill: seqIds 51..400 are loaded, so the
-      // approximate progress is (400 - 51) / 400 = 87%.
-      expect(progressBar).toHaveAttribute("aria-valuenow", "87");
+      const skeleton = document.querySelector(
+        "[data-history-backfill-skeleton]",
+      );
+      const firstMessage = document.querySelector('[data-role="assistant"]');
+      if (
+        !(messageContainer instanceof HTMLElement) ||
+        !(skeleton instanceof HTMLElement) ||
+        !(firstMessage instanceof HTMLElement)
+      ) {
+        throw new Error("Expected the loading skeleton above a chat message");
+      }
+      expect(skeleton.parentElement).toBe(messageContainer);
+      expect(
+        skeleton.querySelectorAll("[data-chat-message-skeleton]"),
+      ).toHaveLength(2);
+      expect(
+        skeleton.compareDocumentPosition(firstMessage) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
     });
 
     finalHistoryPage.resolve();
     await waitFor(() => {
       expect(
-        document.querySelector("[data-history-backfill-progress]"),
+        document.querySelector("[data-history-backfill-skeleton]"),
       ).toBeNull();
     });
   });
@@ -121,7 +149,7 @@ describe("chat history backfill progress", () => {
       expect(beforeSeqIds).toContain(GATED_BEFORE_SEQ_ID);
     });
     expect(
-      document.querySelector("[data-history-backfill-progress]"),
+      document.querySelector("[data-history-backfill-skeleton]"),
     ).toBeNull();
     finalHistoryPage.resolve();
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2823,6 +2823,7 @@ function ChatThreadMessagesMain({ thread }: { thread: ChatThreadSignals }) {
       >
         <ChatThreadSessionError thread={thread} />
         <ChatThreadEmptyState thread={thread} />
+        <ChatHistoryBackfillSkeleton thread={thread} />
         <ChatThreadRenderedMessageGroups thread={thread} />
         <ChatThreadThinkingIndicator thread={thread} />
       </div>
@@ -3628,7 +3629,7 @@ function ChatThreadMessagesPane({ thread }: { thread: ChatThreadSignals }) {
   );
 }
 
-function ChatHistoryBackfillProgress({
+function ChatHistoryBackfillSkeleton({
   thread,
 }: {
   thread: ChatThreadSignals;
@@ -3640,21 +3641,14 @@ function ChatHistoryBackfillProgress({
   if (!enabled || progress === null || progress === undefined) {
     return null;
   }
-  const percent = Math.min(100, Math.max(0, progress * 100));
   return (
     <div
-      data-history-backfill-progress
-      role="progressbar"
-      aria-label="Loading message history"
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={Math.round(percent)}
-      className="h-0.5 w-full shrink-0 overflow-hidden"
+      data-history-backfill-skeleton
+      role="status"
+      aria-label="Loading earlier messages"
+      className="flex flex-col gap-6"
     >
-      <div
-        className="h-full bg-primary/60 transition-[width] duration-500 ease-out"
-        style={{ width: `${percent}%` }}
-      />
+      <ChatMessageSkeletonPair />
     </div>
   );
 }
@@ -3663,7 +3657,6 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   return (
     <>
       <ChatThreadHeader thread={thread} />
-      <ChatHistoryBackfillProgress key={thread.threadId} thread={thread} />
 
       <div className="relative min-h-0 flex-1">
         <div className="flex h-full min-w-0 flex-col">
@@ -4426,34 +4419,45 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
 // Skeleton placeholder while session loads
 // ---------------------------------------------------------------------------
 
-function ChatSkeleton() {
+function ChatMessageSkeletonPair({ compact = false }: { compact?: boolean }) {
   return (
     <>
       {/* User bubble skeleton */}
-      <div className="flex justify-end">
-        <Skeleton className="h-10 w-[60%] rounded-xl" />
+      <div
+        data-chat-message-skeleton="user"
+        aria-hidden
+        className="flex justify-end"
+      >
+        <Skeleton
+          className={cn("h-10 rounded-xl", compact ? "w-[45%]" : "w-[60%]")}
+        />
       </div>
       {/* Assistant bubble skeleton */}
-      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div
+        data-chat-message-skeleton="assistant"
+        aria-hidden
+        className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start"
+      >
         <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 rounded-xl" />
         <div className="flex flex-col gap-2">
-          <Skeleton className="h-4 w-[90%] rounded-lg" />
-          <Skeleton className="h-4 w-[75%] rounded-lg" />
-          <Skeleton className="h-4 w-[40%] rounded-lg" />
+          <Skeleton
+            className={cn("h-4 rounded-lg", compact ? "w-[85%]" : "w-[90%]")}
+          />
+          <Skeleton
+            className={cn("h-4 rounded-lg", compact ? "w-[60%]" : "w-[75%]")}
+          />
+          {!compact && <Skeleton className="h-4 w-[40%] rounded-lg" />}
         </div>
       </div>
-      {/* User bubble skeleton */}
-      <div className="flex justify-end">
-        <Skeleton className="h-10 w-[45%] rounded-xl" />
-      </div>
-      {/* Assistant bubble skeleton */}
-      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-        <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 rounded-xl" />
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-4 w-[85%] rounded-lg" />
-          <Skeleton className="h-4 w-[60%] rounded-lg" />
-        </div>
-      </div>
+    </>
+  );
+}
+
+function ChatSkeleton() {
+  return (
+    <>
+      <ChatMessageSkeletonPair />
+      <ChatMessageSkeletonPair compact />
     </>
   );
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -405,7 +405,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatHistoryBackfillProgress]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Progress bar under the chat thread header showing history backfill progress while older messages load.",
+      "Chat message skeletons above the first visible message while older history loads.",
     // Not rolled out to anyone yet; enable per-user via the Lab page.
     enabled: false,
   },


### PR DESCRIPTION
## Summary

- replace the chat header backfill progress bar with one user and assistant message skeleton pair above the first visible message
- reuse the existing chat skeleton layout and existing backfill lifecycle so the placeholder disappears when loading completes or the feature switch is off
- update the feature switch description and integration coverage for placement, skeleton count, completion, and disabled behavior

## User impact

Older message loading now appears directly where history is being prepended, keeping the loading state visually connected to the conversation.

## Verification

- `pnpm exec prettier --write apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx packages/core/src/feature-switch.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx --maxWorkers=1` — 2 tests passed

Browser walkthrough was not completed because the local checkout does not have `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW`.
