### PR TITLE
test(runner): cover duplicate network policy refresh

### DIFF
--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1588,7 +1588,7 @@ mod tests {
     async fn duplicate_network_policy_refresh_fails_closed() {
         let server = MockServer::start();
         let run_id = RunId::nil();
-        server.mock(|when, then| {
+        let refresh_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
             then.status(200)
@@ -1621,6 +1621,7 @@ mod tests {
 
         let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
         harness.refresh_slack().await;
+        refresh_mock.assert_calls(1);
         let policy = harness.slack_policy().await;
         assert_fail_closed_policy(&policy);
 

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1585,6 +1585,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn duplicate_network_policy_refresh_fails_closed() {
+        let server = MockServer::start();
+        let run_id = RunId::nil();
+        server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "refreshes": [
+                        {
+                            "connectorRef": "slack",
+                            "networkPolicy": {
+                                "allow": ["chat:write", "files:write"],
+                                "deny": [],
+                                "ask": ["channels:read"],
+                                "unknownPolicy": "allow",
+                            },
+                            "nextRefreshAt": null,
+                        },
+                        {
+                            "connectorRef": "slack",
+                            "networkPolicy": {
+                                "allow": ["channels:read"],
+                                "deny": ["files:write"],
+                                "ask": ["chat:write"],
+                                "unknownPolicy": "ask",
+                            },
+                            "nextRefreshAt": null,
+                        },
+                    ],
+                }));
+        });
+
+        let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
+        harness.refresh_slack().await;
+        let policy = harness.slack_policy().await;
+        assert_fail_closed_policy(&policy);
+
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn invalid_network_policy_refresh_deadline_fails_closed() {
         let server = MockServer::start();
         let run_id = RunId::nil();


### PR DESCRIPTION
## Summary

- cover duplicate connector entries returned by the network-policy refresh API
- verify the runner persists the complete fail-closed policy instead of applying either conflicting response
- protect the documented safety invariant from first-write-wins and last-write-wins regressions

## Scope

- test-only runner change
- no production logic, API contract, persisted format, migration, or rollout change

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner duplicate_network_policy_refresh_fails_closed`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2,862 passed, 0 failed)
- mutation sanity check: bypassing the duplicate branch made the new test fail by applying a returned policy; restoring the branch made it pass

Closes #23445
