### PR TITLE
fix(platform): disable browser locale auto-selection

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -430,12 +430,10 @@
         var orgId = sessionStorage.getItem("clerk-active-org-id");
         var cacheKey = orgId ? "vm0:locale:" + orgId : null;
         var cached = cacheKey ? localStorage.getItem(cacheKey) : null;
+        // Browser-language auto-selection stays disabled during rollout.
+        // Locale changes come from the workspace cache or gated preference UI.
         var locale =
-          cached === "en-US" || cached === "zh-CN"
-            ? cached
-            : /^zh(?:-|$)/i.test(navigator.language)
-              ? "zh-CN"
-              : "en-US";
+          cached === "en-US" || cached === "zh-CN" ? cached : "en-US";
 
         document.documentElement.lang = locale;
         if (cacheKey) localStorage.setItem(cacheKey, locale);

--- a/turbo/apps/platform/src/i18n/locale-storage.ts
+++ b/turbo/apps/platform/src/i18n/locale-storage.ts
@@ -12,12 +12,6 @@ function parseSupportedLocale(
   return value === "en-US" || value === "zh-CN" ? value : null;
 }
 
-export function resolveBrowserLocale(
-  language: string = navigator.language,
-): SupportedLocale {
-  return /^zh(?:-|$)/iu.test(language) ? "zh-CN" : DEFAULT_LOCALE;
-}
-
 export function resolveDocumentLocale(): SupportedLocale {
   return parseSupportedLocale(document.documentElement.lang) ?? DEFAULT_LOCALE;
 }

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -9,7 +9,9 @@ import { testContext } from "./test-helpers.ts";
 const context = testContext();
 
 describe("bootstrap locale", () => {
-  it("initializes English and supports changing to a bundled locale", async () => {
+  it("ignores the browser language and supports changing to a bundled locale", async () => {
+    context.mocks.browser.language("zh-CN");
+
     await setupPage({
       context,
       path: "/error",
@@ -32,7 +34,7 @@ describe("bootstrap locale", () => {
     await context.store.set(setLocale$, DEFAULT_LOCALE, context.signal);
   });
 
-  it("initializes i18next from the locale selected by the inline script", async () => {
+  it("initializes i18next from the cached locale selected by the inline script", async () => {
     document.documentElement.lang = "zh-CN";
 
     await setupPage({

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-locale.test.ts
@@ -1,16 +1,74 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+
+import indexHtml from "../../../index.html?raw";
 import { setupPage } from "../../__tests__/page-helper.ts";
 import { DEFAULT_LOCALE } from "../../i18n/resources.ts";
 import { i18n } from "../../i18n/index.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
 import { locale$, setLocale$ } from "../locale.ts";
 import { testContext } from "./test-helpers.ts";
 
+const ACTIVE_ORG_STORAGE_KEY = "clerk-active-org-id";
+const TEST_ORG_ID = "org_inline_locale";
+const TEST_LOCALE_STORAGE_KEY = `vm0:locale:${TEST_ORG_ID}`;
+const testLocaleStorage = localStorageSignals(TEST_LOCALE_STORAGE_KEY);
+
+type LocaleEntrypointScript = (
+  documentObject: Document,
+  sessionStorageObject: Storage,
+  navigatorObject: Navigator,
+) => void;
+
+function getLocaleEntrypointSource(): string {
+  const inlineScripts = [
+    ...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi),
+  ]
+    .map((match) => {
+      return match[1];
+    })
+    .filter((script): script is string => {
+      return script !== undefined;
+    });
+  const source = inlineScripts.find((script) => {
+    return script.includes('"vm0:locale:"');
+  });
+
+  if (source === undefined) {
+    throw new Error("Unable to locate the locale resolver in index.html");
+  }
+  return source;
+}
+
+function executeLocaleEntrypoint(): void {
+  const executeEntrypointScript = new Function(
+    "document",
+    "sessionStorage",
+    "navigator",
+    `${getLocaleEntrypointSource()}\n//# sourceURL=platform-locale-entrypoint-test.js`,
+  ) as LocaleEntrypointScript;
+
+  executeEntrypointScript(document, sessionStorage, navigator);
+}
+
 const context = testContext();
+
+afterEach(() => {
+  sessionStorage.removeItem(ACTIVE_ORG_STORAGE_KEY);
+  testLocaleStorage.updateRaw(() => {
+    return null;
+  });
+});
 
 describe("bootstrap locale", () => {
   it("ignores the browser language and supports changing to a bundled locale", async () => {
     context.mocks.browser.language("zh-CN");
+    sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
+    context.store.set(testLocaleStorage.clear$);
+    executeLocaleEntrypoint();
+
+    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE);
+    expect(context.store.get(testLocaleStorage.get$)).toBe(DEFAULT_LOCALE);
 
     await setupPage({
       context,
@@ -35,7 +93,9 @@ describe("bootstrap locale", () => {
   });
 
   it("initializes i18next from the cached locale selected by the inline script", async () => {
-    document.documentElement.lang = "zh-CN";
+    sessionStorage.setItem(ACTIVE_ORG_STORAGE_KEY, TEST_ORG_ID);
+    context.store.set(testLocaleStorage.set$, "zh-CN");
+    executeLocaleEntrypoint();
 
     await setupPage({
       context,

--- a/turbo/apps/platform/src/signals/locale.ts
+++ b/turbo/apps/platform/src/signals/locale.ts
@@ -3,7 +3,6 @@ import { i18n, initializeI18n } from "../i18n/index.ts";
 import { DEFAULT_LOCALE, type SupportedLocale } from "../i18n/resources.ts";
 import {
   localeStorageKey,
-  resolveBrowserLocale,
   resolveDocumentLocale,
 } from "../i18n/locale-storage.ts";
 import { clerk$ } from "./auth.ts";
@@ -76,7 +75,7 @@ export const syncLocalePreference$ = command(
       return;
     }
 
-    const locale = preferences.locale ?? resolveBrowserLocale();
+    const locale = preferences.locale ?? resolveDocumentLocale();
     await set(applyLocalePreference$, clerk.organization.id, locale, signal);
 
     if (preferences.locale === null) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -72,7 +72,7 @@ function createPreferences(locale: UserLocale | null): UserPreferencesResponse {
 }
 
 describe("settings dialog", () => {
-  it("persists the browser language when the workspace has no server preference", async () => {
+  it("defaults to English instead of the browser language before user selection", async () => {
     const submittedLocales: UserLocale[] = [];
     let serverLocale: UserLocale | null = null;
     context.mocks.browser.language("zh-CN");
@@ -98,23 +98,67 @@ describe("settings dialog", () => {
       name: "Language",
     });
     await waitFor(() => {
+      expect(submittedLocales).toContain("en-US");
+      expect(languageSelect).toHaveTextContent("English");
+      expect(languageSelect).toBeEnabled();
+      expect(document.documentElement.lang).toBe("en-US");
+      expect(cachedLocale()).toBe("en-US");
+    });
+
+    click(languageSelect);
+    click(screen.getByRole("option", { name: "简体中文" }));
+
+    await waitFor(() => {
+      expect(submittedLocales).toContain("zh-CN");
+      expect(
+        screen.getByRole("combobox", { name: "Language" }),
+      ).toHaveTextContent("简体中文");
+      expect(document.documentElement.lang).toBe("zh-CN");
+      expect(cachedLocale()).toBe("zh-CN");
+    });
+
+    click(screen.getByRole("combobox", { name: "Language" }));
+    click(screen.getByRole("option", { name: "English" }));
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe("en-US");
+    });
+  });
+
+  it("persists a cached locale when the workspace has no server preference", async () => {
+    const submittedLocales: UserLocale[] = [];
+    document.documentElement.lang = "zh-CN";
+    context.store.set(setCachedLocale$, "zh-CN");
+    context.mocks.api(zeroUserPreferencesContract.get, ({ respond }) => {
+      return respond(200, createPreferences(null));
+    });
+    context.mocks.api(
+      zeroUserPreferencesContract.update,
+      ({ body, respond }) => {
+        if (body.locale !== undefined) {
+          submittedLocales.push(body.locale);
+        }
+        return respond(200, createPreferences(body.locale ?? null));
+      },
+    );
+
+    await openDialog("admin", "preference", {
+      [FeatureSwitchKey.LanguagePreference]: true,
+    });
+
+    const languageSelect = await screen.findByRole("combobox", {
+      name: "Language",
+    });
+    await waitFor(() => {
       expect(submittedLocales).toContain("zh-CN");
       expect(languageSelect).toHaveTextContent("简体中文");
-      expect(languageSelect).toBeEnabled();
       expect(document.documentElement.lang).toBe("zh-CN");
       expect(cachedLocale()).toBe("zh-CN");
     });
 
     click(languageSelect);
     click(screen.getByRole("option", { name: "English" }));
-
     await waitFor(() => {
-      expect(submittedLocales).toContain("en-US");
-      expect(
-        screen.getByRole("combobox", { name: "Language" }),
-      ).toHaveTextContent("English");
       expect(document.documentElement.lang).toBe("en-US");
-      expect(cachedLocale()).toBe("en-US");
     });
   });
 


### PR DESCRIPTION
## Summary

- stop selecting `zh-CN` from `navigator.language` before the Platform bundle loads
- preserve a valid workspace-local locale cache and otherwise default to `en-US`
- when the server preference is unset, reconcile from the cached/document locale instead of the browser locale
- keep server preference synchronization and the language selector behind `LanguagePreference`
- cover Chinese-browser, cached-locale, and gated user-selection paths

## Rollout behavior

| Workspace cache | `LanguagePreference` | Result |
| --- | --- | --- |
| Missing | Off | `en-US`; browser language is ignored |
| Valid | Off | Cached locale is restored |
| Missing | On | `en-US` is applied and persisted as the initial preference |
| Valid | On | Cached locale is applied and persisted when the server preference is unset |
| Any | On with server preference | Server preference wins |

## Validation

- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/bootstrap-locale.test.ts src/views/zero-page/__tests__/settings-dialog.test.tsx --silent=passed-only` (12 tests)
- pre-commit full-repository Knip and Turbo type checks

## Follow-up

Full Platform localization coverage is tracked in #23456 and its module sub-issues.
