### PR TITLE
chore(api): detect helpers with retained sql operands

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1736,7 +1736,7 @@ function providerEnvironmentFromSecretMap(
 }
 
 function vm0ApiKeySelectionOrder() {
-  return sql`case when ${vm0ApiKeys.label} = 'dev-seed' then 0 else 1 end`;
+  return sql`case when ${eq(vm0ApiKeys.label, sql`'dev-seed'`)} then 0 else 1 end`;
 }
 
 async function multiAuthModelProviderEnvironment(

--- a/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lte, or, sql } from "drizzle-orm";
 import type {
   ArtifactCatalogKind,
   ArtifactDetail,
@@ -424,7 +424,10 @@ async function syncHostedArtifact(args: {
       .where(
         and(
           eq(artifacts.id, existingArtifact.id),
-          sql`(${artifacts.projectionCreatedAt}, ${artifacts.projectionFileId}) <= (${args.row.createdAt}::timestamp, ${args.row.id}::uuid)`,
+          lte(
+            sql`(${artifacts.projectionCreatedAt}, ${artifacts.projectionFileId})`,
+            sql`(${args.row.createdAt}::timestamp, ${args.row.id}::uuid)`,
+          ),
         ),
       )
       .returning({ id: artifacts.id });
@@ -456,7 +459,10 @@ async function runHasHostedProjection(
     .where(
       and(
         eq(runUploadedFiles.runId, runId),
-        sql`${runUploadedFiles.metadata} ->> 'artifactKind' IN ('hosted-site', 'presentation-html')`,
+        inArray(
+          sql`${runUploadedFiles.metadata} ->> 'artifactKind'`,
+          sql`('hosted-site', 'presentation-html')`,
+        ),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -136,7 +136,10 @@ async function latestHistoricalThreadSession(args: {
         eq(agentSessions.userId, args.userId),
         eq(agentSessions.orgId, args.orgId),
         eq(agentSessions.agentComposeId, args.agentComposeId),
-        sql`${agentRuns.result}->>'agentSessionId' = ${agentSessions.id}::text`,
+        eq(
+          sql`${agentRuns.result}->>'agentSessionId'`,
+          sql`${agentSessions.id}::text`,
+        ),
       ),
     )
     .orderBy(desc(agentRuns.createdAt))

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -18,7 +18,7 @@ import {
   connectorCatalogSyncState,
 } from "@vm0/db/schema/connector-catalog";
 import { command } from "ccstate";
-import { and, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, eq, isNull, lte, ne, or, sql } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
@@ -356,7 +356,10 @@ export async function persistConnectorCatalogCompatibility(args: {
         isNull(
           connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion,
         ),
-        sql`string_to_array(${connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion}, '.')::numeric[] <= string_to_array(${args.validator.backendVersion}, '.')::numeric[]`,
+        lte(
+          sql`string_to_array(${connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion}, '.')::numeric[]`,
+          sql`string_to_array(${args.validator.backendVersion}, '.')::numeric[]`,
+        ),
       ),
     });
 }

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -468,7 +468,7 @@ async function markConnectorCredentialNeedsReconnectAfterRefreshFailure(args: {
           eq(connectors.userId, args.userId),
           eq(connectors.type, args.connection.connectorRef),
           eq(connectors.authMethod, args.connection.runtimeMethod.authMethodId),
-          sql`${connectors.updatedAt}::text = ${args.connection.stateRevision}`,
+          eq(sql`${connectors.updatedAt}::text`, args.connection.stateRevision),
         ),
       );
   });

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { and, count, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { and, count, gte, isNotNull, lt, sql, sum } from "drizzle-orm";
 
 import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
@@ -30,7 +30,9 @@ export const aggregateUsageDaily$ = command(
         ${agentRuns.orgId},
         ${targetDate}::date,
         ${count()}::int,
-        COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint
+        COALESCE(${sum(
+          sql`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`,
+        )}, 0)::bigint
       FROM ${agentRuns}
       WHERE ${and(
         gte(agentRuns.createdAt, yesterday),

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -270,10 +270,10 @@ const cleanupSingleRun$ = command(
           and(
             eq(agentRuns.id, run.id),
             eq(agentRuns.status, run.status),
-            sql`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt}) < ${sql.param(
-              cutoff,
-              agentRuns.createdAt,
-            )}`,
+            lt(
+              sql`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt})`,
+              sql.param(cutoff, agentRuns.createdAt),
+            ),
           ),
         )
         .returning({ id: agentRuns.id });

--- a/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, inArray, lt, or, sql } from "drizzle-orm";
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
 
 import { isStoredScreenshotPointer } from "@vm0/api-contracts/contracts/zero-computer-use";
 import { computerUseCommands } from "@vm0/db/schema/computer-use-host";
@@ -37,8 +37,14 @@ export const cleanupComputerUseScreenshots$ = command(
             lt(computerUseCommands.createdAt, cutoff),
             sql`jsonb_exists(${computerUseCommands.result}, 'screenshot')`,
             or(
-              sql`${computerUseCommands.result}->'screenshot'->>'type' = 's3'`,
-              sql`jsonb_typeof(${computerUseCommands.result}->'screenshot') = 'string'`,
+              eq(
+                sql`${computerUseCommands.result}->'screenshot'->>'type'`,
+                sql`'s3'`,
+              ),
+              eq(
+                sql`jsonb_typeof(${computerUseCommands.result}->'screenshot')`,
+                sql`'string'`,
+              ),
             ),
           ),
         )

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -535,7 +535,7 @@ function collectSessionRuns(
       .where(
         or(
           eq(agentRuns.continuedFromSessionId, agentSessionId),
-          sql`${agentRuns.result}->>'agentSessionId' = ${agentSessionId}`,
+          eq(sql`${agentRuns.result}->>'agentSessionId'`, agentSessionId),
         ),
       )
       .orderBy(agentRuns.createdAt);

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -279,7 +279,9 @@ async function selectModelRankings(
       WITH current_period AS (
       SELECT
         ${modelExpr} AS model,
-        COALESCE(SUM(${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS input_tokens,
+        COALESCE(${sum(
+          sql`${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}`,
+        )}, 0)::bigint AS input_tokens,
         COALESCE(${sum(modelStat.outputTokens)}, 0)::bigint AS output_tokens,
         COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS total_tokens
       FROM ${modelStat}

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -5,7 +5,7 @@ import type {
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { and, count, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { and, count, eq, gte, isNotNull, lt, sql, sum } from "drizzle-orm";
 
 import {
   pgInt8ToSafeIntegerDecoder,
@@ -62,10 +62,11 @@ async function queryAgentRunsDaily(
     .select({
       date: sql`DATE(${agentRuns.createdAt})`.mapWith(pgTextDecoder).as("date"),
       run_count: count().as("run_count"),
-      run_time_ms:
-        sql`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`
-          .mapWith(pgInt8ToSafeIntegerDecoder)
-          .as("run_time_ms"),
+      run_time_ms: sql`COALESCE(${sum(
+        sql`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`,
+      )}, 0)::bigint`
+        .mapWith(pgInt8ToSafeIntegerDecoder)
+        .as("run_time_ms"),
     })
     .from(agentRuns)
     .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -66,8 +66,13 @@ async function selectIncompleteRoundFrontier(
   readonly successfulRunId: string | null;
 }> {
   const isSuccessfulRun = sql`COALESCE(
-    ${agentRuns.result} ? 'agentSessionId'
-    AND jsonb_typeof(${agentRuns.result}->'agentSessionId') = 'string',
+    ${and(
+      sql`${agentRuns.result} ? 'agentSessionId'`,
+      eq(
+        sql`jsonb_typeof(${agentRuns.result}->'agentSessionId')`,
+        sql`'string'`,
+      ),
+    )},
     FALSE
   )`;
   // Terminal chat materialization runs in waitUntil, so lifecycle rows can lag
@@ -111,7 +116,10 @@ async function selectIncompleteRoundFrontier(
           or(
             isSuccessfulRun,
             and(
-              sql`${agentRuns.status} IN ('cancelled', 'failed', 'timeout')`,
+              inArray(
+                agentRuns.status,
+                sql`('cancelled', 'failed', 'timeout')`,
+              ),
               chatEventTypeIn(CHAT_EVENT_TYPES),
             ),
           ),

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -76,6 +76,7 @@ import {
   isNotNull,
   isNull,
   lt,
+  ne,
   notExists,
   or,
   type SQL,
@@ -1237,11 +1238,14 @@ export function zeroChatThreadDraftIds(args: {
         and(
           eq(chatThreads.userId, args.userId),
           or(
-            sql`COALESCE(${chatThreads.draftContent}, '') <> ''`,
+            ne(sql`COALESCE(${chatThreads.draftContent}, '')`, sql`''`),
             isNotNull(chatThreads.draftUserMessage),
             and(
               isNotNull(chatThreads.draftAttachments),
-              sql`jsonb_array_length(${chatThreads.draftAttachments}) > 0`,
+              gt(
+                sql`jsonb_array_length(${chatThreads.draftAttachments})`,
+                sql`0`,
+              ),
             ),
           ),
         ),

--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -121,10 +121,11 @@ export async function checkCreditAmountForLockedOrg(
   const reserved = writeDb.$with("reserved").as(
     writeDb
       .select({
-        total:
-          sql`COALESCE(SUM(GREATEST(${browserSessions.maxCredits} - ${browserSessions.grossCredits}, 0)), 0)::bigint`
-            .mapWith(pgInt8ToBigIntDecoder)
-            .as("reserved_total"),
+        total: sql`COALESCE(${sum(
+          sql`GREATEST(${browserSessions.maxCredits} - ${browserSessions.grossCredits}, 0)`,
+        )}, 0)::bigint`
+          .mapWith(pgInt8ToBigIntDecoder)
+          .as("reserved_total"),
       })
       .from(browserSessions)
       .where(
@@ -237,10 +238,11 @@ export const checkManagedCredits$ = command(
     const reserved = writeDb.$with("reserved").as(
       writeDb
         .select({
-          total:
-            sql`COALESCE(SUM(GREATEST(${browserSessions.maxCredits} - ${browserSessions.grossCredits}, 0)), 0)::bigint`
-              .mapWith(pgInt8ToBigIntDecoder)
-              .as("reserved_total"),
+          total: sql`COALESCE(${sum(
+            sql`GREATEST(${browserSessions.maxCredits} - ${browserSessions.grossCredits}, 0)`,
+          )}, 0)::bigint`
+            .mapWith(pgInt8ToBigIntDecoder)
+            .as("reserved_total"),
         })
         .from(browserSessions)
         .where(

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -5,6 +5,7 @@ import {
   isNotNull,
   max,
   sql,
+  sum,
   type SQLWrapper,
 } from "drizzle-orm";
 
@@ -150,10 +151,11 @@ export function buildFinalizedUsageRunTotalsSubquery(db: Db, orgId: string) {
       "cache_tokens_sum",
     ),
     creditsCharged: usageCreditsSum(usage, "credits_sum"),
-    model:
-      sql`MAX(CASE WHEN ${eq(usage.kind, MODEL_USAGE_KIND)} THEN ${usage.provider} ELSE NULL END)`
-        .mapWith(nullableTextDecoder)
-        .as("model"),
+    model: max(
+      sql`CASE WHEN ${eq(usage.kind, MODEL_USAGE_KIND)} THEN ${usage.provider} ELSE NULL END`,
+    )
+      .mapWith(nullableTextDecoder)
+      .as("model"),
     userId: max(usage.userId).mapWith(pgTextDecoder).as("user_id"),
   } satisfies Record<keyof UsageRunTotalsRow, unknown>;
 
@@ -200,10 +202,12 @@ function finalizedUsageTokenSum(
   categories: readonly string[],
   alias: string,
 ) {
-  return sql`COALESCE(SUM(CASE WHEN ${and(
-    eq(usage.kind, MODEL_USAGE_KIND),
-    inArray(usage.category, categories),
-  )} THEN ${usage.quantity} ELSE 0 END), 0)::bigint`
+  return sql`COALESCE(${sum(
+    sql`CASE WHEN ${and(
+      eq(usage.kind, MODEL_USAGE_KIND),
+      inArray(usage.category, categories),
+    )} THEN ${usage.quantity} ELSE 0 END`,
+  )}, 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -312,7 +312,6 @@ interface WriteDescendantError {
 const queryBuilderCases = {
   writeValid: [
     {
-      descendantErrors: [{ messageId: "typedApi", data: { helper: "lte" } }],
       code: `${deletePreamble}
         import { and, lte, sql, type SQL } from "drizzle-orm";
         declare function dynamicPredicate(): SQL;

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -182,10 +182,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const left = 1;
         const right = 2;
         sql\`\${left} = \${right}\`;
-        db.query.users.findMany({
-          where: (fields, operators) =>
-            operators.sql\`length(\${fields.name}) > 0\`,
-        });
       `,
     },
     {
@@ -619,15 +615,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select()
           .from(users)
           .innerJoin(users, flag ? sql.empty() : sql\`true\`);
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
-        const column = sql\`\${users.id}\`;
-        db.select()
-          .from(users)
-          .where(sql\`COALESCE(\${column} = \${1}, FALSE)\`);
       `,
     },
     {
@@ -2173,6 +2160,279 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             not(
               sql\`\${users.id} = \${1} AND \${users.name} = \${"name"}\`,
             ),
+          );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+  ],
+});
+
+ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
+  valid: [
+    {
+      name: "raw identifiers and scalar-only transformations have no schema boundary",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(raw_name) = \${"name"}\`);
+        db.select()
+          .from(users)
+          .where(sql\`left_alias = right_alias\`);
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(\${"name"}) = \${"other"}\`);
+      `,
+    },
+    {
+      name: "table and unsupported operator operands remain raw",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(\${users}) = \${"users"}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.id} IS DISTINCT FROM \${1}\`);
+      `,
+    },
+    {
+      name: "membership subqueries and transformed lists retain their contracts",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const names = ["one", "two"];
+        const transformed = sql.join(
+          names.map((name) => sql\`\${name.toUpperCase()}\`),
+          sql\`, \`,
+        );
+        const selected = db.select({ name: users.name }).from(users);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} IN (\${transformed})\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} IN (\${selected})\`);
+        db.select()
+          .from(users)
+          .where(
+            sql\`(SELECT \${users.id} FROM \${users} LIMIT 1) = \${1}\`,
+          );
+      `,
+    },
+    {
+      name: "aggregate retained operands still require result mapping",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`SUM(\${users.id} + 1)\`,
+        }).from(users);
+        db.select({
+          value: sql\`MAX(\${users.id} + 1) OVER (ORDER BY \${users.id})\`
+            .mapWith(Number),
+        }).from(users);
+      `,
+    },
+    {
+      name: "ambiguous retained interpolation remains raw",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const suffixes = ["one", "two"];
+        const bounds = [1, 2];
+        db.select()
+          .from(users)
+          .where(
+            sql\`LOWER(\${users.name} || \${suffixes}) = \${"name"}\`,
+          );
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} = \${suffixes}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.id} BETWEEN \${bounds} AND \${2}\`);
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "relational callback transformed comparison",
+      code: `${drizzlePreamble}
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`length(\${fields.name}) > 0\`,
+        });
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      name: "transformed comparison",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(\${users.name}) = \${"name"}\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "retained comparison operands",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = 1;
+        db.select()
+          .from(users)
+          .where(sql\`\${users.id}::text = \${"1"}\`);
+        db.select()
+          .from(users)
+          .where(sql\`\${users.id} = \${value} + 1\`);
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      name: "transformed null operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(\${users.name}) IS NULL\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "isNull" } }],
+    },
+    {
+      name: "json comparison operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`\${users.tags}->>'kind' = \${"site"}\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "transformed pattern operands",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const prefix = "prefix";
+        db.select()
+          .from(users)
+          .where(
+            sql\`LOWER(\${users.name}) LIKE LOWER(\${prefix}) || '%'\`,
+          );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "like" } }],
+    },
+    {
+      name: "transformed ordering operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .orderBy(sql\`COALESCE(\${users.name}, '') DESC\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "desc" } }],
+    },
+    {
+      name: "static literal memberships",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select()
+          .from(users)
+          .where(sql\`\${users.name} IN ('one', 'two')\`);
+        db.select()
+          .from(users)
+          .where(sql\`LOWER(\${users.name}) NOT IN ('one', 'two')\`);
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "notInArray" } },
+      ],
+    },
+    {
+      name: "mapped aggregate arithmetic operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`COALESCE(SUM(\${users.id} + 1), 0)\`.mapWith(Number),
+        }).from(users);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "sum" } }],
+    },
+    {
+      name: "mapped aggregate case operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`MAX(CASE WHEN \${users.id} > \${0} THEN \${users.name} ELSE NULL END)\`
+            .mapWith(users.name),
+        }).from(users);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "max" } }],
+    },
+    {
+      name: "locally returned descendant reports at each use site",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function selectionOrder() {
+          return sql\`CASE WHEN \${users.name} = 'dev-seed' THEN 0 ELSE 1 END\`;
+        }
+        db.select().from(users).orderBy(selectionOrder());
+        db.select().from(users).orderBy(selectionOrder());
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" }, line: 23 },
+        { messageId: "typedApi", data: { helper: "eq" }, line: 24 },
+      ],
+    },
+    {
+      name: "unsupported case and complete statement expose descendants",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`CASE WHEN \${users.name} = 'dev-seed' THEN 0 ELSE 1 END\`,
+        }).from(users);
+        await db.execute(
+          sql\`
+            SELECT CASE
+              WHEN LOWER(\${users.name}) = \${"name"} THEN 1
+              ELSE 0
+            END
+            FROM \${users}
+            FOR SHARE
+          \`,
+        );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+    {
+      name: "nested composed descendant reports at the editable root",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const column = sql\`\${users.id}\`;
+        db.select()
+          .from(users)
+          .where(sql\`COALESCE(\${column} = \${1}, FALSE)\`);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "all transformed variants must agree",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const flag: boolean;
+        db.select()
+          .from(users)
+          .where(
+            flag
+              ? sql\`LOWER(\${users.name}) = \${"one"}\`
+              : sql\`UPPER(\${users.name}) = \${"two"}\`,
           );
       `,
       errors: [

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -1606,6 +1606,8 @@ type DrizzleOperandRole =
   | "string-or-wrapper"
   | "wrapper";
 
+type RetainedOperandRequirement = "interpolation" | "schema-column";
+
 function directMarkerMatchesRole(
   marker: SqlMarker,
   role: DrizzleOperandRole,
@@ -1648,10 +1650,148 @@ function nodeMatchesRole(
   return isDrizzleWrapperType(checker, type);
 }
 
-function operandNode(
+function directStructuralChildren(
+  expression: StructuralExpression,
+): readonly StructuralExpression[] {
+  if (expression.kind === "marker" || expression.kind === "constant") {
+    return [];
+  }
+  if (expression.kind === "comparison" || expression.kind === "array") {
+    return [expression.left, expression.right];
+  }
+  if (expression.kind === "boolean") {
+    return expression.items;
+  }
+  if (expression.kind === "aggregate") {
+    return [
+      expression.argument,
+      expression.filter,
+      ...expression.orderings.map((ordering) => {
+        return ordering.expression;
+      }),
+    ].filter((item): item is StructuralExpression => {
+      return item !== undefined;
+    });
+  }
+  if (expression.kind === "pattern") {
+    return [expression.left, expression.right, expression.escape].filter(
+      (item): item is StructuralExpression => {
+        return item !== undefined;
+      },
+    );
+  }
+  if (expression.kind === "membership") {
+    return [expression.left, ...expression.values];
+  }
+  if (expression.kind === "range") {
+    return [expression.left, expression.minimum, expression.maximum];
+  }
+  if (expression.kind === "null") {
+    return [expression.operand];
+  }
+  return expression.children;
+}
+
+function structuralMarkers(
+  expression: StructuralExpression,
+): readonly SqlMarker[] {
+  if (expression.kind === "marker") {
+    return [expression.marker];
+  }
+  return directStructuralChildren(expression).flatMap(structuralMarkers);
+}
+
+function containsSubquery(expression: StructuralExpression): boolean {
+  return (
+    expression.kind === "existence" ||
+    (expression.kind === "opaque" && expression.nodeKey === "SubLink") ||
+    directStructuralChildren(expression).some(containsSubquery)
+  );
+}
+
+function retainableInlineMarkers(
+  expression: StructuralExpression,
+): readonly SqlMarker[] | undefined {
+  if (containsSubquery(expression)) {
+    return undefined;
+  }
+  const markers = structuralMarkers(expression);
+  return markers.every((marker) => {
+    return (
+      !marker.isTable &&
+      !marker.isSelect &&
+      marker.isAnalyzableWriteInterpolation
+    );
+  })
+    ? markers
+    : undefined;
+}
+
+function hasInlineValueBoundary(
+  expression: StructuralExpression,
+  context: ClassificationContext,
+): boolean {
+  return (
+    commonCompositionBoundaries([...expression.sourceChunks], context.root)
+      .length > 0
+  );
+}
+
+function isSafeHelperValueOperand(
+  expression: StructuralExpression,
+  context: ClassificationContext,
+): boolean {
+  if (expression.kind === "constant") {
+    return true;
+  }
+  if (expression.kind === "marker") {
+    const marker = expression.marker;
+    return (
+      !marker.isTable &&
+      !marker.isSelect &&
+      (marker.isBoundScalar || marker.isWrapper)
+    );
+  }
+  const markers = retainableInlineMarkers(expression);
+  return (
+    markers !== undefined &&
+    (markers.length === 0 || hasInlineValueBoundary(expression, context))
+  );
+}
+
+// A retained operand has no standalone TypeScript node. PostgreSQL has already
+// proved the expression boundary, so keep its original chunks and use a
+// schema-aware interpolation only as the diagnostic anchor.
+function retainedOperandAnchor(
+  expression: StructuralExpression,
+  role: DrizzleOperandRole,
+  requirement: RetainedOperandRequirement,
+  context: ClassificationContext,
+): TSESTree.Expression | undefined {
+  const markers = retainableInlineMarkers(expression);
+  if (
+    role === "array" ||
+    role === "column" ||
+    markers === undefined ||
+    markers.length === 0 ||
+    !hasInlineValueBoundary(expression, context)
+  ) {
+    return undefined;
+  }
+  const schemaColumn = markers.find((marker) => {
+    return marker.isColumn;
+  });
+  if (requirement === "schema-column") {
+    return schemaColumn?.node;
+  }
+  return (schemaColumn ?? markers[0])?.node;
+}
+
+function operandAnchor(
   expression: StructuralExpression,
   role: DrizzleOperandRole,
   classificationContext: ClassificationContext,
+  retainedRequirement: RetainedOperandRequirement = "schema-column",
 ): TSESTree.Expression | undefined {
   if (expression.kind === "marker") {
     return directMarkerMatchesRole(expression.marker, role)
@@ -1673,7 +1813,12 @@ function operandNode(
       classificationContext.services,
     )
     ? boundary
-    : undefined;
+    : retainedOperandAnchor(
+        expression,
+        role,
+        retainedRequirement,
+        classificationContext,
+      );
 }
 
 function nestedClassificationContext(
@@ -1782,8 +1927,12 @@ function classifyExpression(
     const leftNode =
       helper === undefined
         ? undefined
-        : operandNode(expression.left, "wrapper", context);
-    if (helper !== undefined && leftNode !== undefined) {
+        : operandAnchor(expression.left, "wrapper", context);
+    if (
+      helper !== undefined &&
+      leftNode !== undefined &&
+      isSafeHelperValueOperand(expression.right, context)
+    ) {
       return {
         anchor: leftNode,
         findings: [
@@ -1842,7 +1991,7 @@ function classifyExpression(
   }
 
   if (expression.kind === "null") {
-    const node = operandNode(expression.operand, "wrapper", context);
+    const node = operandAnchor(expression.operand, "wrapper", context);
     if (node !== undefined) {
       return {
         anchor: node,
@@ -1859,8 +2008,13 @@ function classifyExpression(
   }
 
   if (expression.kind === "pattern") {
-    const left = operandNode(expression.left, "pattern", context);
-    const right = operandNode(expression.right, "string-or-wrapper", context);
+    const left = operandAnchor(expression.left, "pattern", context);
+    const right = operandAnchor(
+      expression.right,
+      "string-or-wrapper",
+      context,
+      "interpolation",
+    );
     if (left !== undefined && right !== undefined) {
       return {
         anchor: left,
@@ -1896,8 +2050,8 @@ function classifyExpression(
   }
 
   if (expression.kind === "array") {
-    const left = operandNode(expression.left, "array", context);
-    const right = operandNode(expression.right, "wrapper", context);
+    const left = operandAnchor(expression.left, "array", context);
+    const right = operandAnchor(expression.right, "wrapper", context);
     if (left !== undefined && right !== undefined) {
       return {
         anchor: left,
@@ -1920,29 +2074,27 @@ function classifyExpression(
   }
 
   if (expression.kind === "membership") {
-    const directColumn =
-      expression.left.kind === "marker" && expression.left.marker.isColumn
-        ? expression.left.marker.node
-        : undefined;
-    const lowerColumn =
-      expression.left.kind === "opaque" &&
-      expression.left.nodeKey === "FuncCall:lower" &&
-      expression.left.children.length === 1 &&
-      expression.left.children[0]?.kind === "marker" &&
-      expression.left.children[0].marker.isColumn
-        ? expression.left.children[0].marker.node
-        : undefined;
+    const directColumn = operandAnchor(expression.left, "column", context);
+    const left =
+      directColumn ?? operandAnchor(expression.left, "wrapper", context);
     const value =
       expression.values.length === 1 && expression.values[0]?.kind === "marker"
         ? expression.values[0].marker.node
         : undefined;
-    const validValues =
+    const hasExactLiteralValues =
+      expression.values.length > 0 &&
+      expression.values.every((item) => {
+        return item.kind === "constant";
+      });
+    const hasParameterListValues =
       value !== undefined &&
-      (lowerColumn === undefined
+      (directColumn !== undefined
         ? context.capabilities.hasParameterListOrigin(value)
         : context.capabilities.isInlineParameterList(value));
-    const left = directColumn ?? lowerColumn;
-    if (left !== undefined && validValues) {
+    if (
+      left !== undefined &&
+      (hasExactLiteralValues || hasParameterListValues)
+    ) {
       return {
         anchor: left,
         findings: [
@@ -1967,8 +2119,12 @@ function classifyExpression(
   }
 
   if (expression.kind === "range") {
-    const left = operandNode(expression.left, "wrapper", context);
-    if (left !== undefined) {
+    const left = operandAnchor(expression.left, "wrapper", context);
+    if (
+      left !== undefined &&
+      isSafeHelperValueOperand(expression.minimum, context) &&
+      isSafeHelperValueOperand(expression.maximum, context)
+    ) {
       return {
         anchor: left,
         findings: [
@@ -2019,7 +2175,7 @@ function classifyExpression(
     const argumentNode =
       expression.argument === undefined
         ? undefined
-        : operandNode(expression.argument, "wrapper", context);
+        : operandAnchor(expression.argument, "wrapper", context);
     const validArgument = expression.isStar
       ? expression.helper === "count"
       : argumentNode !== undefined;
@@ -2027,7 +2183,7 @@ function classifyExpression(
     const sameColumnDecoder =
       (helper === "max" || helper === "min") &&
       expression.argument !== undefined &&
-      operandNode(expression.argument, "column", context) !== undefined;
+      operandAnchor(expression.argument, "column", context) !== undefined;
     const mappingAllowed =
       !context.ownsResultMapping ||
       context.capabilities.hasDirectResultMapping(context.root) ||
@@ -4353,7 +4509,7 @@ function classifyOrdering(
   if (ordering.direction === undefined) {
     return classifyExpression(ordering.expression, context);
   }
-  const node = operandNode(ordering.expression, "wrapper", context);
+  const node = operandAnchor(ordering.expression, "wrapper", context);
   if (node === undefined) {
     return classifyExpression(
       ordering.expression,
@@ -4389,6 +4545,18 @@ function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
       };
 }
 
+function sameSourceChunks(
+  left: ReadonlySet<SqlSourceChunk>,
+  right: ReadonlySet<SqlSourceChunk>,
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every((chunk) => {
+      return right.has(chunk);
+    })
+  );
+}
+
 function replacementBoundaryForFinding(
   finding: ClassifiedHelperFinding,
   variant: SqlSourceVariant,
@@ -4397,16 +4565,15 @@ function replacementBoundaryForFinding(
   services: ParserServicesWithTypeInformation,
   capabilities: SqlCapabilityChecks,
 ): TSESTree.Expression | undefined {
-  if (finding.isPartial) {
-    return undefined;
-  }
   // A parsed descendant can cross template boundaries because Drizzle inserts
   // nested SQL without parentheses. Reparse each editable boundary in
-  // isolation before claiming that the helper can replace it.
+  // isolation before claiming either a whole replacement or a descendant
+  // diagnostic at the current use site.
   const candidates = commonCompositionBoundaries(
     [...finding.sourceChunks],
     root,
   );
+  let descendantBoundary: TSESTree.Expression | undefined;
   for (const candidate of candidates) {
     const candidateVariant = {
       chunks: variant.chunks.filter((chunk) => {
@@ -4451,19 +4618,34 @@ function replacementBoundaryForFinding(
               return classifyExpression(expression, classificationContext);
             },
           );
+    const matchingFinding = classifications
+      .flatMap((classification) => {
+        return classification.findings;
+      })
+      .find((candidateFinding) => {
+        return (
+          candidateFinding.kind === finding.kind &&
+          candidateFinding.helper === finding.helper &&
+          candidateFinding.isolationContext === finding.isolationContext &&
+          candidateFinding.isPartial === finding.isPartial &&
+          sameSourceChunks(candidateFinding.sourceChunks, finding.sourceChunks)
+        );
+      });
+    if (matchingFinding === undefined) {
+      continue;
+    }
     const classification = classifications[0];
-    const candidateFinding = classification?.findings[0];
     if (
       classifications.length === 1 &&
       classification?.isWholeReplacement === true &&
       classification.findings.length === 1 &&
-      candidateFinding?.kind === finding.kind &&
-      candidateFinding.helper === finding.helper
+      classification.findings[0] === matchingFinding
     ) {
       return candidate;
     }
+    descendantBoundary ??= candidate;
   }
-  return undefined;
+  return descendantBoundary;
 }
 
 function analyzeParsed(

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -1692,39 +1692,32 @@ function directStructuralChildren(
   return expression.children;
 }
 
-function structuralMarkers(
-  expression: StructuralExpression,
-): readonly SqlMarker[] {
-  if (expression.kind === "marker") {
-    return [expression.marker];
-  }
-  return directStructuralChildren(expression).flatMap(structuralMarkers);
-}
-
-function containsSubquery(expression: StructuralExpression): boolean {
-  return (
-    expression.kind === "existence" ||
-    (expression.kind === "opaque" && expression.nodeKey === "SubLink") ||
-    directStructuralChildren(expression).some(containsSubquery)
-  );
-}
-
 function retainableInlineMarkers(
   expression: StructuralExpression,
 ): readonly SqlMarker[] | undefined {
-  if (containsSubquery(expression)) {
-    return undefined;
-  }
-  const markers = structuralMarkers(expression);
-  return markers.every((marker) => {
-    return (
-      !marker.isTable &&
+  if (expression.kind === "marker") {
+    const marker = expression.marker;
+    return !marker.isTable &&
       !marker.isSelect &&
       marker.isAnalyzableWriteInterpolation
-    );
-  })
-    ? markers
-    : undefined;
+      ? [marker]
+      : undefined;
+  }
+  if (
+    expression.kind === "existence" ||
+    (expression.kind === "opaque" && expression.nodeKey === "SubLink")
+  ) {
+    return undefined;
+  }
+  const markers: SqlMarker[] = [];
+  for (const child of directStructuralChildren(expression)) {
+    const childMarkers = retainableInlineMarkers(child);
+    if (childMarkers === undefined) {
+      return undefined;
+    }
+    markers.push(...childMarkers);
+  }
+  return markers;
 }
 
 function hasInlineValueBoundary(


### PR DESCRIPTION
## Summary

- extend the PostgreSQL parser-backed SQL analysis to retain schema-backed inline operands for existing Drizzle helper capabilities
- preserve isolated local-composition ownership while reporting exact matching descendants under unsupported SQL ancestors
- detect safe static membership and transformed aggregate operands without accepting subqueries, ambiguous arrays, uncertain values, or decoder mismatches
- convert all 23 current API diagnostics while preserving SQL structure, parameter order, literal shape, and result mappings

## Safety

- retained operands still require installed Drizzle types, a conventional source boundary, analyzable interpolations, and meaningful schema provenance
- direct comparison and range values reject select/table values, arrays, `undefined`-capable values, and other ambiguous interpolation semantics
- static `IN` lists remain literal SQL wrappers rather than becoming bound JavaScript arrays
- no autofix, suppression, allowlist, dependency, schema, persisted-data, API/protocol, statement-count, or rollout change is included

## Validation

- `pnpm -F @vm0/eslint-rules test` — 47 files, 924 tests passed
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only <14 affected route test files>` — 370 tests passed
- `pnpm knip --workspace @vm0/eslint-rules`
- `pnpm knip --workspace api`
- full pre-commit Prettier, Knip, and serial workspace type checks
- `git diff --check`
- 25 production-shape serialization comparisons preserved parameter arrays, typings, and normalized PostgreSQL ASTs

Performance used clean detached worktrees at base `974eacfabe` and candidate
`db2290e2d1`, identical lockfiles/install method, 25 ms process-tree sampling,
one warm-up per side, and five order-alternating runs:

- base wall ms: `27196.48`, `27714.54`, `25809.94`, `25474.54`, `26487.35`
- candidate wall ms: `27905.52`, `27212.19`, `25596.57`, `25822.14`, `25599.26`
- wall medians: `26487.35` vs `25822.14` (`-2.511%`, gate `<= +5%`)
- base peak RSS KiB: `3553852`, `3505360`, `3506520`, `3513236`, `3487036`
- candidate peak RSS KiB: `3501912`, `3502944`, `3502288`, `3461680`, `3566596`
- RSS medians: `3506520` vs `3502288` (`-0.121%`, gate `<= +10%`)

Closes #23474

Parent context: #23047
