### PR TITLE
refactor(python): retire raw server binding recorder

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -41,7 +41,6 @@ __all__ = (
     "has_server_binding",
     "normalize_upstream_destination",
     "record_normalized_server_binding",
-    "record_server_binding",
     "refresh_server_binding_connected_address_if_matching",
     "reset_for_tests",
     "reuse_server_binding_kind_if_matching",
@@ -166,27 +165,6 @@ def record_normalized_server_binding(
         original_address=original_address,
     )
     _associate_server_with_client(server_id, client)
-
-
-def record_server_binding(
-    server: object,
-    *,
-    client: object | None = None,
-    host: str,
-    port: int,
-    kinds: frozenset[BindingKind],
-    original_address: tuple[str, int] | None,
-) -> None:
-    """Normalize and record a destination after retargeting or verification."""
-    if _connection_id(server) is None:
-        return
-    record_normalized_server_binding(
-        server,
-        client=client,
-        destination=normalize_upstream_destination(host=host, port=port),
-        kinds=kinds,
-        original_address=original_address,
-    )
 
 
 def _matching_server_binding(

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -32,6 +32,7 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
+from tests.upstream_connection_helpers import seed_server_binding
 
 
 class TestErrorHandler:
@@ -42,7 +43,7 @@ class TestErrorHandler:
             host="api.github.com",
             path="/repos/octocat/hello",
         )
-        upstream_destination_binding.record_server_binding(
+        seed_server_binding(
             flow.server_conn,
             client=flow.client_conn,
             host="api.github.com",

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -9,7 +9,7 @@ import mitm_addon
 import upstream_destination_binding
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _write_github_firewall_registry
-from tests.upstream_connection_helpers import bind_flow_upstream
+from tests.upstream_connection_helpers import bind_flow_upstream, seed_server_binding
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -43,7 +43,7 @@ async def test_rejects_spoofed_host_before_firewall_auth(
         path="/repos",
         request_headers=headers(("Host", "api.github.com")),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
@@ -19,6 +19,7 @@ from tests.request_handler_helpers import (
 from tests.upstream_connection_helpers import (
     bind_flow_upstream,
     mark_connected_tls_upstream,
+    seed_server_binding,
 )
 
 
@@ -254,7 +255,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_early_b
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("140.82.112.5", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -294,7 +295,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_after_retarg
         server_address=("api.github.com", 443),
         peername=("140.82.112.5", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -337,7 +338,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_verifie
         peername=None,
         client_sockname=("140.82.112.5", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -375,7 +376,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_without_endp
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = None
     flow.client_conn.sockname = ("127.0.0.1", 8080)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -437,7 +438,7 @@ async def test_matching_sni_and_host_blocks_non_authoritative_connected_endpoint
         peername=None,
         client_sockname=client_sockname,
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -481,7 +482,7 @@ async def test_matching_sni_and_host_allows_equivalent_ipv6_binding_peer(
         tuple[str, int],
         ("2001:4860:4860:0:0:0:0:8888", 443, 0, 0),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -515,7 +516,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_stale_b
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("203.0.113.99", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -625,7 +626,7 @@ async def test_test_connector_extends_existing_api_allow_binding(
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("203.0.113.10", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -666,7 +667,7 @@ async def test_test_connector_without_bypass_does_not_extend_existing_api_allow_
         ),
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -738,7 +739,7 @@ async def test_test_connector_without_bypass_does_not_reuse_connector_auth_bindi
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("203.0.113.10", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -778,7 +779,7 @@ async def test_test_connector_rejects_stale_unconnected_api_allow_binding(
         ),
     )
     flow.server_conn.address = ("203.0.113.99", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -818,7 +819,7 @@ async def test_test_connector_rejects_mismatched_existing_binding(
         ),
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -24,6 +24,7 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.requestheaders_helpers import await_requestheaders_result
+from tests.upstream_connection_helpers import seed_server_binding
 
 
 def _resolved_firewall_auth() -> auth_client.FirewallAuthSuccess:
@@ -388,7 +389,7 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     flow = real_flow(
         with_response=False, client_ip="10.200.0.5", host="api.github.com", path="/orgs"
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -1444,7 +1445,7 @@ async def test_request_stream_metadata_error_clears_upstream_binding(tmp_path, r
         path="/repos/octocat/hello",
     )
     flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {}
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -14,6 +14,7 @@ from tests.auth_state_helpers import auth_cache_key, has_auth_state
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.upstream_connection_helpers import seed_server_binding
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -365,7 +366,7 @@ async def test_vm0_model_proxy_path_on_vm0_api_host_uses_firewall_auth(
         method="POST",
         path="/api/internal/vm0-model/v1/responses",
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.vm0.ai",

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -23,7 +23,10 @@ from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import _assert_no_request_stream
-from tests.upstream_connection_helpers import mark_connected_tls_upstream
+from tests.upstream_connection_helpers import (
+    mark_connected_tls_upstream,
+    seed_server_binding,
+)
 
 
 def _write_public_destination_firewall_registry(
@@ -357,7 +360,7 @@ async def test_public_destination_blocks_prebound_private_original_destination(
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -386,7 +389,7 @@ async def test_public_destination_allows_prebound_public_original_destination(
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -416,7 +419,7 @@ async def test_public_destination_blocks_private_transparent_host_despite_public
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="10.0.0.1")
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -445,7 +448,7 @@ async def test_public_destination_blocks_bracketed_private_host_despite_public_o
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="[::1]")
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -478,7 +481,7 @@ async def test_public_destination_allows_bracketed_public_ipv6_host_with_public_
         destination_host="[2001:4860:4860::8888]",
     )
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -516,7 +519,7 @@ async def test_public_destination_blocks_legacy_ipv4_host_despite_public_origina
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host=destination_host)
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -556,7 +559,7 @@ async def test_public_destination_blocks_percent_encoded_host_despite_public_ori
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host=destination_host)
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -595,7 +598,7 @@ async def test_public_destination_blocks_malformed_host_despite_public_original(
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host=destination_host)
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -624,7 +627,7 @@ async def test_public_destination_blocks_prebound_public_original_port_mismatch(
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
     flow.server_conn.address = ("service.example.com", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -658,7 +661,7 @@ async def test_public_destination_allows_connected_prebound_public_original_dest
         server_address=("service.example.com", 443),
         peername=("93.184.216.35", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -730,7 +733,7 @@ async def test_public_destination_blocks_connected_private_transparent_host_desp
         server_address=("service.example.com", 443),
         peername=("93.184.216.35", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -764,7 +767,7 @@ async def test_public_destination_blocks_connected_public_original_port_mismatch
         server_address=("service.example.com", 443),
         peername=("93.184.216.35", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -1031,7 +1034,7 @@ async def test_public_destination_blocks_connected_private_peer_despite_public_o
         server_address=("service.example.com", 443),
         peername=("10.0.0.1", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -1065,7 +1068,7 @@ async def test_public_destination_blocks_private_original_despite_connected_publ
         server_address=("service.example.com", 443),
         peername=("93.184.216.35", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",
@@ -1093,7 +1096,7 @@ async def test_public_destination_ignores_stale_prebound_public_original_destina
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="10.0.0.1")
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="service.example.com",

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -15,7 +15,10 @@ from tests.requestheaders_helpers import (
     _assert_no_request_stream,
     track_trusted_authority_validations,
 )
-from tests.upstream_connection_helpers import mark_connected_tls_upstream
+from tests.upstream_connection_helpers import (
+    mark_connected_tls_upstream,
+    seed_server_binding,
+)
 
 
 def _write_api_registry(tmp_path: Path, *, capture_network_bodies: bool) -> Path:
@@ -194,7 +197,7 @@ async def test_capture_enabled_api_allow_uses_prior_client_binding_when_server_c
     )
 
     server_connect_server = connection.Server(address=("198.18.20.34", 443))
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         server_connect_server,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -236,7 +239,7 @@ async def test_api_allow_prior_client_binding_endpoint_mismatch_blocks(
     flow.client_conn.sockname = ("203.0.113.10", 443)
 
     server_connect_server = connection.Server(address=("198.18.20.34", 443))
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         server_connect_server,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -281,7 +284,7 @@ async def test_api_allow_current_server_binding_mismatch_blocks_even_with_prior_
     flow.server_conn.state = connection.ConnectionState.OPEN
 
     server_connect_server = connection.Server(address=("198.18.20.34", 443))
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         server_connect_server,
         client=flow.client_conn,
         host="api.vm0.ai",
@@ -289,7 +292,7 @@ async def test_api_allow_current_server_binding_mismatch_blocks_even_with_prior_
         kinds=frozenset(("api_allow",)),
         original_address=("198.18.20.34", 443),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="attacker.example.com",

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -27,7 +27,10 @@ from tests.requestheaders_helpers import (
     await_requestheaders_result,
     track_trusted_authority_validations,
 )
-from tests.upstream_connection_helpers import mark_connected_tls_upstream
+from tests.upstream_connection_helpers import (
+    mark_connected_tls_upstream,
+    seed_server_binding,
+)
 
 
 async def test_firewall_allow_current_server_binding_address_mismatch_blocks(
@@ -50,7 +53,7 @@ async def test_firewall_allow_current_server_binding_address_mismatch_blocks(
         ),
     )
     flow.server_conn.address = ("203.0.113.99", 443)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",
@@ -207,7 +210,7 @@ async def test_test_connector_bounded_requestheaders_uses_connector_binding(
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-def test_raw_binding_helpers_normalize_noncanonical_authority(
+def test_normalized_binding_matches_noncanonical_raw_authority(
     real_flow,
     headers,
 ):
@@ -219,11 +222,16 @@ def test_raw_binding_helpers_normalize_noncanonical_authority(
     )
     flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "API.GITHUB.COM."
     flow.server_conn.address = ("api.github.com", 443)
-    upstream_destination_binding.record_server_binding(
-        flow.server_conn,
-        client=flow.client_conn,
+    destination = upstream_destination_binding.normalize_upstream_destination(
         host="API.GITHUB.COM.",
         port=443,
+    )
+    assert destination.host == "api.github.com"
+    assert destination.port == 443
+    upstream_destination_binding.record_normalized_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        destination=destination,
         kinds=frozenset(("connector_auth",)),
         original_address=("203.0.113.10", 443),
     )
@@ -232,6 +240,22 @@ def test_raw_binding_helpers_normalize_noncanonical_authority(
         flow,
         allowed_kinds=frozenset(("connector_auth",)),
     )
+
+
+def test_normalized_binding_ignores_server_without_usable_id():
+    destination = upstream_destination_binding.normalize_upstream_destination(
+        host="api.github.com",
+        port=443,
+    )
+
+    upstream_destination_binding.record_normalized_server_binding(
+        SimpleNamespace(id=None),
+        destination=destination,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("203.0.113.10", 443),
+    )
+
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
 async def test_test_connector_bounded_requestheaders_without_bypass_blocks(
@@ -547,7 +571,7 @@ async def test_firewall_allow_prior_client_binding_endpoint_mismatch_blocks(
     flow.client_conn.sockname = ("198.18.20.34", 443)
 
     server_connect_server = connection.Server(address=("198.18.20.34", 443))
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         server_connect_server,
         client=flow.client_conn,
         host="api.github.com",
@@ -602,7 +626,7 @@ async def test_firewall_allow_prior_client_binding_endpoint_match_still_requires
     flow.server_conn.state = connection.ConnectionState.OPEN
 
     server_connect_server = connection.Server(address=("172.66.0.243", 443))
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         server_connect_server,
         client=flow.client_conn,
         host="api.github.com",
@@ -733,7 +757,7 @@ def test_bounded_requestheaders_keeps_matching_connector_binding_without_classif
         path="/repos/octocat/hello",
         request_headers=headers(("Host", "api.github.com"), ("Content-Length", "4")),
     )
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         client=flow.client_conn,
         host="api.github.com",

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -12,6 +12,29 @@ _NO_CONNECTED_CLIENT_SOCKNAME = ("", 0)
 _TLS_CERTIFICATE_PROOF = cast(certs.Cert, object())
 
 
+def seed_server_binding(
+    server: object,
+    *,
+    client: object | None = None,
+    host: str,
+    port: int,
+    kinds: frozenset[upstream_destination_binding.BindingKind],
+    original_address: tuple[str, int] | None,
+) -> None:
+    """Seed normalized upstream binding state for a test."""
+    destination = upstream_destination_binding.normalize_upstream_destination(
+        host=host,
+        port=port,
+    )
+    upstream_destination_binding.record_normalized_server_binding(
+        server,
+        client=client,
+        destination=destination,
+        kinds=kinds,
+        original_address=original_address,
+    )
+
+
 def bind_flow_upstream(
     flow: http.HTTPFlow,
     *,
@@ -22,7 +45,7 @@ def bind_flow_upstream(
     """Bind a flow to an admitted upstream destination."""
     original_address = flow.server_conn.address
     flow.server_conn.address = (host, port)
-    upstream_destination_binding.record_server_binding(
+    seed_server_binding(
         flow.server_conn,
         host=host,
         port=port,


### PR DESCRIPTION
## Summary

- remove the unused raw `host`/`port` server-binding recorder from the embedded addon runtime
- route repeated test binding setup through a test-only state builder backed by the normalized recorder
- keep explicit coverage for non-canonical authority normalization and missing server ids

## Compatibility

- no API, protocol, queue, database, persisted-state, or feature-switch changes
- old and new runners continue to own independent embedded addon code and process-local binding state
- raw flow matching, endpoint/TLS validation, admission, association, error, and cleanup behavior are unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused requestheaders, request, public-destination, passthrough, error, cleanup, and server-connect suite (307 passed)
- `uv run --no-sync python -m pytest tests/` (4,394 passed)

Closes #23509
