### PR TITLE
perf(runner): skip no-op private directory chmod

### DIFF
--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -418,7 +418,10 @@ fn secure_dir_component(
                     walk.expected_uid
                 )));
             }
-            chmod_dir_fd(fd, component_path, PRIVATE_DIR_MODE, walk.context)?;
+            let component_mode = (stat.st_mode as u32) & 0o7777;
+            if component_mode != PRIVATE_DIR_MODE {
+                chmod_dir_fd(fd, component_path, PRIVATE_DIR_MODE, walk.context)?;
+            }
         }
         DirMode::TrustedParent if is_final => {
             validate_trusted_component_owner(

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1036,13 +1036,19 @@ fn validate_optional_cancel_dir(group_dir: &Path, cancel_dir: &Path) -> std::io:
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use super::*;
 
     fn mode(path: &Path) -> u32 {
-        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    fn ctime(path: &Path) -> (i64, i64) {
+        let metadata = std::fs::metadata(path).unwrap();
+        (metadata.ctime(), metadata.ctime_nsec())
     }
 
     fn write_job_request(group_dir: &Path, run_id: RunId, profile: &str) -> PathBuf {
@@ -1111,7 +1117,7 @@ mod tests {
         let group_dir = dir.path();
         let result_dir = super::super::results_dir(group_dir);
         std::fs::create_dir_all(&result_dir).unwrap();
-        std::fs::set_permissions(&result_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&result_dir, std::fs::Permissions::from_mode(0o1755)).unwrap();
         let queue = LocalQueue::new(group_dir.to_path_buf());
 
         assert!(queue.write_result_sync(RunId::new_v4(), 0, None));
@@ -1638,6 +1644,20 @@ mod tests {
             .expect("fallback should still discover an eligible job");
 
         assert_eq!(candidate.run_id, eligible);
+    }
+
+    #[test]
+    fn collect_cancel_markers_keeps_private_cancel_dir_ctime() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let cancel_dir = super::super::ensure_cancels_dir(group_dir).unwrap();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let before = ctime(&cancel_dir);
+        std::thread::sleep(Duration::from_millis(20));
+
+        assert!(queue.collect_cancel_markers_sync().is_empty());
+
+        assert_eq!(ctime(&cancel_dir), before);
     }
 
     #[test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1653,6 +1653,7 @@ mod tests {
         let cancel_dir = super::super::ensure_cancels_dir(group_dir).unwrap();
         let queue = LocalQueue::new(group_dir.to_path_buf());
         let before = ctime(&cancel_dir);
+        // Separate filesystem clock ticks so an unexpected chmod changes the observed ctime.
         std::thread::sleep(Duration::from_millis(20));
 
         assert!(queue.collect_cancel_markers_sync().is_empty());


### PR DESCRIPTION
## Summary

- skip descriptor chmod when a final private directory already has the exact `0700` mode
- preserve exact hardening for differing permission and special bits
- cover the idle cancel-scan path by asserting that compliant directory ctime remains unchanged

## Scope

This keeps the existing descriptor walk, ownership checks, symlink and non-directory rejection, parent safety validation, and polling cadence unchanged. It does not add validation caching or change shared trusted directory policy.

There are no schema, migration, persisted-data, dependency, API, queue payload, runner/backend protocol, or runner/guest contract changes.

## Validation

- `cargo test -p runner --bin runner local_queue::state::tests::collect_cancel_markers_keeps_private_cancel_dir_ctime -- --exact`
- `cargo test -p runner --bin runner local_queue::state::tests::write_result_sync_tightens_existing_permissive_result_dir -- --exact`
- `cargo test -p runner --bin runner host_file::tests`
- `cargo test -p runner --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- repeated the ctime regression 10 times successfully

Closes #23529
