### PR TITLE
test(api): isolate legacy catalog validation fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1303,6 +1303,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
   it("fully validates legacy catalog attestations before caching them", async () => {
     const api = createRunsApi(context);
+    // Catalog rows are global by source, so isolate mutations from parallel test files.
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      "test-run-lifecycle-legacy-catalog",
+    );
     onTestFinished(async () => {
       mockApiTestConnectorProviderConfiguration();
       await installApiTestConnectorCatalog();


### PR DESCRIPTION
## Summary

- isolate the legacy connector catalog validation test with its own catalog source
- prevent parallel API test setup from replacing the validation authority under test
- remove the late cleanup write that could still modify the shared default source

## Exclusions

- no changes to production connector catalog loading, caching, or telemetry
- no timeout increases, retries, or skipped assertions

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
