### PR TITLE
test(python): cover compatibility-mapped tld billing

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -448,6 +448,7 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
         "Accent mañana.com",
         "Sharp S faß.de",
         "Fullwidth compatibility \uff26\uff2f\uff2f.com",
+        "Fullwidth terminal example.\uff23\uff2f\uff2d",
     ],
 )
 def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_flow, text):
@@ -482,6 +483,7 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
         "Fullwidth mention \uff20twitter.com",
         "Fullwidth tag \uff03twitter.com",
         "Plus suffix example.com+tag",
+        "Fullwidth terminal plus suffix example.\uff23\uff2f\uff2d+tag",
         "At suffix example.com@user",
         "Hyphen suffix example.com-tag",
         "ASCII suffix example.comuser",


### PR DESCRIPTION
## Summary

- cover a compatibility-mapped fullwidth terminal TLD at a valid boundary through the X connector usage flow
- cover the same terminal label followed by an invalid direct `+` boundary
- preserve the existing conservative billing behavior without changing production code

## Scope

- test-only change in the X connector write-flow matrix
- no API, protocol, dependency, persisted-data, migration, deployment-order, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py` — 92 passed
- `uv run --no-sync python -m pytest tests/` — 4,382 passed

Closes #23441
