### PR TITLE
feat(cli): show automation model and management guidance

### DIFF
--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
@@ -64,6 +64,7 @@ describe("zero chat model command", () => {
   }) as never);
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-zero-token");

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
@@ -15,8 +15,10 @@ import { server } from "../../../../mocks/server";
 import { zeroChatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
 const GET_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/metadata`;
-const MODEL_SELECTION_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/model-selection`;
+const OTHER_GET_URL = `http://localhost:3000/api/zero/chat-threads/${OTHER_THREAD_ID}/metadata`;
+const OTHER_MODEL_SELECTION_URL = `http://localhost:3000/api/zero/chat-threads/${OTHER_THREAD_ID}/model-selection`;
 const MODEL_POLICIES_URL = "http://localhost:3000/api/zero/model-policies";
 
 const MODEL_POLICIES_RESPONSE = {
@@ -90,6 +92,7 @@ describe("zero chat model command", () => {
     expect(output).toContain("Switchable models:");
     expect(output).toContain("Claude Sonnet 5");
     expect(output).toContain("claude-sonnet-5");
+    expect(output).toContain("--thread <id>");
     expect(output).not.toContain("No personal subscription connected");
     expect(output).not.toContain("gpt-5.5");
   });
@@ -115,17 +118,46 @@ describe("zero chat model command", () => {
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Chat thread loaded");
-    expect(output).toContain("Model:  claude-sonnet-5");
+    expect(output).toContain("Model:  Claude Sonnet 5 (claude-sonnet-5)");
     expect(output).toContain("Switchable models:");
-    expect(output).toContain("zero chat model <model>");
+    expect(output).toContain(`zero chat model --thread ${THREAD_ID} <model>`);
   });
 
-  it("switches the current chat thread to a valid model", async () => {
+  it("shows the model for --thread outside a web chat environment", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    server.use(
+      http.get(OTHER_GET_URL, () => {
+        return HttpResponse.json({
+          id: OTHER_THREAD_ID,
+          title: "Daily report",
+          selectedModel: "claude-sonnet-5",
+        });
+      }),
+      http.get(MODEL_POLICIES_URL, () => {
+        return HttpResponse.json(MODEL_POLICIES_RESPONSE);
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "model",
+      "--thread",
+      OTHER_THREAD_ID,
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(`Thread: ${OTHER_THREAD_ID}`);
+    expect(output).toContain("Model:  Claude Sonnet 5 (claude-sonnet-5)");
+  });
+
+  it("switches the model for --thread outside a web chat environment", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(MODEL_POLICIES_URL, () => {
         return HttpResponse.json(MODEL_POLICIES_RESPONSE);
       }),
-      http.post(MODEL_SELECTION_URL, async ({ request }) => {
+      http.post(OTHER_MODEL_SELECTION_URL, async ({ request }) => {
         expect(request.headers.get("authorization")).toBe(
           "Bearer test-zero-token",
         );
@@ -140,12 +172,14 @@ describe("zero chat model command", () => {
       "node",
       "cli",
       "model",
+      "--thread",
+      OTHER_THREAD_ID,
       "claude-sonnet-5",
     ]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Chat model updated");
-    expect(output).toContain(`Thread: ${THREAD_ID}`);
+    expect(output).toContain(`Thread: ${OTHER_THREAD_ID}`);
     expect(output).toContain("Model:  Claude Sonnet 5 (claude-sonnet-5)");
   });
 

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -19,6 +19,7 @@ Examples:
   List agent chats:  zero chat list
   Show this chat:    zero chat get
   Switch model:      zero chat model claude-sonnet-5
+  Switch another:    zero chat model --thread <thread-id> claude-sonnet-5
   Rename this chat:  zero chat rename "Launch plan"
   Rename another:    zero chat rename --thread <thread-id> "Launch plan"`,
   );

--- a/turbo/apps/cli/src/commands/zero/chat/model.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/model.ts
@@ -1,7 +1,11 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import type { ChatThreadMetadata } from "@vm0/api-contracts/contracts/chat-threads";
-import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
+import type {
+  OrgModelPoliciesResponse,
+  OrgModelPolicy,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
 
 import {
   getZeroChatThread,
@@ -10,9 +14,11 @@ import {
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { formatModelProviderRoute } from "../../../lib/domain/model-policy-display";
+import { isUuid } from "../../../lib/utils/uuid";
 
 interface ModelOptions {
   readonly help?: boolean;
+  readonly thread?: string;
 }
 
 function getCurrentChatThreadId(): string | undefined {
@@ -49,11 +55,28 @@ function printSwitchableModels(policies: readonly OrgModelPolicy[]): void {
   }
 }
 
-function printCurrentModel(thread: ChatThreadMetadata): void {
+function formatThreadModel(
+  thread: ChatThreadMetadata,
+  policies: OrgModelPoliciesResponse,
+): string {
+  const model = thread.selectedModel ?? policies.workspaceDefaultModel;
+  if (!model) {
+    return "(default)";
+  }
+  const policy = policies.policies.find((candidate) => {
+    return candidate.model === model;
+  });
+  return `${policy?.modelLabel ?? getModelDisplayName(model)} (${model})`;
+}
+
+function printCurrentModel(
+  thread: ChatThreadMetadata,
+  policies: OrgModelPoliciesResponse,
+): void {
   console.log(chalk.green("✓ Chat thread loaded"));
   console.log(chalk.dim(`  Thread: ${thread.id}`));
   console.log(chalk.dim(`  Title:  ${thread.title ?? "(untitled)"}`));
-  console.log(chalk.dim(`  Model:  ${thread.selectedModel ?? "(default)"}`));
+  console.log(chalk.dim(`  Model:  ${formatThreadModel(thread, policies)}`));
 }
 
 async function printModelHelp(command: Command): Promise<void> {
@@ -64,7 +87,7 @@ async function printModelHelp(command: Command): Promise<void> {
   printSwitchableModels(result.policies);
   console.log();
   console.log("Use the model id in parentheses:");
-  console.log(chalk.cyan("  zero chat model <model>"));
+  console.log(chalk.cyan("  zero chat model [--thread <thread-id>] <model>"));
 }
 
 async function printCurrentModelAndChoices(threadId: string): Promise<void> {
@@ -73,13 +96,13 @@ async function printCurrentModelAndChoices(threadId: string): Promise<void> {
     listZeroModelPolicies(),
   ]);
 
-  printCurrentModel(thread);
+  printCurrentModel(thread, result);
   console.log();
   console.log(chalk.bold("Switchable models:"));
   printSwitchableModels(result.policies);
   console.log();
   console.log("Switch models:");
-  console.log(chalk.cyan("  zero chat model <model>"));
+  console.log(chalk.cyan(`  zero chat model --thread ${threadId} <model>`));
 }
 
 async function switchModel(threadId: string, model: string): Promise<void> {
@@ -117,16 +140,19 @@ export const modelCommand = new Command()
   .description("Show or switch the current web chat thread model")
   .argument("[model]", "Model id to use for this chat thread")
   .helpOption(false)
+  .option("--thread <id>", "Chat thread ID (defaults to ZERO_CHAT_THREAD_ID)")
   .option("-h, --help", "Show help with switchable models")
   .addHelpText(
     "after",
     `
 Examples:
-  Show this chat model:  zero chat model
-  Switch this model:    zero chat model claude-sonnet-5
+  Show this chat model:     zero chat model
+  Show another chat model:  zero chat model --thread <thread-id>
+  Switch this model:        zero chat model claude-sonnet-5
+  Switch another model:     zero chat model --thread <thread-id> claude-sonnet-5
 
 Notes:
-  - Uses ZERO_CHAT_THREAD_ID from the current web chat thread
+  - Defaults --thread to ZERO_CHAT_THREAD_ID
   - Authenticates via ZERO_TOKEN (requires chat-thread:write capability to switch)`,
   )
   .action(
@@ -137,11 +163,17 @@ Notes:
           return;
         }
 
-        const threadId = getCurrentChatThreadId();
+        const threadId = options.thread?.trim() || getCurrentChatThreadId();
         if (!threadId) {
           printUsageError(
             "ZERO_CHAT_THREAD_ID is not set",
-            "Run this command from a Zero web chat thread.",
+            "Pass --thread <thread-id> or run inside a Zero web chat thread.",
+          );
+        }
+        if (!isUuid(threadId)) {
+          printUsageError(
+            `Invalid thread ID "${threadId}" — expected a UUID`,
+            "Pass a valid UUID with --thread <thread-id>.",
           );
         }
 

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -26,6 +26,7 @@ const MODEL_ID = "gpt-5.6-sol";
 const STRAPI_INTEGRATION_ID = "55555555-5555-4555-8555-555555555556";
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const THREAD_METADATA_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/metadata`;
+const MODEL_POLICIES_URL = "http://localhost:3000/api/zero/model-policies";
 
 function zeroToken(orgId: string): string {
   const payload = Buffer.from(
@@ -289,6 +290,9 @@ describe("zero workflow automation commands", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  const mockConsoleWarn = vi
+    .spyOn(console, "warn")
+    .mockImplementation(() => {});
   const tempDirs: string[] = [];
 
   beforeEach(() => {
@@ -310,6 +314,7 @@ describe("zero workflow automation commands", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+    mockConsoleWarn.mockClear();
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -353,6 +358,48 @@ describe("zero workflow automation commands", () => {
         return capturedUrl;
       },
     };
+  }
+
+  function failThreadModelLookup(
+    boundary: "metadata" | "model-policy" = "metadata",
+  ): void {
+    if (boundary === "metadata") {
+      server.use(
+        http.get(THREAD_METADATA_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                code: "SERVER_ERROR",
+                message: "Thread metadata unavailable",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+      return;
+    }
+
+    server.use(
+      http.get(THREAD_METADATA_URL, () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          title: "Tell a joke",
+          selectedModel: null,
+        });
+      }),
+      http.get(MODEL_POLICIES_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "SERVER_ERROR",
+              message: "Model policies unavailable",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
   }
 
   describe("add", () => {
@@ -405,6 +452,33 @@ describe("zero workflow automation commands", () => {
       expect(logCalls).toContain(`--thread ${THREAD_ID}`);
       expect(logCalls).toContain("zero model list");
     });
+
+    it.each(["metadata", "model-policy"] as const)(
+      "should preserve a successful add when %s lookup fails",
+      async (boundary) => {
+        const captured = captureCreateAutomation(cronAutomation);
+        failThreadModelLookup(boundary);
+
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "cron",
+          "--expr",
+          "0 9 * * *",
+        ]);
+
+        expect(captured.workflowId).toBe(WORKFLOW_ID);
+        expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+          `Automation added to workflow "${WORKFLOW_ID}"`,
+        );
+        expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
+          "Automation changed, but thread model details could not be loaded",
+        );
+        expect(mockExit).not.toHaveBeenCalled();
+      },
+    );
 
     it("should resolve a workflow name under ZERO_AGENT_ID", async () => {
       vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
@@ -1337,6 +1411,36 @@ describe("zero workflow automation commands", () => {
       expect(logCalls).not.toContain("Manage with Zero CLI:");
     });
 
+    it("should preserve a successful update when thread model lookup fails", async () => {
+      const captured = captureUpdateAutomation(cronAutomation);
+      failThreadModelLookup();
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "update",
+        AUTOMATION_ID,
+        "--expr",
+        "0 9 * * *",
+      ]);
+
+      expect(captured.id).toBe(AUTOMATION_ID);
+      expect(captured.body).toEqual({
+        schedule: {
+          type: "cron",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+        },
+      });
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `Automation ${AUTOMATION_ID} updated`,
+      );
+      expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
+        "Automation changed, but thread model details could not be loaded",
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
     it("should update a Gmail new message automation with text match flags", async () => {
       const updated = {
         ...gmailAutomation,
@@ -1649,6 +1753,12 @@ describe("zero workflow automation commands", () => {
   describe("show", () => {
     it("should display automation details", async () => {
       server.use(
+        http.get(
+          "http://localhost:3000/api/zero/workflow-automations/:id",
+          () => {
+            return HttpResponse.json({ ...gmailAutomation, enabled: false });
+          },
+        ),
         http.get("http://localhost:3000/api/zero/workflow-automations", () => {
           return HttpResponse.json([
             {
@@ -1676,6 +1786,39 @@ describe("zero workflow automation commands", () => {
       expect(logCalls).toContain("Resume automation:");
       expect(logCalls).toContain("zero workflow automation enable");
       expect(logCalls).toContain("zero workflow automation update --help");
+    });
+
+    it("should display an automation owned by another user on a visible workflow", async () => {
+      const sharedAutomation = {
+        ...gmailAutomation,
+        ownerUserId: "another-user",
+      };
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/workflow-automations/:id",
+          ({ params }) => {
+            expect(params.id).toBe(AUTOMATION_ID);
+            return HttpResponse.json(sharedAutomation);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/workflow-automations", () => {
+          return HttpResponse.json([]);
+        }),
+      );
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "show",
+        AUTOMATION_ID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(AUTOMATION_ID);
+      expect(logCalls).toContain("another-user");
+      expect(logCalls).toContain("Gmail new message");
+      expect(logCalls).not.toContain("Manage with Zero CLI:");
+      expect(mockExit).not.toHaveBeenCalled();
     });
   });
 
@@ -1751,5 +1894,38 @@ describe("zero workflow automation commands", () => {
         `Thread model: GPT 5.6 Sol (${MODEL_ID})`,
       );
     });
+
+    it.each(["enable", "disable"] as const)(
+      "should preserve a successful %s when thread model lookup fails",
+      async (command) => {
+        server.use(
+          http.post(
+            `http://localhost:3000/api/zero/workflow-automations/:id/${command}`,
+            () => {
+              return HttpResponse.json({
+                ...cronAutomation,
+                enabled: command === "enable",
+              });
+            },
+          ),
+        );
+        failThreadModelLookup();
+
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          command,
+          AUTOMATION_ID,
+        ]);
+
+        expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+          `Automation ${AUTOMATION_ID} ${command}d`,
+        );
+        expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
+          "Automation changed, but thread model details could not be loaded",
+        );
+        expect(mockExit).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -296,6 +296,7 @@ describe("zero workflow automation commands", () => {
   const tempDirs: string[] = [];
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -22,8 +22,10 @@ const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const WORKFLOW_ID = "22222222-2222-4222-8222-222222222222";
 const AUTOMATION_ID = "33333333-3333-4333-8333-333333333333";
 const THREAD_ID = "44444444-4444-4444-8444-444444444444";
+const MODEL_ID = "gpt-5.6-sol";
 const STRAPI_INTEGRATION_ID = "55555555-5555-4555-8555-555555555556";
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+const THREAD_METADATA_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/metadata`;
 
 function zeroToken(orgId: string): string {
   const payload = Buffer.from(
@@ -293,6 +295,15 @@ describe("zero workflow automation commands", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-token");
+    server.use(
+      http.get(THREAD_METADATA_URL, () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          title: "Tell a joke",
+          selectedModel: MODEL_ID,
+        });
+      }),
+    );
   });
 
   afterEach(() => {
@@ -375,6 +386,24 @@ describe("zero workflow automation commands", () => {
       );
       expect(logCalls).toContain(AUTOMATION_ID);
       expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain(`Thread model: GPT 5.6 Sol (${MODEL_ID})`);
+      expect(logCalls).toContain("Manage with Zero CLI:");
+      expect(logCalls).toContain(`zero workflow edit ${WORKFLOW_ID}`);
+      expect(logCalls).toContain('--expr "<cron-expression>" -z <timezone>');
+      expect(logCalls).toContain("Pause automation:");
+      expect(logCalls).toContain(
+        `zero workflow automation disable \\\n      ${AUTOMATION_ID}`,
+      );
+      expect(logCalls).toContain("About model selection:");
+      expect(logCalls).toContain(
+        "The selected model affects run behavior, output quality, and cost.",
+      );
+      expect(logCalls).toContain(
+        "All automations on this workflow\n  share one chat thread",
+      );
+      expect(logCalls).toContain("Model commands:");
+      expect(logCalls).toContain(`--thread ${THREAD_ID}`);
+      expect(logCalls).toContain("zero model list");
     });
 
     it("should resolve a workflow name under ZERO_AGENT_ID", async () => {
@@ -397,6 +426,10 @@ describe("zero workflow automation commands", () => {
       expect(captured.body).toEqual({
         schedule: { type: "loop", intervalSeconds: 900 },
       });
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Change interval:");
+      expect(logCalls).toContain("--every <duration>");
+      expect(logCalls).not.toContain("<cron-expression>");
     });
 
     it("should convert a timezone-local one-time fire to UTC", async () => {
@@ -421,6 +454,9 @@ describe("zero workflow automation commands", () => {
           timezone: "Asia/Shanghai",
         },
       });
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Change run time:");
+      expect(logCalls).toContain('--at "<iso-time>" -z <timezone>');
     });
 
     it("should add a Gmail new message automation without match rules", async () => {
@@ -446,6 +482,8 @@ describe("zero workflow automation commands", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Gmail new message");
       expect(logCalls).toContain("all inbound messages");
+      expect(logCalls).toContain("Edit automation:");
+      expect(logCalls).toContain("zero workflow automation update --help");
     });
 
     it("should add a Gmail new message automation with text match flags", async () => {
@@ -1294,6 +1332,9 @@ describe("zero workflow automation commands", () => {
       expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
         `Automation ${AUTOMATION_ID} updated`,
       );
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`Thread model: GPT 5.6 Sol (${MODEL_ID})`);
+      expect(logCalls).not.toContain("Manage with Zero CLI:");
     });
 
     it("should update a Gmail new message automation with text match flags", async () => {
@@ -1608,13 +1649,14 @@ describe("zero workflow automation commands", () => {
   describe("show", () => {
     it("should display automation details", async () => {
       server.use(
-        http.get(
-          "http://localhost:3000/api/zero/workflow-automations/:id",
-          ({ params }) => {
-            expect(params.id).toBe(AUTOMATION_ID);
-            return HttpResponse.json(gmailAutomation);
-          },
-        ),
+        http.get("http://localhost:3000/api/zero/workflow-automations", () => {
+          return HttpResponse.json([
+            {
+              workflow: workflowSummary,
+              automation: { ...gmailAutomation, enabled: false },
+            },
+          ]);
+        }),
       );
 
       await automationCommand.parseAsync([
@@ -1629,6 +1671,11 @@ describe("zero workflow automation commands", () => {
       expect(logCalls).toContain("Gmail new message");
       expect(logCalls).toContain('subject contains "invoice"');
       expect(logCalls).toContain(THREAD_ID);
+      expect(logCalls).toContain(`Workflow:     ${workflowSummary.name}`);
+      expect(logCalls).toContain(`Thread model: GPT 5.6 Sol (${MODEL_ID})`);
+      expect(logCalls).toContain("Resume automation:");
+      expect(logCalls).toContain("zero workflow automation enable");
+      expect(logCalls).toContain("zero workflow automation update --help");
     });
   });
 
@@ -1675,6 +1722,9 @@ describe("zero workflow automation commands", () => {
       expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
         `Automation ${AUTOMATION_ID} enabled`,
       );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `Thread model: GPT 5.6 Sol (${MODEL_ID})`,
+      );
     });
 
     it("should disable a workflow automation", async () => {
@@ -1696,6 +1746,9 @@ describe("zero workflow automation commands", () => {
 
       expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
         `Automation ${AUTOMATION_ID} disabled`,
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `Thread model: GPT 5.6 Sol (${MODEL_ID})`,
       );
     });
   });

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
@@ -8,6 +8,17 @@ type GmailMatchRules = NonNullable<GmailNewMessageEventConfig["match"]>;
 type GmailTextMatcher = NonNullable<GmailMatchRules["from"]>;
 type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
 
+export interface WorkflowAutomationThreadModel {
+  readonly id: string;
+  readonly label: string;
+}
+
+interface WorkflowAutomationDetailsOptions {
+  readonly workflowRef?: string;
+  readonly workflowId?: string;
+  readonly threadModel?: WorkflowAutomationThreadModel;
+}
+
 const GMAIL_TEXT_FIELDS: readonly GmailTextField[] = [
   "from",
   "subject",
@@ -449,9 +460,139 @@ function printGithubFilters(automation: ZeroWorkflowAutomationSummary): void {
   }
 }
 
+function printCommand(lines: readonly string[]): void {
+  for (const line of lines) {
+    console.log(chalk.cyan(`    ${line}`));
+  }
+}
+
+function automationUpdateGuidance(automation: ZeroWorkflowAutomationSummary): {
+  readonly label: string;
+  readonly command: readonly string[];
+} {
+  if (automation.kind !== "schedule") {
+    return {
+      label: "Edit automation",
+      command: ["zero workflow automation update --help"],
+    };
+  }
+
+  switch (automation.schedule.type) {
+    case "cron":
+      return {
+        label: "Change schedule",
+        command: [
+          "zero workflow automation update \\",
+          `  ${automation.id} \\`,
+          '  --expr "<cron-expression>" -z <timezone>',
+        ],
+      };
+    case "loop":
+      return {
+        label: "Change interval",
+        command: [
+          "zero workflow automation update \\",
+          `  ${automation.id} \\`,
+          "  --every <duration>",
+        ],
+      };
+    case "once":
+      return {
+        label: "Change run time",
+        command: [
+          "zero workflow automation update \\",
+          `  ${automation.id} \\`,
+          '  --at "<iso-time>" -z <timezone>',
+        ],
+      };
+  }
+}
+
+function printManagementCommands(
+  automation: ZeroWorkflowAutomationSummary,
+  options: WorkflowAutomationDetailsOptions,
+): void {
+  if (!options.workflowId) {
+    return;
+  }
+
+  const update = automationUpdateGuidance(automation);
+  const statusAction = automation.enabled
+    ? {
+        label: "Pause automation",
+        command: "disable",
+      }
+    : {
+        label: "Resume automation",
+        command: "enable",
+      };
+
+  console.log("");
+  console.log(chalk.bold("Manage with Zero CLI:"));
+  console.log("  Edit workflow:");
+  printCommand([
+    `zero workflow edit ${options.workflowId} \\`,
+    "  --instruction-file <path>",
+  ]);
+  console.log("");
+  console.log(`  ${update.label}:`);
+  printCommand(update.command);
+  console.log("");
+  console.log(`  ${statusAction.label}:`);
+  printCommand([
+    `zero workflow automation ${statusAction.command} \\`,
+    `  ${automation.id}`,
+  ]);
+  console.log("");
+  console.log("  More automation options:");
+  printCommand(["zero workflow automation --help"]);
+
+  if (!automation.chatThreadId || !options.threadModel) {
+    return;
+  }
+
+  console.log("");
+  console.log(chalk.bold("About model selection:"));
+  console.log(
+    "  The selected model affects run behavior, output quality, and cost.",
+  );
+  console.log(
+    "  Automations do not store a separate model. All automations on this workflow",
+  );
+  console.log(
+    "  share one chat thread and use that thread's model. Changing the thread model",
+  );
+  console.log("  changes the model used by all of them.");
+  console.log("");
+  console.log(chalk.bold("Model commands:"));
+  console.log("  Show:");
+  printCommand(["zero chat model \\", `  --thread ${automation.chatThreadId}`]);
+  console.log("");
+  console.log("  Change:");
+  printCommand([
+    "zero chat model \\",
+    `  --thread ${automation.chatThreadId} \\`,
+    "  <model-id>",
+  ]);
+  console.log("");
+  console.log("  Options:");
+  printCommand(["zero model list"]);
+}
+
+export function printWorkflowAutomationThreadModel(
+  model: WorkflowAutomationThreadModel | undefined,
+): void {
+  if (!model) {
+    return;
+  }
+  console.log(
+    `${"Thread model:".padEnd(14)}${model.label} ${chalk.dim(`(${model.id})`)}`,
+  );
+}
+
 export function printWorkflowAutomationDetails(
   automation: ZeroWorkflowAutomationSummary,
-  options?: { readonly workflowRef?: string },
+  options: WorkflowAutomationDetailsOptions = {},
 ): void {
   const status = automation.enabled
     ? chalk.green("enabled")
@@ -550,10 +691,12 @@ export function printWorkflowAutomationDetails(
   console.log(
     `${"Chat thread:".padEnd(14)}${automation.chatThreadId ?? chalk.dim("-")}`,
   );
+  printWorkflowAutomationThreadModel(options.threadModel);
   console.log(
     `${"Next run:".padEnd(14)}${formatRunTime(automation.nextRunAt)}`,
   );
   console.log(
     `${"Last run:".padEnd(14)}${formatRunTime(automation.lastRunAt)}`,
   );
+  printManagementCommands(automation, options);
 }

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
@@ -182,6 +182,23 @@ async function loadWorkflowAutomationThreadModel(
   };
 }
 
+async function tryLoadWorkflowAutomationThreadModel(
+  automation: ZeroWorkflowAutomationSummary,
+): Promise<WorkflowAutomationThreadModel | undefined> {
+  try {
+    return await loadWorkflowAutomationThreadModel(automation);
+  } catch (error) {
+    console.warn(
+      chalk.yellow(
+        `⚠ Automation changed, but thread model details could not be loaded: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+      ),
+    );
+    return undefined;
+  }
+}
+
 function githubWebhookEventKind(
   kind: string,
 ): kind is (typeof GITHUB_WEBHOOK_EVENT_KINDS)[number] {
@@ -1894,11 +1911,12 @@ Notes:
         const workflowId = await resolveWorkflowRef(workflowRef, options);
         const body = buildCreateRequest(kind, options);
         const automation = await createWorkflowAutomation(workflowId, body);
-        const threadModel = await loadWorkflowAutomationThreadModel(automation);
 
         console.log(
           chalk.green(`✓ Automation added to workflow "${workflowRef}"`),
         );
+        const threadModel =
+          await tryLoadWorkflowAutomationThreadModel(automation);
         printWorkflowAutomationDetails(automation, {
           workflowRef,
           workflowId,
@@ -1940,10 +1958,11 @@ Examples:
     withErrorHandler(async (id: string, options: UpdateOptions) => {
       const existing = await getWorkflowAutomation(id);
       const body = buildUpdate(options, existing);
-      const threadModel = await loadWorkflowAutomationThreadModel(existing);
       const automation = await updateWorkflowAutomation(id, body);
 
       console.log(chalk.green(`✓ Automation ${automation.id} updated`));
+      const threadModel =
+        await tryLoadWorkflowAutomationThreadModel(automation);
       printWorkflowAutomationDetails(automation, { threadModel });
     }),
   );
@@ -1988,12 +2007,14 @@ const showCommand = new Command()
   .argument("<automation>", "Workflow automation ID")
   .action(
     withErrorHandler(async (id: string) => {
+      const automation = await getWorkflowAutomation(id);
       const entries = await listWorkspaceWorkflowAutomations();
       const entry = entries.find(({ automation }) => {
         return automation.id === id;
       });
       if (!entry) {
-        throw new Error(`Workflow automation "${id}" not found`);
+        printWorkflowAutomationDetails(automation);
+        return;
       }
       const threadModel = await loadWorkflowAutomationThreadModel(
         entry.automation,
@@ -2025,8 +2046,9 @@ const enableCommand = new Command()
   .action(
     withErrorHandler(async (id: string) => {
       const automation = await enableWorkflowAutomation(id);
-      const threadModel = await loadWorkflowAutomationThreadModel(automation);
       console.log(chalk.green(`✓ Automation ${automation.id} enabled`));
+      const threadModel =
+        await tryLoadWorkflowAutomationThreadModel(automation);
       printWorkflowAutomationThreadModel(threadModel);
     }),
   );
@@ -2038,8 +2060,9 @@ const disableCommand = new Command()
   .action(
     withErrorHandler(async (id: string) => {
       const automation = await disableWorkflowAutomation(id);
-      const threadModel = await loadWorkflowAutomationThreadModel(automation);
       console.log(chalk.green(`✓ Automation ${automation.id} disabled`));
+      const threadModel =
+        await tryLoadWorkflowAutomationThreadModel(automation);
       printWorkflowAutomationThreadModel(threadModel);
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
@@ -9,6 +9,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   type ZeroWorkflowAutomationCreateRequest,
   type ZeroWorkflowAutomationSummary,
@@ -17,7 +18,10 @@ import {
   deleteWorkflowAutomation,
   disableWorkflowAutomation,
   enableWorkflowAutomation,
+  getZeroChatThread,
   getWorkflowAutomation,
+  listWorkspaceWorkflowAutomations,
+  listZeroModelPolicies,
   listWorkflowAutomations,
   updateWorkflowAutomation,
 } from "../../../../lib/api";
@@ -30,7 +34,9 @@ import {
 } from "../resolve-workflow-ref";
 import {
   printWorkflowAutomationDetails,
+  printWorkflowAutomationThreadModel,
   printWorkflowAutomationsTable,
+  type WorkflowAutomationThreadModel,
 } from "./display";
 import {
   buildGmailLabelAppliedEventConfig,
@@ -149,6 +155,31 @@ function automationKinds(): readonly string[] {
     ...(githubWebhookAutomationsEnabled() ? GITHUB_WEBHOOK_EVENT_KINDS : []),
     ...(strapiIntegrationEnabled() ? STRAPI_EVENT_KINDS : []),
   ];
+}
+
+async function loadWorkflowAutomationThreadModel(
+  automation: ZeroWorkflowAutomationSummary,
+): Promise<WorkflowAutomationThreadModel | undefined> {
+  if (!automation.chatThreadId) {
+    return undefined;
+  }
+
+  const thread = await getZeroChatThread({
+    threadId: automation.chatThreadId,
+  });
+  const modelId =
+    thread.selectedModel ??
+    (await listZeroModelPolicies()).workspaceDefaultModel;
+  if (!modelId) {
+    throw new Error(
+      `Chat thread "${automation.chatThreadId}" has no available model`,
+    );
+  }
+
+  return {
+    id: modelId,
+    label: getModelDisplayName(modelId),
+  };
 }
 
 function githubWebhookEventKind(
@@ -1863,11 +1894,16 @@ Notes:
         const workflowId = await resolveWorkflowRef(workflowRef, options);
         const body = buildCreateRequest(kind, options);
         const automation = await createWorkflowAutomation(workflowId, body);
+        const threadModel = await loadWorkflowAutomationThreadModel(automation);
 
         console.log(
           chalk.green(`✓ Automation added to workflow "${workflowRef}"`),
         );
-        printWorkflowAutomationDetails(automation, { workflowRef });
+        printWorkflowAutomationDetails(automation, {
+          workflowRef,
+          workflowId,
+          threadModel,
+        });
       },
     ),
   );
@@ -1903,13 +1939,12 @@ Examples:
   .action(
     withErrorHandler(async (id: string, options: UpdateOptions) => {
       const existing = await getWorkflowAutomation(id);
-      const automation = await updateWorkflowAutomation(
-        id,
-        buildUpdate(options, existing),
-      );
+      const body = buildUpdate(options, existing);
+      const threadModel = await loadWorkflowAutomationThreadModel(existing);
+      const automation = await updateWorkflowAutomation(id, body);
 
       console.log(chalk.green(`✓ Automation ${automation.id} updated`));
-      printWorkflowAutomationDetails(automation);
+      printWorkflowAutomationDetails(automation, { threadModel });
     }),
   );
 
@@ -1953,8 +1988,21 @@ const showCommand = new Command()
   .argument("<automation>", "Workflow automation ID")
   .action(
     withErrorHandler(async (id: string) => {
-      const automation = await getWorkflowAutomation(id);
-      printWorkflowAutomationDetails(automation);
+      const entries = await listWorkspaceWorkflowAutomations();
+      const entry = entries.find(({ automation }) => {
+        return automation.id === id;
+      });
+      if (!entry) {
+        throw new Error(`Workflow automation "${id}" not found`);
+      }
+      const threadModel = await loadWorkflowAutomationThreadModel(
+        entry.automation,
+      );
+      printWorkflowAutomationDetails(entry.automation, {
+        workflowRef: entry.workflow.name,
+        workflowId: entry.workflow.id,
+        threadModel,
+      });
     }),
   );
 
@@ -1977,7 +2025,9 @@ const enableCommand = new Command()
   .action(
     withErrorHandler(async (id: string) => {
       const automation = await enableWorkflowAutomation(id);
+      const threadModel = await loadWorkflowAutomationThreadModel(automation);
       console.log(chalk.green(`✓ Automation ${automation.id} enabled`));
+      printWorkflowAutomationThreadModel(threadModel);
     }),
   );
 
@@ -1988,7 +2038,9 @@ const disableCommand = new Command()
   .action(
     withErrorHandler(async (id: string) => {
       const automation = await disableWorkflowAutomation(id);
+      const threadModel = await loadWorkflowAutomationThreadModel(automation);
       console.log(chalk.green(`✓ Automation ${automation.id} disabled`));
+      printWorkflowAutomationThreadModel(threadModel);
     }),
   );
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
@@ -23,6 +23,10 @@ export type ZeroWorkflowAutomationSummary = ServerInferResponseBody<
   typeof zeroWorkflowAutomationsContract.get,
   200
 >;
+type ZeroWorkflowAutomationListEntry = ServerInferResponseBody<
+  typeof zeroWorkflowAutomationsContract.listWorkspace,
+  200
+>[number];
 
 export async function listWorkflows(query: {
   agentId?: string;
@@ -110,6 +114,16 @@ export async function listWorkflowAutomations(
     result,
     `Failed to list automations for workflow "${workflowId}"`,
   );
+}
+
+export async function listWorkspaceWorkflowAutomations(): Promise<
+  readonly ZeroWorkflowAutomationListEntry[]
+> {
+  const config = await getClientConfig();
+  const client = initClient(zeroWorkflowAutomationsContract, config);
+  const result = await client.listWorkspace({ headers: {} });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to list workflow automations");
 }
 
 export async function createWorkflowAutomation(

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -97,6 +97,7 @@ export {
   deleteWorkflow,
   copyWorkflow,
   listWorkflowAutomations,
+  listWorkspaceWorkflowAutomations,
   createWorkflowAutomation,
   getWorkflowAutomation,
   updateWorkflowAutomation,


### PR DESCRIPTION
## Summary

- show the bound thread model as a human-readable label and model ID in automation details
- add context-aware workflow, automation, status, and model commands after `automation add` and `automation show`
- provide concrete update examples for cron, loop, and once automations, while routing event automations to `zero workflow automation update --help`
- add `--thread <id>` to `zero chat model` so the generated show and change commands are directly executable

## User impact

Automation output now explains that model selection affects behavior, quality, and cost, and that every automation on the workflow shares the bound thread model. Users can immediately see the effective model and copy the relevant CLI command to edit the workflow, update or pause the automation, inspect or change the model, or discover more options.

Update, enable, and disable results include the thread model without repeating the full management guide. Automation lists remain compact.

## Implementation

- reuse the existing workspace automation projection to recover workflow context for `automation show`
- read the bound chat thread metadata for model selection, resolving the workspace default only for an unpinned legacy thread
- use the shared model display-name registry and keep the server API contract unchanged

## Verification

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/workflow/automation/__tests__/automation.test.ts src/commands/zero/chat/__tests__/model.test.ts` (51 tests passed)
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm knip --workspace @vm0/cli`
- `pnpm -F @vm0/cli build`
- `git diff --check`