### PR TITLE
docs(runner): document claim cooldown rediscovery

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -170,6 +170,26 @@ enum DiscoveryWakeup {
 /// - **Discovery**: HTTP poll fallback (adaptive interval)
 /// - **Claim**: `POST /api/runners/jobs/{id}/claim`
 /// - **Complete**: `POST /api/webhooks/agent/complete` with per-job sandbox token
+///
+/// ## Claim failure and rediscovery
+///
+/// Claim is also feedback into discovery. A successful or unavailable claim
+/// clears any per-run cooldown; an unavailable claim promptly polls the backlog.
+/// Other failures are classified as transient or deterministic and give that run
+/// a corresponding runner-local cooldown.
+///
+/// While a run is cooling down, matching direct candidates are skipped and the
+/// bounded active run IDs are sent as optional poll exclusions. Recording a
+/// per-run cooldown requests an immediate poll so unrelated candidates can make
+/// progress. An empty excluded poll schedules a deferred retry through the
+/// `PollWakeups` state machine. If every exclusion expires while that poll is in
+/// flight, the provider immediately polls again without the stale exclusions.
+///
+/// An older API may ignore the additive exclusions and return a cooled run. The
+/// provider therefore checks returned candidates locally and defers rather than
+/// reclaiming that run at network-round-trip cadence. Cooldown capacity never
+/// evicts an active entry; saturation instead applies a short provider-wide
+/// cooldown and defers all discovery before retrying.
 pub struct ApiProvider {
     api: ApiClient,
     runner_id: String,

--- a/crates/runner/src/provider/api_claim_cooldowns.rs
+++ b/crates/runner/src/provider/api_claim_cooldowns.rs
@@ -1,3 +1,18 @@
+//! Bounded runner-local deadlines for failed API claims.
+//!
+//! [`ApiProvider`](super::api::ApiProvider) owns the claim-to-rediscovery
+//! lifecycle. This module only stores its ephemeral cooldown state: per-run
+//! deadlines plus an optional provider-wide deadline used when per-run capacity
+//! is saturated. It owns no timer or wakeup; the provider routes retry deadlines
+//! through [`PollWakeups`](super::api_ably_supervisor::PollWakeups).
+//!
+//! Recording refreshes an existing run or inserts a new run while capacity is
+//! available. It never evicts an unexpired entry: saturation is returned to the
+//! provider so it can apply the provider-wide fallback. Reads and records prune
+//! expired state. A snapshot exposes sorted per-run exclusions and the earliest
+//! effective retry deadline, preferring the provider-wide deadline while it is
+//! active.
+
 use std::collections::{BTreeMap, btree_map::Entry};
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary

- document how API claim outcomes feed runner discovery, per-run suppression, alternative-candidate polling, and deadline-based retry
- document the cooldown container's bounded, expiring, non-evicting state contract and its interaction with `PollWakeups`
- record old-API exclusion defense and provider-wide saturation behavior without duplicating numeric constants or scheduler internals

## Scope

Documentation only. Runtime behavior, API contracts, persistence, and tests are unchanged; existing provider HTTP-boundary tests remain the executable behavior contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `git diff --check`

Closes #23526
