### PR TITLE
perf(python): reuse upstream admission targets

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -130,52 +130,31 @@ def _request_allows_platform_connector_auth(flow: http.HTTPFlow) -> bool:
     return _request_has_platform_test_endpoint_bypass(flow)
 
 
-def _requires_platform_connector_auth_bypass(
-    *,
-    kind: upstream_destination_binding.BindingKind,
-    normalized_host: str,
-    port: int,
-    api_url: str,
-) -> bool:
-    return kind == "connector_auth" and api_destination_matches(
-        api_url,
-        normalized_host,
-        port,
-    )
-
-
-def _flow_requires_platform_connector_auth_bypass(
-    flow: http.HTTPFlow,
-    *,
-    kind: upstream_destination_binding.BindingKind,
-    api_url: str,
-) -> bool:
-    if kind != "connector_auth":
-        return False
-    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
-    if not trusted_host:
-        return False
-    try:
-        normalized_host = normalize_trusted_hostname(trusted_host)
-    except (UnicodeError, ValueError):
-        return False
-    return _requires_platform_connector_auth_bypass(
-        kind=kind,
-        normalized_host=normalized_host,
-        port=flow.request.port,
-        api_url=api_url,
-    )
-
-
 def api_destination_matches(api_url: str, hostname: str, port: int) -> bool:
     api_destination = _api_destination(api_url)
     if api_destination is None:
         return False
-    api_hostname, api_port = api_destination
-    return port == api_port and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
+    return _hostname_port_matches_api_destination(
+        hostname=hostname,
+        port=port,
+        api_destination=api_destination,
+    )
 
 
-def _api_destination(api_url: str) -> tuple[str, int] | None:
+def _hostname_port_matches_api_destination(
+    *,
+    hostname: str,
+    port: int,
+    api_destination: upstream_destination_binding.NormalizedUpstreamDestination,
+) -> bool:
+    return port == api_destination.port and (
+        hostname == api_destination.host or hostname.endswith(f".{api_destination.host}")
+    )
+
+
+def _api_destination(
+    api_url: str,
+) -> upstream_destination_binding.NormalizedUpstreamDestination | None:
     if not api_url:
         return None
     parsed_api = urllib.parse.urlparse(api_url)
@@ -191,7 +170,10 @@ def _api_destination(api_url: str) -> tuple[str, int] | None:
         api_port = 80
     else:
         api_port = 443
-    return api_hostname, api_port
+    return upstream_destination_binding.NormalizedUpstreamDestination(
+        host=api_hostname,
+        port=api_port,
+    )
 
 
 def _server_connect_binding_kinds(
@@ -239,31 +221,37 @@ def _bind_privileged_upstream_destination(
 
     if not isinstance(raw_sni, str) or not raw_sni.strip():
         return
-    try:
-        hostname = normalize_trusted_hostname(raw_sni.strip())
-    except (UnicodeError, ValueError):
-        return
 
     address = connection_endpoints.server_address(server)
     if address is None:
         return
     _original_host, port = address
-    is_api_destination = api_destination_matches(api_url, hostname, port)
+    try:
+        destination = upstream_destination_binding.normalize_upstream_destination(
+            host=raw_sni.strip(),
+            port=port,
+        )
+    except (UnicodeError, ValueError):
+        return
+    is_api_destination = api_destination_matches(
+        api_url,
+        destination.host,
+        destination.port,
+    )
     reusable_kind: upstream_destination_binding.BindingKind = (
         "api_allow" if is_api_destination else "connector_auth"
     )
     if upstream_destination_binding.reuse_server_binding_kind_if_matching(
         server,
         client=client,
-        host=hostname,
-        port=port,
+        destination=destination,
         kind=reusable_kind,
     ):
         return
 
     kinds = _server_connect_binding_kinds(
-        hostname=hostname,
-        port=port,
+        hostname=destination.host,
+        port=destination.port,
         compiled_firewalls=registry_state.compiled_firewalls.get(client_ip),
         is_api_destination=is_api_destination,
     )
@@ -275,8 +263,7 @@ def _bind_privileged_upstream_destination(
             upstream_destination_binding.add_server_binding_kind_if_matching(
                 server,
                 client=client,
-                host=hostname,
-                port=port,
+                destination=destination,
                 kind=kind,
             )
             for kind in kinds
@@ -287,13 +274,12 @@ def _bind_privileged_upstream_destination(
     if bool(getattr(server, "connected", False)):
         return
 
-    server.address = (hostname, port)
+    server.address = (destination.host, destination.port)
 
-    upstream_destination_binding.record_server_binding(
+    upstream_destination_binding.record_normalized_server_binding(
         server,
         client=client,
-        host=hostname,
-        port=port,
+        destination=destination,
         kinds=kinds,
         original_address=address,
     )
@@ -419,41 +405,25 @@ def has_bound_destination(
 def _bind_flow_upstream_destination(
     flow: http.HTTPFlow,
     *,
+    destination: upstream_destination_binding.NormalizedUpstreamDestination,
     kind: upstream_destination_binding.BindingKind,
-    api_url: str,
 ) -> bool:
-    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
-    if not trusted_host:
-        return False
-    try:
-        normalized_host = normalize_trusted_hostname(trusted_host)
-    except (UnicodeError, ValueError):
-        return False
-
     original_address = connection_endpoints.server_address(flow.server_conn)
     has_server_binding = upstream_destination_binding.has_server_binding(flow.server_conn)
-    if _requires_platform_connector_auth_bypass(
-        kind=kind,
-        normalized_host=normalized_host,
-        port=flow.request.port,
-        api_url=api_url,
-    ) and not _request_allows_platform_connector_auth(flow):
-        return False
 
     if has_server_binding:
         if upstream_destination_binding.add_server_binding_kind_if_matching(
             flow.server_conn,
             client=flow.client_conn,
-            host=normalized_host,
-            port=flow.request.port,
+            destination=destination,
             kind=kind,
         ):
             return True
         if flow.server_conn.connected:
             connected_address = _connected_verified_tls_destination_endpoint(
                 flow.server_conn,
-                host=normalized_host,
-                port=flow.request.port,
+                host=destination.host,
+                port=destination.port,
                 extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
             )
             if connected_address is None:
@@ -462,8 +432,7 @@ def _bind_flow_upstream_destination(
                 upstream_destination_binding.refresh_server_binding_connected_address_if_matching(
                     flow.server_conn,
                     client=flow.client_conn,
-                    host=normalized_host,
-                    port=flow.request.port,
+                    destination=destination,
                     kind=kind,
                     connected_address=connected_address,
                 )
@@ -473,21 +442,20 @@ def _bind_flow_upstream_destination(
     if flow.server_conn.connected:
         connected_address = _connected_verified_tls_destination_endpoint(
             flow.server_conn,
-            host=normalized_host,
-            port=flow.request.port,
+            host=destination.host,
+            port=destination.port,
             extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
         )
         if connected_address is None:
             return False
         original_address = connected_address
     else:
-        flow.server_conn.address = (normalized_host, flow.request.port)
+        flow.server_conn.address = (destination.host, destination.port)
 
-    upstream_destination_binding.record_server_binding(
+    upstream_destination_binding.record_normalized_server_binding(
         flow.server_conn,
         client=flow.client_conn,
-        host=normalized_host,
-        port=flow.request.port,
+        destination=destination,
         kinds=frozenset((kind,)),
         original_address=original_address,
     )
@@ -523,21 +491,45 @@ def ensure_bound_destination(
     callers must fail closed before API auto-allow or ordinary connector
     credential injection.
     """
-    if _flow_requires_platform_connector_auth_bypass(
-        flow,
-        kind=kind,
-        api_url=api_url,
-    ) and not _request_allows_platform_connector_auth(flow):
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
+        return False
+    try:
+        destination = upstream_destination_binding.normalize_upstream_destination(
+            host=trusted_host,
+            port=flow.request.port,
+        )
+    except (UnicodeError, ValueError):
+        return False
+
+    api_destination = _api_destination(api_url) if kind == "connector_auth" else None
+    if (
+        api_destination is not None
+        and _hostname_port_matches_api_destination(
+            hostname=destination.host,
+            port=destination.port,
+            api_destination=api_destination,
+        )
+        and not _request_allows_platform_connector_auth(flow)
+    ):
         return False
 
     allowed_kinds = frozenset((kind,))
-    has_bound = has_bound_destination(flow, allowed_kinds=allowed_kinds)
+    has_bound = upstream_destination_binding.flow_matches_normalized_destination(
+        flow,
+        destination=destination,
+        allowed_kinds=allowed_kinds,
+    )
     if has_bound and upstream_destination_binding.has_server_binding(flow.server_conn):
         return True
     # If has_bound is true here, it is only an unconnected address or
     # prior-client match. That is retargetable, not durable proof for later
     # keepalive reuse, and connected flows still need current upstream TLS proof.
-    return _bind_flow_upstream_destination(flow, kind=kind, api_url=api_url)
+    return _bind_flow_upstream_destination(
+        flow,
+        destination=destination,
+        kind=kind,
+    )
 
 
 def forget_server_binding(server: object) -> None:

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -178,6 +178,8 @@ def record_server_binding(
     original_address: tuple[str, int] | None,
 ) -> None:
     """Normalize and record a destination after retargeting or verification."""
+    if _connection_id(server) is None:
+        return
     record_normalized_server_binding(
         server,
         client=client,
@@ -510,7 +512,12 @@ def flow_matches_normalized_destination(
     destination: NormalizedUpstreamDestination,
     allowed_kinds: frozenset[BindingKind],
 ) -> bool:
-    """Match current binding evidence against an already-normalized authority."""
+    """Match current binding evidence against an already-normalized authority.
+
+    The caller must derive ``destination`` from the current flow authority.
+    This function revalidates mutable endpoint evidence but does not authorize
+    an unrelated destination.
+    """
     server = flow.server_conn
     server_id = _connection_id(server)
     binding = _bindings_by_server_id.get(server_id) if server_id is not None else None

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -27,6 +27,7 @@ from url_utils import normalize_trusted_hostname
 # endpoint matching details and are intentionally not exported.
 __all__ = (
     "BindingKind",
+    "NormalizedUpstreamDestination",
     "UpstreamDestinationBinding",
     "add_server_binding_kind_if_matching",
     "binding_snapshot_for_tests",
@@ -34,9 +35,12 @@ __all__ = (
     "diagnostic_snapshot_for_flow",
     "flow_matches_bound_destination",
     "flow_matches_direct_bound_destination",
+    "flow_matches_normalized_destination",
     "forget_client_bindings",
     "forget_server_binding",
     "has_server_binding",
+    "normalize_upstream_destination",
+    "record_normalized_server_binding",
     "record_server_binding",
     "refresh_server_binding_connected_address_if_matching",
     "reset_for_tests",
@@ -47,6 +51,14 @@ __all__ = (
 # `api_allow` authorizes VM0 API traffic. `connector_auth` authorizes ordinary
 # upstream credential injection for connector firewalls.
 BindingKind = Literal["api_allow", "connector_auth"]
+
+
+@dataclass(frozen=True)
+class NormalizedUpstreamDestination:
+    """Normalized authority text, not proof about a live upstream endpoint."""
+
+    host: str
+    port: int
 
 
 @dataclass(frozen=True)
@@ -68,6 +80,18 @@ class UpstreamDestinationBinding:
 _bindings_by_server_id: dict[str, UpstreamDestinationBinding] = {}
 _server_ids_by_client_id: dict[str, set[str]] = {}
 _client_id_by_server_id: dict[str, str] = {}
+
+
+def normalize_upstream_destination(
+    *,
+    host: str,
+    port: int,
+) -> NormalizedUpstreamDestination:
+    """Normalize raw authority text for target-aware binding operations."""
+    return NormalizedUpstreamDestination(
+        host=normalize_trusted_hostname(host),
+        port=port,
+    )
 
 
 def _connection_id(connection: object) -> str | None:
@@ -123,6 +147,27 @@ def _associate_server_with_client(server_id: str, client: object | None) -> None
     _server_ids_by_client_id.setdefault(client_id, set()).add(server_id)
 
 
+def record_normalized_server_binding(
+    server: object,
+    *,
+    client: object | None = None,
+    destination: NormalizedUpstreamDestination,
+    kinds: frozenset[BindingKind],
+    original_address: tuple[str, int] | None,
+) -> None:
+    """Record a normalized destination after retargeting or verification."""
+    server_id = _connection_id(server)
+    if server_id is None:
+        return
+    _bindings_by_server_id[server_id] = UpstreamDestinationBinding(
+        host=destination.host,
+        port=destination.port,
+        kinds=kinds,
+        original_address=original_address,
+    )
+    _associate_server_with_client(server_id, client)
+
+
 def record_server_binding(
     server: object,
     *,
@@ -132,24 +177,20 @@ def record_server_binding(
     kinds: frozenset[BindingKind],
     original_address: tuple[str, int] | None,
 ) -> None:
-    """Record a destination after the caller retargeted or verified upstream."""
-    server_id = _connection_id(server)
-    if server_id is None:
-        return
-    _bindings_by_server_id[server_id] = UpstreamDestinationBinding(
-        host=normalize_trusted_hostname(host),
-        port=port,
+    """Normalize and record a destination after retargeting or verification."""
+    record_normalized_server_binding(
+        server,
+        client=client,
+        destination=normalize_upstream_destination(host=host, port=port),
         kinds=kinds,
         original_address=original_address,
     )
-    _associate_server_with_client(server_id, client)
 
 
 def _matching_server_binding(
     server: object,
     *,
-    host: str,
-    port: int,
+    destination: NormalizedUpstreamDestination,
 ) -> tuple[str, UpstreamDestinationBinding] | None:
     server_id = _connection_id(server)
     if server_id is None:
@@ -157,8 +198,7 @@ def _matching_server_binding(
     binding = _bindings_by_server_id.get(server_id)
     if binding is None:
         return None
-    normalized_host = normalize_trusted_hostname(host)
-    if binding.host != normalized_host or binding.port != port:
+    if binding.host != destination.host or binding.port != destination.port:
         return None
     if not _server_binding_matches_current_destination(server, binding):
         return None
@@ -169,12 +209,11 @@ def reuse_server_binding_kind_if_matching(
     server: object,
     *,
     client: object | None = None,
-    host: str,
-    port: int,
+    destination: NormalizedUpstreamDestination,
     kind: BindingKind,
 ) -> bool:
     """Reuse an existing binding kind without authorizing a missing kind."""
-    matched = _matching_server_binding(server, host=host, port=port)
+    matched = _matching_server_binding(server, destination=destination)
     if matched is None:
         return False
     server_id, binding = matched
@@ -188,12 +227,11 @@ def add_server_binding_kind_if_matching(
     server: object,
     *,
     client: object | None = None,
-    host: str,
-    port: int,
+    destination: NormalizedUpstreamDestination,
     kind: BindingKind,
 ) -> bool:
     """Add a binding kind only if the current server destination still matches."""
-    matched = _matching_server_binding(server, host=host, port=port)
+    matched = _matching_server_binding(server, destination=destination)
     if matched is None:
         return False
     server_id, binding = matched
@@ -212,8 +250,7 @@ def refresh_server_binding_connected_address_if_matching(
     server: object,
     *,
     client: object | None = None,
-    host: str,
-    port: int,
+    destination: NormalizedUpstreamDestination,
     kind: BindingKind,
     connected_address: tuple[str, int],
 ) -> bool:
@@ -224,8 +261,7 @@ def refresh_server_binding_connected_address_if_matching(
     binding = _bindings_by_server_id.get(server_id)
     if binding is None:
         return False
-    normalized_host = normalize_trusted_hostname(host)
-    if binding.host != normalized_host or binding.port != port:
+    if binding.host != destination.host or binding.port != destination.port:
         return False
     connected_pair = connection_endpoints.authoritative_connected_endpoint(connected_address)
     if connected_pair is None:
@@ -454,26 +490,42 @@ def flow_matches_bound_destination(
     if not trusted_host:
         return False
     try:
-        normalized_host = normalize_trusted_hostname(trusted_host)
+        destination = normalize_upstream_destination(
+            host=trusted_host,
+            port=flow.request.port,
+        )
     except (UnicodeError, ValueError):
         return False
 
-    port = flow.request.port
+    return flow_matches_normalized_destination(
+        flow,
+        destination=destination,
+        allowed_kinds=allowed_kinds,
+    )
+
+
+def flow_matches_normalized_destination(
+    flow: http.HTTPFlow,
+    *,
+    destination: NormalizedUpstreamDestination,
+    allowed_kinds: frozenset[BindingKind],
+) -> bool:
+    """Match current binding evidence against an already-normalized authority."""
     server = flow.server_conn
     server_id = _connection_id(server)
     binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
     if binding is not None:
         return _binding_matches(
             binding,
-            host=normalized_host,
-            port=port,
+            host=destination.host,
+            port=destination.port,
             allowed_kinds=allowed_kinds,
         ) and _server_binding_matches_current_destination(server, binding)
 
     matching_client_bindings = _matching_client_bindings(
         flow.client_conn,
-        host=normalized_host,
-        port=port,
+        host=destination.host,
+        port=destination.port,
         allowed_kinds=allowed_kinds,
     )
     if bool(getattr(server, "connected", False)):
@@ -481,13 +533,17 @@ def flow_matches_bound_destination(
             _client_binding_connected_endpoint(
                 client=flow.client_conn,
                 server=server,
-                port=port,
+                port=destination.port,
                 bindings=matching_client_bindings,
             )
             is not None
         )
 
-    return _address_matches(normalized_host, port, getattr(server, "address", None))
+    return _address_matches(
+        destination.host,
+        destination.port,
+        getattr(server, "address", None),
+    )
 
 
 def flow_matches_direct_bound_destination(

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -1,6 +1,7 @@
 """Connector requestheaders upstream-admission tests."""
 
 import asyncio
+import urllib.parse
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -119,7 +120,7 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
     active_api_urls: list[str] | None = None
     ensure_bound_destination = upstream_admission.ensure_bound_destination
     normalize_upstream_destination = upstream_destination_binding.normalize_upstream_destination
-    api_destination = upstream_admission._api_destination
+    parse_api_url = urllib.parse.urlparse
 
     def track_ensure_bound_destination(
         tracked_flow: http.HTTPFlow,
@@ -152,12 +153,18 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
             active_destinations.append((host, port))
         return normalize_upstream_destination(host=host, port=port)
 
-    def track_api_destination(
+    def track_api_url_parse(
         api_url: str,
-    ) -> upstream_destination_binding.NormalizedUpstreamDestination | None:
+        scheme: str = "",
+        allow_fragments: bool = True,
+    ) -> urllib.parse.ParseResult:
         if active_api_urls is not None:
             active_api_urls.append(api_url)
-        return api_destination(api_url)
+        return parse_api_url(
+            api_url,
+            scheme=scheme,
+            allow_fragments=allow_fragments,
+        )
 
     monkeypatch.setattr(
         upstream_admission,
@@ -170,9 +177,9 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
         track_normalized_destination,
     )
     monkeypatch.setattr(
-        upstream_admission,
-        "_api_destination",
-        track_api_destination,
+        urllib.parse,
+        "urlparse",
+        track_api_url_parse,
     )
     expected_derivation = (
         (("api.vm0.ai", 443),),

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from mitmproxy import connection
+from mitmproxy import connection, http
 
 import auth
 import flow_metadata_keys as metadata_keys
@@ -114,17 +114,83 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
         ),
     )
     monkeypatch.setenv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret")
+    admission_derivations: list[tuple[tuple[tuple[str, int], ...], tuple[str, ...]]] = []
+    active_destinations: list[tuple[str, int]] | None = None
+    active_api_urls: list[str] | None = None
+    ensure_bound_destination = upstream_admission.ensure_bound_destination
+    normalize_upstream_destination = upstream_destination_binding.normalize_upstream_destination
+    api_destination = upstream_admission._api_destination
+
+    def track_ensure_bound_destination(
+        tracked_flow: http.HTTPFlow,
+        *,
+        kind: upstream_destination_binding.BindingKind,
+        api_url: str,
+    ) -> bool:
+        nonlocal active_destinations, active_api_urls
+        destinations: list[tuple[str, int]] = []
+        api_urls: list[str] = []
+        active_destinations = destinations
+        active_api_urls = api_urls
+        try:
+            return ensure_bound_destination(
+                tracked_flow,
+                kind=kind,
+                api_url=api_url,
+            )
+        finally:
+            admission_derivations.append((tuple(destinations), tuple(api_urls)))
+            active_destinations = None
+            active_api_urls = None
+
+    def track_normalized_destination(
+        *,
+        host: str,
+        port: int,
+    ) -> upstream_destination_binding.NormalizedUpstreamDestination:
+        if active_destinations is not None:
+            active_destinations.append((host, port))
+        return normalize_upstream_destination(host=host, port=port)
+
+    def track_api_destination(
+        api_url: str,
+    ) -> upstream_destination_binding.NormalizedUpstreamDestination | None:
+        if active_api_urls is not None:
+            active_api_urls.append(api_url)
+        return api_destination(api_url)
+
+    monkeypatch.setattr(
+        upstream_admission,
+        "ensure_bound_destination",
+        track_ensure_bound_destination,
+    )
+    monkeypatch.setattr(
+        upstream_destination_binding,
+        "normalize_upstream_destination",
+        track_normalized_destination,
+    )
+    monkeypatch.setattr(
+        upstream_admission,
+        "_api_destination",
+        track_api_destination,
+    )
+    expected_derivation = (
+        (("api.vm0.ai", 443),),
+        ("https://api.vm0.ai",),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
     ):
         assert mitm_addon.requestheaders(flow) is None
+        assert admission_derivations == [expected_derivation]
         _assert_no_request_stream(flow)
         assert flow.server_conn.address == ("api.vm0.ai", 443)
 
         await mitm_addon.request(flow)
 
+    assert admission_derivations == [expected_derivation, expected_derivation]
     auth_fetch.assert_awaited_once()
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer resolved"
@@ -132,6 +198,33 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
     assert binding.host == "api.vm0.ai"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("203.0.113.10", 443)
+
+
+def test_raw_binding_helpers_normalize_noncanonical_authority(
+    real_flow,
+    headers,
+):
+    flow = real_flow(
+        with_response=False,
+        host="api.github.com",
+        sni="api.github.com",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "API.GITHUB.COM."
+    flow.server_conn.address = ("api.github.com", 443)
+    upstream_destination_binding.record_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="API.GITHUB.COM.",
+        port=443,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("203.0.113.10", 443),
+    )
+
+    assert upstream_admission.has_bound_destination(
+        flow,
+        allowed_kinds=frozenset(("connector_auth",)),
+    )
 
 
 async def test_test_connector_bounded_requestheaders_without_bypass_blocks(


### PR DESCRIPTION
## Summary

- normalize each flow authority once per upstream admission and carry it as an immutable destination value
- derive the platform API destination once per connector admission while keeping the bypass gate ahead of binding reuse and creation
- keep raw binding helpers self-validating and preserve independent live address, endpoint, and TLS checks
- add real request-header/request-hook coverage for fresh and directly bound admissions, plus non-canonical raw helper inputs

## Exclusions

- no cross-call URL, authorization, flow, or endpoint cache
- no API, protocol, persisted-state, database, dependency, or deployment-contract changes
- no changes to current server-address, connected-endpoint, certificate, or TLS verification rules

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_headers_api_admission.py tests/test_request_headers_connector_admission.py tests/test_request_handler_authority_validation.py tests/test_server_connect_hook.py -q` (109 passed)
- `uv run --no-sync python -m pytest tests/ -q` (4,380 passed)

Closes #23432
