### PR TITLE
refactor(chat): stop derived role dual-write

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
@@ -64,6 +64,11 @@ describe("dev bench seed profile rows", () => {
       expect(rows.zeroRunRows).toHaveLength(expected.runs);
       expect(rows.messageRows).toHaveLength(expected.messages);
       expect(
+        rows.messageRows.some((row) => {
+          return "role" in row;
+        }),
+      ).toBeFalsy();
+      expect(
         countWhere(rows.messageRows, (row) => {
           return chatEventCompatibilityRole(row.eventType) === "user";
         }),

--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -31,7 +31,7 @@ type Database = ReturnType<typeof db>;
 type AgentRunInsert = typeof agentRuns.$inferInsert;
 type ZeroRunInsert = typeof zeroRuns.$inferInsert;
 type ChatMessageInsert = typeof chatMessages.$inferInsert;
-type SeedChatMessageRow = Omit<ChatMessageInsert, "seqId"> & {
+type SeedChatMessageRow = Omit<ChatMessageInsert, "role" | "seqId"> & {
   id: string;
   createdAt: Date;
   sequenceNumber?: number | null;
@@ -651,7 +651,6 @@ function appendRunMessages(
     chatThreadId: args.threadId,
     runId,
     eventType: "input.prompt",
-    role: "user",
     content: prompt,
     userMessage: { version: 1, parts: [{ type: "text", text: prompt }] },
     createdAt: baseCreatedAt,

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -1,6 +1,5 @@
 /** Typed append-only commands for the canonical ChatEvent stream. */
 import {
-  chatEventCompatibilityRole,
   chatEventRunLifecycle,
   isValidChatEventRevocation,
 } from "@vm0/api-contracts/contracts/chat-events";
@@ -210,7 +209,7 @@ interface ChatEventBatchCommandResult {
 type InsertChatEventConflict = "none" | "any" | "id" | "run-lifecycle";
 type InsertChatEventsConflict = "any" | "run-sequence";
 
-type PersistedChatEvent = Omit<ChatEventInsert, "seqId">;
+type PersistedChatEvent = Omit<ChatEventInsert, "role" | "seqId">;
 
 function persistedChatEventValues(values: NewChatEvent): PersistedChatEvent {
   const runLifecycleEvent = chatEventRunLifecycle(values.eventType);
@@ -221,7 +220,6 @@ function persistedChatEventValues(values: NewChatEvent): PersistedChatEvent {
       content: null,
       error: pauseReason,
       eventType: event.eventType,
-      role: chatEventCompatibilityRole(event.eventType),
     };
   }
   return {
@@ -231,7 +229,6 @@ function persistedChatEventValues(values: NewChatEvent): PersistedChatEvent {
       ? { content: null }
       : {}),
     eventType: values.eventType,
-    role: chatEventCompatibilityRole(values.eventType),
     ...(runLifecycleEvent === null ? {} : { runLifecycleEvent }),
   };
 }


### PR DESCRIPTION
## Summary

- stop canonical ChatEvent persistence from deriving and writing `chat_messages.role`
- make the production writer and dev benchmark fixture types exclude the legacy column so the dual-write cannot be reintroduced accidentally
- cover the benchmark fixture output to confirm generated rows no longer carry `role`

## User impact

New chat events now persist only the canonical `event_type` discriminator and leave the nullable legacy `role` column unset. API responses, transcript/model role projections, and visible chat behavior are unchanged.

## Roadmap and rollout safety

This is **PR B** of the three-step roadmap in #22757. Its entry gate is satisfied: PR A (#23541) rolled out in `api-v1.338.0` / `app-v0.649.0`, and the current release list has advanced to `api-v1.338.2` / `app-v0.649.2`.

Migration `0713` already made `chat_messages.role` nullable. That keeps the deployment window compatible without another migration: pre-B API instances may continue writing the derived value, while B instances omit it, and both write shapes are accepted by the existing schema.

This PR intentionally leaves the physical `chat_messages.role` column and its schema definition in place. It also leaves queue code unchanged.

**PR C must wait until this PR has been released and fully rolled out, and production verification confirms that no lagging pre-B instances still write `role`. Only then can the physical column be dropped in a separate migration.**

## Verification

Passed locally:

- Prettier 3.8.1 for all changed files
- `pnpm turbo run lint --filter=api --log-order grouped --concurrency=1`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run check-types --filter=api --log-order grouped --concurrency=1`
- `pnpm knip` (exit 0; configuration hints only)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/scripts/__tests__/dev-bench-seed.test.ts` (1 passed)
- final writer/caller search and `git diff --check`

Full-suite tests are delegated to the PR pipeline per repository guidance.

Refs #22757
