### PR TITLE
feat(runner): enforce remote mcp policy

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -62,6 +62,15 @@ pub mod codex_oauth_token {
     }
 }
 
+/// Firewall contract constants shared by TypeScript and Rust.
+pub mod firewall {
+    /// Maximum accepted MCP tool name length.
+    pub const MCP_TOOL_NAME_MAX_LENGTH: u64 = 256;
+
+    /// Maximum exact MCP tool names accepted in one firewall policy.
+    pub const MCP_TOOL_POLICY_MAX_EXACT_NAMES: u64 = 128;
+}
+
 /// Model-provider environment contract constants shared by TypeScript and Rust.
 pub mod model_provider_env {
     /// Fake model-provider environment placeholder marker values.

--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -11,6 +11,7 @@ import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_network_log
 import matching
+import mcp_policy
 import registry
 from logging_utils import log_proxy_entry
 from url_utils import AuthorityValidationError
@@ -19,7 +20,40 @@ _BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
 _AMBIGUOUS_CONNECTOR_ROUTE_ERROR: Final = "ambiguous_connector_route"
 _STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
 _UPSTREAM_DESTINATION_UNBOUND_ERROR: Final = "upstream_destination_unbound"
+_MCP_POLICY_DENIED_ERROR: Final = "mcp_policy_denied"
 _HTTP_STATUS_CONFLICT = 409
+
+
+def block_mcp_policy_violation(
+    flow: http.HTTPFlow,
+    violation: mcp_policy.McpPolicyViolation,
+) -> None:
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "Request blocked by MCP policy",
+        type="mcp_policy",
+        reason=violation.reason,
+        method=violation.method,
+    )
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_MCP_POLICY_DENIED_ERROR,
+    )
+    flow.response = http.Response.make(
+        violation.status_code,
+        json.dumps(
+            {
+                "error": _MCP_POLICY_DENIED_ERROR,
+                "message": violation.message,
+                "reason": violation.reason,
+                "method": violation.method,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
 
 
 def block_authority_validation_error(

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1869,3 +1869,24 @@ def match_compiled_firewall_request(
         intent=intent or connector_intent.ABSENT,
         is_asterisk_form=is_asterisk_form,
     )
+
+
+def matches_compiled_mcp_api(
+    url: str,
+    compiled_firewalls: CompiledFirewallSet | None,
+) -> bool:
+    """Return whether a request URL is within a configured MCP API base."""
+
+    if compiled_firewalls is None:
+        return False
+    url_parts = _split_base_match_url(
+        url,
+        allow_runtime_backslash_syntax="\\" in url,
+    )
+    if url_parts is None:
+        return False
+    return any(
+        isinstance(candidate.api.raw_api_entry.get("mcp"), dict)
+        and _match_compiled_base_url_parts(url_parts, candidate.api.base) is not None
+        for candidate in compiled_firewalls.indexed_api_candidates(url_parts)
+    )

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -439,6 +439,10 @@ def _api_routing_identity(api_entry: dict) -> str | None:
     }
     if "hostPolicy" in api_entry:
         identity["hostPolicy"] = api_entry["hostPolicy"]
+    if "mcp" in api_entry:
+        identity["mcp"] = api_entry["mcp"]
+    if "suppressBodyCapture" in api_entry:
+        identity["suppressBodyCapture"] = api_entry["suppressBodyCapture"]
     try:
         return json.dumps(
             identity,

--- a/crates/runner/mitm-addon/src/mcp_policy.py
+++ b/crates/runner/mitm-addon/src/mcp_policy.py
@@ -1,0 +1,643 @@
+"""Remote MCP request authorization for matched firewall entries."""
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from typing import Final, Literal
+from urllib.parse import SplitResult, urlsplit
+
+from mitmproxy import http
+
+import flow_metadata
+import matching
+
+MCP_REQUEST_BODY_MAX_BYTES: Final = 64 * 1024
+MCP_TOOL_NAME_MAX_LENGTH: Final = 256
+MCP_TOOL_POLICY_MAX_EXACT_NAMES: Final = 128
+MCP_PROTOCOL_VERSION_MODERN: Final = "2026-07-28"
+_CONTENT_TYPE_MAX_PARTS: Final = 2
+_SUPPORTED_PROTOCOL_VERSIONS: Final = frozenset(
+    (
+        "2024-11-05",
+        "2025-03-26",
+        "2025-06-18",
+        "2025-11-25",
+        MCP_PROTOCOL_VERSION_MODERN,
+    )
+)
+_ALLOWED_METHODS: Final = frozenset(
+    (
+        "server/discover",
+        "initialize",
+        "notifications/initialized",
+        "notifications/cancelled",
+        "tools/list",
+        "tools/call",
+    )
+)
+_NOTIFICATION_METHODS: Final = frozenset(("notifications/initialized", "notifications/cancelled"))
+_TOP_LEVEL_FIELDS: Final = frozenset(("jsonrpc", "id", "method", "params"))
+_PROTOCOL_META_KEY: Final = "io.modelcontextprotocol/protocolVersion"
+_STANDARD_HEADERS: Final = (
+    "MCP-Protocol-Version",
+    "Mcp-Method",
+    "Mcp-Name",
+    "Mcp-Session-Id",
+)
+_McpToolPolicyKind = Literal["exact", "all"]
+
+
+@dataclass(frozen=True)
+class McpPolicyViolation:
+    reason: str
+    message: str
+    status_code: int
+    method: str
+
+
+@dataclass(frozen=True)
+class _McpToolPolicy:
+    kind: _McpToolPolicyKind
+    tool_names: frozenset[str]
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def is_mcp_allow(allow: matching.FirewallAllow) -> bool:
+    return isinstance(allow.api_entry.get("mcp"), dict)
+
+
+def preflight_request(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> McpPolicyViolation | None:
+    """Validate endpoint, transport method, and bounded HTTP framing."""
+
+    if not is_mcp_allow(allow):
+        return _violation("invalid_policy", "MCP policy is unavailable", 403, "")
+
+    destination_error = _validate_exact_destination(flow, allow)
+    if destination_error is not None:
+        return destination_error
+
+    method = flow.request.method.upper()
+    if method not in ("POST", "GET", "DELETE"):
+        return _violation(
+            "transport_method_not_allowed",
+            "MCP transport method is not allowed",
+            405,
+            method,
+        )
+
+    for header_name in _STANDARD_HEADERS:
+        if len(flow.request.headers.get_all(header_name)) > 1:
+            return _violation(
+                "duplicate_protocol_header",
+                "MCP protocol header must appear at most once",
+                400,
+                method,
+            )
+
+    if flow.request.headers.get_all("Transfer-Encoding"):
+        return _violation(
+            "transfer_encoding_not_allowed",
+            "MCP requests do not support transfer encoding",
+            400,
+            method,
+        )
+    if flow.request.headers.get_all("Content-Encoding"):
+        return _violation(
+            "content_encoding_not_allowed",
+            "MCP requests do not support content encoding",
+            415,
+            method,
+        )
+
+    if method == "POST":
+        content_length = _content_length(flow)
+        if isinstance(content_length, McpPolicyViolation):
+            return content_length
+        if content_length == 0:
+            return _violation(
+                "empty_body",
+                "MCP POST requests require a JSON body",
+                400,
+                method,
+            )
+        if content_length > MCP_REQUEST_BODY_MAX_BYTES:
+            return _violation(
+                "body_too_large",
+                "MCP request body exceeds the size limit",
+                413,
+                method,
+            )
+        if not _is_json_content_type(flow.request.headers.get("Content-Type")):
+            return _violation(
+                "unsupported_content_type",
+                "MCP POST requests require application/json",
+                415,
+                method,
+            )
+        return None
+
+    raw_content_lengths = flow.request.headers.get_all("Content-Length")
+    if raw_content_lengths:
+        content_length = _content_length(flow)
+        if isinstance(content_length, McpPolicyViolation):
+            return content_length
+        if content_length != 0:
+            return _violation(
+                "body_not_allowed",
+                "MCP lifecycle requests must not contain a body",
+                400,
+                method,
+            )
+    return None
+
+
+def authorize_request(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> McpPolicyViolation | None:
+    """Authorize one fully buffered MCP request before it reaches upstream."""
+
+    preflight_error = preflight_request(flow, allow)
+    if preflight_error is not None:
+        return preflight_error
+
+    transport_method = flow.request.method.upper()
+    body = flow.request.raw_content or b""
+    if transport_method in ("GET", "DELETE"):
+        if body:
+            return _violation(
+                "body_not_allowed",
+                "MCP lifecycle requests must not contain a body",
+                400,
+                transport_method,
+            )
+        protocol_header = _header(flow, "MCP-Protocol-Version")
+        if protocol_header == MCP_PROTOCOL_VERSION_MODERN:
+            return _violation(
+                "modern_lifecycle_method_not_allowed",
+                "Modern MCP transport does not support lifecycle GET or DELETE",
+                400,
+                transport_method,
+            )
+        if protocol_header is not None and protocol_header not in _SUPPORTED_PROTOCOL_VERSIONS:
+            return _violation(
+                "unsupported_protocol_version",
+                "MCP protocol version is not supported",
+                400,
+                transport_method,
+            )
+        if _header(flow, "Mcp-Method") is not None or _header(flow, "Mcp-Name") is not None:
+            return _violation(
+                "unexpected_protocol_header",
+                "MCP semantic headers require the modern protocol",
+                400,
+                transport_method,
+            )
+        return None
+
+    declared_length = _content_length(flow)
+    if isinstance(declared_length, McpPolicyViolation):
+        return declared_length
+    if len(body) != declared_length:
+        return _violation(
+            "content_length_mismatch",
+            "MCP request body length does not match Content-Length",
+            400,
+            transport_method,
+        )
+    if not body or len(body) > MCP_REQUEST_BODY_MAX_BYTES:
+        return _violation(
+            "body_size_invalid",
+            "MCP request body size is invalid",
+            413 if body else 400,
+            transport_method,
+        )
+
+    try:
+        text = body.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return _violation(
+            "invalid_utf8",
+            "MCP request body must be valid UTF-8",
+            400,
+            transport_method,
+        )
+    try:
+        message = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_non_finite_json_number,
+        )
+    except (json.JSONDecodeError, _DuplicateJsonKeyError, ValueError):
+        return _violation(
+            "invalid_json",
+            "MCP request body must be strict JSON",
+            400,
+            transport_method,
+        )
+    if not isinstance(message, dict):
+        return _violation(
+            "invalid_jsonrpc_message",
+            "MCP request must contain one JSON-RPC object",
+            400,
+            transport_method,
+        )
+    if set(message) - _TOP_LEVEL_FIELDS:
+        return _violation(
+            "unknown_jsonrpc_field",
+            "MCP JSON-RPC request contains unsupported fields",
+            400,
+            transport_method,
+        )
+    if message.get("jsonrpc") != "2.0":
+        return _violation(
+            "invalid_jsonrpc_version",
+            "MCP request must use JSON-RPC 2.0",
+            400,
+            transport_method,
+        )
+
+    method = message.get("method")
+    if not isinstance(method, str) or method not in _ALLOWED_METHODS:
+        return _violation(
+            "method_not_allowed",
+            "MCP method is not allowed",
+            403,
+            "",
+        )
+    if not _valid_message_id(message, method):
+        return _violation(
+            "invalid_jsonrpc_id",
+            "MCP request has an invalid JSON-RPC id",
+            400,
+            method,
+        )
+    params = message.get("params", {})
+    if not isinstance(params, dict):
+        return _violation(
+            "invalid_params",
+            "MCP request params must be an object",
+            400,
+            method,
+        )
+
+    tool_name: str | None = None
+    if method == "tools/call":
+        raw_tool_name = params.get("name")
+        if not _valid_tool_name(raw_tool_name):
+            return _violation(
+                "invalid_tool_name",
+                "MCP tool name is invalid",
+                400,
+                method,
+            )
+        tool_name = raw_tool_name
+        tool_policy = _tool_policy(allow)
+        if tool_policy is None:
+            return _violation(
+                "invalid_policy",
+                "MCP tool policy is invalid",
+                403,
+                method,
+            )
+        if tool_policy.kind == "exact" and tool_name not in tool_policy.tool_names:
+            return _violation(
+                "tool_not_allowed",
+                "MCP tool is not allowed",
+                403,
+                method,
+            )
+
+    protocol_error = _validate_protocol_headers(
+        flow,
+        params=params,
+        method=method,
+        tool_name=tool_name,
+    )
+    if protocol_error is not None:
+        return protocol_error
+    return None
+
+
+def _validate_exact_destination(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> McpPolicyViolation | None:
+    raw_base = allow.api_entry.get("base")
+    original_url = flow_metadata.original_url(flow.metadata)
+    if not isinstance(raw_base, str):
+        return _violation("invalid_policy", "MCP endpoint policy is invalid", 403, "")
+    try:
+        base = urlsplit(raw_base)
+        request = urlsplit(original_url)
+    except ValueError:
+        return _violation("endpoint_mismatch", "MCP endpoint does not match policy", 403, "")
+    if (
+        _endpoint_identity(base) is None
+        or _endpoint_identity(request) is None
+        or _endpoint_identity(base) != _endpoint_identity(request)
+        or request.query != ""
+    ):
+        return _violation("endpoint_mismatch", "MCP endpoint does not match policy", 403, "")
+    return None
+
+
+def _endpoint_identity(parts: SplitResult) -> tuple[str, str, int, str] | None:
+    if (
+        parts.scheme.lower() != "https"
+        or parts.hostname is None
+        or parts.username is not None
+        or parts.password is not None
+        or parts.query != ""
+        or parts.fragment != ""
+    ):
+        return None
+    try:
+        port = parts.port or 443
+    except ValueError:
+        return None
+    path = parts.path or "/"
+    return (parts.scheme.lower(), parts.hostname.lower(), port, path)
+
+
+def _content_length(flow: http.HTTPFlow) -> int | McpPolicyViolation:
+    values = flow.request.headers.get_all("Content-Length")
+    if len(values) != 1 or "," in values[0]:
+        return _violation(
+            "content_length_required",
+            "MCP request requires one Content-Length header",
+            400,
+            flow.request.method.upper(),
+        )
+    value = values[0].strip(" \t")
+    if not value or not value.isascii() or not value.isdecimal():
+        return _violation(
+            "invalid_content_length",
+            "MCP Content-Length is invalid",
+            400,
+            flow.request.method.upper(),
+        )
+    return int(value)
+
+
+def _is_json_content_type(value: str | None) -> bool:
+    if value is None:
+        return False
+    parts = [part.strip() for part in value.split(";")]
+    if not parts or parts[0].lower() != "application/json":
+        return False
+    if len(parts) == 1:
+        return True
+    return (
+        len(parts) == _CONTENT_TYPE_MAX_PARTS
+        and parts[1].lower().replace(" ", "") == "charset=utf-8"
+    )
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _reject_non_finite_json_number(value: str) -> None:
+    raise ValueError(value)
+
+
+def _valid_message_id(message: dict[str, object], method: str) -> bool:
+    if method in _NOTIFICATION_METHODS:
+        return "id" not in message
+    if "id" not in message:
+        return False
+    value = message["id"]
+    return isinstance(value, str) or (isinstance(value, int) and not isinstance(value, bool))
+
+
+def _valid_tool_name(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and len(value) <= MCP_TOOL_NAME_MAX_LENGTH
+
+
+def _tool_policy(allow: matching.FirewallAllow) -> _McpToolPolicy | None:
+    mcp = allow.api_entry.get("mcp")
+    if not isinstance(mcp, dict):
+        return None
+    raw_policy = mcp.get("toolPolicy")
+    if not isinstance(raw_policy, dict):
+        return None
+    kind = raw_policy.get("kind")
+    if kind == "all" and set(raw_policy) == {"kind"}:
+        return _McpToolPolicy(kind="all", tool_names=frozenset())
+    if kind != "exact" or set(raw_policy) != {"kind", "toolNames"}:
+        return None
+    raw_names = raw_policy.get("toolNames")
+    if (
+        not isinstance(raw_names, list)
+        or not raw_names
+        or len(raw_names) > MCP_TOOL_POLICY_MAX_EXACT_NAMES
+        or not all(_valid_tool_name(name) for name in raw_names)
+    ):
+        return None
+    names = frozenset(raw_names)
+    if len(names) != len(raw_names):
+        return None
+    return _McpToolPolicy(kind="exact", tool_names=names)
+
+
+def _validate_protocol_headers(
+    flow: http.HTTPFlow,
+    *,
+    params: dict[str, object],
+    method: str,
+    tool_name: str | None,
+) -> McpPolicyViolation | None:
+    protocol_header = _header(flow, "MCP-Protocol-Version")
+    method_header = _header(flow, "Mcp-Method")
+    name_header = _header(flow, "Mcp-Name")
+    session_header = _header(flow, "Mcp-Session-Id")
+    body_protocol = _body_protocol_version(params, method=method)
+    if isinstance(body_protocol, McpPolicyViolation):
+        return body_protocol
+
+    for claimed_version in (protocol_header, body_protocol):
+        if claimed_version is not None and claimed_version not in _SUPPORTED_PROTOCOL_VERSIONS:
+            return _violation(
+                "unsupported_protocol_version",
+                "MCP protocol version is not supported",
+                400,
+                method,
+            )
+
+    modern = MCP_PROTOCOL_VERSION_MODERN in (protocol_header, body_protocol)
+    if not modern:
+        if method == "server/discover":
+            return _violation(
+                "method_protocol_mismatch",
+                "MCP server discovery requires the modern protocol",
+                400,
+                method,
+            )
+        if method_header is not None or name_header is not None:
+            return _violation(
+                "unexpected_protocol_header",
+                "MCP semantic headers require the modern protocol",
+                400,
+                method,
+            )
+        if (
+            protocol_header is not None
+            and body_protocol is not None
+            and protocol_header != body_protocol
+        ):
+            return _violation(
+                "protocol_version_mismatch",
+                "MCP protocol version claims do not agree",
+                400,
+                method,
+            )
+        return None
+
+    if method in ("initialize", "notifications/initialized"):
+        return _violation(
+            "method_protocol_mismatch",
+            "Modern MCP requests do not support legacy initialization",
+            400,
+            method,
+        )
+    if (
+        protocol_header != MCP_PROTOCOL_VERSION_MODERN
+        or body_protocol != MCP_PROTOCOL_VERSION_MODERN
+    ):
+        return _violation(
+            "modern_protocol_incomplete",
+            "Modern MCP requests require matching protocol claims",
+            400,
+            method,
+        )
+    if session_header is not None:
+        return _violation(
+            "modern_session_not_allowed",
+            "Modern MCP requests do not support session headers",
+            400,
+            method,
+        )
+    if method_header != method:
+        return _violation(
+            "method_header_mismatch",
+            "MCP method header does not match the request",
+            400,
+            method,
+        )
+    if tool_name is None:
+        if name_header is not None:
+            return _violation(
+                "unexpected_name_header",
+                "MCP name header is not valid for this method",
+                400,
+                method,
+            )
+        return None
+    if name_header is None:
+        return _violation(
+            "name_header_required",
+            "MCP tool call requires a name header",
+            400,
+            method,
+        )
+    decoded_name = _decode_mcp_name_header(name_header)
+    if decoded_name is None or decoded_name != tool_name:
+        return _violation(
+            "name_header_mismatch",
+            "MCP name header does not match the request",
+            400,
+            method,
+        )
+    return None
+
+
+def _body_protocol_version(
+    params: dict[str, object],
+    *,
+    method: str,
+) -> str | McpPolicyViolation | None:
+    raw_meta = params.get("_meta")
+    if raw_meta is not None and not isinstance(raw_meta, dict):
+        return _violation(
+            "invalid_protocol_metadata",
+            "MCP protocol metadata must be an object",
+            400,
+            "",
+        )
+    raw_meta_version = raw_meta.get(_PROTOCOL_META_KEY) if isinstance(raw_meta, dict) else None
+    if raw_meta_version is not None and not isinstance(raw_meta_version, str):
+        return _violation(
+            "invalid_protocol_metadata",
+            "MCP protocol version metadata must be a string",
+            400,
+            "",
+        )
+    if method != "initialize":
+        return raw_meta_version
+
+    initialize_version = params.get("protocolVersion")
+    if not isinstance(initialize_version, str):
+        return _violation(
+            "invalid_protocol_version",
+            "MCP initialize requires a protocol version",
+            400,
+            method,
+        )
+    if raw_meta_version is not None and raw_meta_version != initialize_version:
+        return _violation(
+            "protocol_version_mismatch",
+            "MCP protocol version claims do not agree",
+            400,
+            method,
+        )
+    return initialize_version
+
+
+def _header(flow: http.HTTPFlow, name: str) -> str | None:
+    values = flow.request.headers.get_all(name)
+    if not values:
+        return None
+    return values[0].strip(" \t")
+
+
+def _decode_mcp_name_header(value: str) -> str | None:
+    prefix = "=?base64?"
+    if not value.startswith(prefix):
+        return value
+    if not value.endswith("?="):
+        return None
+    encoded = value[len(prefix) : -2]
+    try:
+        decoded = base64.b64decode(encoded, validate=True)
+        if base64.b64encode(decoded).decode("ascii") != encoded:
+            return None
+        return decoded.decode("utf-8", errors="strict")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+
+
+def _violation(
+    reason: str,
+    message: str,
+    status_code: int,
+    method: str,
+) -> McpPolicyViolation:
+    return McpPolicyViolation(
+        reason=reason,
+        message=message,
+        status_code=status_code,
+        method=method,
+    )

--- a/crates/runner/mitm-addon/src/mcp_policy.py
+++ b/crates/runner/mitm-addon/src/mcp_policy.py
@@ -398,7 +398,11 @@ def _content_length(flow: http.HTTPFlow) -> int | McpPolicyViolation:
             400,
             flow.request.method.upper(),
         )
-    return int(value)
+    normalized = value.lstrip("0") or "0"
+    limit = str(MCP_REQUEST_BODY_MAX_BYTES)
+    if len(normalized) > len(limit) or (len(normalized) == len(limit) and normalized > limit):
+        return MCP_REQUEST_BODY_MAX_BYTES + 1
+    return int(normalized)
 
 
 def _is_json_content_type(value: str | None) -> bool:

--- a/crates/runner/mitm-addon/src/mcp_policy.py
+++ b/crates/runner/mitm-addon/src/mcp_policy.py
@@ -11,15 +11,15 @@ from mitmproxy import http
 
 import flow_metadata
 import matching
+from body_limits import STREAM_BUFFER_LIMIT
 
-MCP_REQUEST_BODY_MAX_BYTES: Final = 64 * 1024
+MCP_REQUEST_BODY_MAX_BYTES: Final = STREAM_BUFFER_LIMIT
 MCP_TOOL_NAME_MAX_LENGTH: Final = 256
 MCP_TOOL_POLICY_MAX_EXACT_NAMES: Final = 128
 MCP_PROTOCOL_VERSION_MODERN: Final = "2026-07-28"
 _CONTENT_TYPE_MAX_PARTS: Final = 2
 _SUPPORTED_PROTOCOL_VERSIONS: Final = frozenset(
     (
-        "2024-11-05",
         "2025-03-26",
         "2025-06-18",
         "2025-11-25",
@@ -73,6 +73,9 @@ def is_mcp_allow(allow: matching.FirewallAllow) -> bool:
 def preflight_request(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
+    *,
+    request_end_stream: bool | None = None,
+    request_body_buffered: bool = False,
 ) -> McpPolicyViolation | None:
     """Validate endpoint, transport method, and bounded HTTP framing."""
 
@@ -155,6 +158,13 @@ def preflight_request(
                 400,
                 method,
             )
+    elif request_end_stream is not True and not request_body_buffered:
+        return _violation(
+            "body_framing_ambiguous",
+            "MCP lifecycle request body framing is ambiguous",
+            400,
+            method,
+        )
     return None
 
 
@@ -164,7 +174,11 @@ def authorize_request(
 ) -> McpPolicyViolation | None:
     """Authorize one fully buffered MCP request before it reaches upstream."""
 
-    preflight_error = preflight_request(flow, allow)
+    preflight_error = preflight_request(
+        flow,
+        allow,
+        request_body_buffered=True,
+    )
     if preflight_error is not None:
         return preflight_error
 

--- a/crates/runner/mitm-addon/src/mcp_policy.py
+++ b/crates/runner/mitm-addon/src/mcp_policy.py
@@ -183,6 +183,13 @@ def authorize_request(
         return preflight_error
 
     transport_method = flow.request.method.upper()
+    if flow.request.trailers:
+        return _violation(
+            "request_trailers_not_allowed",
+            "MCP requests do not support trailers",
+            400,
+            transport_method,
+        )
     body = flow.request.raw_content or b""
     if transport_method in ("GET", "DELETE"):
         if body:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -51,6 +51,7 @@ import flow_metadata_keys as metadata_keys
 import http_local_responses
 import http_network_log
 import matching
+import mcp_policy
 import mitmproxy_compat
 import model_usage_pricing
 import network_log_sanitization
@@ -665,7 +666,9 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         request_end_stream=request_end_stream,
     )
     body_fits_stream_buffer = body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
-    if body_fits_stream_buffer:
+    if body_fits_stream_buffer and upstream_destination_binding.has_server_binding(
+        flow.server_conn
+    ):
         _prebind_bounded_requestheaders_upstream_destination(flow)
         return None
 
@@ -688,6 +691,32 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
+        return None
+
+    if classification.kind == "firewall_allow" and mcp_policy.is_mcp_allow(
+        classification.firewall_allow
+    ):
+        _start_request_timing(flow)
+        prepare_firewall_metadata(
+            flow,
+            classification.firewall_allow,
+            classification.vm_info,
+        )
+        violation = mcp_policy.preflight_request(
+            flow,
+            classification.firewall_allow,
+        )
+        if violation is not None:
+            http_local_responses.block_mcp_policy_violation(flow, violation)
+            flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+            upstream_admission.forget_server_binding(flow.server_conn)
+            return None
+        request_classification.cache_classification(flow, classification)
+        return None
+
+    if body_fits_stream_buffer:
+        _prebind_requestheaders_upstream_destination(flow, classification)
+        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         return None
 
     if (
@@ -881,6 +910,8 @@ def _block_public_destination_denied(
     *,
     send_response: bool = True,
 ) -> None:
+    if denial.suppress_body_capture:
+        flow.metadata[metadata_keys.CAPTURE_BODY] = False
     http_local_responses.block_public_destination_denied(
         flow,
         name=denial.name,
@@ -1022,6 +1053,18 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "firewall_allow":
             allow = classification.firewall_allow
             vm_info = classification.vm_info
+            if mcp_policy.is_mcp_allow(allow):
+                prepare_firewall_metadata(flow, allow, vm_info)
+                violation = mcp_policy.authorize_request(flow, allow)
+                if violation is not None:
+                    http_local_responses.block_mcp_policy_violation(flow, violation)
+                    auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+                    terminal_usage.release_tracked_flow(flow)
+                    return
+                flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+                flow.metadata.pop(metadata_keys.MODEL_USAGE_PROVIDER, None)
+                flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
+                return
             if connector_diagnostics.maybe_make_firewall_allow_local_response(
                 flow,
                 classification,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -693,6 +693,22 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         flow.kill()
         return None
 
+    if (
+        isinstance(
+            classification,
+            request_classification.FirewallAmbiguous | request_classification.FirewallBlock,
+        )
+        and classification.mcp_destination
+    ):
+        _start_request_timing(flow)
+        if isinstance(classification, request_classification.FirewallAmbiguous):
+            _set_firewall_ambiguous_response(flow, classification.firewall_ambiguous)
+        else:
+            _set_firewall_block_response(flow, classification.firewall_block)
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        upstream_admission.forget_server_binding(flow.server_conn)
+        return None
+
     if classification.kind == "firewall_allow" and mcp_policy.is_mcp_allow(
         classification.firewall_allow
     ):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -705,6 +705,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         violation = mcp_policy.preflight_request(
             flow,
             classification.firewall_allow,
+            request_end_stream=request_end_stream,
         )
         if violation is not None:
             http_local_responses.block_mcp_policy_violation(flow, violation)

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -423,12 +423,15 @@ def _classify_request(
     is_asterisk_form = flow.request.path == "*"
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     browser_request = bool(flow.metadata.get(metadata_keys.BROWSER_USER_AGENT))
-    # Browser provenance is spoofable and the platform origin can also host an
-    # explicitly configured endpoint. MCP policy remains authoritative for both.
-    if (platform_api_request or browser_request) and not matching.matches_compiled_mcp_api(
+    mcp_api_request = (
+        platform_api_request or browser_request
+    ) and matching.matches_compiled_mcp_api(
         original_url,
         compiled_firewalls,
-    ):
+    )
+    # Browser provenance is spoofable and the platform origin can also host an
+    # explicitly configured endpoint. MCP policy remains authoritative for both.
+    if (platform_api_request or browser_request) and not mcp_api_request:
         if platform_api_request:
             return ApiAllow(vm_info=vm_info)
         return BrowserAllow(vm_info=vm_info)
@@ -443,12 +446,19 @@ def _classify_request(
             connector_intent.from_flow(flow),
             is_asterisk_form=is_asterisk_form,
         )
-        if isinstance(result, matching.FirewallAmbiguous):
-            return FirewallAmbiguous(
-                vm_info=vm_info,
-                firewall_ambiguous=result,
-            )
-        if isinstance(result, matching.FirewallBlock):
+        if isinstance(result, matching.FirewallAmbiguous | matching.FirewallBlock):
+            # MCP payload privacy belongs to the destination match, even when
+            # owner selection or another firewall decision rejects the route.
+            if mcp_api_request or matching.matches_compiled_mcp_api(
+                original_url,
+                compiled_firewalls,
+            ):
+                flow.metadata[metadata_keys.CAPTURE_BODY] = False
+            if isinstance(result, matching.FirewallAmbiguous):
+                return FirewallAmbiguous(
+                    vm_info=vm_info,
+                    firewall_ambiguous=result,
+                )
             return FirewallBlock(
                 vm_info=vm_info,
                 firewall_block=result,

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -95,6 +95,7 @@ class PublicDestinationDenial:
     trusted_authority_host: str
     destination_host: str
     reason: public_destination.DestinationDenialReason
+    suppress_body_capture: bool
 
 
 @dataclass(frozen=True)
@@ -449,6 +450,7 @@ def _classify_request(
                 if isinstance(result, matching.FirewallPolicyAllow)
                 else result
             )
+            _apply_firewall_body_capture_policy(flow, firewall_allow)
             public_destination_denial = _public_destination_denial(
                 flow,
                 firewall_allow,
@@ -512,6 +514,14 @@ def should_try_firewall_stream_capture_request(classification: RequestClassifica
 def firewall_allow_uses_public_destination(allow: matching.FirewallAllow) -> bool:
     host_policy = allow.api_entry.get("hostPolicy")
     return isinstance(host_policy, dict) and host_policy.get("kind") == "publicDestination"
+
+
+def _apply_firewall_body_capture_policy(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> None:
+    if allow.api_entry.get("suppressBodyCapture") is True:
+        flow.metadata[metadata_keys.CAPTURE_BODY] = False
 
 
 def current_public_destination_denial(
@@ -635,6 +645,7 @@ def _public_destination_denial(
         trusted_authority_host=trusted_authority_host,
         destination_host=validation.destination_host,
         reason=validation.reason,
+        suppress_body_capture=allow.api_entry.get("suppressBodyCapture") is True,
     )
 
 

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -289,6 +289,8 @@ def classify_request(
     The decision order is registry/TLS admission, registered VM resolution,
     trusted authority validation, platform API allow, browser passthrough,
     firewall match, publicDestination runtime validation, and default allow.
+    A configured MCP API base bypasses neither platform API nor browser
+    classification because those heuristics must not skip protocol policy.
 
     After registry and TLS admission checks accept a registered VM,
     classification stores VM/run metadata on the flow. Once trusted authority
@@ -412,18 +414,25 @@ def _classify_request(
         port=trusted_authority.port,
     )
 
-    if upstream_admission.api_destination_matches(
+    platform_api_request = upstream_admission.api_destination_matches(
         api_url,
         trusted_authority.host,
         trusted_authority.port,
-    ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
-        return ApiAllow(vm_info=vm_info)
-
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-        return BrowserAllow(vm_info=vm_info)
+    ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path)
 
     is_asterisk_form = flow.request.path == "*"
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
+    browser_request = bool(flow.metadata.get(metadata_keys.BROWSER_USER_AGENT))
+    # Browser provenance is spoofable and the platform origin can also host an
+    # explicitly configured endpoint. MCP policy remains authoritative for both.
+    if (platform_api_request or browser_request) and not matching.matches_compiled_mcp_api(
+        original_url,
+        compiled_firewalls,
+    ):
+        if platform_api_request:
+            return ApiAllow(vm_info=vm_info)
+        return BrowserAllow(vm_info=vm_info)
+
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
     if compiled_firewalls:
         result = matching.match_compiled_firewall_request(

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -149,6 +149,7 @@ class BrowserAllow:
 class FirewallAmbiguous:
     vm_info: dict
     firewall_ambiguous: matching.FirewallAmbiguous
+    mcp_destination: bool
     kind: Literal["firewall_ambiguous"] = field(init=False, default="firewall_ambiguous")
 
 
@@ -156,6 +157,7 @@ class FirewallAmbiguous:
 class FirewallBlock:
     vm_info: dict
     firewall_block: matching.FirewallBlock
+    mcp_destination: bool
     kind: Literal["firewall_block"] = field(init=False, default="firewall_block")
 
 
@@ -449,19 +451,22 @@ def _classify_request(
         if isinstance(result, matching.FirewallAmbiguous | matching.FirewallBlock):
             # MCP payload privacy belongs to the destination match, even when
             # owner selection or another firewall decision rejects the route.
-            if mcp_api_request or matching.matches_compiled_mcp_api(
+            mcp_destination = mcp_api_request or matching.matches_compiled_mcp_api(
                 original_url,
                 compiled_firewalls,
-            ):
+            )
+            if mcp_destination:
                 flow.metadata[metadata_keys.CAPTURE_BODY] = False
             if isinstance(result, matching.FirewallAmbiguous):
                 return FirewallAmbiguous(
                     vm_info=vm_info,
                     firewall_ambiguous=result,
+                    mcp_destination=mcp_destination,
                 )
             return FirewallBlock(
                 vm_info=vm_info,
                 firewall_block=result,
+                mcp_destination=mcp_destination,
             )
         if isinstance(result, matching.FirewallAllow | matching.FirewallPolicyAllow):
             firewall_allow = (

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -391,6 +391,26 @@ async def test_mcp_header_preflight_bounds_oversized_content_length_digits(
     assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
 
 
+async def test_mcp_rejects_request_trailers_before_upstream(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(real_flow, headers)
+    flow.request.trailers = headers(("Mcp-Name", "delete-all"))
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "request_trailers_not_allowed"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+
+
 async def test_mcp_public_destination_header_denial_suppresses_body_capture(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -249,23 +249,24 @@ async def test_mcp_policy_cannot_be_bypassed_on_the_platform_api_origin(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
 
 
-async def test_mcp_ambiguous_route_never_captures_request_body(
+async def test_mcp_ambiguous_route_rejects_oversized_body_at_headers_without_capture(
     tmp_path,
     real_flow,
     headers,
     mitm_ctx,
 ):
     registry_path = _write_mcp_registry(tmp_path, duplicate_owner=True)
-    flow = _mcp_flow(real_flow, headers)
+    body = b'{"secret":"must-not-be-logged"}' + b"x" * (64 * 1024)
+    flow = _mcp_flow(real_flow, headers, body=body)
 
     with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
         mitm_addon.requestheaders(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 409
+        assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
         await mitm_addon.request(flow)
         mitm_addon.response(flow)
 
-    assert flow.response is not None
-    assert flow.response.status_code == 409
-    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
     [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert "request_body" not in network_entry
     assert "must-not-be-logged" not in json.dumps(network_entry)

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -15,6 +15,9 @@ from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 _PUBLIC_DESTINATION = "93.184.216.34"
 _MCP_HOST = "mcp.example.com"
 _MCP_PATH = "/v1/mcp"
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36"
+)
 
 
 def _write_mcp_registry(
@@ -182,6 +185,103 @@ async def test_mcp_all_tool_policy_allows_an_unlisted_tool(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
+async def test_mcp_policy_cannot_be_bypassed_with_a_browser_user_agent(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=_modern_tool_call("delete-all"),
+        semantic_name="delete-all",
+        extra_headers=(("User-Agent", _BROWSER_USER_AGENT),),
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "tool_not_allowed"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+
+
+async def test_mcp_policy_cannot_be_bypassed_on_the_platform_api_origin(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=_modern_tool_call("delete-all"),
+        semantic_name="delete-all",
+    )
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        api_url=f"https://{_MCP_HOST}",
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "tool_not_allowed"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+
+
+async def test_mcp_rejection_logs_never_capture_request_or_response_bodies(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "delete-all",
+                "arguments": {"secret": "must-not-be-logged"},
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=body,
+        protocol_version=None,
+        semantic_method=None,
+        semantic_name=None,
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert "request_body" not in network_entry
+    assert "response_body" not in network_entry
+    serialized_logs = json.dumps(
+        [
+            network_entry,
+            *read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl"),
+        ]
+    )
+    assert "must-not-be-logged" not in serialized_logs
+
+
 @pytest.mark.parametrize(
     ("body", "expected_reason"),
     [
@@ -320,6 +420,61 @@ async def test_mcp_legacy_bodyless_lifecycle_request_is_allowed(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
+@pytest.mark.parametrize("request_end_stream", [None, False])
+async def test_mcp_bodyless_lifecycle_rejects_ambiguous_http2_framing(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    request_end_stream,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=b"",
+        method="GET",
+        protocol_version="2025-11-25",
+        semantic_method=None,
+        semantic_name=None,
+    )
+    if request_end_stream is not None:
+        flow.metadata["_vm0_request_end_stream"] = request_end_stream
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "body_framing_ambiguous"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+
+
+async def test_mcp_bodyless_lifecycle_accepts_confirmed_http2_end_stream(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=b"",
+        method="GET",
+        protocol_version="2025-11-25",
+        semantic_method=None,
+        semantic_name=None,
+    )
+    flow.metadata["_vm0_request_end_stream"] = True
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
 async def test_mcp_legacy_initialize_validates_its_negotiated_protocol_version(
     tmp_path,
     real_flow,
@@ -365,7 +520,7 @@ async def test_mcp_legacy_initialize_validates_its_negotiated_protocol_version(
                 "jsonrpc": "2.0",
                 "id": 1,
                 "method": "initialize",
-                "params": {"protocolVersion": "unsupported"},
+                "params": {"protocolVersion": "2024-11-05"},
             },
             None,
             None,

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -373,6 +373,24 @@ async def test_mcp_header_preflight_rejects_before_request_body_handling(
     assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
 
 
+async def test_mcp_header_preflight_bounds_oversized_content_length_digits(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(real_flow, headers)
+    flow.request.headers["Content-Length"] = "9" * 5_000
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "body_too_large"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+
+
 async def test_mcp_public_destination_header_denial_suppresses_body_capture(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -24,24 +24,36 @@ def _write_mcp_registry(
     tmp_path,
     *,
     tool_policy: dict[str, object] | None = None,
+    duplicate_owner: bool = False,
 ):
-    return _write_registry(
+    api_entry = {
+        "base": f"https://{_MCP_HOST}{_MCP_PATH}",
+        "hostPolicy": {"kind": "publicDestination"},
+        "auth": {},
+        "mcp": {"toolPolicy": tool_policy or {"kind": "exact", "toolNames": ["search"]}},
+        "suppressBodyCapture": True,
+    }
+    vm_info = _single_firewall_vm(
         tmp_path,
-        vm_info=_single_firewall_vm(
-            tmp_path,
-            firewall_name="remote-mcp",
-            api_entry={
-                "base": f"https://{_MCP_HOST}{_MCP_PATH}",
-                "hostPolicy": {"kind": "publicDestination"},
-                "auth": {},
-                "mcp": {"toolPolicy": tool_policy or {"kind": "exact", "toolNames": ["search"]}},
-                "suppressBodyCapture": True,
-            },
-            network_policy=None,
-            include_encrypted_secrets=False,
-            vm_fields={"captureNetworkBodies": True},
-        ),
+        firewall_name="remote-mcp",
+        api_entry=api_entry,
+        network_policy=None,
+        include_encrypted_secrets=False,
+        vm_fields={"captureNetworkBodies": True},
     )
+    if duplicate_owner:
+        firewalls = vm_info["firewalls"]
+        assert isinstance(firewalls, list)
+        firewalls.append(
+            {
+                "kind": "inline",
+                "firewall": {
+                    "name": "remote-mcp-copy",
+                    "apis": [api_entry],
+                },
+            }
+        )
+    return _write_registry(tmp_path, vm_info=vm_info)
 
 
 def _modern_tool_call(tool_name: str = "search") -> bytes:
@@ -235,6 +247,28 @@ async def test_mcp_policy_cannot_be_bypassed_on_the_platform_api_origin(
     assert json.loads(flow.response.content)["reason"] == "tool_not_allowed"
     assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+
+
+async def test_mcp_ambiguous_route_never_captures_request_body(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path, duplicate_owner=True)
+    flow = _mcp_flow(real_flow, headers)
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 409
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert "request_body" not in network_entry
+    assert "must-not-be-logged" not in json.dumps(network_entry)
 
 
 async def test_mcp_rejection_logs_never_capture_request_or_response_bodies(

--- a/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_mcp_policy.py
@@ -1,0 +1,450 @@
+"""Remote MCP firewall authorization tests."""
+
+import base64
+import json
+
+import pytest
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import request_classification
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+
+_PUBLIC_DESTINATION = "93.184.216.34"
+_MCP_HOST = "mcp.example.com"
+_MCP_PATH = "/v1/mcp"
+
+
+def _write_mcp_registry(
+    tmp_path,
+    *,
+    tool_policy: dict[str, object] | None = None,
+):
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="remote-mcp",
+            api_entry={
+                "base": f"https://{_MCP_HOST}{_MCP_PATH}",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": tool_policy or {"kind": "exact", "toolNames": ["search"]}},
+                "suppressBodyCapture": True,
+            },
+            network_policy=None,
+            include_encrypted_secrets=False,
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+
+
+def _modern_tool_call(tool_name: str = "search") -> bytes:
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {"secret": "must-not-be-logged"},
+                "_meta": {"io.modelcontextprotocol/protocolVersion": "2026-07-28"},
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+
+
+def _mcp_flow(
+    real_flow,
+    headers,
+    *,
+    body: bytes | None = None,
+    method: str = "POST",
+    path: str = _MCP_PATH,
+    destination_host: str = _PUBLIC_DESTINATION,
+    protocol_version: str | None = "2026-07-28",
+    semantic_method: str | None = "tools/call",
+    semantic_name: str | None = "search",
+    extra_headers: tuple[tuple[str, str], ...] = (),
+):
+    body = _modern_tool_call() if body is None and method == "POST" else body
+    request_headers: list[tuple[str, str]] = [("Host", _MCP_HOST)]
+    if method == "POST":
+        request_headers.extend(
+            (
+                ("Content-Type", "application/json; charset=utf-8"),
+                ("Content-Length", str(len(body or b""))),
+            )
+        )
+    if protocol_version is not None:
+        request_headers.append(("MCP-Protocol-Version", protocol_version))
+    if semantic_method is not None:
+        request_headers.append(("Mcp-Method", semantic_method))
+    if semantic_name is not None:
+        request_headers.append(("Mcp-Name", semantic_name))
+    request_headers.extend(extra_headers)
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=destination_host,
+        sni=_MCP_HOST,
+        path=path,
+        method=method,
+        request_body=body,
+        request_headers=headers(*request_headers),
+    )
+
+
+async def test_mcp_exact_tool_call_is_authorized_and_never_captures_bodies(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(real_flow, headers)
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        assert mitm_addon.requestheaders(flow) is None
+        assert flow.response is None
+        assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
+
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+        flow.response = http.Response.make(
+            200,
+            b'{"result":{"secret":"must-not-be-logged"}}',
+            {"Content-Type": "application/json"},
+        )
+        mitm_addon.response(flow)
+
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert "request_body" not in network_entry
+    assert "response_body" not in network_entry
+    assert "must-not-be-logged" not in json.dumps(network_entry)
+
+
+async def test_mcp_encoded_modern_tool_name_matches_exact_policy(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    tool_name = "天气 搜索"
+    encoded_name = base64.b64encode(tool_name.encode()).decode()
+    registry_path = _write_mcp_registry(
+        tmp_path,
+        tool_policy={"kind": "exact", "toolNames": [tool_name]},
+    )
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=_modern_tool_call(tool_name),
+        semantic_name=f"=?base64?{encoded_name}?=",
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
+async def test_mcp_all_tool_policy_allows_an_unlisted_tool(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(
+        tmp_path,
+        tool_policy={"kind": "all"},
+    )
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=_modern_tool_call("future-tool"),
+        semantic_name="future-tool",
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_reason"),
+    [
+        (
+            b'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search","arguments":{"x":1,"x":2}}}',
+            "invalid_json",
+        ),
+        (
+            b'[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]',
+            "invalid_jsonrpc_message",
+        ),
+        (
+            b'{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}',
+            "method_not_allowed",
+        ),
+        (
+            b'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete-all"}}',
+            "tool_not_allowed",
+        ),
+    ],
+)
+async def test_mcp_rejects_unauthorized_or_malformed_jsonrpc_before_upstream(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    body,
+    expected_reason,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=body,
+        protocol_version=None,
+        semantic_method=None,
+        semantic_name=None,
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == expected_reason
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+
+
+@pytest.mark.parametrize(
+    ("flow_options", "expected_reason"),
+    [
+        ({"path": f"{_MCP_PATH}?tenant=1"}, "endpoint_mismatch"),
+        ({"method": "PUT"}, "transport_method_not_allowed"),
+        (
+            {"extra_headers": (("Content-Encoding", "gzip"),)},
+            "content_encoding_not_allowed",
+        ),
+        (
+            {"extra_headers": (("Transfer-Encoding", "chunked"),)},
+            "transfer_encoding_not_allowed",
+        ),
+        (
+            {"extra_headers": (("MCP-Protocol-Version", "2026-07-28"),)},
+            "duplicate_protocol_header",
+        ),
+        (
+            {"body": b"x" * (64 * 1024 + 1)},
+            "body_too_large",
+        ),
+    ],
+)
+async def test_mcp_header_preflight_rejects_before_request_body_handling(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    flow_options,
+    expected_reason,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(real_flow, headers, **flow_options)
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == expected_reason
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+
+
+async def test_mcp_public_destination_header_denial_suppresses_body_capture(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        destination_host="10.0.0.1",
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.error is not None
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_public_destination"
+
+
+async def test_mcp_legacy_bodyless_lifecycle_request_is_allowed(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=b"",
+        method="GET",
+        protocol_version="2025-11-25",
+        semantic_method=None,
+        semantic_name=None,
+        extra_headers=(("Content-Length", "0"), ("Mcp-Session-Id", "session-1")),
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
+async def test_mcp_legacy_initialize_validates_its_negotiated_protocol_version(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=body,
+        protocol_version=None,
+        semantic_method=None,
+        semantic_name=None,
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
+@pytest.mark.parametrize(
+    ("body", "protocol_version", "semantic_method", "expected_reason"),
+    [
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "unsupported"},
+            },
+            None,
+            None,
+            "unsupported_protocol_version",
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {},
+            },
+            None,
+            None,
+            "method_protocol_mismatch",
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2026-07-28",
+                    "_meta": {"io.modelcontextprotocol/protocolVersion": "2026-07-28"},
+                },
+            },
+            "2026-07-28",
+            "initialize",
+            "method_protocol_mismatch",
+        ),
+    ],
+)
+async def test_mcp_rejects_protocol_and_lifecycle_era_mismatches(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    body,
+    protocol_version,
+    semantic_method,
+    expected_reason,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    encoded_body = json.dumps(body, separators=(",", ":")).encode()
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        body=encoded_body,
+        protocol_version=protocol_version,
+        semantic_method=semantic_method,
+        semantic_name=None,
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == expected_reason
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False
+
+
+async def test_mcp_modern_header_and_body_claims_must_agree(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+):
+    registry_path = _write_mcp_registry(tmp_path)
+    flow = _mcp_flow(
+        real_flow,
+        headers,
+        semantic_method="tools/list",
+    )
+
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["reason"] == "method_header_mismatch"
+    assert flow.metadata[metadata_keys.CAPTURE_BODY] is False

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -9,7 +9,7 @@ use super::cli_framework::{
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path};
 use crate::ids::RunId;
-use crate::types::{CodexRuntimeConfig, ExecutionContext, SandboxReuseResult};
+use crate::types::{CodexRuntimeConfig, ExecutionContext, FirewallEntry, SandboxReuseResult};
 
 pub(super) struct ProtectedModelProviderEnvKey {
     name: &'static str,
@@ -122,6 +122,7 @@ pub(super) fn validate_execution_context_before_sandbox_with_host_env(
 ) -> Result<(), String> {
     validate_resume_session_id(context)?;
     validate_model_provider_env_placeholders(context)?;
+    validate_inline_mcp_firewalls(context)?;
     validate_user_environment_for_guest(context)?;
     validate_claude_tool_lists(context)?;
     validate_run_payload_fields_before_sandbox(context)?;
@@ -129,6 +130,18 @@ pub(super) fn validate_execution_context_before_sandbox_with_host_env(
         build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, host_env)
             .map_err(|error| error.to_string())?;
     validate_bootstrap_environment_for_guest(&bootstrap_env)?;
+    Ok(())
+}
+
+fn validate_inline_mcp_firewalls(context: &ExecutionContext) -> Result<(), String> {
+    let Some(firewalls) = &context.firewalls else {
+        return Ok(());
+    };
+    for entry in firewalls {
+        if let FirewallEntry::Inline { firewall } = entry {
+            firewall.validate_mcp_policies()?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1621,6 +1621,8 @@ mod tests {
                             description: None,
                             rules: vec!["GET /records".to_string()],
                         }]),
+                        mcp: None,
+                        suppress_body_capture: false,
                     }],
                 },
             },

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -28,7 +28,11 @@ use crate::host_env::{
 };
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
-use crate::types::{CodexRuntimeConfig, ExecutionContext, ResumeSession, SandboxReuseResult};
+use crate::types::{
+    CodexRuntimeConfig, ExecutionContext, Firewall, FirewallApi, FirewallAuth,
+    FirewallBaseHostPolicy, FirewallEntry, FirewallMcpPolicy, FirewallMcpToolPolicy, ResumeSession,
+    SandboxReuseResult,
+};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();
@@ -159,6 +163,50 @@ fn execution_context_validation_accepts_minimal_context() {
     let ctx = minimal_context();
 
     assert!(validate_context_for_test(&ctx).is_ok());
+}
+
+#[test]
+fn execution_context_validation_enforces_inline_mcp_firewall_policy() {
+    let mut ctx = minimal_context();
+    ctx.firewalls = Some(vec![FirewallEntry::Inline {
+        firewall: Firewall {
+            name: "remote-mcp".to_string(),
+            apis: vec![FirewallApi {
+                id: String::new(),
+                base: "https://mcp.example.com/v1/mcp".to_string(),
+                auth: FirewallAuth {
+                    headers: HashMap::new(),
+                    base: None,
+                    query: None,
+                    aws_sigv4: None,
+                },
+                host_policy: Some(FirewallBaseHostPolicy::PublicDestination),
+                permissions: None,
+                mcp: Some(FirewallMcpPolicy {
+                    tool_policy: FirewallMcpToolPolicy::Exact {
+                        tool_names: vec!["search".to_string()],
+                    },
+                }),
+                suppress_body_capture: true,
+            }],
+        },
+    }]);
+
+    validate_context_for_test(&ctx).unwrap();
+
+    let Some(FirewallEntry::Inline { firewall }) = ctx
+        .firewalls
+        .as_mut()
+        .and_then(|entries| entries.first_mut())
+    else {
+        panic!("expected inline firewall");
+    };
+    firewall.apis[0].suppress_body_capture = false;
+
+    assert_eq!(
+        validate_context_for_test(&ctx).unwrap_err(),
+        "firewall remote-mcp apis[0]: MCP firewall requires body capture suppression"
+    );
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -207,6 +207,21 @@ fn execution_context_validation_enforces_inline_mcp_firewall_policy() {
         validate_context_for_test(&ctx).unwrap_err(),
         "firewall remote-mcp apis[0]: MCP firewall requires body capture suppression"
     );
+
+    let Some(FirewallEntry::Inline { firewall }) = ctx
+        .firewalls
+        .as_mut()
+        .and_then(|entries| entries.first_mut())
+    else {
+        panic!("expected inline firewall");
+    };
+    firewall.apis[0].suppress_body_capture = true;
+    firewall.apis[0].permissions = Some(Vec::new());
+
+    assert_eq!(
+        validate_context_for_test(&ctx).unwrap_err(),
+        "firewall remote-mcp apis[0]: MCP firewall does not support route permissions"
+    );
 }
 
 #[test]

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -512,6 +512,8 @@ mod tests {
                             description: None,
                             rules: vec!["GET /items".to_string()],
                         }]),
+                        mcp: None,
+                        suppress_body_capture: false,
                     }],
                 },
             )]),

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -354,7 +354,10 @@ pub(super) async fn write_empty_registry(path: &Path) -> RunnerResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry, FirewallPermission};
+    use crate::types::{
+        Firewall, FirewallApi, FirewallAuth, FirewallBaseHostPolicy, FirewallEntry,
+        FirewallMcpPolicy, FirewallMcpToolPolicy, FirewallPermission,
+    };
     use std::os::unix::fs::PermissionsExt;
 
     struct RegistryHarness {
@@ -430,6 +433,8 @@ mod tests {
                                 rules: vec!["POST /repos/{owner}/{repo}/issues".to_string()],
                             },
                         ]),
+                        mcp: None,
+                        suppress_body_capture: false,
                     }],
                 },
             })
@@ -1064,6 +1069,8 @@ mod tests {
                             "GET /messages/{id}".to_string(),
                         ],
                     }]),
+                    mcp: None,
+                    suppress_body_capture: false,
                 }],
             },
         }];
@@ -1116,6 +1123,54 @@ mod tests {
 
         // Empty billableFirewalls round-trips as [] (Python reads vm_info["billableFirewalls"]).
         assert_eq!(vm_json["billableFirewalls"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn registry_preserves_mcp_enforcement_policy() {
+        let harness = RegistryHarness::new().await;
+        let firewall_entries = vec![FirewallEntry::Inline {
+            firewall: Firewall {
+                name: "remote-mcp".to_string(),
+                apis: vec![FirewallApi {
+                    id: String::new(),
+                    base: "https://mcp.example.com/v1/mcp".to_string(),
+                    auth: FirewallAuth {
+                        headers: HashMap::new(),
+                        base: None,
+                        query: None,
+                        aws_sigv4: None,
+                    },
+                    host_policy: Some(FirewallBaseHostPolicy::PublicDestination),
+                    permissions: None,
+                    mcp: Some(FirewallMcpPolicy {
+                        tool_policy: FirewallMcpToolPolicy::Exact {
+                            tool_names: vec!["search".to_string()],
+                        },
+                    }),
+                    suppress_body_capture: true,
+                }],
+            },
+        }];
+        let registration = VmRegistration {
+            firewalls: Some(&firewall_entries),
+            ..base_registration()
+        };
+
+        harness
+            .handle
+            .register_vm("10.200.0.5", &registration)
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(harness.registry_path())
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let api = &value["vms"]["10.200.0.5"]["firewalls"][0]["firewall"]["apis"][0];
+        assert_eq!(api["hostPolicy"]["kind"], "publicDestination");
+        assert_eq!(api["mcp"]["toolPolicy"]["kind"], "exact");
+        assert_eq!(api["mcp"]["toolPolicy"]["toolNames"][0], "search");
+        assert_eq!(api["suppressBodyCapture"], true);
     }
 
     #[tokio::test]
@@ -1217,6 +1272,8 @@ mod tests {
                     },
                     host_policy: None,
                     permissions: None,
+                    mcp: None,
+                    suppress_body_capture: false,
                 }],
             },
         }];
@@ -1268,6 +1325,8 @@ mod tests {
                     },
                     host_policy: None,
                     permissions: None,
+                    mcp: None,
+                    suppress_body_capture: false,
                 }],
             },
         }];

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -193,6 +193,16 @@ impl Firewall {
         }
         Ok(())
     }
+
+    pub(crate) fn validate_mcp_policies(&self) -> Result<(), String> {
+        for (index, api) in self.apis.iter().enumerate() {
+            if let Some(mcp) = &api.mcp {
+                api.validate_mcp_policy(mcp)
+                    .map_err(|e| format!("firewall {} apis[{index}]: {e}", self.name))?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A single firewall API entry with base URL and auth headers for proxy-side matching.
@@ -249,12 +259,12 @@ impl FirewallApi {
             }
         }
         if let Some(mcp) = &self.mcp {
-            self.validate_mcp_for_cache(mcp)?;
+            self.validate_mcp_policy(mcp)?;
         }
         Ok(())
     }
 
-    fn validate_mcp_for_cache(&self, mcp: &FirewallMcpPolicy) -> Result<(), String> {
+    fn validate_mcp_policy(&self, mcp: &FirewallMcpPolicy) -> Result<(), String> {
         let parsed =
             url::Url::parse(&self.base).map_err(|_| "MCP base URL is invalid".to_string())?;
         if self.base.contains("${{")

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -213,6 +213,14 @@ pub struct FirewallApi {
     pub host_policy: Option<FirewallBaseHostPolicy>,
     #[serde(default)]
     pub permissions: Option<Vec<FirewallPermission>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<FirewallMcpPolicy>,
+    #[serde(
+        default,
+        rename = "suppressBodyCapture",
+        skip_serializing_if = "is_false"
+    )]
+    pub suppress_body_capture: bool,
 }
 
 impl FirewallApi {
@@ -238,6 +246,99 @@ impl FirewallApi {
                         permission.name
                     ));
                 }
+            }
+        }
+        if let Some(mcp) = &self.mcp {
+            self.validate_mcp_for_cache(mcp)?;
+        }
+        Ok(())
+    }
+
+    fn validate_mcp_for_cache(&self, mcp: &FirewallMcpPolicy) -> Result<(), String> {
+        let parsed =
+            url::Url::parse(&self.base).map_err(|_| "MCP base URL is invalid".to_string())?;
+        if self.base.contains("${{")
+            || self.base.contains('{')
+            || self.base.contains('}')
+            || parsed.scheme() != "https"
+            || parsed.host_str().is_none()
+            || !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            return Err(
+                "MCP base must be a static HTTPS URL without credentials, query, or fragment"
+                    .to_string(),
+            );
+        }
+        if self.host_policy != Some(FirewallBaseHostPolicy::PublicDestination) {
+            return Err("MCP firewall requires publicDestination hostPolicy".to_string());
+        }
+        if !self.auth.headers.is_empty()
+            || self.auth.base.is_some()
+            || self
+                .auth
+                .query
+                .as_ref()
+                .is_some_and(|query| !query.is_empty())
+            || self.auth.aws_sigv4.is_some()
+        {
+            return Err("MCP firewall V1 does not support authentication".to_string());
+        }
+        if !self.suppress_body_capture {
+            return Err("MCP firewall requires body capture suppression".to_string());
+        }
+        mcp.validate_for_cache()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FirewallMcpPolicy {
+    pub tool_policy: FirewallMcpToolPolicy,
+}
+
+impl FirewallMcpPolicy {
+    fn validate_for_cache(&self) -> Result<(), String> {
+        self.tool_policy.validate_for_cache()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+pub enum FirewallMcpToolPolicy {
+    #[serde(rename = "exact", rename_all = "camelCase")]
+    Exact { tool_names: Vec<String> },
+    #[serde(rename = "all")]
+    All,
+}
+
+impl FirewallMcpToolPolicy {
+    fn validate_for_cache(&self) -> Result<(), String> {
+        use api_contracts::generated::constants::firewall::{
+            MCP_TOOL_NAME_MAX_LENGTH, MCP_TOOL_POLICY_MAX_EXACT_NAMES,
+        };
+
+        let Self::Exact { tool_names } = self else {
+            return Ok(());
+        };
+        if tool_names.is_empty() {
+            return Err("exact MCP tool policy requires tool names".to_string());
+        }
+        if tool_names.len() > MCP_TOOL_POLICY_MAX_EXACT_NAMES as usize {
+            return Err("exact MCP tool policy has too many tool names".to_string());
+        }
+        let mut seen = HashSet::new();
+        for name in tool_names {
+            if name.trim().is_empty() {
+                return Err("MCP tool name must not be empty".to_string());
+            }
+            if name.chars().count() > MCP_TOOL_NAME_MAX_LENGTH as usize {
+                return Err("MCP tool name is too long".to_string());
+            }
+            if !seen.insert(name) {
+                return Err(format!("duplicate exact MCP tool name {name:?}"));
             }
         }
         Ok(())
@@ -1521,6 +1622,8 @@ mod tests {
                     description: Some("read repo metadata".into()),
                     rules: vec!["GET /repos/{owner}/{repo}".into()],
                 }]),
+                mcp: None,
+                suppress_body_capture: false,
             }],
         };
         let json = serde_json::to_value(&fw).unwrap();
@@ -1583,6 +1686,85 @@ mod tests {
             round_trip["apis"][0]["auth"]["awsSigv4"]["accessKeyId"],
             "${{ secrets.AWS_ACCESS_KEY_ID }}"
         );
+    }
+
+    #[test]
+    fn firewall_preserves_and_validates_mcp_policy() {
+        let json = serde_json::json!({
+            "name": "remote-mcp",
+            "apis": [{
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {
+                    "toolPolicy": {
+                        "kind": "exact",
+                        "toolNames": ["search", "calendar.create"]
+                    }
+                },
+                "suppressBodyCapture": true
+            }]
+        });
+
+        let firewall: Firewall = serde_json::from_value(json).unwrap();
+        firewall.validate_for_cache().unwrap();
+        let round_trip = serde_json::to_value(&firewall).unwrap();
+
+        assert_eq!(
+            round_trip["apis"][0]["mcp"]["toolPolicy"]["toolNames"],
+            serde_json::json!(["search", "calendar.create"])
+        );
+        assert_eq!(round_trip["apis"][0]["suppressBodyCapture"], true);
+    }
+
+    #[test]
+    fn firewall_mcp_validation_fails_closed_on_unsafe_entries() {
+        let invalid_apis = [
+            serde_json::json!({
+                "base": "http://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://user:password@mcp.example.com/v1/mcp?tenant=1#fragment",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "providerOwned", "exactHosts": ["mcp.example.com"]},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "exact", "toolNames": ["search", "search"]}},
+                "suppressBodyCapture": true
+            }),
+        ];
+
+        for api in invalid_apis {
+            let firewall: Firewall = serde_json::from_value(serde_json::json!({
+                "name": "remote-mcp",
+                "apis": [api]
+            }))
+            .unwrap();
+            assert!(firewall.validate_for_cache().is_err());
+        }
     }
 
     #[test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -284,7 +284,7 @@ impl FirewallApi {
                 .is_some_and(|query| !query.is_empty())
             || self.auth.aws_sigv4.is_some()
         {
-            return Err("MCP firewall V1 does not support authentication".to_string());
+            return Err("MCP firewall does not support authentication".to_string());
         }
         if !self.suppress_body_capture {
             return Err("MCP firewall requires body capture suppression".to_string());

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -299,7 +299,7 @@ impl FirewallApi {
         if !self.suppress_body_capture {
             return Err("MCP firewall requires body capture suppression".to_string());
         }
-        mcp.validate_for_cache()
+        mcp.validate()
     }
 }
 
@@ -310,8 +310,8 @@ pub struct FirewallMcpPolicy {
 }
 
 impl FirewallMcpPolicy {
-    fn validate_for_cache(&self) -> Result<(), String> {
-        self.tool_policy.validate_for_cache()
+    fn validate(&self) -> Result<(), String> {
+        self.tool_policy.validate()
     }
 }
 
@@ -325,7 +325,7 @@ pub enum FirewallMcpToolPolicy {
 }
 
 impl FirewallMcpToolPolicy {
-    fn validate_for_cache(&self) -> Result<(), String> {
+    fn validate(&self) -> Result<(), String> {
         use api_contracts::generated::constants::firewall::{
             MCP_TOOL_NAME_MAX_LENGTH, MCP_TOOL_POLICY_MAX_EXACT_NAMES,
         };

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1728,11 +1728,35 @@ mod tests {
             serde_json::json!(["search", "calendar.create"])
         );
         assert_eq!(round_trip["apis"][0]["suppressBodyCapture"], true);
+
+        let all_tools_firewall: Firewall = serde_json::from_value(serde_json::json!({
+            "name": "remote-mcp",
+            "apis": [{
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }]
+        }))
+        .unwrap();
+        all_tools_firewall.validate_for_cache().unwrap();
     }
 
     #[test]
     fn firewall_mcp_validation_fails_closed_on_unsafe_entries() {
-        let invalid_apis = [
+        use api_contracts::generated::constants::firewall::{
+            MCP_TOOL_NAME_MAX_LENGTH, MCP_TOOL_POLICY_MAX_EXACT_NAMES,
+        };
+
+        let invalid_apis = vec![
+            serde_json::json!({
+                "base": "not a URL",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
             serde_json::json!({
                 "base": "http://mcp.example.com/v1/mcp",
                 "hostPolicy": {"kind": "publicDestination"},
@@ -1774,6 +1798,46 @@ mod tests {
                 "hostPolicy": {"kind": "publicDestination"},
                 "auth": {},
                 "mcp": {"toolPolicy": {"kind": "exact", "toolNames": ["search", "search"]}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "exact", "toolNames": []}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {
+                    "toolPolicy": {
+                        "kind": "exact",
+                        "toolNames": (0..=MCP_TOOL_POLICY_MAX_EXACT_NAMES)
+                            .map(|index| format!("tool-{index}"))
+                            .collect::<Vec<_>>()
+                    }
+                },
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {"toolPolicy": {"kind": "exact", "toolNames": [" "]}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "mcp": {
+                    "toolPolicy": {
+                        "kind": "exact",
+                        "toolNames": ["x".repeat(MCP_TOOL_NAME_MAX_LENGTH as usize + 1)]
+                    }
+                },
                 "suppressBodyCapture": true
             }),
         ];

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -285,6 +285,9 @@ impl FirewallApi {
         if self.host_policy != Some(FirewallBaseHostPolicy::PublicDestination) {
             return Err("MCP firewall requires publicDestination hostPolicy".to_string());
         }
+        if self.permissions.is_some() {
+            return Err("MCP firewall does not support route permissions".to_string());
+        }
         if !self.auth.headers.is_empty()
             || self.auth.base.is_some()
             || self
@@ -1748,6 +1751,14 @@ mod tests {
                 "base": "https://mcp.example.com/v1/mcp",
                 "hostPolicy": {"kind": "providerOwned", "exactHosts": ["mcp.example.com"]},
                 "auth": {},
+                "mcp": {"toolPolicy": {"kind": "all"}},
+                "suppressBodyCapture": true
+            }),
+            serde_json::json!({
+                "base": "https://mcp.example.com/v1/mcp",
+                "hostPolicy": {"kind": "publicDestination"},
+                "auth": {},
+                "permissions": [],
                 "mcp": {"toolPolicy": {"kind": "all"}},
                 "suppressBodyCapture": true
             }),

--- a/turbo/packages/api-contracts/src/contracts/zero-mcp.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mcp.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  firewallMcpToolNameSchema,
+  firewallMcpToolPolicySchema,
+  MCP_TOOL_NAME_MAX_LENGTH,
+  MCP_TOOL_POLICY_MAX_EXACT_NAMES,
+} from "@vm0/connectors/firewall-types";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 
@@ -8,8 +14,8 @@ export const MCP_SERVER_REF_MAX_LENGTH = 64;
 export const MCP_SERVER_DISPLAY_NAME_MAX_LENGTH = 128;
 export const MCP_SERVER_ENDPOINT_MAX_LENGTH = 2048;
 export const MCP_AGENT_GRANT_MAX_SERVERS = 32;
-export const MCP_AGENT_GRANT_MAX_TOOL_NAMES = 128;
-export const MCP_TOOL_NAME_MAX_LENGTH = 256;
+export const MCP_AGENT_GRANT_MAX_TOOL_NAMES = MCP_TOOL_POLICY_MAX_EXACT_NAMES;
+export { MCP_TOOL_NAME_MAX_LENGTH };
 export const MCP_AGENT_GRANTS_MAX_ENCODED_BYTES = 64 * 1024;
 
 const MCP_SERVER_REF_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
@@ -69,50 +75,8 @@ export const patchMcpServerBodySchema = z
   );
 export type PatchMcpServerBody = z.infer<typeof patchMcpServerBodySchema>;
 
-export const mcpToolNameSchema = z
-  .string()
-  .min(1)
-  .max(MCP_TOOL_NAME_MAX_LENGTH)
-  .refine(
-    (name) => {
-      return name.trim().length > 0;
-    },
-    { message: "Tool name cannot contain only whitespace" },
-  );
-
-const exactMcpToolPolicySchema = z
-  .object({
-    kind: z.literal("exact"),
-    toolNames: z
-      .array(mcpToolNameSchema)
-      .min(1)
-      .max(MCP_AGENT_GRANT_MAX_TOOL_NAMES),
-  })
-  .strict()
-  .superRefine((policy, ctx) => {
-    const seen = new Set<string>();
-    for (const [index, name] of policy.toolNames.entries()) {
-      if (seen.has(name)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["toolNames", index],
-          message: `Duplicate exact tool name: ${name}`,
-        });
-      }
-      seen.add(name);
-    }
-  });
-
-const allMcpToolsPolicySchema = z
-  .object({
-    kind: z.literal("all"),
-  })
-  .strict();
-
-export const mcpToolPolicySchema = z.discriminatedUnion("kind", [
-  exactMcpToolPolicySchema,
-  allMcpToolsPolicySchema,
-]);
+export const mcpToolNameSchema = firewallMcpToolNameSchema;
+export const mcpToolPolicySchema = firewallMcpToolPolicySchema;
 export type McpToolPolicy = z.infer<typeof mcpToolPolicySchema>;
 
 export const mcpAgentGrantSchema = z

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -14,6 +14,10 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
 } from "../../contracts/model-providers";
 import {
+  MCP_TOOL_NAME_MAX_LENGTH,
+  MCP_TOOL_POLICY_MAX_EXACT_NAMES,
+} from "@vm0/connectors/firewall-types";
+import {
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_APP,
@@ -100,7 +104,6 @@ const clientSessionIdHeaderDoc = [
 const clientRequestIdHeaderDoc = [
   "HTTP header carrying the per-request vm0 client request identifier.",
 ] as const;
-
 function rustString(value: string): RustConstantValue {
   return { kind: "string", value };
 }
@@ -117,6 +120,18 @@ function placeholderRustDoc(name: string): readonly string[] {
 }
 
 const expectedBindings = [
+  {
+    rustModulePath: ["firewall"],
+    rustConstName: "MCP_TOOL_NAME_MAX_LENGTH",
+    value: rustU64(MCP_TOOL_NAME_MAX_LENGTH),
+    rustDoc: ["Maximum accepted MCP tool name length."],
+  },
+  {
+    rustModulePath: ["firewall"],
+    rustConstName: "MCP_TOOL_POLICY_MAX_EXACT_NAMES",
+    value: rustU64(MCP_TOOL_POLICY_MAX_EXACT_NAMES),
+    rustDoc: ["Maximum exact MCP tool names accepted in one firewall policy."],
+  },
   {
     rustModulePath: ["client", "headers"],
     rustConstName: "CLIENT_VERSION_HEADER",

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -3,6 +3,10 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
 } from "../contracts/model-providers";
 import {
+  MCP_TOOL_NAME_MAX_LENGTH,
+  MCP_TOOL_POLICY_MAX_EXACT_NAMES,
+} from "@vm0/connectors/firewall-types";
+import {
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_APP,
@@ -83,6 +87,7 @@ const modelProviderEnvPlaceholderModule = [
 const clientHeadersModule = ["client", "headers"] as const;
 const clientTypesModule = ["client", "types"] as const;
 const runnerPathsModule = ["runners", "paths"] as const;
+const firewallModule = ["firewall"] as const;
 
 export const rustConstantRootDoc = [
   "Generated Rust constants for `@vm0/api-contracts`.",
@@ -141,6 +146,10 @@ export const rustConstantModuleDocs = [
     rustDoc: ["Runner contract constants shared by TypeScript and Rust."],
   },
   {
+    rustModulePath: firewallModule,
+    rustDoc: ["Firewall contract constants shared by TypeScript and Rust."],
+  },
+  {
     rustModulePath: runnerPathsModule,
     rustDoc: [
       "Runner and guest filesystem path constants shared across Rust and TypeScript.",
@@ -188,6 +197,18 @@ function rustU64(value: number): RustConstantValue {
 }
 
 export const rustConstantBindings = [
+  {
+    rustModulePath: firewallModule,
+    rustConstName: "MCP_TOOL_NAME_MAX_LENGTH",
+    value: rustU64(MCP_TOOL_NAME_MAX_LENGTH),
+    rustDoc: ["Maximum accepted MCP tool name length."],
+  },
+  {
+    rustModulePath: firewallModule,
+    rustConstName: "MCP_TOOL_POLICY_MAX_EXACT_NAMES",
+    value: rustU64(MCP_TOOL_POLICY_MAX_EXACT_NAMES),
+    rustDoc: ["Maximum exact MCP tool names accepted in one firewall policy."],
+  },
   {
     rustModulePath: clientHeadersModule,
     rustConstName: "CLIENT_VERSION_HEADER",

--- a/turbo/packages/connectors/src/__tests__/firewall-mcp-policy.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-mcp-policy.test.ts
@@ -32,6 +32,7 @@ describe("MCP firewall API contract", () => {
     { base: "https://mcp.example.com/v1/mcp?tenant=1" },
     { base: "https://${{ vars.HOST }}/v1/mcp" },
     { hostPolicy: { kind: "providerOwned", exactHosts: ["mcp.example.com"] } },
+    { permissions: [] },
     { auth: { headers: { Authorization: "Bearer token" } } },
     { suppressBodyCapture: undefined },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-mcp-policy.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-mcp-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { firewallApiSchema } from "../firewall-types";
+
+const validMcpApi = {
+  base: "https://mcp.example.com/v1/mcp",
+  hostPolicy: { kind: "publicDestination" },
+  auth: {},
+  mcp: {
+    toolPolicy: {
+      kind: "exact",
+      toolNames: ["search", "calendar.create"],
+    },
+  },
+  suppressBodyCapture: true,
+} as const;
+
+describe("MCP firewall API contract", () => {
+  it("accepts static no-auth public HTTPS endpoints and explicit tool policy", () => {
+    expect(firewallApiSchema.safeParse(validMcpApi).success).toBe(true);
+    expect(
+      firewallApiSchema.safeParse({
+        ...validMcpApi,
+        auth: { headers: {}, query: {} },
+        mcp: { toolPolicy: { kind: "all" } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it.each([
+    { base: "http://mcp.example.com/v1/mcp" },
+    { base: "https://mcp.example.com/v1/mcp?tenant=1" },
+    { base: "https://${{ vars.HOST }}/v1/mcp" },
+    { hostPolicy: { kind: "providerOwned", exactHosts: ["mcp.example.com"] } },
+    { auth: { headers: { Authorization: "Bearer token" } } },
+    { suppressBodyCapture: undefined },
+    {
+      mcp: {
+        toolPolicy: {
+          kind: "exact",
+          toolNames: ["search", "search"],
+        },
+      },
+    },
+  ])("rejects an unsafe MCP API entry: %j", (override) => {
+    expect(
+      firewallApiSchema.safeParse({ ...validMcpApi, ...override }).success,
+    ).toBe(false);
+  });
+});

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -12,6 +12,8 @@ export { normalizeFirewallFixedHost } from "./firewall-url-utils";
 const HOST_DOT_EQUIVALENT_PATTERN = /[\u3002\uff0e\uff61]/g;
 const HOST_POLICY_HOST_FORBIDDEN_PATTERN = /[%*[\]/?#@\\:{}<>^|]/u;
 const DNS_HOST_FORBIDDEN_ASCII_CHARS = new Set(["<", ">", "[", "]", "^", "|"]);
+export const MCP_TOOL_POLICY_MAX_EXACT_NAMES = 128;
+export const MCP_TOOL_NAME_MAX_LENGTH = 256;
 
 /**
  * Proxy-side firewall configuration for token replacement.
@@ -164,17 +166,135 @@ export const firewallBaseHostPolicySchema = z.union([
   firewallPublicDestinationHostPolicySchema,
 ]);
 
+export const firewallMcpToolNameSchema = z
+  .string()
+  .min(1)
+  .max(MCP_TOOL_NAME_MAX_LENGTH)
+  .refine(
+    (name) => {
+      return name.trim().length > 0;
+    },
+    { message: "Tool name cannot contain only whitespace" },
+  );
+
+const firewallExactMcpToolPolicySchema = z
+  .object({
+    kind: z.literal("exact"),
+    toolNames: z
+      .array(firewallMcpToolNameSchema)
+      .min(1)
+      .max(MCP_TOOL_POLICY_MAX_EXACT_NAMES),
+  })
+  .strict()
+  .superRefine((policy, ctx) => {
+    const seen = new Set<string>();
+    for (const [index, name] of policy.toolNames.entries()) {
+      if (seen.has(name)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["toolNames", index],
+          message: `Duplicate exact tool name: ${name}`,
+        });
+      }
+      seen.add(name);
+    }
+  });
+
+const firewallAllMcpToolsPolicySchema = z
+  .object({
+    kind: z.literal("all"),
+  })
+  .strict();
+
+export const firewallMcpToolPolicySchema = z.discriminatedUnion("kind", [
+  firewallExactMcpToolPolicySchema,
+  firewallAllMcpToolsPolicySchema,
+]);
+
+export const firewallMcpPolicySchema = z
+  .object({
+    toolPolicy: firewallMcpToolPolicySchema,
+  })
+  .strict();
+
+function isStaticHttpsMcpBase(base: string): boolean {
+  if (
+    base.includes("${{") ||
+    base.includes("{") ||
+    base.includes("}") ||
+    base.includes("?") ||
+    base.includes("#")
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(base);
+    return (
+      url.protocol === "https:" &&
+      url.hostname.length > 0 &&
+      url.username === "" &&
+      url.password === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Firewall API entry — a base URL with optional auth headers/query/base and permissions.
  * An entry without permissions is the owner's fallback when no concrete
  * permission route matches.
  */
-export const firewallApiSchema = z.object({
-  base: z.string(),
-  hostPolicy: firewallBaseHostPolicySchema.optional(),
-  auth: firewallAuthSchema,
-  permissions: z.array(firewallPermissionSchema).optional(),
-});
+export const firewallApiSchema = z
+  .object({
+    base: z.string(),
+    hostPolicy: firewallBaseHostPolicySchema.optional(),
+    auth: firewallAuthSchema,
+    permissions: z.array(firewallPermissionSchema).optional(),
+    mcp: firewallMcpPolicySchema.optional(),
+    suppressBodyCapture: z.literal(true).optional(),
+  })
+  .superRefine((api, ctx) => {
+    if (!api.mcp) {
+      return;
+    }
+    if (!isStaticHttpsMcpBase(api.base)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["base"],
+        message:
+          "MCP firewall base must be a static HTTPS URL without credentials, query, or fragment",
+      });
+    }
+    if (api.hostPolicy?.kind !== "publicDestination") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["hostPolicy"],
+        message: "MCP firewall requires publicDestination host policy",
+      });
+    }
+    if (
+      api.auth.base !== undefined ||
+      api.auth.awsSigv4 !== undefined ||
+      (api.auth.headers !== undefined &&
+        Object.keys(api.auth.headers).length > 0) ||
+      (api.auth.query !== undefined && Object.keys(api.auth.query).length > 0)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["auth"],
+        message: "MCP firewall V1 does not support authentication",
+      });
+    }
+    if (api.suppressBodyCapture !== true) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["suppressBodyCapture"],
+        message: "MCP firewall requires body capture suppression",
+      });
+    }
+  });
 
 /**
  * A single firewall with its name and API entries.
@@ -278,6 +398,8 @@ export type FirewallApi = z.infer<typeof firewallApiSchema>;
 export type FirewallBaseHostPolicy = z.infer<
   typeof firewallBaseHostPolicySchema
 >;
+export type FirewallMcpPolicy = z.infer<typeof firewallMcpPolicySchema>;
+export type FirewallMcpToolPolicy = z.infer<typeof firewallMcpToolPolicySchema>;
 
 export class FirewallBaseUrlResolutionError extends Error {
   constructor(message: string) {

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -284,7 +284,7 @@ export const firewallApiSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["auth"],
-        message: "MCP firewall V1 does not support authentication",
+        message: "MCP firewall does not support authentication",
       });
     }
     if (api.suppressBodyCapture !== true) {

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -274,6 +274,13 @@ export const firewallApiSchema = z
         message: "MCP firewall requires publicDestination host policy",
       });
     }
+    if (api.permissions !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["permissions"],
+        message: "MCP firewall does not support route permissions",
+      });
+    }
     if (
       api.auth.base !== undefined ||
       api.auth.awsSigv4 !== undefined ||


### PR DESCRIPTION
## Summary

- add a static no-auth HTTPS MCP firewall policy with exact-or-all tool authorization and mandatory bidirectional body-capture suppression
- carry the policy through the Rust runner and enforce bounded Streamable HTTP requests in the Python MITM boundary
- validate exact destination, framing, JSON-RPC shape, supported protocol era, allowed method, and exact tool before forwarding
- keep explicit MCP enforcement authoritative over browser and platform-origin passthrough paths
- rely on a runner-first rollout gate instead of introducing MCP-specific runtime capability negotiation or scheduler state

Closes #23482
Context: #23376

## Correctness and deployment compatibility

- this remains receiver-only: current backend writers emit no MCP firewall policy, so merging and deploying the receiver cannot activate MCP traffic
- a later writer must remain disabled until every production runner uses this release and runners from earlier releases are drained
- the final diff adds no runner capability, heartbeat inventory, queue requirement, scheduler filtering, capability endpoint, or database migration
- inline MCP policies are validated at the runner's pre-sandbox execution boundary; builtin policies remain validated when the catalog cache is loaded
- MCP entries reject generic route permissions so one dedicated tool policy remains the only application authorization model
- MCP traffic reuses the existing `publicDestination` DNS/IP and bound-connection protections, then requires the configured HTTPS authority and path exactly
- MCP destination matches suppress body capture even when owner selection or another firewall decision rejects the route before a concrete allow
- blocked or ambiguous MCP destinations return a local header-phase rejection before mitmproxy buffers a request body
- bodyless HTTP/2 lifecycle requests require a confirmed end-of-stream; open or unknown framing fails before buffering
- oversized numeric `Content-Length` values are bounded without an untrusted arbitrary-size integer conversion
- request trailers are rejected before upstream forwarding
- MCP request and response bodies stay unavailable to network capture and rejection logs, even when the run enables general network body capture

## Explicit exclusions

- no MCP management tables, APIs, run snapshots, Zero CLI, settings UI, or feature activation
- no MCP authentication or credential injection
- no backend creation of MCP policies
- no legacy HTTP+SSE-only transport
- no permanent heterogeneous-runner capability protocol

## Validation

- Turbo formatting and scoped lint for `@vm0/connectors` and `@vm0/api-contracts`
- full Turbo TypeScript type checks and Knip; latest-base contract type checks
- `pnpm -F @vm0/connectors test` — 33 files, 827 tests
- `pnpm -F @vm0/api-contracts test` — 21 files, 489 tests on the latest base
- Rust fmt, Clippy with warnings denied, docs with warnings denied, and `cargo test -p runner` — 2,869 tests
- `cargo test -p api-contracts` — 18 tests on the latest base
- `uv lock --check`, locked sync, Ruff format/lint, BasedPyright, and full mitm-addon pytest — 4,434 tests
