### PR TITLE
fix: trigger api platform and runner releases

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,4 +1,4 @@
-// Trigger another runner release on 2026-07-26.
+// Trigger another runner release on 2026-07-28.
 mod active_input;
 mod axiom_layer;
 mod ca;

--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-26)
+// (no-op API release marker refreshed again on 2026-07-28)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -11,7 +11,7 @@ import { setLogErrorHandler } from "./signals/log.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
-// (no-op Platform release marker refreshed again on 2026-07-26)
+// (no-op Platform release marker refreshed again on 2026-07-28)
 
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();


### PR DESCRIPTION
## Summary

- refresh the API and Platform no-op release markers
- refresh the Runner release marker
- trigger release-please component releases without changing runtime behavior

## Validation

- `cargo fmt --package runner -- --check`
- `pnpm exec prettier --check apps/api/src/index.ts apps/platform/src/main.ts`
- pre-commit hooks: file-size check, Prettier, Cargo fmt, Clippy, Rust docs, Knip, and TypeScript type checks

## Exclusions

- no release workflow or runtime behavior changes
