### PR TITLE
fix(chat): hide one-hour expiry on permission cards

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -2123,7 +2123,11 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: isoFromNowMs(30 * 60 * 1000),
+            expiresAt: isoFromNowMs(
+              grant.permission === "spreadsheets.create"
+                ? 30 * 60 * 1000
+                : 60 * 60 * 1000,
+            ),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },
@@ -2189,7 +2193,7 @@ describe("chat message action cards", () => {
       ).toBeInTheDocument();
     });
     expect(
-      within(writeCard).queryByText("Expires in less than 1 hour"),
+      within(writeCard).queryByText("Expires in 1 hour"),
     ).not.toBeInTheDocument();
 
     expect(capturedPermissionGrantBodies).toStrictEqual([

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4731,7 +4731,10 @@ function PermissionActionCardContent({
     ? permissionGrantExpiryText(expiresAt)
     : null;
   const expiryText =
-    rawExpiryText === "Expires in less than 1 hour" ? null : rawExpiryText;
+    rawExpiryText === "Expires in less than 1 hour" ||
+    rawExpiryText === "Expires in 1 hour"
+      ? null
+      : rawExpiryText;
   const showDurationSelect =
     expirationAvailable &&
     (status.kind === "ready" ||


### PR DESCRIPTION
## Summary

- hide the `Expires in 1 hour` line on chat permission cards so short grants keep the compact two-line layout
- preserve the existing sub-hour hiding behavior, longer expiry labels, and permission grant duration behavior
- cover both sub-hour and one-hour grant responses in the page-level permission card test

## Verification

- `pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx`
- platform static asset, i18n, Oxlint, type-aware Oxlint, and ESLint checks
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx -t "renders and confirms multiple permission cards from one assistant message"`

Browser verification was not run, following the repository preference to rely on the PR pipeline unless explicitly requested.
