### PR TITLE
perf(api): avoid catalog loading during runner claim

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -688,6 +688,29 @@ export function createRunsApi(context: TestContext) {
       );
     },
 
+    async replaceUserPermissionGrants(
+      actor: ApiTestUser,
+      body: {
+        readonly agentId: string;
+        readonly connectorRef: string;
+        readonly grants: readonly ApplyUserPermissionGrant[];
+      },
+    ): Promise<readonly UserPermissionGrantResponse[]> {
+      const response = await accept(
+        runApp(context)(zeroUserPermissionGrantsContract).apply({
+          headers: authenticate(context, actor),
+          body: {
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            mode: "replace",
+            grants: [...body.grants],
+          },
+        }),
+        [200],
+      );
+      return response.body;
+    },
+
     async listUserPermissionGrants(
       actor: ApiTestUser,
       agentId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -108,6 +108,23 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
   });
 }
 
+export async function mutateRunnerJobConnectorPermissionBaseline(
+  context: TestContext,
+  runId: string,
+  mode:
+    | "remove"
+    | "malformed"
+    | "catalog-mismatch"
+    | "authority-mismatch"
+    | "inconsistent",
+): Promise<void> {
+  await postAction(context, {
+    action: "mutate-runner-job-connector-permission-baseline",
+    run_id: runId,
+    mode,
+  });
+}
+
 export async function setRunnerJobContextProfileAsPreviousApi(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -116,7 +116,8 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
     | "malformed"
     | "catalog-mismatch"
     | "authority-mismatch"
-    | "inconsistent",
+    | "inconsistent"
+    | "incomplete",
 ): Promise<void> {
   await postAction(context, {
     action: "mutate-runner-job-connector-permission-baseline",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4419,6 +4419,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(thirdClaim.secretValues).toContain(zeroToken);
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
     expect(thirdClaim).not.toHaveProperty("runContextStorage");
+    expectClaimNetworkPolicyRefreshPath(third.runId, "baseline_empty");
     const apiToRunnerQueueMs = sandboxOperationDurationForRun(
       third.runId,
       "api_to_runner_queue",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -83,6 +83,7 @@ import {
   deleteVm0ManagedDefaultModelKey,
   enableFakeKms,
   holdOrgAdmissionLock,
+  mutateRunnerJobConnectorPermissionBaseline,
   mutateRunnerJobSecretValueEnvironmentKeys,
   removeRunCanonicalStorageState,
   replaceCustomConnectorPrefixes,
@@ -772,6 +773,27 @@ function expectClaimRouteResponseTimingActions(args: {
       expect(serialized).not.toContain(forbiddenValue);
     }
   }
+}
+
+function expectClaimNetworkPolicyRefreshPath(
+  runId: string,
+  path:
+    | "baseline"
+    | "baseline_empty"
+    | "full_missing_baseline"
+    | "full_invalid_baseline"
+    | "full_incompatible_baseline",
+): void {
+  expect(
+    singleSandboxOperationEvent(
+      claimRouteTimingEventsForRun(runId),
+      "claim_route_response_network_policy_refresh",
+    ),
+  ).toStrictEqual(
+    expect.objectContaining({
+      policy_refresh_path: path,
+    }),
+  );
 }
 
 function expectCustomConnectorRuntimePhaseTimingEvents(
@@ -2807,7 +2829,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     expectClaimRouteResponseTimingActions({
       runId: resumed.runId,
-      expectedActionTypes: ["claim_route_response_resume_session"],
+      expectedActionTypes: [
+        "claim_route_response_resume_session",
+        "claim_route_response_network_policy_refresh",
+      ],
       forbiddenValues: [
         history,
         historyHash,
@@ -2815,6 +2840,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         resumedClaim.sandboxToken,
       ],
     });
+    expectClaimNetworkPolicyRefreshPath(resumed.runId, "baseline_empty");
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });
@@ -7722,6 +7748,158 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expectApiError(rejected.body);
   });
 
+  it("refreshes queued connector grants from the stored permission baseline", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, runnerGroup } = await entitledRunActor();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD queued permission baseline agent",
+    });
+    const agentId = agent.agentId;
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-baseline",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["slack"]);
+    await api.heartbeatRunner(runnerGroup);
+
+    await api.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorRef: "slack",
+      permission: "chat:write",
+      action: "allow",
+      expiresIn: "1h",
+    });
+    const expiringRun = await api.createRun(actor, {
+      agentId,
+      prompt: "expire a queued permission",
+      modelProvider: "anthropic-api-key",
+    });
+    mockNow(now() + 2 * 3_600_000);
+    const expiredClaim = await api.claimRunnerJob(expiringRun.runId);
+    expect(expiredClaim.networkPolicies?.slack?.deny).toContain("chat:write");
+    expect(expiredClaim.networkPolicies?.slack?.allow).not.toContain(
+      "chat:write",
+    );
+    expectClaimNetworkPolicyRefreshPath(expiringRun.runId, "baseline");
+    await api.requestCancelRun(actor, expiringRun.runId, [200]);
+
+    await api.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorRef: "slack",
+      permission: "chat:write",
+      action: "allow",
+    });
+    const revokedRun = await api.createRun(actor, {
+      agentId,
+      prompt: "revoke a queued permission",
+      modelProvider: "anthropic-api-key",
+    });
+    await expect(
+      api.replaceUserPermissionGrants(actor, {
+        agentId,
+        connectorRef: "slack",
+        grants: [],
+      }),
+    ).resolves.toStrictEqual([]);
+    const revokedClaim = await api.claimRunnerJob(revokedRun.runId);
+    expect(revokedClaim.networkPolicies?.slack?.deny).toContain("chat:write");
+    expect(revokedClaim.networkPolicies?.slack?.allow).not.toContain(
+      "chat:write",
+    );
+    expect(revokedClaim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(revokedRun.runId, "baseline");
+    await api.requestCancelRun(actor, revokedRun.runId, [200]);
+  });
+
+  it("skips connector catalog work for a current writer without built-ins", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const { actor, runnerGroup } = await entitledRunActor();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD empty permission baseline agent",
+    });
+    await api.heartbeatRunner(runnerGroup);
+
+    const run = await api.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "claim without built-in connectors",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.networkPolicies).toHaveProperty(
+      "model-provider:anthropic-api-key",
+    );
+    expect(claim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(run.runId, "baseline_empty");
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("falls back for old, invalid, and incompatible permission baselines", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, runnerGroup } = await entitledRunActor();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD permission baseline fallback agent",
+    });
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-baseline-fallback",
+    });
+    await api.enableAgentConnectors(actor, agent.agentId, ["slack"]);
+    await api.heartbeatRunner(runnerGroup);
+
+    const cases = [
+      {
+        mode: "remove",
+        path: "full_missing_baseline",
+      },
+      {
+        mode: "malformed",
+        path: "full_invalid_baseline",
+      },
+      {
+        mode: "inconsistent",
+        path: "full_invalid_baseline",
+      },
+      {
+        mode: "catalog-mismatch",
+        path: "full_incompatible_baseline",
+      },
+      {
+        mode: "authority-mismatch",
+        path: "full_incompatible_baseline",
+      },
+    ] as const;
+
+    for (const fallbackCase of cases) {
+      const run = await api.createRun(actor, {
+        agentId: agent.agentId,
+        prompt: `fallback ${fallbackCase.mode}`,
+        modelProvider: "anthropic-api-key",
+      });
+      await mutateRunnerJobConnectorPermissionBaseline(
+        context,
+        run.runId,
+        fallbackCase.mode,
+      );
+      const claim = await api.claimRunnerJob(run.runId);
+
+      expect(claim.networkPolicies?.slack?.allow).toContain(
+        "conversations:read",
+      );
+      expect(claim.networkPolicies?.slack?.deny).toContain("chat:write");
+      expect(claim).not.toHaveProperty("connectorPermissionBaseline");
+      expectClaimNetworkPolicyRefreshPath(run.runId, fallbackCase.path);
+      await api.requestCancelRun(actor, run.runId, [200]);
+    }
+  });
+
   it("applies, scopes, expires, and snapshots user permission grants", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
@@ -7843,6 +8021,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         grantedContext.claim.sandboxToken,
       ],
     });
+    expectClaimNetworkPolicyRefreshPath(grantedContext.claim.runId, "baseline");
+    expect(grantedContext.claim).not.toHaveProperty(
+      "connectorPermissionBaseline",
+    );
     expect(
       grantedContext.claim.networkPolicyRefreshes?.slack?.nextRefreshAt,
     ).toStrictEqual(expect.any(String));
@@ -9058,12 +9240,13 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     expect(claimed.body.sandboxToken).not.toBe("");
     expectClaimRouteResponseTimingActions({
       runId: first.runId,
-      expectedActionTypes: [],
+      expectedActionTypes: ["claim_route_response_network_policy_refresh"],
       forbiddenValues: [firstPrompt, claimed.body.sandboxToken, apiKey.token],
     });
+    expectClaimNetworkPolicyRefreshPath(first.runId, "baseline_empty");
     const claimRouteTimingEvents = claimRouteTimingEventsForRun(first.runId);
     expect(claimRouteTimingEvents).toHaveLength(
-      CLAIM_ROUTE_TIMING_ACTION_TYPES.length,
+      CLAIM_ROUTE_TIMING_ACTION_TYPES.length + 1,
     );
     const observedClaimRouteActionTypes = new Set(
       claimRouteTimingEvents.map((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7442,6 +7442,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
+    expectClaimNetworkPolicyRefreshPath(run.runId, "baseline_empty");
 
     const idPart = saved.connector.id.replaceAll("-", "");
     const internalName = `custom_connector_${idPart}`;
@@ -7866,6 +7867,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       },
       {
         mode: "inconsistent",
+        path: "full_invalid_baseline",
+      },
+      {
+        mode: "incomplete",
         path: "full_invalid_baseline",
       },
       {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
+  compatibleStoredExecutionContextSchema,
   elapsedSinceApiStartMs,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   runnersNetworkPolicyRefreshContract,
@@ -9,7 +10,7 @@ import {
   runnersJobClaimContract,
   runnersPollContract,
   storedConnectorPermissionBaselineSchema,
-  storedExecutionContextSchema,
+  type CompatibleStoredExecutionContext,
   type ExecutionContext,
   type HeldSessionState,
   type SessionHistoryDownloadSource,
@@ -1103,6 +1104,51 @@ type PreparedSecretValuesResult =
       readonly status: "invalid-keys";
     };
 
+type ConnectorPermissionBaselineRead =
+  | { readonly kind: "missing" }
+  | { readonly kind: "invalid" }
+  | {
+      readonly kind: "valid";
+      readonly value: StoredConnectorPermissionBaseline;
+    };
+
+function decodeCompatibleStoredExecutionContext(
+  context: CompatibleStoredExecutionContext,
+): {
+  readonly context: StoredExecutionContext;
+  readonly connectorPermissionBaseline: ConnectorPermissionBaselineRead;
+} {
+  const {
+    connectorPermissionBaseline: rawConnectorPermissionBaseline,
+    ...contextWithoutConnectorPermissionBaseline
+  } = context;
+  if (rawConnectorPermissionBaseline === undefined) {
+    return {
+      context: contextWithoutConnectorPermissionBaseline,
+      connectorPermissionBaseline: { kind: "missing" },
+    };
+  }
+  const baselineResult = storedConnectorPermissionBaselineSchema.safeParse(
+    rawConnectorPermissionBaseline,
+  );
+  if (!baselineResult.success) {
+    return {
+      context: contextWithoutConnectorPermissionBaseline,
+      connectorPermissionBaseline: { kind: "invalid" },
+    };
+  }
+  return {
+    context: {
+      ...contextWithoutConnectorPermissionBaseline,
+      connectorPermissionBaseline: baselineResult.data,
+    },
+    connectorPermissionBaseline: {
+      kind: "valid",
+      value: baselineResult.data,
+    },
+  };
+}
+
 function preparedSecretValuesForRunner(
   storedContext: StoredExecutionContext,
 ): PreparedSecretValuesResult {
@@ -1184,6 +1230,7 @@ async function refreshClaimNetworkPolicies(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
   readonly storedContext: StoredExecutionContext;
+  readonly connectorPermissionBaseline: ConnectorPermissionBaselineRead;
   readonly timing: ClaimRouteTimingCollector;
 }): Promise<
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
@@ -1226,17 +1273,17 @@ async function refreshClaimNetworkPolicies(args: {
     };
 
     const selectRefresh = async () => {
-      if (args.storedContext.connectorPermissionBaseline === undefined) {
+      if (args.connectorPermissionBaseline.kind === "missing") {
         return await fullRefresh("full_missing_baseline");
       }
-      const baselineResult = storedConnectorPermissionBaselineSchema.safeParse(
-        args.storedContext.connectorPermissionBaseline,
-      );
+      if (args.connectorPermissionBaseline.kind === "invalid") {
+        return await fullRefresh("full_invalid_baseline");
+      }
+      const baseline = args.connectorPermissionBaseline.value;
       if (
-        !baselineResult.success ||
         !connectorPermissionBaselineMatchesStoredContext(
           args.storedContext,
-          baselineResult.data,
+          baseline,
         )
       ) {
         return await fullRefresh("full_invalid_baseline");
@@ -1244,7 +1291,7 @@ async function refreshClaimNetworkPolicies(args: {
       const resolution = await resolveActiveNetworkPolicyRefreshesFromBaseline(
         args.db,
         scope,
-        baselineResult.data,
+        baseline,
       );
       if (resolution.kind === "incompatible") {
         return await fullRefresh("full_incompatible_baseline");
@@ -1583,6 +1630,7 @@ async function buildClaimResponseBody(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
   readonly storedContext: StoredExecutionContext;
+  readonly connectorPermissionBaseline: ConnectorPermissionBaselineRead;
   readonly timing: ClaimRouteTimingCollector;
   readonly signal: AbortSignal;
   readonly loadIdentityRepresentation: (
@@ -1629,6 +1677,7 @@ async function buildClaimResponseBody(args: {
             db: args.db,
             run: args.run,
             storedContext: args.storedContext,
+            connectorPermissionBaseline: args.connectorPermissionBaseline,
             timing: args.timing,
           }),
         ]);
@@ -1689,6 +1738,7 @@ const buildClaimResponseBodyForClaim$ = command(
       readonly db: Db;
       readonly run: ClaimedRun;
       readonly storedContext: StoredExecutionContext;
+      readonly connectorPermissionBaseline: ConnectorPermissionBaselineRead;
       readonly timing: ClaimRouteTimingCollector;
       readonly signal: AbortSignal;
     },
@@ -1697,6 +1747,7 @@ const buildClaimResponseBodyForClaim$ = command(
       db: args.db,
       run: args.run,
       storedContext: args.storedContext,
+      connectorPermissionBaseline: args.connectorPermissionBaseline,
       timing: args.timing,
       signal: args.signal,
       loadIdentityRepresentation(hash: string) {
@@ -2115,9 +2166,10 @@ const claimAuthorizedJob$ = command(
     const run = jobWithRun.run;
 
     const contextParseStartedAt = now();
-    const storedContextResult = storedExecutionContextSchema.safeParse(
-      jobWithRun.job.executionContext,
-    );
+    const storedContextResult =
+      compatibleStoredExecutionContextSchema.safeParse(
+        jobWithRun.job.executionContext,
+      );
     claimRouteTiming.recordElapsed(
       "claim_route_context_parse",
       "top_level",
@@ -2140,13 +2192,15 @@ const claimAuthorizedJob$ = command(
         },
       });
     }
-    const storedContext = storedContextResult.data;
+    const { context: storedContext, connectorPermissionBaseline } =
+      decodeCompatibleStoredExecutionContext(storedContextResult.data);
 
     const responseBodyResult = await settle(
       set(buildClaimResponseBodyForClaim$, {
         db,
         run,
         storedContext,
+        connectorPermissionBaseline,
         timing: claimRouteTiming,
         signal,
       }),

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -7,6 +7,7 @@ import {
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
+  storedConnectorPermissionBaselineSchema,
   storedExecutionContextSchema,
   type ExecutionContext,
   type HeldSessionState,
@@ -70,6 +71,7 @@ import {
   mergeNetworkPolicyRefreshes,
   networkPolicyRefreshConnectorRefs,
   resolveActiveNetworkPolicyRefreshes,
+  resolveActiveNetworkPolicyRefreshesFromBaseline,
 } from "../services/zero-user-permission-grants.service";
 import {
   type CompressedSessionHistoryBlobEncoding,
@@ -142,6 +144,12 @@ function isResumeSessionHistoryLoadError(
 }
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
+type ClaimNetworkPolicyRefreshPath =
+  | "baseline"
+  | "baseline_empty"
+  | "full_missing_baseline"
+  | "full_invalid_baseline"
+  | "full_incompatible_baseline";
 type ClaimRouteTimingActionType =
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
@@ -159,6 +167,7 @@ interface ClaimRouteTimingRecord {
   readonly durationMs: number;
   readonly timestamp: string;
   readonly fallbackReason?: "invalid_keys";
+  readonly policyRefreshPath?: ClaimNetworkPolicyRefreshPath;
 }
 
 class ClaimRouteTimingCollector {
@@ -205,6 +214,28 @@ class ClaimRouteTimingCollector {
     });
   }
 
+  async measureNetworkPolicyRefresh<T>(
+    operation: () => Promise<{
+      readonly value: T;
+      readonly path: ClaimNetworkPolicyRefreshPath;
+    }>,
+  ): Promise<T> {
+    const startedAt = now();
+    const result = await settle(operation());
+    const finishedAt = now();
+    this.records.push({
+      actionType: "claim_route_response_network_policy_refresh",
+      spanKind: "nested",
+      durationMs: Math.max(0, finishedAt - startedAt),
+      timestamp: new Date(finishedAt).toISOString(),
+      ...(result.ok ? { policyRefreshPath: result.value.path } : {}),
+    });
+    if (!result.ok) {
+      throw result.error;
+    }
+    return result.value.value;
+  }
+
   flush(args: {
     readonly runId: string;
     readonly runnerGroup: string;
@@ -240,6 +271,9 @@ class ClaimRouteTimingCollector {
             span_kind: record.spanKind,
             ...(record.fallbackReason
               ? { fallback_reason: record.fallbackReason }
+              : {}),
+            ...(record.policyRefreshPath
+              ? { policy_refresh_path: record.policyRefreshPath }
               : {}),
           },
         };
@@ -1127,50 +1161,92 @@ async function refreshClaimNetworkPolicies(args: {
 }): Promise<
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
 > {
-  const networkPolicyConnectorRefs = Object.keys(
-    args.storedContext.networkPolicies ?? {},
-  );
+  const storedNetworkPolicies = args.storedContext.networkPolicies ?? {};
+  const networkPolicyConnectorRefs = Object.keys(storedNetworkPolicies);
   if (networkPolicyConnectorRefs.length === 0) {
     return {
       networkPolicies: args.storedContext.networkPolicies,
       networkPolicyRefreshes: undefined,
     };
   }
-  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(args.db);
-  const connectorRefs = networkPolicyRefreshConnectorRefs(
-    connectorCatalogSnapshot.serverFirewalls,
-    networkPolicyConnectorRefs,
-  );
-  if (connectorRefs.length === 0) {
-    return {
-      networkPolicies: args.storedContext.networkPolicies,
-      networkPolicyRefreshes: undefined,
-    };
-  }
 
-  return await args.timing.measure(
-    "claim_route_response_network_policy_refresh",
-    "nested",
-    async () => {
-      const refreshes = await resolveActiveNetworkPolicyRefreshes(
+  return await args.timing.measureNetworkPolicyRefresh(async () => {
+    const scope = {
+      orgId: args.run.orgId,
+      userId: args.run.userId,
+      agentId: args.run.agentId,
+    };
+    const fullRefresh = async (
+      path: Extract<ClaimNetworkPolicyRefreshPath, `full_${string}`>,
+    ) => {
+      const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(
         args.db,
-        {
-          orgId: args.run.orgId,
-          userId: args.run.userId,
-          agentId: args.run.agentId,
-        },
-        connectorRefs,
-        connectorCatalogSnapshot,
       );
+      const connectorRefs = networkPolicyRefreshConnectorRefs(
+        connectorCatalogSnapshot.serverFirewalls,
+        networkPolicyConnectorRefs,
+      );
+      const refreshes =
+        connectorRefs.length === 0
+          ? []
+          : await resolveActiveNetworkPolicyRefreshes(
+              args.db,
+              scope,
+              connectorRefs,
+              connectorCatalogSnapshot,
+            );
+      return { refreshes, path };
+    };
+
+    const selectRefresh = async () => {
+      if (args.storedContext.connectorPermissionBaseline === undefined) {
+        return await fullRefresh("full_missing_baseline");
+      }
+      const baselineResult = storedConnectorPermissionBaselineSchema.safeParse(
+        args.storedContext.connectorPermissionBaseline,
+      );
+      if (
+        !baselineResult.success ||
+        Object.keys(baselineResult.data.connectors).some((connectorRef) => {
+          return !(connectorRef in storedNetworkPolicies);
+        })
+      ) {
+        return await fullRefresh("full_invalid_baseline");
+      }
+      const resolution = await resolveActiveNetworkPolicyRefreshesFromBaseline(
+        args.db,
+        scope,
+        baselineResult.data,
+      );
+      if (resolution.kind === "incompatible") {
+        return await fullRefresh("full_incompatible_baseline");
+      }
+      if (resolution.kind === "empty") {
+        return {
+          refreshes: resolution.refreshes,
+          path: "baseline_empty" as const,
+        };
+      }
       return {
-        networkPolicies: mergeNetworkPolicyRefreshes(
-          args.storedContext.networkPolicies,
-          refreshes,
-        ),
-        networkPolicyRefreshes: networkPolicyRefreshesRecord(refreshes),
+        refreshes: resolution.refreshes,
+        path: "baseline" as const,
       };
-    },
-  );
+    };
+    const selected = await selectRefresh();
+
+    return {
+      value: {
+        networkPolicies: mergeNetworkPolicyRefreshes(
+          storedNetworkPolicies,
+          selected.refreshes,
+        ),
+        networkPolicyRefreshes: networkPolicyRefreshesRecord(
+          selected.refreshes,
+        ),
+      },
+      path: selected.path,
+    };
+  });
 }
 
 type StoredResumeSessionWithHistoryRef = Extract<
@@ -1546,6 +1622,7 @@ async function buildClaimResponseBody(args: {
       const refreshedPolicies = refreshedPoliciesResult.value;
       args.signal.throwIfAborted();
       const {
+        connectorPermissionBaseline: _connectorPermissionBaseline,
         secretValueEnvironmentKeys: _secretValueEnvironmentKeys,
         storageManifest: _legacyStorageManifest,
         storageMounts: _storedStorageMounts,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   elapsedSinceApiStartMs,
   RESUME_SESSION_HISTORY_MAX_BYTES,
@@ -12,6 +13,7 @@ import {
   type ExecutionContext,
   type HeldSessionState,
   type SessionHistoryDownloadSource,
+  type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
@@ -1153,6 +1155,31 @@ async function secretValuesForRunner(
   });
 }
 
+function connectorPermissionBaselineMatchesStoredContext(
+  storedContext: StoredExecutionContext,
+  baseline: StoredConnectorPermissionBaseline,
+): boolean {
+  const baselineConnectorRefs = Object.keys(baseline.connectors);
+  const storedBuiltinConnectorRefs = new Set(
+    (storedContext.firewalls ?? []).flatMap((firewall) => {
+      return firewall.kind === "builtin" &&
+        connectorRefSchema.safeParse(firewall.name).success
+        ? [firewall.name]
+        : [];
+    }),
+  );
+  const storedNetworkPolicies = storedContext.networkPolicies ?? {};
+  return (
+    baselineConnectorRefs.length === storedBuiltinConnectorRefs.size &&
+    baselineConnectorRefs.every((connectorRef) => {
+      return (
+        storedBuiltinConnectorRefs.has(connectorRef) &&
+        Object.hasOwn(storedNetworkPolicies, connectorRef)
+      );
+    })
+  );
+}
+
 async function refreshClaimNetworkPolicies(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
@@ -1207,9 +1234,10 @@ async function refreshClaimNetworkPolicies(args: {
       );
       if (
         !baselineResult.success ||
-        Object.keys(baselineResult.data.connectors).some((connectorRef) => {
-          return !Object.hasOwn(storedNetworkPolicies, connectorRef);
-        })
+        !connectorPermissionBaselineMatchesStoredContext(
+          args.storedContext,
+          baselineResult.data,
+        )
       ) {
         return await fullRefresh("full_invalid_baseline");
       }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1208,7 +1208,7 @@ async function refreshClaimNetworkPolicies(args: {
       if (
         !baselineResult.success ||
         Object.keys(baselineResult.data.connectors).some((connectorRef) => {
-          return !(connectorRef in storedNetworkPolicies);
+          return !Object.hasOwn(storedNetworkPolicies, connectorRef);
         })
       ) {
         return await fullRefresh("full_invalid_baseline");

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -387,7 +387,7 @@ async function mutateRunnerJobConnectorPermissionBaseline(
     case "inconsistent": {
       executionContext = sql`jsonb_set(
         ${runnerJobQueue.executionContext},
-        '{connectorPermissionBaseline,connectors,github}',
+        '{connectorPermissionBaseline,connectors,constructor}',
         '{
           "permissionNames": [],
           "defaultPolicy": {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -399,6 +399,15 @@ async function mutateRunnerJobConnectorPermissionBaseline(
       )`;
       break;
     }
+    case "incomplete": {
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline,connectors}',
+        '{}'::jsonb,
+        true
+      )`;
+      break;
+    }
   }
   const [updated] = await db
     .update(runnerJobQueue)

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -14,7 +14,7 @@ import {
   testRuntimeStateContract,
   type TestRuntimeStateActionBody,
 } from "@vm0/api-contracts/contracts/test-runtime-state";
-import { storedExecutionContextSchema } from "@vm0/api-contracts/contracts/runners";
+import { compatibleStoredExecutionContextSchema } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -499,7 +499,7 @@ async function readRunnerJobStorageState(
   const rawContext = z
     .record(z.string(), z.unknown())
     .parse(job.executionContext);
-  const context = storedExecutionContextSchema.parse(rawContext);
+  const context = compatibleStoredExecutionContextSchema.parse(rawContext);
   let legacyManifestState: "missing" | "null" | "object";
   if (!Object.hasOwn(rawContext, "storageManifest")) {
     legacyManifestState = "missing";

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -28,7 +28,7 @@ import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -339,6 +339,76 @@ async function mutateRunnerJobSecretValueEnvironmentKeys(
     .set({ executionContext })
     .where(eq(runnerJobQueue.runId, runId));
   signal.throwIfAborted();
+}
+
+type ConnectorPermissionBaselineMutationAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "mutate-runner-job-connector-permission-baseline" }
+>;
+
+async function mutateRunnerJobConnectorPermissionBaseline(
+  db: Db,
+  body: ConnectorPermissionBaselineMutationAction,
+  signal: AbortSignal,
+): Promise<void> {
+  let executionContext: SQL;
+  switch (body.mode) {
+    case "remove": {
+      executionContext = sql`${runnerJobQueue.executionContext} - 'connectorPermissionBaseline'`;
+      break;
+    }
+    case "malformed": {
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline}',
+        '{"version":2}'::jsonb,
+        true
+      )`;
+      break;
+    }
+    case "catalog-mismatch": {
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline,catalogIdentity,catalogDigest}',
+        '"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"'::jsonb,
+        true
+      )`;
+      break;
+    }
+    case "authority-mismatch": {
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline,validationAuthority,backendVersion}',
+        '"999.0.0"'::jsonb,
+        true
+      )`;
+      break;
+    }
+    case "inconsistent": {
+      executionContext = sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorPermissionBaseline,connectors,github}',
+        '{
+          "permissionNames": [],
+          "defaultPolicy": {
+            "permissionDefault": "allow",
+            "unknownPolicy": "allow"
+          }
+        }'::jsonb,
+        true
+      )`;
+      break;
+    }
+  }
+  const [updated] = await db
+    .update(runnerJobQueue)
+    .set({ executionContext })
+    .where(eq(runnerJobQueue.runId, body.run_id))
+    .returning({ runId: runnerJobQueue.runId });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected a runner job permission baseline");
+  }
 }
 
 async function removeRunCanonicalStorageState(
@@ -752,7 +822,8 @@ type CompatibilityFixtureAction =
   | LegacyArtifactCatalogFileAction
   | PreviousApiComputerAccessAction
   | PreviousApiRunnerJobContextProfileAction
-  | PreviousApiBrowserProfileAction;
+  | PreviousApiBrowserProfileAction
+  | ConnectorPermissionBaselineMutationAction;
 
 function isCompatibilityFixtureAction(
   body: TestRuntimeStateActionBody,
@@ -762,6 +833,7 @@ function isCompatibilityFixtureAction(
     "set-computer-use-host-as-previous-api",
     "set-runner-job-context-profile-as-previous-api",
     "read-browser-profile-as-previous-api",
+    "mutate-runner-job-connector-permission-baseline",
   ].includes(body.action);
 }
 
@@ -782,6 +854,10 @@ async function compatibilityFixtureActionResponse(
     }
     case "read-browser-profile-as-previous-api": {
       return await readBrowserProfileAsPreviousApi(db, body, signal);
+    }
+    case "mutate-runner-job-connector-permission-baseline": {
+      await mutateRunnerJobConnectorPermissionBaseline(db, body, signal);
+      return { status: 200 as const, body: { ok: true as const } };
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PROFILE,
   type ArtifactEntry,
   type SecretConnectorMetadata,
+  type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
@@ -183,6 +184,7 @@ import {
   defaultFirewallPolicyForPermissionIndex,
   networkPolicyForFirewallPolicy,
 } from "./firewall-network-policy.service";
+import { currentConnectorCatalogValidatorIdentity } from "./connector-catalog-validator-authority";
 import { logger } from "../../lib/log";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
@@ -603,6 +605,7 @@ interface ResolvedModelProviderEnvironment {
 interface PermissionManifest {
   readonly firewalls: ExecutionFirewalls;
   readonly networkPolicies: NetworkPolicies;
+  readonly connectorPermissionBaseline?: StoredConnectorPermissionBaseline;
   readonly environmentSecretPlaceholders:
     | Readonly<Record<string, string>>
     | undefined;
@@ -3819,6 +3822,52 @@ interface BuiltinConnectorManifestSource {
   readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
 }
 
+function buildConnectorPermissionBaseline(
+  snapshot: ConnectorRuntimeSnapshot,
+  sources: readonly BuiltinConnectorManifestSource[],
+): StoredConnectorPermissionBaseline {
+  const validationAuthority = currentConnectorCatalogValidatorIdentity();
+  return {
+    version: 1,
+    catalogIdentity: snapshot.acceptedSnapshot.identity,
+    validationAuthority: {
+      backendVersion: validationAuthority.backendVersion,
+      buildCommitSha: validationAuthority.buildCommitSha,
+    },
+    connectors: Object.fromEntries(
+      sources.map((source) => {
+        const defaultPolicy = source.permissionIndex.defaultPolicy;
+        const permissionOverrides = defaultPolicy.permissionOverrides;
+        return [
+          source.metadata.connectorRef,
+          {
+            permissionNames: [...source.permissionIndex.permissionNames],
+            defaultPolicy: {
+              permissionDefault: defaultPolicy.permissionDefault,
+              ...(permissionOverrides
+                ? {
+                    permissionOverrides: {
+                      ...(permissionOverrides.allow
+                        ? { allow: [...permissionOverrides.allow] }
+                        : {}),
+                      ...(permissionOverrides.deny
+                        ? { deny: [...permissionOverrides.deny] }
+                        : {}),
+                      ...(permissionOverrides.ask
+                        ? { ask: [...permissionOverrides.ask] }
+                        : {}),
+                    },
+                  }
+                : {}),
+              unknownPolicy: defaultPolicy.unknownPolicy,
+            },
+          },
+        ];
+      }),
+    ),
+  };
+}
+
 function applyBuiltinConnectorMetadataPolicies(
   sources: readonly BuiltinConnectorManifestSource[],
   policies: FirewallPolicies | undefined,
@@ -3967,6 +4016,10 @@ async function buildPermissionManifest(args: {
 
       return Promise.resolve({
         firewalls,
+        connectorPermissionBaseline: buildConnectorPermissionBaseline(
+          args.connectorCatalogSnapshot,
+          builtinSources,
+        ),
         environmentSecretPlaceholders: mergeRecords(
           providerManifest?.environmentSecretPlaceholders,
           connectorManifest.environmentSecretPlaceholders,
@@ -4754,6 +4807,7 @@ async function buildStoredExecutionContextDraft(args: {
       userTimezone: args.userTimezone,
       firewalls: permissions?.firewalls,
       networkPolicies: permissions?.networkPolicies,
+      connectorPermissionBaseline: permissions?.connectorPermissionBaseline,
       disallowedTools: args.body.disallowedTools,
       tools: args.body.tools,
       settings: args.body.settings,

--- a/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
@@ -1,5 +1,6 @@
 import {
-  storedExecutionContextSchema,
+  compatibleStoredExecutionContextSchema,
+  type CompatibleStoredExecutionContext,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
@@ -19,7 +20,7 @@ const queuedRunnerJobPayloadWireSchema = z.object({
   // Wire/backing payload compatibility field. Semantically this is the
   // Claude/Codex CLI agent session id used for runner sandbox reuse affinity.
   sessionId: z.string().nullable(),
-  executionContext: storedExecutionContextSchema,
+  executionContext: compatibleStoredExecutionContextSchema,
 });
 
 interface QueuedRunnerJobPayload {
@@ -31,8 +32,15 @@ interface QueuedRunnerJobPayload {
   readonly executionContext: StoredExecutionContext;
 }
 
+interface CompatibleQueuedRunnerJobPayload extends Omit<
+  QueuedRunnerJobPayload,
+  "executionContext"
+> {
+  readonly executionContext: CompatibleStoredExecutionContext;
+}
+
 function historyGenerationRunId(
-  executionContext: StoredExecutionContext,
+  executionContext: Pick<StoredExecutionContext, "resumeSession">,
 ): string | undefined {
   const resumeSession = executionContext.resumeSession;
   return resumeSession && "historyRef" in resumeSession
@@ -65,7 +73,7 @@ export async function encryptQueuedRunnerJobPayload(
 export async function decryptQueuedRunnerJobPayload(
   encryptedParams: string | null,
   ctx: FeatureSwitchContext = {},
-): Promise<QueuedRunnerJobPayload | null> {
+): Promise<CompatibleQueuedRunnerJobPayload | null> {
   if (!encryptedParams) {
     return null;
   }

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -1,13 +1,23 @@
 import { command } from "ccstate";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
+import type { StoredConnectorPermissionBaseline } from "@vm0/api-contracts/contracts/runners";
+import {
+  createFirewallMetadataPolicyResolver,
+  permissionGrantsToFirewallPolicies,
+  type FirewallPermissionPolicyDefaultMetadata,
+} from "@vm0/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicies,
   type FirewallPolicy,
+  type FirewallPolicyValue,
   type NetworkPolicies,
   type NetworkPolicy,
 } from "@vm0/connectors/firewall-types";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
+import {
+  connectorCatalogActiveSnapshot,
+  connectorCatalogCompatibilityEvaluation,
+} from "@vm0/db/schema/connector-catalog";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -35,18 +45,26 @@ import {
   publishNetworkPolicyRefreshToRunnerGroup,
 } from "../external/realtime";
 import { nowDate } from "../external/time";
-import {
-  defaultFirewallPolicyForPermissionIndex,
-  networkPolicyForFirewallPolicy,
-} from "./firewall-network-policy.service";
+import { networkPolicyForFirewallPolicy } from "./firewall-network-policy.service";
 import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 import type { ConnectorServerFirewallCatalog } from "./connector-server-firewall-catalog.service";
+import { connectorCatalogSource } from "./connector-catalog-source";
+import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
+import { SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION } from "./connector-catalog-artifacts/artifacts";
+import {
+  connectorCatalogValidationAuthorityIsCurrent,
+  currentConnectorCatalogValidatorIdentity,
+} from "./connector-catalog-validator-authority";
 
 type UserPermissionGrantRow = typeof userPermissionGrants.$inferSelect;
 type StoredPermissionGrantRow = UserPermissionGrantRow;
+type ResolvedPermissionGrant = Pick<
+  UserPermissionGrantRow,
+  "connectorRef" | "permission" | "action" | "expiresAt"
+>;
 type UserPermissionGrantAction = UserPermissionGrantResponse["action"];
 
 interface ActiveNetworkPolicyRefresh {
@@ -54,6 +72,23 @@ interface ActiveNetworkPolicyRefresh {
   readonly networkPolicy: NetworkPolicy;
   readonly nextRefreshAt: string | null;
 }
+
+interface ConnectorPermissionPolicyBaseline {
+  readonly connectorRef: string;
+  readonly permissionNames: readonly string[];
+  readonly defaultPolicy: FirewallPermissionPolicyDefaultMetadata;
+}
+
+type BaselineNetworkPolicyRefreshResolution =
+  | {
+      readonly kind: "compatible";
+      readonly refreshes: readonly ActiveNetworkPolicyRefresh[];
+    }
+  | {
+      readonly kind: "empty";
+      readonly refreshes: readonly ActiveNetworkPolicyRefresh[];
+    }
+  | { readonly kind: "incompatible" };
 
 interface UserPermissionGrantBaseScope {
   readonly orgId: string;
@@ -234,7 +269,7 @@ function resolvedExpiresAt({
 }
 
 function earliestTemporaryAllowExpiresAt(
-  grants: readonly StoredPermissionGrantRow[],
+  grants: readonly ResolvedPermissionGrant[],
   connectorRef: string,
 ): Date | null {
   let earliest: Date | null = null;
@@ -254,7 +289,7 @@ function earliestTemporaryAllowExpiresAt(
 }
 
 function resolvedConnectorFirewallPolicies(
-  grants: readonly StoredPermissionGrantRow[],
+  grants: readonly ResolvedPermissionGrant[],
 ): FirewallPolicies {
   return permissionGrantsToFirewallPolicies(grants) ?? {};
 }
@@ -299,8 +334,6 @@ export async function resolveActiveNetworkPolicyRefreshes(
     uniqueConnectorRefs,
     checkedAt,
   );
-  const policies = resolvedConnectorFirewallPolicies(grants);
-
   const indexes = await Promise.all(
     uniqueConnectorRefs.map(async (connectorRef) => {
       return {
@@ -310,13 +343,89 @@ export async function resolveActiveNetworkPolicyRefreshes(
     }),
   );
 
-  const refreshes: ActiveNetworkPolicyRefresh[] = [];
-  for (const { connectorRef, index } of indexes) {
-    if (!index) {
-      continue;
-    }
+  return activeNetworkPolicyRefreshesForPermissionBaselines(
+    indexes.flatMap(({ connectorRef, index }) => {
+      return index
+        ? [
+            {
+              connectorRef,
+              permissionNames: [...index.permissionNames],
+              defaultPolicy: index.defaultPolicy,
+            },
+          ]
+        : [];
+    }),
+    grants,
+  );
+}
 
-    const defaultPolicy = defaultFirewallPolicyForPermissionIndex(index);
+function connectorCatalogIdentityJoin() {
+  return and(
+    eq(
+      connectorCatalogCompatibilityEvaluation.sourceId,
+      connectorCatalogActiveSnapshot.sourceId,
+    ),
+    eq(
+      connectorCatalogCompatibilityEvaluation.schemaVersion,
+      connectorCatalogActiveSnapshot.schemaVersion,
+    ),
+    eq(
+      connectorCatalogCompatibilityEvaluation.catalogVersion,
+      connectorCatalogActiveSnapshot.catalogVersion,
+    ),
+    eq(
+      connectorCatalogCompatibilityEvaluation.catalogDigest,
+      connectorCatalogActiveSnapshot.catalogDigest,
+    ),
+  );
+}
+
+function baselineStaticIdentityIsCurrent(
+  baseline: StoredConnectorPermissionBaseline,
+  current: {
+    readonly sourceId: string;
+    readonly capabilityDigest: string;
+    readonly validator: ReturnType<
+      typeof currentConnectorCatalogValidatorIdentity
+    >;
+  },
+): boolean {
+  return (
+    baseline.catalogIdentity.sourceId === current.sourceId &&
+    baseline.catalogIdentity.schemaVersion ===
+      SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION &&
+    baseline.catalogIdentity.capabilityDigest === current.capabilityDigest &&
+    connectorCatalogValidationAuthorityIsCurrent({
+      authority: baseline.validationAuthority,
+      validator: current.validator,
+    })
+  );
+}
+
+function defaultFirewallPolicyForBaseline(
+  baseline: ConnectorPermissionPolicyBaseline,
+): FirewallPolicy {
+  const resolver = createFirewallMetadataPolicyResolver({
+    defaultPolicy: baseline.defaultPolicy,
+  });
+  const policies: Record<string, FirewallPolicyValue> = {};
+  for (const permissionName of baseline.permissionNames) {
+    policies[permissionName] = resolver.permission(permissionName);
+  }
+  return {
+    policies,
+    unknownPolicy: resolver.unknown(),
+  };
+}
+
+function activeNetworkPolicyRefreshesForPermissionBaselines(
+  baselines: readonly ConnectorPermissionPolicyBaseline[],
+  grants: readonly ResolvedPermissionGrant[],
+): readonly ActiveNetworkPolicyRefresh[] {
+  const policies = resolvedConnectorFirewallPolicies(grants);
+  return baselines.map((baseline) => {
+    const defaultPolicy = defaultFirewallPolicyForBaseline(baseline);
+    const connectorRef = baseline.connectorRef;
     const overlay = policies[connectorRef];
     const policy: FirewallPolicy = overlay
       ? {
@@ -325,17 +434,109 @@ export async function resolveActiveNetworkPolicyRefreshes(
         }
       : defaultPolicy;
     const nextRefreshAt = earliestTemporaryAllowExpiresAt(grants, connectorRef);
-    refreshes.push({
+    return {
       connectorRef,
       networkPolicy: networkPolicyForFirewallPolicy(
-        [...index.permissionNames],
+        baseline.permissionNames,
         policy,
       ),
       nextRefreshAt: nextRefreshAt?.toISOString() ?? null,
-    });
+    };
+  });
+}
+
+export async function resolveActiveNetworkPolicyRefreshesFromBaseline(
+  db: ReadonlyDb,
+  scope: UserPermissionGrantScope,
+  baseline: StoredConnectorPermissionBaseline,
+  checkedAt: Date = nowDate(),
+): Promise<BaselineNetworkPolicyRefreshResolution> {
+  const connectorRefs = Object.keys(baseline.connectors);
+  if (connectorRefs.length === 0) {
+    return { kind: "empty", refreshes: [] };
+  }
+  const current = {
+    sourceId: connectorCatalogSource().sourceId,
+    capabilityDigest: connectorCatalogExecutableCapabilityDigest(),
+    validator: currentConnectorCatalogValidatorIdentity(),
+  };
+  if (!baselineStaticIdentityIsCurrent(baseline, current)) {
+    return { kind: "incompatible" };
   }
 
-  return refreshes;
+  const rows = await db
+    .select({
+      identity: {
+        schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
+        catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
+        catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
+      },
+      grant: {
+        connectorRef: userPermissionGrants.connectorRef,
+        permission: userPermissionGrants.permission,
+        action: userPermissionGrants.action,
+        expiresAt: userPermissionGrants.expiresAt,
+      },
+    })
+    .from(connectorCatalogActiveSnapshot)
+    .innerJoin(
+      connectorCatalogCompatibilityEvaluation,
+      connectorCatalogIdentityJoin(),
+    )
+    .leftJoin(
+      userPermissionGrants,
+      and(
+        eq(userPermissionGrants.orgId, scope.orgId),
+        eq(userPermissionGrants.userId, scope.userId),
+        eq(userPermissionGrants.agentId, scope.agentId),
+        inArray(userPermissionGrants.connectorRef, connectorRefs),
+        activeUserPermissionGrantCondition(checkedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(connectorCatalogActiveSnapshot.sourceId, current.sourceId),
+        eq(
+          connectorCatalogActiveSnapshot.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(
+          connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+          current.capabilityDigest,
+        ),
+      ),
+    )
+    .orderBy(
+      asc(userPermissionGrants.connectorRef),
+      asc(userPermissionGrants.permission),
+    );
+
+  const first = rows[0];
+  if (
+    first === undefined ||
+    first.identity.schemaVersion !== baseline.catalogIdentity.schemaVersion ||
+    first.identity.catalogVersion !== baseline.catalogIdentity.catalogVersion ||
+    first.identity.catalogDigest !== baseline.catalogIdentity.catalogDigest
+  ) {
+    return { kind: "incompatible" };
+  }
+
+  const grants = rows.flatMap((row): readonly ResolvedPermissionGrant[] => {
+    return row.grant === null ? [] : [row.grant];
+  });
+  return {
+    kind: "compatible",
+    refreshes: activeNetworkPolicyRefreshesForPermissionBaselines(
+      Object.entries(baseline.connectors).map(([connectorRef, entry]) => {
+        return {
+          connectorRef,
+          permissionNames: entry.permissionNames,
+          defaultPolicy: entry.defaultPolicy,
+        };
+      }),
+      grants,
+    ),
+  };
 }
 
 export function networkPolicyRefreshesRecord(

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -564,7 +564,10 @@ export function mergeNetworkPolicyRefreshes(
   }
   const merged: NetworkPolicies = { ...networkPolicies };
   for (const refresh of refreshes) {
-    if (networkPolicies && !(refresh.connectorRef in networkPolicies)) {
+    if (
+      networkPolicies &&
+      !Object.hasOwn(networkPolicies, refresh.connectorRef)
+    ) {
       continue;
     }
     merged[refresh.connectorRef] = refresh.networkPolicy;

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -3,7 +3,6 @@ import type { StoredConnectorPermissionBaseline } from "@vm0/api-contracts/contr
 import {
   createFirewallMetadataPolicyResolver,
   permissionGrantsToFirewallPolicies,
-  type FirewallPermissionPolicyDefaultMetadata,
 } from "@vm0/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -45,7 +44,10 @@ import {
   publishNetworkPolicyRefreshToRunnerGroup,
 } from "../external/realtime";
 import { nowDate } from "../external/time";
-import { networkPolicyForFirewallPolicy } from "./firewall-network-policy.service";
+import {
+  defaultFirewallPolicyForPermissionIndex,
+  networkPolicyForFirewallPolicy,
+} from "./firewall-network-policy.service";
 import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
@@ -76,7 +78,7 @@ interface ActiveNetworkPolicyRefresh {
 interface ConnectorPermissionPolicyBaseline {
   readonly connectorRef: string;
   readonly permissionNames: readonly string[];
-  readonly defaultPolicy: FirewallPermissionPolicyDefaultMetadata;
+  readonly defaultPolicy: FirewallPolicy;
 }
 
 type BaselineNetworkPolicyRefreshResolution =
@@ -350,7 +352,7 @@ export async function resolveActiveNetworkPolicyRefreshes(
             {
               connectorRef,
               permissionNames: [...index.permissionNames],
-              defaultPolicy: index.defaultPolicy,
+              defaultPolicy: defaultFirewallPolicyForPermissionIndex(index),
             },
           ]
         : [];
@@ -403,7 +405,7 @@ function baselineStaticIdentityIsCurrent(
 }
 
 function defaultFirewallPolicyForBaseline(
-  baseline: ConnectorPermissionPolicyBaseline,
+  baseline: StoredConnectorPermissionBaseline["connectors"][string],
 ): FirewallPolicy {
   const resolver = createFirewallMetadataPolicyResolver({
     defaultPolicy: baseline.defaultPolicy,
@@ -424,7 +426,7 @@ function activeNetworkPolicyRefreshesForPermissionBaselines(
 ): readonly ActiveNetworkPolicyRefresh[] {
   const policies = resolvedConnectorFirewallPolicies(grants);
   return baselines.map((baseline) => {
-    const defaultPolicy = defaultFirewallPolicyForBaseline(baseline);
+    const defaultPolicy = baseline.defaultPolicy;
     const connectorRef = baseline.connectorRef;
     const overlay = policies[connectorRef];
     const policy: FirewallPolicy = overlay
@@ -531,7 +533,7 @@ export async function resolveActiveNetworkPolicyRefreshesFromBaseline(
         return {
           connectorRef,
           permissionNames: entry.permissionNames,
-          defaultPolicy: entry.defaultPolicy,
+          defaultPolicy: defaultFirewallPolicyForBaseline(entry),
         };
       }),
       grants,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  compatibleStoredExecutionContextSchema,
   elapsedSinceApiStartMs,
   executionContextSchema,
   heartbeatBodySchema,
@@ -151,12 +152,16 @@ describe("stored connector permission baseline contract", () => {
     ).toBe(false);
   });
 
-  it("keeps malformed future metadata outside stored-context validity", () => {
+  it("isolates future metadata to the compatible persisted reader", () => {
     const futureBaseline = { version: 2, payload: "future" };
-    const parsed = storedExecutionContextSchema.parse({
+    const context = {
       ...storedContext,
       connectorPermissionBaseline: futureBaseline,
-    });
+    };
+
+    expect(storedExecutionContextSchema.safeParse(context).success).toBe(false);
+
+    const parsed = compatibleStoredExecutionContextSchema.parse(context);
 
     expect(parsed.connectorPermissionBaseline).toEqual(futureBaseline);
     expect(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -19,6 +19,7 @@ import {
   runnersPollContract,
   storageMountEntrySchema,
   storageManifestSchema,
+  storedConnectorPermissionBaselineSchema,
   storedExecutionContextSchema,
   storedResumeSessionSchema,
 } from "../runners";
@@ -30,6 +31,35 @@ function loadRunnerClaimResponseFixture(): unknown {
       "utf-8",
     ),
   );
+}
+
+function connectorPermissionBaselineFixture() {
+  return {
+    version: 1 as const,
+    catalogIdentity: {
+      sourceId: "connector-catalog",
+      schemaVersion: 1,
+      catalogVersion: "2026-07-28",
+      catalogDigest: `sha256:${"a".repeat(64)}`,
+      capabilityDigest: `sha256:${"b".repeat(64)}`,
+    },
+    validationAuthority: {
+      backendVersion: "1.337.1",
+      buildCommitSha: "c".repeat(40),
+    },
+    connectors: {
+      slack: {
+        permissionNames: ["conversations:read", "chat:write"],
+        defaultPolicy: {
+          permissionDefault: "allow" as const,
+          permissionOverrides: {
+            deny: ["chat:write"],
+          },
+          unknownPolicy: "deny" as const,
+        },
+      },
+    },
+  };
 }
 
 describe("runner claim response contract", () => {
@@ -45,6 +75,108 @@ describe("runner claim response contract", () => {
       modelUsageProvider: "fixture-model",
     });
     expect(context).not.toHaveProperty("experimentalProfile");
+  });
+
+  it("does not expose the API-only connector permission baseline", () => {
+    const fixture = executionContextSchema.parse(
+      loadRunnerClaimResponseFixture(),
+    );
+    const context = executionContextSchema.parse({
+      ...fixture,
+      connectorPermissionBaseline: connectorPermissionBaselineFixture(),
+    });
+
+    expect(context).not.toHaveProperty("connectorPermissionBaseline");
+  });
+});
+
+describe("stored connector permission baseline contract", () => {
+  const storedContext = {
+    storageMounts: [],
+    environment: null,
+    secretValueEnvironmentKeys: null,
+    resumeSession: null,
+    encryptedSecrets: null,
+    cliAgentType: "codex",
+  };
+
+  it("accepts compact versioned defaults", () => {
+    expect(
+      storedConnectorPermissionBaselineSchema.parse(
+        connectorPermissionBaselineFixture(),
+      ),
+    ).toEqual(connectorPermissionBaselineFixture());
+  });
+
+  it("rejects unsupported, overlapping, and unknown permission metadata", () => {
+    const baseline = connectorPermissionBaselineFixture();
+    expect(
+      storedConnectorPermissionBaselineSchema.safeParse({
+        ...baseline,
+        version: 2,
+      }).success,
+    ).toBe(false);
+    expect(
+      storedConnectorPermissionBaselineSchema.safeParse({
+        ...baseline,
+        connectors: {
+          slack: {
+            ...baseline.connectors.slack,
+            defaultPolicy: {
+              ...baseline.connectors.slack.defaultPolicy,
+              permissionOverrides: {
+                allow: ["chat:write"],
+                deny: ["chat:write"],
+              },
+            },
+          },
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      storedConnectorPermissionBaselineSchema.safeParse({
+        ...baseline,
+        connectors: {
+          slack: {
+            ...baseline.connectors.slack,
+            defaultPolicy: {
+              ...baseline.connectors.slack.defaultPolicy,
+              permissionOverrides: {
+                deny: ["files:write"],
+              },
+            },
+          },
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps malformed future metadata outside stored-context validity", () => {
+    const futureBaseline = { version: 2, payload: "future" };
+    const parsed = storedExecutionContextSchema.parse({
+      ...storedContext,
+      connectorPermissionBaseline: futureBaseline,
+    });
+
+    expect(parsed.connectorPermissionBaseline).toEqual(futureBaseline);
+    expect(
+      storedConnectorPermissionBaselineSchema.safeParse(
+        parsed.connectorPermissionBaseline,
+      ).success,
+    ).toBe(false);
+  });
+
+  it("allows a previous reader to ignore the new optional field", () => {
+    const previousStoredExecutionContextSchema =
+      storedExecutionContextSchema.omit({
+        connectorPermissionBaseline: true,
+      });
+    const parsed = previousStoredExecutionContextSchema.parse({
+      ...storedContext,
+      connectorPermissionBaseline: connectorPermissionBaselineFixture(),
+    });
+
+    expect(parsed).not.toHaveProperty("connectorPermissionBaseline");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import {
   executionFirewallsSchema,
+  firewallPolicyValueSchema,
   firewallSchema,
   networkPolicySchema,
   networkPoliciesSchema,
@@ -121,6 +122,90 @@ const networkPolicyRefreshesSchema = z.record(
   z.string(),
   networkPolicyRefreshSchema,
 );
+const connectorPermissionNameListSchema = z
+  .array(z.string().min(1))
+  .superRefine((names, context) => {
+    if (new Set(names).size !== names.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Connector permission names must be unique",
+      });
+    }
+  });
+const connectorPermissionDefaultOverridesSchema = z
+  .object({
+    allow: connectorPermissionNameListSchema.optional(),
+    deny: connectorPermissionNameListSchema.optional(),
+    ask: connectorPermissionNameListSchema.optional(),
+  })
+  .strict();
+const connectorPermissionBaselineEntrySchema = z
+  .object({
+    permissionNames: connectorPermissionNameListSchema,
+    defaultPolicy: z
+      .object({
+        permissionDefault: firewallPolicyValueSchema,
+        permissionOverrides:
+          connectorPermissionDefaultOverridesSchema.optional(),
+        unknownPolicy: firewallPolicyValueSchema,
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((entry, context) => {
+    const permissionNames = new Set(entry.permissionNames);
+    const overrideNames = Object.values(
+      entry.defaultPolicy.permissionOverrides ?? {},
+    ).flat();
+    if (new Set(overrideNames).size !== overrideNames.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["defaultPolicy", "permissionOverrides"],
+        message: "Connector permission overrides must not overlap",
+      });
+    }
+    for (const permissionName of overrideNames) {
+      if (!permissionNames.has(permissionName)) {
+        context.addIssue({
+          code: "custom",
+          path: ["defaultPolicy", "permissionOverrides"],
+          message: "Connector permission override must name a permission",
+        });
+      }
+    }
+  });
+const connectorCatalogDigestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+const connectorCatalogBackendVersionSchema = z
+  .string()
+  .regex(/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u);
+const connectorCatalogBuildCommitShaSchema = z
+  .string()
+  .regex(/^[a-f0-9]{40}$/u);
+
+export const storedConnectorPermissionBaselineSchema = z
+  .object({
+    version: z.literal(1),
+    catalogIdentity: z
+      .object({
+        sourceId: z.string().min(1),
+        schemaVersion: z.number().int().positive(),
+        catalogVersion: z.string().min(1),
+        catalogDigest: connectorCatalogDigestSchema,
+        capabilityDigest: connectorCatalogDigestSchema,
+      })
+      .strict(),
+    validationAuthority: z
+      .object({
+        backendVersion: connectorCatalogBackendVersionSchema,
+        buildCommitSha: connectorCatalogBuildCommitShaSchema.nullable(),
+      })
+      .strict(),
+    connectors: z.record(
+      connectorRefSchema,
+      connectorPermissionBaselineEntrySchema,
+    ),
+  })
+  .strict();
 const runnerBuiltinFirewallNameSchema = z
   .string()
   .min(1)
@@ -563,6 +648,10 @@ export const storedExecutionContextSchema = z.object({
   // Per-connector runtime network policy refresh deadlines. Used by runners to refresh
   // active sandbox policy when temporary allow grants expire.
   networkPolicyRefreshes: networkPolicyRefreshesSchema.optional(),
+  // API-only catalog-derived permission defaults for claim-time grant refresh.
+  // Kept unknown here so malformed or future versions fall back independently
+  // instead of invalidating the complete queued execution context.
+  connectorPermissionBaseline: z.unknown().optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
@@ -806,6 +895,9 @@ export type HeldSessionState = z.infer<typeof heldSessionStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;
 export type StoredExecutionContext = z.infer<
   typeof storedExecutionContextSchema
+>;
+export type StoredConnectorPermissionBaseline = z.infer<
+  typeof storedConnectorPermissionBaselineSchema
 >;
 export type NetworkPolicyRefresh = z.infer<typeof networkPolicyRefreshSchema>;
 export type RunnerBuiltinFirewallsResolveBody = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -649,9 +649,8 @@ export const storedExecutionContextSchema = z.object({
   // active sandbox policy when temporary allow grants expire.
   networkPolicyRefreshes: networkPolicyRefreshesSchema.optional(),
   // API-only catalog-derived permission defaults for claim-time grant refresh.
-  // Kept unknown here so malformed or future versions fall back independently
-  // instead of invalidating the complete queued execution context.
-  connectorPermissionBaseline: z.unknown().optional(),
+  connectorPermissionBaseline:
+    storedConnectorPermissionBaselineSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
@@ -670,6 +669,17 @@ export const storedExecutionContextSchema = z.object({
     .nullable()
     .optional(),
 });
+
+/**
+ * Tolerant reader for execution contexts already persisted in a database or
+ * encrypted queue payload. The optional baseline is derived performance data,
+ * so malformed or future versions must remain an independent cache miss rather
+ * than invalidating the complete queued execution context.
+ */
+export const compatibleStoredExecutionContextSchema =
+  storedExecutionContextSchema.extend({
+    connectorPermissionBaseline: z.unknown().optional(),
+  });
 
 /**
  * Execution context returned when claiming a job.
@@ -895,6 +905,9 @@ export type HeldSessionState = z.infer<typeof heldSessionStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;
 export type StoredExecutionContext = z.infer<
   typeof storedExecutionContextSchema
+>;
+export type CompatibleStoredExecutionContext = z.infer<
+  typeof compatibleStoredExecutionContextSchema
 >;
 export type StoredConnectorPermissionBaseline = z.infer<
   typeof storedConnectorPermissionBaselineSchema

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -42,6 +42,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
       "catalog-mismatch",
       "authority-mismatch",
       "inconsistent",
+      "incomplete",
     ]),
   }),
   z.object({

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -34,6 +34,17 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     mode: z.enum(["remove", "invalid"]),
   }),
   z.object({
+    action: z.literal("mutate-runner-job-connector-permission-baseline"),
+    run_id: z.uuid(),
+    mode: z.enum([
+      "remove",
+      "malformed",
+      "catalog-mismatch",
+      "authority-mismatch",
+      "inconsistent",
+    ]),
+  }),
+  z.object({
     action: z.literal("remove-run-canonical-storage-state"),
     run_id: z.uuid(),
   }),


### PR DESCRIPTION
## Summary

- persist a compact, versioned, API-only connector permission baseline while run creation already has the accepted catalog metadata
- recompute claim-time policies from fresh grants and the current catalog identity in one database statement, without loading or materializing the complete catalog on the compatible path
- retain the existing full-catalog resolver for old, malformed, inconsistent, or incompatible queued contexts
- strip the baseline from the runner response and emit a fixed `policy_refresh_path` timing dimension

Closes #23545
Context: #21674

## Correctness and compatibility

- Claim-time grant creation, replacement, deletion, and expiration semantics remain authoritative.
- Database failures still propagate; only explicit compatibility failures use the full resolver.
- Current writers use the strict, versioned permission-baseline schema and type.
- Database and encrypted-queue readers accept the optional baseline as raw compatibility data, immediately classify it as missing, invalid, or valid, and expose only valid data to the typed claim path. Future or malformed optimization metadata therefore remains an independent cache miss instead of invalidating the queued job.
- Old writers fall back in new claimers, and old claimers ignore the new field.
- The runner-facing execution-context schema is unchanged.
- No database schema, migration, backfill, cleanup job, or runner/Rust protocol change is included.

## Expected performance

The compatible warm path removes one sequential database round trip. The compatible cold path additionally removes the complete catalog payload fetch, decompression, validation, and runtime materialization.

Current evidence estimates approximately 60–90 ms for a typical affected cold claim and 100–150 ms for slower examples. At the observed cold rate, the cold-work contribution is approximately 7–10 ms across all claims before connector incidence and unrelated stages dilute the end-to-end result.

Synthetic serialized baseline sizes, using production-shaped identities and Slack-like permission metadata:

| Shape | Baseline JSON |
| --- | ---: |
| no built-in connector | 441 B |
| 1 connector | 733 B |
| 5 connectors | 1,935 B |
| 16 connectors | 5,230 B |
| conservative 256-connector projection | 77,386 B |

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `pnpm -F @vm0/api-contracts test` — 21 files, 494 tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` — 125 tests
- pre-commit full-repository Knip and TypeScript check-types

The pre-rebase full Turbo Vitest run completed 7,362 tests successfully and reported three unrelated local-state failures: one queue timing assertion passed immediately in isolation, while two Strapi cases stopped before this change's paths because the fixed test organization retained an older random Stripe customer binding in the persistent local database. The scoped suites above passed again after rebasing onto the latest `main` and after the stored-context type-boundary fix.

## Merge gate

Do not merge until #23545 records at least 50 current-release cold claims on the pre-change path and completes the required production evidence review. Post-deployment path coverage, timing, correctness, errors, and stored-context size will also be reported on #23545.
