### PR TITLE
fix(platform): show host-aware brand copy on okou hosts

### DIFF
--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -1,5 +1,6 @@
 const CACHE_VERSION = String(Date.now());
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"];
 
 const STATIC_RE =
   /\.(?:js|css|png|svg|jpe?g|gif|ico|woff2?|ttf|eot|webp|avif|json|wasm|map)$/i;
@@ -12,6 +13,14 @@ function isApiRequest(url) {
   return (
     url.origin === self.location.origin && url.pathname.startsWith("/api/")
   );
+}
+
+function defaultNotificationTitle() {
+  const hostname = self.location.hostname.toLowerCase();
+  const isOkou = OKOU_ROOT_DOMAINS.some((domain) => {
+    return hostname === domain || hostname.endsWith(`.${domain}`);
+  });
+  return isOkou ? "Okou" : "VM0";
 }
 
 function isCacheableAssetResponse(response) {
@@ -138,7 +147,10 @@ self.addEventListener("push", (event) => {
   };
 
   event.waitUntil(
-    self.registration.showNotification(data.title ?? "vm0", options),
+    self.registration.showNotification(
+      data.title ?? defaultNotificationTitle(),
+      options,
+    ),
   );
 });
 

--- a/turbo/apps/platform/src/signals/branding.ts
+++ b/turbo/apps/platform/src/signals/branding.ts
@@ -1,6 +1,7 @@
 import { computed } from "ccstate";
 
 type Branding = "vm0" | "okou";
+export type BrandName = "VM0" | "Okou";
 
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"] as const;
 
@@ -11,4 +12,8 @@ export const branding$ = computed<Branding>(() => {
   });
 
   return isOkou ? "okou" : "vm0";
+});
+
+export const brandName$ = computed<BrandName>((get) => {
+  return get(branding$) === "okou" ? "Okou" : "VM0";
 });

--- a/turbo/apps/platform/src/signals/branding.ts
+++ b/turbo/apps/platform/src/signals/branding.ts
@@ -5,7 +5,7 @@ export type BrandName = "VM0" | "Okou";
 
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"] as const;
 
-export const branding$ = computed<Branding>(() => {
+const branding$ = computed<Branding>(() => {
   const hostname = location.host.toLowerCase().replace(/:\d+$/u, "");
   const isOkou = OKOU_ROOT_DOMAINS.some((domain) => {
     return hostname === domain || hostname.endsWith(`.${domain}`);

--- a/turbo/apps/platform/src/signals/document-title.ts
+++ b/turbo/apps/platform/src/signals/document-title.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
-import { branding$ } from "./branding.ts";
+import { brandName$ } from "./branding.ts";
 
 export const updateDocumentTitle$ = command(({ get }, pageName: string) => {
-  const brandName = get(branding$) === "okou" ? "Okou" : "VM0";
-  document.title = `${pageName} | ${brandName}`;
+  document.title = `${pageName} | ${get(brandName$)}`;
 });

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
@@ -23,6 +23,7 @@ import {
   OnboardingVideoRunPage,
 } from "../../views/onboarding/onboarding-template-run-pages.tsx";
 import { hideAppSkeleton$, showAppSkeleton$ } from "../app-skeleton.ts";
+import { brandName$, type BrandName } from "../branding.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
@@ -41,7 +42,7 @@ import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 
 interface OnboardingPageConfig {
   readonly step: OnboardingRouteStep;
-  readonly title: string;
+  readonly title: string | ((brandName: BrandName) => string);
   readonly Page: ComponentType;
   readonly fallbackPath?: RoutePath;
 }
@@ -143,15 +144,21 @@ function createOnboardingPageSetup(
       return;
     }
 
+    const title =
+      typeof config.title === "string"
+        ? config.title
+        : config.title(get(brandName$));
     set(updatePage$, createElement(config.Page), "none");
-    set(updateDocumentTitle$, config.title);
+    set(updateDocumentTitle$, title);
     await set(hideAppSkeleton$, signal);
   });
 }
 
 export const setupOnboardingMakePage$ = createOnboardingPageSetup({
   step: "make",
-  title: "Welcome to VM0",
+  title: (brandName) => {
+    return `Welcome to ${brandName}`;
+  },
   Page: OnboardingMakePage,
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -9,6 +9,7 @@ import {
 import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
+import { brandName$, type BrandName } from "../../branding.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
 import { bestEffort, resetSignal, setLoop, tapError } from "../../utils.ts";
 import { writeToClipboard } from "../clipboard.ts";
@@ -62,15 +63,18 @@ function secondsToMilliseconds(seconds: number): number {
   return seconds * 1000;
 }
 
-function codexDeviceAuthErrorMessage(error: {
-  readonly code: string;
-  readonly message: string;
-}): string {
+function codexDeviceAuthErrorMessage(
+  error: {
+    readonly code: string;
+    readonly message: string;
+  },
+  brandName: BrandName,
+): string {
   if (error.code === "CODEX_AUTH_JSON_SHAPE_INVALID") {
-    return "Codex produced a login token format vm0 does not recognize. Update Codex and try again.";
+    return `Codex produced a login token format ${brandName} does not recognize. Update Codex and try again.`;
   }
   if (error.code === "CODEX_FREE_PLAN_REJECTED") {
-    return "Free ChatGPT plans cannot use Codex via vm0. Upgrade to Plus or Pro and try again.";
+    return `Free ChatGPT plans cannot use Codex via ${brandName}. Upgrade to Plus or Pro and try again.`;
   }
   return error.message;
 }
@@ -234,7 +238,10 @@ function createCodexPollFlow$(ctx: CodexDeviceAuthSignalContext) {
           if (completion.status !== 200) {
             set(ctx.internalFlowState$, {
               status: "error",
-              message: codexDeviceAuthErrorMessage(completion.body.error),
+              message: codexDeviceAuthErrorMessage(
+                completion.body.error,
+                get(brandName$),
+              ),
             });
             return true;
           }

--- a/turbo/apps/platform/src/views/auth/clerk-localization.ts
+++ b/turbo/apps/platform/src/views/auth/clerk-localization.ts
@@ -1,12 +1,12 @@
-const CLERK_BANNED_ACCOUNT_ERROR_TEXT =
-  "Account access suspended because activity on this account violated the vm0 Terms of Use. If you have questions, contact support@vm0.ai.";
+import type { BrandName } from "../../signals/branding.ts";
+
 const CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT = "Access is not allowed.";
 
-export function getVm0ClerkLocalization() {
+export function getClerkLocalization(brandName: BrandName) {
   return {
     unstable__errors: {
       not_allowed_access: CLERK_NOT_ALLOWED_ACCESS_ERROR_TEXT,
-      user_banned: CLERK_BANNED_ACCOUNT_ERROR_TEXT,
+      user_banned: `Account access suspended because activity on this account violated the ${brandName} Terms of Use. If you have questions, contact support@vm0.ai.`,
     },
   };
 }

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -5,6 +5,7 @@ import {
 import { useGet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { resolvePlatformRuntimeConfig } from "../../lib/platform-host.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import {
   clerkInstance$,
   clerkUi$,
@@ -13,7 +14,7 @@ import {
   resolveAppUrl,
   resolveClerkSatelliteConfig,
 } from "../../signals/auth.ts";
-import { getVm0ClerkLocalization } from "../auth/clerk-localization.ts";
+import { getClerkLocalization } from "../auth/clerk-localization.ts";
 import { getClerkAppearance } from "./clerk-appearance.ts";
 
 interface ClerkProviderProps {
@@ -23,6 +24,7 @@ interface ClerkProviderProps {
 export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const clerkInstance = useGet(clerkInstance$);
   const clerkUi = useGet(clerkUi$);
+  const brandName = useGet(brandName$);
 
   const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
   const appUrl = resolveAppUrl();
@@ -34,7 +36,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     afterSignOutUrl: resolveAppAuthUrl("/sign-in"),
     allowedRedirectOrigins,
     appearance: getClerkAppearance(),
-    localization: getVm0ClerkLocalization(),
+    localization: getClerkLocalization(brandName),
     publishableKey,
     signInFallbackRedirectUrl: appUrl,
     signInUrl: resolveAppAuthUrl("/sign-in"),

--- a/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
@@ -36,7 +36,7 @@ describe("force upgrade dialog", () => {
       name: "Update required",
     });
     expect(dialog).toHaveTextContent(
-      "This version of vm0 is no longer supported.",
+      "This version of VM0 is no longer supported.",
     );
 
     await userEvent.click(screen.getByText("Refresh"));

--- a/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 
 import { forceUpgradeDialogOpen$ } from "../../signals/force-upgrade.ts";
+import { brandName$ } from "../../signals/branding.ts";
 
 type ForceUpgradeDialogProps = {
   readonly reload?: () => void;
@@ -23,6 +24,7 @@ export function ForceUpgradeDialog({
   reload = reloadPage,
 }: ForceUpgradeDialogProps) {
   const open = useGet(forceUpgradeDialogOpen$);
+  const brandName = useGet(brandName$);
 
   return (
     <Dialog open={open}>
@@ -41,8 +43,8 @@ export function ForceUpgradeDialog({
         <DialogHeader>
           <DialogTitle>Update required</DialogTitle>
           <DialogDescription>
-            This version of vm0 is no longer supported. Refresh to load the
-            latest version.
+            This version of {brandName} is no longer supported. Refresh to load
+            the latest version.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
@@ -2,6 +2,7 @@ import { useGet, useSet } from "ccstate-react";
 import { Button } from "@vm0/ui";
 import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import {
   confirmEmailUnsubscribe$,
   emailUnsubscribeStatus$,
@@ -10,11 +11,9 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 
-const DESCRIPTION =
-  "You will no longer receive system-initiated email notifications from VM0.";
-
 export function EmailUnsubscribePage() {
   const pageSignal = useGet(pageSignal$);
+  const brandName = useGet(brandName$);
   const status = useGet(emailUnsubscribeStatus$);
   const token = useGet(emailUnsubscribeToken$);
   const confirm = useSet(confirmEmailUnsubscribe$);
@@ -29,7 +28,10 @@ export function EmailUnsubscribePage() {
             <h1 className="text-lg font-medium text-foreground">
               Unsubscribed
             </h1>
-            <p className="text-sm text-muted-foreground">{DESCRIPTION}</p>
+            <p className="text-sm text-muted-foreground">
+              You will no longer receive system-initiated email notifications
+              from {brandName}.
+            </p>
           </div>
         ) : status === "error" || !token ? (
           <div className="flex flex-col items-center gap-2.5">
@@ -48,7 +50,10 @@ export function EmailUnsubscribePage() {
               <h1 className="text-lg font-medium text-foreground">
                 Unsubscribe from email notifications?
               </h1>
-              <p className="text-sm text-muted-foreground">{DESCRIPTION}</p>
+              <p className="text-sm text-muted-foreground">
+                You will no longer receive system-initiated email notifications
+                from {brandName}.
+              </p>
             </div>
             <Button
               disabled={status === "submitting"}

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../signals/redeem-campaign/redeem-campaign-signals.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { clerk$ } from "../../signals/auth.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import { Link } from "../router/link.tsx";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 
@@ -126,6 +127,8 @@ function PrimaryAction({
   response: RedeemResponse | null;
   stripeSuccess: boolean;
 }): ReactNode {
+  const brandName = useGet(brandName$);
+
   if (!stripeSuccess && response?.status === "ready") {
     // Render as an <a> (via asChild) so the browser handles cmd/ctrl+click,
     // middle-click, and right-click → "open in new tab" natively. A plain
@@ -142,7 +145,7 @@ function PrimaryAction({
   // where the new credit balance is visible. Error cards just send them home.
   return (
     <Button className="w-full" asChild>
-      <Link pathname={ROUTES.home}>Back to VM0</Link>
+      <Link pathname={ROUTES.home}>Back to {brandName}</Link>
     </Button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -12,12 +12,12 @@ const MOBILE_WARNING =
 const IPHONE_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
 
-function backToVm0Link(): HTMLElement {
+function backToBrandLink(brandName: "VM0" | "Okou"): HTMLElement {
   const link = queryAllByRoleFast("link").find((candidate) => {
-    return candidate.textContent?.trim() === "Back to VM0";
+    return candidate.textContent?.trim() === `Back to ${brandName}`;
   });
   if (!link) {
-    throw new Error("Back to VM0 link not found");
+    throw new Error(`Back to ${brandName} link not found`);
   }
   return link;
 }
@@ -43,7 +43,7 @@ describe("connector redirecting page", () => {
     expect(
       screen.getByLabelText("Connector icon unavailable"),
     ).toBeInTheDocument();
-    expect(backToVm0Link()).toHaveAttribute("href", "/");
+    expect(backToBrandLink("VM0")).toHaveAttribute("href", "/");
     expect(screen.queryByText(MOBILE_WARNING)).not.toBeInTheDocument();
   });
 
@@ -118,6 +118,25 @@ describe("connector redirecting page", () => {
     expect(
       screen.getByText("Return to VM0 and try connecting again."),
     ).toBeInTheDocument();
-    expect(backToVm0Link()).toHaveAttribute("href", "/");
+    expect(backToBrandLink("VM0")).toHaveAttribute("href", "/");
+  });
+
+  it("uses Okou copy on an Okou host", async () => {
+    window.location.href =
+      "https://app.okou.ai/connectors/github/redirecting?label=GitHub";
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/redirecting?label=GitHub",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Redirecting to GitHub…" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText("You’ll continue on GitHub to authorize Okou."),
+    ).toBeInTheDocument();
+    expect(backToBrandLink("Okou")).toHaveAttribute("href", "/");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -27,6 +27,7 @@ import {
   submitClaudeCodeDeviceAuthPersonal$,
   type ClaudeCodeDeviceAuthFlowState,
 } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
+import { brandName$ } from "../../../../signals/branding.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
@@ -187,6 +188,8 @@ function ClaudeCodeDeviceAuthBody({
   setAuthorizationCode: (value: string) => void;
   submitting: boolean;
 }) {
+  const brandName = useGet(brandName$);
+
   switch (flow.status) {
     case "idle": {
       return <ClaudeCodeDeviceAuthLoadingContent />;
@@ -205,9 +208,9 @@ function ClaudeCodeDeviceAuthBody({
         >
           <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs leading-5 text-muted-foreground">
             <p>
-              First click Open Claude approval page. Then approve vm0 in Claude
-              and copy the authorization code shown after approval. Finally
-              paste that code here and click Connect.
+              First click Open Claude approval page. Then approve {brandName} in
+              Claude and copy the authorization code shown after approval.
+              Finally paste that code here and click Connect.
             </p>
           </div>
           <Button

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
@@ -23,6 +23,7 @@ import {
   runCodexDeviceAuthPersonal$,
   type CodexDeviceAuthFlowState,
 } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
+import { brandName$ } from "../../../../signals/branding.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
@@ -138,6 +139,8 @@ function CodexDeviceAuthBody({
   openApprovalPage: (signal: AbortSignal) => Promise<boolean>;
   pageSignal: AbortSignal;
 }) {
+  const brandName = useGet(brandName$);
+
   switch (flow.status) {
     case "idle": {
       return <CodexDeviceAuthLoadingContent />;
@@ -154,7 +157,7 @@ function CodexDeviceAuthBody({
             <p>
               First click Copy code and open approval page. Then paste the
               device code into OpenAI when prompted. Finally approve access and
-              keep this dialog open while vm0 finishes the connection.
+              keep this dialog open while {brandName} finishes the connection.
             </p>
           </div>
           <div className="rounded-lg border border-border bg-muted/30 p-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -10,6 +10,7 @@ import {
 } from "@vm0/ui/components/ui/select";
 
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { brandName$ } from "../../../../signals/branding.ts";
 import {
   locale$,
   localePreferenceSupported$,
@@ -19,6 +20,7 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 
 export function LanguageSettings() {
   const supportLoadable = useLoadable(localePreferenceSupported$);
+  const brandName = useGet(brandName$);
   const locale = useGet(locale$);
   const pageSignal = useGet(pageSignal$);
   const [updateLoadable, updateLocale] = useLoadableSet(
@@ -53,7 +55,7 @@ export function LanguageSettings() {
         <div className="flex flex-1 flex-col gap-1 min-w-0">
           <div className="text-sm font-medium text-foreground">Language</div>
           <div className="text-sm text-muted-foreground">
-            Choose your preferred language for the VM0 interface
+            Choose your preferred language for the {brandName} interface
           </div>
         </div>
         <div className="w-40 shrink-0">

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -55,6 +55,7 @@ import {
   defaultAgentName$,
   sortedAgents$,
 } from "../../signals/agent.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
@@ -451,6 +452,8 @@ function canSubmitFeishuSetup(
 }
 
 function FeishuCreateStep() {
+  const brandName = useGet(brandName$);
+
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
@@ -467,8 +470,8 @@ function FeishuCreateStep() {
           >
             Feishu developer console
           </a>
-          , create an enterprise custom app named VM0, upload the VM0 icon, then
-          add the Bot capability.
+          , create an enterprise custom app named {brandName}, upload the{" "}
+          {brandName} icon, then add the Bot capability.
         </p>
         <div className="mt-4">
           <FeishuGuideImage
@@ -480,7 +483,7 @@ function FeishuCreateStep() {
       <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-4">
         <div>
           <div className="text-sm font-medium text-foreground">
-            VM0 app icon
+            {brandName} app icon
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
             <a
@@ -488,14 +491,14 @@ function FeishuCreateStep() {
               download="vm0-feishu-app-icon.png"
               className="font-medium text-foreground underline underline-offset-4"
             >
-              Download the VM0 icon
+              Download the {brandName} icon
             </a>
             , or use any icon you prefer.
           </p>
         </div>
         <img
           src="/icons/icon-512.png"
-          alt="VM0 app icon"
+          alt={`${brandName} app icon`}
           className="h-14 w-14 shrink-0 rounded-xl"
         />
       </div>
@@ -641,6 +644,8 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
 }
 
 function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
+  const brandName = useGet(brandName$);
+
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
@@ -659,7 +664,7 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
           </a>
           , open Development Configuration → Security Settings. Add the URL
           below under Redirect URLs so workspace members can connect their
-          Feishu account to VM0.
+          Feishu account to {brandName}.
         </p>
       </div>
       <div className="flex gap-2">
@@ -1560,6 +1565,7 @@ function FeishuSetupDialog({
 }
 
 function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
+  const brandName = useGet(brandName$);
   const setUninstallInstallationId = useSet(setFeishuUninstallInstallationId$);
   const [uninstallLoadable, uninstallInstallation] = useLoadableSet(
     uninstallFeishuInstallation$,
@@ -1580,8 +1586,8 @@ function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
         <DialogHeader>
           <DialogTitle>Uninstall Feishu bot?</DialogTitle>
           <DialogDescription>
-            This uninstalls {title} from the workspace and disconnects every VM0
-            account using it. This action cannot be undone.
+            This uninstalls {title} from the workspace and disconnects every{" "}
+            {brandName} account using it. This action cannot be undone.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -8,6 +8,7 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import { connectAgentPhoneAccount$ } from "../../signals/zero-page/agentphone-connect-signals.ts";
@@ -23,13 +24,15 @@ import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets
 const imessageIconImg = settingsIconAssetUrl("imessage");
 
 function BackLink() {
+  const brandName = useGet(brandName$);
+
   return (
     <Link
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to VM0
+      Back to {brandName}
     </Link>
   );
 }
@@ -115,6 +118,7 @@ function getAgentPhoneConnectErrorMessage(error: unknown): string {
 }
 
 export function ZeroAgentPhoneConnectPage(): JSX.Element {
+  const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseAgentPhoneConnectParams(params);
   const [connectLoadable, connectAgentPhone] = useLoadableSet(
@@ -159,7 +163,7 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
       <MessageMark state={connecting ? "loading" : "idle"} />
       <CenterText
         title="Connect phone number"
-        body="Link this phone number to your VM0 account so you can interact with Zero from text messages."
+        body={`Link this phone number to your ${brandName} account so you can interact with Zero from text messages.`}
       />
       <SmsMmsRiskNotice channel={parsed.channel} />
       {error ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -10,6 +10,7 @@ import {
   connectorRedirectingMobileWarningVisible$,
   type ConnectorRedirectingStatus,
 } from "../../signals/connectors-page/connector-redirecting.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
@@ -24,6 +25,7 @@ export function ZeroConnectorRedirectingPage({
   readonly status: ConnectorRedirectingStatus;
 }) {
   const hasError = status === "error";
+  const brandName = useGet(brandName$);
   const showMobileWarning = useGet(connectorRedirectingMobileWarningVisible$);
 
   return (
@@ -36,8 +38,8 @@ export function ZeroConnectorRedirectingPage({
       }
       description={
         hasError
-          ? "Return to VM0 and try connecting again."
-          : `You’ll continue on ${connectorLabel} to authorize VM0.`
+          ? `Return to ${brandName} and try connecting again.`
+          : `You’ll continue on ${connectorLabel} to authorize ${brandName}.`
       }
     >
       <div className="flex flex-col items-center gap-4">
@@ -59,13 +61,13 @@ export function ZeroConnectorRedirectingPage({
         {!hasError && showMobileWarning && (
           <p className="w-72 max-w-full text-sm text-amber-600 dark:text-amber-400">
             The {connectorLabel} app may not support this OAuth link. Please
-            complete this connection in the VM0 web app on a computer.
+            complete this connection in the {brandName} web app on a computer.
           </p>
         )}
         <Button variant="outline" asChild>
           <Link pathname={ROUTES.home}>
             <IconArrowLeft size={16} aria-hidden="true" />
-            Back to VM0
+            Back to {brandName}
           </Link>
         </Button>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-feishu-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-feishu-connect-page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
 
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   connectFeishuAccount$,
@@ -69,6 +70,7 @@ function errorMessage(error: unknown): string {
 }
 
 export function ZeroFeishuConnectPage() {
+  const brandName = useGet(brandName$);
   const params = useGet(feishuConnectParams$);
   const statusLoadable = useLoadable(feishuConnectStatus$);
   const [connectLoadable, connect] = useLoadableSet(connectFeishuAccount$);
@@ -142,7 +144,7 @@ export function ZeroFeishuConnectPage() {
         body={
           checking
             ? "Please wait while we verify your connection."
-            : "Link your VM0 account to this Feishu bot so you can work with your agent directly from Feishu."
+            : `Link your ${brandName} account to this Feishu bot so you can work with your agent directly from Feishu.`
         }
       />
       {error ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
 import { clerk$, resolveAppAuthUrl } from "../../signals/auth.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import {
@@ -173,18 +174,20 @@ function LoadingState({
 }
 
 function SignInState(): JSX.Element {
+  const brandName = useGet(brandName$);
+
   return (
     <PageShell>
       <GithubMark />
       <CenterText
         title="Sign in to continue"
-        body="Use your VM0 account before connecting this GitHub user."
+        body={`Use your ${brandName} account before connecting this GitHub user.`}
       />
       <a
         href={signInHref()}
         className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
       >
-        Sign in to VM0
+        Sign in to {brandName}
       </a>
     </PageShell>
   );
@@ -201,6 +204,8 @@ function ConnectState({
   connecting: boolean;
   onConnect: () => void;
 }): JSX.Element {
+  const brandName = useGet(brandName$);
+
   return (
     <PageShell>
       <GithubMark />
@@ -208,7 +213,7 @@ function ConnectState({
         title="Connect to GitHub"
         body={
           <>
-            Link your VM0 account to{" "}
+            Link your {brandName} account to{" "}
             <span className="font-medium">
               {githubUserLabel(params.githubUsername)}
             </span>{" "}
@@ -241,6 +246,7 @@ function ConnectState({
 }
 
 export function ZeroGithubConnectPage(): JSX.Element {
+  const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseGithubConnectParams(params);
   const clerkLoadable = useLoadable(clerk$);
@@ -267,7 +273,7 @@ export function ZeroGithubConnectPage(): JSX.Element {
     return (
       <LoadingState
         title="Checking account status..."
-        body="Please wait while we verify your VM0 session."
+        body={`Please wait while we verify your ${brandName} session.`}
       />
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { Button, CopyButton } from "@vm0/ui";
 import { clerk$, resolveAppAuthUrl } from "../../signals/auth.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import {
@@ -332,6 +333,7 @@ function ConnectActions({
 }
 
 export function ZeroTelegramConnectPage(): JSX.Element {
+  const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseTelegramConnectParams(params);
   const clerkLoadable = useLoadable(clerk$);
@@ -360,7 +362,7 @@ export function ZeroTelegramConnectPage(): JSX.Element {
         <TelegramMark state="loading" />
         <CenterText
           title="Checking account status..."
-          body="Please wait while we verify your VM0 session."
+          body={`Please wait while we verify your ${brandName} session.`}
         />
       </PageShell>
     );
@@ -381,13 +383,13 @@ export function ZeroTelegramConnectPage(): JSX.Element {
         <TelegramMark />
         <CenterText
           title="Sign in to continue"
-          body="Use your VM0 account before connecting this Telegram user."
+          body={`Use your ${brandName} account before connecting this Telegram user.`}
         />
         <a
           href={signInHref()}
           className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
-          Sign in to VM0
+          Sign in to {brandName}
         </a>
       </PageShell>
     );

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -49,6 +49,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@vm0/ui/components/ui/popover";
+import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { apiBase$ } from "../../signals/fetch.ts";
@@ -661,6 +662,8 @@ function AddTelegramCreateStep({
   disabled: boolean;
   onAgentChange: (value: string) => void;
 }) {
+  const brandName = useGet(brandName$);
+
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
@@ -669,8 +672,8 @@ function AddTelegramCreateStep({
         </div>
         <div>
           {setupStatus?.username
-            ? `VM0 will register @${setupStatus.username} and configure its webhook.`
-            : "VM0 will register this bot and configure its webhook."}{" "}
+            ? `${brandName} will register @${setupStatus.username} and configure its webhook.`
+            : `${brandName} will register this bot and configure its webhook.`}{" "}
           After setup, mention the bot in a group or send it a DM to talk with
           the selected agent.
         </div>
@@ -1542,6 +1545,7 @@ function TelegramBotRow({
   canManage: boolean;
   disabled: boolean;
 }) {
+  const brandName = useGet(brandName$);
   const savingBotId = useGet(telegramSavingBotId$);
   const unlinkingBotId = useGet(telegramUnlinkingBotId$);
   const uninstallingBotId = useGet(telegramUninstallingBotId$);
@@ -1577,7 +1581,7 @@ function TelegramBotRow({
           </div>
           {isOfficial ? (
             <div className="mt-1 text-sm text-muted-foreground">
-              Official bot provided by VM0.
+              Official bot provided by {brandName}.
             </div>
           ) : bot.tokenStatus === "invalid" ? (
             <div className="mt-1 text-sm text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import { currentChatAgentDisplayName$ } from "../../signals/agent-chat.ts";
+import { brandName$ } from "../../signals/branding.ts";
 import {
   slackOrgData$,
   disconnectSlackOrg$,
@@ -470,6 +471,7 @@ function teamsCardDescription(args: {
 }
 
 function TeamsCard({ displayName }: { displayName: string }) {
+  const brandName = useGet(brandName$);
   const teamsDataLoadable = useLastLoadable(teamsOrgData$);
   const teamsData =
     teamsDataLoadable.state === "hasData" ? teamsDataLoadable.data : null;
@@ -543,8 +545,8 @@ function TeamsCard({ displayName }: { displayName: string }) {
           <DialogHeader>
             <DialogTitle>Uninstall Microsoft Teams integration?</DialogTitle>
             <DialogDescription>
-              This removes the Microsoft Teams integration from VM0 for your
-              workspace. All connected users will be disconnected and{" "}
+              This removes the Microsoft Teams integration from {brandName} for
+              your workspace. All connected users will be disconnected and{" "}
               {displayName} will no longer respond to Teams messages for this
               workspace until an admin reconnects it.
             </DialogDescription>


### PR DESCRIPTION
## Summary

- derive a shared display name from the existing host-aware platform branding signal
- show Okou across runtime product copy on Okou hosts while preserving VM0 on all other hosts
- update onboarding, account linking, connector setup, settings, auth errors, upgrade prompts, email unsubscribe, campaign navigation, and push notification fallback copy
- add page-level coverage for Okou connector authorization copy

This follows up on #23453, which made the document title suffix host-aware.

## Scope

This intentionally leaves static metadata, logo assets and their labels, infrastructure domains and email addresses, historical changelog content, default agent seed, Ideation examples, package names, and protocol or internal identifiers unchanged.

## Verification

- Prettier check passed for all changed files
- Platform production and test TypeScript checks passed
- ESLint passed for all changed TypeScript files
- Type-aware oxlint passed for all changed files
- Knip passed after keeping the internal branding signal unexported
- 3 focused Vitest files passed (19 tests), covering host branding, connector redirect copy, and the force-upgrade dialog

The non-type-aware oxlint run reported one existing vi.fn type-parameter warning in force-upgrade-dialog.test.tsx; this PR does not change that line.