### PR TITLE
fix(mitm-addon): ignore literal auth text in connector diagnostics

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -14,6 +14,7 @@ _DIAGNOSTIC_CANDIDATE_KEY: Final = "_diagnostic_candidate"
 _MODEL_PROVIDER_PREFIX: Final = "model-provider:"
 # Keep this regular grammar aligned with AUTH_REFERENCE_PATTERN and
 # parseBasicAuthTemplates() in the TypeScript connector contract.
+# basic() uses explicit ASCII whitespace; simple references use ECMAScript \s.
 _BASIC_TEMPLATE_WHITESPACE: Final = r"[\u0009-\u000d\u0020]"
 _SIMPLE_TEMPLATE_WHITESPACE: Final = (
     r"[\u0009-\u000d\u0020\u00a0\u1680\u2000-\u200a"

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -12,7 +12,50 @@ _DIAGNOSTIC_ANY_PERMISSION: Final = "__connector_diagnostic_any__"
 _DIAGNOSTIC_ANY_RULES: Final = ("ANY /", "ANY /{path+}")
 _DIAGNOSTIC_CANDIDATE_KEY: Final = "_diagnostic_candidate"
 _MODEL_PROVIDER_PREFIX: Final = "model-provider:"
-_REFERENCE_NAME_PATTERN: Final = re.compile(r"\b(?:secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)")
+# Keep this regular grammar aligned with AUTH_REFERENCE_PATTERN and
+# parseBasicAuthTemplates() in the TypeScript connector contract.
+_BASIC_TEMPLATE_WHITESPACE: Final = r"[\u0009-\u000d\u0020]"
+_SIMPLE_TEMPLATE_WHITESPACE: Final = (
+    r"[\u0009-\u000d\u0020\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000\ufeff]"
+)
+_TEMPLATE_IDENTIFIER: Final = r"[a-zA-Z_][a-zA-Z0-9_]*"
+_BASIC_LITERAL: Final = r'"[^"\\]*"'
+_BASIC_FIRST_REFERENCE: Final = rf"(?:secrets|vars)\.(?P<basic_first_name>{_TEMPLATE_IDENTIFIER})"
+_BASIC_SECOND_REFERENCE: Final = rf"(?:secrets|vars)\.(?P<basic_second_name>{_TEMPLATE_IDENTIFIER})"
+_BASIC_FIRST_ARGUMENT: Final = (
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*"
+    rf"(?:(?:{_BASIC_LITERAL}|{_BASIC_FIRST_REFERENCE})"
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*)?"
+)
+_BASIC_SECOND_ARGUMENT: Final = (
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*"
+    rf"(?:(?:{_BASIC_LITERAL}|{_BASIC_SECOND_REFERENCE})"
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*)?"
+)
+_BASIC_AUTH_TEMPLATE_PATTERN: Final = (
+    r"\$\{\{"
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*basic\("
+    rf"{_BASIC_FIRST_ARGUMENT},"
+    rf"{_BASIC_SECOND_ARGUMENT}\)"
+    rf"{_BASIC_TEMPLATE_WHITESPACE}*"
+    r"\}\}"
+)
+_SIMPLE_AUTH_REFERENCE_PATTERN: Final = (
+    r"\$\{\{"
+    rf"{_SIMPLE_TEMPLATE_WHITESPACE}*(?:secrets|vars)\."
+    rf"(?P<simple_name>{_TEMPLATE_IDENTIFIER})"
+    rf"{_SIMPLE_TEMPLATE_WHITESPACE}*"
+    r"\}\}"
+)
+_DIAGNOSTIC_TEMPLATE_PATTERN: Final = re.compile(
+    rf"(?:{_BASIC_AUTH_TEMPLATE_PATTERN}|{_SIMPLE_AUTH_REFERENCE_PATTERN})"
+)
+_REFERENCE_NAME_GROUPS: Final = (
+    "basic_first_name",
+    "basic_second_name",
+    "simple_name",
+)
 _SHARED_BASE_MIN_CANDIDATES: Final = 2
 
 
@@ -463,11 +506,12 @@ def _diagnostic_reference_names(value: object) -> tuple[str, ...]:
 
     def visit(nested: object) -> None:
         if isinstance(nested, str):
-            for match in _REFERENCE_NAME_PATTERN.finditer(nested):
-                name = match.group(1)
-                if name not in seen:
-                    seen.add(name)
-                    names.append(name)
+            for match in _DIAGNOSTIC_TEMPLATE_PATTERN.finditer(nested):
+                for group_name in _REFERENCE_NAME_GROUPS:
+                    name = match.group(group_name)
+                    if name is not None and name not in seen:
+                        seen.add(name)
+                        names.append(name)
             return
         if isinstance(nested, list):
             for item in nested:

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -176,6 +176,106 @@ def test_skips_static_connector_without_injectable_auth_references():
     assert candidate is None
 
 
+def test_skips_static_connector_with_reference_looking_basic_literals():
+    snapshot = _diagnostic_snapshot(
+        [
+            _firewall(
+                "literal-auth",
+                "UNUSED_TOKEN",
+                base="https://literal-auth.example.com",
+                auth={
+                    "headers": {
+                        "Authorization": '${{ basic("secrets.FAKE", "vars.FAKE") }}',
+                        "X-Bare": "secrets.BARE vars.BARE",
+                        "X-Nested": (
+                            '${{ basic("${{ secrets.NESTED_FAKE }}", "${{ vars.NESTED_FAKE }}") }}'
+                        ),
+                    }
+                },
+            )
+        ]
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
+        "https://literal-auth.example.com/items",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is None
+
+
+def test_classifies_mixed_basic_auth_with_only_real_references():
+    snapshot = _diagnostic_snapshot(
+        [
+            _firewall(
+                "mixed-auth",
+                "UNUSED_TOKEN",
+                base="https://mixed-auth.example.com",
+                auth={
+                    "headers": {
+                        "Authorization": '${{ basic("secrets.FAKE", secrets.REAL_TOKEN) }}',
+                        "X-Bare": "secrets.BARE",
+                        "X-Nested": (
+                            '${{ basic("${{ secrets.NESTED_FAKE }}", secrets.REAL_TOKEN) }}'
+                        ),
+                        "X-Second": '${{\t basic(vars.REAL_USER, "vars.FAKE") \r}}',
+                        "X-Simple": "Bearer ${{ vars.SIMPLE_VAR }}",
+                    }
+                },
+            )
+        ]
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
+        "https://mixed-auth.example.com/items",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is not None
+    assert candidate.env_names == ("REAL_TOKEN", "REAL_USER", "SIMPLE_VAR")
+
+
+def test_malformed_basic_auth_keeps_later_valid_templates_visible():
+    snapshot = _diagnostic_snapshot(
+        [
+            _firewall(
+                "malformed-auth",
+                "UNUSED_TOKEN",
+                base="https://malformed-auth.example.com",
+                auth={
+                    "headers": {
+                        "Authorization": (
+                            'prefix ${{ basic("unterminated '
+                            "${{ basic(secrets.USER, secrets.PASS) }}"
+                        ),
+                        "X-Escaped": (
+                            'prefix ${{ basic("bad '
+                            "${{ basic(secrets.USER, secrets.PASS) }}"
+                            '\\", secrets.SKIP) }}'
+                        ),
+                        "X-Long": "${{ basic(" + "\t" * 20_000,
+                        "X-Repeated": ('${{ basic("' + "\t" * 20) * 1_000,
+                    }
+                },
+            )
+        ]
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
+        "https://malformed-auth.example.com/items",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is not None
+    assert candidate.env_names == ("USER", "PASS")
+
+
 def test_model_provider_route_excludes_connector_on_same_host():
     snapshot = _diagnostic_snapshot(
         [
@@ -228,6 +328,34 @@ def test_find_candidate_suppresses_shared_base_only_candidates():
     )
 
     assert candidate is None
+
+
+def test_literal_only_connector_does_not_create_shared_base_ambiguity():
+    snapshot = _diagnostic_snapshot(
+        [
+            _firewall("credentialed", "REAL_TOKEN"),
+            _firewall(
+                "literal-only",
+                "UNUSED_TOKEN",
+                auth={
+                    "headers": {
+                        "Authorization": '${{ basic("secrets.FAKE", "fixed") }}',
+                    }
+                },
+            ),
+        ]
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is not None
+    assert candidate.connector_type == "credentialed"
+    assert candidate.env_names == ("REAL_TOKEN",)
 
 
 def test_find_candidate_selects_unique_shared_base_route_owner():


### PR DESCRIPTION
## Summary

- parse connector diagnostic auth values using the established simple-reference and `basic()` template grammar
- keep quoted `basic()` arguments opaque and ignore bare reference-looking text
- preserve malformed-template recovery and prevent literal-only connectors from affecting shared-base ownership
- add Python candidate-level regressions aligned with the existing TypeScript contract

## Scope

This change is limited to Python diagnostic catalog projection and its tests. It does not change the connector catalog API, Rust cache types, cache schema, persisted data, migrations, or request-path parsing.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_builtin_connector_diagnostics.py` — 19 passed
- `uv run --no-sync python -m pytest tests/` — 4383 passed
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-auth-base.test.ts` — 21 passed

Closes #23439
