### PR TITLE
fix(vsock-host): bound exec start writes by host deadlines

### DIFF
--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -154,6 +154,7 @@ pub(crate) async fn probe_guest_dns_once(
     let command = format!("/usr/bin/getent ahostsv4 {DNS_READINESS_HOSTNAME}");
     let request = ExecOperationRequest {
         timeout_ms: PROCESS_TIMEOUT_MS,
+        start_write_timeout: wait_timeout,
         command: &command,
         env: RESOLVER_ENV,
         sudo: false,

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -13,6 +13,7 @@ shell-quote.workspace = true
 vsock-proto.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }
 tracing-test-support.workspace = true
 

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
@@ -300,12 +301,13 @@ impl ExecWaitCore {
         }
     }
 
-    pub(in crate::exec_operation) async fn wait_with_timeout(
+    async fn wait_with_timeout_future(
         &mut self,
-        timeout: Duration,
+        timeout: impl Future<Output = ()>,
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
     ) -> io::Result<ExecOperationResult> {
+        tokio::pin!(timeout);
         let seq = self.active_seq_or_closed(lifecycle.operation_closed_message())?;
         let rx = self.result_rx.as_mut().ok_or_else(|| {
             io::Error::new(
@@ -324,10 +326,34 @@ impl ExecWaitCore {
                     "connection closed",
                 ))?
             }
-            _ = tokio::time::sleep(timeout) => {
+            _ = &mut timeout => {
                 Err(self.abandon_timed_out_operation(seq, poison_on_timeout, lifecycle))
             }
         }
+    }
+
+    pub(in crate::exec_operation) async fn wait_with_timeout(
+        &mut self,
+        timeout: Duration,
+        poison_on_timeout: bool,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Result<ExecOperationResult> {
+        self.wait_with_timeout_future(tokio::time::sleep(timeout), poison_on_timeout, lifecycle)
+            .await
+    }
+
+    pub(in crate::exec_operation) async fn wait_with_deadline(
+        &mut self,
+        deadline: Instant,
+        poison_on_timeout: bool,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Result<ExecOperationResult> {
+        self.wait_with_timeout_future(
+            tokio::time::sleep_until(deadline),
+            poison_on_timeout,
+            lifecycle,
+        )
+        .await
     }
 
     async fn send_cancel_before_terminal_with_deadline(
@@ -443,6 +469,15 @@ impl ExecOperationHandle {
     pub async fn wait(mut self, timeout: Duration) -> io::Result<ExecOperationResult> {
         self.wait_core
             .wait_with_timeout(timeout, false, ExecWaitLifecycle::OneShot)
+            .await
+    }
+
+    pub(in crate::exec_operation) async fn wait_until(
+        mut self,
+        deadline: Instant,
+    ) -> io::Result<ExecOperationResult> {
+        self.wait_core
+            .wait_with_deadline(deadline, false, ExecWaitLifecycle::OneShot)
             .await
     }
 

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::oneshot;
+use tokio::time::{self, Instant};
 use vsock_proto::{
     ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecTimeoutPolicy, MSG_EXEC_CANCEL,
 };
@@ -26,6 +27,22 @@ use super::types::{
 };
 use super::{EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT, SMALL_EXEC_CAPTURE_LIMIT_BYTES};
 
+fn exec_start_timeout_error() -> io::Error {
+    io::Error::new(io::ErrorKind::TimedOut, "exec start timeout")
+}
+
+fn exec_start_deadline(timeout: Duration) -> io::Result<Instant> {
+    if timeout.is_zero() {
+        return Err(exec_start_timeout_error());
+    }
+    Instant::now().checked_add(timeout).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "exec start timeout is too large",
+        )
+    })
+}
+
 pub(crate) fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
     if diagnostic.is_empty() {
         return;
@@ -40,13 +57,14 @@ pub(crate) async fn start_exec_operation_on_shared(
     shared: &Arc<Shared>,
     request: ExecOperationRequest<'_>,
 ) -> io::Result<ExecOperationHandle> {
-    start_exec_operation_on_shared_with_tracking(
+    let (handle, _) = start_exec_operation_on_shared_with_tracking(
         shared,
         request,
         ExecOperationTracking::Tracked,
         FrameWriteObserver::default(),
     )
-    .await
+    .await?;
+    Ok(handle)
 }
 
 async fn start_exec_operation_on_shared_with_tracking(
@@ -54,7 +72,7 @@ async fn start_exec_operation_on_shared_with_tracking(
     request: ExecOperationRequest<'_>,
     tracking: ExecOperationTracking<'_>,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecOperationHandle> {
+) -> io::Result<(ExecOperationHandle, Instant)> {
     if request.timeout_ms == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -85,6 +103,7 @@ async fn start_exec_operation_on_shared_with_tracking(
         },
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let deadline = exec_start_deadline(request.start_write_timeout)?;
 
     let ExecOperationRegistration {
         seq,
@@ -104,21 +123,28 @@ async fn start_exec_operation_on_shared_with_tracking(
             tracking,
         },
     )?;
-    write_exec_start_frame(
-        shared,
-        seq,
-        &payload,
-        &diagnostic,
-        tracks_normal_operation,
-        write_observer,
+    time::timeout_at(
+        deadline,
+        write_exec_start_frame(
+            shared,
+            seq,
+            &payload,
+            &diagnostic,
+            tracks_normal_operation,
+            write_observer,
+        ),
     )
-    .await?;
+    .await
+    .map_err(|_| exec_start_timeout_error())??;
     registration_guard.disarm();
 
-    Ok(ExecOperationHandle {
-        wait_core: ExecWaitCore::new(Arc::clone(shared), seq, diagnostic, result_rx),
-        stream_rx,
-    })
+    Ok((
+        ExecOperationHandle {
+            wait_core: ExecWaitCore::new(Arc::clone(shared), seq, diagnostic, result_rx),
+            stream_rx,
+        },
+        deadline,
+    ))
 }
 
 pub(crate) async fn start_supervised_exec_on_shared(
@@ -190,6 +216,7 @@ where
         },
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let deadline = exec_start_deadline(request.start_timeout)?;
 
     let (start_tx, start_rx) = oneshot::channel();
     let ExecOperationRegistration {
@@ -215,15 +242,20 @@ where
     )?;
     let mut start_cancel_on_drop =
         ExecOperationCancelOnDropGuard::new_for_seq(Arc::clone(shared), seq, diagnostic.clone());
-    let start_write_result = write_exec_start_frame(
-        shared,
-        seq,
-        &payload,
-        &diagnostic,
-        tracks_normal_operation,
-        FrameWriteObserver::default(),
+    let start_write_result = time::timeout_at(
+        deadline,
+        write_exec_start_frame(
+            shared,
+            seq,
+            &payload,
+            &diagnostic,
+            tracks_normal_operation,
+            FrameWriteObserver::default(),
+        ),
     )
-    .await;
+    .await
+    .map_err(|_| exec_start_timeout_error())
+    .and_then(|result| result);
     if let Err(error) = start_write_result {
         start_cancel_on_drop.disarm();
         return Err(error);
@@ -248,7 +280,7 @@ where
                 }
             }
         }
-        _ = tokio::time::sleep(request.start_timeout) => {
+        _ = time::sleep_until(deadline) => {
             let payload = vsock_proto::encode_exec_cancel();
             shared.remove_operation(seq);
             registration_guard.disarm();
@@ -335,7 +367,7 @@ async fn exec_operation_capture_on_shared_with_tracking(
     tracking: ExecOperationTracking<'_>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationResult> {
-    let handle = start_exec_operation_on_shared_with_tracking(
+    let (handle, deadline) = start_exec_operation_on_shared_with_tracking(
         shared,
         ExecOperationRequest {
             timeout_ms: request.timeout_ms,
@@ -352,12 +384,13 @@ async fn exec_operation_capture_on_shared_with_tracking(
             expected_exit_codes: request.expected_exit_codes,
             stdin_bytes: request.stdin_bytes,
             stream_queue_capacity: None,
+            start_write_timeout: request.wait_timeout,
         },
         tracking,
         write_observer,
     )
     .await?;
-    handle.wait(request.wait_timeout).await
+    handle.wait_until(deadline).await
 }
 
 pub(crate) async fn exec_operation_stream_on_shared(
@@ -386,7 +419,7 @@ async fn exec_operation_stream_on_shared_with_tracking(
         ));
     }
 
-    start_exec_operation_on_shared_with_tracking(
+    let (handle, _) = start_exec_operation_on_shared_with_tracking(
         shared,
         ExecOperationRequest {
             timeout_ms: request.timeout_ms,
@@ -399,11 +432,13 @@ async fn exec_operation_stream_on_shared_with_tracking(
             expected_exit_codes: request.expected_exit_codes,
             stdin_bytes: request.stdin_bytes,
             stream_queue_capacity: request.stream_queue_capacity,
+            start_write_timeout: request.start_write_timeout,
         },
         tracking,
         write_observer,
     )
-    .await
+    .await?;
+    Ok(handle)
 }
 
 pub(crate) async fn exec_operation_stream_with_composite_on_shared_and_observer(

--- a/crates/vsock-host/src/exec_operation/types.rs
+++ b/crates/vsock-host/src/exec_operation/types.rs
@@ -111,6 +111,12 @@ pub struct ExecOperationRequest<'a> {
     /// `Some` is valid only when stdout or stderr streams; zero and oversized
     /// capacities are rejected.
     pub stream_queue_capacity: Option<usize>,
+    /// Maximum host-side time to write the complete exec-start frame.
+    ///
+    /// This includes waiting for the shared writer and is separate from
+    /// `timeout_ms`, which is the guest-side process timeout. A zero duration
+    /// expires before the frame is sent.
+    pub start_write_timeout: Duration,
 }
 
 /// Request parameters for a capture-only exec operation helper.
@@ -135,10 +141,12 @@ pub struct ExecCaptureRequest<'a> {
     pub expected_exit_codes: &'a [i32],
     /// Optional bounded stdin payload written to the child and then closed.
     pub stdin_bytes: Option<&'a [u8]>,
-    /// Maximum host-side wait for the terminal result after the request starts.
+    /// Maximum total host-side time to write the start frame and wait for the
+    /// terminal result.
     ///
     /// This is separate from `timeout_ms`, which is the guest-side process
-    /// timeout encoded in the exec request.
+    /// timeout encoded in the exec request. A zero duration expires before the
+    /// frame is sent.
     pub wait_timeout: Duration,
 }
 
@@ -173,6 +181,12 @@ pub struct ExecStreamRequest<'a> {
     /// `None` uses the default queue capacity. Zero and oversized capacities
     /// are rejected.
     pub stream_queue_capacity: Option<usize>,
+    /// Maximum host-side time to write the complete exec-start frame.
+    ///
+    /// This includes waiting for the shared writer and is separate from
+    /// `timeout_ms`, which is the guest-side process timeout. A zero duration
+    /// expires before the frame is sent.
+    pub start_write_timeout: Duration,
 }
 
 /// Exec control policy for supervised host operations.
@@ -219,17 +233,20 @@ pub struct SupervisedExecRequest<'a> {
     /// `Some` is valid only when stdout or stderr streams; zero and oversized
     /// capacities are rejected.
     pub stream_queue_capacity: Option<usize>,
-    /// Maximum time to wait for the guest `exec_started` acknowledgement.
+    /// Maximum total host-side time to write the start frame and wait for the
+    /// guest `exec_started` acknowledgement.
     ///
-    /// If this elapses after the start frame is written, the host sends
-    /// `MSG_EXEC_CANCEL` for the operation before returning a timeout error.
-    /// If that cancel frame cannot be written within the bounded fallback
-    /// window, the connection is poisoned because the guest process state is
-    /// no longer known.
+    /// If this elapses before the complete start frame is written, no cancel
+    /// frame is sent. If it elapses while waiting for the acknowledgement after
+    /// a complete write, the host sends `MSG_EXEC_CANCEL` for the operation
+    /// before returning a timeout error. If that cancel frame cannot be written
+    /// within the bounded fallback window, the connection is poisoned because
+    /// the guest process state is no longer known.
     ///
     /// A successful start-timeout cancellation still abandons terminal proof
     /// for this operation, so the connection should not be reused for later
-    /// normal operations.
+    /// normal operations. A zero duration expires before the start frame is
+    /// sent.
     pub start_timeout: Duration,
 }
 

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -538,11 +538,13 @@ impl VsockHost {
         } else {
             &[]
         };
+        let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
         let mut handle =
             exec_operation::exec_operation_stream_with_composite_on_shared_and_observer(
                 &self.shared,
                 ExecStreamRequest {
                     timeout_ms,
+                    start_write_timeout: wait_timeout,
                     command: &command,
                     env: &[],
                     sudo: false,
@@ -570,7 +572,6 @@ impl VsockHost {
                 "copy_file exec operation did not create a stream receiver",
             ))
         })?;
-        let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
         let mut bytes_copied = 0u64;
 
         let drain_result = tokio::time::timeout(wait_timeout, async {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -291,6 +291,9 @@ impl VsockHost {
     }
 
     /// Start a request-scoped exec operation using the exec operation protocol.
+    ///
+    /// `request.start_write_timeout` bounds waiting for the shared writer and
+    /// writing the complete start frame.
     pub async fn start_exec_operation(
         &self,
         request: ExecOperationRequest<'_>,
@@ -300,12 +303,13 @@ impl VsockHost {
 
     /// Start a supervised exec operation and wait for its PID acknowledgement.
     ///
-    /// If `request.start_timeout` elapses after the start frame is written,
-    /// the host sends `MSG_EXEC_CANCEL` before returning a timeout error. If
-    /// the bounded cancel write also times out, the connection is poisoned.
-    /// If the cancel write succeeds, the connection remains open but should
-    /// not be reused for later normal operations because terminal proof for the
-    /// timed-out operation was abandoned.
+    /// `request.start_timeout` bounds both start-frame writing and waiting for
+    /// `MSG_EXEC_STARTED`. If it elapses after the complete start frame is
+    /// written, the host sends `MSG_EXEC_CANCEL` before returning a timeout
+    /// error. If the bounded cancel write also times out, the connection is
+    /// poisoned. If the cancel write succeeds, the connection remains open but
+    /// should not be reused for later normal operations because terminal proof
+    /// for the timed-out operation was abandoned.
     pub async fn start_supervised_exec(
         &self,
         request: SupervisedExecRequest<'_>,
@@ -389,6 +393,9 @@ impl VsockHost {
     }
 
     /// Start a streaming exec operation with a bounded output event receiver.
+    ///
+    /// `request.start_write_timeout` bounds waiting for the shared writer and
+    /// writing the complete start frame.
     pub async fn exec_operation_stream(
         &self,
         request: ExecStreamRequest<'_>,

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -3,18 +3,22 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use nix::sys::socket::{setsockopt, sockopt};
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::support::{
     assert_connection_accepts_exec_operation, captured_output_bytes, exec_capture_default,
-    exec_capture_with_write_observer, is_connected, normal_operation_readiness, operation_count,
-    read_guest_message, send_exec_result, setup_host_and_guest, wait_for_operation_count,
+    exec_capture_with_write_observer, host_from_stream, is_connected, make_pair, mock_handshake,
+    normal_operation_readiness, operation_count, read_guest_message, send_exec_result,
+    setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ExecCaptureRequest, FrameWriteObserver};
+
+const EXEC_START_WRITE_TEST_TIMEOUT: Duration = Duration::from_millis(50);
 
 fn capture_request(command: &str) -> ExecCaptureRequest<'_> {
     ExecCaptureRequest {
@@ -72,6 +76,175 @@ async fn exec_start_cancelled_before_write_does_not_poison_or_send_frame() {
     let exec_result = exec_task.await.unwrap().unwrap();
     assert_eq!(captured_output_bytes(&exec_result.stdout), b"ok");
     assert!(is_connected(&host));
+}
+
+#[tokio::test]
+async fn exec_capture_start_timeout_before_write_cleans_state_and_preserves_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            exec_capture_with_write_observer(
+                &host,
+                ExecCaptureRequest {
+                    wait_timeout: EXEC_START_WRITE_TEST_TIMEOUT,
+                    ..capture_request("writer-timeout")
+                },
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    wait_for_operation_count(&host, 1).await;
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("exec start should respect its writer deadline")
+        .unwrap();
+    let err = match result {
+        Ok(_) => panic!("exec start should time out while waiting for the writer"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(err.to_string(), "exec start timeout");
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(is_connected(&host));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("pre-write timeout must not send an exec frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after pre-write timeout: {err}"),
+    }
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out exec start must not send a stale frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after releasing the writer: {err}"),
+    }
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn exec_capture_wait_timeout_is_not_restarted_after_start_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    tokio::time::pause();
+    let writer_guard = host.shared.writer.lock().await;
+    let wait_timeout = Duration::from_secs(1);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.exec_operation_capture(ExecCaptureRequest {
+                wait_timeout,
+                ..capture_request("single-capture-deadline")
+            })
+            .await
+        })
+    };
+
+    wait_for_operation_count(&host, 1).await;
+    tokio::time::advance(Duration::from_millis(900)).await;
+    drop(writer_guard);
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(operation_count(&host), 0);
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"late",
+        b"",
+    )
+    .await;
+    let result = task.await.unwrap();
+    let err = match result {
+        Ok(_) => panic!("capture wait must use the deadline established before frame writing"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(err.to_string(), "exec operation timeout");
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(is_connected(&host));
+}
+
+#[tokio::test]
+async fn exec_capture_start_timeout_during_write_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
+    mock_handshake(&mut guest).await;
+    let host = Arc::new(host_task.await.unwrap());
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        let stdin_bytes = vec![0xA5; vsock_proto::MAX_EXEC_STDIN_BYTES];
+        tokio::spawn(async move {
+            exec_capture_with_write_observer(
+                &host,
+                ExecCaptureRequest {
+                    command: "cat",
+                    stdin_bytes: Some(&stdin_bytes),
+                    wait_timeout: EXEC_START_WRITE_TEST_TIMEOUT,
+                    ..capture_request("blocked-write")
+                },
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while write_start_count.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("exec start should reach the frame write boundary");
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("blocked exec start write should respect its deadline")
+        .unwrap();
+    let err = match result {
+        Ok(_) => panic!("blocked exec start write should time out"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(err.to_string(), "exec start timeout");
+
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(!is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/capture.rs
+++ b/crates/vsock-host/src/tests/exec_operation/capture.rs
@@ -124,6 +124,7 @@ async fn fenced_capture_excludes_normal_operations_until_fence_drops() {
     let error = match host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "competing-operation",
             env: &[],
             sudo: false,
@@ -216,6 +217,7 @@ async fn exec_operation_capture_sends_stdin_bytes() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "cat",
             env: &[],
             sudo: false,
@@ -255,6 +257,7 @@ async fn exec_operation_rejects_oversized_stdin_without_sending_frame() {
     let err = match host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "cat",
             env: &[],
             sudo: false,
@@ -288,6 +291,7 @@ async fn exec_start_sends_expected_exit_codes() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "optional",
             env: &[],
             sudo: false,
@@ -330,6 +334,7 @@ async fn exec_operation_capture_repeated_short_operations_soak() {
         let handle = host
             .start_exec_operation(ExecOperationRequest {
                 timeout_ms: 5000,
+                start_write_timeout: Duration::from_secs(5),
                 command: "printf ok",
                 env: &[],
                 sudo: false,
@@ -378,6 +383,7 @@ async fn exec_operation_capture_large_stdout_stderr_within_limits_soak() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "large-capture",
             env: &[],
             sudo: false,
@@ -431,6 +437,7 @@ async fn exec_result_preserves_non_default_metadata() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "metadata",
             env: &[],
             sudo: false,
@@ -480,6 +487,7 @@ async fn exec_result_capture_for_discard_policy_poisons_connection() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "discard",
             env: &[],
             sudo: false,
@@ -520,6 +528,7 @@ async fn exec_result_over_capture_limit_poisons_connection() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "capture-limit",
             env: &[],
             sudo: false,
@@ -560,6 +569,7 @@ async fn exec_result_discard_for_capture_policy_poisons_connection() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "missing-capture",
             env: &[],
             sudo: false,
@@ -597,6 +607,7 @@ async fn exec_result_zero_capture_limit_accepts_empty_capture() {
     let handle = host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "zero-capture",
             env: &[],
             sudo: false,

--- a/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/lifecycle.rs
@@ -60,6 +60,7 @@ async fn exec_operation_connection_close_wakes_result_and_stream() {
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "stream",
             env: &[],
             sudo: false,
@@ -100,6 +101,7 @@ async fn exec_start_after_connection_close_returns_connection_reset() {
     let err = match host
         .start_exec_operation(ExecOperationRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "echo ok",
             env: &[],
             sudo: false,
@@ -125,6 +127,7 @@ async fn host_drop_closes_active_exec_result_and_stream() {
     let mut handle = host
         .exec_operation_stream(ExecStreamRequest {
             timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
             command: "stream",
             env: &[],
             sudo: false,

--- a/crates/vsock-host/src/tests/exec_operation/mod.rs
+++ b/crates/vsock-host/src/tests/exec_operation/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use vsock_proto::ExecOutputPolicy;
 
 use crate::{ExecOperationHandle, ExecOperationRequest};
@@ -5,6 +7,7 @@ use crate::{ExecOperationHandle, ExecOperationRequest};
 async fn start_capture_operation(host: &crate::VsockHost, command: &str) -> ExecOperationHandle {
     host.start_exec_operation(ExecOperationRequest {
         timeout_ms: 5000,
+        start_write_timeout: Duration::from_secs(5),
         command,
         env: &[],
         sudo: false,

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -19,6 +19,7 @@ use crate::{
 fn stream_request(label: &str) -> ExecStreamRequest<'_> {
     ExecStreamRequest {
         timeout_ms: 5000,
+        start_write_timeout: Duration::from_secs(5),
         command: "stream",
         env: &[],
         sudo: false,
@@ -37,6 +38,7 @@ fn stream_request(label: &str) -> ExecStreamRequest<'_> {
 fn operation_request(label: &str) -> ExecOperationRequest<'_> {
     ExecOperationRequest {
         timeout_ms: 5000,
+        start_write_timeout: Duration::from_secs(5),
         command: "stream",
         env: &[],
         sudo: false,
@@ -49,8 +51,9 @@ fn operation_request(label: &str) -> ExecOperationRequest<'_> {
     }
 }
 
-async fn assert_stream_request_rejected_without_frame(
+async fn assert_stream_request_fails_without_frame(
     request: ExecStreamRequest<'_>,
+    expected_kind: io::ErrorKind,
     expected_message_substring: Option<&str>,
 ) {
     let (host, mut guest) = setup_host_and_guest().await;
@@ -63,7 +66,7 @@ async fn assert_stream_request_rejected_without_frame(
     };
     assert_eq!(
         err.kind(),
-        io::ErrorKind::InvalidInput,
+        expected_kind,
         "stream request {label:?} returned unexpected error: {err}",
     );
     if let Some(expected) = expected_message_substring {
@@ -81,8 +84,9 @@ async fn assert_stream_request_rejected_without_frame(
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
-async fn assert_start_request_rejected_without_frame(
+async fn assert_start_request_fails_without_frame(
     request: ExecOperationRequest<'_>,
+    expected_kind: io::ErrorKind,
     expected_message_substring: Option<&str>,
 ) {
     let (host, mut guest) = setup_host_and_guest().await;
@@ -95,7 +99,7 @@ async fn assert_start_request_rejected_without_frame(
     };
     assert_eq!(
         err.kind(),
-        io::ErrorKind::InvalidInput,
+        expected_kind,
         "exec start request {label:?} returned unexpected error: {err}",
     );
     if let Some(expected) = expected_message_substring {
@@ -170,11 +174,12 @@ async fn assert_stream_output_frames_poison_connection(
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_zero_capacity_without_sending_frame() {
-    assert_stream_request_rejected_without_frame(
+    assert_stream_request_fails_without_frame(
         ExecStreamRequest {
             stream_queue_capacity: Some(0),
             ..stream_request("zero-capacity")
         },
+        io::ErrorKind::InvalidInput,
         None,
     )
     .await;
@@ -182,11 +187,12 @@ async fn exec_operation_stream_rejects_zero_capacity_without_sending_frame() {
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_oversized_capacity_without_sending_frame() {
-    assert_stream_request_rejected_without_frame(
+    assert_stream_request_fails_without_frame(
         ExecStreamRequest {
             stream_queue_capacity: Some(exec_operation_impl::test_support::MAX_STREAM_CAPACITY + 1),
             ..stream_request("oversized-capacity")
         },
+        io::ErrorKind::InvalidInput,
         None,
     )
     .await;
@@ -196,12 +202,13 @@ async fn exec_operation_stream_rejects_oversized_capacity_without_sending_frame(
 async fn exec_operation_stream_rejects_oversized_stdin_without_sending_frame() {
     let stdin_bytes = vec![0; vsock_proto::MAX_EXEC_STDIN_BYTES + 1];
 
-    assert_stream_request_rejected_without_frame(
+    assert_stream_request_fails_without_frame(
         ExecStreamRequest {
             command: "cat",
             stdin_bytes: Some(&stdin_bytes),
             ..stream_request("stream-oversized-stdin")
         },
+        io::ErrorKind::InvalidInput,
         Some("stdin_bytes"),
     )
     .await;
@@ -282,13 +289,14 @@ async fn exec_operation_stream_sends_stdin_bytes() {
 
 #[tokio::test]
 async fn exec_start_rejects_receiver_without_stream_policy() {
-    assert_start_request_rejected_without_frame(
+    assert_start_request_fails_without_frame(
         ExecOperationRequest {
             command: "capture",
             stderr: ExecOutputPolicy::Discard,
             stream_queue_capacity: Some(1),
             ..operation_request("unexpected-receiver")
         },
+        io::ErrorKind::InvalidInput,
         None,
     )
     .await;
@@ -296,13 +304,14 @@ async fn exec_start_rejects_receiver_without_stream_policy() {
 
 #[tokio::test]
 async fn exec_operation_stream_rejects_non_streaming_policy() {
-    assert_stream_request_rejected_without_frame(
+    assert_stream_request_fails_without_frame(
         ExecStreamRequest {
             command: "capture",
             stdout: ExecOutputPolicy::Capture { limit_bytes: 1024 },
             stderr: ExecOutputPolicy::Discard,
             ..stream_request("non-streaming-helper")
         },
+        io::ErrorKind::InvalidInput,
         None,
     )
     .await;
@@ -310,7 +319,7 @@ async fn exec_operation_stream_rejects_non_streaming_policy() {
 
 #[tokio::test]
 async fn exec_start_encode_error_does_not_register_or_send_frame() {
-    assert_start_request_rejected_without_frame(
+    assert_start_request_fails_without_frame(
         ExecOperationRequest {
             stdout: ExecOutputPolicy::Stream {
                 limit_bytes: 1024,
@@ -320,6 +329,7 @@ async fn exec_start_encode_error_does_not_register_or_send_frame() {
             stream_queue_capacity: Some(1),
             ..operation_request("bad-policy")
         },
+        io::ErrorKind::InvalidInput,
         None,
     )
     .await;
@@ -327,13 +337,53 @@ async fn exec_start_encode_error_does_not_register_or_send_frame() {
 
 #[tokio::test]
 async fn exec_start_rejects_zero_timeout_without_sending_frame() {
-    assert_start_request_rejected_without_frame(
+    assert_start_request_fails_without_frame(
         ExecOperationRequest {
             timeout_ms: 0,
             command: "sleep 60",
             ..operation_request("zero-timeout")
         },
+        io::ErrorKind::InvalidInput,
         None,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn exec_start_zero_write_timeout_does_not_send_frame() {
+    assert_start_request_fails_without_frame(
+        ExecOperationRequest {
+            start_write_timeout: Duration::ZERO,
+            ..operation_request("zero-start-write-timeout")
+        },
+        io::ErrorKind::TimedOut,
+        Some("exec start timeout"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn exec_start_oversized_write_timeout_does_not_send_frame() {
+    assert_start_request_fails_without_frame(
+        ExecOperationRequest {
+            start_write_timeout: Duration::MAX,
+            ..operation_request("oversized-start-write-timeout")
+        },
+        io::ErrorKind::InvalidInput,
+        Some("exec start timeout is too large"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn exec_operation_stream_zero_write_timeout_does_not_send_frame() {
+    assert_stream_request_fails_without_frame(
+        ExecStreamRequest {
+            start_write_timeout: Duration::ZERO,
+            ..stream_request("stream-zero-start-write-timeout")
+        },
+        io::ErrorKind::TimedOut,
+        Some("exec start timeout"),
     )
     .await;
 }

--- a/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
@@ -209,18 +209,19 @@ pub(super) fn assert_no_guest_frame(guest: &mut UnixStream, context: &str) {
     }
 }
 
-pub(super) async fn assert_supervised_start_rejected_without_frame(
+pub(super) async fn assert_supervised_start_fails_without_frame(
     request: SupervisedExecRequest<'_>,
+    expected_kind: io::ErrorKind,
     expected_message: &str,
 ) {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host.start_supervised_exec(request).await {
-        Ok(_) => panic!("invalid supervised exec request should be rejected"),
+        Ok(_) => panic!("supervised exec request should fail before sending a frame"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(err.kind(), expected_kind);
     assert!(
         err.to_string().contains(expected_message),
         "unexpected error: {err}",
@@ -230,6 +231,7 @@ pub(super) async fn assert_supervised_start_rejected_without_frame(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+    assert_no_guest_frame(&mut guest, "failed supervised exec must not send a frame");
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }

--- a/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
@@ -9,13 +9,16 @@ use vsock_proto::{
 };
 
 use super::super::super::support::{
-    is_connected, normal_operation_readiness, operation_count, read_guest_message,
-    send_discarded_exec_result, send_exec_started, setup_host_and_guest, wait_for_operation_count,
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    operation_count, read_guest_message, send_discarded_exec_result, send_exec_started,
+    setup_host_and_guest, wait_for_operation_count,
 };
 use super::support::supervised_request;
 use crate::SupervisedExecRequest;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
+
+const START_ACK_TEST_TIMEOUT: Duration = Duration::from_millis(50);
 
 #[tokio::test]
 async fn supervised_exec_terminal_wait_timeout_does_not_send_cancel() {
@@ -53,7 +56,7 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
 
     let err = match host
         .start_supervised_exec(SupervisedExecRequest {
-            start_timeout: Duration::ZERO,
+            start_timeout: START_ACK_TEST_TIMEOUT,
             ..supervised_request("start-timeout")
         })
         .await
@@ -77,13 +80,115 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
 }
 
 #[tokio::test]
+async fn supervised_exec_start_timeout_before_write_preserves_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                start_timeout: START_ACK_TEST_TIMEOUT,
+                ..supervised_request("writer-timeout")
+            })
+            .await
+        })
+    };
+
+    wait_for_operation_count(&host, 1).await;
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("supervised exec should respect its writer deadline")
+        .unwrap();
+    let err = match result {
+        Ok(_) => panic!("supervised exec should time out while waiting for the writer"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(err.to_string(), "exec start timeout");
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert!(is_connected(&host));
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("pre-write timeout must not send start or cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after pre-write timeout: {err}"),
+    }
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out supervised start must not send a stale frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after releasing the writer: {err}"),
+    }
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn supervised_exec_start_timeout_is_not_restarted_after_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let (deadline_elapsed_tx, deadline_elapsed_rx) = tokio::sync::oneshot::channel();
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            exec_operation_impl::test_support::start_supervised_exec_after_start_write(
+                &host.shared,
+                SupervisedExecRequest {
+                    start_timeout: START_ACK_TEST_TIMEOUT,
+                    ..supervised_request("single-start-deadline")
+                },
+                async move {
+                    tokio::time::sleep(START_ACK_TEST_TIMEOUT).await;
+                    let _ = deadline_elapsed_tx.send(());
+                },
+                Duration::from_secs(5),
+            )
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    tokio::time::timeout(Duration::from_secs(5), deadline_elapsed_rx)
+        .await
+        .expect("after-write hook should consume the start deadline")
+        .expect("after-write hook should notify");
+    assert_eq!(operation_count(&host), 0);
+    send_exec_started(&mut guest, start.seq, 123).await;
+
+    let result = task.await.unwrap();
+    let err = match result {
+        Ok(_) => panic!("elapsed start deadline must win before a late acknowledgement"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        err.to_string(),
+        "supervised exec start acknowledgement timeout"
+    );
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn supervised_exec_late_start_frames_after_start_timeout_are_ignored() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = match host
         .start_supervised_exec(SupervisedExecRequest {
-            start_timeout: Duration::ZERO,
+            start_timeout: START_ACK_TEST_TIMEOUT,
             ..supervised_request("late-start-after-timeout")
         })
         .await
@@ -142,7 +247,7 @@ async fn supervised_exec_start_ack_timeout_removes_operation_before_cancel_write
             exec_operation_impl::test_support::start_supervised_exec_after_start_write(
                 &host.shared,
                 SupervisedExecRequest {
-                    start_timeout: Duration::ZERO,
+                    start_timeout: START_ACK_TEST_TIMEOUT,
                     ..supervised_request("blocked-start-timeout-late-result")
                 },
                 async move {
@@ -220,7 +325,7 @@ async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
             exec_operation_impl::test_support::start_supervised_exec_after_start_write(
                 &host.shared,
                 SupervisedExecRequest {
-                    start_timeout: Duration::ZERO,
+                    start_timeout: START_ACK_TEST_TIMEOUT,
                     ..supervised_request("blocked-start-timeout-cancel")
                 },
                 async move {

--- a/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
@@ -132,6 +132,7 @@ async fn supervised_exec_start_timeout_before_write_preserves_connection() {
 async fn supervised_exec_start_timeout_is_not_restarted_after_write() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
+    tokio::time::pause();
     let (deadline_elapsed_tx, deadline_elapsed_rx) = tokio::sync::oneshot::channel();
     let task = {
         let host = Arc::clone(&host);
@@ -154,6 +155,7 @@ async fn supervised_exec_start_timeout_is_not_restarted_after_write() {
 
     let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
+    tokio::time::advance(START_ACK_TEST_TIMEOUT).await;
     tokio::time::timeout(Duration::from_secs(5), deadline_elapsed_rx)
         .await
         .expect("after-write hook should consume the start deadline")

--- a/crates/vsock-host/src/tests/exec_operation/supervised/validation.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/validation.rs
@@ -1,18 +1,22 @@
+use std::io;
+use std::time::Duration;
+
 use vsock_proto::{ExecOutputPolicy, ExecTimeoutPolicy};
 
 use super::support::{
-    assert_supervised_start_rejected_without_frame, supervised_request, supervised_stream_request,
+    assert_supervised_start_fails_without_frame, supervised_request, supervised_stream_request,
 };
 use crate::SupervisedExecRequest;
 
 #[tokio::test]
 async fn supervised_exec_rejects_zero_stream_capacity_without_sending_frame() {
-    assert_supervised_start_rejected_without_frame(
+    assert_supervised_start_fails_without_frame(
         SupervisedExecRequest {
             stdin_bytes: None,
             stream_queue_capacity: Some(0),
             ..supervised_stream_request("zero-stream-capacity")
         },
+        io::ErrorKind::InvalidInput,
         "exec stream queue capacity must be positive",
     )
     .await;
@@ -21,11 +25,12 @@ async fn supervised_exec_rejects_zero_stream_capacity_without_sending_frame() {
 #[tokio::test]
 async fn supervised_exec_rejects_oversized_stdin_without_sending_frame() {
     let stdin_bytes = vec![0; vsock_proto::MAX_EXEC_STDIN_BYTES + 1];
-    assert_supervised_start_rejected_without_frame(
+    assert_supervised_start_fails_without_frame(
         SupervisedExecRequest {
             stdin_bytes: Some(&stdin_bytes),
             ..supervised_request("oversized-stdin")
         },
+        io::ErrorKind::InvalidInput,
         "stdin_bytes",
     )
     .await;
@@ -33,12 +38,13 @@ async fn supervised_exec_rejects_oversized_stdin_without_sending_frame() {
 
 #[tokio::test]
 async fn supervised_exec_rejects_receiver_without_stream_policy() {
-    assert_supervised_start_rejected_without_frame(
+    assert_supervised_start_fails_without_frame(
         SupervisedExecRequest {
             stdin_bytes: None,
             stream_queue_capacity: Some(1),
             ..supervised_request("receiver-without-stream")
         },
+        io::ErrorKind::InvalidInput,
         "exec stream queue capacity requires a streaming output policy",
     )
     .await;
@@ -46,7 +52,7 @@ async fn supervised_exec_rejects_receiver_without_stream_policy() {
 
 #[tokio::test]
 async fn supervised_exec_rejects_invalid_output_policy_without_sending_frame() {
-    assert_supervised_start_rejected_without_frame(
+    assert_supervised_start_fails_without_frame(
         SupervisedExecRequest {
             stdout: ExecOutputPolicy::Stream {
                 limit_bytes: 1024,
@@ -56,6 +62,7 @@ async fn supervised_exec_rejects_invalid_output_policy_without_sending_frame() {
             stream_queue_capacity: Some(1),
             ..supervised_request("invalid-output-policy")
         },
+        io::ErrorKind::InvalidInput,
         "exec output chunk limit must be non-zero",
     )
     .await;
@@ -63,12 +70,39 @@ async fn supervised_exec_rejects_invalid_output_policy_without_sending_frame() {
 
 #[tokio::test]
 async fn supervised_exec_rejects_zero_duration_timeout_without_sending_frame() {
-    assert_supervised_start_rejected_without_frame(
+    assert_supervised_start_fails_without_frame(
         SupervisedExecRequest {
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 0 },
             ..supervised_request("zero-duration-timeout")
         },
+        io::ErrorKind::InvalidInput,
         "exec start timeout duration must be positive",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn supervised_exec_zero_start_timeout_does_not_send_frame() {
+    assert_supervised_start_fails_without_frame(
+        SupervisedExecRequest {
+            start_timeout: Duration::ZERO,
+            ..supervised_request("zero-start-timeout")
+        },
+        io::ErrorKind::TimedOut,
+        "exec start timeout",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn supervised_exec_oversized_start_timeout_does_not_send_frame() {
+    assert_supervised_start_fails_without_frame(
+        SupervisedExecRequest {
+            start_timeout: Duration::MAX,
+            ..supervised_request("oversized-start-timeout")
+        },
+        io::ErrorKind::InvalidInput,
+        "exec start timeout is too large",
     )
     .await;
 }


### PR DESCRIPTION
## Summary

- require explicit host-side write deadlines for raw one-shot and streaming exec starts
- make capture and supervised start budgets cover frame delivery plus their terminal result or PID acknowledgement
- preserve connection reuse when expiry happens before writing and poison the connection when a partial frame may have been emitted
- propagate existing caller-owned host budgets through DNS readiness and guest-to-host file copy
- cover writer contention, real socket backpressure, zero and oversized deadlines, stale-frame prevention, and remaining-budget behavior

## Scope

This is a host-side Rust timeout and lifecycle change. It does not change the guest protocol, guest-side process timeout encoding, database or persisted state, API payloads, queue contracts, feature switches, or deployment compatibility. Raw stream start delivery remains separate from the later file-copy drain budget.

## Validation

- `cargo check --manifest-path crates/Cargo.toml --workspace --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test`
- repeated the real blocked-write regression 5 times
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `git diff --check`
- repository pre-commit hooks

Closes #23534
