### PR TITLE
test(e2e): remove competing clerk auth navigations

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -60,8 +60,6 @@ export async function signInWithClerkTestingHelper(
     await page.evaluate(async (organizationId) => {
       await window.Clerk?.setActive({ organization: organizationId });
     }, options.activeOrganizationId);
-    await gotoAboutBlankAfterClerkNavigation(page);
-    await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
     await page.waitForFunction(
       () => Boolean(window.Clerk?.loaded && window.Clerk?.session),
       undefined,

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -57,9 +57,22 @@ export async function signInWithClerkTestingHelper(
     timeout: 30_000,
   });
   if (options.activeOrganizationId) {
-    await page.evaluate(async (organizationId) => {
-      await window.Clerk?.setActive({ organization: organizationId });
-    }, options.activeOrganizationId);
+    // Activating the organization lets the skeleton route redirect to the app.
+    // Observe that redirect before setActive so it cannot race the token read.
+    await Promise.all([
+      page.waitForURL(
+        (url) =>
+          url.origin === helperUrl.origin &&
+          url.pathname !== helperUrl.pathname,
+        {
+          timeout: 30_000,
+          waitUntil: "domcontentloaded",
+        },
+      ),
+      page.evaluate(async (organizationId) => {
+        await window.Clerk?.setActive({ organization: organizationId });
+      }, options.activeOrganizationId),
+    ]);
     await page.waitForFunction(
       () => Boolean(window.Clerk?.loaded && window.Clerk?.session),
       undefined,


### PR DESCRIPTION
## Summary

- remove the intermediate `about:blank` navigation after activating the Clerk organization
- stop reopening `/_/skeleton` solely to verify session rehydration
- retain the Clerk loaded, session, organization, and token assertions

## Why

The app already reacts to an active organization change by refreshing the Clerk token and navigating to `/`. The test simultaneously forced `about:blank` and then reloaded `/_/skeleton`, creating competing navigations and an unnecessary Clerk cold rehydration. Recent Playwright failures timed out at that post-reload session wait before reaching business assertions.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`

The hosted Playwright suite is intentionally left to PR CI so it runs against the immutable preview deployment with real Clerk and Stripe infrastructure.