### PR TITLE
fix: upload large attachments through r2 multipart

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -432,7 +432,31 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
 });
 
 vi.mock("@aws-sdk/client-s3", () => {
+  class AbortMultipartUploadCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  class CompleteMultipartUploadCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
   class CopyObjectCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  class CreateMultipartUploadCommand {
     readonly input: unknown;
 
     constructor(input: unknown) {
@@ -457,6 +481,14 @@ vi.mock("@aws-sdk/client-s3", () => {
   }
 
   class ListObjectsV2Command {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  class ListPartsCommand {
     readonly input: unknown;
 
     constructor(input: unknown) {
@@ -490,14 +522,27 @@ vi.mock("@aws-sdk/client-s3", () => {
     }
   }
 
+  class UploadPartCommand {
+    readonly input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
   return {
+    AbortMultipartUploadCommand,
+    CompleteMultipartUploadCommand,
     CopyObjectCommand,
+    CreateMultipartUploadCommand,
     DeleteObjectsCommand,
     GetObjectCommand,
     HeadObjectCommand,
     ListObjectsV2Command,
+    ListPartsCommand,
     PutObjectCommand,
     S3Client,
+    UploadPartCommand,
   };
 });
 

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -1,12 +1,17 @@
 import { computed, type Computed } from "ccstate";
 import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
   type GetObjectCommandOutput,
   HeadObjectCommand,
+  ListPartsCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
+  UploadPartCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import {
@@ -28,6 +33,11 @@ interface S3FileEntry {
   readonly path: string;
   readonly hash: string;
   readonly size: number;
+}
+
+interface MultipartS3Part {
+  readonly partNumber: number;
+  readonly etag: string;
 }
 
 interface S3StorageManifest {
@@ -455,6 +465,113 @@ export function generatePresignedPutUrl(
     contentType,
     expiresIn,
   );
+}
+
+export function createMultipartS3Upload(
+  bucket: string,
+  key: string,
+  contentType: string,
+): Computed<Promise<string>> {
+  return computed(async (get): Promise<string> => {
+    const client = get(s3ClientForBucket(bucket));
+    const response = await client.send(
+      new CreateMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        ContentType: contentType,
+      }),
+    );
+    if (!response.UploadId) {
+      throw new Error("R2 did not return a multipart upload ID");
+    }
+    return response.UploadId;
+  });
+}
+
+export function generatePresignedUploadPartUrl(
+  bucket: string,
+  key: string,
+  uploadId: string,
+  partNumber: number,
+  expiresIn: number,
+): Computed<Promise<string>> {
+  return computed((get): Promise<string> => {
+    const client = get(s3ClientForBucket(bucket, true));
+    return getSignedUrl(
+      client,
+      new UploadPartCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+        PartNumber: partNumber,
+      }),
+      { expiresIn },
+    );
+  });
+}
+
+export function listMultipartS3Parts(
+  bucket: string,
+  key: string,
+  uploadId: string,
+): Computed<Promise<readonly MultipartS3Part[]>> {
+  return computed(async (get): Promise<readonly MultipartS3Part[]> => {
+    const client = get(s3ClientForBucket(bucket));
+    const response = await client.send(
+      new ListPartsCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+        MaxParts: 1000,
+      }),
+    );
+    return (response.Parts ?? []).map((part) => {
+      if (part.PartNumber === undefined || part.ETag === undefined) {
+        throw new Error("R2 returned incomplete multipart part metadata");
+      }
+      return { partNumber: part.PartNumber, etag: part.ETag };
+    });
+  });
+}
+
+export function completeMultipartS3Upload(
+  bucket: string,
+  key: string,
+  uploadId: string,
+  parts: readonly MultipartS3Part[],
+): Computed<Promise<void>> {
+  return computed(async (get): Promise<void> => {
+    const client = get(s3ClientForBucket(bucket));
+    await client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+        MultipartUpload: {
+          Parts: parts.map((part) => {
+            return { ETag: part.etag, PartNumber: part.partNumber };
+          }),
+        },
+      }),
+    );
+  });
+}
+
+export function abortMultipartS3Upload(
+  bucket: string,
+  key: string,
+  uploadId: string,
+): Computed<Promise<void>> {
+  return computed(async (get): Promise<void> => {
+    const client = get(s3ClientForBucket(bucket));
+    await client.send(
+      new AbortMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+      }),
+    );
+  });
 }
 
 function generatePresignedPutUrlWithClient(

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -87,6 +87,7 @@ function createS3Client(
     endpoint,
     credentials,
     forcePathStyle: env("S3_FORCE_PATH_STYLE") === "true",
+    requestChecksumCalculation: "WHEN_REQUIRED",
   });
 }
 

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -183,6 +183,7 @@ import { zeroTeamsOauthRoutes } from "./routes/zero-teams-oauth";
 import { zeroTeamRoutes } from "./routes/zero-team";
 import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsImportImageRoutes } from "./routes/zero-uploads-import-image";
+import { zeroUploadsMultipartRoutes } from "./routes/zero-uploads-multipart";
 import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
 import { zeroUsageInsightRoutes } from "./routes/zero-usage-insight";
 import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
@@ -388,6 +389,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsImportImageRoutes,
+  ...zeroUploadsMultipartRoutes,
   ...zeroUploadsPrepareRoutes,
   ...registryResourceDownloadRoutes,
   ...zeroUsageInsightRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -752,7 +752,9 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
       contentType: "text/plain",
       size: 12,
     });
-    expect(prepared.uploadUrl).toMatch(/^https?:\/\//);
+    expect("uploadUrl" in prepared ? prepared.uploadUrl : "").toMatch(
+      /^https?:\/\//,
+    );
     expect(prepared.url).toContain(`/artifacts/${actor.userId}/`);
 
     api.mockCompletedUploadObject(actor, prepared.id, "notes.txt", 12);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
@@ -106,6 +106,48 @@ describe("multipart user artifact uploads", () => {
     expect(response.body).not.toHaveProperty("multipart");
   });
 
+  it("aborts the multipart session when the API owner is cancelled after creation", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    const controller = new AbortController();
+    const abortError = new Error("API owner cancelled multipart preparation");
+    abortError.name = "AbortError";
+    const ownerContext = {
+      mocks: context.mocks,
+      sessionHistoryBlobs: context.sessionHistoryBlobs,
+      signal: controller.signal,
+    };
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command?.constructor.name === "CreateMultipartUploadCommand") {
+        controller.abort(abortError);
+        return Promise.resolve({ UploadId: "multipart-upload-cancelled" });
+      }
+      return Promise.resolve({});
+    });
+
+    const response = await setupApp({ context: ownerContext })(
+      zeroUploadsContract,
+    ).prepare({
+      body: {
+        filename: "cancelled.mp4",
+        contentType: "video/mp4",
+        size: 5 * 1024 * 1024,
+        multipart: true,
+      },
+      headers: authHeaders(),
+    });
+
+    expect(response.status).toBe(500);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.send.mock.calls[1]?.[0]).toMatchObject({
+      input: {
+        Bucket: "test-user-artifacts",
+        UploadId: "multipart-upload-cancelled",
+      },
+    });
+  });
+
   it("lists uploaded parts and completes the multipart upload", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-multipart.test.ts
@@ -1,0 +1,210 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+function apiClient() {
+  return setupApp({ context })(zeroUploadsContract);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+describe("multipart user artifact uploads", () => {
+  it("prepares 5 MiB parts for a large upload", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command?.constructor.name === "CreateMultipartUploadCommand") {
+        return Promise.resolve({ UploadId: "multipart-upload-1" });
+      }
+      return Promise.resolve({});
+    });
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      (_client: unknown, command: unknown) => {
+        if (
+          typeof command === "object" &&
+          command !== null &&
+          "input" in command &&
+          typeof command.input === "object" &&
+          command.input !== null &&
+          "PartNumber" in command.input
+        ) {
+          return Promise.resolve(
+            `https://r2.example.com/part-${String(command.input.PartNumber)}`,
+          );
+        }
+        return Promise.resolve("https://r2.example.com/upload");
+      },
+    );
+
+    const response = await accept(
+      apiClient().prepare({
+        body: {
+          filename: "recording.mp4",
+          contentType: "video/mp4",
+          size: 20 * 1024 * 1024,
+          multipart: true,
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      filename: "recording.mp4",
+      contentType: "video/mp4",
+      size: 20 * 1024 * 1024,
+      multipart: {
+        uploadId: "multipart-upload-1",
+        partSize: 5 * 1024 * 1024,
+        parts: [
+          { partNumber: 1, uploadUrl: "https://r2.example.com/part-1" },
+          { partNumber: 2, uploadUrl: "https://r2.example.com/part-2" },
+          { partNumber: 3, uploadUrl: "https://r2.example.com/part-3" },
+          { partNumber: 4, uploadUrl: "https://r2.example.com/part-4" },
+        ],
+      },
+    });
+    expect(context.mocks.s3.send.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        Bucket: "test-user-artifacts",
+        ContentType: "video/mp4",
+      },
+    });
+  });
+
+  it("keeps the legacy single PUT response for small multipart requests", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const response = await accept(
+      apiClient().prepare({
+        body: {
+          filename: "small.mp4",
+          contentType: "video/mp4",
+          size: 5 * 1024 * 1024 - 1,
+          multipart: true,
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      uploadUrl: "https://r2.example.com/upload?sig=test",
+    });
+    expect(response.body).not.toHaveProperty("multipart");
+  });
+
+  it("lists uploaded parts and completes the multipart upload", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command?.constructor.name === "ListPartsCommand") {
+        return Promise.resolve({
+          Parts: [
+            { PartNumber: 1, ETag: '"etag-1"' },
+            { PartNumber: 2, ETag: '"etag-2"' },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const response = await accept(
+      apiClient().completeMultipart({
+        body: {
+          id: "3a513aef-a376-49c4-8f15-61f7e8e40526",
+          filename: "my recording.mp4",
+          uploadId: "multipart-upload-1",
+          partCount: 2,
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: "3a513aef-a376-49c4-8f15-61f7e8e40526",
+      url: `https://cdn.vm7.io/artifacts/${userId}/3a513aef-a376-49c4-8f15-61f7e8e40526/my_recording.mp4`,
+    });
+    expect(context.mocks.s3.send.mock.calls[1]?.[0]).toMatchObject({
+      input: {
+        Bucket: "test-user-artifacts",
+        UploadId: "multipart-upload-1",
+        MultipartUpload: {
+          Parts: [
+            { PartNumber: 1, ETag: '"etag-1"' },
+            { PartNumber: 2, ETag: '"etag-2"' },
+          ],
+        },
+      },
+    });
+  });
+
+  it("rejects completion when an uploaded part is missing", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockResolvedValue({
+      Parts: [{ PartNumber: 1, ETag: '"etag-1"' }],
+    });
+
+    const response = await accept(
+      apiClient().completeMultipart({
+        body: {
+          id: "857873df-23b7-47e8-8273-4bf9014b5dbe",
+          filename: "recording.mp4",
+          uploadId: "multipart-upload-2",
+          partCount: 2,
+        },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe("Multipart upload is incomplete");
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts an unfinished multipart upload", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const response = await accept(
+      apiClient().abortMultipart({
+        body: {
+          id: "ba428dc9-af58-4785-b45f-bbed9633ecde",
+          filename: "my recording.mp4",
+          uploadId: "multipart-upload-3",
+        },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      id: "ba428dc9-af58-4785-b45f-bbed9633ecde",
+    });
+    expect(context.mocks.s3.send.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        Bucket: "test-user-artifacts",
+        Key: `artifacts/${userId}/ba428dc9-af58-4785-b45f-bbed9633ecde/my_recording.mp4`,
+        UploadId: "multipart-upload-3",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -279,6 +279,7 @@ describe("POST /api/zero/uploads/prepare", () => {
       },
       region: "auto",
       forcePathStyle: false,
+      requestChecksumCalculation: "WHEN_REQUIRED",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -66,7 +66,9 @@ describe("POST /api/zero/uploads/prepare", () => {
     if (response.status !== 200) {
       return;
     }
-    expect(response.body.uploadUrl).toMatch(/^https?:\/\//);
+    expect("uploadUrl" in response.body ? response.body.uploadUrl : "").toMatch(
+      /^https?:\/\//,
+    );
     expect(response.body.url).toMatch(/^https?:\/\//);
     expect(response.body.id).toMatch(/^[0-9a-f-]{36}$/);
   });
@@ -146,7 +148,9 @@ describe("POST /api/zero/uploads/prepare", () => {
       contentType: "text/plain",
       size: 13,
     });
-    expect(response.body.uploadUrl).toMatch(/^https?:\/\//);
+    expect("uploadUrl" in response.body ? response.body.uploadUrl : "").toMatch(
+      /^https?:\/\//,
+    );
     expect(response.body.url).toBe(
       `https://cdn.vm7.io/artifacts/${userId}/${response.body.id}/hello.txt`,
     );

--- a/turbo/apps/api/src/signals/routes/zero-uploads-multipart.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-multipart.ts
@@ -1,0 +1,110 @@
+import { command } from "ccstate";
+import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+
+import { env } from "../../lib/env";
+import { badRequestMessage } from "../../lib/error";
+import {
+  buildArtifactKey,
+  buildFileUrl,
+  sanitizeArtifactFilename,
+} from "../../lib/file-url";
+import { authContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import {
+  abortMultipartS3Upload,
+  completeMultipartS3Upload,
+  listMultipartS3Parts,
+} from "../external/s3";
+import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
+import type { RouteEntry } from "../route-entry";
+
+const completeMultipartInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const bodyResult = await get(
+      bodyResultOf(zeroUploadsContract.completeMultipart),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    if (auth.orgId) {
+      const suspended = await set(rejectSuspendedOrg$, auth.orgId, signal);
+      if (suspended) {
+        return suspended;
+      }
+    }
+
+    const { id, filename, uploadId, partCount } = bodyResult.data;
+    const sanitizedName = sanitizeArtifactFilename(filename);
+    const key = buildArtifactKey(auth.userId, id, sanitizedName);
+    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    const parts = await get(listMultipartS3Parts(bucket, key, uploadId));
+    signal.throwIfAborted();
+    const completePartSet =
+      parts.length === partCount &&
+      parts.every((part, index) => {
+        return part.partNumber === index + 1;
+      });
+    if (!completePartSet) {
+      return badRequestMessage("Multipart upload is incomplete");
+    }
+
+    await get(completeMultipartS3Upload(bucket, key, uploadId, parts));
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        id,
+        url: buildFileUrl(auth.userId, id, sanitizedName),
+      },
+    };
+  },
+);
+
+const abortMultipartInner$ = command(async ({ get }, signal: AbortSignal) => {
+  const auth = get(authContext$);
+  const bodyResult = await get(
+    bodyResultOf(zeroUploadsContract.abortMultipart),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const { id, filename, uploadId } = bodyResult.data;
+  const key = buildArtifactKey(
+    auth.userId,
+    id,
+    sanitizeArtifactFilename(filename),
+  );
+  await get(
+    abortMultipartS3Upload(env("R2_USER_ARTIFACTS_BUCKET_NAME"), key, uploadId),
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { id },
+  };
+});
+
+export const zeroUploadsMultipartRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroUploadsContract.completeMultipart,
+    handler: authRoute(
+      { requiredCapability: "file:write" },
+      completeMultipartInner$,
+    ),
+  },
+  {
+    route: zeroUploadsContract.abortMultipart,
+    handler: authRoute(
+      { requiredCapability: "file:write" },
+      abortMultipartInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -67,13 +67,14 @@ const prepareUploadInner$ = command(
       bodyResult.data.multipart === true &&
       size >= MULTIPART_PART_SIZE_BYTES
     ) {
-      const uploadId = await get(
-        createMultipartS3Upload(bucket, s3Key, contentType),
-      );
-      signal.throwIfAborted();
-      const partCount = Math.ceil(size / MULTIPART_PART_SIZE_BYTES);
-      const parts = await onRejection(
+      let uploadId: string | undefined;
+      return await onRejection(
         (async () => {
+          uploadId = await get(
+            createMultipartS3Upload(bucket, s3Key, contentType),
+          );
+          signal.throwIfAborted();
+          const partCount = Math.ceil(size / MULTIPART_PART_SIZE_BYTES);
           const signedParts: {
             partNumber: number;
             uploadUrl: string;
@@ -91,29 +92,30 @@ const prepareUploadInner$ = command(
             signal.throwIfAborted();
             signedParts.push({ partNumber, uploadUrl });
           }
-          return signedParts;
+          return {
+            status: 200 as const,
+            body: {
+              id,
+              filename,
+              contentType,
+              size,
+              url,
+              multipart: {
+                uploadId,
+                partSize: MULTIPART_PART_SIZE_BYTES,
+                parts: signedParts,
+              },
+            },
+          };
         })(),
         async () => {
-          await tapError(get(abortMultipartS3Upload(bucket, s3Key, uploadId)));
+          if (uploadId !== undefined) {
+            await tapError(
+              get(abortMultipartS3Upload(bucket, s3Key, uploadId)),
+            );
+          }
         },
       );
-      signal.throwIfAborted();
-
-      return {
-        status: 200 as const,
-        body: {
-          id,
-          filename,
-          contentType,
-          size,
-          url,
-          multipart: {
-            uploadId,
-            partSize: MULTIPART_PART_SIZE_BYTES,
-            parts,
-          },
-        },
-      };
     }
 
     const uploadUrl = await get(

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -16,11 +16,18 @@ import {
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { generatePresignedPutUrl } from "../external/s3";
+import {
+  abortMultipartS3Upload,
+  createMultipartS3Upload,
+  generatePresignedPutUrl,
+  generatePresignedUploadPartUrl,
+} from "../external/s3";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
+import { onRejection, tapError } from "../utils";
 
 const PUT_URL_TTL_SECONDS = 3600;
+const MULTIPART_PART_SIZE_BYTES = 5 * 1024 * 1024;
 
 const prepareUploadInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -54,6 +61,60 @@ const prepareUploadInner$ = command(
     const sanitizedName = sanitizeArtifactFilename(filename);
     const s3Key = buildArtifactKey(auth.userId, id, sanitizedName);
     const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    const url = buildFileUrl(auth.userId, id, sanitizedName);
+
+    if (
+      bodyResult.data.multipart === true &&
+      size >= MULTIPART_PART_SIZE_BYTES
+    ) {
+      const uploadId = await get(
+        createMultipartS3Upload(bucket, s3Key, contentType),
+      );
+      signal.throwIfAborted();
+      const partCount = Math.ceil(size / MULTIPART_PART_SIZE_BYTES);
+      const parts = await onRejection(
+        (async () => {
+          const signedParts: {
+            partNumber: number;
+            uploadUrl: string;
+          }[] = [];
+          for (let partNumber = 1; partNumber <= partCount; partNumber += 1) {
+            const uploadUrl = await get(
+              generatePresignedUploadPartUrl(
+                bucket,
+                s3Key,
+                uploadId,
+                partNumber,
+                PUT_URL_TTL_SECONDS,
+              ),
+            );
+            signal.throwIfAborted();
+            signedParts.push({ partNumber, uploadUrl });
+          }
+          return signedParts;
+        })(),
+        async () => {
+          await tapError(get(abortMultipartS3Upload(bucket, s3Key, uploadId)));
+        },
+      );
+      signal.throwIfAborted();
+
+      return {
+        status: 200 as const,
+        body: {
+          id,
+          filename,
+          contentType,
+          size,
+          url,
+          multipart: {
+            uploadId,
+            partSize: MULTIPART_PART_SIZE_BYTES,
+            parts,
+          },
+        },
+      };
+    }
 
     const uploadUrl = await get(
       generatePresignedPutUrl(
@@ -65,7 +126,6 @@ const prepareUploadInner$ = command(
       ),
     );
     signal.throwIfAborted();
-    const url = buildFileUrl(auth.userId, id, sanitizedName);
 
     return {
       status: 200 as const,

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -32,6 +32,37 @@ interface FileInfo {
 const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
 const MAX_PART_UPLOAD_ATTEMPTS = 5;
 const PART_UPLOAD_RETRY_BASE_DELAY_MS = 250;
+const MULTIPART_ABORT_TIMEOUT_MS = 5000;
+
+interface MultipartUploadReference {
+  id: string;
+  filename: string;
+  uploadId: string;
+}
+
+const abortMultipartUpload$ = command(
+  async (
+    { get },
+    upload: MultipartUploadReference,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(zeroUploadsContract);
+    await tapError(
+      accept(
+        client.abortMultipart({
+          body: upload,
+          fetchOptions: {
+            keepalive: true,
+            signal,
+          },
+        }),
+        [200],
+        signal,
+        { showErrorToast: false },
+      ),
+    );
+  },
+);
 
 function uploadContentTypeByExtension(ext: string): string | undefined {
   const contentTypeByExtension: Record<string, string | undefined> = {
@@ -213,12 +244,12 @@ function createChatAttachment(file: File): ZeroChatAttachment {
         }),
         [200],
       );
-      signal.throwIfAborted();
 
       if ("multipart" in prepared.body) {
         const multipart = prepared.body.multipart;
         return await onRejection(
           (async () => {
+            signal.throwIfAborted();
             for (const part of multipart.parts) {
               const start = (part.partNumber - 1) * multipart.partSize;
               const end = Math.min(start + multipart.partSize, file.size);
@@ -246,23 +277,23 @@ function createChatAttachment(file: File): ZeroChatAttachment {
             return completed.body;
           })(),
           async () => {
-            await tapError(
-              accept(
-                client.abortMultipart({
-                  body: {
-                    id: prepared.body.id,
-                    filename: prepared.body.filename,
-                    uploadId: multipart.uploadId,
-                  },
-                  fetchOptions: { signal: parentSignal },
-                }),
-                [200],
-              ),
+            const cleanupSignal = AbortSignal.timeout(
+              MULTIPART_ABORT_TIMEOUT_MS,
+            );
+            await set(
+              abortMultipartUpload$,
+              {
+                id: prepared.body.id,
+                filename: prepared.body.filename,
+                uploadId: multipart.uploadId,
+              },
+              cleanupSignal,
             );
           },
         );
       }
 
+      signal.throwIfAborted();
       const putRes = await fetch(prepared.body.uploadUrl, {
         method: "PUT",
         body: file,

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -6,9 +6,11 @@ import {
   type Computed,
   type State,
 } from "ccstate";
+import { delay } from "signal-timers";
 import { onRejection, resetSignal, settle, tapError } from "../utils.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
+import { IN_VITEST } from "../../env.ts";
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
@@ -28,7 +30,8 @@ interface FileInfo {
 }
 
 const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
-const MAX_PART_UPLOAD_ATTEMPTS = 3;
+const MAX_PART_UPLOAD_ATTEMPTS = 5;
+const PART_UPLOAD_RETRY_BASE_DELAY_MS = 250;
 
 function uploadContentTypeByExtension(ext: string): string | undefined {
   const contentTypeByExtension: Record<string, string | undefined> = {
@@ -151,6 +154,10 @@ async function uploadPartWithRetry(
     } else if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
       throw result.error;
     }
+    await delay(
+      IN_VITEST ? 0 : PART_UPLOAD_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+      { signal },
+    );
   }
   throw new Error("Multipart upload retry loop ended unexpectedly");
 }

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -6,7 +6,7 @@ import {
   type Computed,
   type State,
 } from "ccstate";
-import { resetSignal, tapError } from "../utils.ts";
+import { onRejection, resetSignal, settle, tapError } from "../utils.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import type {
@@ -26,6 +26,9 @@ interface FileInfo {
   id: string;
   url: string;
 }
+
+const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
+const MAX_PART_UPLOAD_ATTEMPTS = 3;
 
 function uploadContentTypeByExtension(ext: string): string | undefined {
   const contentTypeByExtension: Record<string, string | undefined> = {
@@ -120,6 +123,38 @@ function inferUploadContentType(file: File): string {
     : "application/octet-stream";
 }
 
+async function uploadPartWithRetry(
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+  signal: AbortSignal,
+): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_PART_UPLOAD_ATTEMPTS; attempt += 1) {
+    const result = await settle(
+      fetch(uploadUrl, {
+        method: "PUT",
+        body,
+        headers: { "content-type": contentType },
+        signal,
+      }),
+      signal,
+    );
+    if (result.ok) {
+      if (result.value.ok) {
+        return;
+      }
+      if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
+        throw new Error(
+          `storage returned ${result.value.status} ${result.value.statusText}`,
+        );
+      }
+    } else if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
+      throw result.error;
+    }
+  }
+  throw new Error("Multipart upload retry loop ended unexpectedly");
+}
+
 export interface ZeroChatAttachment {
   filename: string;
   contentType: string;
@@ -155,15 +190,17 @@ function createChatAttachment(file: File): ZeroChatAttachment {
     const signal = set(resetSignal$, parentSignal);
 
     const promise = (async () => {
-      // Step 1: ask the server to sign a PUT URL for R2. The file body never
-      // travels through the Next.js runtime, which lets us exceed Vercel's
-      // serverless body cap and next dev's multipart parser limits.
+      // Step 1: ask the server to sign either one PUT URL or retryable R2
+      // multipart URLs. The file body never travels through the app runtime.
       const prepared = await accept(
         client.prepare({
           body: {
             filename: file.name,
             contentType,
             size: file.size,
+            ...(file.size >= MULTIPART_UPLOAD_THRESHOLD_BYTES
+              ? { multipart: true as const }
+              : {}),
           },
           fetchOptions: { signal },
         }),
@@ -171,13 +208,61 @@ function createChatAttachment(file: File): ZeroChatAttachment {
       );
       signal.throwIfAborted();
 
+      if ("multipart" in prepared.body) {
+        const multipart = prepared.body.multipart;
+        return await onRejection(
+          (async () => {
+            for (const part of multipart.parts) {
+              const start = (part.partNumber - 1) * multipart.partSize;
+              const end = Math.min(start + multipart.partSize, file.size);
+              await uploadPartWithRetry(
+                part.uploadUrl,
+                file.slice(start, end, prepared.body.contentType),
+                prepared.body.contentType,
+                signal,
+              );
+            }
+
+            const completed = await accept(
+              client.completeMultipart({
+                body: {
+                  id: prepared.body.id,
+                  filename: prepared.body.filename,
+                  uploadId: multipart.uploadId,
+                  partCount: multipart.parts.length,
+                },
+                fetchOptions: { signal },
+              }),
+              [200],
+            );
+            signal.throwIfAborted();
+            return completed.body;
+          })(),
+          async () => {
+            await tapError(
+              accept(
+                client.abortMultipart({
+                  body: {
+                    id: prepared.body.id,
+                    filename: prepared.body.filename,
+                    uploadId: multipart.uploadId,
+                  },
+                  fetchOptions: { signal: parentSignal },
+                }),
+                [200],
+              ),
+            );
+          },
+        );
+      }
+
       const putRes = await fetch(prepared.body.uploadUrl, {
         method: "PUT",
         body: file,
         headers: { "content-type": prepared.body.contentType },
         signal,
       });
-      parentSignal.throwIfAborted();
+      signal.throwIfAborted();
 
       if (!putRes.ok) {
         throw new Error(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1058,6 +1058,244 @@ describe("chat drafts", () => {
     });
   });
 
+  it("uploads large attachments in retryable R2 parts", async () => {
+    const user = userEvent.setup({ delay: null });
+    const preparedBodies: unknown[] = [];
+    const uploadedPartSizes: number[] = [];
+    let firstPartAttempts = 0;
+    let completeBody: unknown = null;
+
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.http.post(
+      "*/api/zero/uploads/prepare",
+      async ({ request }) => {
+        preparedBodies.push(await request.json());
+        return HttpResponse.json({
+          id: "f58e50a2-5546-4ac9-8713-13443e726241",
+          filename: "recording.mp4",
+          contentType: "video/mp4",
+          size: 5 * 1024 * 1024 + 1,
+          url: "https://example.com/recording.mp4",
+          multipart: {
+            uploadId: "multipart-upload-1",
+            partSize: 5 * 1024 * 1024,
+            parts: [
+              {
+                partNumber: 1,
+                uploadUrl: "https://mock-upload.example.com/recording-part-1",
+              },
+              {
+                partNumber: 2,
+                uploadUrl: "https://mock-upload.example.com/recording-part-2",
+              },
+            ],
+          },
+        });
+      },
+    );
+    context.mocks.http.put(
+      "https://mock-upload.example.com/recording-part-1",
+      async ({ request }) => {
+        firstPartAttempts += 1;
+        if (firstPartAttempts === 1) {
+          return new HttpResponse(null, { status: 503 });
+        }
+        uploadedPartSizes.push((await request.arrayBuffer()).byteLength);
+        return new HttpResponse(null, { status: 200 });
+      },
+    );
+    context.mocks.http.put(
+      "https://mock-upload.example.com/recording-part-2",
+      async ({ request }) => {
+        uploadedPartSizes.push((await request.arrayBuffer()).byteLength);
+        return new HttpResponse(null, { status: 200 });
+      },
+    );
+    context.mocks.http.post(
+      "*/api/zero/uploads/multipart/complete",
+      async ({ request }) => {
+        completeBody = await request.json();
+        return HttpResponse.json({
+          id: "f58e50a2-5546-4ac9-8713-13443e726241",
+          url: "https://example.com/recording.mp4",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_UPLOADS_ID}` });
+
+    await waitFor(() => {
+      expect(textarea()).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File([new Uint8Array(5 * 1024 * 1024 + 1)], "recording.mp4", {
+        type: "video/mp4",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Remove recording.mp4")).toBeInTheDocument();
+      expect(preparedBodies).toStrictEqual([
+        {
+          filename: "recording.mp4",
+          contentType: "video/mp4",
+          size: 5 * 1024 * 1024 + 1,
+          multipart: true,
+        },
+      ]);
+      expect(firstPartAttempts).toBe(2);
+      expect(uploadedPartSizes).toStrictEqual([5 * 1024 * 1024, 1]);
+      expect(completeBody).toStrictEqual({
+        id: "f58e50a2-5546-4ac9-8713-13443e726241",
+        filename: "recording.mp4",
+        uploadId: "multipart-upload-1",
+        partCount: 2,
+      });
+    });
+  });
+
+  it("falls back to a legacy single PUT response during API rollout", async () => {
+    const user = userEvent.setup({ delay: null });
+    let prepareBody: unknown = null;
+    let uploadedSize = 0;
+
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.http.post(
+      "*/api/zero/uploads/prepare",
+      async ({ request }) => {
+        prepareBody = await request.json();
+        return HttpResponse.json({
+          id: "3b649e8a-c608-4355-a7d9-12e21af26df5",
+          filename: "legacy.mp4",
+          contentType: "video/mp4",
+          size: 5 * 1024 * 1024 + 1,
+          uploadUrl: "https://mock-upload.example.com/legacy.mp4",
+          url: "https://example.com/legacy.mp4",
+        });
+      },
+    );
+    context.mocks.http.put(
+      "https://mock-upload.example.com/legacy.mp4",
+      async ({ request }) => {
+        uploadedSize = (await request.arrayBuffer()).byteLength;
+        return new HttpResponse(null, { status: 200 });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_UPLOADS_ID}` });
+
+    await waitFor(() => {
+      expect(textarea()).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File([new Uint8Array(5 * 1024 * 1024 + 1)], "legacy.mp4", {
+        type: "video/mp4",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Remove legacy.mp4")).toBeInTheDocument();
+      expect(prepareBody).toMatchObject({ multipart: true });
+      expect(uploadedSize).toBe(5 * 1024 * 1024 + 1);
+    });
+  });
+
+  it("aborts multipart storage after the final part retry fails", async () => {
+    const user = userEvent.setup({ delay: null });
+    let partAttempts = 0;
+    let abortBody: unknown = null;
+
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.http.post("*/api/zero/uploads/prepare", () => {
+      return HttpResponse.json({
+        id: "8d70fdfa-2eb4-4a32-a2e2-635799804ad6",
+        filename: "failed-recording.mp4",
+        contentType: "video/mp4",
+        size: 5 * 1024 * 1024 + 1,
+        url: "https://example.com/failed-recording.mp4",
+        multipart: {
+          uploadId: "multipart-upload-failed",
+          partSize: 5 * 1024 * 1024,
+          parts: [
+            {
+              partNumber: 1,
+              uploadUrl:
+                "https://mock-upload.example.com/failed-recording-part-1",
+            },
+            {
+              partNumber: 2,
+              uploadUrl:
+                "https://mock-upload.example.com/failed-recording-part-2",
+            },
+          ],
+        },
+      });
+    });
+    context.mocks.http.put(
+      "https://mock-upload.example.com/failed-recording-part-1",
+      () => {
+        partAttempts += 1;
+        return new HttpResponse(null, { status: 503 });
+      },
+    );
+    context.mocks.http.post(
+      "*/api/zero/uploads/multipart/abort",
+      async ({ request }) => {
+        abortBody = await request.json();
+        return HttpResponse.json({
+          id: "8d70fdfa-2eb4-4a32-a2e2-635799804ad6",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_UPLOADS_ID}` });
+
+    await waitFor(() => {
+      expect(textarea()).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File([new Uint8Array(5 * 1024 * 1024 + 1)], "failed-recording.mp4", {
+        type: "video/mp4",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to upload failed-recording.mp4"),
+      ).toBeInTheDocument();
+      expect(partAttempts).toBe(3);
+      expect(abortBody).toStrictEqual({
+        id: "8d70fdfa-2eb4-4a32-a2e2-635799804ad6",
+        filename: "failed-recording.mp4",
+        uploadId: "multipart-upload-failed",
+      });
+    });
+  });
+
   it("infers attachment content type when the browser reports a generic file type", async () => {
     const user = userEvent.setup({ delay: null });
     let capturedPrepareBody: unknown = null;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -17,6 +17,7 @@ import {
 import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { resetSignal } from "../../../signals/utils.ts";
 import {
   click,
   detachedSetupPage as baseDetachedSetupPage,
@@ -1292,6 +1293,103 @@ describe("chat drafts", () => {
         id: "8d70fdfa-2eb4-4a32-a2e2-635799804ad6",
         filename: "failed-recording.mp4",
         uploadId: "multipart-upload-failed",
+      });
+    });
+  });
+
+  it("aborts multipart storage when the upload owner is cancelled", async () => {
+    const user = userEvent.setup({ delay: null });
+    const resetUploadOwnerSignal$ = resetSignal();
+    const ownerSignal = context.store.set(
+      resetUploadOwnerSignal$,
+      context.signal,
+    );
+    const ownerContext = {
+      mocks: context.mocks,
+      signal: ownerSignal,
+      store: context.store,
+    };
+    const partStarted = context.mocks.deferred<void>();
+    let abortBody: unknown = null;
+    let abortRequestWasCancelled = true;
+
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-sonnet-4-6",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+    mockThreadDetails();
+    context.mocks.http.post("*/api/zero/uploads/prepare", () => {
+      return HttpResponse.json({
+        id: "6eb9fa2a-c5ec-4a6a-afbf-a28939735454",
+        filename: "cancelled-recording.mp4",
+        contentType: "video/mp4",
+        size: 5 * 1024 * 1024 + 1,
+        url: "https://example.com/cancelled-recording.mp4",
+        multipart: {
+          uploadId: "multipart-upload-cancelled",
+          partSize: 5 * 1024 * 1024,
+          parts: [
+            {
+              partNumber: 1,
+              uploadUrl:
+                "https://mock-upload.example.com/cancelled-recording-part-1",
+            },
+            {
+              partNumber: 2,
+              uploadUrl:
+                "https://mock-upload.example.com/cancelled-recording-part-2",
+            },
+          ],
+        },
+      });
+    });
+    context.mocks.http.put(
+      "https://mock-upload.example.com/cancelled-recording-part-1",
+      ({ deferred }) => {
+        partStarted.resolve();
+        return deferred<Response>().promise;
+      },
+    );
+    context.mocks.http.post(
+      "*/api/zero/uploads/multipart/abort",
+      async ({ request }) => {
+        abortRequestWasCancelled = request.signal.aborted;
+        abortBody = await request.json();
+        return HttpResponse.json({
+          id: "6eb9fa2a-c5ec-4a6a-afbf-a28939735454",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context: ownerContext,
+      path: `/chats/${THREAD_UPLOADS_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(textarea()).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(
+        [new Uint8Array(5 * 1024 * 1024 + 1)],
+        "cancelled-recording.mp4",
+        { type: "video/mp4" },
+      ),
+    );
+    await partStarted.promise;
+
+    context.store.set(resetUploadOwnerSignal$);
+
+    await waitFor(() => {
+      expect(abortRequestWasCancelled).toBeFalsy();
+      expect(abortBody).toStrictEqual({
+        id: "6eb9fa2a-c5ec-4a6a-afbf-a28939735454",
+        filename: "cancelled-recording.mp4",
+        uploadId: "multipart-upload-cancelled",
       });
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1287,7 +1287,7 @@ describe("chat drafts", () => {
       expect(
         screen.getByText("Failed to upload failed-recording.mp4"),
       ).toBeInTheDocument();
-      expect(partAttempts).toBe(3);
+      expect(partAttempts).toBe(5);
       expect(abortBody).toStrictEqual({
         id: "8d70fdfa-2eb4-4a32-a2e2-635799804ad6",
         filename: "failed-recording.mp4",

--- a/turbo/packages/api-contracts/src/contracts/zero-uploads.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-uploads.ts
@@ -12,21 +12,67 @@ const prepareRequestSchema = z.object({
   filename: z.string().min(1).max(255),
   contentType: z.string().min(1).max(200),
   size: z.number().int().nonnegative(),
+  /**
+   * New clients request multipart uploads for large files. Older API
+   * deployments ignore this unknown field and return the legacy single PUT
+   * response, which keeps frontend/backend rolling deploys compatible.
+   */
+  multipart: z.literal(true).optional(),
 });
 
 const importImageRequestSchema = z.object({
   url: z.string().url(),
 });
 
-const prepareResponseSchema = z.object({
+const uploadMetadataSchema = z.object({
   id: z.string(),
   filename: z.string(),
   contentType: z.string(),
   size: z.number(),
-  /** Presigned PUT URL — browser uploads the file body here directly. */
-  uploadUrl: z.string().url(),
   /** Public CDN URL returned to the app after upload succeeds. */
   url: z.string().url(),
+});
+
+const prepareResponseSchema = uploadMetadataSchema.extend({
+  /** Presigned PUT URL — browser uploads the file body here directly. */
+  uploadUrl: z.string().url(),
+});
+
+const multipartUploadPartSchema = z.object({
+  partNumber: z.number().int().positive(),
+  uploadUrl: z.string().url(),
+});
+
+const multipartPrepareResponseSchema = uploadMetadataSchema.extend({
+  multipart: z.object({
+    uploadId: z.string().min(1),
+    partSize: z.number().int().positive(),
+    parts: z.array(multipartUploadPartSchema).min(1),
+  }),
+});
+
+const prepareResultSchema = z.union([
+  prepareResponseSchema,
+  multipartPrepareResponseSchema,
+]);
+
+const multipartUploadIdentitySchema = z.object({
+  id: z.string().uuid(),
+  filename: z.string().min(1).max(255),
+  uploadId: z.string().min(1),
+});
+
+const multipartCompleteRequestSchema = multipartUploadIdentitySchema.extend({
+  partCount: z.number().int().min(1).max(1000),
+});
+
+const multipartResponseSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string().url(),
+});
+
+const multipartAbortResponseSchema = z.object({
+  id: z.string().uuid(),
 });
 
 const completeRequestSchema = z.object({
@@ -61,7 +107,7 @@ export const zeroUploadsContract = c.router({
     headers: authHeadersSchema,
     body: prepareRequestSchema,
     responses: {
-      200: prepareResponseSchema,
+      200: prepareResultSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       402: apiErrorSchema,
@@ -69,6 +115,35 @@ export const zeroUploadsContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Prepare a direct-to-R2 upload",
+  },
+  completeMultipart: {
+    method: "POST",
+    path: "/api/zero/uploads/multipart/complete",
+    headers: authHeadersSchema,
+    body: multipartCompleteRequestSchema,
+    responses: {
+      200: multipartResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      402: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Complete a multipart R2 upload",
+  },
+  abortMultipart: {
+    method: "POST",
+    path: "/api/zero/uploads/multipart/abort",
+    headers: authHeadersSchema,
+    body: multipartUploadIdentitySchema,
+    responses: {
+      200: multipartAbortResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Abort a multipart R2 upload",
   },
   complete: {
     method: "POST",
@@ -107,6 +182,6 @@ export const zeroUploadsContract = c.router({
 export type ZeroUploadsContract = typeof zeroUploadsContract;
 
 // Inferred types
-export type UploadPrepareResponse = z.infer<typeof prepareResponseSchema>;
+export type UploadPrepareResponse = z.infer<typeof prepareResultSchema>;
 export type UploadCompleteResponse = z.infer<typeof completeResponseSchema>;
 export type UploadImportImageResponse = z.infer<typeof completeResponseSchema>;


### PR DESCRIPTION
## Summary

- upload attachments at least 5 MiB through presigned R2 multipart uploads
- retry each 5 MiB part up to five times with exponential backoff and abort incomplete uploads on failure or cancellation
- disable optional AWS SDK request checksums so presigned upload URLs do not contain an empty CRC32 value
- preserve rolling-deploy compatibility with the legacy single-PUT response and request shape

## Validation

- completed and deleted a real 5 MiB + 1 byte multipart object in the development R2 bucket
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-uploads-multipart.test.ts src/signals/routes/__tests__/zero-uploads-prepare.test.ts src/signals/routes/__tests__/chat-files.bdd.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-draft.test.tsx --silent=passed-only`
- affected API and Platform lint and type checks
- Knip and pre-commit checks
