### PR TITLE
test(api): avoid shared catalog cleanup write

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -45,7 +45,6 @@ import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
   installApiTestConnectorCatalog,
-  mockApiTestConnectorProviderConfiguration,
   readApiTestConnectorCatalogValidationAuthority,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
@@ -1308,10 +1307,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "R2_USER_STORAGES_BUCKET_NAME",
       "test-run-lifecycle-legacy-catalog",
     );
-    onTestFinished(async () => {
-      mockApiTestConnectorProviderConfiguration();
-      await installApiTestConnectorCatalog();
-    });
 
     const missingCatalogVersion = `api-test-missing-validation-${randomUUID()}`;
     await installApiTestConnectorCatalog({


### PR DESCRIPTION
## Summary

- remove the late catalog restore from the isolated legacy validation test
- prevent `onTestFinished` from writing to the shared default catalog source after environment cleanup

## Exclusions

- no production connector catalog behavior changes
- no timeout increases, retries, or skipped assertions

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Follow-up to #23563.
