### PR TITLE
chore(api): analyze conventional sql tag leaves

### DIFF
--- a/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, asc, desc, eq, inArray, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
 import type {
   ArtifactCatalogKind,
   ArtifactDetail,
@@ -245,7 +245,10 @@ async function upsertArtifact(args: UpsertArtifactArgs): Promise<void> {
         thumbnail: args.thumbnail,
         updatedAt: nowDate(),
       },
-      setWhere: sql`(${artifacts.projectionCreatedAt}, ${artifacts.projectionFileId}) <= (excluded.projection_created_at, excluded.projection_file_id)`,
+      setWhere: lte(
+        sql`(${artifacts.projectionCreatedAt}, ${artifacts.projectionFileId})`,
+        sql`(excluded.projection_created_at, excluded.projection_file_id)`,
+      ),
     });
 }
 
@@ -753,7 +756,10 @@ export const listArtifactCatalog$ = command(
             ? chatThreadFilter(db, args.chatThreadId)
             : undefined,
           cursor
-            ? sql`(${artifacts.createdAt}, ${artifacts.id}) < (${cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${cursor.id}::uuid)`
+            ? lt(
+                sql`(${artifacts.createdAt}, ${artifacts.id})`,
+                sql`(${cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${cursor.id}::uuid)`,
+              )
             : undefined,
         ),
       )

--- a/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
@@ -150,10 +150,13 @@ function connectorIdentityExists(
           eq(credentialAccessConnector.storageVersion, access.storageVersion),
           connectorStateRevision === undefined
             ? undefined
-            : sql`(
-                EXTRACT(EPOCH FROM ${credentialAccessConnector.updatedAt})
-                * 1000000
-              )::bigint = ${connectorStateRevision}`,
+            : eq(
+                sql`(
+                  EXTRACT(EPOCH FROM ${credentialAccessConnector.updatedAt})
+                  * 1000000
+                )::bigint`,
+                connectorStateRevision,
+              ),
         ),
       ),
   );

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -19,6 +19,7 @@ import {
   lt,
   max,
   sql,
+  sum,
 } from "drizzle-orm";
 
 import {
@@ -947,10 +948,11 @@ async function queryFinalizedUsageCreditRows(
         sql`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`
           .mapWith(pgTextDecoder)
           .as("agent_name"),
-      credits:
-        sql`COALESCE(SUM(${usage.creditsCharged} + ${usage.allowanceUnits}), 0)::bigint`
-          .mapWith(pgInt8ToSafeIntegerDecoder)
-          .as("credits"),
+      credits: sql`COALESCE(${sum(
+        sql`${usage.creditsCharged} + ${usage.allowanceUnits}`,
+      )}, 0)::bigint`
+        .mapWith(pgInt8ToSafeIntegerDecoder)
+        .as("credits"),
     })
     .from(usage)
     .leftJoin(agentRuns, eq(usage.runId, agentRuns.id))

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -191,7 +191,10 @@ export const recordHostedSiteArtifact$ = command(
           ...(args.deploymentVersion === null
             ? {
                 previewImageUrl: sql`case
-                  when ${runUploadedFiles.metadata}->>'deploymentId' = ${args.deploymentId}
+                  when ${eq(
+                    sql`${runUploadedFiles.metadata}->>'deploymentId'`,
+                    args.deploymentId,
+                  )}
                   then ${runUploadedFiles.previewImageUrl}
                   else null
                 end`,

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -145,18 +145,24 @@ export function runnerSessionAffinityPollPriority(args: {
   const hasGlobalWorkspace = global(workspaceCondition);
   const hasLocalWorkspace = local(workspaceCondition);
   return sql`CASE
-    WHEN ${gt(runnerJobQueue.createdAt, generationProtectedAfter)}
-    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
-    AND ${isNotNull(targetGenerationRunId)}
-    AND ${hasGlobalExact}
+    WHEN ${and(
+      gt(runnerJobQueue.createdAt, generationProtectedAfter),
+      isNotNull(runnerJobQueue.cliAgentSessionId),
+      isNotNull(targetGenerationRunId),
+      hasGlobalExact,
+    )}
     THEN CASE WHEN ${hasLocalExact} THEN 5 ELSE 0 END
-    WHEN ${gt(runnerJobQueue.createdAt, protectedAfter)}
-    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
-    AND ${hasGlobalReusable}
+    WHEN ${and(
+      gt(runnerJobQueue.createdAt, protectedAfter),
+      isNotNull(runnerJobQueue.cliAgentSessionId),
+      hasGlobalReusable,
+    )}
     THEN CASE WHEN ${hasLocalReusable} THEN 4 ELSE 0 END
-    WHEN ${gt(runnerJobQueue.createdAt, protectedAfter)}
-    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
-    AND ${hasGlobalWorkspace}
+    WHEN ${and(
+      gt(runnerJobQueue.createdAt, protectedAfter),
+      isNotNull(runnerJobQueue.cliAgentSessionId),
+      hasGlobalWorkspace,
+    )}
     THEN CASE
       WHEN ${hasLocalReusable} THEN 4
       WHEN ${hasLocalWorkspace} THEN 3

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -10,6 +10,7 @@ import {
   asc,
   desc,
   eq,
+  gt,
   inArray,
   isNotNull,
   not,
@@ -161,20 +162,23 @@ async function selectIncompleteRoundFrontier(
 }
 
 function afterSuccessfulRunBoundary(threadId: string, successfulRunId: string) {
-  return sql`${chatMessages.seqId} > COALESCE(
-    (
-      SELECT MAX(boundary_message.seq_id)
-      FROM chat_messages boundary_message
-      WHERE boundary_message.chat_thread_id = ${threadId}
-        AND boundary_message.run_id = ${successfulRunId}
-        AND NOT EXISTS (
-          SELECT 1
-          FROM chat_messages boundary_revoker
-          WHERE boundary_revoker.revokes_message_id = boundary_message.id
-        )
-    ),
-    0::bigint
-  )`;
+  return gt(
+    chatMessages.seqId,
+    sql`COALESCE(
+      (
+        SELECT MAX(boundary_message.seq_id)
+        FROM chat_messages boundary_message
+        WHERE boundary_message.chat_thread_id = ${threadId}
+          AND boundary_message.run_id = ${successfulRunId}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM chat_messages boundary_revoker
+            WHERE boundary_revoker.revokes_message_id = boundary_message.id
+          )
+      ),
+      0::bigint
+    )`,
+  );
 }
 
 async function loadSelectedIncompleteRounds(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1636,8 +1636,14 @@ async function listChangedArtifacts(args: {
     visible_runs.metadata_updated_at
   )`;
   const lowerBoundClause = args.cursor
-    ? sql`(${effectiveUpdatedAt}, ${runUploadedFiles.id}) > (${args.cursor.updatedAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
-    : sql`${effectiveUpdatedAt} >= (${args.updatedAfter}::timestamptz AT TIME ZONE 'UTC') - (${ARTIFACT_SYNC_REPLAY_WINDOW_MINUTES} * interval '1 minute')`;
+    ? gt(
+        sql`(${effectiveUpdatedAt}, ${runUploadedFiles.id})`,
+        sql`(${args.cursor.updatedAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`,
+      )
+    : gte(
+        effectiveUpdatedAt,
+        sql`(${args.updatedAfter}::timestamptz AT TIME ZONE 'UTC') - (${ARTIFACT_SYNC_REPLAY_WINDOW_MINUTES} * interval '1 minute')`,
+      );
   const callerConditions = artifactCallerVisibilityConditions(args.query);
   const fileConditions = artifactFileVisibilityConditions(args.db);
   const rows = await executeRawRows(
@@ -1747,7 +1753,10 @@ async function listArtifactHistory(args: {
   // The full path returns visible rows. IndexedDB owns stable-ID merging and
   // hosted-run shadowing, so this query avoids a history-wide URL sort.
   const keysetCondition = args.cursor
-    ? sql`(${runUploadedFiles.createdAt}, ${runUploadedFiles.id}) < (${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
+    ? lt(
+        sql`(${runUploadedFiles.createdAt}, ${runUploadedFiles.id})`,
+        sql`(${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`,
+      )
     : undefined;
   const conditions = artifactVisibilityConditions(args.db, args.query);
   const rows: ArtifactListRow[] = await args.db

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -15,6 +15,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   and,
+  asc,
   count,
   desc,
   eq,
@@ -390,7 +391,7 @@ function agentNameExpr() {
 
 function chatRankExpr(credits: SQLWrapper, stableKey: SQLWrapper) {
   return sql`ROW_NUMBER() OVER (
-    ORDER BY ${desc(sum(credits))} NULLS LAST, ${stableKey} ASC
+    ORDER BY ${desc(sum(credits))} NULLS LAST, ${asc(stableKey)}
   )`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { count, sql, type SQL } from "drizzle-orm";
+import { and, count, eq, inArray, sql, type SQL } from "drizzle-orm";
 import {
   type UsageRecordKind,
   type UsageRecordRow,
@@ -111,13 +111,10 @@ type UsageRecordBreakdownSqlRow = z.output<
 >;
 
 function tokenExpr(usage: FinalizedUsageRelation) {
-  const list = sql.join(
-    MODEL_TOKEN_CATEGORIES.map((category) => {
-      return sql`${category}`;
-    }),
-    sql`, `,
-  );
-  return sql`CASE WHEN ${usage.kind} = ${MODEL_USAGE_KIND} AND ${usage.category} IN (${list}) THEN ${usage.quantity} ELSE 0 END`;
+  return sql`CASE WHEN ${and(
+    eq(usage.kind, MODEL_USAGE_KIND),
+    inArray(usage.category, MODEL_TOKEN_CATEGORIES),
+  )} THEN ${usage.quantity} ELSE 0 END`;
 }
 
 function sourceExpr() {
@@ -137,15 +134,9 @@ function sourceExpr() {
 }
 
 function usageKindExpr(usage: FinalizedUsageRelation) {
-  const usageKindList = sql.join(
-    USAGE_RECORD_KINDS.map((kind) => {
-      return sql`${kind}`;
-    }),
-    sql`, `,
-  );
   return sql`
     CASE
-      WHEN ${usage.kind} IN (${usageKindList}) THEN ${usage.kind}
+      WHEN ${inArray(usage.kind, USAGE_RECORD_KINDS)} THEN ${usage.kind}
       ELSE 'other'
     END`;
 }
@@ -172,7 +163,7 @@ function recordWith(
   );
   const usage = buildFinalizedUsageRelation(period ?? undefined);
   const userPredicate =
-    userId === null ? sql.empty() : sql`AND ${usage.userId} = ${userId}`;
+    userId === null ? sql.empty() : sql`AND ${eq(usage.userId, userId)}`;
   return sql`
     WITH usage_rows AS (
       SELECT
@@ -314,9 +305,15 @@ function rowKeyExpr() {
   );
   return sql`
     CASE
-      WHEN chat_thread_id IS NOT NULL AND source IN (${threadedSourceList})
+      WHEN ${and(
+        sql`chat_thread_id IS NOT NULL`,
+        sql`source IN (${threadedSourceList})`,
+      )}
         THEN CONCAT(source, ':thread:', chat_thread_id::text, ':user:', user_id)
-      WHEN chat_thread_id IS NULL AND source IN (${threadedSourceList})
+      WHEN ${and(
+        sql`chat_thread_id IS NULL`,
+        sql`source IN (${threadedSourceList})`,
+      )}
         THEN CONCAT(source, ':deleted-thread:user:', user_id)
       ELSE CONCAT(source, ':run:', run_id::text, ':user:', user_id)
     END`;
@@ -335,7 +332,7 @@ async function queryUsageRecordBreakdown(
 
   const usage = buildFinalizedUsageRelation(period ?? undefined);
   const userPredicate =
-    userId === null ? sql.empty() : sql`AND ${usage.userId} = ${userId}`;
+    userId === null ? sql.empty() : sql`AND ${eq(usage.userId, userId)}`;
   const rowKeyList = sql.join(
     rowKeys.map((rowKey) => {
       return sql`${rowKey}`;

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -219,7 +219,9 @@ function coalesceRunTotal(column: SQLWrapper, alias: string) {
 }
 
 function usageCreditsSum(usage: FinalizedUsageRelation, alias: string) {
-  return sql`COALESCE(SUM(${usage.creditsCharged} + ${usage.allowanceUnits}), 0)::bigint`
+  return sql`COALESCE(${sum(
+    sql`${usage.creditsCharged} + ${usage.allowanceUnits}`,
+  )}, 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -160,6 +160,19 @@ const directQuery = `
   \`
 `;
 
+const safeDirectQuery = `
+  sql\`
+    SELECT \${runs.id} AS "id"
+    FROM \${runs}
+    WHERE \${eq(runs.threadId, threadId)}
+    LIMIT 1
+  \`
+`;
+
+const opaqueQuery = `
+  sql\`SELECT pg_advisory_xact_lock(\${threadId})\`
+`;
+
 const joinedHistoryQuery = `
   sql\`
     SELECT
@@ -205,7 +218,7 @@ const runnerLockingQuery = `
   sql\`
     SELECT
       \${runs.id} AS "runId",
-      \${runs.threadId} > 0 AS "isExpired"
+      \${gt(runs.threadId, sql\`0\`)} AS "isExpired"
     FROM \${runs}
     WHERE \${eq(runs.id, threadId)}
     FOR UPDATE
@@ -648,7 +661,7 @@ const queryBuilderCases = {
     },
     {
       code: `${unnestUpdatePreamble}
-        import { sql } from "drizzle-orm";
+        import { eq, sql } from "drizzle-orm";
         const customExecutor = {
           async execute(query: unknown) {
             return query;
@@ -658,7 +671,7 @@ const queryBuilderCases = {
           UPDATE \${allowanceWindows}
           SET consumed_units = consumption.units_applied
           FROM unnest(\${sql.param(windowIds)}::uuid[]) AS consumption(window_id)
-          WHERE \${allowanceWindows.id} = consumption.window_id
+          WHERE \${eq(allowanceWindows.id, sql\`consumption.window_id\`)}
         \`);
       `,
     },
@@ -1455,27 +1468,27 @@ const queryBuilderCases = {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         async function executeRawRows(...args: unknown[]) { return args; }
-        await executeRawRows(db, ${directQuery}, rowSchema);
+        await executeRawRows(db, ${safeDirectQuery}, rowSchema);
       `,
     },
     {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         import { executeRawRows } from "./other/db-raw-rows";
-        await executeRawRows(db, ${directQuery}, rowSchema);
+        await executeRawRows(db, ${safeDirectQuery}, rowSchema);
       `,
     },
     {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         import { executeRawRows } from "@fake/lib/db-raw-rows";
-        await executeRawRows(db, ${directQuery}, rowSchema);
+        await executeRawRows(db, ${safeDirectQuery}, rowSchema);
       `,
     },
     {
       code: `${rawRowsImport}${schemaPreamble}
-        import { eq, sql } from "drizzle-orm";
-        const query = ${directQuery};
+        import { sql } from "drizzle-orm";
+        const query = ${opaqueQuery};
         await executeRawRows(db, query, rowSchema);
       `,
     },
@@ -1486,7 +1499,7 @@ const queryBuilderCases = {
         function runLocal(
           decodeRows: (...args: unknown[]) => unknown,
         ) {
-          return decodeRows(db, ${directQuery}, rowSchema);
+          return decodeRows(db, ${safeDirectQuery}, rowSchema);
         }
         runLocal(() => undefined);
       `,
@@ -1982,7 +1995,7 @@ const queryBuilderCases = {
     },
     {
       code: `${schemaPreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, gt, sql } from "drizzle-orm";
         async function executeRawRows(...args: unknown[]) { return args; }
         await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
       `,
@@ -1993,6 +2006,7 @@ const queryBuilderCases = {
           return { strings, values };
         }
         const eq = (...values: unknown[]) => values;
+        const gt = (...values: unknown[]) => values;
         await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
       `,
     },
@@ -2557,16 +2571,16 @@ const queryBuilderCases = {
     },
     {
       code: `${deletePreamble}
-        import { sql } from "drizzle-orm";
+        import { gt, lte, sql } from "drizzle-orm";
         declare const firstPredicate: boolean;
         const query = firstPredicate
           ? sql\`
               DELETE FROM \${cleanupRows}
-              WHERE \${cleanupRows.expiresAt} <= \${cutoff}
+              WHERE \${lte(cleanupRows.expiresAt, cutoff)}
             \`
           : sql\`
               DELETE FROM \${cleanupRows}
-              WHERE \${cleanupRows.id} > \${0}
+              WHERE \${gt(cleanupRows.id, 0)}
             \`;
         await db.execute(query);
       `,
@@ -2628,7 +2642,7 @@ const queryBuilderCases = {
     },
     {
       code: `${rawRowsImport}${schemaPreamble}
-        import { eq, sql, type SQL } from "drizzle-orm";
+        import { eq, gt, sql, type SQL } from "drizzle-orm";
         const query: SQL = ${runnerLockingQuery};
         await executeRawRows(db, query, rowSchema);
       `,
@@ -2652,7 +2666,11 @@ const queryBuilderCases = {
           WHERE \${cacheRows.cacheKey} = locked.cache_key
         \`);
       `,
-      errors: [{ messageId: "lockingCteUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "lockingCteUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${lockingCteUpdatePreamble}
@@ -2672,7 +2690,12 @@ const queryBuilderCases = {
           WHERE \${cacheRows.cacheKey} = locked.cache_key;
         \`);
       `,
-      errors: [{ messageId: "lockingCteUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "lockingCteUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "asc" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${lockingCteUpdatePreamble}
@@ -2692,7 +2715,12 @@ const queryBuilderCases = {
           WHERE \${cacheRows.cacheKey} = locked.cache_key
         \`);
       `,
-      errors: [{ messageId: "lockingCteUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "lockingCteUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "desc" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${unnestUpdatePreamble}
@@ -2709,7 +2737,10 @@ const queryBuilderCases = {
           WHERE \${allowanceWindows.id} = consumption.window_id
         \`);
       `,
-      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "unnestUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${unnestUpdatePreamble}
@@ -2729,7 +2760,10 @@ const queryBuilderCases = {
           WHERE \${usageEvents.id} = settlement.usage_event_id
         \`);
       `,
-      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "unnestUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${unnestUpdatePreamble}
@@ -2744,7 +2778,10 @@ const queryBuilderCases = {
           WHERE \${allowanceWindows.id} = consumption.window_id;
         \`);
       `,
-      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "unnestUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${unnestUpdatePreamble}
@@ -2760,7 +2797,10 @@ const queryBuilderCases = {
           WHERE \${allowanceWindows.id} = consumption.window_id
         \`);
       `,
-      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "unnestUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `${unnestUpdatePreamble}
@@ -2775,7 +2815,10 @@ const queryBuilderCases = {
           WHERE \${allowanceWindows.id} = consumption.window_id
         \`);
       `,
-      errors: [{ messageId: "unnestUpdateQueryBuilder" }],
+      errors: [
+        { messageId: "unnestUpdateQueryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       code: `
@@ -2853,14 +2896,16 @@ const queryBuilderCases = {
     },
     {
       code: `${deletePreamble}
-        import { gte, inArray, lt, sql } from "drizzle-orm";
+        import { and, gte, inArray, lt, sql } from "drizzle-orm";
         declare const windowStart: Date;
         declare const windowEnd: Date;
         await db.execute(sql\`
           DELETE FROM \${cleanupRows}
-          WHERE \${gte(cleanupRows.expiresAt, windowStart)}
-            AND \${lt(cleanupRows.expiresAt, windowEnd)}
-            AND \${inArray(cleanupRows.id, [1, 2])}
+          WHERE \${and(
+            gte(cleanupRows.expiresAt, windowStart),
+            lt(cleanupRows.expiresAt, windowEnd),
+            inArray(cleanupRows.id, [1, 2]),
+          )}
         \`);
       `,
       errors: [{ messageId: "deleteQueryBuilder" }],
@@ -3100,14 +3145,24 @@ const queryBuilderCases = {
         import { desc, eq, sql } from "drizzle-orm";
         await executeRawRows(db, ${joinedHistoryQuery}, rowSchema);
       `,
-      errors: [{ messageId: "queryBuilder" }],
+      errors: [
+        { messageId: "queryBuilder" },
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+      ],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         await executeRawRows(db, ${joinedExistsQuery}, rowSchema);
       `,
-      errors: [{ messageId: "existsQueryBuilder" }],
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        { messageId: "existsQueryBuilder" },
+      ],
     },
     {
       code: `${rawRowsImport}${schemaPreamble}
@@ -3129,7 +3184,7 @@ const queryBuilderCases = {
     },
     {
       code: `${rawRowsImport}${schemaPreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, gt, sql } from "drizzle-orm";
         await executeRawRows(db, ${runnerLockingQuery}, rowSchema);
       `,
       errors: [{ messageId: "lockingQueryBuilder" }],

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -101,7 +101,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
   valid: [
     {
       code: `${drizzlePreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, gt, sql } from "drizzle-orm";
         import { executeRawRows } from "./lib/db-raw-rows";
         declare const chooseLock: boolean;
         declare const rowSchema: never;
@@ -128,15 +128,10 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         const condition = gte(users.id, 1);
         const fragment = sql\`\${users.id} + \${value}\`;
         sql\`SELECT \${users.id} FROM \${users} WHERE \${fragment}\`;
-        sql\`\${users.id}::text = \${"1"}\`;
-        sql\`LOWER(\${users.name}) = \${"name"}\`;
-        sql\`LOWER(\${users.name}) IS NULL\`;
         sql\`\${users.id} IS DISTINCT FROM \${value}\`;
         sql\`UPDATE users SET \${users.id} = \${value}\`;
-        sql\`1 + \${users.id} = \${value}\`;
-        sql\`\${users.id} = \${value} + 1\`;
         sql\`\${gte(users.deletedAt, sql\`\${"2026-01-01"}::timestamp\`)}\`;
-        sql\`MAX(\${users.id} + 1) FILTER (WHERE \${users.id} > 0)\`;
+        sql\`MAX(\${users.id} + 1) FILTER (WHERE \${condition})\`;
         sql\`MAX(\${users.id}) OVER (ORDER BY id)\`;
         sql\`COUNT(\${users.id}) FILTER (WHERE (\${condition})) OVER (ORDER BY id)\`;
         db.select({
@@ -276,16 +271,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           names.map((name) => sql\`\${name}\`),
           sql\`, \`,
         )})\`;
-        query\`upper(\${users.name}) IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )})\`;
-        query\`lower(\${users.name}) NOT IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )})\`;
-        query\`lower(\${users.name}) IN (\${nameList})\`;
-        query\`lower(\${users.name}) IN (\${nameSqlList()})\`;
         query\`lower(\${users.name}) IN (\${otherSql.join(names)})\`;
         query\`lower(\${users.name}) IN (\${subquery})\`;
         query\`lower(\${users.name}) IN (\${query.join(
@@ -296,18 +281,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           names.map((name) => query\`\${name}\`),
           query\`; \`,
         )})\`;
-        query\`SELECT lower(\${users.name}) IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )}) FROM \${users}\`;
-        query\`prefix_lower(\${users.name}) IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )})\`;
-        query\`lower(\${users.name}) IN (\${query.join(
-          names.map((name) => query\`\${name}\`),
-          query\`, \`,
-        )}) IS TRUE\`;
         query\`lower(\${condition}) IN (\${query.join(
           names.map((name) => query\`\${name}\`),
           query\`, \`,
@@ -377,7 +350,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, or, sql } from "drizzle-orm";
         import { alias } from "drizzle-orm/pg-core";
         const otherUsers = alias(users, "other_users");
         const condition = eq(users.id, 1);
@@ -392,18 +365,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           LEFT JOIN \${otherUsers} ON \${condition}
           WHERE \${condition}
         )\`;
-        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition} OR \${condition})\`;
+        sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${or(condition, condition)})\`;
         sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition} FOR UPDATE)\`;
-        sql\`EXISTS (
-          SELECT 1 FROM \${users}
-          WHERE EXISTS (SELECT 1 FROM \${otherUsers} WHERE \${condition})
-        )\`;
-        sql\`SELECT EXISTS (SELECT 1 FROM \${users} WHERE \${condition})\`;
-        sql\`NOT EXISTS (SELECT 1 FROM \${users} WHERE \${condition}) AND \${condition}\`;
         sql\`EXISTS (SELECT 1 FROM \${users} WHERE \${condition}); SELECT 1\`;
-        sql\`WITH selected AS (SELECT 1) SELECT EXISTS (
-          SELECT 1 FROM \${users} WHERE \${condition}
-        )\`;
       `,
     },
     {
@@ -516,19 +480,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
-        declare const flag: boolean;
-        db.select()
-          .from(users)
-          .where(
-            flag
-              ? sql\`\${users.id} = \${1}\`
-              : sql\`\${users.id} > \${1}\`,
-          );
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
         import { sql, type SQL } from "drizzle-orm";
         const customSqlComposer = {
           empty(): SQL {
@@ -631,19 +582,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
-        const selection = sql\`\${users.id} = \${1} AS matched\`;
+        import { eq } from "drizzle-orm";
+        const selection = eq(users.id, 1);
         db.select({ matched: selection }).from(users);
-      `,
-    },
-    {
-      code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
-        const predicate = sql\`
-          \${users.id} = \${1}
-          ORDER BY \${users.id}
-        \`;
-        db.select().from(users).where(predicate);
       `,
     },
     {
@@ -725,7 +666,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${readQueryPreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, gt, sql } from "drizzle-orm";
         await executeRawRows(
           db,
           sql\`
@@ -741,17 +682,23 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           rowSchema,
         );
       `,
-      errors: [{ messageId: "existsQueryBuilder" }],
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        { messageId: "existsQueryBuilder" },
+      ],
     },
     {
       code: `${readQueryPreamble}
-        import { eq, sql } from "drizzle-orm";
+        import { eq, gt, sql } from "drizzle-orm";
         await executeRawRows(
           db,
           sql\`
             SELECT
               \${runs.id} AS "runId",
-              \${runs.threadId} > 0 AS "isExpired"
+              \${gt(runs.threadId, sql\`0\`)} AS "isExpired"
             FROM \${runs}
             WHERE \${eq(runs.id, threadId)}
             FOR UPDATE
@@ -870,7 +817,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "eq" },
-          line: 23,
         },
       ],
     },
@@ -886,12 +832,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "eq" },
-          line: 23,
-        },
-        {
-          messageId: "typedApi",
-          data: { helper: "eq" },
-          line: 23,
         },
       ],
     },
@@ -930,13 +870,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             )}, FALSE)\`,
           );
       `,
-      errors: [
-        {
-          messageId: "typedApi",
-          data: { helper: "and" },
-          line: 26,
-        },
-      ],
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
     },
     {
       code: `${drizzlePreamble}
@@ -950,10 +884,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .where(sql\`EXISTS (SELECT 1 WHERE \${fragment})\`);
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 26,
         },
       ],
     },
@@ -994,11 +929,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [
         {
           messageId: "typedApi",
-          data: { helper: "and" },
+          data: { helper: "isNotNull" },
         },
         {
           messageId: "typedApi",
-          data: { helper: "isNotNull" },
+          data: { helper: "and" },
         },
       ],
     },
@@ -1013,15 +948,15 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select().from(users).having(sql\`NOT \${fragment}\`);
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 24,
         },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 25,
         },
       ],
     },
@@ -1035,10 +970,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select().from(users).where(sql\`NOT \${fragment}\`);
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 24,
         },
       ],
     },
@@ -1056,10 +992,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           );
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 27,
         },
       ],
     },
@@ -1077,10 +1014,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           );
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "or" },
-          line: 27,
         },
       ],
     },
@@ -1094,10 +1032,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select().from(users).where(sql\` \${fragment} \`);
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 24,
         },
       ],
     },
@@ -1111,12 +1050,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "eq" },
-          line: 21,
-        },
-        {
-          messageId: "typedApi",
-          data: { helper: "eq" },
-          line: 21,
         },
       ],
     },
@@ -1144,8 +1077,15 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [
         {
           messageId: "typedApi",
+          data: { helper: "eq" },
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
+        },
+        {
+          messageId: "typedApi",
           data: { helper: "and" },
-          line: 26,
         },
       ],
     },
@@ -1165,11 +1105,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           );
       `,
       errors: [
-        {
-          messageId: "typedApi",
-          data: { helper: "and" },
-          line: 23,
-        },
+        { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
       ],
     },
     {
@@ -1184,10 +1122,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select().from(users).where(comparison(users.id, 1));
         db.select().from(users).having(comparison(users.id, 2));
       `,
-      errors: [
-        { messageId: "typedApi", data: { helper: "eq" } },
-        { messageId: "typedApi", data: { helper: "eq" } },
-      ],
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
     },
     {
       code: `${drizzlePreamble}
@@ -1216,13 +1151,15 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 26,
         },
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         {
           messageId: "typedApi",
           data: { helper: "and" },
-          line: 34,
         },
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
       ],
     },
     {
@@ -1245,7 +1182,10 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         {
           messageId: "typedApi",
           data: { helper: "eq" },
-          line: 27,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "eq" },
         },
       ],
     },
@@ -1279,8 +1219,12 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           );
       `,
       errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
         { messageId: "typedApi", data: { helper: "and" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
       ],
     },
     {
@@ -1303,7 +1247,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
+        import { isNull, sql } from "drizzle-orm";
         import { executeRawRows } from "./lib/db-raw-rows";
         declare const rowSchema: never;
         await executeRawRows(
@@ -1311,7 +1255,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           sql\`
             SELECT \${users.id}
             FROM \${users}
-            WHERE \${users.deletedAt} IS NULL
+            WHERE \${isNull(users.deletedAt)}
             LIMIT 1
           \`,
           rowSchema,
@@ -1350,7 +1294,10 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           rowSchema,
         );
       `,
-      errors: [{ messageId: "queryBuilder" }],
+      errors: [
+        { messageId: "queryBuilder" },
+        { messageId: "typedApi", data: { helper: "and" } },
+      ],
     },
     {
       code: `${drizzlePreamble}
@@ -2035,6 +1982,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "countDistinct" } },
         { messageId: "typedApi", data: { helper: "max" } },
         { messageId: "typedApi", data: { helper: "or" } },
+        { messageId: "typedApi", data: { helper: "and" } },
         { messageId: "typedApi", data: { helper: "arrayContains" } },
       ],
     },
@@ -2215,11 +2163,6 @@ ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
         db.select()
           .from(users)
           .where(sql\`\${users.name} IN (\${selected})\`);
-        db.select()
-          .from(users)
-          .where(
-            sql\`(SELECT \${users.id} FROM \${users} LIMIT 1) = \${1}\`,
-          );
       `,
     },
     {
@@ -2374,7 +2317,7 @@ ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
       errors: [{ messageId: "typedApi", data: { helper: "max" } }],
     },
     {
-      name: "locally returned descendant reports at each use site",
+      name: "locally returned descendant reports at its source",
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         function selectionOrder() {
@@ -2383,10 +2326,7 @@ ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
         db.select().from(users).orderBy(selectionOrder());
         db.select().from(users).orderBy(selectionOrder());
       `,
-      errors: [
-        { messageId: "typedApi", data: { helper: "eq" }, line: 23 },
-        { messageId: "typedApi", data: { helper: "eq" }, line: 24 },
-      ],
+      errors: [{ messageId: "typedApi", data: { helper: "eq" }, line: 21 }],
     },
     {
       name: "unsupported case and complete statement expose descendants",
@@ -2434,6 +2374,300 @@ ruleTester.run("prefer-drizzle-apis retained operands", preferDrizzleApis, {
               ? sql\`LOWER(\${users.name}) = \${"one"}\`
               : sql\`UPPER(\${users.name}) = \${"two"}\`,
           );
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
+    },
+  ],
+});
+
+ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
+  valid: [
+    {
+      name: "consumerless logical and unmapped aggregate contracts stay raw",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const first = eq(users.id, 1);
+        const second = eq(users.name, "name");
+        sql\`\${first} AND \${second}\`;
+        sql\`SUM(\${users.id} + 1)\`;
+      `,
+    },
+    {
+      name: "unsupported and raw-identifier source remains allowed",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`LOWER(raw_name) = \${"name"}\`;
+        sql\`\${users.id} IS DISTINCT FROM \${1}\`;
+        sql\`\${users.id} = ANY(\${[1, 2]})\`;
+      `,
+    },
+    {
+      name: "unqualified conflict target remains raw",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        await db
+          .insert(users)
+          .values({ id: 1, name: "name", tags: [] })
+          .onConflictDoUpdate({
+            target: users.id,
+            set: { name: "other" },
+            targetWhere: sql\`raw_id IS NULL\`,
+          });
+      `,
+    },
+    {
+      name: "dynamic predicate spread remains opaque",
+      code: `${drizzlePreamble}
+        import { and, type SQL } from "drizzle-orm";
+        declare const fragments: SQL[];
+        db.select().from(users).where(and(...fragments));
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "direct unsupported expression exposes its comparison leaf",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`COALESCE(LOWER(\${users.name}) = \${"name"}, FALSE)\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "postgres inequality alias reaches the ne capability",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`COALESCE(\${users.id} != \${1}, FALSE)\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "ne" } }],
+    },
+    {
+      name: "leading interpolation does not hide a nested comparison leaf",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const first = eq(users.id, 1);
+        const fragment =
+          sql\`\${first} AND LOWER(\${users.name}) = \${"name"}\`;
+        void fragment;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "complete statement exposes its nested comparison leaf",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`
+          SELECT CASE WHEN \${users.id} > \${1} THEN 1 ELSE 0 END
+          FROM \${users}
+        \`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      name: "leading predicate fragments use deterministic hosts",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const whereFragment = sql\`WHERE \${users.id} = \${1}\`;
+        const andFragment = sql\`AND \${users.name} IS NOT NULL\`;
+        void whereFragment;
+        void andFragment;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "isNotNull" } },
+      ],
+    },
+    {
+      name: "conditional spread branch is analyzed at its own source",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const enabled: boolean;
+        const fragments = [
+          ...(enabled
+            ? [sql\`LOWER(\${users.name}) = \${"name"}\`]
+            : []),
+        ];
+        void fragments;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "optional conditional branch is analyzed at its own source",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const enabled: boolean;
+        const predicate = enabled
+          ? sql\`LOWER(\${users.name}) = \${"name"}\`
+          : undefined;
+        void predicate;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "optional predicate branch provides the logical result contract",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        declare const enabled: boolean;
+        const first = eq(users.id, 1);
+        const second = eq(users.name, "name");
+        db.select()
+          .from(users)
+          .where(enabled ? sql\`\${first} AND \${second}\` : undefined);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      name: "conditional array spread provides the logical result contract",
+      code: `${drizzlePreamble}
+        import { and, eq, sql } from "drizzle-orm";
+        declare const enabled: boolean;
+        const first = eq(users.id, 1);
+        const second = eq(users.name, "name");
+        db.select()
+          .from(users)
+          .where(
+            and(
+              ...(enabled
+                ? [sql\`\${first} AND \${second}\`]
+                : []),
+            ),
+          );
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "and" } }],
+    },
+    {
+      name: "local factory declarations do not hide source leaves",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function rank() {
+          const threshold = 1;
+          return sql\`CASE WHEN \${users.id} > \${threshold} THEN 1 ELSE 0 END\`;
+        }
+        void rank();
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      name: "conflict update fields use write and predicate contexts",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        await db
+          .insert(users)
+          .values({ id: 1, name: "name", tags: [] })
+          .onConflictDoUpdate({
+            target: users.id,
+            set: {
+              name: sql\`CASE WHEN LOWER(\${users.name}) = \${"name"} THEN 'same' ELSE 'other' END\`,
+            },
+            setWhere: sql\`\${eq(users.id, 1)} AND \${eq(users.name, "name")}\`,
+          });
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "and" } },
+      ],
+    },
+    {
+      name: "mapped aggregate and window ordering expose nested leaves",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const total =
+          sql\`COALESCE(SUM(\${users.id} + 1), 0)\`.mapWith(Number);
+        const rank =
+          sql\`ROW_NUMBER() OVER (ORDER BY \${users.name} ASC)\`.mapWith(
+            Number,
+          );
+        void total;
+        void rank;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "sum" } },
+        { messageId: "typedApi", data: { helper: "asc" } },
+      ],
+    },
+    {
+      name: "scalar subquery comparison keeps the subquery operand",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const userId: number;
+        sql\`\${users.id} > COALESCE(
+          (
+            SELECT MAX(other.id)
+            FROM users other
+            WHERE other.id = \${userId}
+              AND NOT EXISTS (
+                SELECT 1 FROM users nested WHERE nested.id = other.id
+              )
+          ),
+          0
+        )\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      name: "nested hand-built existence leaves remain source-local",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const otherUsers = alias(users, "other_users");
+        const condition = eq(users.id, 1);
+        sql\`EXISTS (
+          SELECT 1 FROM \${users}
+          WHERE EXISTS (
+            SELECT 1 FROM \${otherUsers} WHERE \${condition}
+          )
+        )\`;
+        sql\`SELECT EXISTS (
+          SELECT 1 FROM \${users} WHERE \${condition}
+        )\`;
+        sql\`NOT EXISTS (
+          SELECT 1 FROM \${users} WHERE \${condition}
+        ) AND \${condition}\`;
+        sql\`WITH selected AS (SELECT 1) SELECT EXISTS (
+          SELECT 1 FROM \${users} WHERE \${condition}
+        )\`;
+      `,
+      errors: [
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "notExists" },
+        },
+        {
+          messageId: "existencePredicate",
+          data: { helper: "exists" },
+        },
+      ],
+    },
+    {
+      name: "one source leaf reused by multiple consumers reports once",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const predicate = sql\`LOWER(\${users.name}) = \${"name"}\`;
+        db.select().from(users).where(predicate);
+        db.select().from(users).having(predicate);
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "eq" } }],
+    },
+    {
+      name: "distinct same-helper leaves remain distinct",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`CASE
+          WHEN \${users.id} = \${1} THEN 1
+          WHEN \${users.id} = \${2} THEN 2
+          ELSE 0
+        END\`;
       `,
       errors: [
         { messageId: "typedApi", data: { helper: "eq" } },

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -39,9 +39,12 @@ import {
 import { createExecuteRawRowsMatcher } from "../execute-raw-rows.ts";
 import {
   analyzeSql,
+  analyzeSqlSource,
+  sqlTagMightContainHelper,
   type SqlAnalysis,
   type SqlAnalysisContext,
   type SqlCapabilityChecks,
+  type SqlAnalysisFinding,
 } from "../sql-analysis/sql-analysis.ts";
 import { createSqlSourceComposer } from "../sql-analysis/sql-source.ts";
 import { createRule } from "../utils.ts";
@@ -161,6 +164,7 @@ export const preferDrizzleApis = createRule({
       checker,
       services,
     );
+    const sourceLocalCandidates: TSESTree.TaggedTemplateExpression[] = [];
     const structuralCallInspections: Array<() => void> = [];
     const structuredScalarCandidates =
       new Set<TSESTree.TaggedTemplateExpression>();
@@ -169,6 +173,7 @@ export const preferDrizzleApis = createRule({
       TSESTree.Node,
       Set<string>
     >();
+    const reportedSourceLocalFindings = new Set<string>();
     const resolvedCallSignatureCache = new WeakMap<
       TSESTree.CallExpression,
       Signature | null
@@ -291,8 +296,22 @@ export const preferDrizzleApis = createRule({
       });
     }
 
-    function reportStructuralAnalysis(analysis: SqlAnalysis): void {
-      for (const finding of analysis.findings) {
+    function reportStructuralFindings(
+      findings: readonly SqlAnalysisFinding[],
+      sourceLocal = false,
+    ): void {
+      for (const finding of findings) {
+        const sourceKey =
+          finding.kind === "helper" || finding.kind === "existence-predicate"
+            ? `${finding.kind}:${finding.helper}:${finding.sourceKey}`
+            : undefined;
+        if (sourceKey !== undefined) {
+          if (sourceLocal) {
+            reportedSourceLocalFindings.add(sourceKey);
+          } else if (reportedSourceLocalFindings.has(sourceKey)) {
+            continue;
+          }
+        }
         const key =
           finding.kind === "query-builder"
             ? finding.kind
@@ -347,6 +366,10 @@ export const preferDrizzleApis = createRule({
           reportTypedApi(finding.node, finding.helper);
         }
       }
+    }
+
+    function reportStructuralAnalysis(analysis: SqlAnalysis): void {
+      reportStructuralFindings(analysis.findings);
     }
 
     function memberName(node: TSESTree.MemberExpression): string | undefined {
@@ -520,31 +543,44 @@ export const preferDrizzleApis = createRule({
       const predicate = node.arguments[predicateIndex];
       if (
         predicate === undefined ||
-        predicate.type === AST_NODE_TYPES.SpreadElement ||
-        !sqlSourceComposer.couldCompose(predicate)
+        predicate.type === AST_NODE_TYPES.SpreadElement
       ) {
         return;
       }
+      const roots = contextRoots(predicate);
+      if (roots.length === 0) {
+        return;
+      }
       structuralCallInspections.push(() => {
-        const analysis = analyzeSql(
-          predicate,
-          "predicate",
-          checker,
-          services,
-          sqlSourceComposer,
-          sqlCapabilityChecks,
-        );
+        const analyses = roots.map((root) => {
+          return analyzeSql(
+            root,
+            root === predicate ? "predicate" : "optional-predicate",
+            checker,
+            services,
+            sqlSourceComposer,
+            sqlCapabilityChecks,
+          );
+        });
+        const isTrueJoinPredicate =
+          roots.length === 1 &&
+          roots[0] === predicate &&
+          analyses[0]?.isTruePredicate === true;
         if (
-          analysis.findings.length === 0 &&
-          !(method === "innerJoin" && analysis.isTruePredicate)
+          !analyses.some((analysis) => {
+            return analysis.findings.length > 0;
+          }) &&
+          !(method === "innerJoin" && isTrueJoinPredicate)
         ) {
           return;
         }
         if (!isDrizzleMethodCall(node, method)) {
           return;
         }
-        reportStructuralAnalysis(analysis);
-        if (method === "innerJoin" && analysis.isTruePredicate) {
+        for (const analysis of analyses) {
+          reportStructuralAnalysis(analysis);
+        }
+        if (method === "innerJoin" && isTrueJoinPredicate) {
           context.report({ node, messageId: "crossJoin" });
         }
       });
@@ -562,11 +598,18 @@ export const preferDrizzleApis = createRule({
       }
       if (node.type === AST_NODE_TYPES.ArrayExpression) {
         return node.elements.flatMap((element) => {
-          return element === null ||
-            element.type === AST_NODE_TYPES.SpreadElement
+          return element === null
             ? []
-            : contextRoots(element);
+            : element.type === AST_NODE_TYPES.SpreadElement
+              ? contextRoots(element.argument)
+              : contextRoots(element);
         });
+      }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        return [
+          ...contextRoots(node.consequent),
+          ...contextRoots(node.alternate),
+        ];
       }
       if (
         node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
@@ -587,7 +630,6 @@ export const preferDrizzleApis = createRule({
       if (
         node.type === AST_NODE_TYPES.CallExpression ||
         node.type === AST_NODE_TYPES.ChainExpression ||
-        node.type === AST_NODE_TYPES.ConditionalExpression ||
         node.type === AST_NODE_TYPES.Identifier ||
         node.type === AST_NODE_TYPES.TaggedTemplateExpression ||
         node.type === AST_NODE_TYPES.TSAsExpression ||
@@ -840,7 +882,7 @@ export const preferDrizzleApis = createRule({
       if (helper !== undefined && helperContext !== undefined) {
         const roots = node.arguments.flatMap((argument) => {
           return argument.type === AST_NODE_TYPES.SpreadElement
-            ? []
+            ? contextRoots(argument.argument)
             : contextRoots(argument);
         });
         if (roots.length > 0) {
@@ -848,7 +890,9 @@ export const preferDrizzleApis = createRule({
             const analyses = roots.map((root) => {
               return analyzeSql(
                 root,
-                helperContext,
+                helper === "and" || helper === "or"
+                  ? "optional-predicate"
+                  : helperContext,
                 checker,
                 services,
                 sqlSourceComposer,
@@ -935,7 +979,7 @@ export const preferDrizzleApis = createRule({
         }
         const roots = argumentsToInspect.flatMap((argument) => {
           return argument.type === AST_NODE_TYPES.SpreadElement
-            ? []
+            ? contextRoots(argument.argument)
             : contextRoots(argument);
         });
         if (roots.length === 0) {
@@ -984,8 +1028,90 @@ export const preferDrizzleApis = createRule({
     }
 
     interface ContextualRoot {
-      readonly context: "ordering" | "predicate" | "selection";
+      readonly context:
+        | "ordering"
+        | "optional-predicate"
+        | "predicate"
+        | "selection"
+        | "write-expression";
       readonly node: TSESTree.Expression;
+    }
+
+    function conflictUpdateRoots(
+      options: TSESTree.ObjectExpression,
+    ): readonly ContextualRoot[] {
+      return options.properties.flatMap<ContextualRoot>((property) => {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.kind !== "init"
+        ) {
+          return [];
+        }
+        const name = staticPropertyName(property);
+        if (
+          name === "set" &&
+          property.value.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          return property.value.properties.flatMap<ContextualRoot>((field) => {
+            return field.type === AST_NODE_TYPES.Property &&
+              field.kind === "init" &&
+              !field.computed
+              ? contextRoots(field.value).map((root) => {
+                  return { context: "write-expression", node: root };
+                })
+              : [];
+          });
+        }
+        return name === "setWhere" || name === "targetWhere"
+          ? contextRoots(property.value).map((root) => {
+              return { context: "optional-predicate", node: root };
+            })
+          : [];
+      });
+    }
+
+    function inspectConflictUpdateCall(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "onConflictDoUpdate" ||
+        node.arguments.length !== 1
+      ) {
+        return;
+      }
+      const options = node.arguments[0];
+      if (
+        options === undefined ||
+        options.type !== AST_NODE_TYPES.ObjectExpression
+      ) {
+        return;
+      }
+      const roots = conflictUpdateRoots(options);
+      if (roots.length === 0) {
+        return;
+      }
+      structuralCallInspections.push(() => {
+        const analyses = roots.map((root) => {
+          return analyzeSql(
+            root.node,
+            root.context,
+            checker,
+            services,
+            sqlSourceComposer,
+            sqlCapabilityChecks,
+          );
+        });
+        if (
+          !analyses.some((analysis) => {
+            return analysis.findings.length > 0;
+          }) ||
+          !isDrizzleMethodCall(node, "onConflictDoUpdate")
+        ) {
+          return;
+        }
+        for (const analysis of analyses) {
+          reportStructuralAnalysis(analysis);
+        }
+      });
     }
 
     function relationalConfigRoots(
@@ -1439,6 +1565,7 @@ export const preferDrizzleApis = createRule({
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
         inspectAdditionalContextCall(node);
+        inspectConflictUpdateCall(node);
         inspectLateralJoin(node);
         inspectRelationalQueryCall(node);
         inspectStructuredSelectionCall(node);
@@ -1464,6 +1591,9 @@ export const preferDrizzleApis = createRule({
           firstQuasi !== undefined &&
           (firstQuasi.value.cooked ?? firstQuasi.value.raw) === "";
         if (!isExactEmpty) {
+          if (sqlTagMightContainHelper(node)) {
+            sourceLocalCandidates.push(node);
+          }
           return;
         }
         structuralCallInspections.push(() => {
@@ -1474,6 +1604,21 @@ export const preferDrizzleApis = createRule({
         });
       },
       "Program:exit"(): void {
+        for (const node of sourceLocalCandidates) {
+          if (!isDrizzleSqlTag(checker, services, node.tag)) {
+            continue;
+          }
+          reportStructuralFindings(
+            analyzeSqlSource(
+              node,
+              checker,
+              services,
+              sqlSourceComposer,
+              sqlCapabilityChecks,
+            ),
+            true,
+          );
+        }
         for (const inspect of structuralCallInspections) {
           inspect();
         }

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -50,11 +50,17 @@ import {
 
 export type SqlAnalysisContext =
   | "ordering"
+  | "optional-predicate"
   | "predicate"
   | "relation"
   | "selection"
+  | "source-predicate-prefix"
+  | "source-selection"
+  | "source-statement"
+  | "source-where-prefix"
   | "statement"
-  | "structured-selection";
+  | "structured-selection"
+  | "write-expression";
 
 type QueryCapability =
   | "composed-cte"
@@ -73,11 +79,17 @@ export type SqlAnalysisFinding =
       readonly helper: SqlHelper;
       readonly kind: "helper";
       readonly node: TSESTree.Node;
+      readonly sourceKey: string;
+      readonly sourceLocalEligible: boolean;
+      readonly sourceTemplateKey: string;
     }
   | {
       readonly helper: "exists" | "notExists";
       readonly kind: "existence-predicate";
       readonly node: TSESTree.Node;
+      readonly sourceKey: string;
+      readonly sourceLocalEligible: boolean;
+      readonly sourceTemplateKey: string;
     }
   | {
       readonly kind: "empty-fragment";
@@ -300,10 +312,18 @@ interface StructuralOrdering {
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 }
 
-type ClassifiedHelperFinding = Extract<
-  SqlAnalysisFinding,
-  { readonly kind: "existence-predicate" | "helper" }
-> & {
+type ClassifiedHelperFinding = (
+  | {
+      readonly helper: SqlHelper;
+      readonly kind: "helper";
+      readonly node: TSESTree.Node;
+    }
+  | {
+      readonly helper: "exists" | "notExists";
+      readonly kind: "existence-predicate";
+      readonly node: TSESTree.Node;
+    }
+) & {
   readonly isolationContext: "ordering" | "predicate" | "selection";
   readonly isPartial: boolean;
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
@@ -317,6 +337,7 @@ interface ExpressionClassification {
 
 interface ClassificationContext {
   readonly allowsOptionalSql: boolean;
+  readonly allowsRetainedSqlWrapper: boolean;
   readonly capabilities: SqlCapabilityChecks;
   readonly checker: TypeChecker;
   readonly ownsResultMapping: boolean;
@@ -944,15 +965,22 @@ function parseSqlVariant(
   const markerNames: string[] = [];
   const selectCandidateNames = new Set<string>();
   const contextPrefix =
-    context === "statement"
+    context === "statement" || context === "source-statement"
       ? ""
-      : context === "predicate"
+      : context === "predicate" || context === "optional-predicate"
         ? "SELECT 1 WHERE "
-        : context === "selection" || context === "structured-selection"
-          ? "SELECT "
-          : context === "ordering"
-            ? "SELECT 1 ORDER BY "
-            : "SELECT 1 FROM ";
+        : context === "source-predicate-prefix"
+          ? "SELECT 1 WHERE TRUE "
+          : context === "source-where-prefix"
+            ? "SELECT 1 "
+            : context === "selection" ||
+                context === "source-selection" ||
+                context === "structured-selection" ||
+                context === "write-expression"
+              ? "SELECT "
+              : context === "ordering"
+                ? "SELECT 1 ORDER BY "
+                : "SELECT 1 FROM ";
   let markerIndex = 0;
   let precedingLiteral = "";
   for (const chunk of variant.chunks) {
@@ -1694,24 +1722,20 @@ function directStructuralChildren(
 
 function retainableInlineMarkers(
   expression: StructuralExpression,
+  context: ClassificationContext,
 ): readonly SqlMarker[] | undefined {
   if (expression.kind === "marker") {
     const marker = expression.marker;
     return !marker.isTable &&
       !marker.isSelect &&
-      marker.isAnalyzableWriteInterpolation
+      (marker.isAnalyzableWriteInterpolation ||
+        (context.allowsRetainedSqlWrapper && marker.isWrapper))
       ? [marker]
       : undefined;
   }
-  if (
-    expression.kind === "existence" ||
-    (expression.kind === "opaque" && expression.nodeKey === "SubLink")
-  ) {
-    return undefined;
-  }
   const markers: SqlMarker[] = [];
   for (const child of directStructuralChildren(expression)) {
-    const childMarkers = retainableInlineMarkers(child);
+    const childMarkers = retainableInlineMarkers(child, context);
     if (childMarkers === undefined) {
       return undefined;
     }
@@ -1745,7 +1769,7 @@ function isSafeHelperValueOperand(
       (marker.isBoundScalar || marker.isWrapper)
     );
   }
-  const markers = retainableInlineMarkers(expression);
+  const markers = retainableInlineMarkers(expression, context);
   return (
     markers !== undefined &&
     (markers.length === 0 || hasInlineValueBoundary(expression, context))
@@ -1761,7 +1785,7 @@ function retainedOperandAnchor(
   requirement: RetainedOperandRequirement,
   context: ClassificationContext,
 ): TSESTree.Expression | undefined {
-  const markers = retainableInlineMarkers(expression);
+  const markers = retainableInlineMarkers(expression, context);
   if (
     role === "array" ||
     role === "column" ||
@@ -2168,7 +2192,12 @@ function classifyExpression(
     const argumentNode =
       expression.argument === undefined
         ? undefined
-        : operandAnchor(expression.argument, "wrapper", context);
+        : operandAnchor(
+            expression.argument,
+            "wrapper",
+            context,
+            "interpolation",
+          );
     const validArgument = expression.isStar
       ? expression.helper === "count"
       : argumentNode !== undefined;
@@ -4175,13 +4204,23 @@ function structuralExpressionsForContext(
   context: SqlAnalysisContext,
   parsed: ParsedSql,
 ): readonly StructuralExpression[] {
-  if (context === "predicate") {
+  if (
+    context === "predicate" ||
+    context === "optional-predicate" ||
+    context === "source-predicate-prefix" ||
+    context === "source-where-prefix"
+  ) {
     const predicate = predicateExpression(parsed.statement);
     return predicate === undefined
       ? []
       : [structuralExpression(predicate, parsed.markers, parsed.sourceRanges)];
   }
-  if (context === "selection" || context === "structured-selection") {
+  if (
+    context === "selection" ||
+    context === "source-selection" ||
+    context === "structured-selection" ||
+    context === "write-expression"
+  ) {
     return selectedExpressions(parsed.statement).map((expression) => {
       return structuralExpression(
         expression,
@@ -4524,17 +4563,102 @@ function classifyOrdering(
   };
 }
 
-function publicFinding(finding: ClassifiedHelperFinding): SqlAnalysisFinding {
+function findingSourceProvenance(
+  chunks: ReadonlySet<SqlSourceChunk>,
+  findingNode: TSESTree.Node,
+): {
+  readonly sourceKey: string;
+  readonly sourceTemplateKey: string;
+} {
+  const sourceChunks = [...chunks];
+  const firstChunk = sourceChunks[0];
+  let sourceTemplate: TSESTree.TaggedTemplateExpression | undefined;
+  if (firstChunk !== undefined) {
+    for (let index = firstChunk.origins.length - 1; index >= 0; index -= 1) {
+      const candidate = firstChunk.origins[index];
+      if (
+        candidate?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        sourceChunks.every((chunk) => {
+          return chunk.origins.includes(candidate);
+        })
+      ) {
+        sourceTemplate = candidate;
+        break;
+      }
+    }
+  }
+  const origins = [
+    ...new Set(
+      sourceChunks.flatMap((chunk) => {
+        let origin = chunk.origins.at(-1);
+        if (sourceTemplate !== undefined) {
+          for (let index = chunk.origins.length - 1; index >= 0; index -= 1) {
+            const candidate = chunk.origins[index];
+            if (
+              candidate !== undefined &&
+              candidate.range[0] >= sourceTemplate.range[0] &&
+              candidate.range[1] <= sourceTemplate.range[1]
+            ) {
+              origin = candidate;
+              break;
+            }
+          }
+        }
+        return origin === undefined ||
+          origin.type === AST_NODE_TYPES.TemplateElement
+          ? []
+          : [origin];
+      }),
+    ),
+  ].sort((left, right) => {
+    return (
+      left.range[0] - right.range[0] ||
+      left.range[1] - right.range[1] ||
+      left.type.localeCompare(right.type)
+    );
+  });
+  const originKey = origins
+    .map((origin) => {
+      return `${origin.type}:${origin.range[0]}:${origin.range[1]}`;
+    })
+    .join("|");
+  const sourceTemplateKey =
+    sourceTemplate === undefined
+      ? ""
+      : `${sourceTemplate.type}:${sourceTemplate.range[0]}:${sourceTemplate.range[1]}`;
+  return {
+    sourceKey:
+      originKey === ""
+        ? `${sourceTemplateKey}:${findingNode.type}:${findingNode.range[0]}:${findingNode.range[1]}`
+        : originKey,
+    sourceTemplateKey,
+  };
+}
+
+function publicFinding(
+  finding: ClassifiedHelperFinding,
+  sourceLocalEligible: boolean,
+): SqlAnalysisFinding {
+  const { sourceKey, sourceTemplateKey } = findingSourceProvenance(
+    finding.sourceChunks,
+    finding.node,
+  );
   return finding.kind === "existence-predicate"
     ? {
         helper: finding.helper,
         kind: finding.kind,
         node: finding.node,
+        sourceKey,
+        sourceLocalEligible,
+        sourceTemplateKey,
       }
     : {
         helper: finding.helper,
         kind: finding.kind,
         node: finding.node,
+        sourceKey,
+        sourceLocalEligible,
+        sourceTemplateKey,
       };
 }
 
@@ -4557,6 +4681,7 @@ function replacementBoundaryForFinding(
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
   capabilities: SqlCapabilityChecks,
+  allowsRetainedSqlWrapper: boolean,
 ): TSESTree.Expression | undefined {
   // A parsed descendant can cross template boundaries because Drizzle inserts
   // nested SQL without parentheses. Reparse each editable boundary in
@@ -4590,6 +4715,7 @@ function replacementBoundaryForFinding(
     }
     const classificationContext: ClassificationContext = {
       allowsOptionalSql: true,
+      allowsRetainedSqlWrapper,
       capabilities,
       checker,
       ownsResultMapping: false,
@@ -4688,21 +4814,42 @@ function analyzeParsed(
           parsed.markers,
           parsed.sourceRanges,
         )
-      : context === "statement"
+      : context === "statement" || context === "source-statement"
         ? collectStructuralOrderings(
             parsed.statement,
             parsed.markers,
             parsed.sourceRanges,
           )
-        : [];
+        : context === "selection" ||
+            context === "source-selection" ||
+            context === "structured-selection" ||
+            context === "write-expression"
+          ? selectedExpressions(parsed.statement).flatMap((expression) => {
+              return collectStructuralOrderings(
+                expression,
+                parsed.markers,
+                parsed.sourceRanges,
+              );
+            })
+          : [];
   const ownsResultMapping =
-    (context === "selection" || context === "structured-selection") &&
+    (context === "selection" ||
+      context === "source-selection" ||
+      context === "structured-selection") &&
     structuralExpressions.length === 1;
   const classificationContext: ClassificationContext = {
     allowsOptionalSql:
       context === "statement" ||
+      context === "source-statement" ||
+      context === "source-where-prefix" ||
+      context === "optional-predicate" ||
       context === "relation" ||
       capabilities.acceptsOptionalSql(node),
+    allowsRetainedSqlWrapper:
+      context === "source-predicate-prefix" ||
+      context === "source-selection" ||
+      context === "source-statement" ||
+      context === "source-where-prefix",
     capabilities,
     checker,
     ownsResultMapping,
@@ -4721,16 +4868,27 @@ function analyzeParsed(
   const rootClassification =
     classifications.length === 1 ? classifications[0] : undefined;
   const rootFinding = rootClassification?.findings[0];
-  const canReplaceRoot =
-    hasLocalExpansion &&
+  const contextOwnsSourceExpression =
     (context === "ordering" ||
+      context === "optional-predicate" ||
       context === "predicate" ||
       context === "selection" ||
-      context === "structured-selection") &&
+      context === "source-selection" ||
+      context === "structured-selection" ||
+      context === "write-expression") &&
     contextOwnsWholeExpression(
-      context === "structured-selection" ? "selection" : context,
+      context === "optional-predicate"
+        ? "predicate"
+        : context === "structured-selection" ||
+            context === "source-selection" ||
+            context === "write-expression"
+          ? "selection"
+          : context,
       parsed.statement,
-    ) &&
+    );
+  const canReplaceRoot =
+    hasLocalExpansion &&
+    contextOwnsSourceExpression &&
     rootClassification?.isWholeReplacement === true &&
     rootClassification.findings.length === 1 &&
     rootFinding !== undefined &&
@@ -4741,12 +4899,30 @@ function analyzeParsed(
   const hasWholeReplacementBoundary = replacementBoundary !== undefined;
   const findingEntries = deduplicateFindingEntries(
     classifications.flatMap((classification) => {
+      function isSourceLocalEligible(
+        finding: ClassifiedHelperFinding,
+      ): boolean {
+        return (
+          (finding.helper !== "and" && finding.helper !== "or") ||
+          !(
+            contextOwnsSourceExpression &&
+            classification === rootClassification &&
+            classification.isWholeReplacement &&
+            classification.findings.length === 1 &&
+            finding === rootFinding
+          )
+        );
+      }
+
       if (hasWholeReplacementBoundary) {
         return classification.findings.map((finding) => {
-          const publicResult = publicFinding({
-            ...finding,
-            node: replacementBoundary ?? node,
-          });
+          const publicResult = publicFinding(
+            {
+              ...finding,
+              node: replacementBoundary ?? node,
+            },
+            isSourceLocalEligible(finding),
+          );
           return {
             finding: publicResult,
             signature: {
@@ -4763,7 +4939,10 @@ function analyzeParsed(
       }
       return classification.findings.flatMap((finding) => {
         if (!hasLocalExpansion) {
-          const publicResult = publicFinding(finding);
+          const publicResult = publicFinding(
+            finding,
+            isSourceLocalEligible(finding),
+          );
           return [
             {
               finding: publicResult,
@@ -4786,11 +4965,15 @@ function analyzeParsed(
           checker,
           services,
           capabilities,
+          classificationContext.allowsRetainedSqlWrapper,
         );
         if (boundary === undefined) {
           return [];
         }
-        const publicResult = publicFinding({ ...finding, node: boundary });
+        const publicResult = publicFinding(
+          { ...finding, node: boundary },
+          isSourceLocalEligible(finding),
+        );
         return [
           {
             finding: publicResult,
@@ -4886,8 +5069,16 @@ function emptyTemplateFindings(
 }
 
 const SQL_CAPABILITY_TOKEN =
-  /(?:<>|>=|<=|@>|<@|&&|(?<![-=>])=(?!=|>)|(?<![-@>])>|<(?![@=>])|\b(?:AND|ASC|AVG|BETWEEN|COUNT|DESC|EXISTS|ILIKE|IN|IS|LIKE|MAX|MIN|NOT|NULL|OR|SUM|TRUE)\b)/i;
+  /(?:<>|!=|>=|<=|@>|<@|&&|(?<![-=>])=(?!=|>)|(?<![-@>])>|<(?![@=>])|\b(?:AND|ASC|AVG|BETWEEN|COUNT|DESC|EXISTS|ILIKE|IN|IS|LIKE|MAX|MIN|NOT|NULL|OR|SUM|TRUE)\b)/i;
 const WRITE_CAPABILITY_TOKEN = /\b(?:DELETE|INSERT|UPDATE)\b/i;
+
+export function sqlTagMightContainHelper(
+  node: TSESTree.TaggedTemplateExpression,
+): boolean {
+  return node.quasi.quasis.some((quasi) => {
+    return SQL_CAPABILITY_TOKEN.test(quasi.value.cooked ?? quasi.value.raw);
+  });
+}
 
 function variantMightContainCapability(
   variant: SqlSourceVariant,
@@ -5028,4 +5219,54 @@ export function analyzeSql(
     nodeCache.set(context, analysis);
   }
   return analysis;
+}
+
+function sourceLocalContext(
+  node: TSESTree.TaggedTemplateExpression,
+): SqlAnalysisContext {
+  const leadingLiteral =
+    node.quasi.quasis[0]?.value.cooked ?? node.quasi.quasis[0]?.value.raw ?? "";
+  if (/^\s*(?:DELETE|INSERT|SELECT|UPDATE|WITH)\b/iu.test(leadingLiteral)) {
+    return "source-statement";
+  }
+  if (/^\s*WHERE\b/iu.test(leadingLiteral)) {
+    return "source-where-prefix";
+  }
+  if (/^\s*(?:AND|OR)\b/iu.test(leadingLiteral)) {
+    return "source-predicate-prefix";
+  }
+  return "source-selection";
+}
+
+export function analyzeSqlSource(
+  node: TSESTree.TaggedTemplateExpression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  composer: SqlSourceComposer,
+  capabilities: SqlCapabilityChecks = NO_CAPABILITY_CHECKS,
+): readonly SqlAnalysisFinding[] {
+  const context = sourceLocalContext(node);
+  const sourceTemplateKey = `${node.type}:${node.range[0]}:${node.range[1]}`;
+  return analyzeSql(
+    node,
+    context,
+    checker,
+    services,
+    composer,
+    capabilities,
+  ).findings.filter((finding) => {
+    if (finding.kind !== "helper" && finding.kind !== "existence-predicate") {
+      return false;
+    }
+    if (finding.sourceTemplateKey !== sourceTemplateKey) {
+      return false;
+    }
+    if (
+      context === "source-predicate-prefix" &&
+      (finding.helper === "and" || finding.helper === "or")
+    ) {
+      return false;
+    }
+    return finding.sourceLocalEligible;
+  });
 }


### PR DESCRIPTION
## Summary

- analyze every conventional real Drizzle `sql` tag for source-contained helper-equivalent leaves while keeping consumer-sensitive decisions at their use sites
- cover optional branches, conditional spreads, conflict-update fields, nested window ordering, and source/use-site diagnostic deduplication
- convert all newly proven production leaves to Drizzle helpers without changing their surrounding statements, mappings, decoders, or execution paths

## Safety and scope

- preserves interpolation order, parameters and typings, normalized PostgreSQL ASTs, result decoders, cardinality, statements, locks, and transaction boundaries
- keeps unsupported PostgreSQL and opaque or dynamic composition as valid escape hatches
- does not add a schema migration, persisted-data rewrite, runtime API or protocol change, feature switch, compatibility shim, SQL allowlist, or broad `sql`-tag ban

## Validation

- `pnpm -F @vm0/eslint-rules test -- --maxWorkers=1 --silent=passed-only` (47 files, 942 tests)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected API integration tests (315 passed after resetting the isolated local database)
- 13-family serialization probe comparing parameters, typings, and normalized PostgreSQL ASTs
- `pnpm knip`
- Prettier check for all changed files
- `git diff --check`
- five same-mount interleaved API ESLint pairs: median wall time `+1.99%`, median peak process-tree RSS `-1.03%`
- pre-commit hooks, including repository-wide Turbo type checks

Closes #23549

Parent context: #23047
