### PR TITLE
refactor: reduce fallback slop in notion automations

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
@@ -1419,30 +1419,34 @@ function buildNotionPageContentUpdatedCreateRequest(
   }
   const pageUrl = options.pageUrl?.trim();
   const databaseUrl = options.databaseUrl?.trim();
-  if (
-    (pageUrl !== undefined && pageUrl.length > 0) ===
-    (databaseUrl !== undefined && databaseUrl.length > 0)
-  ) {
-    throw new Error(
-      'notion-page-content-updated automations require exactly one of --page-url "https://www.notion.so/..." or --database-url "https://www.notion.so/..."',
-    );
+  const invalidScopeMessage =
+    'notion-page-content-updated automations require exactly one of --page-url "https://www.notion.so/..." or --database-url "https://www.notion.so/..."';
+  if (pageUrl && databaseUrl) {
+    throw new Error(invalidScopeMessage);
   }
 
+  if (pageUrl) {
+    return {
+      kind: "event",
+      eventType: "notion-page-content-updated",
+      eventConfig: {
+        provider: "notion",
+        event: "page_content_updated",
+        pageUrl,
+      },
+    };
+  }
+  if (!databaseUrl) {
+    throw new Error(invalidScopeMessage);
+  }
   return {
     kind: "event",
     eventType: "notion-page-content-updated",
-    eventConfig:
-      pageUrl !== undefined && pageUrl.length > 0
-        ? {
-            provider: "notion",
-            event: "page_content_updated",
-            pageUrl,
-          }
-        : {
-            provider: "notion",
-            event: "page_content_updated",
-            databaseUrl: databaseUrl ?? "",
-          },
+    eventConfig: {
+      provider: "notion",
+      event: "page_content_updated",
+      databaseUrl,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- Enforce the already-required Notion page-content automation scope before constructing the request.
- Preserve the page and database URL paths while removing the empty database URL fallback.
- Fail with the existing validation message when neither URL or both URLs are supplied.

## Scan

- Timestamp: `2026-07-28T20:02:31.218Z`
- Base commit: `a2247ee072c508d39916621c3bc34980aabded40`
- Files scanned: 3,780
- Scanner actionable matches: 4,224
- Scanner high-confidence production matches: 231
- Scanner suggested 5% budget: 12
- Context-reviewed `actionable_total`: 1
- Adjusted `edit_budget`: 1
- Candidates changed: 1

Matches by category:

- `nullish`: 5,972
- `nullish-chain`: 133
- `field-fallback-chain`: 105
- `optional-prop`: 5,903
- `zod-optional`: 2,565
- `zod-loose-optional`: 4
- `loose-record`: 1,057
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 30
- `empty-fallback`: 595
- `string-fallback`: 663
- `null-undefined-fallback`: 1,615
- `empty-catch`: 3
- `promise-catch-swallow`: 16
- `rust-unwrap-or`: 646
- `rust-ok-discard`: 153

## Changed file

- `turbo/apps/cli/src/commands/zero/workflow/automation/index.ts`
  - The command contract requires exactly one non-empty page or database URL.
  - Explicit branches now preserve that invariant and pass the validated database URL directly instead of manufacturing `databaseUrl: ""`.

The manual budget was reduced because the remaining scanner candidates examined in context were tests or rule examples, external API adapters, presentational fallbacks, compatibility readers, or intentional precedence chains.

## Verification

- `pnpm exec prettier --write apps/cli/src/commands/zero/workflow/automation/index.ts`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/workflow/automation/__tests__/automation.test.ts` — 52 passed
- `git diff --check`
- Follow-up scanner output no longer reports a fallback in the changed request builder.

This workflow intentionally leaves the remaining candidates for later daily runs.
