### PR TITLE
feat(platform): enable chat history backfill progress globally

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -402,7 +402,8 @@ describe("GET /api/zero/usage/insight", () => {
     expect(seriesKeys).toStrictEqual(new Set([...names.slice(0, 7), "others"]));
   });
 
-  it("today produces hourly bucket strings", async () => {
+  it("today includes first-hour activity in an hourly bucket", async () => {
+    mockNow(new Date("2026-07-29T00:30:00.500Z"));
     const actor = await entitledInsightActor();
     const compose = await createInsightCompose(actor);
     const runId = await createSourceRun(actor, compose.composeId, "cli");
@@ -420,10 +421,8 @@ describe("GET /api/zero/usage/insight", () => {
       [200],
     );
 
-    expect(response.body.buckets.length).toBeGreaterThanOrEqual(1);
-    for (const bucket of response.body.buckets) {
-      expect(bucket.ts).toMatch(/:00:00/);
-    }
+    expect(response.body.buckets).toHaveLength(1);
+    expect(response.body.buckets[0]?.ts).toBe("2026-07-29T00:00:00.000Z");
   });
 
   it("day window returns the selected calendar day with hourly buckets", async () => {

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -202,7 +202,8 @@ function startOfDayInTz(date: Date, tz: string): Date {
     10,
   );
 
-  const elapsed = ((hour * 60 + minute) * 60 + second) * 1000;
+  const elapsed =
+    ((hour * 60 + minute) * 60 + second) * 1000 + date.getUTCMilliseconds();
   let result = new Date(date.getTime() - elapsed);
 
   const verify = (candidate: Date): boolean => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -141,7 +141,13 @@ describe("chat history backfill loading", () => {
   it("stays hidden during backfill when the feature switch is off", async () => {
     const { finalHistoryPage, beforeSeqIds } = mockPagedHistory();
 
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatHistoryBackfillProgress]: false,
+      },
+    });
 
     await waitFor(() => {
       expect(beforeSeqIds).toContain(GATED_BEFORE_SEQ_ID);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -16,6 +16,9 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ChatHistoryBackfillProgress, {}),
+    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -393,8 +393,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Chat message skeletons above the first visible message while older history loads.",
-    // Not rolled out to anyone yet; enable per-user via the Lab page.
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ThreeColumnNav]: {
     maintainer: "ming@vm0.ai",


### PR DESCRIPTION
## Summary

- Enable `chatHistoryBackfillProgress` by default for every organization so chat history loading skeletons appear while older messages are backfilled.
- Remove the obsolete per-user rollout comment and cover the globally enabled state in the core feature-switch test.

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests passed)
