### PR TITLE
fix(runner): preserve drain override removal after cleanup error

### DIFF
--- a/crates/runner/src/cmd/service/drain_override.rs
+++ b/crates/runner/src/cmd/service/drain_override.rs
@@ -1,6 +1,8 @@
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 use crate::error::{RunnerError, RunnerResult};
 
 use super::target::RunnerServiceUnit;
@@ -14,6 +16,10 @@ pub(super) fn write_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerRe
     write_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
 
+/// Returns whether the effective drop-in file was removed.
+///
+/// Cleanup of its containing directory is best-effort because an empty
+/// directory does not affect systemd configuration.
 pub(super) fn remove_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
     remove_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
@@ -43,7 +49,7 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
     let path = drain_restart_override_path_at(root, unit);
     cleanup_unit_staging_files(&path)?;
 
-    let mut changed = match std::fs::remove_file(&path) {
+    let override_removed = match std::fs::remove_file(&path) {
         Ok(()) => true,
         Err(e) if e.kind() == ErrorKind::NotFound => false,
         Err(e) => {
@@ -56,17 +62,18 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
 
     let dir = drain_restart_override_dir_at(root, unit);
     match std::fs::remove_dir(&dir) {
-        Ok(()) => changed = true,
+        Ok(()) => {}
         Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) => {}
         Err(e) => {
-            return Err(RunnerError::Internal(format!(
-                "remove empty drain restart override directory {}: {e}",
-                dir.display()
-            )));
+            warn!(
+                directory = %dir.display(),
+                error = %e,
+                "failed to remove empty drain restart override directory"
+            );
         }
     }
 
-    Ok(changed)
+    Ok(override_removed)
 }
 
 #[cfg(test)]
@@ -135,6 +142,18 @@ mod tests {
     }
 
     #[test]
+    fn remove_cleans_empty_directory_without_reporting_override_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
+        std::fs::create_dir(&drop_in_dir).unwrap();
+
+        assert!(!remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+
+        assert!(!drop_in_dir.exists());
+    }
+
+    #[test]
     fn remove_deletes_empty_drop_in_directory() {
         let dir = tempfile::tempdir().unwrap();
         let unit = service_unit();
@@ -160,5 +179,27 @@ mod tests {
         assert!(drop_in_dir.exists());
         assert!(other.exists());
         assert!(!drain_restart_override_path_at(dir.path(), &unit).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_reports_override_change_when_directory_cleanup_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
+        std::os::unix::fs::symlink(target.path(), &drop_in_dir).unwrap();
+        let path = drain_restart_override_path_at(dir.path(), &unit);
+        std::fs::write(&path, DRAIN_DROP_IN_CONTENT).unwrap();
+
+        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+
+        assert!(!path.exists());
+        assert!(
+            std::fs::symlink_metadata(&drop_in_dir)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 }

--- a/crates/runner/src/cmd/service/drain_override.rs
+++ b/crates/runner/src/cmd/service/drain_override.rs
@@ -16,10 +16,7 @@ pub(super) fn write_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerRe
     write_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
 
-/// Returns whether the effective drop-in file was removed.
-///
-/// Cleanup of its containing directory is best-effort because an empty
-/// directory does not affect systemd configuration.
+/// Returns whether cleanup found state that warrants reloading systemd.
 pub(super) fn remove_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
     remove_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
@@ -49,7 +46,7 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
     let path = drain_restart_override_path_at(root, unit);
     cleanup_unit_staging_files(&path)?;
 
-    let override_removed = match std::fs::remove_file(&path) {
+    let mut changed = match std::fs::remove_file(&path) {
         Ok(()) => true,
         Err(e) if e.kind() == ErrorKind::NotFound => false,
         Err(e) => {
@@ -62,7 +59,7 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
 
     let dir = drain_restart_override_dir_at(root, unit);
     match std::fs::remove_dir(&dir) {
-        Ok(()) => {}
+        Ok(()) => changed = true,
         Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) => {}
         Err(e) => {
             warn!(
@@ -73,7 +70,7 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
         }
     }
 
-    Ok(override_removed)
+    Ok(changed)
 }
 
 #[cfg(test)]
@@ -142,13 +139,13 @@ mod tests {
     }
 
     #[test]
-    fn remove_cleans_empty_directory_without_reporting_override_change() {
+    fn remove_reports_change_when_empty_directory_is_cleaned() {
         let dir = tempfile::tempdir().unwrap();
         let unit = service_unit();
         let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
         std::fs::create_dir(&drop_in_dir).unwrap();
 
-        assert!(!remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
 
         assert!(!drop_in_dir.exists());
     }


### PR DESCRIPTION
## Summary

- preserve the existing reload signal when drain cleanup removes either the
  effective drop-in or a pre-existing empty drop-in directory
- warn when empty-directory cleanup fails after target unlink while still
  reporting the known removal to callers
- cover directory-only cleanup and post-unlink cleanup failure with the real
  filesystem, including a root-safe failure case

## Scope

This changes only the runner's private systemd drop-in cleanup contract. It
does not change service CLI arguments, unit contents, successful cleanup
semantics, caller ordering, APIs, protocols, persisted state, schemas, or
rollout behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::drain_override`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `git diff --check`
- repository pre-commit hooks

Closes #23532
