### PR TITLE
refactor(api): prepare storage queue manifest contraction

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -192,8 +192,23 @@ application readers require canonical run, session, and checkpoint persistence.
 Legacy API response shapes are still projected from canonical mounts. After the
 detached API release was healthy and every rollback-eligible API version that
 accessed them had drained, the physical legacy run, session, and checkpoint
-columns were removed. The short-lived runner job queue still retains its legacy
-claim projection for the previous API version and rollback.
+columns were removed.
+
+The short-lived direct and delayed runner queues use a separate expand/contract
+sequence. Preparation-release readers accept the previous full
+`storageManifest`, `null`, or omission while still requiring canonical
+`storageMounts`. New writers explicitly store `storageManifest: null`; the
+preceding API reader already accepts that value, so rollback remains safe
+without serializing a second set of presigned URLs. Run-context volume and
+artifact observations are created before persistence and are not part of queue
+or Runner state.
+
+Do not omit the queue field until every active and rollback-eligible API has the
+tolerant reader and null writer, the database-clock cutoff for the last
+full-object writer is recorded, more than the two-hour queue TTL has elapsed,
+and neither queue contains an unexpired row predating that cutoff. Runner/guest
+legacy reader removal is independently gated on canonical claim producers; the
+backend field and legacy schema are removed only after both gates pass.
 
 Phase 4A contracts the migration denominator to the latest state used by
 session continuation. Every session continuation head must have canonical
@@ -213,8 +228,8 @@ Runner and guest binaries ship together, so the Runner-to-guest manifest uses
 the canonical shape while the guest reader temporarily accepts both
 representations. This keeps a newly promoted Runner compatible with the
 previous API during a cross-version window. Remove the legacy readers and queue
-projection only after canonical-only API output is stable and rollback-eligible
-API versions have drained.
+field only after canonical-only API output is stable, rollback-eligible API
+versions have drained, and the queue gate above has passed.
 
 ### Firewall hostname policy
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -130,6 +130,24 @@ export async function removeRunCanonicalStorageState(
   });
 }
 
+export async function readRunnerJobStorageState(
+  context: TestContext,
+  runId: string,
+): Promise<
+  NonNullable<TestRuntimeStateActionResponse["runner_job_storage_state"]>
+> {
+  const response = await postAction(context, {
+    action: "read-runner-job-storage-state",
+    run_id: runId,
+  });
+  if (!response.runner_job_storage_state) {
+    throw new Error(
+      "readRunnerJobStorageState missing runner_job_storage_state",
+    );
+  }
+  return response.runner_job_storage_state;
+}
+
 export async function readStoragePersistenceState(
   context: TestContext,
   ids: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -89,6 +89,7 @@ import {
   readFakeKmsDecryptCallCount,
   readOrgAdmissionLockState,
   readRunApiStart,
+  readRunnerJobStorageState,
   readStoragePersistenceState,
   releaseOrgAdmissionLock,
   resetFakeKms,
@@ -2080,10 +2081,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     expect(created.status).toBe("pending");
 
+    const directStorageState = await readRunnerJobStorageState(
+      context,
+      created.runId,
+    );
+    expect(directStorageState.legacy_manifest_state).toBe("null");
+    expect(directStorageState.canonical_mount_count).toBeGreaterThan(0);
+    expect(directStorageState.has_run_context_storage).toBeFalsy();
+
     const claim = await api.claimRunnerJob(created.runId);
-    expect(
-      expectCanonicalStorageManifest(claim.storageManifest)?.storageMounts,
-    ).toStrictEqual(
+    const manifest = expectCanonicalStorageManifest(claim.storageManifest);
+    if (!manifest) {
+      throw new Error("Expected canonical Storage mounts");
+    }
+    expect(manifest.storageMounts).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
           mountPath: "/primary",
@@ -2092,13 +2103,31 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         }),
       ]),
     );
-    expect(
-      expectCanonicalStorageManifest(claim.storageManifest)?.storageMounts.some(
-        (mount) => {
-          return mount.name === "memory";
+    const memoryMount = manifest.storageMounts.find((mount) => {
+      return mount.name === "memory";
+    });
+    if (!memoryMount) {
+      throw new Error("Expected canonical memory mount");
+    }
+    expect(claim).not.toHaveProperty("runContextStorage");
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith("run-context", [
+      expect.objectContaining({
+        runId: created.runId,
+        volumes: expect.arrayContaining([
+          {
+            name: "primary",
+            mountPath: "/primary",
+            vasStorageName: storageName,
+            vasVersionId: prepared.versionId,
+          },
+        ]),
+        artifact: {
+          mountPath: memoryMount.mountPath,
+          vasStorageName: memoryMount.name,
+          vasVersionId: memoryMount.versionId,
         },
-      ),
-    ).toBeTruthy();
+      }),
+    ]);
 
     await api.requestCancelRun(actor, created.runId, [200]);
   });
@@ -4346,6 +4375,13 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(promoted.status).toBe("pending");
     const drained = await waitForRunQueueLength(api, actor, 0);
     expect(drained.body.queue).toHaveLength(0);
+    const promotedStorageState = await readRunnerJobStorageState(
+      context,
+      third.runId,
+    );
+    expect(promotedStorageState.legacy_manifest_state).toBe("null");
+    expect(promotedStorageState.canonical_mount_count).toBeGreaterThan(0);
+    expect(promotedStorageState.has_run_context_storage).toBeFalsy();
     const decryptCountBeforeClaim = await readFakeKmsDecryptCallCount(context);
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
@@ -4356,6 +4392,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     }
     expect(thirdClaim.secretValues).toContain(zeroToken);
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
+    expect(thirdClaim).not.toHaveProperty("runContextStorage");
     const apiToRunnerQueueMs = sandboxOperationDurationForRun(
       third.runId,
       "api_to_runner_queue",

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -14,6 +14,7 @@ import {
   testRuntimeStateContract,
   type TestRuntimeStateActionBody,
 } from "@vm0/api-contracts/contracts/test-runtime-state";
+import { storedExecutionContextSchema } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -402,6 +403,39 @@ async function readStoragePersistenceState(
   };
 }
 
+async function readRunnerJobStorageState(
+  db: Db,
+  runId: string,
+  signal: AbortSignal,
+) {
+  const [job] = await db
+    .select({ executionContext: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!job) {
+    throw new Error("Runner job queue row not found");
+  }
+  const rawContext = z
+    .record(z.string(), z.unknown())
+    .parse(job.executionContext);
+  const context = storedExecutionContextSchema.parse(rawContext);
+  let legacyManifestState: "missing" | "null" | "object";
+  if (!Object.hasOwn(rawContext, "storageManifest")) {
+    legacyManifestState = "missing";
+  } else if (rawContext.storageManifest === null) {
+    legacyManifestState = "null";
+  } else {
+    legacyManifestState = "object";
+  }
+  return {
+    legacy_manifest_state: legacyManifestState,
+    canonical_mount_count: context.storageMounts.length,
+    has_run_context_storage: Object.hasOwn(rawContext, "runContextStorage"),
+  };
+}
+
 type StorageStateAction = Extract<
   TestRuntimeStateActionBody,
   { action: "remove-run-canonical-storage-state" }
@@ -411,7 +445,14 @@ type ReadStorageStateAction = Extract<
   TestRuntimeStateActionBody,
   { action: "read-storage-persistence-state" }
 >;
-type AnyStorageStateAction = StorageStateAction | ReadStorageStateAction;
+type ReadRunnerJobStorageStateAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "read-runner-job-storage-state" }
+>;
+type AnyStorageStateAction =
+  | StorageStateAction
+  | ReadStorageStateAction
+  | ReadRunnerJobStorageStateAction;
 
 function isStorageStateAction(
   body: TestRuntimeStateActionBody,
@@ -419,6 +460,9 @@ function isStorageStateAction(
   switch (body.action) {
     case "remove-run-canonical-storage-state":
     case "read-storage-persistence-state": {
+      return true;
+    }
+    case "read-runner-job-storage-state": {
       return true;
     }
     default: {
@@ -441,25 +485,42 @@ async function storageStateActionResponse(
   body: AnyStorageStateAction,
   signal: AbortSignal,
 ) {
-  if (body.action === "read-storage-persistence-state") {
-    return {
-      status: 200 as const,
-      body: {
-        ok: true as const,
-        storage_persistence: await readStoragePersistenceState(
-          db,
-          {
-            runId: body.run_id,
-            sessionId: body.session_id,
-            checkpointId: body.checkpoint_id,
-          },
-          signal,
-        ),
-      },
-    };
+  switch (body.action) {
+    case "read-storage-persistence-state": {
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          storage_persistence: await readStoragePersistenceState(
+            db,
+            {
+              runId: body.run_id,
+              sessionId: body.session_id,
+              checkpointId: body.checkpoint_id,
+            },
+            signal,
+          ),
+        },
+      };
+    }
+    case "read-runner-job-storage-state": {
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          runner_job_storage_state: await readRunnerJobStorageState(
+            db,
+            body.run_id,
+            signal,
+          ),
+        },
+      };
+    }
+    case "remove-run-canonical-storage-state": {
+      await mutateStorageState(db, body, signal);
+      return { status: 200 as const, body: { ok: true as const } };
+    }
   }
-  await mutateStorageState(db, body, signal);
-  return { status: 200 as const, body: { ok: true as const } };
 }
 
 type TimingStateAction = Extract<

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4,8 +4,8 @@ import {
   CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
   DEFAULT_PROFILE,
+  type ArtifactEntry,
   type SecretConnectorMetadata,
-  type LegacyStorageManifest,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
@@ -150,8 +150,8 @@ import {
 } from "./zero-custom-connector.service";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
 import {
-  prepareAgentRunStorageManifest,
-  type PreparedAgentRunStorageManifest,
+  prepareAgentRunStorage,
+  type PreparedAgentRunStorage,
   StorageManifestBuildStats,
   type StorageManifestSource,
 } from "./agent-run-storage.service";
@@ -228,7 +228,7 @@ import {
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
 type ArtifactMissingRootPolicy = NonNullable<
-  LegacyStorageManifest["artifacts"][number]["missingRootPolicy"]
+  ArtifactEntry["missingRootPolicy"]
 >;
 const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
   "preserveParentVersion";
@@ -629,6 +629,7 @@ interface StoredExecutionSecrets {
 interface BuiltStoredExecutionContext {
   readonly context: StoredExecutionContext;
   readonly persistedStorageMounts: readonly PersistedStorageMount[];
+  readonly runContextStorage: PreparedAgentRunStorage["runContextStorage"];
   readonly secretNames: readonly string[];
   // Plain secret values used for run-context redaction; values, not names.
   readonly secretValues: readonly string[];
@@ -636,7 +637,7 @@ interface BuiltStoredExecutionContext {
 
 type BuiltStoredExecutionContextDraft = Omit<
   BuiltStoredExecutionContext,
-  "context" | "persistedStorageMounts"
+  "context" | "persistedStorageMounts" | "runContextStorage"
 > & {
   readonly context: Omit<
     StoredExecutionContext,
@@ -4767,16 +4768,16 @@ async function buildStoredExecutionContextDraft(args: {
 }
 
 async function resolveBuiltStoredExecutionContext(
-  storageManifestPromise: Promise<PreparedAgentRunStorageManifest>,
+  preparedStoragePromise: Promise<PreparedAgentRunStorage>,
   builtContextDraftPromise: Promise<BuiltStoredExecutionContextDraft>,
 ): Promise<BuiltStoredExecutionContext> {
-  const [storageManifestResult, builtContextDraftResult] =
+  const [preparedStorageResult, builtContextDraftResult] =
     await Promise.allSettled([
-      storageManifestPromise,
+      preparedStoragePromise,
       builtContextDraftPromise,
     ]);
-  if (storageManifestResult.status === "rejected") {
-    throw storageManifestResult.reason;
+  if (preparedStorageResult.status === "rejected") {
+    throw preparedStorageResult.reason;
   }
   if (builtContextDraftResult.status === "rejected") {
     throw builtContextDraftResult.reason;
@@ -4784,12 +4785,13 @@ async function resolveBuiltStoredExecutionContext(
   return {
     ...builtContextDraftResult.value,
     persistedStorageMounts: [
-      ...storageManifestResult.value.persistedStorageMounts,
+      ...preparedStorageResult.value.persistedStorageMounts,
     ],
+    runContextStorage: preparedStorageResult.value.runContextStorage,
     context: {
       ...builtContextDraftResult.value.context,
-      storageManifest: storageManifestResult.value.storageManifest,
-      storageMounts: [...storageManifestResult.value.storageMounts],
+      storageManifest: null,
+      storageMounts: [...preparedStorageResult.value.storageMounts],
     },
   };
 }
@@ -4855,7 +4857,6 @@ function buildRunContextSnapshot(args: {
   readonly builtContext: BuiltStoredExecutionContext;
 }): RunContextAxiomSnapshot {
   const storedContext = args.builtContext.context;
-  const manifest: LegacyStorageManifest | null = storedContext.storageManifest;
   const sanitizedEnvironment = sanitizeEnvironment(
     storedContext.environment,
     args.builtContext.secretValues,
@@ -4875,22 +4876,8 @@ function buildRunContextSnapshot(args: {
     networkPolicyEntries: networkPoliciesRecordToEntries(
       storedContext.networkPolicies,
     ),
-    volumes: (manifest?.storages ?? []).map((storage) => {
-      return {
-        name: storage.name,
-        mountPath: storage.mountPath,
-        vasStorageName: storage.vasStorageName,
-        vasVersionId: storage.vasVersionId,
-      };
-    }),
-    artifact:
-      manifest && manifest.artifacts.length > 0
-        ? {
-            mountPath: manifest.artifacts[0]!.mountPath,
-            vasStorageName: manifest.artifacts[0]!.vasStorageName,
-            vasVersionId: manifest.artifacts[0]!.vasVersionId,
-          }
-        : null,
+    volumes: args.builtContext.runContextStorage.volumes,
+    artifact: args.builtContext.runContextStorage.artifact,
     featureFlagEntries: featureFlagsRecordToEntries(storedContext.featureFlags),
   };
   return snapshot;
@@ -5264,13 +5251,13 @@ function buildRunnerJobPayload(
     const storageManifestStats = args.timing
       ? new StorageManifestBuildStats()
       : undefined;
-    const storageManifestPromise = measureApiDispatchTiming(
+    const preparedStoragePromise = measureApiDispatchTiming(
       args.timing,
       "api_dispatch_prepare_storage_manifest",
       "nested",
       async () => {
         return await get(
-          prepareAgentRunStorageManifest({
+          prepareAgentRunStorage({
             db,
             content: args.resolved.content,
             vars: body.vars,
@@ -5305,7 +5292,7 @@ function buildRunnerJobPayload(
       },
     );
     const builtContext = await resolveBuiltStoredExecutionContext(
-      storageManifestPromise,
+      preparedStoragePromise,
       builtContextDraftPromise,
     );
     const runContextSnapshot = buildRunContextSnapshot({

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -2,6 +2,7 @@ import type {
   LegacyStorageManifest,
   StoredStorageMountEntry,
 } from "@vm0/api-contracts/contracts/runners";
+import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { expandVariablesInString } from "@vm0/core/variable-expander";
 import {
   getInstructionsFilename,
@@ -217,10 +218,15 @@ interface StorageManifestEntries {
   readonly resolvedAdditionalEntryCount: number;
 }
 
-export interface PreparedAgentRunStorageManifest {
-  readonly storageManifest: LegacyStorageManifest;
+interface RunContextStorageObservation {
+  readonly volumes: RunContextResponse["volumes"];
+  readonly artifact: RunContextResponse["artifact"];
+}
+
+export interface PreparedAgentRunStorage {
   readonly storageMounts: readonly StoredStorageMountEntry[];
   readonly persistedStorageMounts: readonly PersistedStorageMount[];
+  readonly runContextStorage: RunContextStorageObservation;
 }
 
 interface BuildStorageManifestEntriesArgs {
@@ -2802,7 +2808,7 @@ function combineStorageManifestEntries(args: {
   };
 }
 
-async function assembleStorageManifest(args: {
+async function finalizePreparedStorage(args: {
   readonly composeEntries: readonly ManifestStorage[];
   readonly additionalEntries: readonly ManifestStorage[];
   readonly artifactEntries: ManifestArtifact[];
@@ -2812,7 +2818,7 @@ async function assembleStorageManifest(args: {
   readonly resolvedAdditionalEntryCount: number;
   readonly timing?: ApiDispatchTimingCollector;
   readonly stats?: StorageManifestBuildStats;
-}): Promise<PreparedAgentRunStorageManifest> {
+}): Promise<PreparedAgentRunStorage> {
   return await measureApiDispatchTiming(
     args.timing,
     "api_dispatch_prepare_storage_manifest_assemble",
@@ -2830,10 +2836,24 @@ async function assembleStorageManifest(args: {
         resolvedComposeEntryCount: args.resolvedComposeEntryCount,
         resolvedAdditionalEntryCount: args.resolvedAdditionalEntryCount,
       });
+      const artifact = args.artifactEntries[0];
       return {
-        storageManifest: {
-          storages: [...storages],
-          artifacts: args.artifactEntries,
+        runContextStorage: {
+          volumes: storages.map((storage) => {
+            return {
+              name: storage.name,
+              mountPath: storage.mountPath,
+              vasStorageName: storage.vasStorageName,
+              vasVersionId: storage.vasVersionId,
+            };
+          }),
+          artifact: artifact
+            ? {
+                mountPath: artifact.mountPath,
+                vasStorageName: artifact.vasStorageName,
+                vasVersionId: artifact.vasVersionId,
+              }
+            : null,
         },
         storageMounts: args.storageMounts,
         persistedStorageMounts: args.persistedStorageMounts,
@@ -2951,11 +2971,11 @@ async function buildLegacyStorageManifestEntries(
   });
 }
 
-async function prepareStorageManifestWithSessionOverlay(
+async function prepareStorageWithSessionOverlay(
   get: ComputedGetter,
   args: PrepareAgentRunStorageManifestArgs,
   bucket: string,
-): Promise<PreparedAgentRunStorageManifest> {
+): Promise<PreparedAgentRunStorage> {
   const { artifacts, composeVolumes } =
     await resolveStorageManifestInputs(args);
   const { canonicalWritebackMounts, legacyArtifacts } =
@@ -2986,18 +3006,18 @@ async function prepareStorageManifestWithSessionOverlay(
             },
           ),
         });
-  return await assembleStorageManifest({
+  return await finalizePreparedStorage({
     ...entries,
     timing: args.timing,
     stats: args.stats,
   });
 }
 
-export function prepareAgentRunStorageManifest(
+export function prepareAgentRunStorage(
   args: PrepareAgentRunStorageManifestArgs,
-): Computed<Promise<PreparedAgentRunStorageManifest>> {
-  return computed(async (get): Promise<PreparedAgentRunStorageManifest> => {
+): Computed<Promise<PreparedAgentRunStorage>> {
+  return computed(async (get): Promise<PreparedAgentRunStorage> => {
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-    return await prepareStorageManifestWithSessionOverlay(get, args, bucket);
+    return await prepareStorageWithSessionOverlay(get, args, bucket);
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -72,13 +72,39 @@ describe("runner poll response contract", () => {
 });
 
 describe("runner storage manifest contract", () => {
-  it("requires canonical mounts in stored execution contexts", () => {
+  it("preserves stored context compatibility while preparing field removal", () => {
+    const context = {
+      storageMounts: [],
+      environment: null,
+      secretValueEnvironmentKeys: null,
+      resumeSession: null,
+      encryptedSecrets: null,
+      cliAgentType: "codex",
+    };
+    const legacyManifest = { storages: [], artifacts: [] };
+    const previousStoredExecutionContextSchema =
+      storedExecutionContextSchema.extend({
+        storageManifest: legacyStorageManifestSchema.nullable(),
+      });
+
     expect(
-      storedExecutionContextSchema.shape.storageMounts.safeParse([]).success,
+      previousStoredExecutionContextSchema.safeParse({
+        ...context,
+        storageManifest: null,
+      }).success,
     ).toBe(true);
     expect(
-      storedExecutionContextSchema.shape.storageMounts.safeParse(undefined)
-        .success,
+      storedExecutionContextSchema.safeParse({
+        ...context,
+        storageManifest: legacyManifest,
+      }).success,
+    ).toBe(true);
+    expect(storedExecutionContextSchema.safeParse(context).success).toBe(true);
+    expect(
+      storedExecutionContextSchema.safeParse({
+        ...context,
+        storageMounts: undefined,
+      }).success,
     ).toBe(false);
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -94,9 +94,18 @@ describe("runner storage manifest contract", () => {
       }).success,
     ).toBe(true);
     expect(
+      previousStoredExecutionContextSchema.safeParse(context).success,
+    ).toBe(false);
+    expect(
       storedExecutionContextSchema.safeParse({
         ...context,
         storageManifest: legacyManifest,
+      }).success,
+    ).toBe(true);
+    expect(
+      storedExecutionContextSchema.safeParse({
+        ...context,
+        storageManifest: null,
       }).success,
     ).toBe(true);
     expect(storedExecutionContextSchema.safeParse(context).success).toBe(true);

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -516,9 +516,9 @@ export const secretConnectorMetadataMapSchema = z.record(
  */
 export const storedExecutionContextSchema = z.object({
   // Compatibility projection for the previous API version and rollback. The
-  // API emits storageMounts to every runner; remove this projection after
-  // rollback-eligible API versions have drained.
-  storageManifest: legacyStorageManifestSchema.nullable(),
+  // API writes null while storageMounts drive every claim. Omission is accepted
+  // for the final contraction after rollback-eligible APIs and queues drain.
+  storageManifest: legacyStorageManifestSchema.nullable().optional(),
   storageMounts: z
     .array(storedStorageMountEntrySchema)
     .superRefine(uniqueStorageMountPaths),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -38,6 +38,10 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("read-runner-job-storage-state"),
+    run_id: z.uuid(),
+  }),
+  z.object({
     action: z.literal("read-storage-persistence-state"),
     run_id: z.uuid(),
     session_id: z.uuid(),
@@ -130,6 +134,13 @@ export const testRuntimeStateActionResponseSchema = z.object({
       run_canonical: z.boolean(),
       session_canonical: z.boolean(),
       checkpoint_canonical: z.boolean(),
+    })
+    .optional(),
+  runner_job_storage_state: z
+    .object({
+      legacy_manifest_state: z.enum(["missing", "null", "object"]),
+      canonical_mount_count: z.number().int().nonnegative(),
+      has_run_context_storage: z.boolean(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary

- write an explicit `null` legacy storage manifest sentinel while allowing the new reader to accept the previous object, `null`, or a future omission
- derive exact run-context storage observations separately from canonical queued mounts so presigned storage data is not duplicated in queue state or runner payloads
- cover direct and delayed queue paths with integration tests and document the compatibility and rollout gates for the later field removal

## Compatibility

- previous API readers can consume newly queued `null` manifests
- new API readers can consume rows written by previous API versions
- canonical storage mounts remain required
- this PR does not change the database schema, Runner or Guest contracts, or remove the legacy field

## Validation

- `pnpm exec prettier --check <affected files>`
- `pnpm -F @vm0/api-contracts run lint`
- `pnpm -F @vm0/api-contracts run check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=1`
- `pnpm -F api run lint`
- `pnpm -F api run check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1`
- `pnpm knip`

Closes #23498

Parent: #23442
