### PR TITLE
ci: use larger runner for coverage

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -379,7 +379,7 @@ jobs:
               --ignored --exact production_write_file_identity_matches_sudo_policy
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 20
     env:
       CARGO_PROFILE_TEST_DEBUG: line-tables-only


### PR DESCRIPTION
## Summary

- run the Rust coverage job on the existing `ubuntu-latest-8-cores` larger runner
- keep the coverage command, cache, toolchain container, timeout, trigger, and Codecov upload unchanged

## Scope

This PR changes only the runner size for the coverage job. It does not change coverage selection, test scheduling, cache behavior, or any Rust code.

## Validation

- `git diff --check`
- `actionlint .github/workflows/crates.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- pre-commit `check-file-size`
- commit-message lint

Rust tests were not rerun because the test command and application behavior are unchanged.
