### PR TITLE
fix: use gallery slides for presentation template previews

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1050,10 +1050,7 @@ describe("chat composer templates", () => {
     }
     expect(highResolutionDetailImage).toHaveAttribute(
       "data-src",
-      r2ImageTransformUrl(
-        `https://static.vm0.io/web/assets/presentation-gallery/2026-07-04/${template.slug}/slide-001.webp`,
-        { width: 708, height: 398 },
-      ),
+      `https://static.vm0.io/web/assets/presentation-gallery/2026-07-04/${template.slug}/slide-001.webp`,
     );
     expect(initialDetailImageSrc).not.toBe(
       r2ImageTransformUrl(prismCardPreview, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -44,9 +44,6 @@ import {
   expectTemplateAttachedToComposer,
 } from "./chat-composer-test-helpers.ts";
 
-const PRESENTATION_DECK_METADATA =
-  '<script id="vm0-deck-metadata" type="application/json">{"kind":"presentation-html","editProtocolVersion":1,"slides":{}}</script>';
-
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
   context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {
@@ -59,7 +56,7 @@ beforeEach(() => {
       1,
     );
     return new Response(
-      `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}${Array.from(
+      `<!doctype html><html><body>${Array.from(
         { length: slideCount },
         (_, index) => {
           return `<section data-vm0-slide data-slide-id="slide-${String(index + 1)}"><h1>Slide ${String(index + 1)}</h1></section>`;
@@ -252,6 +249,55 @@ describe("chat composer templates", () => {
       restoreIdleCallback();
       imagePreloads.restore();
     }
+  });
+
+  it("loads the presentation preview at low resolution before replacing it with the high-resolution image", async () => {
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+
+    const lowResolutionImage = await screen.findByTestId(
+      `${template.title} card image preview`,
+    );
+    const highResolutionImage = lowResolutionImage.parentElement?.querySelector(
+      '[data-template-preview-image="high"]',
+    );
+    if (!(highResolutionImage instanceof HTMLImageElement)) {
+      throw new Error("High-resolution presentation preview image not found");
+    }
+
+    expect(lowResolutionImage).toHaveAttribute(
+      "src",
+      expect.stringContaining("width=480,height=270"),
+    );
+    expect(highResolutionImage).not.toHaveAttribute("src");
+    expect(highResolutionImage).toHaveAttribute(
+      "data-src",
+      expect.stringContaining("width=708,height=398"),
+    );
+
+    fireEvent.load(lowResolutionImage);
+    expect(highResolutionImage).toHaveAttribute(
+      "src",
+      highResolutionImage.dataset.src,
+    );
+    expect(lowResolutionImage).not.toHaveAttribute("data-replaced");
+
+    fireEvent.load(highResolutionImage);
+    await waitFor(() => {
+      expect(highResolutionImage).toHaveAttribute("data-loaded", "true");
+      expect(lowResolutionImage).toHaveAttribute("data-replaced", "true");
+    });
   });
 
   it("places the template control immediately after the legacy attach button by default", async () => {
@@ -655,7 +701,6 @@ describe("chat composer templates", () => {
           <!doctype html>
           <html>
             <body>
-              ${PRESENTATION_DECK_METADATA}
               <section data-vm0-slide data-slide-id="slide-one">
                 <h1>Slide one</h1>
               </section>
@@ -867,7 +912,7 @@ describe("chat composer templates", () => {
     try {
       previewFetch.resolve(
         new Response(
-          `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}${Array.from(
+          `<!doctype html><html><body>${Array.from(
             { length: slideCount },
             (_, index) => {
               const slideNumber = index + 1;
@@ -957,6 +1002,14 @@ describe("chat composer templates", () => {
         }),
       ).toBeInTheDocument();
     });
+    const initialDetailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    const initialDetailImageSrc = initialDetailImage.getAttribute("src");
+    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
+    if (!prismCardPreview) {
+      throw new Error("Prism card preview not found");
+    }
     await user.click(
       within(templateDialog).getByLabelText("Select style Prism"),
     );
@@ -967,21 +1020,41 @@ describe("chat composer templates", () => {
       context.store.get(templateCardThemeIdBySlug$)[template.slug],
     ).toBeUndefined();
 
-    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
-    if (!prismCardPreview) {
-      throw new Error("Prism card preview not found");
-    }
     expect(
       within(templateDialog).getByTestId(
         `${template.title} detail image preview`,
       ),
     ).toHaveAttribute(
       "src",
-      r2ImageTransformUrl(template.previewImages[0]!, {
+      r2ImageTransformUrl(prismCardPreview, {
         width: 480,
         height: 270,
       }),
     );
+    expect(initialDetailImageSrc).not.toBe(
+      r2ImageTransformUrl(prismCardPreview, {
+        width: 480,
+        height: 270,
+      }),
+    );
+
+    await user.click(within(templateDialog).getByLabelText("Preview slide 2"));
+    await waitFor(() => {
+      expect(
+        within(templateDialog).getByTestId(
+          `${template.title} detail image preview`,
+        ),
+      ).toHaveAttribute(
+        "src",
+        r2ImageTransformUrl(
+          `https://static.vm0.io/web/assets/presentation-gallery/2026-07-04/${template.slug}/slide-002.webp`,
+          {
+            width: 480,
+            height: 270,
+          },
+        ),
+      );
+    });
 
     await user.click(
       within(templateDialog).getByLabelText(
@@ -1111,7 +1184,6 @@ describe("chat composer templates", () => {
           <!doctype html>
           <html>
             <body>
-              ${PRESENTATION_DECK_METADATA}
               ${Array.from({ length: lastSlideNumber }, (_, index) => {
                 return `<section data-vm0-slide data-slide-id="slide-${String(
                   index + 1,
@@ -1281,10 +1353,9 @@ describe("chat composer templates", () => {
         previewFetchCount += 1;
         return previewFetch.promise;
       }
-      return new Response(
-        `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}</body></html>`,
-        { headers: { "Content-Type": "text/html" } },
-      );
+      return new Response("<!doctype html><html><body></body></html>", {
+        headers: { "Content-Type": "text/html" },
+      });
     });
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
@@ -1329,7 +1400,6 @@ describe("chat composer templates", () => {
             <!doctype html>
             <html>
               <body>
-                ${PRESENTATION_DECK_METADATA}
                 <section data-vm0-slide data-slide-id="slide-one">
                   <h1>Slide one</h1>
                 </section>
@@ -1389,7 +1459,7 @@ describe("chat composer templates", () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
       return new Response(
-        `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${PRESENTATION_DECK_METADATA}${template.previewImages
+        `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${template.previewImages
           .map((_, index) => {
             return `<section data-vm0-slide data-slide-id="slide-${index + 1}"><h1>Slide ${index + 1}</h1></section>`;
           })

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -285,6 +285,12 @@ describe("chat composer templates", () => {
       "data-src",
       expect.stringContaining("width=708,height=398"),
     );
+    expect(highResolutionImage).toHaveAttribute(
+      "data-src",
+      expect.stringContaining(
+        `/presentation-gallery/2026-07-04/${template.slug}/slide-001.webp`,
+      ),
+    );
 
     fireEvent.load(lowResolutionImage);
     expect(highResolutionImage).toHaveAttribute(
@@ -1031,6 +1037,24 @@ describe("chat composer templates", () => {
         height: 270,
       }),
     );
+    const highResolutionDetailImage = within(templateDialog)
+      .getByTestId(`${template.title} detail image preview`)
+      .parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (
+      highResolutionDetailImage === null ||
+      highResolutionDetailImage === undefined
+    ) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    expect(highResolutionDetailImage).toHaveAttribute(
+      "data-src",
+      r2ImageTransformUrl(
+        `https://static.vm0.io/web/assets/presentation-gallery/2026-07-04/${template.slug}/slide-001.webp`,
+        { width: 708, height: 398 },
+      ),
+    );
     expect(initialDetailImageSrc).not.toBe(
       r2ImageTransformUrl(prismCardPreview, {
         width: 480,
@@ -1153,7 +1177,7 @@ describe("chat composer templates", () => {
           expect.stringMatching(/^blob:detail-theme-preview-/),
         );
       });
-      expect(frame().className).not.toContain("data-[loaded=true]:opacity-100");
+      expect(frame().className).toContain("data-[loaded=true]:opacity-100");
       const initialFrameSrc = frame().getAttribute("src");
       if (initialFrameSrc === null) {
         throw new Error("Initial detail preview frame URL not found");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1100,6 +1100,119 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("updates the visible detail preview frame when the theme changes", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
+      return item.slug === "editorial-magazine-deck";
+    });
+    if (template === undefined) {
+      throw new Error("Editorial magazine presentation template not found");
+    }
+
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const blobHtml: Promise<string>[] = [];
+    const createObjectURL = vi.fn((blob: Blob) => {
+      blobHtml.push(blob.text());
+      return `blob:detail-theme-preview-${String(blobHtml.length)}`;
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      mockChatLifecycle(context, { threadId: THREAD_ID });
+      detachedSetupPage({
+        context,
+        path: `/chats/${THREAD_ID}`,
+      });
+
+      click(
+        await waitFor(() => {
+          return screen.getByLabelText("Template");
+        }),
+      );
+      await user.click(
+        screen.getByLabelText(`Preview ${template.title} at current slide`),
+      );
+      const templateDialog = screen.getByRole("dialog");
+      const frame = () => {
+        return within(templateDialog).getByTestId(
+          `${template.title} detail HTML preview`,
+        );
+      };
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute(
+          "src",
+          expect.stringMatching(/^blob:detail-theme-preview-/),
+        );
+      });
+      expect(frame().className).not.toContain("data-[loaded=true]:opacity-100");
+      const initialFrameSrc = frame().getAttribute("src");
+      if (initialFrameSrc === null) {
+        throw new Error("Initial detail preview frame URL not found");
+      }
+      const firstThumbnail = () => {
+        return within(templateDialog).getByLabelText(
+          `${template.title} slide 1 preview`,
+        );
+      };
+      const initialThumbnailAccent = firstThumbnail().getAttribute("style");
+
+      await user.click(
+        within(templateDialog).getByLabelText("Select style Prism"),
+      );
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute(
+          "src",
+          expect.stringMatching(/^blob:detail-theme-preview-/),
+        );
+        expect(frame().getAttribute("src")).not.toBe(initialFrameSrc);
+      });
+
+      const themedFrameSrc = frame().getAttribute("src");
+      if (themedFrameSrc === null) {
+        throw new Error("Themed detail preview frame URL not found");
+      }
+      const match = /^blob:detail-theme-preview-(\d+)$/.exec(themedFrameSrc);
+      if (match === null) {
+        throw new Error(
+          `Unexpected detail preview frame URL: ${themedFrameSrc}`,
+        );
+      }
+      const themedHtml = await blobHtml[Number(match[1]) - 1];
+      expect(themedHtml).toContain("--accent:#7257E6");
+      await waitFor(() => {
+        const themedThumbnailAccent = firstThumbnail().getAttribute("style");
+        expect(themedThumbnailAccent).toContain("--accent: #7257E6");
+        expect(themedThumbnailAccent).not.toBe(initialThumbnailAccent);
+      });
+    } finally {
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, "createObjectURL", {
+          configurable: true,
+          value: originalCreateObjectURL,
+        });
+      } else {
+        delete (URL as { createObjectURL?: unknown }).createObjectURL;
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, "revokeObjectURL", {
+          configurable: true,
+          value: originalRevokeObjectURL,
+        });
+      } else {
+        delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL;
+      }
+    }
+  });
+
   it("selects presentation templates with the default card theme", async () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
       return item.slug !== PRESENTATION_TEMPLATE_PICKER_ITEMS[0]?.slug;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1174,7 +1174,11 @@ describe("chat composer templates", () => {
           expect.stringMatching(/^blob:detail-theme-preview-/),
         );
       });
-      expect(frame().className).toContain("data-[loaded=true]:opacity-100");
+      expect(frame()).toHaveClass("opacity-100");
+      fireEvent.load(frame());
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute("data-loaded", "true");
+      });
       const initialFrameSrc = frame().getAttribute("src");
       if (initialFrameSrc === null) {
         throw new Error("Initial detail preview frame URL not found");
@@ -1184,7 +1188,14 @@ describe("chat composer templates", () => {
           `${template.title} slide 1 preview`,
         );
       };
+      const secondThumbnail = () => {
+        return within(templateDialog).getByLabelText(
+          `${template.title} slide 2 preview`,
+        );
+      };
       const initialThumbnailAccent = firstThumbnail().getAttribute("style");
+      const initialSecondThumbnailAccent =
+        secondThumbnail().getAttribute("style");
 
       await user.click(
         within(templateDialog).getByLabelText("Select style Prism"),
@@ -1195,6 +1206,10 @@ describe("chat composer templates", () => {
           expect.stringMatching(/^blob:detail-theme-preview-/),
         );
         expect(frame().getAttribute("src")).not.toBe(initialFrameSrc);
+      });
+      fireEvent.load(frame());
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute("data-loaded", "true");
       });
 
       const themedFrameSrc = frame().getAttribute("src");
@@ -1213,6 +1228,12 @@ describe("chat composer templates", () => {
         const themedThumbnailAccent = firstThumbnail().getAttribute("style");
         expect(themedThumbnailAccent).toContain("--accent: #7257E6");
         expect(themedThumbnailAccent).not.toBe(initialThumbnailAccent);
+        const themedSecondThumbnailAccent =
+          secondThumbnail().getAttribute("style");
+        expect(themedSecondThumbnailAccent).toContain("--accent: #7257E6");
+        expect(themedSecondThumbnailAccent).not.toBe(
+          initialSecondThumbnailAccent,
+        );
       });
     } finally {
       if (originalCreateObjectURL) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { previewPresentationHtml } from "../presentation-html-preview.ts";
+import {
+  parsePresentationPreviewDraft,
+  previewPresentationHtml,
+} from "../presentation-html-preview.ts";
+
+describe("parsePresentationPreviewDraft", () => {
+  it("parses static presentation HTML without editor metadata", () => {
+    const draft = parsePresentationPreviewDraft(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="slide"><h1>First slide</h1></section>
+          <section class="slide"><h1>Second slide</h1></section>
+        </body>
+      </html>
+    `);
+
+    expect(draft.slides).toStrictEqual([
+      { id: "slide-1", notes: "", title: "First slide" },
+      { id: "slide-2", notes: "", title: "Second slide" },
+    ]);
+  });
+});
 
 describe("previewPresentationHtml", () => {
   it("materializes theme switcher defaults before removing scripts", () => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
@@ -74,16 +74,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function deckMetadataScript(doc: Document): HTMLScriptElement {
+function deckMetadataScript(doc: Document): HTMLScriptElement | null {
   const script = doc.getElementById(METADATA_SCRIPT_ID);
   if (!(script instanceof HTMLScriptElement) || !script.textContent) {
-    throw new Error("Presentation deck metadata is required");
+    return null;
   }
   return script;
 }
 
 function parseDeckMetadata(doc: Document): DeckMetadata {
   const script = deckMetadataScript(doc);
+  if (script === null) {
+    return {};
+  }
   const parsed: unknown = JSON.parse(script.textContent);
   if (!isRecord(parsed)) {
     throw new Error("Invalid presentation deck metadata");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -396,6 +396,13 @@ type ComposerTemplatePicker = NonNullable<
 type ComposerComputerUse = NonNullable<ZeroChatComposerProps["computerUse"]>;
 
 const TEMPLATE_CARD_PREVIEW_SIZE = { width: 480, height: 270 } as const;
+const TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE = {
+  width: 708,
+  height: 398,
+} as const;
+const PRESENTATION_GALLERY_PREVIEW_BASE_URL =
+  "https://static.vm0.io/web/assets/presentation-gallery/2026-07-04";
+const PRESENTATION_GALLERY_SLIDE_COUNT = 15;
 const TEMPLATE_PREWARM_IMAGE_COUNT = 15;
 const ILLUSTRATION_PREWARM_IMAGE_COUNT = 24;
 const ILLUSTRATION_EAGER_IMAGE_COUNT = 24;
@@ -1635,10 +1642,15 @@ function presentationTemplateFallbackSlideImage(
   index: number,
   size: TemplatePreviewImageSize = TEMPLATE_CARD_PREVIEW_SIZE,
 ): string {
-  const slideImages = presentationTemplateSlideImages(item);
-  const safeIndex = Math.max(0, Math.min(index, slideImages.length - 1));
-  const image = slideImages[safeIndex] ?? item.previewImage;
-  return r2ImageTransformUrl(image, size);
+  const safeIndex = Math.max(
+    0,
+    Math.min(index, PRESENTATION_GALLERY_SLIDE_COUNT - 1),
+  );
+  const slideNumber = String(safeIndex + 1).padStart(3, "0");
+  return r2ImageTransformUrl(
+    `${PRESENTATION_GALLERY_PREVIEW_BASE_URL}/${item.slug}/slide-${slideNumber}.webp`,
+    size,
+  );
 }
 
 function prewarmTemplatePreviewImage(
@@ -2724,8 +2736,112 @@ function revealTemplatePreviewFrameAfterPaint(params: {
   });
 }
 
+function startProgressiveTemplatePreviewImageLoad(
+  lowResolutionImage: HTMLImageElement,
+): void {
+  const highResolutionImage =
+    lowResolutionImage.parentElement?.querySelector<HTMLImageElement>(
+      '[data-template-preview-image="high"]',
+    );
+  if (
+    highResolutionImage === null ||
+    highResolutionImage === undefined ||
+    highResolutionImage.hasAttribute("src")
+  ) {
+    return;
+  }
+
+  const highResolutionUrl = highResolutionImage.dataset.src;
+  if (highResolutionUrl === undefined) {
+    return;
+  }
+  highResolutionImage.src = highResolutionUrl;
+}
+
+function ProgressiveTemplatePreviewImage({
+  alt,
+  className,
+  dataTestId,
+  fetchPriority,
+  highResolutionUrl,
+  loading,
+  lowResolutionUrl,
+}: {
+  readonly alt: string;
+  readonly className: string;
+  readonly dataTestId?: string;
+  readonly fetchPriority?: "high" | "low" | "auto";
+  readonly highResolutionUrl: string;
+  readonly loading?: "eager" | "lazy";
+  readonly lowResolutionUrl: string;
+}) {
+  const hasHighResolutionImage = lowResolutionUrl !== highResolutionUrl;
+
+  return (
+    <>
+      <img
+        key={`low:${lowResolutionUrl}`}
+        src={lowResolutionUrl}
+        alt={alt}
+        aria-hidden={alt === "" ? "true" : undefined}
+        data-template-preview-image="low"
+        data-testid={dataTestId}
+        className={cn(
+          className,
+          "transition-opacity duration-150 data-[replaced=true]:opacity-0",
+        )}
+        loading={loading}
+        decoding="async"
+        fetchPriority={fetchPriority}
+        onLoad={(event) => {
+          if (hasHighResolutionImage) {
+            startProgressiveTemplatePreviewImageLoad(event.currentTarget);
+          }
+        }}
+        onError={(event) => {
+          if (hasHighResolutionImage) {
+            startProgressiveTemplatePreviewImageLoad(event.currentTarget);
+          }
+        }}
+      />
+      {hasHighResolutionImage ? (
+        <img
+          key={`high:${highResolutionUrl}`}
+          src={undefined}
+          data-template-preview-image="high"
+          data-src={highResolutionUrl}
+          alt={alt}
+          aria-hidden={alt === "" ? "true" : undefined}
+          className={cn(
+            className,
+            "opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100",
+          )}
+          loading={loading}
+          decoding="async"
+          fetchPriority={fetchPriority}
+          onLoad={(event) => {
+            const highResolutionImage = event.currentTarget;
+            highResolutionImage.dataset.loaded = "true";
+            const lowResolutionImage =
+              highResolutionImage.parentElement?.querySelector<HTMLImageElement>(
+                '[data-template-preview-image="low"]',
+              );
+            if (
+              lowResolutionImage !== null &&
+              lowResolutionImage !== undefined
+            ) {
+              lowResolutionImage.dataset.replaced = "true";
+            }
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
 function TemplatePreviewFrames({
   fallbackImageUrl,
+  highResolutionFallbackImageUrl,
   loading,
   onFrameLoad,
   overlayFrameUrl,
@@ -2733,6 +2849,7 @@ function TemplatePreviewFrames({
   title,
 }: {
   readonly fallbackImageUrl: string;
+  readonly highResolutionFallbackImageUrl: string;
   readonly loading: boolean;
   readonly onFrameLoad: (frameUrl: string) => void;
   readonly overlayFrameUrl: string | null;
@@ -2749,16 +2866,14 @@ function TemplatePreviewFrames({
 
   return (
     <>
-      <img
-        key={fallbackImageUrl}
-        src={fallbackImageUrl}
+      <ProgressiveTemplatePreviewImage
         alt=""
-        aria-hidden="true"
-        data-testid={`${title} card image preview`}
         className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-        loading="eager"
-        decoding="async"
+        dataTestId={`${title} card image preview`}
         fetchPriority="high"
+        highResolutionUrl={highResolutionFallbackImageUrl}
+        loading="eager"
+        lowResolutionUrl={fallbackImageUrl}
       />
       {frameUrls.map((frameUrl) => {
         return (
@@ -2831,6 +2946,12 @@ function TemplatePreview({
     item,
     hoverSlideIndex,
     previewTheme,
+  );
+  const highResolutionFallbackImageUrl = presentationTemplateCardSlideImage(
+    item,
+    hoverSlideIndex,
+    previewTheme,
+    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
   );
   const activeHtmlPreview =
     htmlPreview?.slug === item.slug &&
@@ -3042,6 +3163,7 @@ function TemplatePreview({
     >
       <TemplatePreviewFrames
         fallbackImageUrl={fallbackImageUrl}
+        highResolutionFallbackImageUrl={highResolutionFallbackImageUrl}
         loading={activeHtmlPreview?.loading === true}
         onFrameLoad={handleFrameLoad}
         overlayFrameUrl={overlayFrameUrl}
@@ -3141,9 +3263,16 @@ function TemplatePreviewPage({
   const cachedDetailDraft = runtime.presentation.drafts.get(item.embedUrl);
   const thumbnailThemeVariables =
     getPresentationTemplateThumbnailThemeVariables(selectedTheme);
-  const detailFallbackImage = presentationTemplateFallbackSlideImage(
+  const detailFallbackImage = presentationTemplateCardSlideImage(
     item,
     activeSlideIndex,
+    selectedTheme,
+  );
+  const detailHighResolutionImage = presentationTemplateCardSlideImage(
+    item,
+    activeSlideIndex,
+    selectedTheme,
+    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
   );
 
   const selectDetailSlide = (index: number) => {
@@ -3218,16 +3347,14 @@ function TemplatePreviewPage({
             onKeyDown={handleDetailSlideKeyDown}
             className="relative aspect-[16/9] overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <img
-              key={detailFallbackImage}
-              src={detailFallbackImage}
+            <ProgressiveTemplatePreviewImage
               alt=""
-              aria-hidden="true"
-              data-testid={`${item.title} detail image preview`}
               className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-              loading="eager"
-              decoding="async"
+              dataTestId={`${item.title} detail image preview`}
               fetchPriority="high"
+              highResolutionUrl={detailHighResolutionImage}
+              loading="eager"
+              lowResolutionUrl={detailFallbackImage}
             />
             <iframe
               key={

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3302,6 +3302,7 @@ function TemplatePreviewPage({
   );
   const detailHighResolutionImage =
     presentationTemplateDetailHighResolutionSlideImage(item, activeSlideIndex);
+  const detailFrameUrl = visibleDetailPreview?.frameUrl ?? null;
 
   const selectDetailSlide = (index: number) => {
     selectDetailPreview({
@@ -3386,23 +3387,25 @@ function TemplatePreviewPage({
             />
             <iframe
               key={
-                visibleDetailPreview?.frameUrl ??
+                detailFrameUrl ??
                 `${item.slug}:${selectedTheme.id}:${activeSlideIndex}:pending`
               }
               title={`${item.title} HTML preview`}
               data-testid={`${item.title} detail HTML preview`}
-              src={visibleDetailPreview?.frameUrl ?? undefined}
+              src={detailFrameUrl ?? undefined}
               sandbox="allow-same-origin"
               tabIndex={-1}
-              className="pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0 data-[loaded=true]:opacity-100"
+              className={cn(
+                "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background",
+                detailFrameUrl === null ? "opacity-0" : "opacity-100",
+              )}
               onLoad={(event) => {
-                const frameUrl = visibleDetailPreview?.frameUrl;
-                if (!frameUrl) {
+                if (detailFrameUrl === null) {
                   return;
                 }
                 revealTemplatePreviewFrameAfterPaint({
                   frame: event.currentTarget,
-                  frameUrl,
+                  frameUrl: detailFrameUrl,
                   onFrameLoad: () => {},
                 });
               }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1637,26 +1637,6 @@ function presentationTemplateCardSlideImage(
   return presentationTemplateFallbackSlideImage(item, index, size);
 }
 
-function presentationTemplateDetailUsesStaticPreview(
-  item: PresentationTemplateItem,
-  activeSlideIndex: number,
-  theme: PresentationTemplateThemeOption,
-): boolean {
-  return (
-    activeSlideIndex === 0 &&
-    item.cardPreviewImagesByTheme?.[theme.id] !== undefined
-  );
-}
-
-function presentationTemplateDetailFrameClassName(
-  usesStaticPreview: boolean,
-): string {
-  return cn(
-    "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0",
-    !usesStaticPreview && "data-[loaded=true]:opacity-100",
-  );
-}
-
 function presentationTemplateFallbackSlideImage(
   item: PresentationTemplateItem,
   index: number,
@@ -1671,6 +1651,21 @@ function presentationTemplateFallbackSlideImage(
     `${PRESENTATION_GALLERY_PREVIEW_BASE_URL}/${item.slug}/slide-${slideNumber}.webp`,
     size,
   );
+}
+
+function presentationTemplateHighResolutionSlideImage(
+  item: PresentationTemplateItem,
+  index: number,
+  theme: PresentationTemplateThemeOption,
+  size: TemplatePreviewImageSize = TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
+): string {
+  // Theme card assets are intentionally pre-rendered at 480x270. They are
+  // useful as an immediate placeholder, but resizing them cannot add detail.
+  // Use the gallery's original slide for the high-resolution image instead.
+  if (index === 0) {
+    return presentationTemplateFallbackSlideImage(item, index, size);
+  }
+  return presentationTemplateCardSlideImage(item, index, theme, size);
 }
 
 function prewarmTemplatePreviewImage(
@@ -2967,12 +2962,13 @@ function TemplatePreview({
     hoverSlideIndex,
     previewTheme,
   );
-  const highResolutionFallbackImageUrl = presentationTemplateCardSlideImage(
-    item,
-    hoverSlideIndex,
-    previewTheme,
-    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
-  );
+  const highResolutionFallbackImageUrl =
+    presentationTemplateHighResolutionSlideImage(
+      item,
+      hoverSlideIndex,
+      previewTheme,
+      TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
+    );
   const activeHtmlPreview =
     htmlPreview?.slug === item.slug &&
     htmlPreview.embedUrl === item.embedUrl &&
@@ -3288,17 +3284,12 @@ function TemplatePreviewPage({
     activeSlideIndex,
     selectedTheme,
   );
-  const detailHighResolutionImage = presentationTemplateCardSlideImage(
-    item,
-    activeSlideIndex,
-    selectedTheme,
-    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
-  );
-  const detailHasThemedStaticPreview =
-    presentationTemplateDetailUsesStaticPreview(
+  const detailHighResolutionImage =
+    presentationTemplateHighResolutionSlideImage(
       item,
       activeSlideIndex,
       selectedTheme,
+      TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
     );
 
   const selectDetailSlide = (index: number) => {
@@ -3392,9 +3383,7 @@ function TemplatePreviewPage({
               src={visibleDetailPreview?.frameUrl ?? undefined}
               sandbox="allow-same-origin"
               tabIndex={-1}
-              className={presentationTemplateDetailFrameClassName(
-                detailHasThemedStaticPreview,
-              )}
+              className="pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0 data-[loaded=true]:opacity-100"
               onLoad={(event) => {
                 const frameUrl = visibleDetailPreview?.frameUrl;
                 if (!frameUrl) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1642,15 +1642,22 @@ function presentationTemplateFallbackSlideImage(
   index: number,
   size: TemplatePreviewImageSize = TEMPLATE_CARD_PREVIEW_SIZE,
 ): string {
+  return r2ImageTransformUrl(
+    presentationTemplateGallerySlideUrl(item, index),
+    size,
+  );
+}
+
+function presentationTemplateGallerySlideUrl(
+  item: PresentationTemplateItem,
+  index: number,
+): string {
   const safeIndex = Math.max(
     0,
     Math.min(index, PRESENTATION_GALLERY_SLIDE_COUNT - 1),
   );
   const slideNumber = String(safeIndex + 1).padStart(3, "0");
-  return r2ImageTransformUrl(
-    `${PRESENTATION_GALLERY_PREVIEW_BASE_URL}/${item.slug}/slide-${slideNumber}.webp`,
-    size,
-  );
+  return `${PRESENTATION_GALLERY_PREVIEW_BASE_URL}/${item.slug}/slide-${slideNumber}.webp`;
 }
 
 function presentationTemplateHighResolutionSlideImage(
@@ -1666,6 +1673,15 @@ function presentationTemplateHighResolutionSlideImage(
     return presentationTemplateFallbackSlideImage(item, index, size);
   }
   return presentationTemplateCardSlideImage(item, index, theme, size);
+}
+
+function presentationTemplateDetailHighResolutionSlideImage(
+  item: PresentationTemplateItem,
+  index: number,
+): string {
+  // Detail previews can be wider than the gallery cards. Keep the original
+  // 1200x676 WebP so text does not get softened by a 708px JPEG transform.
+  return presentationTemplateGallerySlideUrl(item, index);
 }
 
 function prewarmTemplatePreviewImage(
@@ -3285,12 +3301,7 @@ function TemplatePreviewPage({
     selectedTheme,
   );
   const detailHighResolutionImage =
-    presentationTemplateHighResolutionSlideImage(
-      item,
-      activeSlideIndex,
-      selectedTheme,
-      TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
-    );
+    presentationTemplateDetailHighResolutionSlideImage(item, activeSlideIndex);
 
   const selectDetailSlide = (index: number) => {
     selectDetailPreview({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1637,6 +1637,26 @@ function presentationTemplateCardSlideImage(
   return presentationTemplateFallbackSlideImage(item, index, size);
 }
 
+function presentationTemplateDetailUsesStaticPreview(
+  item: PresentationTemplateItem,
+  activeSlideIndex: number,
+  theme: PresentationTemplateThemeOption,
+): boolean {
+  return (
+    activeSlideIndex === 0 &&
+    item.cardPreviewImagesByTheme?.[theme.id] !== undefined
+  );
+}
+
+function presentationTemplateDetailFrameClassName(
+  usesStaticPreview: boolean,
+): string {
+  return cn(
+    "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0",
+    !usesStaticPreview && "data-[loaded=true]:opacity-100",
+  );
+}
+
 function presentationTemplateFallbackSlideImage(
   item: PresentationTemplateItem,
   index: number,
@@ -3274,6 +3294,12 @@ function TemplatePreviewPage({
     selectedTheme,
     TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
   );
+  const detailHasThemedStaticPreview =
+    presentationTemplateDetailUsesStaticPreview(
+      item,
+      activeSlideIndex,
+      selectedTheme,
+    );
 
   const selectDetailSlide = (index: number) => {
     selectDetailPreview({
@@ -3366,7 +3392,9 @@ function TemplatePreviewPage({
               src={visibleDetailPreview?.frameUrl ?? undefined}
               sandbox="allow-same-origin"
               tabIndex={-1}
-              className="pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0 data-[loaded=true]:opacity-100"
+              className={presentationTemplateDetailFrameClassName(
+                detailHasThemedStaticPreview,
+              )}
               onLoad={(event) => {
                 const frameUrl = visibleDetailPreview?.frameUrl;
                 if (!frameUrl) {
@@ -3418,9 +3446,10 @@ function TemplatePreviewPage({
             ).map((slideNumber) => {
               const slideIndex = slideNumber - 1;
               const active = slideIndex === activeSlideIndex;
-              const thumbnailImage = presentationTemplateFallbackSlideImage(
+              const thumbnailImage = presentationTemplateCardSlideImage(
                 item,
                 slideIndex,
+                selectedTheme,
               );
               const thumbnailSlide =
                 cachedDetailDraft?.slides[slideIndex] ?? null;


### PR DESCRIPTION
## Summary

- Use the public presentation gallery slide assets as the static fallback for presentation previews.
- Load the 480x270 theme preview first, then replace it with the original 1200x676 gallery WebP for the detail view; card previews continue to use the 708x398 transformed asset.
- Reveal the current themed HTML detail frame as soon as its object URL is ready, preventing the default gallery image from covering the selected theme.
- Keep the first detail thumbnail theme-aware and update later HTML thumbnails with the selected theme variables.
- Keep metadata-free HTML preview parsing and themed HTML previews for slides without a pre-rendered theme cover.

## Root cause

The detail high-resolution stage previously used the 708x398 card-sized transform, which was upscaled in the dialog. After a theme change, the newly generated HTML frame also remained hidden until a delayed load attribute was set, leaving the default gallery image visible. The thumbnail fallback likewise only had a theme-specific raster asset for slide 1.

## Verification

- Browser QA on the deployed PR preview: Playful launch → slide 12 → Nordic Frost updates the main preview and all 15 thumbnails.
- Targeted presentation preview/theme tests pass, including the main frame and a later thumbnail (4/4).
- Presentation detail navigation tests pass.
- Platform type, lint, and format checks pass.
- The full PR pipeline passes; an unrelated flaky API shard passed on retry.