### PR TITLE
fix(ci): retry cloudflare ssh preconnections

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -8,6 +8,10 @@ inputs:
   ssh-hosts:
     description: "Comma-separated metal runner hosts to pre-connect"
     required: true
+  require-all-hosts:
+    description: "Fail setup unless every SSH host pre-connects"
+    required: false
+    default: "true"
   ssh-key:
     description: "SSH private key for metal runner"
     required: true
@@ -102,4 +106,5 @@ runs:
       env:
         SSH_USER: ${{ inputs.ssh-user }}
         SSH_HOSTS: ${{ inputs.ssh-hosts }}
-      run: bash "$GITHUB_WORKSPACE/.github/scripts/cloudflare-ssh-preconnect.sh" "$SSH_USER" "$SSH_HOSTS"
+        REQUIRE_ALL_HOSTS: ${{ inputs.require-all-hosts }}
+      run: bash "$GITHUB_WORKSPACE/.github/scripts/cloudflare-ssh-preconnect.sh" "$SSH_USER" "$SSH_HOSTS" "$REQUIRE_ALL_HOSTS"

--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -2,6 +2,12 @@ name: "Setup SSH via Cloudflare Tunnel"
 description: "Install cloudflared and configure SSH to proxy through Cloudflare Tunnel"
 
 inputs:
+  ssh-user:
+    description: "SSH user for metal runner hosts"
+    required: true
+  ssh-hosts:
+    description: "Comma-separated metal runner hosts to pre-connect"
+    required: true
   ssh-key:
     description: "SSH private key for metal runner"
     required: true
@@ -75,6 +81,9 @@ runs:
           "  TCPKeepAlive yes" \
           "  IPQoS throughput" \
           "  IdentityFile $HOME/.ssh/runner.pem" \
+          "  ControlMaster auto" \
+          "  ControlPath $HOME/.ssh/vm0-ssh-%C" \
+          "  ControlPersist 600s" \
           "  ProxyCommand $HOME/.ssh/cf-proxy.sh %h")"
 
         # Write to system config so all SSH clients (ssh, scp, ansible) read it
@@ -85,3 +94,10 @@ runs:
           mkdir -p /etc/ssh/ssh_config.d
           echo "$SSH_CONFIG" > /etc/ssh/ssh_config.d/tunnel.conf
         fi
+
+    - name: Establish replay-safe SSH transport
+      shell: bash
+      env:
+        SSH_USER: ${{ inputs.ssh-user }}
+        SSH_HOSTS: ${{ inputs.ssh-hosts }}
+      run: bash "$GITHUB_WORKSPACE/.github/scripts/cloudflare-ssh-preconnect.sh" "$SSH_USER" "$SSH_HOSTS"

--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -71,13 +71,15 @@ runs:
 
         # Cloudflare Access setup and the origin SSH banner share this timeout.
         # ConnectionAttempts does not restart an active ProxyCommand.
+        # The shared master preserves the native SSH 15-second keepalive
+        # cadence and Ansible's existing 300-second missed-response tolerance.
         SSH_CONFIG="$(printf '%s\n' \
           "Host *.vm3.ai" \
           "  StrictHostKeyChecking no" \
           "  UserKnownHostsFile /dev/null" \
           "  ConnectTimeout 30" \
           "  ServerAliveInterval 15" \
-          "  ServerAliveCountMax 4" \
+          "  ServerAliveCountMax 20" \
           "  TCPKeepAlive yes" \
           "  IPQoS throughput" \
           "  IdentityFile $HOME/.ssh/runner.pem" \

--- a/.github/scripts/cloudflare-ssh-preconnect.sh
+++ b/.github/scripts/cloudflare-ssh-preconnect.sh
@@ -17,9 +17,19 @@ fi
 
 TEMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 TEMP_DIR=$(mktemp -d "${TEMP_ROOT%/}/cloudflare-ssh-preconnect.XXXXXX")
+connected_targets=()
 
 cleanup() {
+  local status=$?
+  local target
+  trap - EXIT
+  if [ "$status" -ne 0 ]; then
+    for target in "${connected_targets[@]}"; do
+      ssh -n -O exit "$target" > /dev/null 2>&1 || true
+    done
+  fi
   rm -rf "$TEMP_DIR"
+  exit "$status"
 }
 trap cleanup EXIT
 
@@ -74,6 +84,7 @@ preconnect_host() {
       GITHUB_STEP_SUMMARY="$summary_file" \
         ssh -n -O check "$target" 2>> "$stderr_file" || status=$?
       if [ "$status" -eq 0 ]; then
+        connected_targets+=("$target")
         echo "Established replay-safe SSH transport to ${host}"
         return 0
       fi

--- a/.github/scripts/cloudflare-ssh-preconnect.sh
+++ b/.github/scripts/cloudflare-ssh-preconnect.sh
@@ -3,15 +3,21 @@ set -euo pipefail
 
 SSH_USER="${1:-}"
 SSH_HOSTS="${2:-}"
+REQUIRE_ALL_HOSTS="${3:-true}"
 MAX_ATTEMPTS=3
 
 if [ -z "$SSH_USER" ] || [ -z "$SSH_HOSTS" ]; then
-  echo "Usage: $0 <ssh-user> <ssh-hosts>" >&2
+  echo "Usage: $0 <ssh-user> <ssh-hosts> [require-all-hosts]" >&2
   exit 2
 fi
 
 if [[ ! "$SSH_USER" =~ ^[A-Za-z0-9._-]+$ ]]; then
   echo "Invalid SSH user: ${SSH_USER}" >&2
+  exit 2
+fi
+
+if [ "$REQUIRE_ALL_HOSTS" != "true" ] && [ "$REQUIRE_ALL_HOSTS" != "false" ]; then
+  echo "require-all-hosts must be true or false" >&2
   exit 2
 fi
 
@@ -57,8 +63,13 @@ emit_failure() {
   local host="$1"
   local reason="$2"
   local diagnostics_file="$3"
+  local annotation="error"
 
-  echo "::error title=Cloudflare SSH preconnection failed::Unable to establish replay-safe SSH transport to ${host}: ${reason}" >&2
+  if [ "$REQUIRE_ALL_HOSTS" = "false" ]; then
+    annotation="warning"
+  fi
+
+  echo "::${annotation} title=Cloudflare SSH preconnection failed::Unable to establish replay-safe SSH transport to ${host}: ${reason}" >&2
   if [ -s "$diagnostics_file" ]; then
     echo "----- SSH preconnection stderr (last 20 lines, redacted) -----" >&2
     redact_diagnostics "$diagnostics_file" \
@@ -130,5 +141,10 @@ while IFS= read -r host; do
     continue
   fi
   seen_hosts[$host_key]=1
-  preconnect_host "$host"
+
+  preconnect_status=0
+  preconnect_host "$host" || preconnect_status=$?
+  if [ "$preconnect_status" -ne 0 ] && [ "$REQUIRE_ALL_HOSTS" = "true" ]; then
+    exit "$preconnect_status"
+  fi
 done <<< "$host_lines"

--- a/.github/scripts/cloudflare-ssh-preconnect.sh
+++ b/.github/scripts/cloudflare-ssh-preconnect.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SSH_USER="${1:-}"
+SSH_HOSTS="${2:-}"
+MAX_ATTEMPTS=3
+
+if [ -z "$SSH_USER" ] || [ -z "$SSH_HOSTS" ]; then
+  echo "Usage: $0 <ssh-user> <ssh-hosts>" >&2
+  exit 2
+fi
+
+if [[ ! "$SSH_USER" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "Invalid SSH user: ${SSH_USER}" >&2
+  exit 2
+fi
+
+TEMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+TEMP_DIR=$(mktemp -d "${TEMP_ROOT%/}/cloudflare-ssh-preconnect.XXXXXX")
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+redact_diagnostics() {
+  local file="$1"
+  sed -E \
+    -e 's/(--secret(=|[[:space:]]+))[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(--id(=|[[:space:]]+))[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(CF_ACCESS_CLIENT_SECRET=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(CF_ACCESS_CLIENT_ID=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(TUNNEL_SERVICE_TOKEN_SECRET=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(TUNNEL_SERVICE_TOKEN_ID=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(Authorization:[[:space:]]*Bearer[[:space:]]+)[^[:space:]]+/\1[redacted]/Ig' \
+    "$file"
+}
+
+is_permanent_failure() {
+  local file="$1"
+  grep -Eiq \
+    "Permission denied|Host key verification failed|REMOTE HOST IDENTIFICATION HAS CHANGED|Bad configuration option|Unsupported option|no such identity|Identity file .* not accessible|Could not open a connection to your authentication agent|Cloudflare Access credentials rejected|Cloudflare Access SSH not configured|cloudflared is not installed" \
+    "$file"
+}
+
+emit_failure() {
+  local host="$1"
+  local reason="$2"
+  local diagnostics_file="$3"
+
+  echo "::error title=Cloudflare SSH preconnection failed::Unable to establish replay-safe SSH transport to ${host}: ${reason}" >&2
+  if [ -s "$diagnostics_file" ]; then
+    echo "----- SSH preconnection stderr (last 20 lines, redacted) -----" >&2
+    redact_diagnostics "$diagnostics_file" \
+      | sed -E 's/^::(error|warning)( title=[^:]*)?:://' \
+      | tail -n 20 >&2
+  fi
+}
+
+preconnect_host() {
+  local host="$1"
+  local target="${SSH_USER}@${host}"
+  local attempt stderr_file summary_file status
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    stderr_file="${TEMP_DIR}/${host}.${attempt}.stderr"
+    summary_file="${TEMP_DIR}/${host}.${attempt}.summary"
+    status=0
+
+    GITHUB_STEP_SUMMARY="$summary_file" \
+      ssh -n -M -N -f "$target" 2> "$stderr_file" || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      GITHUB_STEP_SUMMARY="$summary_file" \
+        ssh -n -O check "$target" 2>> "$stderr_file" || status=$?
+      if [ "$status" -eq 0 ]; then
+        echo "Established replay-safe SSH transport to ${host}"
+        return 0
+      fi
+
+      GITHUB_STEP_SUMMARY="$summary_file" \
+        ssh -n -O exit "$target" >> "$stderr_file" 2>&1 || true
+    fi
+
+    if [ "$status" -ne 255 ] || is_permanent_failure "$stderr_file"; then
+      emit_failure "$host" "permanent connection failure (exit ${status})" "$stderr_file"
+      return "$status"
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      emit_failure "$host" "retry limit reached after ${MAX_ATTEMPTS} attempts" "$stderr_file"
+      return "$status"
+    fi
+
+    echo "::warning title=Retrying Cloudflare SSH preconnection::Transient SSH transport failure for ${host} on attempt ${attempt}/${MAX_ATTEMPTS}; retrying before any remote command is submitted" >&2
+    sleep "$attempt"
+  done
+}
+
+host_lines=$(printf '%s\n' "$SSH_HOSTS" \
+  | tr ',' '\n' \
+  | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+  | sed '/^$/d')
+
+if [ -z "$host_lines" ]; then
+  echo "No SSH hosts configured" >&2
+  exit 2
+fi
+
+declare -A seen_hosts=()
+while IFS= read -r host; do
+  if [[ ! "$host" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$ ]]; then
+    echo "Invalid SSH host: ${host}" >&2
+    exit 2
+  fi
+
+  host_key=${host,,}
+  if [ -n "${seen_hosts[$host_key]+x}" ]; then
+    continue
+  fi
+  seen_hosts[$host_key]=1
+  preconnect_host "$host"
+done <<< "$host_lines"

--- a/.github/scripts/cloudflare-ssh-proxy.sh
+++ b/.github/scripts/cloudflare-ssh-proxy.sh
@@ -22,7 +22,7 @@ if [ -z "${CF_ACCESS_CLIENT_ID:-}" ] || [ -z "${CF_ACCESS_CLIENT_SECRET:-}" ]; t
 fi
 
 DOMAIN="${CF_TUNNEL_DOMAIN:-vm3.ai}"
-SUB="${HOST%.${DOMAIN}}"
+SUB="${HOST%."${DOMAIN}"}"
 TUNNEL_HOST="${SUB//./-}-ssh.${DOMAIN}"
 CLOUDFLARED_BIN="${CLOUDFLARED_BIN:-cloudflared}"
 LOG_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
@@ -45,6 +45,8 @@ redact_cloudflared_log() {
     -e 's/(--id(=|[[:space:]]+))[^[:space:]]+/\1[redacted]/g' \
     -e 's/(CF_ACCESS_CLIENT_SECRET=)[^[:space:]]+/\1[redacted]/g' \
     -e 's/(CF_ACCESS_CLIENT_ID=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(TUNNEL_SERVICE_TOKEN_SECRET=)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/(TUNNEL_SERVICE_TOKEN_ID=)[^[:space:]]+/\1[redacted]/g' \
     -e 's/(Authorization:[[:space:]]*Bearer[[:space:]]+)[^[:space:]]+/\1[redacted]/Ig' \
     "$LOG_FILE"
 }
@@ -172,10 +174,10 @@ trap 'handle_signal INT 130' INT
 trap 'handle_signal TERM 143' TERM
 
 status=0
-"$CLOUDFLARED_BIN" access ssh \
+TUNNEL_SERVICE_TOKEN_ID="$CF_ACCESS_CLIENT_ID" \
+  TUNNEL_SERVICE_TOKEN_SECRET="$CF_ACCESS_CLIENT_SECRET" \
+  "$CLOUDFLARED_BIN" access ssh \
   --hostname "$TUNNEL_HOST" \
-  --id "$CF_ACCESS_CLIENT_ID" \
-  --secret "$CF_ACCESS_CLIENT_SECRET" \
   <&0 2> "$LOG_FILE" &
 cloudflared_pid=$!
 wait "$cloudflared_pid" || status=$?

--- a/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
@@ -127,6 +127,12 @@ case "$FAKE_SSH_SCENARIO" in
     ;;
   check-failure-success)
     ;;
+  partial-failure)
+    if [[ "$*" == *"metal@dev-11.gcp.aws.vm3.ai"* ]]; then
+      echo "Permission denied (publickey)." >&2
+      exit 255
+    fi
+    ;;
   *)
     echo "unexpected fake SSH scenario: $FAKE_SSH_SCENARIO" >&2
     exit 2
@@ -220,6 +226,14 @@ if [ -e "$tmp/permanent/outer-summary" ]; then
   exit 1
 fi
 assert_runner_temp_empty "$tmp/permanent/runner-temp"
+
+run_case partial-failure partial-failure "dev-1.aws.vm3.ai,dev-11.gcp.aws.vm3.ai"
+assert_contains "$tmp/partial-failure/status" "255"
+assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -O check metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -M -N -f metal@dev-11.gcp.aws.vm3.ai"
+assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -O exit metal@dev-1.aws.vm3.ai"
+assert_runner_temp_empty "$tmp/partial-failure/runner-temp"
 
 run_case exhaustion exhaustion "dev-1.aws.vm3.ai"
 assert_contains "$tmp/exhaustion/status" "255"

--- a/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
@@ -153,6 +153,7 @@ run_case() {
   local name="$1"
   local scenario="$2"
   local hosts="$3"
+  local require_all_hosts="${4:-true}"
   local case_dir="$tmp/$name"
 
   mkdir -p "$case_dir/state" "$case_dir/runner-temp"
@@ -167,7 +168,7 @@ run_case() {
   FAKE_SLEEP_INVOCATIONS="$case_dir/sleep-invocations" \
   GITHUB_STEP_SUMMARY="$case_dir/outer-summary" \
   RUNNER_TEMP="$case_dir/runner-temp" \
-  bash "$PRECONNECT" metal "$hosts" \
+  bash "$PRECONNECT" metal "$hosts" "$require_all_hosts" \
     > "$case_dir/stdout" 2> "$case_dir/stderr" || status=$?
 
   printf '%s\n' "$status" > "$case_dir/status"
@@ -234,6 +235,19 @@ assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -O check metal@de
 assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -M -N -f metal@dev-11.gcp.aws.vm3.ai"
 assert_line_count "$tmp/partial-failure/ssh-invocations" 1 "-n -O exit metal@dev-1.aws.vm3.ai"
 assert_runner_temp_empty "$tmp/partial-failure/runner-temp"
+
+run_case partial-best-effort partial-failure "dev-1.aws.vm3.ai,dev-11.gcp.aws.vm3.ai,dev-2.aws.vm3.ai" false
+assert_contains "$tmp/partial-best-effort/status" "0"
+assert_contains "$tmp/partial-best-effort/stderr" "::warning title=Cloudflare SSH preconnection failed::"
+assert_not_contains "$tmp/partial-best-effort/stderr" "::error"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 1 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 1 "-n -O check metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 1 "-n -M -N -f metal@dev-11.gcp.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 1 "-n -M -N -f metal@dev-2.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 1 "-n -O check metal@dev-2.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 0 "-n -O exit metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/partial-best-effort/ssh-invocations" 0 "-n -O exit metal@dev-2.aws.vm3.ai"
+assert_runner_temp_empty "$tmp/partial-best-effort/runner-temp"
 
 run_case exhaustion exhaustion "dev-1.aws.vm3.ai"
 assert_contains "$tmp/exhaustion/status" "255"

--- a/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
@@ -261,6 +261,10 @@ fi
 assert_runner_temp_empty "$tmp/multiple/runner-temp"
 
 assert_contains "$SSH_ACTION" "ControlPath \$HOME/.ssh/vm0-ssh-%C"
+assert_contains "$SSH_ACTION" "ServerAliveInterval 15"
+assert_contains "$SSH_ACTION" "ServerAliveCountMax 20"
 assert_contains "$ANSIBLE_CONFIG" 'control_path = ~/.ssh/vm0-ssh-%%C'
+assert_contains "$ANSIBLE_CONFIG" "ServerAliveInterval=15"
+assert_contains "$ANSIBLE_CONFIG" "ServerAliveCountMax=20"
 
 echo "cloudflare-ssh-preconnect-test: ok"

--- a/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PRECONNECT="$REPO_ROOT/.github/scripts/cloudflare-ssh-preconnect.sh"
+SSH_ACTION="$REPO_ROOT/.github/actions/setup-ssh-tunnel/action.yml"
+ANSIBLE_CONFIG="$REPO_ROOT/ansible/ansible.cfg"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "expected ${file} to contain: ${expected}" >&2
+    echo "--- ${file} ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    echo "expected ${file} not to contain: ${unexpected}" >&2
+    echo "--- ${file} ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_line_count() {
+  local file="$1"
+  local expected="$2"
+  local pattern="$3"
+  local actual
+  actual=$(grep -Fxc -- "$pattern" "$file" || true)
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${file} to contain ${expected} exact line(s): ${pattern}; got ${actual}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_runner_temp_empty() {
+  local dir="$1"
+  if find "$dir" -mindepth 1 -print -quit | grep -q .; then
+    echo "expected runner temp to be empty: ${dir}" >&2
+    find "$dir" -mindepth 1 -maxdepth 2 -print >&2
+    exit 1
+  fi
+}
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+
+fake_ssh="$fake_bin/ssh"
+cat > "$fake_ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_SSH_INVOCATIONS"
+
+if [[ " $* " == *" -O check "* ]]; then
+  check_count_file="$FAKE_SSH_STATE_DIR/check-count"
+  check_count=0
+  if [ -f "$check_count_file" ]; then
+    check_count=$(<"$check_count_file")
+  fi
+  check_count=$((check_count + 1))
+  printf '%s\n' "$check_count" > "$check_count_file"
+  if [ "$FAKE_SSH_SCENARIO" = "check-failure-success" ] && [ "$check_count" -eq 1 ]; then
+    echo "Control socket connect failed: Connection refused" >&2
+    exit 255
+  fi
+  echo "Master running"
+  exit 0
+fi
+
+if [[ " $* " == *" -O exit "* ]]; then
+  exit 0
+fi
+
+count_file="$FAKE_SSH_STATE_DIR/master-count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(<"$count_file")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+
+case "$FAKE_SSH_SCENARIO" in
+  transient-success)
+    if [ "$count" -eq 1 ]; then
+      echo "Connection closed by UNKNOWN port 65535 --secret super-secret" >&2
+      echo "TUNNEL_SERVICE_TOKEN_ID=client-id" >&2
+      if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "intermediate failure" >> "$GITHUB_STEP_SUMMARY"
+      fi
+      exit 255
+    fi
+    ;;
+  permanent)
+    echo "Permission denied (publickey)." >&2
+    echo "TUNNEL_SERVICE_TOKEN_SECRET=super-secret" >&2
+    echo "TUNNEL_SERVICE_TOKEN_ID=client-id" >&2
+    echo "::error title=Cloudflare Access credentials rejected::Access denied for TUNNEL_SERVICE_TOKEN_ID=client-id" >&2
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo "permanent failure" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    exit 255
+    ;;
+  exhaustion)
+    echo "Connection reset by peer --secret super-secret --id client-id" >&2
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo "transient failure" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    exit 255
+    ;;
+  success)
+    ;;
+  check-failure-success)
+    ;;
+  *)
+    echo "unexpected fake SSH scenario: $FAKE_SSH_SCENARIO" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$fake_ssh"
+
+fake_sleep="$fake_bin/sleep"
+cat > "$fake_sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_SLEEP_INVOCATIONS"
+EOF
+chmod +x "$fake_sleep"
+
+run_case() {
+  local name="$1"
+  local scenario="$2"
+  local hosts="$3"
+  local case_dir="$tmp/$name"
+
+  mkdir -p "$case_dir/state" "$case_dir/runner-temp"
+  : > "$case_dir/ssh-invocations"
+  : > "$case_dir/sleep-invocations"
+
+  local status=0
+  PATH="$fake_bin:$PATH" \
+  FAKE_SSH_INVOCATIONS="$case_dir/ssh-invocations" \
+  FAKE_SSH_SCENARIO="$scenario" \
+  FAKE_SSH_STATE_DIR="$case_dir/state" \
+  FAKE_SLEEP_INVOCATIONS="$case_dir/sleep-invocations" \
+  GITHUB_STEP_SUMMARY="$case_dir/outer-summary" \
+  RUNNER_TEMP="$case_dir/runner-temp" \
+  bash "$PRECONNECT" metal "$hosts" \
+    > "$case_dir/stdout" 2> "$case_dir/stderr" || status=$?
+
+  printf '%s\n' "$status" > "$case_dir/status"
+}
+
+run_case transient transient-success "dev-1.aws.vm3.ai"
+assert_contains "$tmp/transient/status" "0"
+assert_contains "$tmp/transient/stdout" "Established replay-safe SSH transport to dev-1.aws.vm3.ai"
+assert_contains "$tmp/transient/stderr" "::warning title=Retrying Cloudflare SSH preconnection::"
+assert_not_contains "$tmp/transient/stderr" "::error"
+assert_not_contains "$tmp/transient/stderr" "super-secret"
+assert_not_contains "$tmp/transient/stderr" "client-id"
+assert_line_count "$tmp/transient/ssh-invocations" 2 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/transient/ssh-invocations" 1 "-n -O check metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/transient/sleep-invocations" 1 "1"
+if [ -e "$tmp/transient/outer-summary" ]; then
+  echo "expected recovered attempt not to write the job summary" >&2
+  cat "$tmp/transient/outer-summary" >&2
+  exit 1
+fi
+assert_runner_temp_empty "$tmp/transient/runner-temp"
+
+run_case check-failure check-failure-success "dev-1.aws.vm3.ai"
+assert_contains "$tmp/check-failure/status" "0"
+assert_contains "$tmp/check-failure/stderr" "::warning title=Retrying Cloudflare SSH preconnection::"
+assert_not_contains "$tmp/check-failure/stderr" "::error"
+assert_line_count "$tmp/check-failure/ssh-invocations" 2 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/check-failure/ssh-invocations" 2 "-n -O check metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/check-failure/ssh-invocations" 1 "-n -O exit metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/check-failure/sleep-invocations" 1 "1"
+assert_runner_temp_empty "$tmp/check-failure/runner-temp"
+
+run_case permanent permanent "dev-1.aws.vm3.ai"
+assert_contains "$tmp/permanent/status" "255"
+assert_contains "$tmp/permanent/stderr" "::error title=Cloudflare SSH preconnection failed::"
+assert_contains "$tmp/permanent/stderr" "permanent connection failure"
+assert_contains "$tmp/permanent/stderr" "Permission denied (publickey)."
+assert_contains "$tmp/permanent/stderr" "TUNNEL_SERVICE_TOKEN_SECRET=[redacted]"
+assert_contains "$tmp/permanent/stderr" "Access denied for TUNNEL_SERVICE_TOKEN_ID=[redacted]"
+assert_not_contains "$tmp/permanent/stderr" "super-secret"
+assert_not_contains "$tmp/permanent/stderr" "client-id"
+if [ "$(grep -c '^::error' "$tmp/permanent/stderr")" -ne 1 ]; then
+  echo "expected one final error annotation for a permanent failure" >&2
+  cat "$tmp/permanent/stderr" >&2
+  exit 1
+fi
+assert_line_count "$tmp/permanent/ssh-invocations" 1 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+if [ -s "$tmp/permanent/sleep-invocations" ]; then
+  echo "expected a permanent failure not to sleep" >&2
+  cat "$tmp/permanent/sleep-invocations" >&2
+  exit 1
+fi
+if [ -e "$tmp/permanent/outer-summary" ]; then
+  echo "expected permanent attempt diagnostics to stay out of the job summary" >&2
+  cat "$tmp/permanent/outer-summary" >&2
+  exit 1
+fi
+assert_runner_temp_empty "$tmp/permanent/runner-temp"
+
+run_case exhaustion exhaustion "dev-1.aws.vm3.ai"
+assert_contains "$tmp/exhaustion/status" "255"
+assert_contains "$tmp/exhaustion/stderr" "retry limit reached after 3 attempts"
+assert_contains "$tmp/exhaustion/stderr" "--secret [redacted]"
+assert_contains "$tmp/exhaustion/stderr" "--id [redacted]"
+assert_not_contains "$tmp/exhaustion/stderr" "super-secret"
+assert_not_contains "$tmp/exhaustion/stderr" "client-id"
+assert_line_count "$tmp/exhaustion/ssh-invocations" 3 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/exhaustion/sleep-invocations" 1 "1"
+assert_line_count "$tmp/exhaustion/sleep-invocations" 1 "2"
+assert_runner_temp_empty "$tmp/exhaustion/runner-temp"
+
+run_case multiple success $' dev-1.aws.vm3.ai,dev-11.gcp.aws.vm3.ai\nDEV-1.AWS.VM3.AI '
+assert_contains "$tmp/multiple/status" "0"
+assert_line_count "$tmp/multiple/ssh-invocations" 1 "-n -M -N -f metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/multiple/ssh-invocations" 1 "-n -O check metal@dev-1.aws.vm3.ai"
+assert_line_count "$tmp/multiple/ssh-invocations" 1 "-n -M -N -f metal@dev-11.gcp.aws.vm3.ai"
+assert_line_count "$tmp/multiple/ssh-invocations" 1 "-n -O check metal@dev-11.gcp.aws.vm3.ai"
+if grep -Fq "DEV-1.AWS.VM3.AI" "$tmp/multiple/ssh-invocations"; then
+  echo "expected duplicate hosts to be pre-connected once" >&2
+  cat "$tmp/multiple/ssh-invocations" >&2
+  exit 1
+fi
+assert_runner_temp_empty "$tmp/multiple/runner-temp"
+
+assert_contains "$SSH_ACTION" "ControlPath \$HOME/.ssh/vm0-ssh-%C"
+assert_contains "$ANSIBLE_CONFIG" 'control_path = ~/.ssh/vm0-ssh-%%C'
+
+echo "cloudflare-ssh-preconnect-test: ok"

--- a/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-proxy-test.sh
@@ -52,10 +52,14 @@ trap cleanup EXIT
 home_success="$tmp/home-success"
 make_home "$home_success"
 args_file="$tmp/cloudflared.args"
+env_file="$tmp/cloudflared.env"
 success_cloudflared="$tmp/cloudflared-success"
 cat > "$success_cloudflared" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$FAKE_ARGS_FILE"
+printf 'TUNNEL_SERVICE_TOKEN_ID=%s\nTUNNEL_SERVICE_TOKEN_SECRET=%s\n' \
+  "$TUNNEL_SERVICE_TOKEN_ID" "$TUNNEL_SERVICE_TOKEN_SECRET" \
+  > "$FAKE_ENV_FILE"
 IFS= read -r input
 printf 'proxied: %s\n' "$input"
 exit 0
@@ -65,11 +69,16 @@ chmod +x "$success_cloudflared"
 HOME="$home_success" \
 CLOUDFLARED_BIN="$success_cloudflared" \
 FAKE_ARGS_FILE="$args_file" \
+FAKE_ENV_FILE="$env_file" \
 "$PROXY" dev-1.aws.vm3.ai <<< "SSH-2.0-test-client" > "$tmp/success.out" 2> "$tmp/success.err"
 
 assert_contains "$args_file" "--hostname dev-1-aws-ssh.vm3.ai"
-assert_contains "$args_file" "--id client-id"
-assert_contains "$args_file" "--secret super-secret"
+assert_not_contains "$args_file" "--id"
+assert_not_contains "$args_file" "--secret"
+assert_not_contains "$args_file" "client-id"
+assert_not_contains "$args_file" "super-secret"
+assert_contains "$env_file" "TUNNEL_SERVICE_TOKEN_ID=client-id"
+assert_contains "$env_file" "TUNNEL_SERVICE_TOKEN_SECRET=super-secret"
 assert_contains "$tmp/success.out" "proxied: SSH-2.0-test-client"
 assert_not_contains "$tmp/success.err" "::error"
 
@@ -80,6 +89,8 @@ failure_cloudflared="$tmp/cloudflared-failure"
 cat > "$failure_cloudflared" <<'EOF'
 #!/usr/bin/env bash
 printf 'failed args: %s\n' "$*" >&2
+printf 'TUNNEL_SERVICE_TOKEN_ID=%s TUNNEL_SERVICE_TOKEN_SECRET=%s\n' \
+  "$TUNNEL_SERVICE_TOKEN_ID" "$TUNNEL_SERVICE_TOKEN_SECRET" >&2
 echo "Unable to reach the origin service: context canceled" >&2
 exit 255
 EOF
@@ -120,6 +131,8 @@ cat > "$hup_cloudflared" <<'EOF'
 trap 'printf "terminated\n" > "$FAKE_SIGNAL_FILE"; exit 143' TERM
 printf '%s\n' "$$" > "$FAKE_PID_FILE"
 printf 'websocket handshake still pending: %s\n' "$*" >&2
+printf 'TUNNEL_SERVICE_TOKEN_ID=%s TUNNEL_SERVICE_TOKEN_SECRET=%s\n' \
+  "$TUNNEL_SERVICE_TOKEN_ID" "$TUNNEL_SERVICE_TOKEN_SECRET" >&2
 while :; do
   :
 done
@@ -176,6 +189,64 @@ if kill -0 "$hup_pid" 2>/dev/null; then
 fi
 if compgen -G "$hup_logs/cloudflared-ssh-*.log" > /dev/null; then
   echo "expected HUP cloudflared logs to be removed" >&2
+  exit 1
+fi
+
+home_term="$tmp/home-term"
+make_home "$home_term"
+term_summary="$tmp/term-summary.md"
+term_logs="$tmp/term-logs"
+term_pid_file="$tmp/term.pid"
+term_signal_file="$tmp/term.signal"
+mkdir -p "$term_logs"
+
+HOME="$home_term" \
+CLOUDFLARED_BIN="$hup_cloudflared" \
+FAKE_PID_FILE="$term_pid_file" \
+FAKE_SIGNAL_FILE="$term_signal_file" \
+GITHUB_STEP_SUMMARY="$term_summary" \
+RUNNER_TEMP="$term_logs" \
+"$PROXY" dev-1.aws.vm3.ai < /dev/null > "$tmp/term.out" 2> "$tmp/term.err" &
+proxy_pid=$!
+
+deadline=$((SECONDS + 5))
+while [ ! -s "$term_pid_file" ]; do
+  if ! kill -0 "$proxy_pid" 2>/dev/null; then
+    echo "proxy exited before starting cloudflared for TERM test" >&2
+    exit 1
+  fi
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "timed out waiting for cloudflared to start for TERM test" >&2
+    exit 1
+  fi
+done
+
+term_pid=$(cat "$term_pid_file")
+kill -TERM "$proxy_pid"
+status=0
+wait "$proxy_pid" || status=$?
+proxy_pid=""
+
+if [ "$status" -ne 143 ]; then
+  echo "expected TERM status 143, got ${status}" >&2
+  exit 1
+fi
+
+assert_contains "$term_signal_file" "terminated"
+assert_contains "$tmp/term.err" "::error title=Cloudflare SSH proxy interrupted::"
+assert_contains "$tmp/term.err" "interrupted by signal TERM"
+assert_contains "$term_summary" "### Cloudflare SSH proxy interrupted"
+assert_contains "$term_summary" "Exit status: \`143\`"
+assert_not_contains "$tmp/term.err" "super-secret"
+assert_not_contains "$tmp/term.err" "client-id"
+assert_not_contains "$term_summary" "super-secret"
+assert_not_contains "$term_summary" "client-id"
+if kill -0 "$term_pid" 2>/dev/null; then
+  echo "expected TERM cloudflared process ${term_pid} to be reaped" >&2
+  exit 1
+fi
+if compgen -G "$term_logs/cloudflared-ssh-*.log" > /dev/null; then
+  echo "expected TERM cloudflared logs to be removed" >&2
   exit 1
 fi
 

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -2,11 +2,11 @@ name: Cleanup Stale Resources
 
 on:
   schedule:
-    - cron: '0 3 * * *' # Daily at 3:00 AM UTC
+    - cron: "0 3 * * *" # Daily at 3:00 AM UTC
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Dry-run mode (no actual deletions)'
+        description: "Dry-run mode (no actual deletions)"
         type: boolean
         default: false
 
@@ -258,9 +258,11 @@ jobs:
         run: pip3 install ansible-core
 
       - name: Setup SSH via Cloudflare Tunnel
-        if: steps.check.outputs.should-cleanup == 'true' && steps.prs.outputs.has-prs == 'true'
+        if: steps.check.outputs.should-cleanup == 'true' && steps.prs.outputs.has-prs == 'true' && env.DRY_RUN != 'true'
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -263,6 +263,7 @@ jobs:
         with:
           ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
           ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          require-all-hosts: "false"
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
           ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          require-all-hosts: "false"
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -116,6 +116,8 @@ jobs:
         if: steps.check.outputs.should-cleanup == 'true'
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -259,6 +259,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -526,6 +528,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -584,6 +588,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -641,6 +647,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -695,6 +703,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -722,6 +732,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -755,6 +767,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -794,6 +808,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2011,6 +2011,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -2089,6 +2091,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -2337,6 +2341,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -282,6 +284,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -231,6 +231,8 @@ jobs:
         if: steps.needed.outputs.current-runner-image-needed == 'true'
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -431,6 +433,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -265,9 +265,12 @@ jobs:
           shellcheck \
             .github/scripts/check-release-please-component-releases.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
+            .github/scripts/cloudflare-ssh-preconnect.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/tests/check-release-please-component-releases-test.sh \
-            .github/scripts/tests/check-workflow-shell-compatibility-test.sh
+            .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
+            .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
+            .github/scripts/tests/cloudflare-ssh-proxy-test.sh
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.
           .github/scripts/check-workflow-shell-compatibility.sh

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1656,6 +1656,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -2110,6 +2112,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -2199,6 +2203,8 @@ jobs:
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1658,6 +1658,7 @@ jobs:
         with:
           ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
           ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          require-all-hosts: "false"
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,8 @@ callback_result_format = yaml
 callback_whitelist = profile_tasks
 
 [ssh_connection]
-# Keep SSH connection alive during long operations (drain can take hours)
-ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10
+# Keep SSH connection alive during long operations (drain can take hours).
+# Match the shared master's 15-second cadence and 300-second tolerance.
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -o ServerAliveCountMax=20
 # Ansible interpolation turns %%C into OpenSSH's %C; match setup-ssh-tunnel.
 control_path = ~/.ssh/vm0-ssh-%%C

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -16,3 +16,5 @@ callback_whitelist = profile_tasks
 [ssh_connection]
 # Keep SSH connection alive during long operations (drain can take hours)
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10
+# Ansible interpolation turns %%C into OpenSSH's %C; match setup-ssh-tunnel.
+control_path = ~/.ssh/vm0-ssh-%%C


### PR DESCRIPTION
## Summary

- establish a no-command OpenSSH ControlMaster in the shared Cloudflare SSH
  action and retry that replay-safe phase up to three times
- route native SSH, SCP, and Ansible through one ControlPath across all 20
  action consumers, using a single selected host where it is already known
- preserve best-effort cleanup semantics by warning and continuing when one
  host cannot pre-connect, while deployment and discovery jobs remain strict
- preserve the native 15-second keepalive cadence and Ansible's existing
  300-second missed-response tolerance on the shared master
- keep intermediate failures warning-only, stop early for permanent failures,
  and emit one bounded redacted error after exhaustion
- pass Cloudflare Access service tokens through cloudflared's supported
  environment variables instead of process arguments
- add integration coverage for recovery, master verification, permanent
  failure, exhaustion, host normalization, credentials, signals, and cleanup

## Safety boundary

Retries run only `ssh -M -N -f`, before any remote session or command exists.
Existing SSH commands, SCP operations, Ansible playbooks, deployment steps, and
cleanup steps remain single-shot and are not replayed after an ambiguous
failure.

Strict consumers fail and close partial masters when any required host cannot
pre-connect. The two cleanup workflows and the Stripe listener retain
successful masters, warn for unavailable hosts, and continue into their
existing best-effort Ansible behavior.

If an established master is lost later in a job, a downstream OpenSSH client
may establish one new connection and submit its requested command once; this PR
does not attempt to heal arbitrary mid-command transport loss.

No application API, database schema, runner protocol, queue payload, or
persisted state changes.

## Validation

- focused Cloudflare SSH preconnect and proxy integration tests, including
  strict partial-failure cleanup and best-effort continuation
- complete `Run workflow script tests` gate from
  `.github/workflows/security.yml`, including all shell tests serially
- configured shellcheck set, including the new preconnect helper and changed shell tests
- actionlint 1.7.12
- Prettier check for the changed action and workflow YAML
- all 20 local action consumers checked for the required user and host inputs
- Ansible 2.16.3 command expansion and OpenSSH `ssh -G` confirmed the action
  and Ansible use the same hashed ControlPath and shared keepalive policy
- `git diff --check`

Closes #23468