### PR TITLE
fix(ci): align ansible ssh control path

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -64,6 +64,12 @@ runs:
         echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
         chmod 600 "$HOME/.ssh/runner.pem"
 
+        # Ansible expands ~ from the system account rather than the HOME
+        # provided by GitHub container jobs. Point it at the shared master
+        # socket created below so both clients use the same connection.
+        printf 'ANSIBLE_SSH_CONTROL_PATH=%s\n' \
+          "$HOME/.ssh/vm0-ssh-%%C" >> "$GITHUB_ENV"
+
         # Store credentials in a restricted file sourced by the proxy script,
         # so they don't appear in SSH config or process listings.
         printf 'export CF_ACCESS_CLIENT_ID="%s"\nexport CF_ACCESS_CLIENT_SECRET="%s"\n' \

--- a/.github/scripts/tests/ansible-ssh-control-path-test.sh
+++ b/.github/scripts/tests/ansible-ssh-control-path-test.sh
@@ -4,16 +4,12 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../../.." && pwd)"
 ansible_config="$repo_root/ansible/ansible.cfg"
+playbook="$script_dir/fixtures/ansible-ssh-control-path.yml"
 
 if ! command -v ansible-playbook >/dev/null; then
   echo "ansible-playbook is required" >&2
   exit 1
 fi
-
-for playbook in "$repo_root"/ansible/playbooks/*.yml; do
-  ANSIBLE_CONFIG="$ansible_config" \
-    ansible-playbook -i "localhost," --syntax-check "$playbook" >/dev/null
-done
 
 tmp="$(mktemp -d)"
 cleanup() {
@@ -56,18 +52,6 @@ touch "$SSH_MARKER"
 printf 'ansible ssh transport ok\n'
 EOF
 chmod +x "$fake_ssh"
-
-playbook="$tmp/control-path.yml"
-cat > "$playbook" <<'EOF'
----
-- name: Exercise the Ansible SSH connection plugin
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Run a command through SSH
-      ansible.builtin.raw: printf 'remote command ok\n'
-      changed_when: false
-EOF
 
 expected_control_path="$test_home/.ssh/vm0-ssh-%C"
 ssh_marker="$tmp/ssh-ran"

--- a/.github/scripts/tests/ansible-ssh-control-path-test.sh
+++ b/.github/scripts/tests/ansible-ssh-control-path-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+ansible_config="$repo_root/ansible/ansible.cfg"
+
+if ! command -v ansible-playbook >/dev/null; then
+  echo "ansible-playbook is required" >&2
+  exit 1
+fi
+
+for playbook in "$repo_root"/ansible/playbooks/*.yml; do
+  ANSIBLE_CONFIG="$ansible_config" \
+    ansible-playbook -i "localhost," --syntax-check "$playbook" >/dev/null
+done
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+test_home="$tmp/github-home"
+mkdir -p "$test_home/.ssh"
+
+fake_ssh="$tmp/ssh"
+cat > "$fake_ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_argument="ControlPath=\"${EXPECTED_CONTROL_PATH}\""
+found_control_path=false
+
+for argument in "$@"; do
+  if [ "$argument" = "$expected_argument" ]; then
+    found_control_path=true
+    break
+  fi
+done
+
+if [ "$found_control_path" != true ]; then
+  echo "expected Ansible SSH arguments to contain ${expected_argument}" >&2
+  printf 'argument: %s\n' "$@" >&2
+  exit 1
+fi
+
+if [ ! -d "$(dirname "$EXPECTED_CONTROL_PATH")" ]; then
+  echo "Ansible SSH control path parent does not exist" >&2
+  exit 1
+fi
+
+touch "$SSH_MARKER"
+printf 'ansible ssh transport ok\n'
+EOF
+chmod +x "$fake_ssh"
+
+playbook="$tmp/control-path.yml"
+cat > "$playbook" <<'EOF'
+---
+- name: Exercise the Ansible SSH connection plugin
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run a command through SSH
+      ansible.builtin.raw: printf 'remote command ok\n'
+      changed_when: false
+EOF
+
+expected_control_path="$test_home/.ssh/vm0-ssh-%C"
+ssh_marker="$tmp/ssh-ran"
+HOME="$test_home" \
+  ANSIBLE_CONFIG="$ansible_config" \
+  ANSIBLE_NOCOLOR=1 \
+  ANSIBLE_SSH_CONTROL_PATH="$test_home/.ssh/vm0-ssh-%%C" \
+  EXPECTED_CONTROL_PATH="$expected_control_path" \
+  SSH_MARKER="$ssh_marker" \
+  ansible-playbook \
+    -i "ansible-test.invalid," \
+    -e "ansible_ssh_executable=$fake_ssh" \
+    "$playbook" >/dev/null
+
+if [ ! -f "$ssh_marker" ]; then
+  echo "expected Ansible to complete an SSH-backed task" >&2
+  exit 1
+fi
+
+echo "ansible-ssh-control-path-test: ok"

--- a/.github/scripts/tests/ansible-ssh-control-path-test.sh
+++ b/.github/scripts/tests/ansible-ssh-control-path-test.sh
@@ -29,18 +29,20 @@ cat > "$fake_ssh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-expected_argument="ControlPath=\"${EXPECTED_CONTROL_PATH}\""
-found_control_path=false
+actual_control_path=""
 
 for argument in "$@"; do
-  if [ "$argument" = "$expected_argument" ]; then
-    found_control_path=true
+  if [[ "$argument" == ControlPath=* ]]; then
+    actual_control_path="${argument#ControlPath=}"
+    actual_control_path="${actual_control_path#\"}"
+    actual_control_path="${actual_control_path%\"}"
     break
   fi
 done
 
-if [ "$found_control_path" != true ]; then
-  echo "expected Ansible SSH arguments to contain ${expected_argument}" >&2
+if [ "$actual_control_path" != "$EXPECTED_CONTROL_PATH" ]; then
+  echo "expected Ansible SSH control path: ${EXPECTED_CONTROL_PATH}" >&2
+  echo "actual Ansible SSH control path: ${actual_control_path:-missing}" >&2
   printf 'argument: %s\n' "$@" >&2
   exit 1
 fi

--- a/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-preconnect-test.sh
@@ -275,6 +275,8 @@ fi
 assert_runner_temp_empty "$tmp/multiple/runner-temp"
 
 assert_contains "$SSH_ACTION" "ControlPath \$HOME/.ssh/vm0-ssh-%C"
+assert_contains "$SSH_ACTION" "ANSIBLE_SSH_CONTROL_PATH=%s"
+assert_contains "$SSH_ACTION" "\$HOME/.ssh/vm0-ssh-%%C"
 assert_contains "$SSH_ACTION" "ServerAliveInterval 15"
 assert_contains "$SSH_ACTION" "ServerAliveCountMax 20"
 assert_contains "$ANSIBLE_CONFIG" 'control_path = ~/.ssh/vm0-ssh-%%C'

--- a/.github/scripts/tests/fixtures/ansible-ssh-control-path.yml
+++ b/.github/scripts/tests/fixtures/ansible-ssh-control-path.yml
@@ -1,0 +1,8 @@
+---
+- name: Exercise the Ansible SSH connection plugin
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run a dummy command through SSH
+      ansible.builtin.raw: printf 'ansible ssh transport ok\n'
+      changed_when: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -254,6 +254,11 @@ jobs:
       - name: Install actionlint
         run: bash <(curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 60 --retry-all-errors https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ansible-core
+
       - name: Run workflow script tests
         run: |
           shopt -s nullglob
@@ -267,6 +272,7 @@ jobs:
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/cloudflare-ssh-preconnect.sh \
             .github/scripts/runner-behavior-*.sh \
+            .github/scripts/tests/ansible-ssh-control-path-test.sh \
             .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -17,5 +17,7 @@ callback_whitelist = profile_tasks
 # Keep SSH connection alive during long operations (drain can take hours).
 # Match the shared master's 15-second cadence and 300-second tolerance.
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -o ServerAliveCountMax=20
-# Ansible interpolation turns %%C into OpenSSH's %C; match setup-ssh-tunnel.
+# Ansible interpolation turns %%C into OpenSSH's %C. setup-ssh-tunnel
+# overrides this with the GitHub job's actual HOME so it reuses the shared
+# master even when the system account has a different home directory.
 control_path = ~/.ssh/vm0-ssh-%%C


### PR DESCRIPTION
## Summary

- export the Ansible SSH control path from the GitHub job's actual `HOME` so playbooks reuse the Cloudflare SSH master connection
- add a committed dummy playbook to PR CI and execute it through Ansible's SSH connection plugin
- verify that Ansible resolves the shared control socket under the GitHub job home

## Scope

This fixes container jobs where Ansible expanded `~/.ssh` to the system account home (`/root`) while the preconnected SSH master lived under GitHub's job home (`/github/home`).

The dummy playbook follows the release workflow's `ansible-playbook -> SSH connection plugin` path. The test replaces only the external SSH process, so it does not connect to development or production hosts.

## Validation

- `bash -n` for all workflow scripts and tests
- `shellcheck` for the affected workflow scripts and tests
- all `.github/scripts/tests/*.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `ansible-playbook --syntax-check` for the dummy playbook
- `actionlint`
- pre-commit and commit-message hooks
