### PR TITLE
test(python): cover registry fstat descriptor cleanup

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -81,6 +81,21 @@ class TestLoadRegistry:
         assert result == {}
         assert isinstance(state, registry.RegistryUnavailable)
 
+    def test_fstat_failure_closes_opened_descriptor(self):
+        opened_fd = 42
+        error = OSError("fstat failed")
+
+        with (
+            patch.object(registry.os, "open", return_value=opened_fd),
+            patch.object(registry.os, "fstat", side_effect=error),
+            patch.object(registry.os, "close") as close,
+            pytest.raises(OSError, match="fstat failed") as exc_info,
+        ):
+            registry._open_registry_for_read(Path("registry.json"))
+
+        assert exc_info.value is error
+        close.assert_called_once_with(opened_fd)
+
     def test_cache_returns_same_on_unchanged(self, registry_file):
         result1 = registry.load_registry(str(registry_file))
         result2 = registry.load_registry(str(registry_file))


### PR DESCRIPTION
## Summary

- add fault injection for registry `fstat` failure after a successful open
- verify the original `OSError` propagates and the acquired descriptor is closed exactly once

## Scope

- test-only change in the existing registry loading suite
- no runtime, dependency, API, data, or deployment changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_registry_loading.py::TestLoadRegistry::test_fstat_failure_closes_opened_descriptor`
- `uv run --no-sync python -m pytest tests/test_registry_loading.py`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,395 passed)
- `git diff --check`

Closes #23530
