### PR TITLE
fix(feishu): limit workspaces to one admin-managed bot

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -23,6 +23,7 @@ import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
+import { createDeferredPromise } from "../../utils";
 import { zeroFeishuBrowserConnectRoutes } from "../zero-feishu-browser-connect";
 import { zeroFeishuEventsRoutes } from "../zero-feishu-events";
 import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
@@ -884,6 +885,92 @@ describe("Feishu integration", () => {
         return installation.appId;
       }),
     ).toStrictEqual([firstAppId]);
+    const installation = status.body.installations?.[0];
+    if (!installation) {
+      throw new Error("Expected one Feishu installation");
+    }
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: installation.id },
+      }),
+      [200],
+    );
+  });
+
+  it("serializes concurrent Feishu app creation per organization", async () => {
+    const actor = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      orgRole: "org:admin",
+    });
+    authOrgApi.acceptAgentStorageWrites();
+    await enableFeishuIntegration(actor);
+    const agent = await authOrgApi.createAgent(actor, {
+      displayName: "Feishu concurrent setup agent",
+      visibility: "public",
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const client = setupApp({ context })(zeroFeishuConnectContract);
+    const bothTokenRequestsStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseTokenRequests = createDeferredPromise<void>(context.signal);
+    let tokenRequestCount = 0;
+    server.use(
+      http.post(
+        "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+        async () => {
+          tokenRequestCount += 1;
+          if (tokenRequestCount === 2) {
+            bothTokenRequestsStarted.resolve();
+          }
+          await releaseTokenRequests.promise;
+          return HttpResponse.json({
+            code: 0,
+            tenant_access_token: "tenant-access-token",
+            expire: 7200,
+          });
+        },
+      ),
+    );
+
+    const setupResponsesPromise = Promise.all(
+      [`cli_${randomUUID()}`, `cli_${randomUUID()}`].map((appId) => {
+        return client.setup({
+          headers: { authorization: "Bearer clerk-session" },
+          body: {
+            appId,
+            appSecret: APP_SECRET,
+            verificationToken: VERIFICATION_TOKEN,
+            defaultAgentId: agent.agentId,
+            createNew: true,
+          },
+        });
+      }),
+    );
+    await bothTokenRequestsStarted.promise;
+    releaseTokenRequests.resolve();
+    const setupResponses = await setupResponsesPromise;
+
+    expect(
+      setupResponses.map((response) => {
+        return response.status;
+      }),
+    ).toContain(200);
+    expect(
+      setupResponses.map((response) => {
+        return response.status;
+      }),
+    ).toContain(409);
+
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body.installations).toHaveLength(1);
     const installation = status.body.installations?.[0];
     if (!installation) {
       throw new Error("Expected one Feishu installation");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -799,7 +799,7 @@ describe("Feishu integration", () => {
     );
   });
 
-  it("keeps multiple Feishu apps installed in the same organization", async () => {
+  it("keeps one Feishu app installed per organization", async () => {
     const firstAppId = `cli_${randomUUID()}`;
     const secondAppId = `cli_${randomUUID()}`;
     const actor = authOrgApi.user({
@@ -810,27 +810,12 @@ describe("Feishu integration", () => {
     authOrgApi.acceptAgentStorageWrites();
     await enableFeishuIntegration(actor);
     const agent = await authOrgApi.createAgent(actor, {
-      displayName: "Feishu multi-bot agent",
+      displayName: "Feishu single-bot agent",
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context })(zeroFeishuConnectContract);
 
-    for (const appId of [firstAppId, secondAppId]) {
-      await accept(
-        client.setup({
-          headers: { authorization: "Bearer clerk-session" },
-          body: {
-            appId,
-            appSecret: APP_SECRET,
-            verificationToken: VERIFICATION_TOKEN,
-            defaultAgentId: agent.agentId,
-            createNew: true,
-          },
-        }),
-        [200],
-      );
-    }
     await accept(
       client.setup({
         headers: { authorization: "Bearer clerk-session" },
@@ -842,7 +827,35 @@ describe("Feishu integration", () => {
           createNew: true,
         },
       }),
+      [200],
+    );
+    await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: firstAppId,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+        },
+      }),
+      [200],
+    );
+    const secondSetup = await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: secondAppId,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+          createNew: true,
+        },
+      }),
       [409],
+    );
+    expect(secondSetup.body.error.message).toBe(
+      "This workspace already has a Feishu bot",
     );
     await accept(
       client.checkAppId({
@@ -865,29 +878,30 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
-    expect(status.body.installations).toHaveLength(2);
+    expect(status.body.installations).toHaveLength(1);
     expect(
       status.body.installations?.map((installation) => {
         return installation.appId;
       }),
-    ).toStrictEqual([firstAppId, secondAppId]);
-
-    for (const installation of status.body.installations ?? []) {
-      await accept(
-        client.removeInstallation({
-          headers: { authorization: "Bearer clerk-session" },
-          params: { installationId: installation.id },
-        }),
-        [200],
-      );
+    ).toStrictEqual([firstAppId]);
+    const installation = status.body.installations?.[0];
+    if (!installation) {
+      throw new Error("Expected one Feishu installation");
     }
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: installation.id },
+      }),
+      [200],
+    );
   });
 
-  it("allows bot owners and organization admins to manage installations", async () => {
+  it("requires organization admins even when the user created the bot", async () => {
     const actor = authOrgApi.user({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
-      orgRole: "org:member",
+      orgRole: "org:admin",
     });
     authOrgApi.acceptAgentStorageWrites();
     await enableFeishuIntegration(actor);
@@ -895,45 +909,76 @@ describe("Feishu integration", () => {
       displayName: "Feishu managed bot agent",
       visibility: "public",
     });
-    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context })(zeroFeishuConnectContract);
 
-    for (const appId of [`cli_${randomUUID()}`, `cli_${randomUUID()}`]) {
-      await accept(
-        client.setup({
-          headers: { authorization: "Bearer clerk-session" },
-          body: {
-            appId,
-            appSecret: APP_SECRET,
-            verificationToken: VERIFICATION_TOKEN,
-            defaultAgentId: agent.agentId,
-            createNew: true,
-          },
-        }),
-        [200],
-      );
+    const configured = await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: `cli_${randomUUID()}`,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+          createNew: true,
+        },
+      }),
+      [200],
+    );
+    const installationId = configured.body.installationId;
+    if (!installationId) {
+      throw new Error("Expected one Feishu installation");
     }
 
-    const ownerStatus = await accept(
+    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
+    const memberStatus = await accept(
       client.getStatus({
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
-    expect(
-      ownerStatus.body.installations?.every((installation) => {
-        return installation.canManage;
+    expect(memberStatus.body.isAdmin).toBeFalsy();
+    await accept(
+      client.checkAppId({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { appId: `cli_${randomUUID()}` },
       }),
-    ).toBeTruthy();
-    const [ownerManagedInstallation, adminManagedInstallation] =
-      ownerStatus.body.installations ?? [];
-    if (!ownerManagedInstallation || !adminManagedInstallation) {
-      throw new Error("Expected two Feishu installations");
-    }
+      [403],
+    );
+    await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: `cli_${randomUUID()}`,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+          createNew: true,
+        },
+      }),
+      [403],
+    );
+    await accept(
+      client.updateInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId },
+        body: { defaultAgentId: agent.agentId, setupCompleted: true },
+      }),
+      [403],
+    );
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId },
+      }),
+      [403],
+    );
+
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const completed = await accept(
       client.updateInstallation({
         headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: ownerManagedInstallation.id },
+        params: { installationId },
         body: {
           defaultAgentId: agent.agentId,
           setupCompleted: true,
@@ -949,57 +994,7 @@ describe("Feishu integration", () => {
     await accept(
       client.removeInstallation({
         headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: ownerManagedInstallation.id },
-      }),
-      [200],
-    );
-
-    const member = authOrgApi.user({
-      userId: `user_${randomUUID()}`,
-      orgId: actor.orgId,
-      orgRole: "org:member",
-    });
-    await enableFeishuIntegration(member);
-    mocks.clerk.session(member.userId, member.orgId, "org:member");
-    const memberStatus = await accept(
-      client.getStatus({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    expect(memberStatus.body.installations?.[0]?.canManage).toBeFalsy();
-    await accept(
-      client.setup({
-        headers: { authorization: "Bearer clerk-session" },
-        body: {
-          appId: adminManagedInstallation.appId,
-          appSecret: APP_SECRET,
-          verificationToken: VERIFICATION_TOKEN,
-          defaultAgentId: agent.agentId,
-          installationId: adminManagedInstallation.id,
-        },
-      }),
-      [403],
-    );
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: adminManagedInstallation.id },
-      }),
-      [403],
-    );
-
-    const admin = authOrgApi.user({
-      userId: `user_${randomUUID()}`,
-      orgId: actor.orgId,
-      orgRole: "org:admin",
-    });
-    await enableFeishuIntegration(admin);
-    mocks.clerk.session(admin.userId, admin.orgId, "org:admin");
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: adminManagedInstallation.id },
+        params: { installationId },
       }),
       [200],
     );
@@ -1007,19 +1002,24 @@ describe("Feishu integration", () => {
 
   it("connects the current Feishu user through signed OAuth state", async () => {
     const appId = `cli_${randomUUID()}`;
-    const actor = authOrgApi.user({
+    const admin = authOrgApi.user({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
+      orgRole: "org:admin",
+    });
+    const member = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: admin.orgId,
       orgRole: "org:member",
     });
     authOrgApi.acceptAgentStorageWrites();
-    await enableFeishuIntegration(actor);
-    const agent = await authOrgApi.createAgent(actor, {
+    await enableFeishuIntegration(admin);
+    await enableFeishuIntegration(member);
+    const agent = await authOrgApi.createAgent(admin, {
       displayName: "Feishu OAuth agent",
       visibility: "public",
     });
-    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
-    mockClerkMembership(context, actor, "org:member");
+    mocks.clerk.session(admin.userId, admin.orgId, "org:admin");
     const client = setupApp({ context })(zeroFeishuConnectContract);
     const configured = await accept(
       client.setup({
@@ -1050,6 +1050,8 @@ describe("Feishu integration", () => {
       [200],
     );
 
+    mocks.clerk.session(member.userId, member.orgId, "org:member");
+    mockClerkMembership(context, member, "org:member");
     const status = await accept(
       client.getStatus({
         headers: { authorization: "Bearer clerk-session" },
@@ -1132,8 +1134,8 @@ describe("Feishu integration", () => {
         responseMode: "json",
         state: legacyFeishuAppOAuthState({
           installationId,
-          orgId: requireValue(actor.orgId, "Expected an organization"),
-          userId: actor.userId,
+          orgId: requireValue(member.orgId, "Expected an organization"),
+          userId: member.userId,
         }),
       })}`,
     );
@@ -1144,7 +1146,7 @@ describe("Feishu integration", () => {
     ]);
     await flushWaitUntilForTest();
 
-    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    mocks.clerk.session(member.userId, member.orgId, member.orgRole);
     const connected = await accept(
       client.getStatus({
         headers: { authorization: "Bearer clerk-session" },
@@ -1164,6 +1166,7 @@ describe("Feishu integration", () => {
     });
     expect(welcome?.msgType).toBe("interactive");
 
+    mocks.clerk.session(admin.userId, admin.orgId, admin.orgRole);
     await accept(
       client.removeInstallation({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-feishu-message.test.ts
@@ -422,37 +422,6 @@ describe("POST /api/zero/integrations/feishu/message", () => {
     });
   });
 
-  it("requires an explicit installation when multiple bots are configured", async () => {
-    const first = await setupFeishuInstallation();
-    await setupFeishuInstallation(first.actor);
-    const client = setupApp({ context })(integrationsFeishuMessageContract);
-    const token = zeroToken(first.actor);
-
-    const ambiguous = await accept(
-      client.sendMessage({
-        headers: { authorization: `Bearer ${token}` },
-        body: { chat: "oc_target_chat", text: "Choose a bot" },
-      }),
-      [400],
-    );
-    expect(ambiguous.body.error.message).toContain(
-      "Multiple Feishu installations",
-    );
-
-    const selected = await accept(
-      client.sendMessage({
-        headers: { authorization: `Bearer ${token}` },
-        body: {
-          installationId: first.installationId,
-          chat: "oc_target_chat",
-          text: "Selected bot",
-        },
-      }),
-      [200],
-    );
-    expect(selected.body.ok).toBeTruthy();
-  });
-
   it("downloads a resource from a Feishu message", async () => {
     const { actor, installationId } = await setupFeishuInstallation();
     const payload = Buffer.from("feishu resource bytes");

--- a/turbo/apps/api/src/signals/routes/zero-feishu-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-connect.ts
@@ -15,7 +15,6 @@ import type { RouteEntry } from "../route-entry";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { settle } from "../utils";
 import {
-  checkFeishuInstallationManagementAccess$,
   configureFeishuInstallation$,
   type ConfigureFeishuResult,
   disconnectFeishuConnection$,
@@ -29,20 +28,7 @@ function adminRequired() {
     status: 403 as const,
     body: {
       error: {
-        message: "Only organization admins can configure Feishu",
-        code: "FORBIDDEN" as const,
-      },
-    },
-  };
-}
-
-function managementRequired() {
-  return {
-    status: 403 as const,
-    body: {
-      error: {
-        message:
-          "Only the bot owner or organization admins can manage this Feishu bot",
+        message: "Only organization admins can manage Feishu bots",
         code: "FORBIDDEN" as const,
       },
     },
@@ -88,6 +74,10 @@ const checkAppId$ = computed(async (get) => {
   if (!(await get(feishuIntegrationEnabled$))) {
     return feishuIntegrationDisabled;
   }
+  const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired();
+  }
   const query = get(queryOf(zeroFeishuConnectContract.checkAppId));
   const [installation] = await get(db$)
     .select({ id: feishuOrgInstallations.id })
@@ -104,6 +94,9 @@ const setup$ = command(async ({ get, set }, signal: AbortSignal) => {
     return feishuIntegrationDisabled;
   }
   const auth = get(organizationAuthContext$);
+  if (auth.orgRole !== "admin") {
+    return adminRequired();
+  }
   const bodyResult = await get(bodyResultOf(zeroFeishuConnectContract.setup));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -115,7 +108,6 @@ const setup$ = command(async ({ get, set }, signal: AbortSignal) => {
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        isAdmin: auth.orgRole === "admin",
         ...bodyResult.data,
       },
       signal,
@@ -141,8 +133,8 @@ const setup$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (result.kind === "app_in_use") {
     return conflict("This Feishu App ID is already registered in VM0");
   }
-  if (result.kind === "forbidden") {
-    return managementRequired();
+  if (result.kind === "installation_exists") {
+    return conflict("This workspace already has a Feishu bot");
   }
   const status = await get(
     feishuConnectStatus({
@@ -192,25 +184,12 @@ const updateInstallation$ = command(
       return feishuIntegrationDisabled;
     }
     const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired();
+    }
     const params = get(
       pathParamsOf(zeroFeishuConnectContract.updateInstallation),
     );
-    const access = await set(
-      checkFeishuInstallationManagementAccess$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        isAdmin: auth.orgRole === "admin",
-        installationId: params.installationId,
-      },
-      signal,
-    );
-    if (access === "not_found") {
-      return notFound("Feishu integration not found");
-    }
-    if (access === "forbidden") {
-      return managementRequired();
-    }
     const bodyResult = await get(
       bodyResultOf(zeroFeishuConnectContract.updateInstallation),
     );
@@ -259,25 +238,12 @@ const removeInstallation$ = command(
       return feishuIntegrationDisabled;
     }
     const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired();
+    }
     const params = get(
       pathParamsOf(zeroFeishuConnectContract.removeInstallation),
     );
-    const access = await set(
-      checkFeishuInstallationManagementAccess$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        isAdmin: auth.orgRole === "admin",
-        installationId: params.installationId,
-      },
-      signal,
-    );
-    if (access === "not_found") {
-      return notFound("Feishu integration not found");
-    }
-    if (access === "forbidden") {
-      return managementRequired();
-    }
     const removed = await set(
       removeFeishuInstallation$,
       { orgId: auth.orgId, installationId: params.installationId },

--- a/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { and, asc, eq, inArray, or } from "drizzle-orm";
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 import type {
   FeishuConnectStatus,
   FeishuInstallationStatus,
@@ -217,20 +217,26 @@ export type ConfigureFeishuResult =
   | { readonly kind: "app_in_use" }
   | { readonly kind: "installation_exists" };
 
-async function persistFeishuInstallation(args: {
-  readonly db: Db;
-  readonly input: ConfigureFeishuArgs;
-  readonly targetInstallationId: string | undefined;
-  readonly signal: AbortSignal;
-}): Promise<ConfigureFeishuResult> {
+interface PreparedFeishuInstallation {
+  readonly encryptedAppSecret: string;
+  readonly encryptedVerificationToken: string;
+  readonly encryptedEncryptKey: string;
+  readonly encryptedTenantAccessToken: string;
+  readonly tokenExpiresAt: Date;
+}
+
+async function prepareFeishuInstallation(
+  input: ConfigureFeishuArgs,
+  signal: AbortSignal,
+): Promise<PreparedFeishuInstallation> {
   const tenantToken = await fetchFeishuTenantAccessToken({
-    appId: args.input.appId,
-    appSecret: args.input.appSecret,
-    signal: args.signal,
+    appId: input.appId,
+    appSecret: input.appSecret,
+    signal,
   });
   const context = {
-    orgId: args.input.orgId,
-    userId: args.input.userId,
+    orgId: input.orgId,
+    userId: input.userId,
   };
   const [
     encryptedAppSecret,
@@ -238,15 +244,30 @@ async function persistFeishuInstallation(args: {
     encryptedEncryptKey,
     encryptedTenantAccessToken,
   ] = await Promise.all([
-    encryptPersistentSecretValue(args.input.appSecret, context),
-    encryptPersistentSecretValue(args.input.verificationToken, context),
-    encryptPersistentSecretValue(args.input.encryptKey, context),
+    encryptPersistentSecretValue(input.appSecret, context),
+    encryptPersistentSecretValue(input.verificationToken, context),
+    encryptPersistentSecretValue(input.encryptKey, context),
     encryptPersistentSecretValue(tenantToken.token, context),
   ]);
-  args.signal.throwIfAborted();
-  const tokenExpiresAt = new Date(
-    nowDate().getTime() + tenantToken.expiresInSeconds * 1000,
-  );
+  signal.throwIfAborted();
+  return {
+    encryptedAppSecret,
+    encryptedVerificationToken,
+    encryptedEncryptKey,
+    encryptedTenantAccessToken,
+    tokenExpiresAt: new Date(
+      nowDate().getTime() + tenantToken.expiresInSeconds * 1000,
+    ),
+  };
+}
+
+async function persistFeishuInstallation(args: {
+  readonly db: Pick<Db, "insert" | "update">;
+  readonly input: ConfigureFeishuArgs;
+  readonly prepared: PreparedFeishuInstallation;
+  readonly targetInstallationId: string | undefined;
+  readonly signal: AbortSignal;
+}): Promise<ConfigureFeishuResult> {
   if (args.targetInstallationId) {
     await args.db
       .update(feishuOrgInstallations)
@@ -255,14 +276,14 @@ async function persistFeishuInstallation(args: {
         botOpenId: null,
         botName: null,
         botAvatarUrl: null,
-        encryptedAppSecret,
-        encryptedVerificationToken,
-        encryptedEncryptKey,
+        encryptedAppSecret: args.prepared.encryptedAppSecret,
+        encryptedVerificationToken: args.prepared.encryptedVerificationToken,
+        encryptedEncryptKey: args.prepared.encryptedEncryptKey,
         defaultComposeId: args.input.defaultAgentId,
         feishuTenantKey: null,
         feishuTenantName: null,
-        encryptedTenantAccessToken,
-        tenantAccessTokenExpiresAt: tokenExpiresAt,
+        encryptedTenantAccessToken: args.prepared.encryptedTenantAccessToken,
+        tenantAccessTokenExpiresAt: args.prepared.tokenExpiresAt,
         callbackVerifiedAt: null,
         setupCompletedAt: null,
         messageReceivedAt: null,
@@ -281,12 +302,12 @@ async function persistFeishuInstallation(args: {
       orgId: args.input.orgId,
       ownerUserId: args.input.userId,
       appId: args.input.appId,
-      encryptedAppSecret,
-      encryptedVerificationToken,
-      encryptedEncryptKey,
+      encryptedAppSecret: args.prepared.encryptedAppSecret,
+      encryptedVerificationToken: args.prepared.encryptedVerificationToken,
+      encryptedEncryptKey: args.prepared.encryptedEncryptKey,
       defaultComposeId: args.input.defaultAgentId,
-      encryptedTenantAccessToken,
-      tenantAccessTokenExpiresAt: tokenExpiresAt,
+      encryptedTenantAccessToken: args.prepared.encryptedTenantAccessToken,
+      tenantAccessTokenExpiresAt: args.prepared.tokenExpiresAt,
     })
     .onConflictDoNothing({
       target: feishuOrgInstallations.appId,
@@ -296,6 +317,69 @@ async function persistFeishuInstallation(args: {
   return created
     ? { kind: "ok", installationId: created.id }
     : { kind: "app_in_use" };
+}
+
+type FeishuInstallationTargetResult =
+  | {
+      readonly kind: "target";
+      readonly installationId: string | undefined;
+    }
+  | { readonly kind: "installation_not_found" }
+  | { readonly kind: "app_in_use" }
+  | { readonly kind: "installation_exists" };
+
+async function resolveFeishuInstallationTarget(
+  db: Pick<Db, "select">,
+  args: ConfigureFeishuArgs,
+  signal: AbortSignal,
+): Promise<FeishuInstallationTargetResult> {
+  const [appOwner] = await db
+    .select({
+      id: feishuOrgInstallations.id,
+      orgId: feishuOrgInstallations.orgId,
+    })
+    .from(feishuOrgInstallations)
+    .where(eq(feishuOrgInstallations.appId, args.appId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (appOwner && appOwner.orgId !== args.orgId) {
+    return { kind: "app_in_use" };
+  }
+  if (args.installationId && appOwner && appOwner.id !== args.installationId) {
+    return { kind: "app_in_use" };
+  }
+  let targetInstallationId =
+    args.installationId ?? (args.createNew ? undefined : appOwner?.id);
+  if (!targetInstallationId) {
+    const [existingInstallation] = await db
+      .select({ id: feishuOrgInstallations.id })
+      .from(feishuOrgInstallations)
+      .where(eq(feishuOrgInstallations.orgId, args.orgId))
+      .orderBy(asc(feishuOrgInstallations.createdAt))
+      .limit(1);
+    signal.throwIfAborted();
+    if (existingInstallation && args.createNew) {
+      return { kind: "installation_exists" };
+    }
+    targetInstallationId = existingInstallation?.id;
+  }
+  if (targetInstallationId) {
+    const [installation] = await db
+      .select({ id: feishuOrgInstallations.id })
+      .from(feishuOrgInstallations)
+      .where(
+        and(
+          eq(feishuOrgInstallations.id, targetInstallationId),
+          eq(feishuOrgInstallations.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    if (!installation) {
+      return { kind: "installation_not_found" };
+    }
+  }
+  return { kind: "target", installationId: targetInstallationId };
 }
 
 export const configureFeishuInstallation$ = command(
@@ -323,62 +407,27 @@ export const configureFeishuInstallation$ = command(
     if (!agent) {
       return { kind: "agent_not_found" };
     }
-    const [appOwner] = await db
-      .select({
-        id: feishuOrgInstallations.id,
-        orgId: feishuOrgInstallations.orgId,
-      })
-      .from(feishuOrgInstallations)
-      .where(eq(feishuOrgInstallations.appId, args.appId))
-      .limit(1);
-    signal.throwIfAborted();
-    if (appOwner && appOwner.orgId !== args.orgId) {
-      return { kind: "app_in_use" };
+    const preflight = await resolveFeishuInstallationTarget(db, args, signal);
+    if (preflight.kind !== "target") {
+      return preflight;
     }
-    if (
-      args.installationId &&
-      appOwner &&
-      appOwner.id !== args.installationId
-    ) {
-      return { kind: "app_in_use" };
-    }
-    let targetInstallationId =
-      args.installationId ?? (args.createNew ? undefined : appOwner?.id);
-    if (!targetInstallationId) {
-      const [existingInstallation] = await db
-        .select({ id: feishuOrgInstallations.id })
-        .from(feishuOrgInstallations)
-        .where(eq(feishuOrgInstallations.orgId, args.orgId))
-        .orderBy(asc(feishuOrgInstallations.createdAt))
-        .limit(1);
+    const prepared = await prepareFeishuInstallation(args, signal);
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('feishu_installation:' || ${args.orgId}))`,
+      );
       signal.throwIfAborted();
-      if (existingInstallation && args.createNew) {
-        return { kind: "installation_exists" };
+      const target = await resolveFeishuInstallationTarget(tx, args, signal);
+      if (target.kind !== "target") {
+        return target;
       }
-      targetInstallationId = existingInstallation?.id;
-    }
-    if (targetInstallationId) {
-      const [installation] = await db
-        .select({ id: feishuOrgInstallations.id })
-        .from(feishuOrgInstallations)
-        .where(
-          and(
-            eq(feishuOrgInstallations.id, targetInstallationId),
-            eq(feishuOrgInstallations.orgId, args.orgId),
-          ),
-        )
-        .limit(1);
-      signal.throwIfAborted();
-      if (!installation) {
-        return { kind: "installation_not_found" };
-      }
-    }
-
-    return await persistFeishuInstallation({
-      db,
-      input: args,
-      targetInstallationId,
-      signal,
+      return await persistFeishuInstallation({
+        db: tx,
+        input: args,
+        prepared,
+        targetInstallationId: target.installationId,
+        signal,
+      });
     });
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
@@ -27,7 +27,6 @@ async function loadFeishuInstallations(db: ReadonlyDb, orgId: string) {
   return await db
     .select({
       id: feishuOrgInstallations.id,
-      ownerUserId: feishuOrgInstallations.ownerUserId,
       appId: feishuOrgInstallations.appId,
       botName: feishuOrgInstallations.botName,
       botAvatarUrl: feishuOrgInstallations.botAvatarUrl,
@@ -91,7 +90,6 @@ function toFeishuInstallationStatus(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly isAdmin: boolean;
   },
 ): FeishuInstallationStatus {
   return {
@@ -121,7 +119,6 @@ function toFeishuInstallationStatus(
       installation.defaultAgentDisplayName ??
       installation.defaultAgentName ??
       null,
-    canManage: args.isAdmin || installation.ownerUserId === args.userId,
   };
 }
 
@@ -204,7 +201,6 @@ export const feishuConnectStatus = (args: {
 interface ConfigureFeishuArgs {
   readonly orgId: string;
   readonly userId: string;
-  readonly isAdmin: boolean;
   readonly appId: string;
   readonly appSecret: string;
   readonly verificationToken: string;
@@ -219,7 +215,7 @@ export type ConfigureFeishuResult =
   | { readonly kind: "agent_not_found" }
   | { readonly kind: "installation_not_found" }
   | { readonly kind: "app_in_use" }
-  | { readonly kind: "forbidden" };
+  | { readonly kind: "installation_exists" };
 
 async function persistFeishuInstallation(args: {
   readonly db: Db;
@@ -336,7 +332,7 @@ export const configureFeishuInstallation$ = command(
       .where(eq(feishuOrgInstallations.appId, args.appId))
       .limit(1);
     signal.throwIfAborted();
-    if (appOwner && (args.createNew || appOwner.orgId !== args.orgId)) {
+    if (appOwner && appOwner.orgId !== args.orgId) {
       return { kind: "app_in_use" };
     }
     if (
@@ -346,23 +342,24 @@ export const configureFeishuInstallation$ = command(
     ) {
       return { kind: "app_in_use" };
     }
-    let targetInstallationId = args.installationId ?? appOwner?.id;
-    if (!targetInstallationId && !args.createNew) {
-      const [legacyInstallation] = await db
+    let targetInstallationId =
+      args.installationId ?? (args.createNew ? undefined : appOwner?.id);
+    if (!targetInstallationId) {
+      const [existingInstallation] = await db
         .select({ id: feishuOrgInstallations.id })
         .from(feishuOrgInstallations)
         .where(eq(feishuOrgInstallations.orgId, args.orgId))
         .orderBy(asc(feishuOrgInstallations.createdAt))
         .limit(1);
       signal.throwIfAborted();
-      targetInstallationId = legacyInstallation?.id;
+      if (existingInstallation && args.createNew) {
+        return { kind: "installation_exists" };
+      }
+      targetInstallationId = existingInstallation?.id;
     }
     if (targetInstallationId) {
       const [installation] = await db
-        .select({
-          id: feishuOrgInstallations.id,
-          ownerUserId: feishuOrgInstallations.ownerUserId,
-        })
+        .select({ id: feishuOrgInstallations.id })
         .from(feishuOrgInstallations)
         .where(
           and(
@@ -375,9 +372,6 @@ export const configureFeishuInstallation$ = command(
       if (!installation) {
         return { kind: "installation_not_found" };
       }
-      if (!args.isAdmin && installation.ownerUserId !== args.userId) {
-        return { kind: "forbidden" };
-      }
     }
 
     return await persistFeishuInstallation({
@@ -386,39 +380,6 @@ export const configureFeishuInstallation$ = command(
       targetInstallationId,
       signal,
     });
-  },
-);
-
-type FeishuInstallationManagementAccess = "allowed" | "forbidden" | "not_found";
-
-export const checkFeishuInstallationManagementAccess$ = command(
-  async (
-    { get },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly isAdmin: boolean;
-      readonly installationId: string;
-    },
-    signal: AbortSignal,
-  ): Promise<FeishuInstallationManagementAccess> => {
-    const [installation] = await get(db$)
-      .select({ ownerUserId: feishuOrgInstallations.ownerUserId })
-      .from(feishuOrgInstallations)
-      .where(
-        and(
-          eq(feishuOrgInstallations.orgId, args.orgId),
-          eq(feishuOrgInstallations.id, args.installationId),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-    if (!installation) {
-      return "not_found";
-    }
-    return args.isAdmin || installation.ownerUserId === args.userId
-      ? "allowed"
-      : "forbidden";
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
@@ -44,10 +44,9 @@ export const feishuOrgData$ = computed(
 
 export interface FeishuBotInstallation extends Omit<
   FeishuInstallationStatus,
-  "canManage" | "connectUrl" | "id" | "oauthRedirectUrl" | "setupCompleted"
+  "connectUrl" | "id" | "oauthRedirectUrl" | "setupCompleted"
 > {
   readonly id: string | null;
-  readonly canManage: boolean;
   readonly connectUrl: string | null;
   readonly oauthRedirectUrl: string | null;
   readonly setupCompleted: boolean;
@@ -62,7 +61,6 @@ export const feishuInstallations$ = computed(
       return data.installations.map((installation) => {
         return {
           ...installation,
-          canManage: installation.canManage ?? data.isAdmin,
           connectUrl: installation.connectUrl ?? null,
           oauthRedirectUrl: installation.oauthRedirectUrl ?? null,
           setupCompleted:
@@ -94,7 +92,6 @@ export const feishuInstallations$ = computed(
         tenantName: data.tenantName,
         defaultAgentId: data.defaultAgentId,
         defaultAgentName: data.defaultAgentName,
-        canManage: data.isAdmin,
       },
     ];
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -298,6 +298,7 @@ describe("works page", () => {
       screen.getByRole("img", { name: "Okou Feishu bot icon" }),
     ).toHaveAttribute("src", "https://example.com/okou-feishu.png");
     expect(screen.getByText("Connected (Feishu User)")).toBeInTheDocument();
+    expect(queryRole("button", "Add bot")).toBeNull();
     click(getRole("button", "More options for Okou Feishu"));
     expect(queryRole("button", "Manage")).toBeNull();
     expect(getRole("button", "Uninstall")).toBeInTheDocument();
@@ -318,7 +319,7 @@ describe("works page", () => {
     expect(screen.queryByText("Feishu bots")).not.toBeInTheDocument();
   });
 
-  it("shows Feishu management actions to a bot owner", async () => {
+  it("hides Feishu management actions from organization members", async () => {
     const installationId = "00000000-0000-4000-8000-000000000001";
     const agentId = "00000000-0000-4000-8000-000000000002";
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
@@ -326,28 +327,26 @@ describe("works page", () => {
       isInstalled: true,
       isAdmin: false,
       installationId,
-      appId: "cli_owner",
+      appId: "cli_member",
       callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
       callbackVerified: true,
       messageReceived: true,
-      tenantKey: "tenant-owner",
-      tenantName: "Owner bot",
+      tenantKey: "tenant-member",
+      tenantName: "Member bot",
       defaultAgentId: agentId,
       defaultAgentName: "Okou",
       installations: [
         {
           id: installationId,
           isConnected: false,
-          appId: "cli_owner",
+          appId: "cli_member",
           callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
-          connectUrl: `https://api.vm0.test/api/zero/feishu/oauth/connect?state=owner`,
           callbackVerified: true,
           messageReceived: true,
-          tenantKey: "tenant-owner",
-          tenantName: "Owner bot",
+          tenantKey: "tenant-member",
+          tenantName: "Member bot",
           defaultAgentId: agentId,
           defaultAgentName: "Okou",
-          canManage: true,
           setupCompleted: false,
         },
       ],
@@ -356,48 +355,42 @@ describe("works page", () => {
     setupWorksPage({ feishuEnabled: true });
     click(await screen.findByTestId("feishu-setup-button"));
     await expect(screen.findByText("Feishu bots")).resolves.toBeInTheDocument();
-    expect(getRole("button", "Add bot")).toBeInTheDocument();
+    expect(queryRole("button", "Add bot")).toBeNull();
     expect(screen.getByText("Setup incomplete")).toBeInTheDocument();
     expect(queryRole("link", "Connect")).toBeNull();
 
-    click(getRole("button", "More options for Owner bot"));
-    expect(getRole("button", "Manage")).toBeInTheDocument();
-    click(getRole("button", "Uninstall"));
-    expect(
-      screen.getByRole("heading", { name: "Uninstall Feishu bot?" }),
-    ).toBeInTheDocument();
+    expect(queryRole("button", "More options for Member bot")).toBeNull();
   });
 
-  it("lets a bot owner use the completed review guide without editing", async () => {
+  it("lets an organization admin use the completed review guide", async () => {
     const installationId = "00000000-0000-4000-8000-000000000001";
     const agentId = "00000000-0000-4000-8000-000000000002";
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
     mockFeishuAPI({
       isConnected: true,
       isInstalled: true,
-      isAdmin: false,
+      isAdmin: true,
       installationId,
-      appId: "cli_completed_owner",
+      appId: "cli_completed_admin",
       callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
       callbackVerified: true,
       messageReceived: true,
-      tenantKey: "tenant-owner",
-      tenantName: "Completed owner bot",
+      tenantKey: "tenant-admin",
+      tenantName: "Completed admin bot",
       defaultAgentId: agentId,
       defaultAgentName: "Okou",
       installations: [
         {
           id: installationId,
           isConnected: true,
-          appId: "cli_completed_owner",
+          appId: "cli_completed_admin",
           callbackUrl: `https://api.vm0.test/api/zero/feishu/events/${installationId}`,
           callbackVerified: true,
           messageReceived: true,
-          tenantKey: "tenant-owner",
-          tenantName: "Completed owner bot",
+          tenantKey: "tenant-admin",
+          tenantName: "Completed admin bot",
           defaultAgentId: agentId,
           defaultAgentName: "Okou",
-          canManage: true,
           setupCompleted: true,
         },
       ],
@@ -406,8 +399,9 @@ describe("works page", () => {
     setupWorksPage({ feishuEnabled: true });
     click(await screen.findByTestId("feishu-setup-button"));
     await expect(screen.findByText("Feishu bots")).resolves.toBeInTheDocument();
+    expect(queryRole("button", "Add bot")).toBeNull();
 
-    click(getRole("button", "More options for Completed owner bot"));
+    click(getRole("button", "More options for Completed admin bot"));
     expect(queryRole("button", "Manage")).toBeNull();
     expect(getRole("button", "Uninstall")).toBeInTheDocument();
     expect(getRole("button", "Disconnect")).toBeInTheDocument();
@@ -421,7 +415,7 @@ describe("works page", () => {
     ).toBeInTheDocument();
 
     click(getRole("button", "Next"));
-    expect(screen.getByLabelText("App ID")).toHaveValue("cli_completed_owner");
+    expect(screen.getByLabelText("App ID")).toHaveValue("cli_completed_admin");
     expect(screen.getByLabelText("App ID")).toBeDisabled();
     expect(screen.getByLabelText("App Secret")).toBeDisabled();
     expect(screen.getByLabelText("App Secret")).toHaveAttribute(
@@ -452,7 +446,7 @@ describe("works page", () => {
     ).toBeNull();
   });
 
-  it("only lets a connected non-owner disconnect their own account", async () => {
+  it("only lets a connected non-admin disconnect their own account", async () => {
     const installationId = "00000000-0000-4000-8000-000000000001";
     const agentId = "00000000-0000-4000-8000-000000000002";
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
@@ -481,7 +475,6 @@ describe("works page", () => {
           tenantName: "Member bot",
           defaultAgentId: agentId,
           defaultAgentName: "Okou",
-          canManage: false,
         },
       ],
     });
@@ -530,7 +523,6 @@ describe("works page", () => {
           tenantName: "Member bot",
           defaultAgentId: agentId,
           defaultAgentName: "Okou",
-          canManage: false,
         },
       ],
     });
@@ -634,9 +626,9 @@ describe("works page", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the guided Feishu custom app setup for organization members", async () => {
-    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
-    mockFeishuAPI({ isAdmin: false });
+  it("shows the guided Feishu custom app setup for organization admins", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    mockFeishuAPI({ isAdmin: true });
     setupWorksPage({ feishuEnabled: true });
 
     click(await screen.findByTestId("feishu-setup-button"));
@@ -672,8 +664,8 @@ describe("works page", () => {
   });
 
   it("rejects a registered Feishu App ID on the credentials step", async () => {
-    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
-    mockFeishuAPI({ isAdmin: false });
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    mockFeishuAPI({ isAdmin: true });
     context.mocks.api(
       zeroFeishuConnectContract.checkAppId,
       ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -1160,16 +1160,18 @@ function FeishuBotAgentSelect({
 function FeishuBotMenu({
   bot,
   title,
+  isAdmin,
 }: {
   bot: FeishuBotInstallation;
   title: string;
+  isAdmin: boolean;
 }) {
   const open = useSet(openFeishuDialog$);
   const setUninstallInstallationId = useSet(setFeishuUninstallInstallationId$);
   const [disconnectLoadable, disconnect] = useLoadableSet(disconnectFeishuOrg$);
   const signal = useGet(pageSignal$);
   const disconnecting = disconnectLoadable.state === "loading";
-  if (!bot.canManage && !bot.isConnected) {
+  if (!isAdmin && !bot.isConnected) {
     return null;
   }
   return (
@@ -1185,7 +1187,7 @@ function FeishuBotMenu({
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
-        {bot.canManage ? (
+        {isAdmin ? (
           <>
             <button
               type="button"
@@ -1234,10 +1236,12 @@ function FeishuBotRow({
   bot,
   agents,
   agentsLoading,
+  isAdmin,
 }: {
   bot: FeishuBotInstallation;
   agents: TeamComposeItem[];
   agentsLoading: boolean;
+  isAdmin: boolean;
 }) {
   const title = bot.botName ?? bot.tenantName ?? "Feishu bot";
   const connectUrl = bot.connectUrl;
@@ -1267,7 +1271,7 @@ function FeishuBotRow({
         </div>
       </div>
       <div className="flex items-center justify-end gap-1.5 sm:w-[420px]">
-        {bot.canManage ? (
+        {isAdmin ? (
           <div className="min-w-0 flex-1">
             <FeishuBotAgentSelect
               bot={bot}
@@ -1291,7 +1295,7 @@ function FeishuBotRow({
             Connect
           </Button>
         ) : null}
-        <FeishuBotMenu bot={bot} title={title} />
+        <FeishuBotMenu bot={bot} title={title} isAdmin={isAdmin} />
       </div>
     </div>
   );
@@ -1301,10 +1305,12 @@ function FeishuBotList({
   bots,
   agents,
   agentsLoading,
+  isAdmin,
 }: {
   bots: FeishuBotInstallation[];
   agents: TeamComposeItem[];
   agentsLoading: boolean;
+  isAdmin: boolean;
 }) {
   if (bots.length === 0) {
     return (
@@ -1316,7 +1322,9 @@ function FeishuBotList({
           No Feishu bots yet
         </div>
         <div className="mt-1 text-sm text-muted-foreground">
-          Add a custom app to route Feishu messages to an agent.
+          {isAdmin
+            ? "Add a custom app to route Feishu messages to an agent."
+            : "Ask an organization admin to add a Feishu bot."}
         </div>
       </div>
     );
@@ -1330,6 +1338,7 @@ function FeishuBotList({
               bot={bot}
               agents={agents}
               agentsLoading={agentsLoading}
+              isAdmin={isAdmin}
             />
             {index < bots.length - 1 ? (
               <div className="mx-5 border-b border-border/50" />
@@ -1345,31 +1354,36 @@ function FeishuBotsCard({
   bots,
   agents,
   agentsLoading,
+  isAdmin,
   onAdd,
 }: {
   bots: FeishuBotInstallation[];
   agents: TeamComposeItem[];
   agentsLoading: boolean;
+  isAdmin: boolean;
   onAdd: () => void;
 }) {
   return (
     <section className="zero-card overflow-hidden">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
         <h2 className="text-sm font-medium text-foreground">Feishu bots</h2>
-        <Button
-          type="button"
-          size="sm"
-          disabled={agentsLoading}
-          onClick={onAdd}
-        >
-          <IconPlus size={16} />
-          Add bot
-        </Button>
+        {isAdmin && bots.length === 0 ? (
+          <Button
+            type="button"
+            size="sm"
+            disabled={agentsLoading}
+            onClick={onAdd}
+          >
+            <IconPlus size={16} />
+            Add bot
+          </Button>
+        ) : null}
       </div>
       <FeishuBotList
         bots={bots}
         agents={agents}
         agentsLoading={agentsLoading}
+        isAdmin={isAdmin}
       />
     </section>
   );
@@ -1468,25 +1482,24 @@ function FeishuSettingsSkeleton() {
 
 function FeishuDialogBody({
   data,
-  canManage,
+  isAdmin,
   agents,
   orgDefaultAgentId,
   orgDefaultAgentName,
   onClose,
 }: {
   data: FeishuDialogData | null;
-  canManage: boolean;
+  isAdmin: boolean;
   agents: TeamComposeItem[];
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
   onClose: () => void;
 }) {
-  if (!canManage) {
+  if (!isAdmin) {
     return (
       <p className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        The bot owner or an organization admin must configure the app. You can
-        connect your own account from the Feishu bot list after setup is
-        complete.
+        An organization admin must configure the app. You can connect your own
+        account from the Feishu bot list after setup is complete.
       </p>
     );
   }
@@ -1505,13 +1518,13 @@ function FeishuDialogBody({
 
 function FeishuSetupDialog({
   data,
-  canManage,
+  isAdmin,
   agents,
   orgDefaultAgentId,
   orgDefaultAgentName,
 }: {
   data: FeishuDialogData | null;
-  canManage: boolean;
+  isAdmin: boolean;
   agents: TeamComposeItem[];
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
@@ -1548,7 +1561,7 @@ function FeishuSetupDialog({
         </DialogHeader>
         <FeishuDialogBody
           data={data}
-          canManage={canManage}
+          isAdmin={isAdmin}
           agents={agents}
           orgDefaultAgentId={orgDefaultAgentId}
           orgDefaultAgentName={orgDefaultAgentName}
@@ -1657,17 +1670,6 @@ function dialogFeishuBot(args: {
     : (args.bots[0] ?? null);
 }
 
-function canManageFeishuDialog(args: {
-  readonly existing: boolean;
-  readonly bot: FeishuBotInstallation | null;
-  readonly isAdmin: boolean;
-}): boolean {
-  if (!args.existing) {
-    return true;
-  }
-  return args.bot?.canManage ?? args.isAdmin;
-}
-
 function initialFeishuAgentId(
   orgDefaultAgentId: string | null,
   agents: readonly TeamComposeItem[],
@@ -1723,11 +1725,6 @@ export function ZeroFeishuSettingsPage() {
     agentsLoadable.state,
   );
   const agentsLoading = agentsLoadable.state === "loading";
-  const canManageDialog = canManageFeishuDialog({
-    existing: dialogExisting,
-    bot: dialogData,
-    isAdmin,
-  });
   const newBotAgentId = initialFeishuAgentId(orgDefaultAgentId, agents);
 
   return (
@@ -1777,6 +1774,7 @@ export function ZeroFeishuSettingsPage() {
                 bots={bots}
                 agents={agents}
                 agentsLoading={agentsLoading}
+                isAdmin={isAdmin}
                 onAdd={() => {
                   open({
                     appId: "",
@@ -1787,7 +1785,7 @@ export function ZeroFeishuSettingsPage() {
               />
               <FeishuSetupDialog
                 data={dialogData}
-                canManage={canManageDialog}
+                isAdmin={isAdmin}
                 agents={agents}
                 orgDefaultAgentId={orgDefaultAgentId}
                 orgDefaultAgentName={orgDefaultAgentName}

--- a/turbo/packages/api-contracts/src/contracts/zero-feishu-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feishu-connect.ts
@@ -22,7 +22,6 @@ const feishuInstallationStatusSchema = z.object({
   tenantName: z.string().nullable(),
   defaultAgentId: z.string().uuid(),
   defaultAgentName: z.string().nullable(),
-  canManage: z.boolean().optional(),
 });
 
 const feishuConnectStatusSchema = z.object({


### PR DESCRIPTION
## Summary

- restrict Feishu bot creation and management to organization admins
- hide Add bot after the workspace has an installation and reject a second create request
- keep member account connect/disconnect behavior and legacy setup updates compatible

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx --silent=passed-only`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
