### PR TITLE
test(python): cover unmatched ipv6 bracket rejection

### DIFF
--- a/crates/runner/mitm-addon/tests/test_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_public_destination.py
@@ -104,3 +104,19 @@ def test_validate_runtime_destination_host(host, allowed, reason):
 
     assert result.allowed is allowed
     assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "[2001:4860:4860::8888",
+        "2001:4860:4860::8888]",
+    ],
+)
+def test_unmatched_ipv6_brackets_are_rejected(host: str):
+    assert public_destination.public_ip_literal_is_public(host) is False
+
+    result = public_destination.validate_runtime_destination_host(host)
+
+    assert result.allowed is False
+    assert result.reason == "invalid_destination"


### PR DESCRIPTION
## Summary

- add focused parameterized coverage for unmatched opening and closing IPv6 brackets
- verify both public destination adapter contracts fail closed
- retain the existing valid bracketed IPv6 behavior without changing runtime code

## Scope

This PR changes tests only. It does not change runtime behavior, dependencies, persisted data, APIs, migrations, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_public_destination.py` (82 passed)
- `uv run --no-sync python -m pytest tests/` (4,396 passed)
- `lefthook run pre-commit`

Closes #23528
