### PR TITLE
fix(platform): stabilize presentation template previews

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/template-preview-runtime.ts
+++ b/turbo/apps/platform/src/signals/zero-page/template-preview-runtime.ts
@@ -1,14 +1,5 @@
 import type { PresentationPreviewDraft } from "../../views/zero-page/presentation-html-preview.ts";
 
-export interface PresentationTemplateDetailSelection {
-  readonly embedUrl: string;
-  readonly index: number;
-  readonly slug: string;
-  readonly themeCss: string;
-  readonly themeId: string;
-  readonly token: symbol;
-}
-
 export interface TemplatePreviewRuntime {
   readonly imagePreloads: Map<string, HTMLImageElement>;
   readonly presentation: {
@@ -20,9 +11,8 @@ export interface TemplatePreviewRuntime {
     >;
     readonly activeTokens: Map<string, symbol>;
     readonly activeIndexes: Map<string, number>;
-    activeDetail: PresentationTemplateDetailSelection | null;
-    detailFrameUrl: string | null;
-    detailOwnerSignal: AbortSignal | null;
+    detailRequestToken: symbol | null;
+    previewOwnerSignal: AbortSignal | null;
     readonly pendingSlideAnimationFrames: Map<string, number>;
     readonly pendingSlideIndexes: Map<string, number>;
     readonly thumbnailHtmlByHost: WeakMap<HTMLDivElement, string>;
@@ -43,9 +33,8 @@ export function createTemplatePreviewRuntime(): TemplatePreviewRuntime {
       pendingLoads: new Map<string, Promise<PresentationPreviewDraft | null>>(),
       activeTokens: new Map<string, symbol>(),
       activeIndexes: new Map<string, number>(),
-      activeDetail: null,
-      detailFrameUrl: null,
-      detailOwnerSignal: null,
+      detailRequestToken: null,
+      previewOwnerSignal: null,
       pendingSlideAnimationFrames: new Map<string, number>(),
       pendingSlideIndexes: new Map<string, number>(),
       thumbnailHtmlByHost: new WeakMap<HTMLDivElement, string>(),

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -4,10 +4,7 @@ import type { PresentationTemplateItem } from "@vm0/core";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { zeroBrowserEnabled$ } from "../external/feature-switch.ts";
 import { jsonParseOr, tapError } from "../utils.ts";
-import type {
-  PresentationTemplateDetailSelection,
-  TemplatePreviewRuntime,
-} from "./template-preview-runtime.ts";
+import type { TemplatePreviewRuntime } from "./template-preview-runtime.ts";
 import {
   parsePresentationPreviewDraft,
   previewPresentationHtml,
@@ -239,7 +236,6 @@ export interface TemplateCardHtmlPreviewState {
   readonly embedUrl: string;
   readonly themeId: string;
   readonly loading: boolean;
-  readonly failed: boolean;
   readonly frameUrl: string | null;
   readonly slideCount: number;
 }
@@ -269,6 +265,21 @@ export const setTemplateCardLoadedHtmlFrameUrl$ = command(
     });
   },
 );
+
+const clearTemplateCardHtmlPreviewFrames$ = command(({ get, set }) => {
+  const activeFrameUrl = get(internalTemplateCardHtmlPreview$)?.frameUrl;
+  const frameUrls = new Set(
+    Object.values(get(internalTemplateCardLoadedHtmlFrameUrls$)),
+  );
+  if (activeFrameUrl !== null && activeFrameUrl !== undefined) {
+    frameUrls.add(activeFrameUrl);
+  }
+  for (const frameUrl of frameUrls) {
+    URL.revokeObjectURL(frameUrl);
+  }
+  set(internalTemplateCardHtmlPreview$, null);
+  set(internalTemplateCardLoadedHtmlFrameUrls$, {});
+});
 
 const internalTemplateCardThemeIdBySlug$ = state<
   Readonly<Record<string, string>>
@@ -318,10 +329,13 @@ interface TemplateDetailHtmlPreviewState {
   readonly slug: string;
   readonly embedUrl: string;
   readonly themeId: string;
+  readonly themeCss: string;
   readonly index: number;
   readonly loading: boolean;
-  readonly failed: boolean;
+  readonly frameLoaded: boolean;
   readonly frameUrl: string | null;
+  readonly previousFrameSlideIndex: number | null;
+  readonly previousFrameUrl: string | null;
   readonly slideCount: number;
 }
 
@@ -331,24 +345,18 @@ export const templateDetailHtmlPreview$ = computed((get) => {
   return get(internalTemplateDetailHtmlPreview$);
 });
 
-const internalTemplateDetailThemeIdBySlug$ = state<
-  Readonly<Record<string, string>>
->({});
-export const templateDetailThemeIdBySlug$ = computed((get) => {
-  return get(internalTemplateDetailThemeIdBySlug$);
-});
-
-const internalTemplateDetailSlideIndexBySlug$ = state<
-  Readonly<Record<string, number>>
->({});
-export const templateDetailSlideIndexBySlug$ = computed((get) => {
-  return get(internalTemplateDetailSlideIndexBySlug$);
-});
-
-function presentationTemplateFallbackSlideCount(
+function presentationTemplateDetailSlideCount(
   item: PresentationTemplateItem,
 ): number {
   return Math.max(item.slideCount ?? item.previewImages.length, 1);
+}
+
+interface PresentationTemplateDetailSelection {
+  readonly embedUrl: string;
+  readonly index: number;
+  readonly slug: string;
+  readonly themeCss: string;
+  readonly themeId: string;
 }
 
 function presentationTemplateDetailPreviewState(params: {
@@ -379,50 +387,171 @@ function presentationTemplateDetailPreviewState(params: {
     slug: params.item.slug,
     embedUrl: params.item.embedUrl,
     themeId: params.selection.themeId,
+    themeCss: params.selection.themeCss,
     index: params.selection.index,
     loading: false,
-    failed: false,
+    frameLoaded: false,
     frameUrl,
+    previousFrameSlideIndex: null,
+    previousFrameUrl: null,
     slideCount: params.draft.slides.length,
   };
 }
 
-const replaceTemplateDetailHtmlPreview$ = command(
-  (
-    { set },
-    runtime: TemplatePreviewRuntime,
-    value: TemplateDetailHtmlPreviewState | null,
-  ) => {
-    if (runtime.presentation.detailFrameUrl !== null) {
-      URL.revokeObjectURL(runtime.presentation.detailFrameUrl);
+interface LoadedTemplateDetailFrame {
+  readonly slideIndex: number;
+  readonly url: string;
+}
+
+function previousTemplateDetailFrame(
+  current: TemplateDetailHtmlPreviewState | null,
+): LoadedTemplateDetailFrame | null {
+  if (current?.frameLoaded && current.frameUrl !== null) {
+    return {
+      slideIndex: current.index,
+      url: current.frameUrl,
+    };
+  }
+  if (
+    current?.previousFrameUrl !== null &&
+    current?.previousFrameUrl !== undefined &&
+    current.previousFrameSlideIndex !== null
+  ) {
+    return {
+      slideIndex: current.previousFrameSlideIndex,
+      url: current.previousFrameUrl,
+    };
+  }
+  return null;
+}
+
+function templateDetailFrameUrls(
+  preview: TemplateDetailHtmlPreviewState | null,
+): ReadonlySet<string> {
+  const frameUrls = new Set<string>();
+  if (preview?.frameUrl !== null && preview?.frameUrl !== undefined) {
+    frameUrls.add(preview.frameUrl);
+  }
+  if (
+    preview?.previousFrameUrl !== null &&
+    preview?.previousFrameUrl !== undefined
+  ) {
+    frameUrls.add(preview.previousFrameUrl);
+  }
+  return frameUrls;
+}
+
+function revokeUnusedTemplateDetailFrameUrls(
+  frameUrls: ReadonlySet<string>,
+  retainedFrameUrls: ReadonlySet<string>,
+): void {
+  for (const frameUrl of frameUrls) {
+    if (!retainedFrameUrls.has(frameUrl)) {
+      URL.revokeObjectURL(frameUrl);
     }
-    runtime.presentation.detailFrameUrl = value?.frameUrl ?? null;
-    set(internalTemplateDetailHtmlPreview$, value);
+  }
+}
+
+const replaceTemplateDetailHtmlPreview$ = command(
+  ({ get, set }, value: TemplateDetailHtmlPreviewState | null) => {
+    const current = get(internalTemplateDetailHtmlPreview$);
+    if (value === null) {
+      revokeUnusedTemplateDetailFrameUrls(
+        templateDetailFrameUrls(current),
+        new Set(),
+      );
+      set(internalTemplateDetailHtmlPreview$, null);
+      return;
+    }
+
+    const previousFrame = previousTemplateDetailFrame(current);
+    const retainedFrameUrls = new Set<string>();
+    if (value.frameUrl !== null) {
+      retainedFrameUrls.add(value.frameUrl);
+    }
+    if (previousFrame !== null) {
+      retainedFrameUrls.add(previousFrame.url);
+    }
+    revokeUnusedTemplateDetailFrameUrls(
+      templateDetailFrameUrls(current),
+      retainedFrameUrls,
+    );
+    set(internalTemplateDetailHtmlPreview$, {
+      ...value,
+      previousFrameSlideIndex: previousFrame?.slideIndex ?? null,
+      previousFrameUrl: previousFrame?.url ?? null,
+    });
+  },
+);
+
+export const settlePresentationTemplateDetailPreviewFrame$ = command(
+  ({ get, set }, frameUrl: string): void => {
+    const current = get(internalTemplateDetailHtmlPreview$);
+    if (current?.frameUrl !== frameUrl) {
+      return;
+    }
+    if (current.previousFrameUrl !== null) {
+      URL.revokeObjectURL(current.previousFrameUrl);
+    }
+    set(internalTemplateDetailHtmlPreview$, {
+      ...current,
+      frameLoaded: true,
+      previousFrameSlideIndex: null,
+      previousFrameUrl: null,
+    });
+  },
+);
+
+export const releaseTemplatePickerPreviewResources$ = command(
+  ({ set }, runtime: TemplatePreviewRuntime) => {
+    const preview = runtime.presentation;
+    preview.detailRequestToken = null;
+    for (const animationFrame of preview.pendingSlideAnimationFrames.values()) {
+      window.cancelAnimationFrame(animationFrame);
+    }
+    preview.pendingSlideAnimationFrames.clear();
+    preview.pendingSlideIndexes.clear();
+    preview.activeIndexes.clear();
+    preview.activeTokens.clear();
+    set(clearTemplateCardHtmlPreviewFrames$);
+    set(internalTemplateCardHover$, null);
+    set(replaceTemplateDetailHtmlPreview$, null);
+    set(internalTemplatePickerPreviewSlug$, null);
+  },
+);
+
+export const ownTemplatePickerPreviewResources$ = command(
+  ({ set }, runtime: TemplatePreviewRuntime, signal: AbortSignal): void => {
+    const preview = runtime.presentation;
+    if (preview.previewOwnerSignal === signal) {
+      return;
+    }
+    preview.previewOwnerSignal = signal;
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (preview.previewOwnerSignal !== signal) {
+          return;
+        }
+        preview.previewOwnerSignal = null;
+        set(releaseTemplatePickerPreviewResources$, runtime);
+      },
+      { once: true },
+    );
   },
 );
 
 const applyPresentationTemplateDetailSelection$ = command(
   (
-    { get, set },
+    { set },
     runtime: TemplatePreviewRuntime,
     item: PresentationTemplateItem,
     selection: PresentationTemplateDetailSelection,
   ) => {
-    runtime.presentation.activeDetail = selection;
-    set(internalTemplateDetailThemeIdBySlug$, {
-      ...get(internalTemplateDetailThemeIdBySlug$),
-      [item.slug]: selection.themeId,
-    });
-    set(internalTemplateDetailSlideIndexBySlug$, {
-      ...get(internalTemplateDetailSlideIndexBySlug$),
-      [item.slug]: selection.index,
-    });
-
     const draft = runtime.presentation.drafts.get(item.embedUrl);
     if (draft !== undefined) {
       set(
         replaceTemplateDetailHtmlPreview$,
-        runtime,
         presentationTemplateDetailPreviewState({
           draft,
           item,
@@ -433,15 +562,18 @@ const applyPresentationTemplateDetailSelection$ = command(
     }
 
     const failed = runtime.presentation.failed.has(item.embedUrl);
-    set(replaceTemplateDetailHtmlPreview$, runtime, {
+    set(replaceTemplateDetailHtmlPreview$, {
       slug: item.slug,
       embedUrl: item.embedUrl,
       themeId: selection.themeId,
+      themeCss: selection.themeCss,
       index: selection.index,
       loading: !failed,
-      failed,
+      frameLoaded: false,
       frameUrl: null,
-      slideCount: presentationTemplateFallbackSlideCount(item),
+      previousFrameSlideIndex: null,
+      previousFrameUrl: null,
+      slideCount: presentationTemplateDetailSlideCount(item),
     });
   },
 );
@@ -476,30 +608,13 @@ interface PresentationTemplateDetailSelectionParams {
 
 export const openPresentationTemplateDetailPreview$ = command(
   async (
-    { set },
+    { get, set },
     params: PresentationTemplateDetailSelectionParams,
     signal: AbortSignal,
   ): Promise<void> => {
     signal.throwIfAborted();
     const cache = params.runtime.presentation;
-    if (cache.detailOwnerSignal !== signal) {
-      cache.detailOwnerSignal = signal;
-      signal.addEventListener(
-        "abort",
-        () => {
-          if (cache.detailOwnerSignal !== signal) {
-            return;
-          }
-          cache.activeDetail = null;
-          cache.detailOwnerSignal = null;
-          if (cache.detailFrameUrl !== null) {
-            URL.revokeObjectURL(cache.detailFrameUrl);
-            cache.detailFrameUrl = null;
-          }
-        },
-        { once: true },
-      );
-    }
+    set(ownTemplatePickerPreviewResources$, params.runtime, signal);
     const token = Symbol(params.item.embedUrl);
     const selection: PresentationTemplateDetailSelection = {
       embedUrl: params.item.embedUrl,
@@ -507,8 +622,8 @@ export const openPresentationTemplateDetailPreview$ = command(
       slug: params.item.slug,
       themeCss: params.themeCss,
       themeId: params.themeId,
-      token,
     };
+    cache.detailRequestToken = token;
     set(
       applyPresentationTemplateDetailSelection$,
       params.runtime,
@@ -548,22 +663,10 @@ export const openPresentationTemplateDetailPreview$ = command(
       cache.drafts.set(params.item.embedUrl, result);
     }
 
-    const activeDetail = cache.activeDetail;
-    if (activeDetail?.token !== token) {
+    if (cache.detailRequestToken !== token) {
       return;
     }
-    set(
-      applyPresentationTemplateDetailSelection$,
-      params.runtime,
-      params.item,
-      activeDetail,
-    );
-  },
-);
-
-export const selectPresentationTemplateDetailPreview$ = command(
-  ({ set }, params: PresentationTemplateDetailSelectionParams) => {
-    const activeDetail = params.runtime.presentation.activeDetail;
+    const activeDetail = get(internalTemplateDetailHtmlPreview$);
     if (
       activeDetail === null ||
       activeDetail.embedUrl !== params.item.embedUrl ||
@@ -576,8 +679,34 @@ export const selectPresentationTemplateDetailPreview$ = command(
       params.runtime,
       params.item,
       {
-        ...activeDetail,
+        embedUrl: activeDetail.embedUrl,
+        index: activeDetail.index,
+        slug: activeDetail.slug,
+        themeCss: activeDetail.themeCss,
+        themeId: activeDetail.themeId,
+      },
+    );
+  },
+);
+
+export const selectPresentationTemplateDetailPreview$ = command(
+  ({ get, set }, params: PresentationTemplateDetailSelectionParams) => {
+    const activeDetail = get(internalTemplateDetailHtmlPreview$);
+    if (
+      activeDetail === null ||
+      activeDetail.embedUrl !== params.item.embedUrl ||
+      activeDetail.slug !== params.item.slug
+    ) {
+      return;
+    }
+    set(
+      applyPresentationTemplateDetailSelection$,
+      params.runtime,
+      params.item,
+      {
+        embedUrl: params.item.embedUrl,
         index: params.index,
+        slug: params.item.slug,
         themeCss: params.themeCss,
         themeId: params.themeId,
       },
@@ -587,8 +716,8 @@ export const selectPresentationTemplateDetailPreview$ = command(
 
 export const closePresentationTemplateDetailPreview$ = command(
   ({ set }, runtime: TemplatePreviewRuntime) => {
-    runtime.presentation.activeDetail = null;
-    set(replaceTemplateDetailHtmlPreview$, runtime, null);
+    runtime.presentation.detailRequestToken = null;
+    set(replaceTemplateDetailHtmlPreview$, null);
     set(internalTemplatePickerPreviewSlug$, null);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -44,9 +44,6 @@ import {
   expectTemplateAttachedToComposer,
 } from "./chat-composer-test-helpers.ts";
 
-const PRESENTATION_DECK_METADATA =
-  '<script id="vm0-deck-metadata" type="application/json">{"kind":"presentation-html","editProtocolVersion":1,"slides":{}}</script>';
-
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
   context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {
@@ -59,7 +56,7 @@ beforeEach(() => {
       1,
     );
     return new Response(
-      `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}${Array.from(
+      `<!doctype html><html><body>${Array.from(
         { length: slideCount },
         (_, index) => {
           return `<section data-vm0-slide data-slide-id="slide-${String(index + 1)}"><h1>Slide ${String(index + 1)}</h1></section>`;
@@ -252,6 +249,65 @@ describe("chat composer templates", () => {
       restoreIdleCallback();
       imagePreloads.restore();
     }
+  });
+
+  it("loads the presentation preview at low resolution before replacing it with the high-resolution image", async () => {
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+
+    const lowResolutionImage = await screen.findByTestId(
+      `${template.title} card image preview`,
+    );
+    const highResolutionImage = lowResolutionImage.parentElement?.querySelector(
+      '[data-template-preview-image="high"]',
+    );
+    if (!(highResolutionImage instanceof HTMLImageElement)) {
+      throw new Error("High-resolution presentation preview image not found");
+    }
+
+    expect(lowResolutionImage).toHaveAttribute(
+      "src",
+      expect.stringContaining("width=480,height=270"),
+    );
+    expect(highResolutionImage).not.toHaveAttribute("src");
+    expect(highResolutionImage).toHaveAttribute(
+      "data-src",
+      expect.stringContaining("width=708,height=398"),
+    );
+    if (template.cardPreviewImage === undefined) {
+      throw new Error("Presentation card preview image not found");
+    }
+    expect(highResolutionImage).toHaveAttribute(
+      "data-src",
+      r2ImageTransformUrl(template.cardPreviewImage, {
+        width: 708,
+        height: 398,
+      }),
+    );
+
+    fireEvent.load(lowResolutionImage);
+    expect(highResolutionImage).toHaveAttribute(
+      "src",
+      highResolutionImage.dataset.src,
+    );
+    expect(lowResolutionImage).not.toHaveAttribute("data-replaced");
+
+    fireEvent.load(highResolutionImage);
+    await waitFor(() => {
+      expect(highResolutionImage).toHaveAttribute("data-loaded", "true");
+      expect(lowResolutionImage).not.toHaveAttribute("data-replaced");
+    });
   });
 
   it("places the template control immediately after the legacy attach button by default", async () => {
@@ -655,7 +711,6 @@ describe("chat composer templates", () => {
           <!doctype html>
           <html>
             <body>
-              ${PRESENTATION_DECK_METADATA}
               <section data-vm0-slide data-slide-id="slide-one">
                 <h1>Slide one</h1>
               </section>
@@ -766,10 +821,27 @@ describe("chat composer templates", () => {
           screen.getByTestId(`${prismTemplate.title} card HTML preview`),
         ).toHaveAttribute("src", expect.stringMatching(/^blob:/));
       });
-      const prismPreviewHtml = await htmlForFrame(currentPrismPreviewFrame());
+      const prismFrame = currentPrismPreviewFrame();
+      const prismFrameUrl = prismFrame.getAttribute("src");
+      if (prismFrameUrl === null) {
+        throw new Error("Prism preview frame URL not found");
+      }
+      const prismPreviewHtml = await htmlForFrame(prismFrame);
       expect(prismPreviewHtml).toContain("--accent:#7257E6");
       expect(prismPreviewHtml).toContain("--s1:#FF6B4A");
       expect(prismPreviewHtml).toContain("--s2:#AEE63E");
+      fireEvent.load(prismFrame);
+      await waitFor(() => {
+        expect(currentPrismPreviewFrame()).toHaveAttribute(
+          "data-loaded",
+          "true",
+        );
+      });
+      click(screen.getByLabelText("Close"));
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(revokeObjectURL).toHaveBeenCalledWith(prismFrameUrl);
     } finally {
       if (originalCreateObjectURL) {
         Object.defineProperty(URL, "createObjectURL", {
@@ -867,7 +939,7 @@ describe("chat composer templates", () => {
     try {
       previewFetch.resolve(
         new Response(
-          `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}${Array.from(
+          `<!doctype html><html><body>${Array.from(
             { length: slideCount },
             (_, index) => {
               const slideNumber = index + 1;
@@ -916,10 +988,10 @@ describe("chat composer templates", () => {
   it("uses the presentation detail theme for template selection", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
-      return item.slug !== PRESENTATION_TEMPLATE_PICKER_ITEMS[0]?.slug;
+      return item.slug === "botane-organic-deck";
     });
     if (template === undefined) {
-      throw new Error("Second presentation template not found");
+      throw new Error("Botane organic presentation template not found");
     }
     let selectedColorSystemId: string | undefined;
     mockChatLifecycle(context, {
@@ -957,6 +1029,35 @@ describe("chat composer templates", () => {
         }),
       ).toBeInTheDocument();
     });
+    const initialDetailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    const initialDetailImageSrc = initialDetailImage.getAttribute("src");
+    const initialHighResolutionDetailImage =
+      initialDetailImage.parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (
+      initialHighResolutionDetailImage === null ||
+      initialHighResolutionDetailImage === undefined
+    ) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    fireEvent.load(initialDetailImage);
+    const initialHighResolutionDetailImageSrc =
+      initialHighResolutionDetailImage.getAttribute("src");
+    if (initialHighResolutionDetailImageSrc === null) {
+      throw new Error("High-resolution detail preview URL not found");
+    }
+    fireEvent.load(initialHighResolutionDetailImage);
+    expect(initialHighResolutionDetailImage).toHaveAttribute(
+      "data-loaded",
+      "true",
+    );
+    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
+    if (!prismCardPreview) {
+      throw new Error("Prism card preview not found");
+    }
     await user.click(
       within(templateDialog).getByLabelText("Select style Prism"),
     );
@@ -967,20 +1068,119 @@ describe("chat composer templates", () => {
       context.store.get(templateCardThemeIdBySlug$)[template.slug],
     ).toBeUndefined();
 
-    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
-    if (!prismCardPreview) {
-      throw new Error("Prism card preview not found");
-    }
-    expect(
-      within(templateDialog).getByTestId(
-        `${template.title} detail image preview`,
-      ),
-    ).toHaveAttribute(
+    const prismDetailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    expect(prismDetailImage).toBe(initialDetailImage);
+    expect(prismDetailImage).toHaveAttribute(
       "src",
-      r2ImageTransformUrl(template.previewImages[0]!, {
+      r2ImageTransformUrl(prismCardPreview, {
+        width: 224,
+        height: 126,
+      }),
+    );
+    const highResolutionDetailImage =
+      prismDetailImage.parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (
+      highResolutionDetailImage === null ||
+      highResolutionDetailImage === undefined
+    ) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    expect(highResolutionDetailImage).toBe(initialHighResolutionDetailImage);
+    expect(highResolutionDetailImage).toHaveAttribute(
+      "src",
+      initialHighResolutionDetailImageSrc,
+    );
+    expect(highResolutionDetailImage).toHaveAttribute("data-loaded", "true");
+    expect(highResolutionDetailImage).toHaveAttribute(
+      "data-src",
+      prismCardPreview,
+    );
+    expect(initialDetailImageSrc).not.toBe(
+      r2ImageTransformUrl(prismCardPreview, {
         width: 480,
         height: 270,
       }),
+    );
+
+    await user.click(within(templateDialog).getByLabelText("Preview slide 2"));
+    const secondSlideDetailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    const secondSlideHighResolutionImage =
+      secondSlideDetailImage.parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (
+      secondSlideHighResolutionImage === null ||
+      secondSlideHighResolutionImage === undefined
+    ) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    expect(secondSlideDetailImage).toBe(initialDetailImage);
+    expect(secondSlideHighResolutionImage).toBe(
+      initialHighResolutionDetailImage,
+    );
+    expect(secondSlideHighResolutionImage).toHaveAttribute(
+      "src",
+      initialHighResolutionDetailImageSrc,
+    );
+    expect(secondSlideHighResolutionImage).toHaveAttribute(
+      "data-loaded",
+      "true",
+    );
+    expect(secondSlideHighResolutionImage).toHaveAttribute(
+      "data-src",
+      template.previewImages[1],
+    );
+    expect(secondSlideDetailImage).toHaveAttribute(
+      "src",
+      r2ImageTransformUrl(template.previewImages[1]!, {
+        width: 224,
+        height: 126,
+      }),
+    );
+
+    fireEvent.load(secondSlideDetailImage);
+    await waitFor(() => {
+      expect(secondSlideHighResolutionImage).toHaveAttribute(
+        "src",
+        secondSlideHighResolutionImage.dataset.src,
+      );
+      expect(secondSlideHighResolutionImage).not.toHaveAttribute("data-loaded");
+    });
+
+    await user.click(within(templateDialog).getByLabelText("Preview slide 11"));
+    const eleventhSlideDetailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    const eleventhSlideHighResolutionImage =
+      eleventhSlideDetailImage.parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (
+      eleventhSlideHighResolutionImage === null ||
+      eleventhSlideHighResolutionImage === undefined
+    ) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    expect(eleventhSlideDetailImage).toHaveAttribute(
+      "src",
+      r2ImageTransformUrl(template.previewImages[10]!, {
+        width: 224,
+        height: 126,
+      }),
+    );
+    expect(eleventhSlideHighResolutionImage).toHaveAttribute(
+      "data-src",
+      template.previewImages[10],
+    );
+    expect(eleventhSlideHighResolutionImage).not.toHaveAttribute(
+      "data-src",
+      expect.stringContaining("presentation-gallery"),
     );
 
     await user.click(
@@ -1025,6 +1225,227 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(selectedColorSystemId).toBe("color-system:prism");
     });
+  });
+
+  it("uses the gallery image only after the detail HTML preview fails", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
+      return item.slug === "botane-organic-deck";
+    });
+    if (template === undefined) {
+      throw new Error("Botane organic presentation template not found");
+    }
+    const previewFetch = createDeferredPromise<Response>(AbortSignal.any([]));
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return previewFetch.promise;
+    });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    await user.click(
+      screen.getByLabelText(`Preview ${template.title} at current slide`),
+    );
+    const templateDialog = screen.getByRole("dialog");
+    await user.click(within(templateDialog).getByLabelText("Preview slide 11"));
+    const detailImage = within(templateDialog).getByTestId(
+      `${template.title} detail image preview`,
+    );
+    const highResolutionImage =
+      detailImage.parentElement?.querySelector<HTMLImageElement>(
+        '[data-template-preview-image="high"]',
+      );
+    if (highResolutionImage === null || highResolutionImage === undefined) {
+      throw new Error("High-resolution detail preview image not found");
+    }
+    expect(highResolutionImage).toHaveAttribute(
+      "data-src",
+      template.previewImages[10],
+    );
+
+    previewFetch.resolve(new Response(null, { status: 500 }));
+
+    await waitFor(() => {
+      expect(highResolutionImage).toHaveAttribute(
+        "data-src",
+        `https://static.vm0.io/web/assets/presentation-gallery/2026-07-04/${template.slug}/slide-011.webp`,
+      );
+    });
+  });
+
+  it("updates the visible detail preview frame when the theme changes", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
+      return item.slug === "editorial-magazine-deck";
+    });
+    if (template === undefined) {
+      throw new Error("Editorial magazine presentation template not found");
+    }
+
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const blobHtml: Promise<string>[] = [];
+    const createObjectURL = vi.fn((blob: Blob) => {
+      blobHtml.push(blob.text());
+      return `blob:detail-theme-preview-${String(blobHtml.length)}`;
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      mockChatLifecycle(context, { threadId: THREAD_ID });
+      detachedSetupPage({
+        context,
+        path: `/chats/${THREAD_ID}`,
+      });
+
+      click(
+        await waitFor(() => {
+          return screen.getByLabelText("Template");
+        }),
+      );
+      await user.click(
+        screen.getByLabelText(`Preview ${template.title} at current slide`),
+      );
+      const templateDialog = screen.getByRole("dialog");
+      const frame = () => {
+        return within(templateDialog).getByTestId(
+          `${template.title} detail HTML preview`,
+        );
+      };
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute(
+          "src",
+          expect.stringMatching(/^blob:detail-theme-preview-/),
+        );
+      });
+      expect(frame()).not.toHaveAttribute("data-loaded");
+      expect(
+        within(templateDialog).getByTestId(
+          `${template.title} detail image preview`,
+        ),
+      ).toBeInTheDocument();
+      fireEvent.load(frame());
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute("data-loaded", "true");
+      });
+      const initialFrameSrc = frame().getAttribute("src");
+      if (initialFrameSrc === null) {
+        throw new Error("Initial detail preview frame URL not found");
+      }
+      const firstThumbnail = () => {
+        return within(templateDialog).getByLabelText(
+          `${template.title} slide 1 preview`,
+        );
+      };
+      const secondThumbnail = () => {
+        return within(templateDialog).getByLabelText(
+          `${template.title} slide 2 preview`,
+        );
+      };
+      const initialThumbnailAccent = firstThumbnail().getAttribute("style");
+      const initialSecondThumbnailAccent =
+        secondThumbnail().getAttribute("style");
+      expect(
+        firstThumbnail().parentElement?.querySelector("img"),
+      ).not.toBeNull();
+      expect(
+        secondThumbnail().parentElement?.querySelector("img"),
+      ).not.toBeNull();
+
+      await user.click(
+        within(templateDialog).getByLabelText("Select style Prism"),
+      );
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute(
+          "src",
+          expect.stringMatching(/^blob:detail-theme-preview-/),
+        );
+        expect(frame().getAttribute("src")).not.toBe(initialFrameSrc);
+      });
+      expect(frame()).not.toHaveAttribute("data-loaded");
+      const previousFrame = templateDialog.querySelector(
+        '[data-template-detail-frame="previous"]',
+      );
+      expect(previousFrame).toHaveAttribute("src", initialFrameSrc);
+      expect(previousFrame).toHaveAttribute("data-loaded", "true");
+      fireEvent.load(frame());
+      await waitFor(() => {
+        expect(frame()).toHaveAttribute("data-loaded", "true");
+        expect(
+          templateDialog.querySelector(
+            '[data-template-detail-frame="previous"]',
+          ),
+        ).not.toBeInTheDocument();
+      });
+      expect(revokeObjectURL).toHaveBeenCalledWith(initialFrameSrc);
+
+      const themedFrameSrc = frame().getAttribute("src");
+      if (themedFrameSrc === null) {
+        throw new Error("Themed detail preview frame URL not found");
+      }
+      const match = /^blob:detail-theme-preview-(\d+)$/.exec(themedFrameSrc);
+      if (match === null) {
+        throw new Error(
+          `Unexpected detail preview frame URL: ${themedFrameSrc}`,
+        );
+      }
+      const themedHtml = await blobHtml[Number(match[1]) - 1];
+      expect(themedHtml).toContain("--accent:#7257E6");
+      await waitFor(() => {
+        const themedThumbnailAccent = firstThumbnail().getAttribute("style");
+        expect(themedThumbnailAccent).toContain("--accent: #7257E6");
+        expect(themedThumbnailAccent).not.toBe(initialThumbnailAccent);
+        const themedSecondThumbnailAccent =
+          secondThumbnail().getAttribute("style");
+        expect(themedSecondThumbnailAccent).toContain("--accent: #7257E6");
+        expect(themedSecondThumbnailAccent).not.toBe(
+          initialSecondThumbnailAccent,
+        );
+      });
+      const closeButton = queryAllByRoleFast("button", templateDialog).find(
+        (candidate) => {
+          return candidate.getAttribute("aria-label") === "Close";
+        },
+      );
+      if (!closeButton) {
+        throw new Error("Close button not found");
+      }
+      await user.click(closeButton);
+      expect(revokeObjectURL).toHaveBeenCalledWith(themedFrameSrc);
+    } finally {
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, "createObjectURL", {
+          configurable: true,
+          value: originalCreateObjectURL,
+        });
+      } else {
+        delete (URL as { createObjectURL?: unknown }).createObjectURL;
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, "revokeObjectURL", {
+          configurable: true,
+          value: originalRevokeObjectURL,
+        });
+      } else {
+        delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL;
+      }
+    }
   });
 
   it("selects presentation templates with the default card theme", async () => {
@@ -1111,7 +1532,6 @@ describe("chat composer templates", () => {
           <!doctype html>
           <html>
             <body>
-              ${PRESENTATION_DECK_METADATA}
               ${Array.from({ length: lastSlideNumber }, (_, index) => {
                 return `<section data-vm0-slide data-slide-id="slide-${String(
                   index + 1,
@@ -1281,10 +1701,9 @@ describe("chat composer templates", () => {
         previewFetchCount += 1;
         return previewFetch.promise;
       }
-      return new Response(
-        `<!doctype html><html><body>${PRESENTATION_DECK_METADATA}</body></html>`,
-        { headers: { "Content-Type": "text/html" } },
-      );
+      return new Response("<!doctype html><html><body></body></html>", {
+        headers: { "Content-Type": "text/html" },
+      });
     });
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
@@ -1306,8 +1725,8 @@ describe("chat composer templates", () => {
       await waitFor(() => {
         expect(previewFetchCount).toBe(1);
         expect(
-          screen.getByTestId(`${template.title} detail HTML preview`),
-        ).not.toHaveAttribute("src");
+          screen.queryByTestId(`${template.title} detail HTML preview`),
+        ).not.toBeInTheDocument();
       });
 
       const templateButton = queryAllByRoleFast("button").find((candidate) => {
@@ -1329,7 +1748,6 @@ describe("chat composer templates", () => {
             <!doctype html>
             <html>
               <body>
-                ${PRESENTATION_DECK_METADATA}
                 <section data-vm0-slide data-slide-id="slide-one">
                   <h1>Slide one</h1>
                 </section>
@@ -1389,7 +1807,7 @@ describe("chat composer templates", () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
       return new Response(
-        `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${PRESENTATION_DECK_METADATA}${template.previewImages
+        `<!doctype html><html><head><style>:root { --bg: white; --ink: black; } section { width: 1600px; height: 900px; background: var(--bg); color: var(--ink); }</style></head><body>${template.previewImages
           .map((_, index) => {
             return `<section data-vm0-slide data-slide-id="slide-${index + 1}"><h1>Slide ${index + 1}</h1></section>`;
           })
@@ -1466,7 +1884,10 @@ describe("chat composer templates", () => {
     fireEvent.keyDown(firstSlidePreviewButton, { key: "Tab" });
     expect(document.activeElement).toBe(secondSlidePreviewButton);
     expect(firstSlidePreviewButton.querySelector("iframe")).toBeNull();
-    expect(firstSlidePreviewButton.querySelector("img")).toBeNull();
+    expect(firstSlidePreviewButton.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("width=224,height=126"),
+    );
     expect(
       firstSlidePreviewButton.querySelector(
         `[aria-label="${template.title} slide 1 preview"]`,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { previewPresentationHtml } from "../presentation-html-preview.ts";
+import {
+  parsePresentationPreviewDraft,
+  previewPresentationHtml,
+} from "../presentation-html-preview.ts";
+
+describe("parsePresentationPreviewDraft", () => {
+  it("parses static presentation HTML without editor metadata", () => {
+    const draft = parsePresentationPreviewDraft(`
+      <!doctype html>
+      <html>
+        <body>
+          <section class="slide"><h1>First slide</h1></section>
+          <section class="slide"><h1>Second slide</h1></section>
+        </body>
+      </html>
+    `);
+
+    expect(draft.slides).toStrictEqual([
+      { id: "slide-1", notes: "", title: "First slide" },
+      { id: "slide-2", notes: "", title: "Second slide" },
+    ]);
+  });
+});
 
 describe("previewPresentationHtml", () => {
   it("materializes theme switcher defaults before removing scripts", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-preview.test.ts
@@ -1,27 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  parsePresentationPreviewDraft,
-  previewPresentationHtml,
-} from "../presentation-html-preview.ts";
-
-describe("parsePresentationPreviewDraft", () => {
-  it("parses static presentation HTML without editor metadata", () => {
-    const draft = parsePresentationPreviewDraft(`
-      <!doctype html>
-      <html>
-        <body>
-          <section class="slide"><h1>First slide</h1></section>
-          <section class="slide"><h1>Second slide</h1></section>
-        </body>
-      </html>
-    `);
-
-    expect(draft.slides).toStrictEqual([
-      { id: "slide-1", notes: "", title: "First slide" },
-      { id: "slide-2", notes: "", title: "Second slide" },
-    ]);
-  });
-});
+import { previewPresentationHtml } from "../presentation-html-preview.ts";
 
 describe("previewPresentationHtml", () => {
   it("materializes theme switcher defaults before removing scripts", () => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-preview.ts
@@ -74,16 +74,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function deckMetadataScript(doc: Document): HTMLScriptElement {
+function deckMetadataScript(doc: Document): HTMLScriptElement | null {
   const script = doc.getElementById(METADATA_SCRIPT_ID);
   if (!(script instanceof HTMLScriptElement) || !script.textContent) {
-    throw new Error("Presentation deck metadata is required");
+    return null;
   }
   return script;
 }
 
 function parseDeckMetadata(doc: Document): DeckMetadata {
   const script = deckMetadataScript(doc);
+  if (script === null) {
+    return {};
+  }
   const parsed: unknown = JSON.parse(script.textContent);
   if (!isRecord(parsed)) {
     throw new Error("Invalid presentation deck metadata");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -217,12 +217,13 @@ import {
   setTemplateCardHtmlPreview$,
   type TemplateCardHtmlPreviewState,
   templateDetailHtmlPreview$,
-  templateDetailThemeIdBySlug$,
-  templateDetailSlideIndexBySlug$,
   closePresentationTemplateDetailPreview$,
   loadPresentationTemplateHtmlPreview,
+  ownTemplatePickerPreviewResources$,
   openPresentationTemplateDetailPreview$,
+  releaseTemplatePickerPreviewResources$,
   selectPresentationTemplateDetailPreview$,
+  settlePresentationTemplateDetailPreviewFrame$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
   audioInputAvailable$,
@@ -403,6 +404,17 @@ type ComposerTemplatePicker = NonNullable<
 type ComposerComputerUse = NonNullable<ZeroChatComposerProps["computerUse"]>;
 
 const TEMPLATE_CARD_PREVIEW_SIZE = { width: 480, height: 270 } as const;
+const TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE = {
+  width: 708,
+  height: 398,
+} as const;
+const TEMPLATE_DETAIL_THUMBNAIL_PREVIEW_SIZE = {
+  width: 224,
+  height: 126,
+} as const;
+const PRESENTATION_GALLERY_PREVIEW_BASE_URL =
+  "https://static.vm0.io/web/assets/presentation-gallery/2026-07-04";
+const PRESENTATION_GALLERY_SLIDE_COUNT = 15;
 const TEMPLATE_PREWARM_IMAGE_COUNT = 15;
 const ILLUSTRATION_PREWARM_IMAGE_COUNT = 24;
 const ILLUSTRATION_EAGER_IMAGE_COUNT = 24;
@@ -1599,12 +1611,6 @@ function TemplateEmptyPanel({
   );
 }
 
-function presentationTemplateSlideImages(
-  item: PresentationTemplateItem,
-): readonly string[] {
-  return item.previewImages;
-}
-
 function presentationTemplateSlideCount(
   item: PresentationTemplateItem,
 ): number {
@@ -1634,18 +1640,63 @@ function presentationTemplateCardSlideImage(
   if (cardPreviewSource !== undefined) {
     return r2ImageTransformUrl(cardPreviewSource, size);
   }
-  return presentationTemplateFallbackSlideImage(item, index, size);
+  return presentationTemplateGallerySlideImage(item, index, size);
 }
 
-function presentationTemplateFallbackSlideImage(
+function presentationTemplateGallerySlideImage(
   item: PresentationTemplateItem,
   index: number,
   size: TemplatePreviewImageSize = TEMPLATE_CARD_PREVIEW_SIZE,
 ): string {
-  const slideImages = presentationTemplateSlideImages(item);
-  const safeIndex = Math.max(0, Math.min(index, slideImages.length - 1));
-  const image = slideImages[safeIndex] ?? item.previewImage;
-  return r2ImageTransformUrl(image, size);
+  return r2ImageTransformUrl(
+    presentationTemplateGallerySlideUrl(item, index),
+    size,
+  );
+}
+
+function presentationTemplateGallerySlideUrl(
+  item: PresentationTemplateItem,
+  index: number,
+): string {
+  const safeIndex = Math.max(
+    0,
+    Math.min(index, PRESENTATION_GALLERY_SLIDE_COUNT - 1),
+  );
+  const slideNumber = String(safeIndex + 1).padStart(3, "0");
+  return `${PRESENTATION_GALLERY_PREVIEW_BASE_URL}/${item.slug}/slide-${slideNumber}.webp`;
+}
+
+function presentationTemplateHighResolutionSlideImage(
+  item: PresentationTemplateItem,
+  index: number,
+  theme: PresentationTemplateThemeOption,
+  size: TemplatePreviewImageSize = TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
+): string {
+  if (index === 0) {
+    return presentationTemplateCardSlideImage(item, index, theme, size);
+  }
+  return presentationTemplateGallerySlideImage(item, index, size);
+}
+
+function presentationTemplateDetailSlideImageSource(
+  item: PresentationTemplateItem,
+  index: number,
+  theme: PresentationTemplateThemeOption,
+  htmlPreviewFailed: boolean,
+): string {
+  if (index === 0) {
+    return (
+      presentationTemplateThemedCardPreviewSource(item, theme) ??
+      presentationTemplateGallerySlideUrl(item, index)
+    );
+  }
+  if (htmlPreviewFailed) {
+    return presentationTemplateGallerySlideUrl(item, index);
+  }
+  return (
+    item.previewImages[index] ??
+    presentationTemplateGallerySlideUrl(item, index)
+  );
 }
 
 function prewarmTemplatePreviewImage(
@@ -2568,14 +2619,14 @@ function renderPresentationTemplateShadowThumbnail(
 
 function PresentationTemplateShadowThumbnail({
   draft,
-  fallbackImage,
+  imageUrl,
   runtime,
   slideId,
   themeVariables,
   title,
 }: {
   readonly draft: PresentationPreviewDraft | undefined;
-  readonly fallbackImage: string;
+  readonly imageUrl: string;
   readonly runtime: TemplatePreviewRuntime;
   readonly slideId: string | null;
   readonly themeVariables: PresentationTemplateThemeVariables;
@@ -2584,14 +2635,12 @@ function PresentationTemplateShadowThumbnail({
   const hasHtmlThumbnail = draft !== undefined && slideId !== null;
   return (
     <>
-      {hasHtmlThumbnail ? null : (
-        <img
-          src={fallbackImage}
-          alt=""
-          loading="lazy"
-          className="absolute inset-0 h-full w-full object-cover"
-        />
-      )}
+      <img
+        src={imageUrl}
+        alt=""
+        loading="lazy"
+        className="absolute inset-0 h-full w-full object-cover"
+      />
       {hasHtmlThumbnail ? (
         <div
           ref={(node) => {
@@ -2645,7 +2694,6 @@ function createPresentationTemplateHtmlPreviewState(params: {
     embedUrl: params.item.embedUrl,
     themeId: params.theme.id,
     loading: false,
-    failed: false,
     frameUrl,
     slideCount: params.draft.slides.length,
   };
@@ -2725,22 +2773,113 @@ function revealTemplatePreviewFrameAfterPaint(params: {
       if (!params.frame.isConnected) {
         return;
       }
-      params.frame.dataset.loaded = "true";
       params.onFrameLoad(params.frameUrl);
     });
   });
 }
 
-function TemplatePreviewFrames({
-  fallbackImageUrl,
+function startProgressiveTemplatePreviewImageLoad(
+  lowResolutionImage: HTMLImageElement,
+): void {
+  const highResolutionImage =
+    lowResolutionImage.parentElement?.querySelector<HTMLImageElement>(
+      '[data-template-preview-image="high"]',
+    );
+  if (highResolutionImage === null || highResolutionImage === undefined) {
+    return;
+  }
+
+  const highResolutionUrl = highResolutionImage.dataset.src;
+  if (
+    highResolutionUrl === undefined ||
+    highResolutionImage.getAttribute("src") === highResolutionUrl
+  ) {
+    return;
+  }
+  delete highResolutionImage.dataset.loaded;
+  highResolutionImage.src = highResolutionUrl;
+}
+
+function ProgressiveTemplatePreviewImage({
+  alt,
+  className,
+  dataTestId,
+  fetchPriority,
+  highResolutionUrl,
   loading,
+  lowResolutionUrl,
+}: {
+  readonly alt: string;
+  readonly className: string;
+  readonly dataTestId?: string;
+  readonly fetchPriority?: "high" | "low" | "auto";
+  readonly highResolutionUrl: string;
+  readonly loading?: "eager" | "lazy";
+  readonly lowResolutionUrl: string;
+}) {
+  const hasHighResolutionImage = lowResolutionUrl !== highResolutionUrl;
+
+  return (
+    <>
+      <img
+        src={lowResolutionUrl}
+        alt={alt}
+        aria-hidden={alt === "" ? "true" : undefined}
+        data-template-preview-image="low"
+        data-testid={dataTestId}
+        className={className}
+        loading={loading}
+        decoding="async"
+        fetchPriority={fetchPriority}
+        onLoad={(event) => {
+          if (hasHighResolutionImage) {
+            startProgressiveTemplatePreviewImageLoad(event.currentTarget);
+          }
+        }}
+        onError={(event) => {
+          if (hasHighResolutionImage) {
+            startProgressiveTemplatePreviewImageLoad(event.currentTarget);
+          }
+        }}
+      />
+      {hasHighResolutionImage ? (
+        <img
+          src={undefined}
+          data-template-preview-image="high"
+          data-src={highResolutionUrl}
+          alt={alt}
+          aria-hidden={alt === "" ? "true" : undefined}
+          className={cn(
+            className,
+            "opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100",
+          )}
+          loading={loading}
+          decoding="async"
+          fetchPriority={fetchPriority}
+          onLoad={(event) => {
+            const highResolutionImage = event.currentTarget;
+            highResolutionImage.dataset.loaded = "true";
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function TemplatePreviewFrames({
+  highResolutionImageUrl,
+  loadedFrameUrl,
+  loading,
+  lowResolutionImageUrl,
   onFrameLoad,
   overlayFrameUrl,
   primaryFrameUrl,
   title,
 }: {
-  readonly fallbackImageUrl: string;
+  readonly highResolutionImageUrl: string;
+  readonly loadedFrameUrl: string | null;
   readonly loading: boolean;
+  readonly lowResolutionImageUrl: string;
   readonly onFrameLoad: (frameUrl: string) => void;
   readonly overlayFrameUrl: string | null;
   readonly primaryFrameUrl: string | null;
@@ -2756,21 +2895,19 @@ function TemplatePreviewFrames({
 
   return (
     <>
-      <img
-        key={fallbackImageUrl}
-        src={fallbackImageUrl}
+      <ProgressiveTemplatePreviewImage
         alt=""
-        aria-hidden="true"
-        data-testid={`${title} card image preview`}
         className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-        loading="eager"
-        decoding="async"
+        dataTestId={`${title} card image preview`}
         fetchPriority="high"
+        highResolutionUrl={highResolutionImageUrl}
+        loading="eager"
+        lowResolutionUrl={lowResolutionImageUrl}
       />
       {frameUrls.map((frameUrl) => {
         return (
           <iframe
-            key={frameUrl ?? "empty"}
+            key={frameUrl}
             title={
               frameUrl === overlayFrameUrl
                 ? `${title} active HTML preview`
@@ -2781,6 +2918,7 @@ function TemplatePreviewFrames({
                 ? `${title} card HTML preview`
                 : undefined
             }
+            data-loaded={frameUrl === loadedFrameUrl ? "true" : undefined}
             src={frameUrl}
             sandbox="allow-same-origin"
             tabIndex={-1}
@@ -2823,21 +2961,24 @@ function TemplatePreview({
   const setHtmlPreview = useSet(setTemplateCardHtmlPreview$);
   const loadedHtmlFrameUrls = useGet(templateCardLoadedHtmlFrameUrls$);
   const setLoadedHtmlFrameUrl = useSet(setTemplateCardLoadedHtmlFrameUrl$);
-  const fallbackSlideCount = presentationTemplateSlideCount(item);
+  const slideCount = presentationTemplateSlideCount(item);
   const hoverSlideIndex = Math.max(
     0,
-    Math.min(
-      hover?.slug === item.slug ? hover.index : 0,
-      fallbackSlideCount - 1,
-    ),
+    Math.min(hover?.slug === item.slug ? hover.index : 0, slideCount - 1),
   );
   const previewTheme =
     theme ??
     findPresentationTemplateTheme(defaultPresentationTemplateThemeId(item));
-  const fallbackImageUrl = presentationTemplateCardSlideImage(
+  const lowResolutionImageUrl = presentationTemplateCardSlideImage(
     item,
     hoverSlideIndex,
     previewTheme,
+  );
+  const highResolutionImageUrl = presentationTemplateHighResolutionSlideImage(
+    item,
+    hoverSlideIndex,
+    previewTheme,
+    TEMPLATE_HIGH_RESOLUTION_PREVIEW_SIZE,
   );
   const activeHtmlPreview =
     htmlPreview?.slug === item.slug &&
@@ -2852,7 +2993,7 @@ function TemplatePreview({
       activeFrameUrl: activeHtmlPreview?.frameUrl ?? null,
       loadedFrameUrl,
     });
-  const scrubSlideCount = activeHtmlPreview?.slideCount ?? fallbackSlideCount;
+  const scrubSlideCount = activeHtmlPreview?.slideCount ?? slideCount;
   const currentPreviewSlideIndex = () => {
     const cache = runtime.presentation;
     const index =
@@ -2903,9 +3044,8 @@ function TemplatePreview({
         embedUrl: item.embedUrl,
         themeId: previewTheme.id,
         loading: false,
-        failed: true,
         frameUrl: null,
-        slideCount: fallbackSlideCount,
+        slideCount,
       });
       return;
     }
@@ -2926,9 +3066,8 @@ function TemplatePreview({
       embedUrl: item.embedUrl,
       themeId: previewTheme.id,
       loading: true,
-      failed: false,
       frameUrl: null,
-      slideCount: fallbackSlideCount,
+      slideCount,
     });
     detach(
       (async () => {
@@ -2948,9 +3087,8 @@ function TemplatePreview({
               embedUrl: item.embedUrl,
               themeId: previewTheme.id,
               loading: false,
-              failed: true,
               frameUrl: null,
-              slideCount: fallbackSlideCount,
+              slideCount,
             });
           }
           return;
@@ -3048,8 +3186,10 @@ function TemplatePreview({
       }}
     >
       <TemplatePreviewFrames
-        fallbackImageUrl={fallbackImageUrl}
+        highResolutionImageUrl={highResolutionImageUrl}
+        loadedFrameUrl={loadedFrameUrl}
         loading={activeHtmlPreview?.loading === true}
+        lowResolutionImageUrl={lowResolutionImageUrl}
         onFrameLoad={handleFrameLoad}
         overlayFrameUrl={overlayFrameUrl}
         primaryFrameUrl={primaryFrameUrl}
@@ -3115,6 +3255,94 @@ function handleTemplateDetailTabKeyDown(
   candidates[nextIndex]?.focus();
 }
 
+function TemplateDetailPreviewFrame({
+  frameLoaded,
+  frameUrl,
+  onFrameLoad,
+  previousFrameSlideIndex,
+  previousFrameUrl,
+  slideIndex,
+  title,
+}: {
+  readonly frameLoaded: boolean;
+  readonly frameUrl: string | null;
+  readonly onFrameLoad: (frameUrl: string) => void;
+  readonly previousFrameSlideIndex: number | null;
+  readonly previousFrameUrl: string | null;
+  readonly slideIndex: number;
+  readonly title: string;
+}) {
+  const frames: readonly {
+    readonly active: boolean;
+    readonly slideIndex: number;
+    readonly url: string;
+  }[] = [
+    ...(previousFrameUrl === null || previousFrameUrl === frameUrl
+      ? []
+      : [
+          {
+            active: false,
+            slideIndex: previousFrameSlideIndex ?? slideIndex,
+            url: previousFrameUrl,
+          },
+        ]),
+    ...(frameUrl === null ? [] : [{ active: true, slideIndex, url: frameUrl }]),
+  ];
+
+  return frames.map((candidateFrame) => {
+    const previousFrameShowsActiveSlide =
+      !candidateFrame.active && candidateFrame.slideIndex === slideIndex;
+    return (
+      <iframe
+        key={candidateFrame.url}
+        title={
+          candidateFrame.active
+            ? `${title} HTML preview`
+            : `${title} previous HTML preview`
+        }
+        data-template-detail-frame={
+          candidateFrame.active ? "active" : "previous"
+        }
+        data-loaded={!candidateFrame.active || frameLoaded ? "true" : undefined}
+        data-testid={
+          candidateFrame.active ? `${title} detail HTML preview` : undefined
+        }
+        src={candidateFrame.url}
+        sandbox="allow-same-origin"
+        tabIndex={-1}
+        className={cn(
+          "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0 data-[loaded=true]:opacity-100",
+          candidateFrame.active
+            ? "z-40"
+            : previousFrameShowsActiveSlide
+              ? "z-30"
+              : "z-10",
+        )}
+        onLoad={(event) => {
+          if (!candidateFrame.active) {
+            return;
+          }
+          revealTemplatePreviewFrameAfterPaint({
+            frame: event.currentTarget,
+            frameUrl: candidateFrame.url,
+            onFrameLoad,
+          });
+        }}
+      />
+    );
+  });
+}
+
+function templateDetailPreviewMatchesItem(
+  preview: {
+    readonly embedUrl: string;
+    readonly slug: string;
+  } | null,
+  item: PresentationTemplateItem,
+): boolean {
+  return preview?.slug === item.slug && preview.embedUrl === item.embedUrl;
+}
+
 function TemplatePreviewPage({
   item,
   onBack,
@@ -3127,32 +3355,39 @@ function TemplatePreviewPage({
   runtime: TemplatePreviewRuntime;
 }) {
   const detailPreview = useGet(templateDetailHtmlPreview$);
-  const themeIdBySlug = useGet(templateDetailThemeIdBySlug$);
   const setCardThemeId = useSet(setTemplateCardThemeId$);
-  const slideIndexBySlug = useGet(templateDetailSlideIndexBySlug$);
   const selectDetailPreview = useSet(selectPresentationTemplateDetailPreview$);
+  const settleDetailPreviewFrame = useSet(
+    settlePresentationTemplateDetailPreviewFrame$,
+  );
+  const visibleDetailPreview = templateDetailPreviewMatchesItem(
+    detailPreview,
+    item,
+  )
+    ? detailPreview
+    : null;
   const selectedThemeId =
-    themeIdBySlug[item.slug] ?? defaultPresentationTemplateThemeId(item);
+    visibleDetailPreview?.themeId ?? defaultPresentationTemplateThemeId(item);
   const selectedTheme = findPresentationTemplateTheme(selectedThemeId);
-  const activeSlideIndex = slideIndexBySlug[item.slug] ?? 0;
-  const visibleDetailPreview =
-    detailPreview?.slug === item.slug &&
-    detailPreview.embedUrl === item.embedUrl &&
-    detailPreview.themeId === selectedTheme.id &&
-    detailPreview.index === activeSlideIndex
-      ? detailPreview
-      : null;
-  const fallbackSlideCount = presentationTemplateSlideCount(item);
+  const activeSlideIndex = visibleDetailPreview?.index ?? 0;
+  const defaultSlideCount = presentationTemplateSlideCount(item);
   const detailSlideCount =
-    visibleDetailPreview?.slideCount ?? fallbackSlideCount;
+    visibleDetailPreview?.slideCount ?? defaultSlideCount;
   const cachedDetailDraft = runtime.presentation.drafts.get(item.embedUrl);
+  const htmlPreviewFailed = runtime.presentation.failed.has(item.embedUrl);
   const thumbnailThemeVariables =
     getPresentationTemplateThumbnailThemeVariables(selectedTheme);
-  const detailFallbackImage = presentationTemplateFallbackSlideImage(
+  const detailImageSource = presentationTemplateDetailSlideImageSource(
     item,
     activeSlideIndex,
+    selectedTheme,
+    htmlPreviewFailed,
   );
-
+  const detailLowResolutionImage = r2ImageTransformUrl(
+    detailImageSource,
+    TEMPLATE_DETAIL_THUMBNAIL_PREVIEW_SIZE,
+  );
+  const detailHighResolutionImage = detailImageSource;
   const selectDetailSlide = (index: number) => {
     selectDetailPreview({
       item,
@@ -3225,39 +3460,27 @@ function TemplatePreviewPage({
             onKeyDown={handleDetailSlideKeyDown}
             className="relative aspect-[16/9] overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <img
-              key={detailFallbackImage}
-              src={detailFallbackImage}
+            <ProgressiveTemplatePreviewImage
               alt=""
-              aria-hidden="true"
-              data-testid={`${item.title} detail image preview`}
-              className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-              loading="eager"
-              decoding="async"
+              className="pointer-events-none absolute inset-0 z-20 h-full w-full object-cover"
+              dataTestId={`${item.title} detail image preview`}
               fetchPriority="high"
+              highResolutionUrl={detailHighResolutionImage}
+              loading="eager"
+              lowResolutionUrl={detailLowResolutionImage}
             />
-            <iframe
-              key={
-                visibleDetailPreview?.frameUrl ??
-                `${item.slug}:${selectedTheme.id}:${activeSlideIndex}:pending`
-              }
-              title={`${item.title} HTML preview`}
-              data-testid={`${item.title} detail HTML preview`}
-              src={visibleDetailPreview?.frameUrl ?? undefined}
-              sandbox="allow-same-origin"
-              tabIndex={-1}
-              className="pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0 data-[loaded=true]:opacity-100"
-              onLoad={(event) => {
-                const frameUrl = visibleDetailPreview?.frameUrl;
-                if (!frameUrl) {
-                  return;
-                }
-                revealTemplatePreviewFrameAfterPaint({
-                  frame: event.currentTarget,
-                  frameUrl,
-                  onFrameLoad: () => {},
-                });
+            <TemplateDetailPreviewFrame
+              frameLoaded={visibleDetailPreview?.frameLoaded ?? false}
+              frameUrl={visibleDetailPreview?.frameUrl ?? null}
+              onFrameLoad={(frameUrl) => {
+                settleDetailPreviewFrame(frameUrl);
               }}
+              previousFrameSlideIndex={
+                visibleDetailPreview?.previousFrameSlideIndex ?? null
+              }
+              previousFrameUrl={visibleDetailPreview?.previousFrameUrl ?? null}
+              slideIndex={activeSlideIndex}
+              title={item.title}
             />
             <button
               type="button"
@@ -3298,9 +3521,14 @@ function TemplatePreviewPage({
             ).map((slideNumber) => {
               const slideIndex = slideNumber - 1;
               const active = slideIndex === activeSlideIndex;
-              const thumbnailImage = presentationTemplateFallbackSlideImage(
-                item,
-                slideIndex,
+              const thumbnailImage = r2ImageTransformUrl(
+                presentationTemplateDetailSlideImageSource(
+                  item,
+                  slideIndex,
+                  selectedTheme,
+                  htmlPreviewFailed,
+                ),
+                TEMPLATE_DETAIL_THUMBNAIL_PREVIEW_SIZE,
               );
               const thumbnailSlide =
                 cachedDetailDraft?.slides[slideIndex] ?? null;
@@ -3322,7 +3550,7 @@ function TemplatePreviewPage({
                 >
                   <PresentationTemplateShadowThumbnail
                     draft={cachedDetailDraft}
-                    fallbackImage={thumbnailImage}
+                    imageUrl={thumbnailImage}
                     runtime={runtime}
                     slideId={thumbnailSlide?.id ?? null}
                     themeVariables={thumbnailThemeVariables}
@@ -4423,13 +4651,15 @@ function TemplatePickerDialog({
     setTemplatePickerPresentationScrollTop$,
   );
   const detailPreview = useGet(templateDetailHtmlPreview$);
-  const detailThemeIdBySlug = useGet(templateDetailThemeIdBySlug$);
+  const ownPreviewResources = useSet(ownTemplatePickerPreviewResources$);
+  const releasePreviewResources = useSet(
+    releaseTemplatePickerPreviewResources$,
+  );
   const openDetailPreview = useSet(openPresentationTemplateDetailPreview$);
   const selectDetailPreview = useSet(selectPresentationTemplateDetailPreview$);
   const closeDetailPreview = useSet(closePresentationTemplateDetailPreview$);
   const openWebsiteTemplatePreview = useSet(openWebsiteTemplatePreview$);
   const cardThemeIdBySlug = useGet(templateCardThemeIdBySlug$);
-  const detailSlideIndexBySlug = useGet(templateDetailSlideIndexBySlug$);
   const illustrationVariantIndex = useGet(illustrationVariantIndex$);
   const setIllustrationVariantIndex = useSet(setIllustrationVariantIndex$);
   const previewItem =
@@ -4497,7 +4727,7 @@ function TemplatePickerDialog({
   };
 
   const closeTemplatePicker = () => {
-    closeDetailPreview(runtime);
+    releasePreviewResources(runtime);
     setPresentationGridScrollTop(0);
     onClose();
   };
@@ -4558,21 +4788,21 @@ function TemplatePickerDialog({
     if (previewItem === null) {
       return null;
     }
-    const selectedThemeId =
-      detailThemeIdBySlug[previewItem.slug] ??
-      defaultPresentationTemplateThemeId(previewItem);
-    const selectedTheme = findPresentationTemplateTheme(selectedThemeId);
-    const visibleDetailPreview =
+    const activeDetailPreview =
       detailPreview?.slug === previewItem.slug &&
-      detailPreview.embedUrl === previewItem.embedUrl &&
-      detailPreview.themeId === selectedTheme.id
+      detailPreview.embedUrl === previewItem.embedUrl
         ? detailPreview
         : null;
+    const selectedThemeId =
+      activeDetailPreview?.themeId ??
+      cardThemeIdBySlug[previewItem.slug] ??
+      defaultPresentationTemplateThemeId(previewItem);
+    const selectedTheme = findPresentationTemplateTheme(selectedThemeId);
     const detailSlideCount =
-      visibleDetailPreview?.slideCount ??
-      Math.max(presentationTemplateSlideImages(previewItem).length, 1);
+      activeDetailPreview?.slideCount ??
+      presentationTemplateSlideCount(previewItem);
     return {
-      activeSlideIndex: detailSlideIndexBySlug[previewItem.slug] ?? 0,
+      activeSlideIndex: activeDetailPreview?.index ?? 0,
       detailSlideCount,
       selectedTheme,
     };
@@ -4666,6 +4896,7 @@ function TemplatePickerDialog({
         }
         onOpenAutoFocus={(event) => {
           event.preventDefault();
+          ownPreviewResources(runtime, pageSignal);
           if (!isPreviewing) {
             prewarmTemplatePreviewsForCategory(selectedCategory);
           }


### PR DESCRIPTION
## Summary

- render the correct slide-specific image instead of repeating the cover
- progressively replace low-resolution previews with same-source high-resolution images
- keep the previous themed HTML frame visible until the replacement has painted to avoid gray flashes
- apply theme changes to the active preview and every detail thumbnail
- use template-owned slide images during normal detail loading and reserve gallery assets for HTML failures or missing images
- release Blob URLs and pending animation frames when the template picker closes

## Testing

- pnpm exec prettier --check on all changed files
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx src/views/zero-page/__tests__/presentation-html-preview.test.ts --reporter=dot

This consolidates and replaces the implementation from #23479 after the follow-up review.