### PR TITLE
refactor(runner): retire legacy claim 409 handling

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -588,7 +588,7 @@ impl JobProvider for ApiProvider {
             }
             Ok(None) => {
                 self.claim_cooldowns.remove(run_id).await;
-                info!(run_id = %run_id, "already claimed, skipping");
+                info!(run_id = %run_id, "job unavailable, skipping");
                 self.poll_wakeups.request_immediate_poll().await;
                 None
             }
@@ -885,8 +885,7 @@ impl ApiClient {
         Ok(())
     }
 
-    /// Claim a job for execution. Treats the current HTTP 404 unavailable
-    /// response and the legacy HTTP 409 conflict response as a lost race so
+    /// Claim a job for execution. Treats HTTP 404 as an unavailable job so
     /// callers can continue gracefully.
     async fn claim(
         &self,
@@ -909,10 +908,6 @@ impl ApiClient {
             "claim",
         )
         .await?;
-
-        if resp.status() == StatusCode::CONFLICT {
-            return Ok(None);
-        }
 
         if resp.status() == StatusCode::NOT_FOUND {
             return Ok(None);
@@ -2472,11 +2467,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lost_claim_race_polls_backlog_without_excluding_run() {
+    async fn unavailable_claim_polls_backlog_without_excluding_run() {
         let server = MockServer::start_async().await;
-        let lost_run_id: RunId = "00000000-0000-0000-0000-00000000001b".parse().unwrap();
+        let unavailable_run_id: RunId = "00000000-0000-0000-0000-00000000001b".parse().unwrap();
         let next_run_id: RunId = "00000000-0000-0000-0000-00000000001c".parse().unwrap();
-        let claim_path = format!("/api/runners/jobs/{lost_run_id}/claim");
+        let claim_path = format!("/api/runners/jobs/{unavailable_run_id}/claim");
         let claim_mock = server
             .mock_async(|when, then| {
                 when.method(POST).path(claim_path.as_str());
@@ -2518,15 +2513,18 @@ mod tests {
         );
         push_direct_candidate_for_test(
             &provider,
-            DirectJobCandidate::new(lost_run_id, crate::profile::DEFAULT_PROFILE.to_string()),
+            DirectJobCandidate::new(
+                unavailable_run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ),
         )
         .await;
 
-        let lost = provider.discover().await.unwrap();
-        assert!(provider.claim(lost).await.is_none());
+        let unavailable = provider.discover().await.unwrap();
+        assert!(provider.claim(unavailable).await.is_none());
         let next = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
-            .expect("lost race should promptly poll the backlog")
+            .expect("unavailable claim should promptly poll the backlog")
             .unwrap();
         assert_eq!(next.run_id(), next_run_id);
 
@@ -2985,25 +2983,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_client_claim_not_found_or_legacy_conflict_is_already_claimed() {
-        for status in [409_u16, 404] {
-            let server = MockServer::start_async().await;
-            let run_id = RunId::nil();
-            let path = format!("/api/runners/jobs/{run_id}/claim");
-            let mock = server
-                .mock_async(|when, then| {
-                    when.method(POST).path(path.as_str());
-                    then.status(status);
-                })
-                .await;
-            let api = api_client_for_server(&server);
+    async fn api_client_claim_not_found_is_unavailable() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(404);
+            })
+            .await;
+        let api = api_client_for_server(&server);
 
-            let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
-            let outcome = api.claim(&candidate).await.unwrap();
+        let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
+        let outcome = api.claim(&candidate).await.unwrap();
 
-            assert!(outcome.is_none());
-            mock.assert_async().await;
-        }
+        assert!(outcome.is_none());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_client_claim_conflict_is_api_status_error() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(409).body("unexpected conflict");
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
+        let error = api.claim(&candidate).await.unwrap_err();
+
+        let ClaimApiError::Request(error) = error else {
+            panic!("expected ClaimApiError::Request");
+        };
+        assert_api_status_error(error, "claim", StatusCode::CONFLICT, "unexpected conflict");
+        mock.assert_async().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- remove the expired Runner compatibility branch that normalized claim HTTP 409 as ordinary unavailability
- keep HTTP 404 as the sole normal unavailable-claim result and describe that path with accurate log and test terminology
- split the direct claim-client coverage so 404 remains `Ok(None)` while 409 preserves its status and body through the ordinary API-status error path

Unexpected claim 409 responses now reuse the existing deterministic failure behavior: structured error telemetry, candidate exclusion, and a 30-second cooldown. Normal HTTP 404 behavior still clears cooldown state, requests an immediate poll, and returns no claimed job.

## Compatibility

- no API request, success payload, TypeScript contract, generated binding, or queue payload changes
- no database schema, migration, or persisted data changes
- old Runners remain compatible with the current API
- a new Runner talking to an unsupported API predating `38fe1b66` would treat claim 409 as a deterministic failure instead of normal contention

At planning time, all seven retained entries in production rollback dashboard #6792 and all 16 open PR heads contained `38fe1b66`. Recheck that ancestry immediately before merge.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner api_client_claim_ --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner unavailable_claim_polls_backlog_without_excluding_run --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner deterministic_claim_failure_excludes_run_and_polls_next_candidate --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner claim_failure_rolls_back_budget --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (`2861 passed`, `14 ignored`; guest inventory passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- pre-commit Rust format, Clippy, documentation, file-size, and commitlint hooks

Closes #23443
