### PR TITLE
fix(api): log managed browser provider schema validation issues

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -404,6 +404,80 @@ describe("zero browser route", () => {
     );
   });
 
+  it("logs provider validation issues without exposing invalid values", async () => {
+    const { runs, chat, actor, agent } = await setupBrowserScenario();
+    const sent = await chat.requestSendEvent(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "Open a managed browser with an invalid provider response",
+        cloudBrowserEnabled: true,
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected a browser test run");
+    }
+    const browserHeaders = {
+      authorization: `Bearer ${runs.zeroTokenForRunWithCapabilities(
+        actor,
+        sent.body.runId,
+        ["browser:read", "browser:write"],
+      )}`,
+    };
+    const privateProviderValue = "private-provider-value";
+    server.use(
+      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+        const body = z
+          .strictObject({ name: z.string() })
+          .parse(await request.json());
+        return HttpResponse.json(providerProfile(randomUUID(), body.name), {
+          status: 201,
+        });
+      }),
+      http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
+        return HttpResponse.json(
+          providerBrowser(randomUUID(), {
+            browserCost: privateProviderValue,
+          }),
+          { status: 201 },
+        );
+      }),
+    );
+
+    context.mocks.axiomLogging.warn.mockClear();
+    const rejected = await requestBrowserCreate(browserHeaders, {
+      name: "invalid-provider-response",
+      proxyCountryCode: null,
+      maxCredits: 150,
+    });
+
+    expect(rejected.status).toBe(502);
+    await expect(rejected.json()).resolves.toMatchObject({
+      error: {
+        code: "BROWSER_USE_INVALID_RESPONSE",
+        message: "Managed browser provider returned an invalid response",
+      },
+    });
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Managed browser provider returned an invalid response",
+      expect.objectContaining({
+        validationIssueCount: 1,
+        validationIssues: [
+          expect.objectContaining({
+            path: "browserCost",
+            code: "invalid_format",
+            message: expect.any(String),
+          }),
+        ],
+        validationIssuesOmitted: 0,
+      }),
+    );
+    expect(
+      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
+    ).not.toContain(privateProviderValue);
+  });
+
   it("isolates profiles across concurrent thread browser sessions", async () => {
     const { runs, chat, webhooks, actor, agent } = await setupBrowserScenario();
     const first = await createClaimedChatRun(

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -34,6 +34,7 @@ import {
 import { z } from "zod";
 
 import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
@@ -61,6 +62,7 @@ const RECONCILE_BATCH_SIZE = 20;
 const PROVIDER_CLEANUP_TIMEOUT_MS = 30_000;
 const PROVIDER_START_LIFECYCLE_TIMEOUT_MS = 90_000;
 const STRANDED_START_GRACE_MS = 60_000;
+const MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG = 10;
 const IDLE_LEASE_MS = ZERO_BROWSER_IDLE_LEASE_MINUTES * 60_000;
 const OWNED_BROWSER_STATUSES = [
   "creating",
@@ -75,6 +77,7 @@ const TERMINAL_RUN_STATUSES = [
   "timeout",
   "cancelled",
 ] as const;
+const L = logger("ZeroBrowser");
 
 type BrowserSessionRow = typeof browserSessions.$inferSelect;
 type BrowserInstanceRow = typeof browserSessionInstances.$inferSelect;
@@ -186,6 +189,26 @@ function providerFailure(error: unknown): BrowserServiceError {
     return serviceError(error.status, error.code, error.message);
   }
   if (error instanceof z.ZodError) {
+    const validationIssueCount = error.issues.length;
+    L.warn("Managed browser provider returned an invalid response", {
+      validationIssueCount,
+      validationIssues: error.issues
+        .slice(0, MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG)
+        .map((issue) => {
+          return {
+            path:
+              issue.path.length === 0
+                ? "<root>"
+                : issue.path.map(String).join("."),
+            code: issue.code,
+            message: issue.message,
+          };
+        }),
+      validationIssuesOmitted: Math.max(
+        0,
+        validationIssueCount - MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG,
+      ),
+    });
     return serviceError(
       502,
       "BROWSER_USE_INVALID_RESPONSE",


### PR DESCRIPTION
## Summary

- log bounded, structured Zod validation issues when Browser Use returns a successful response that fails schema validation
- preserve the generic public 502 response and exclude invalid provider input values from logs
- cover the browser route with an invalid provider cost response

## User impact

Axiom now records the failing field path, Zod issue code, message, total issue count, and omitted count for `BROWSER_USE_INVALID_RESPONSE`, so provider schema mismatches can be diagnosed without retaining the provider payload.

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/zero-browser.service.ts apps/api/src/signals/routes/__tests__/zero-browser.test.ts`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts --testNamePattern "logs provider validation issues without exposing invalid values" --maxWorkers=1`
- `pnpm knip --workspace api`