### PR TITLE
refactor(chat): remove event response aliases

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -215,32 +215,31 @@ describe("chat event background sync", () => {
     }
   });
 
-  it("accepts preceding and canonical API response shapes during rollout", async () => {
+  it("returns canonical API response events unchanged", async () => {
     mockSignedInUser();
-    const precedingEventId = "00000000-0000-4000-8000-000000000806";
-    const canonicalEventId = "00000000-0000-4000-8000-000000000807";
+    const inputEventId = "00000000-0000-4000-8000-000000000806";
+    const outputEventId = "00000000-0000-4000-8000-000000000807";
     const userMessage = {
       version: 1 as const,
-      parts: [{ type: "text" as const, text: "Preceding response" }],
+      parts: [{ type: "text" as const, text: "Canonical input" }],
     };
     context.mocks.http.get("*/api/zero/chat-threads/:threadId/events", () => {
       return Response.json({
         events: [
           {
-            id: precedingEventId,
+            id: inputEventId,
             threadId: THREAD_ID,
             eventType: "input.prompt",
-            role: "user",
-            content: "Preceding response",
-            structuredPrompt: userMessage,
+            content: "Canonical input",
+            userMessage,
             seqId: 1,
             createdAt: CREATED_AT,
           },
           {
-            id: canonicalEventId,
+            id: outputEventId,
             threadId: THREAD_ID,
             eventType: "output.message",
-            content: "Canonical response",
+            content: "Canonical output",
             seqId: 2,
             createdAt: CREATED_AT,
           },
@@ -258,19 +257,19 @@ describe("chat event background sync", () => {
 
     expect(result.events).toStrictEqual([
       {
-        id: precedingEventId,
+        id: inputEventId,
         threadId: THREAD_ID,
         eventType: "input.prompt",
-        content: "Preceding response",
+        content: "Canonical input",
         userMessage,
         seqId: 1,
         createdAt: CREATED_AT,
       },
       {
-        id: canonicalEventId,
+        id: outputEventId,
         threadId: THREAD_ID,
         eventType: "output.message",
-        content: "Canonical response",
+        content: "Canonical output",
         seqId: 2,
         createdAt: CREATED_AT,
       },

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-api.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-api.ts
@@ -1,10 +1,7 @@
 import {
-  chatEventResponseSchema,
-  chatEventSchema,
   chatEventsContract,
   chatThreadEventsContract,
   type ChatEvent,
-  type ChatEventResponse,
   type ChatEventSendBody,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
@@ -22,25 +19,6 @@ interface ChatEventListQuery {
 interface ChatEventListResult {
   readonly events: ChatEvent[];
   readonly hasHistoryBefore: boolean;
-}
-
-function canonicalChatEventFromResponse(
-  response: ChatEventResponse,
-): ChatEvent {
-  const parsed = chatEventResponseSchema.parse(response);
-  if (!("role" in parsed)) {
-    return parsed;
-  }
-  if (
-    parsed.revokesMessageId !== undefined &&
-    parsed.revokesMessageId !== parsed.revokesEventId
-  ) {
-    throw new Error("Chat event revoke compatibility fields disagree");
-  }
-  const { role, revokesMessageId, ...event } = parsed;
-  void role;
-  void revokesMessageId;
-  return chatEventSchema.parse(event);
 }
 
 export async function sendChatEvent(
@@ -75,7 +53,7 @@ export async function listChatEvents(
     signal,
   );
   return {
-    events: result.body.events.map(canonicalChatEventFromResponse),
+    events: result.body.events,
     hasHistoryBefore: result.body.hasHistoryBefore ?? false,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -25,7 +25,6 @@ function eventForSeq(seqId: number): ChatEventResponse {
       id: `00000000-0000-4000-8000-${String(seqId).padStart(12, "0")}`,
       threadId: THREAD_ID,
       eventType: "output.message",
-      role: "assistant",
       content: "Latest visible message",
       seqId,
       createdAt: new Date(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   CHAT_EVENT_TYPES,
-  chatEventCompatibilityRole,
   foldActiveChatGoalObjective,
   foldChatAutomationIntakePause,
   foldChatRunStates,
@@ -255,25 +254,16 @@ describe("ChatEvent catalog", () => {
     }
   });
 
-  it("fails closed for unknown leaves and compatibility-only fields", () => {
+  it("fails closed for unknown leaves and server-only fields", () => {
     const prompt = chatEvents[0];
     expect(
       chatEventSchema.safeParse({ ...prompt, eventType: "input.unknown" })
         .success,
     ).toBe(false);
-    expect(chatEventSchema.safeParse({ ...prompt, role: "user" }).success).toBe(
-      false,
-    );
     expect(
       chatEventSchema.safeParse({
         ...prompt,
         encryptedParams: "must-stay-server-side",
-      }).success,
-    ).toBe(false);
-    expect(
-      chatEventSchema.safeParse({
-        ...prompt,
-        revokesMessageId: "legacy-target",
       }).success,
     ).toBe(false);
     const automation = chatEvents[1];
@@ -285,29 +275,12 @@ describe("ChatEvent catalog", () => {
     ).toBe(false);
   });
 
-  it("keeps the preceding App response shape during receiver-first rollout", () => {
+  it("emits canonical responses for every registered leaf", () => {
     for (const event of chatEvents) {
       const response = chatEventResponse(event);
-      expect(response).toMatchObject({
-        role: chatEventCompatibilityRole(event.eventType),
-      });
-      if (event.revokesEventId !== undefined) {
-        expect(response).toMatchObject({
-          revokesMessageId: event.revokesEventId,
-        });
-      }
+      expect(response).toStrictEqual(event);
       expect(chatEventResponseSchema.parse(response)).toStrictEqual(response);
-      expect(chatEventResponseSchema.parse(event)).toStrictEqual(event);
     }
-  });
-
-  it("rejects a compatibility role that disagrees with eventType", () => {
-    expect(
-      chatEventResponseSchema.safeParse({
-        ...chatEvents[0],
-        role: "assistant",
-      }).success,
-    ).toBe(false);
   });
 
   it("normalizes the preceding rich-input response field", () => {
@@ -320,10 +293,7 @@ describe("ChatEvent catalog", () => {
         ...chatEventResponse(chatEvents[0]!),
         structuredPrompt: userMessage,
       }),
-    ).toMatchObject({
-      userMessage,
-      role: "user",
-    });
+    ).toStrictEqual({ ...chatEvents[0], userMessage });
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -61,7 +61,6 @@ describe("chat message response contract", () => {
       id: "message-1",
       threadId: "thread-1",
       eventType: "input.prompt",
-      role: "user",
       content: "Run the workflow",
       createdAt: "2026-07-13T00:00:00.000Z",
     });

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { chatEventCompatibilityRole, chatEventTypeSchema } from "./chat-events";
+import { chatEventTypeSchema } from "./chat-events";
 import { apiErrorSchema } from "./errors";
 import { hostedArtifactKindSchema } from "./zero-host";
 import { runStatusSchema } from "./runs";
@@ -625,104 +625,12 @@ const chatEventSchema = z.discriminatedUnion("eventType", [
   usageRecordedEventSchema,
 ]);
 
-const userEventCompatibilityResponseShape = {
-  /**
-   * @deprecated Receiver-first compatibility for the preceding App release.
-   * Canonical ChatEvent consumers derive presentation role from eventType.
-   */
-  role: z.literal("user"),
-  /**
-   * @deprecated Use revokesEventId.
-   */
-  revokesMessageId: z.string().optional(),
-} as const;
-
-const assistantEventCompatibilityResponseShape = {
-  /**
-   * @deprecated Receiver-first compatibility for the preceding App release.
-   * Canonical ChatEvent consumers derive presentation role from eventType.
-   */
-  role: z.literal("assistant"),
-  /**
-   * @deprecated Use revokesEventId.
-   */
-  revokesMessageId: z.string().optional(),
-} as const;
-
-/**
- * Receiver-first wire shape for the App release deployed before this cleanup.
- * The current App accepts both this shape and canonical ChatEvent so a later
- * API release can remove these compatibility fields after old clients drain.
- */
-const precedingAppChatEventResponseSchema = z.discriminatedUnion("eventType", [
-  inputPromptEventSchema.extend(userEventCompatibilityResponseShape).strict(),
-  inputAutomationEventSchema
-    .extend(userEventCompatibilityResponseShape)
-    .strict(),
-  inputRejectedEventSchema.extend(userEventCompatibilityResponseShape).strict(),
-  outputMessageEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  outputErrorEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  outputThinkingEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  outputFollowupsEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  runQueuedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  runDequeuedEventSchema
-    .extend({
-      ...assistantEventCompatibilityResponseShape,
-      revokesMessageId: z.string(),
-    })
-    .strict(),
-  runCompletedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  runFailedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  runCancelledEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  queueAutomationPausedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  queueAutomationResumedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  controlInterruptEventSchema
-    .extend(userEventCompatibilityResponseShape)
-    .strict(),
-  controlRevokeEventSchema
-    .extend({
-      ...userEventCompatibilityResponseShape,
-      revokesMessageId: z.string(),
-    })
-    .strict(),
-  goalChangedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-  usageRecordedEventSchema
-    .extend(assistantEventCompatibilityResponseShape)
-    .strict(),
-]);
-
 const chatEventResponseSchema = z.preprocess(
   normalizePrecedingStructuredPrompt,
-  z.union([chatEventSchema, precedingAppChatEventResponseSchema]),
+  chatEventSchema,
 );
 
-if (
-  chatEventTypeSchema.options.length !== chatEventSchema.options.length ||
-  chatEventTypeSchema.options.length !==
-    precedingAppChatEventResponseSchema.options.length
-) {
+if (chatEventTypeSchema.options.length !== chatEventSchema.options.length) {
   throw new Error("ChatEvent schema must cover the complete event catalog");
 }
 
@@ -1667,12 +1575,7 @@ export type ChatEventResponse = z.infer<typeof chatEventResponseSchema>;
 export type ChatEventSendBody = z.infer<typeof chatEventsContract.send.body>;
 
 export function chatEventResponse(event: ChatEvent): ChatEventResponse {
-  const revokesMessageId = event.revokesEventId;
-  return chatEventResponseSchema.parse({
-    ...event,
-    role: chatEventCompatibilityRole(event.eventType),
-    ...(revokesMessageId === undefined ? {} : { revokesMessageId }),
-  });
+  return chatEventResponseSchema.parse(event);
 }
 
 export type ChatInputEvent = Extract<


### PR DESCRIPTION
## Summary

- make canonical `ChatEvent` the only successful `/events` response shape, removing the `role` and `revokesMessageId` aliases plus their compatibility schema checks
- remove the App response normalizer and consume contract-parsed canonical events directly
- update response fixtures and focused coverage to assert the canonical path end to end

## User impact

`/events` responses now expose only canonical event fields. The App no longer carries a rollout-only branch for compatibility responses, so API and App share one event shape.

## Rollout safety

This is **PR A** of the three-step roadmap in #22757. Its entry gate is satisfied: #23394 shipped in `api-v1.337.1` and `app-v0.648.1`, both release notes include #23394, and the production release workflow completed successfully.

This PR intentionally leaves the derived `role` dual-write and the physical `chat_messages.role` column unchanged. **PR B must wait until this PR's API/App release is fully rolled out and preceding readers have drained before stopping the derived `role` dual-write.** There is no migration, and queue code is unchanged.

## Verification

Passed locally:

- Prettier check for all changed files
- `pnpm turbo run lint --filter=@vm0/api-contracts --filter=@vm0/app --filter=api --log-order grouped --concurrency=1`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run check-types --filter=@vm0/api-contracts --filter=@vm0/app --filter=api --log-order grouped --concurrency=1`
- `pnpm knip` (exit 0; no ignore changes)
- API contract tests: 46 passed
- App event sync/backfill tests: 5 passed
- PostgreSQL 18 migrations through `0715` plus the `/events` cursor BDD: 1 passed, 27 skipped by test filter
- final alias caller search and `git diff --check`

Full-suite tests are delegated to the PR pipeline per repository guidance.

Refs #22757
