### PR TITLE
perf(mitm-addon): bound zlib member input tails

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -32,6 +32,11 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
+# Bound how much following compressed input zlib can copy into unused_data at
+# a member boundary. This is larger than zstd validation chunks because zlib's
+# max_length already bounds decoded output and ordinary inputs benefit from
+# fewer Python-to-C calls.
+_ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE = 1024
 # zstd's Python decompression object has no zlib-style max_length argument.
 # Keep validation input chunks small so the discarded decoded output is bounded.
 _ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
@@ -62,6 +67,32 @@ _StreamDecodeFinishError = Callable[[], str | None]
 class StreamDecodeSession(NamedTuple):
     feed: _StreamDecodeFeed
     finish_error: _StreamDecodeFinishError
+
+
+class _ZlibInputCursor:
+    """Advance source bytes once while prioritizing bounded decompressor tails."""
+
+    def __init__(self, data: bytes) -> None:
+        self._source = memoryview(data)
+        self._source_offset = 0
+        self._pending_input = b""
+
+    def __bool__(self) -> bool:
+        return self._source_offset < len(self._source) or bool(self._pending_input)
+
+    def take(self) -> bytes | memoryview:
+        if self._pending_input:
+            chunk = self._pending_input
+            self._pending_input = b""
+            return chunk
+        chunk = self._source[
+            self._source_offset : self._source_offset + _ZLIB_DECOMPRESS_INPUT_CHUNK_SIZE
+        ]
+        self._source_offset += len(chunk)
+        return chunk
+
+    def carry(self, data: bytes) -> None:
+        self._pending_input = data
 
 
 def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
@@ -107,8 +138,13 @@ def _create_zlib_stream_decode_session(
         if chunk:
             saw_input = True
             compressed_bytes_seen += len(chunk)
-        data = chunk
-        while data:
+        input_cursor = _ZlibInputCursor(chunk)
+        # Input slicing can make zlib return partial parser chunks. Coalesce
+        # only within this callback and member so existing delivery boundaries
+        # and the max_decoded_chunk contract remain intact.
+        pending_decoded = bytearray()
+        while input_cursor:
+            data = input_cursor.take()
             member_in_progress = True
             allowed_decoded_bytes = max(
                 STREAM_DECODE_EXPANSION_GRACE,
@@ -119,33 +155,45 @@ def _create_zlib_stream_decode_session(
             max_length = (
                 1
                 if probing_for_additional_output
-                else min(max_decoded_chunk, remaining_decoded_bytes)
+                else min(
+                    max_decoded_chunk - len(pending_decoded),
+                    remaining_decoded_bytes,
+                )
             )
             try:
                 decoded = obj.decompress(data, max_length=max_length)
             except zlib.error as exc:
+                if pending_decoded:
+                    feed(bytes(pending_decoded))
                 decode_error = INVALID_COMPRESSED_BODY
                 _log_streaming_decode_error(encoding, exc)
                 return
             if probing_for_additional_output and decoded:
+                if pending_decoded:
+                    feed(bytes(pending_decoded))
                 decode_error = DECODED_BODY_LIMIT_EXCEEDED
                 return
             if decoded:
                 decoded_bytes_emitted += len(decoded)
-                feed(decoded)
+                pending_decoded.extend(decoded)
+                if len(pending_decoded) == max_decoded_chunk:
+                    feed(bytes(pending_decoded))
+                    pending_decoded.clear()
             if obj.eof:
+                if pending_decoded:
+                    feed(bytes(pending_decoded))
+                    pending_decoded.clear()
                 # At an exact output boundary, zlib can expose the next member
                 # through both unused_data and unconsumed_tail. Reset before
                 # consulting unconsumed_tail so the next member makes progress.
-                data = obj.unused_data
+                input_cursor.carry(obj.unused_data)
                 obj = zlib.decompressobj(wbits)
                 member_in_progress = False
-                if data:
-                    continue
-            if obj.unconsumed_tail:
-                data = obj.unconsumed_tail
                 continue
-            return
+            if obj.unconsumed_tail:
+                input_cursor.carry(obj.unconsumed_tail)
+        if pending_decoded:
+            feed(bytes(pending_decoded))
 
     def finish_error() -> str | None:
         if decode_error is not None:
@@ -275,37 +323,30 @@ def _decompress_zlib_best_effort_bounded(
         return _BodyDecodeResult(b"", False)
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-    remaining_data = data
+    input_cursor = _ZlibInputCursor(data)
     out = bytearray()
     completed_member = False
+    obj = zlib.decompressobj(wbits)
 
-    while remaining_data and len(out) < max_output:
-        obj = zlib.decompressobj(wbits)
-        member_data = remaining_data
+    while input_cursor and len(out) < max_output:
+        member_data = input_cursor.take()
+        try:
+            decoded = obj.decompress(member_data, max_length=max_output - len(out))
+        except zlib.error as exc:
+            if completed_member:
+                return _BodyDecodeResult(bytes(out), False)
+            return _BodyDecodeResult(data, True, exc)
 
-        while member_data and len(out) < max_output:
-            try:
-                decoded = obj.decompress(member_data, max_length=max_output - len(out))
-            except zlib.error as exc:
-                if completed_member:
-                    return _BodyDecodeResult(bytes(out), False)
-                return _BodyDecodeResult(data, True, exc)
-
-            out.extend(decoded)
-            if obj.unconsumed_tail:
-                member_data = obj.unconsumed_tail
-                continue
-            break
-
+        out.extend(decoded)
         if len(out) >= max_output:
             return _BodyDecodeResult(bytes(out), False)
         if obj.eof:
             completed_member = True
-            if obj.unused_data:
-                remaining_data = obj.unused_data
-                continue
-            return _BodyDecodeResult(bytes(out), False)
-        return _BodyDecodeResult(bytes(out), False)
+            input_cursor.carry(obj.unused_data)
+            if input_cursor:
+                obj = zlib.decompressobj(wbits)
+        elif obj.unconsumed_tail:
+            input_cursor.carry(obj.unconsumed_tail)
 
     return _BodyDecodeResult(bytes(out), False)
 
@@ -401,30 +442,36 @@ def _decompress_zlib_json_usage_body(
         return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
-    remaining_data = data
+    input_cursor = _ZlibInputCursor(data)
     out = bytearray()
 
-    while remaining_data:
+    while input_cursor:
         remaining_output = max_output - len(out)
         # One probe byte distinguishes exact completion from real overflow.
         obj = zlib.decompressobj(wbits)
-        try:
-            decoded = obj.decompress(remaining_data, max_length=remaining_output + 1)
-        except zlib.error as exc:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return b"", INVALID_COMPRESSED_BODY
 
-        if len(decoded) > remaining_output:
-            out.extend(decoded[:remaining_output])
-            return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
-        out.extend(decoded)
-        if not obj.eof:
+        while input_cursor:
+            member_data = input_cursor.take()
+            try:
+                decoded = obj.decompress(member_data, max_length=remaining_output + 1)
+            except zlib.error as exc:
+                with contextlib.suppress(AttributeError):
+                    # ctx.log unavailable outside mitmproxy runtime
+                    ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
+                return b"", INVALID_COMPRESSED_BODY
+
+            if len(decoded) > remaining_output:
+                out.extend(decoded[:remaining_output])
+                return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
+            out.extend(decoded)
+            remaining_output -= len(decoded)
+            if obj.eof:
+                input_cursor.carry(obj.unused_data)
+                break
+            if obj.unconsumed_tail:
+                input_cursor.carry(obj.unconsumed_tail)
+        else:
             return bytes(out), INCOMPLETE_COMPRESSED_BODY
-        if not obj.unused_data:
-            return bytes(out), None
-        remaining_data = obj.unused_data
 
     return bytes(out), None
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -325,22 +325,31 @@ def _decompress_zlib_best_effort_bounded(
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     input_cursor = _ZlibInputCursor(data)
     out = bytearray()
+    # A full-input zlib call exposes no partial output when that member raises.
+    # Commit each member only at EOF so bounded slicing preserves that policy.
+    member_out = bytearray()
     completed_member = False
     obj = zlib.decompressobj(wbits)
 
     while input_cursor and len(out) < max_output:
         member_data = input_cursor.take()
         try:
-            decoded = obj.decompress(member_data, max_length=max_output - len(out))
+            decoded = obj.decompress(
+                member_data,
+                max_length=max_output - len(out) - len(member_out),
+            )
         except zlib.error as exc:
             if completed_member:
                 return _BodyDecodeResult(bytes(out), False)
             return _BodyDecodeResult(data, True, exc)
 
-        out.extend(decoded)
-        if len(out) >= max_output:
+        member_out.extend(decoded)
+        if len(out) + len(member_out) >= max_output:
+            out.extend(member_out)
             return _BodyDecodeResult(bytes(out), False)
         if obj.eof:
+            out.extend(member_out)
+            member_out.clear()
             completed_member = True
             input_cursor.carry(obj.unused_data)
             if input_cursor:
@@ -348,6 +357,7 @@ def _decompress_zlib_best_effort_bounded(
         elif obj.unconsumed_tail:
             input_cursor.carry(obj.unconsumed_tail)
 
+    out.extend(member_out)
     return _BodyDecodeResult(bytes(out), False)
 
 

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -515,6 +515,21 @@ class TestDecompressBody:
         assert result == b"prefix"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_corrupt_later_zlib_member_discards_its_partial_output(self, headers, encoding):
+        prefix = b"prefix"
+        trailing_member = bytearray(
+            _compress_one_shot_body(encoding, pseudo_random_ascii(4 * 1024))
+        )
+        assert len(trailing_member) > _ZLIB_INPUT_BOUND
+        trailing_member[-1] ^= 0xFF
+        compressed = _compress_one_shot_body(encoding, prefix) + trailing_member
+
+        hdrs = headers(("Content-Encoding", encoding))
+        result = decompress_body(compressed, hdrs, max_output=64 * 1024)
+
+        assert result == prefix
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_invalid_zlib_first_member_returns_original_data(self, headers, encoding):
         if encoding == "gzip":
             corrupted = bytearray(gzip.compress(b"payload"))

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -27,6 +27,8 @@ from tests.body_decode_helpers import (
     track_brotli_decompressor,
 )
 
+_ZLIB_INPUT_BOUND = 1024
+
 
 def _compress_one_shot_body(encoding: str, body: bytes) -> bytes:
     if encoding == "gzip":
@@ -38,6 +40,61 @@ def _compress_one_shot_body(encoding: str, body: bytes) -> bytes:
     if encoding == "zstd":
         return zstandard.ZstdCompressor().compress(body)
     raise AssertionError(f"unsupported test encoding: {encoding}")
+
+
+def _many_empty_zlib_members(encoding: str) -> bytes:
+    member = _compress_one_shot_body(encoding, b"")
+    return member * (STREAM_BUFFER_LIMIT // len(member))
+
+
+def _track_zlib_decompressor(monkeypatch):
+    real_factory = zlib.decompressobj
+    stats = {
+        "calls": 0,
+        "objects": 0,
+        "max_input": 0,
+        "max_unused_data": 0,
+    }
+
+    class NonConcatenableUnusedData(bytes):
+        def __add__(self, _other: object) -> bytes:
+            raise TypeError("zlib unused data must not be concatenated")
+
+    class TrackingDecompressionObj:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def decompress(self, chunk, *args, **kwargs):
+            stats["calls"] += 1
+            stats["max_input"] = max(stats["max_input"], len(chunk))
+            return self._wrapped.decompress(chunk, *args, **kwargs)
+
+        @property
+        def eof(self):
+            return self._wrapped.eof
+
+        @property
+        def unused_data(self):
+            unused_data = NonConcatenableUnusedData(self._wrapped.unused_data)
+            stats["max_unused_data"] = max(stats["max_unused_data"], len(unused_data))
+            return unused_data
+
+        @property
+        def unconsumed_tail(self):
+            return self._wrapped.unconsumed_tail
+
+    def factory(*args, **kwargs):
+        stats["objects"] += 1
+        return TrackingDecompressionObj(real_factory(*args, **kwargs))
+
+    monkeypatch.setattr("body_decoding.zlib.decompressobj", factory)
+    return stats
+
+
+def _assert_zlib_input_is_bounded(stats) -> None:
+    assert stats["calls"] > 0
+    assert stats["max_input"] <= _ZLIB_INPUT_BOUND
+    assert stats["max_unused_data"] <= _ZLIB_INPUT_BOUND
 
 
 class TestStreamDecodeSession:
@@ -93,6 +150,22 @@ class TestStreamDecodeSession:
 
         assert b"".join(chunks) == plaintext
         assert session.finish_error() is None
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_many_empty_zlib_members_use_bounded_input(self, headers, monkeypatch, encoding):
+        compressed = _many_empty_zlib_members(encoding)
+        stats = _track_zlib_decompressor(monkeypatch)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert chunks == []
+        assert session.finish_error() is None
+        _assert_zlib_input_is_bounded(stats)
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_concatenated_zlib_members_across_callbacks(self, headers, encoding):
@@ -334,41 +407,9 @@ class TestStreamDecodeSession:
         assert chunks == []
 
     def test_short_circuit_skips_decomp_fn_after_failure(self, headers, mitm_ctx, monkeypatch):
-        # Verify the broken flag actually prevents subsequent decoder calls.
-        # ``zlib.Decompress``
-        # is a C type whose ``decompress`` attribute is read-only, so we wrap
-        # the factory's return value in a proxy that counts delegations.
-        real_factory = zlib.decompressobj
-
-        class CountingProxy:
-            def __init__(self, real):
-                self._real = real
-                self.count = 0
-
-            def decompress(self, chunk, *a, **kw):
-                self.count += 1
-                return self._real.decompress(chunk, *a, **kw)
-
-            @property
-            def unconsumed_tail(self):
-                return self._real.unconsumed_tail
-
-            @property
-            def eof(self):
-                return self._real.eof
-
-            @property
-            def unused_data(self):
-                return self._real.unused_data
-
-        proxies: list[CountingProxy] = []
-
-        def factory(*args, **kwargs):
-            proxy = CountingProxy(real_factory(*args, **kwargs))
-            proxies.append(proxy)
-            return proxy
-
-        monkeypatch.setattr("body_decoding.zlib.decompressobj", factory)
+        # zlib's C decompressor type has read-only methods, so the shared
+        # transparent factory proxy records delegations.
+        stats = _track_zlib_decompressor(monkeypatch)
         chunks: list[bytes] = []
         with mitm_ctx():
             session = create_stream_decode_session(
@@ -379,8 +420,8 @@ class TestStreamDecodeSession:
             session.feed(b"more garbage")
             session.feed(b"and more")
         # Only the first chunk reaches zlib; later ones are short-circuited.
-        assert len(proxies) == 1
-        assert proxies[0].count == 1
+        assert stats["objects"] == 1
+        assert stats["calls"] == 1
         assert chunks == []
         assert session.finish_error() == "invalid compressed body"
 
@@ -421,6 +462,17 @@ class TestDecompressBody:
         result = decompress_body(compressed, hdrs, max_output=64 * 1024)
 
         assert result == plaintext
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_many_empty_zlib_members_use_bounded_input(self, headers, monkeypatch, encoding):
+        compressed = _many_empty_zlib_members(encoding)
+        stats = _track_zlib_decompressor(monkeypatch)
+        hdrs = headers(("Content-Encoding", encoding))
+
+        result = decompress_body(compressed, hdrs, max_output=1)
+
+        assert result == b""
+        _assert_zlib_input_is_bounded(stats)
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_concatenated_zlib_members_share_max_output_cap(self, headers, encoding):
@@ -612,6 +664,18 @@ class TestDecodeRequestBodyForNetworkLogCapture:
 
 class TestDecompressJsonUsageBody:
     """Direct tests for strict JSON usage decompression."""
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_many_empty_zlib_members_use_bounded_input(self, headers, monkeypatch, encoding):
+        compressed = _many_empty_zlib_members(encoding)
+        stats = _track_zlib_decompressor(monkeypatch)
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1)
+
+        assert decoded == b""
+        assert error is None
+        _assert_zlib_input_is_bounded(stats)
 
     def test_brotli_exact_limit_consumes_later_frame_trailer(self, headers, monkeypatch):
         body = pseudo_random_ascii(13)


### PR DESCRIPTION
## Summary

- advance gzip/deflate source bytes through a shared 1 KiB cursor so zlib never receives the complete remaining member tail
- preserve streaming, best-effort capture, and strict JSON decode budgets and error policies
- coalesce streaming output within each callback and member to retain existing parser chunk delivery behavior
- buffer best-effort output per member so a corrupt later member cannot leak partial decoded bytes
- cover many empty concatenated gzip and deflate members across all three public decode policies with deterministic zlib input/tail bounds

## Compatibility

- no public API, protocol, persisted data, migration, or deployment contract changes
- Brotli and zstd behavior is unchanged
- valid concatenated members, exact output boundaries, malformed/truncated data, corrupt later members, and trailing-garbage semantics remain covered

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused body decoding, capture, model-provider, and X connector tests
- 600 deterministic gzip/deflate differential cases against `origin/main`
- `uv run --no-sync python -m pytest tests/` (4,402 passed)

Closes #23531
