### PR TITLE
perf(platform): retain composer connector state across chats

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -1,4 +1,4 @@
-import { command, type Command } from "ccstate";
+import { command, computed, type Command } from "ccstate";
 import type {
   ChatThreadDraft,
   GenerationTemplateRequest,
@@ -34,11 +34,28 @@ import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-sour
 import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 import { autoOpenThreadSidebar$ } from "./thread-sidebar-coordinator.ts";
+import {
+  createComposerConnectorAuthorizationSignals,
+  type ComposerConnectorAuthorizationSignals,
+} from "../zero-page/zero-connectors.ts";
 
 export const SIDEBAR_PARAM = "sidebar";
 export { currentLeftThread$, currentRightThread$ };
 
 const L = logger("ChatPanes");
+
+const leftPaneAgentId$ = computed((get): string | null => {
+  const thread = get(currentLeftThread$);
+  return thread ? get(thread.agentId$) : null;
+});
+const rightPaneAgentId$ = computed((get): string | null => {
+  const thread = get(currentRightThread$);
+  return thread ? get(thread.agentId$) : null;
+});
+const leftPaneConnectorAuthorization =
+  createComposerConnectorAuthorizationSignals(leftPaneAgentId$);
+const rightPaneConnectorAuthorization =
+  createComposerConnectorAuthorizationSignals(rightPaneAgentId$);
 
 const resetLeftSetupSignal$ = resetSignal();
 const resetRightSetupSignal$ = resetSignal();
@@ -70,6 +87,7 @@ export const unloadRightThread$ = command(({ get, set }) => {
 interface PaneSpec {
   setPaneThread$: Command<void, [ChatThreadSignals | null]>;
   resetSetupSignal$: ReturnType<typeof resetSignal>;
+  connectorAuthorization: ComposerConnectorAuthorizationSignals;
 }
 
 interface RestoredDraftState {
@@ -230,13 +248,11 @@ const setupPaneThread$ = command(
     const inlineTemplatesEnabled =
       (features[FeatureSwitchKey.StructuredPrompt] ?? false) &&
       (features[FeatureSwitchKey.StructuredPromptInlineTemplates] ?? false);
-    const thread = createChatThreadSignals(
-      threadId,
-      draft,
-      dataSource,
+    const thread = createChatThreadSignals(threadId, draft, dataSource, {
       initialOptimisticEntries,
       inlineTemplatesEnabled,
-    );
+      connectorAuthorization: spec.connectorAuthorization,
+    });
     set(spec.setPaneThread$, thread);
 
     await set(
@@ -263,6 +279,7 @@ export const setupLeftThread$ = command(
         {
           setPaneThread$: setCurrentLeftThread$,
           resetSetupSignal$: resetLeftSetupSignal$,
+          connectorAuthorization: leftPaneConnectorAuthorization,
         },
         threadId,
         parentSignal,
@@ -282,6 +299,7 @@ export const setupRightThread$ = command(
       {
         setPaneThread$: setCurrentRightThread$,
         resetSetupSignal$: resetRightSetupSignal$,
+        connectorAuthorization: rightPaneConnectorAuthorization,
       },
       threadId,
       parentSignal,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -163,7 +163,10 @@ import {
   type BrowserSessionSignals,
 } from "./browser-session-block.ts";
 import { createChatThreadContainerSignals } from "./chat-thread-container.ts";
-import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
+import {
+  createComposerConnectorSignals,
+  type ComposerConnectorAuthorizationSignals,
+} from "../zero-page/zero-connectors.ts";
 import {
   messageDocumentToDisplayText,
   messageDocumentToPrompt,
@@ -4350,6 +4353,7 @@ function createThreadComposer(
   threadId: string,
   agentId$: Computed<string | null>,
   inlineTemplatesEnabled: boolean,
+  connectorAuthorization?: ComposerConnectorAuthorizationSignals,
 ) {
   const workflowComposer = createWorkflowComposerSignals(
     draft,
@@ -4359,7 +4363,10 @@ function createThreadComposer(
   );
   return {
     workflowComposer,
-    composerConnectors: createComposerConnectorSignals(agentId$),
+    composerConnectors: createComposerConnectorSignals(
+      agentId$,
+      connectorAuthorization,
+    ),
     focusInput$: workflowComposer.focus$,
   };
 }
@@ -4368,9 +4375,14 @@ export function createChatThreadSignals(
   threadId: string,
   draft: DraftSignals,
   dataSource: ChatThreadRemote = createRemoteChatThreadDataSource(threadId),
-  initialOptimisticEntries: readonly OptimisticChatMessageEntry[] = [],
-  inlineTemplatesEnabled = false,
+  options: {
+    readonly initialOptimisticEntries?: readonly OptimisticChatMessageEntry[];
+    readonly inlineTemplatesEnabled?: boolean;
+    readonly connectorAuthorization?: ComposerConnectorAuthorizationSignals;
+  } = {},
 ): ChatThreadSignals {
+  const initialOptimisticEntries = options.initialOptimisticEntries ?? [];
+  const inlineTemplatesEnabled = options.inlineTemplatesEnabled ?? false;
   const threadDraft$ = createRemoteThreadDraft(dataSource);
   const threadMeta$ = createThreadMeta(threadId);
   const threadTitle = createThreadTitleParts(threadMeta$);
@@ -4401,6 +4413,7 @@ export function createChatThreadSignals(
     threadId,
     threadOwned.agentId$,
     inlineTemplatesEnabled,
+    options.connectorAuthorization,
   );
   const artifact = createArtifacts(threadId);
   const previewImageUrlsByUrl$ = createArtifactPreviewImageUrls(

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -2,12 +2,15 @@ import { command, computed, state, type Computed } from "ccstate";
 import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
-import { zeroClient$ } from "../api-client.ts";
+import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
+import { withCleanup } from "../utils.ts";
 
-interface AgentConnectorAuthorizations {
+export interface AgentConnectorAuthorizations {
   readonly agentId: string;
   readonly enabledTypes: readonly ConnectorRef[];
 }
+
+type MissingPolicy = "throw" | "null";
 
 const internalAgentConnectorAuthorizationsReload$ = state(0);
 
@@ -19,6 +22,79 @@ export const reloadAgentConnectorAuthorizations$ = command(({ set }) => {
   set(internalAgentConnectorAuthorizationsReload$, (x) => {
     return x + 1;
   });
+});
+
+function pendingRequestKey(params: {
+  readonly agentId: string;
+  readonly missing: MissingPolicy;
+  readonly reloadGeneration: number;
+}): string {
+  return JSON.stringify([
+    params.reloadGeneration,
+    params.missing,
+    params.agentId,
+  ]);
+}
+
+interface AgentConnectorAuthorizationRequestBroker {
+  load(params: {
+    readonly createClient: ZeroClientFactory;
+    readonly agentId: string;
+    readonly missing: MissingPolicy;
+    readonly reloadGeneration: number;
+  }): Promise<AgentConnectorAuthorizations | null>;
+}
+
+function createAgentConnectorAuthorizationRequestBroker(): AgentConnectorAuthorizationRequestBroker {
+  const pendingRequestsByClient = new WeakMap<
+    ZeroClientFactory,
+    Map<string, Promise<AgentConnectorAuthorizations | null>>
+  >();
+
+  return {
+    load(params) {
+      let pendingRequests = pendingRequestsByClient.get(params.createClient);
+      if (!pendingRequests) {
+        pendingRequests = new Map();
+        pendingRequestsByClient.set(params.createClient, pendingRequests);
+      }
+
+      const key = pendingRequestKey(params);
+      const pendingRequest = pendingRequests.get(key);
+      if (pendingRequest) {
+        return pendingRequest;
+      }
+
+      const client = params.createClient(zeroUserConnectorsContract);
+      const response = client.get({ params: { id: params.agentId } });
+      const load = async (): Promise<AgentConnectorAuthorizations | null> => {
+        const result =
+          params.missing === "null"
+            ? await accept(response, [200, 404])
+            : await accept(response, [200]);
+        if (result.status === 404) {
+          return null;
+        }
+        return {
+          agentId: params.agentId,
+          enabledTypes: result.body.enabledTypes,
+        };
+      };
+
+      const sharedRequest = withCleanup(load(), () => {
+        pendingRequests.delete(key);
+        if (pendingRequests.size === 0) {
+          pendingRequestsByClient.delete(params.createClient);
+        }
+      });
+      pendingRequests.set(key, sharedRequest);
+      return sharedRequest;
+    },
+  };
+}
+
+const agentConnectorAuthorizationRequestBroker$ = computed(() => {
+  return createAgentConnectorAuthorizationRequestBroker();
 });
 
 function createAuthorizationsAtom(
@@ -34,17 +110,13 @@ function createAuthorizationsAtom(
   options: { readonly missing: "throw" | "null" },
 ): Computed<Promise<AgentConnectorAuthorizations | null>> {
   return computed(async (get): Promise<AgentConnectorAuthorizations | null> => {
-    get(agentConnectorAuthorizationsReload$);
-    const client = get(zeroClient$)(zeroUserConnectorsContract);
-    const request = client.get({ params: { id: agentId } });
-    const result =
-      options.missing === "null"
-        ? await accept(request, [200, 404])
-        : await accept(request, [200]);
-    if (result.status === 404) {
-      return null;
-    }
-    return { agentId, enabledTypes: result.body.enabledTypes };
+    const reloadGeneration = get(agentConnectorAuthorizationsReload$);
+    return await get(agentConnectorAuthorizationRequestBroker$).load({
+      createClient: get(zeroClient$),
+      agentId,
+      missing: options.missing,
+      reloadGeneration,
+    });
   });
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -11,12 +11,18 @@ import { withCleanup } from "../utils.ts";
 import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
+  type AgentConnectorAuthorizations,
 } from "./agent-connector-authorizations.ts";
 import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 
-export interface ComposerConnectorSignals {
+export interface ComposerConnectorAuthorizationSignals {
   readonly agentId$: Computed<Promise<string | null>>;
-  readonly authorizedConnectors$: Computed<Promise<readonly ConnectorRef[]>>;
+  readonly authorizations$: Computed<
+    Promise<AgentConnectorAuthorizations | null>
+  >;
+}
+
+export interface ComposerConnectorSignals extends ComposerConnectorAuthorizationSignals {
   readonly authorizeConnector$: Command<
     Promise<void>,
     [ConnectorRef, AbortSignal]
@@ -94,27 +100,30 @@ function initialComposerConnectorUiState(): ComposerConnectorUiState {
   };
 }
 
-type ConnectorAuthorizationSignals = Pick<
-  ComposerConnectorSignals,
-  "authorizedConnectors$" | "authorizeConnector$" | "deauthorizeConnector$"
->;
-
-function createConnectorAuthorizationSignals(
-  agentId$: Computed<Promise<string | null>>,
-): ConnectorAuthorizationSignals {
-  const authorizedConnectors$ = computed(
-    async (get): Promise<readonly ConnectorRef[]> => {
+export function createComposerConnectorAuthorizationSignals<
+  T extends AgentIdValue,
+>(agentIdSource$: Computed<T>): ComposerConnectorAuthorizationSignals {
+  const agentId$ = computed(async (get): Promise<string | null> => {
+    return await get(agentIdSource$);
+  });
+  const authorizations$ = computed(
+    async (get): Promise<AgentConnectorAuthorizations | null> => {
       const agentId = await get(agentId$);
       if (!agentId) {
-        return [];
+        return null;
       }
-      const authorizations = await get(
-        agentConnectorAuthorizations({ agentId }),
-      );
-      return authorizations.enabledTypes;
+      return await get(agentConnectorAuthorizations({ agentId }));
     },
   );
+  return { agentId$, authorizations$ };
+}
 
+function createConnectorAuthorizationCommands(
+  agentId$: Computed<Promise<string | null>>,
+): Pick<
+  ComposerConnectorSignals,
+  "authorizeConnector$" | "deauthorizeConnector$"
+> {
   const updateAuthorizedConnectors$ = command(
     async (
       { get, set },
@@ -170,7 +179,6 @@ function createConnectorAuthorizationSignals(
   );
 
   return {
-    authorizedConnectors$,
     authorizeConnector$,
     deauthorizeConnector$,
   };
@@ -178,11 +186,15 @@ function createConnectorAuthorizationSignals(
 
 export function createComposerConnectorSignals<T extends AgentIdValue>(
   agentIdSource$: Computed<T>,
+  authorization?: ComposerConnectorAuthorizationSignals,
 ): ComposerConnectorSignals {
-  const agentId$ = computed(async (get): Promise<string | null> => {
+  const localAgentId$ = computed(async (get): Promise<string | null> => {
     return await get(agentIdSource$);
   });
-  const authorization = createConnectorAuthorizationSignals(agentId$);
+  const resolvedAuthorization =
+    authorization ?? createComposerConnectorAuthorizationSignals(localAgentId$);
+  const authorizationCommands =
+    createConnectorAuthorizationCommands(localAgentId$);
   const initial = initialComposerConnectorUiState();
   const showAddDialog = createStateBinding(initial.showAddDialog);
   const pendingConnectorRef = createStateBinding(initial.pendingConnectorRef);
@@ -207,7 +219,7 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
   });
   const permissionGrants$ = computed(
     async (get): Promise<readonly UserPermissionGrantResponse[]> => {
-      const agentId = await get(agentId$);
+      const agentId = await get(localAgentId$);
       if (!agentId) {
         return [];
       }
@@ -216,8 +228,8 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
   );
 
   return {
-    agentId$,
-    ...authorization,
+    ...resolvedAuthorization,
+    ...authorizationCommands,
     showAddDialog$: showAddDialog.value$,
     setShowAddDialog$: showAddDialog.set$,
     pendingConnectorRef$: pendingConnectorRef.value$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -33,6 +33,7 @@ import {
   resetChatPageModelSelection$,
   setChatPageModelSelection$,
 } from "../../../signals/zero-page/zero-chat-page.ts";
+import { loadLeftThread$ } from "../../../signals/chat-page/chat-thread-panes.ts";
 import {
   click,
   detachedSetupPage,
@@ -77,6 +78,19 @@ import {
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
 });
+
+async function navigateToChatThread(threadId: string): Promise<void> {
+  const link = await waitFor(() => {
+    const candidate = document.querySelector<HTMLAnchorElement>(
+      `a[href="/chats/${threadId}"]`,
+    );
+    if (!candidate) {
+      throw new Error(`Thread link not found: ${threadId}`);
+    }
+    return candidate;
+  });
+  click(link);
+}
 
 describe("chat composer models", () => {
   it("keeps model resources cached across Clerk profile events", async () => {
@@ -2059,6 +2073,204 @@ describe("chat composer models", () => {
       expect(screen.getByLabelText("Add GitHub")).toBeInTheDocument();
       expect(screen.getByLabelText("Remove Slack")).toBeInTheDocument();
       expectTextBefore("GitHub", "Slack");
+    });
+  });
+
+  it("keeps connector access resolved across same-agent chat navigation", async () => {
+    const unexpectedReload = context.mocks.deferred<void>();
+    let authorizationRequestCount = 0;
+
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    mockManyConnectedConnectors();
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "First Scout thread" },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Second Scout thread",
+      },
+    ]);
+    context.mocks.api(
+      zeroUserConnectorsContract.get,
+      async ({ respond, withSignal }) => {
+        authorizationRequestCount += 1;
+        if (authorizationRequestCount > 1) {
+          await withSignal(unexpectedReload.promise);
+        }
+        return respond(200, { enabledTypes: ["github"] });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const initialThread = await screen.findByLabelText("Chat thread");
+    const initialConnectorButton =
+      within(initialThread).getByLabelText("Connectors");
+    await waitFor(() => {
+      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+      expect(authorizationRequestCount).toBe(1);
+    });
+
+    await navigateToChatThread(OTHER_AGENT_THREAD_ID);
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText("Chat thread")).getByText(
+          "Second Scout thread",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    const nextConnectorButton = within(
+      screen.getByLabelText("Chat thread"),
+    ).getByLabelText("Connectors");
+    click(nextConnectorButton);
+    const connectorStatusStayedResolved =
+      screen.queryByLabelText("Remove GitHub") !== null;
+    const requestCountAfterNavigation = authorizationRequestCount;
+    unexpectedReload.resolve();
+
+    expect(connectorStatusStayedResolved).toBeTruthy();
+    expect(requestCountAfterNavigation).toBe(1);
+    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
+  });
+
+  it("does not expose previous-agent connector access while navigation resolves", async () => {
+    const otherAgentAuthorization = context.mocks.deferred<void>();
+    const authorizationAgentIds: string[] = [];
+
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent({ includeOtherAgent: true });
+    mockManyConnectedConnectors();
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "Scout thread" },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: OTHER_AGENT_ID,
+        title: "Other agent thread",
+      },
+    ]);
+    context.mocks.api(
+      zeroUserConnectorsContract.get,
+      async ({ params, respond, withSignal }) => {
+        authorizationAgentIds.push(params.id);
+        if (params.id === OTHER_AGENT_ID) {
+          await withSignal(otherAgentAuthorization.promise);
+          return respond(200, { enabledTypes: ["slack"] });
+        }
+        return respond(200, { enabledTypes: ["github"] });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const initialConnectorButton = within(
+      await screen.findByLabelText("Chat thread"),
+    ).getByLabelText("Connectors");
+    await waitFor(() => {
+      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+    });
+
+    act(() => {
+      context.store.set(loadLeftThread$, OTHER_AGENT_THREAD_ID);
+    });
+    await waitFor(() => {
+      expect(authorizationAgentIds).toContain(OTHER_AGENT_ID);
+      expect(
+        within(screen.getByLabelText("Chat thread")).getByText(
+          "Other agent thread",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    const nextConnectorButton = within(
+      screen.getByLabelText("Chat thread"),
+    ).getByLabelText("Connectors");
+    click(nextConnectorButton);
+    expect(screen.queryByLabelText("Remove GitHub")).not.toBeInTheDocument();
+    expect(nextConnectorButton.querySelector("img")).toBeNull();
+
+    otherAgentAuthorization.resolve();
+    await expect(
+      screen.findByLabelText("Remove Slack"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Add GitHub")).toBeInTheDocument();
+  });
+
+  it("deduplicates same-agent pane reads and reloads both after a mutation", async () => {
+    const user = userEvent.setup({ delay: null });
+    const initialAuthorization = context.mocks.deferred<void>();
+    let authorizationRequestCount = 0;
+    let enabledTypes: string[] = ["slack"];
+    let updatedAuthorizationAgentId: string | undefined;
+
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    mockConnectors([{ type: "slack", externalUsername: "launch-team" }]);
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "First Scout thread" },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Second Scout thread",
+      },
+    ]);
+    context.mocks.api(
+      zeroUserConnectorsContract.get,
+      async ({ respond, withSignal }) => {
+        authorizationRequestCount += 1;
+        if (authorizationRequestCount === 1) {
+          await withSignal(initialAuthorization.promise);
+        }
+        return respond(200, { enabledTypes });
+      },
+    );
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ params, body, respond }) => {
+        updatedAuthorizationAgentId = params.id;
+        enabledTypes = applyUserConnectorUpdate(enabledTypes, body);
+        return respond(200, { enabledTypes });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}?sidebar=${OTHER_AGENT_THREAD_ID}`,
+    });
+
+    const threadRegions = await screen.findAllByLabelText("Chat thread");
+    expect(threadRegions).toHaveLength(2);
+    await waitFor(() => {
+      expect(authorizationRequestCount).toBe(1);
+    });
+
+    initialAuthorization.resolve();
+    const connectorButtons = threadRegions.map((thread) => {
+      return within(thread).getByLabelText("Connectors");
+    });
+    await waitFor(() => {
+      for (const button of connectorButtons) {
+        expect(button.querySelector("img")).not.toBeNull();
+      }
+    });
+
+    const sideConnectorButton = connectorButtons[1];
+    if (!sideConnectorButton) {
+      throw new Error("Side connector button not found");
+    }
+    await user.click(sideConnectorButton);
+    await user.click(await screen.findByLabelText("Remove Slack"));
+
+    await waitFor(() => {
+      expect(updatedAuthorizationAgentId).toBe(AGENT_ID);
+      expect(authorizationRequestCount).toBe(2);
+      for (const button of connectorButtons) {
+        expect(button.querySelector("img")).toBeNull();
+      }
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -178,6 +178,7 @@ import {
   ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import type { ComposerConnectorSignals } from "../../signals/zero-page/zero-connectors.ts";
+import type { AgentConnectorAuthorizations } from "../../signals/zero-page/agent-connector-authorizations.ts";
 import { applyUserPermissionGrants$ } from "../../signals/permission-allow/permission-allow-signals.ts";
 import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission-grants.ts";
 import { savePermissionDraftPolicies } from "../../signals/zero-page/settings/permission-grant-save.ts";
@@ -365,6 +366,12 @@ export interface ZeroChatComposerProps {
   activeGoal?: ActiveGoalComposerItem;
   /** Cancels the active goal through the goal API. */
   onCancelActiveGoal?: () => void;
+}
+
+export interface ComposerConnectorReadState {
+  readonly catalogItems: Loadable<readonly PublicConnectorCatalogStatusItem[]>;
+  readonly agentId: Loadable<string | null>;
+  readonly authorizations: Loadable<AgentConnectorAuthorizations | null>;
 }
 
 export interface QueuedComposerItem {
@@ -6595,45 +6602,89 @@ function nullToUndefined<T>(value: T | null): T | undefined {
   return value === null ? undefined : value;
 }
 
+function equalAgentConnectorAuthorizations(
+  left: AgentConnectorAuthorizations | null,
+  right: AgentConnectorAuthorizations | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return (
+    left.agentId === right.agentId &&
+    equalArrays(left.enabledTypes, right.enabledTypes)
+  );
+}
+
+export function useComposerConnectorReadState(
+  composerConnectors: ComposerConnectorSignals,
+): ComposerConnectorReadState {
+  return {
+    catalogItems: useLastLoadable(allConnectorCatalogItems$),
+    agentId: useLoadable(composerConnectors.agentId$),
+    authorizations: useLastLoadable(composerConnectors.authorizations$, {
+      equalityFn: equalAgentConnectorAuthorizations,
+    }),
+  };
+}
+
+function matchingAuthorizedConnectorRefs(
+  agentId: Loadable<string | null>,
+  authorizations: Loadable<AgentConnectorAuthorizations | null>,
+): readonly ConnectorRef[] | null {
+  if (agentId.state !== "hasData" || authorizations.state !== "hasData") {
+    return null;
+  }
+  if (agentId.data === null) {
+    return authorizations.data === null ? [] : null;
+  }
+  if (authorizations.data?.agentId !== agentId.data) {
+    return null;
+  }
+  return authorizations.data.enabledTypes;
+}
+
 // The thread route invokes this hook from its ccstate-connected composer so
 // dynamic bindings do not cross another React component boundary. The agent
 // landing page uses the component wrapper below for its separate signal scope.
-export function useZeroChatComposer({
-  composer,
-  composerConnectors,
-  onSend,
-  onQueue,
-  sending,
-  queueWhileSending = false,
-  submissionLoading = false,
-  onCancel,
-  displayName,
-  className,
-  autoFocus,
-  enableMobileSingleLine = false,
-  draft,
-  composerFileInput$: composerFileInputProp$,
-  setComposerFileInput$: setComposerFileInputProp$,
-  chatThreadId,
-  onDraftChange,
-  actionsLoading = false,
-  modelPicker,
-  templatePicker,
-  onCreateWorkflowPrompt,
-  computerUse,
-  modelPickerLoading = false,
-  submitBlocker,
-  queuedItems,
-  onRemoveQueuedItem,
-  workflowEventItems,
-  onRemoveWorkflowEvent,
-  workflowEventsPaused = false,
-  workflowEventsPauseReason,
-  onSetWorkflowEventsPaused,
-  onClearWorkflowEvents,
-  activeGoal,
-  onCancelActiveGoal,
-}: ZeroChatComposerProps) {
+export function useZeroChatComposer(
+  {
+    composer,
+    composerConnectors,
+    onSend,
+    onQueue,
+    sending,
+    queueWhileSending = false,
+    submissionLoading = false,
+    onCancel,
+    displayName,
+    className,
+    autoFocus,
+    enableMobileSingleLine = false,
+    draft,
+    composerFileInput$: composerFileInputProp$,
+    setComposerFileInput$: setComposerFileInputProp$,
+    chatThreadId,
+    onDraftChange,
+    actionsLoading = false,
+    modelPicker,
+    templatePicker,
+    onCreateWorkflowPrompt,
+    computerUse,
+    modelPickerLoading = false,
+    submitBlocker,
+    queuedItems,
+    onRemoveQueuedItem,
+    workflowEventItems,
+    onRemoveWorkflowEvent,
+    workflowEventsPaused = false,
+    workflowEventsPauseReason,
+    onSetWorkflowEventsPaused,
+    onClearWorkflowEvents,
+    activeGoal,
+    onCancelActiveGoal,
+  }: ZeroChatComposerProps,
+  connectorReadState: ComposerConnectorReadState,
+) {
   const showAddDialog = useGet(composerConnectors.showAddDialog$);
   const setShowAddDialog = useSet(composerConnectors.setShowAddDialog$);
   const openGoalDialog = useSet(openChatThreadGoalDialog$);
@@ -6782,13 +6833,9 @@ export function useZeroChatComposer({
   };
 
   // Connectors: connected (org-level) + authorized (agent-level) → available
-  const connectorCatalogItemsLoadable = useLastLoadable(
-    allConnectorCatalogItems$,
-  );
-  const authorizedConnectorsLoadable = useLastLoadable(
-    composerConnectors.authorizedConnectors$,
-    { equalityFn: equalArrays },
-  );
+  const connectorCatalogItemsLoadable = connectorReadState.catalogItems;
+  const agentIdLoadable = connectorReadState.agentId;
+  const authorizationsLoadable = connectorReadState.authorizations;
   const pageSignal = useGet(pageSignal$);
   const selectedConnectorRef = useGet(composerConnectors.selectedConnectorRef$);
   const pendingConnectorRef = useGet(composerConnectors.pendingConnectorRef$);
@@ -6813,13 +6860,16 @@ export function useZeroChatComposer({
   const setSavingConnectorRef = useSet(
     composerConnectors.setSavingConnectorRef$,
   );
-  const agentRecordId = loadableDataOrNull(
-    useLastLoadable(composerConnectors.agentId$),
+  const agentRecordId = loadableDataOrNull(agentIdLoadable);
+
+  const authorizedConnectors = matchingAuthorizedConnectorRefs(
+    agentIdLoadable,
+    authorizationsLoadable,
   );
 
   const connectorsLoading =
     connectorCatalogItemsLoadable.state !== "hasData" ||
-    authorizedConnectorsLoadable.state !== "hasData";
+    authorizedConnectors === null;
 
   const connectorCatalogItems =
     connectorCatalogItemsLoadable.state === "hasData"
@@ -6830,11 +6880,7 @@ export function useZeroChatComposer({
       return [connector.connectorRef, connector];
     }),
   );
-  const authorizedConnectors =
-    authorizedConnectorsLoadable.state === "hasData"
-      ? authorizedConnectorsLoadable.data
-      : [];
-  const authorizedSet = new Set(authorizedConnectors);
+  const authorizedSet = new Set(authorizedConnectors ?? []);
 
   const unconnectedConnectors = connectorCatalogItems.filter((connector) => {
     return (
@@ -7242,5 +7288,8 @@ export function useZeroChatComposer({
 }
 
 export function ZeroChatComposer(props: ZeroChatComposerProps) {
-  return useZeroChatComposer(props);
+  const connectorReadState = useComposerConnectorReadState(
+    props.composerConnectors,
+  );
+  return useZeroChatComposer(props, connectorReadState);
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -276,7 +276,9 @@ import {
   setTemplatePickerSearch$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
+  useComposerConnectorReadState,
   useZeroChatComposer,
+  type ComposerConnectorReadState,
   type ZeroChatComposerProps,
   type QueuedComposerItem,
   type WorkflowEventComposerItem,
@@ -2816,6 +2818,9 @@ function ChatHistoryBackfillSkeleton({
 }
 
 function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
+  const connectorReadState = useComposerConnectorReadState(
+    thread.composerConnectors,
+  );
   return (
     <>
       <ChatThreadHeader thread={thread} />
@@ -2825,7 +2830,11 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
           <ChatThreadMessagesPane thread={thread} />
           {/* Command loadables are hook-owned, so keep their identity boundary
               narrower than the persistent thread and message owners. */}
-          <ChatThreadComposer key={thread.threadId} thread={thread} />
+          <ChatThreadComposer
+            key={thread.threadId}
+            thread={thread}
+            connectorReadState={connectorReadState}
+          />
         </div>
       </div>
 
@@ -3468,7 +3477,13 @@ function useQueuedMessageItems(thread: ChatThreadSignals) {
   );
 }
 
-function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
+function ChatThreadComposer({
+  thread,
+  connectorReadState,
+}: {
+  thread: ChatThreadSignals;
+  connectorReadState: ComposerConnectorReadState;
+}) {
   const queuedMessageItems = useQueuedMessageItems(thread);
   const hasMessagesResolved = useLastResolved(thread.hasMessages$);
   const hasMessages = hasMessagesResolved ?? false;
@@ -3553,7 +3568,7 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
     activeGoal,
     onCancelActiveGoal,
   };
-  const composer = useZeroChatComposer(composerOptions);
+  const composer = useZeroChatComposer(composerOptions, connectorReadState);
 
   return (
     <footer


### PR DESCRIPTION
## Summary

- keep connector catalog and agent authorization reads alive at the chat pane boundary when the keyed thread composer remounts
- share only concurrent authorization requests within the ccstate store, while keeping mutations bound to the originating thread
- hide stale authorization data when navigating between threads owned by different agents
- cover same-agent navigation, different-agent transitions, and split-pane mutation reloads with page-level integration tests

## Scope

- no API, schema, migration, or persisted-data changes
- no settled cross-thread authorization cache; only pane-owned read state and in-flight request deduplication
- connector authorization commands and composer-local UI state remain thread-owned

## Testing

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app test -- --silent=passed-only`
- `pnpm knip --workspace @vm0/app`
- pre-commit hooks, including repository type checks and commitlint

Closes #23540
