### PR TITLE
docs(python): correct x includes fallback contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -273,9 +273,13 @@ _INCLUDES_TO_BUCKET: dict[str, str] = {
 
 
 def classify_includes_bucket(key: str) -> str | None:
-    """Return the billing bucket for an ``includes.<key>`` resource
-    type, or ``None`` if the key is not recognized.  Caller is
-    responsible for substituting a safe over-charging fallback.
+    """Return the billing bucket for an ``includes.<key>`` resource type.
+
+    ``None`` means the caller must preserve the unknown type as a bounded
+    synthetic ``includes.<key>`` category or the fixed
+    ``includes.__overflow__`` category, not substitute a known bucket.  The
+    server applies the minimum-rate X ``__fallback__`` price to these
+    categories, records ``fallback_pricing``, and emits underbilling telemetry.
     """
     return _INCLUDES_TO_BUCKET.get(key)
 


### PR DESCRIPTION
## Summary

- correct the `classify_includes_bucket()` caller contract for unknown X include keys
- document bounded synthetic and fixed overflow categories
- document minimum-rate server fallback pricing and fallback/underbilling recording

## Scope

Documentation only. This PR does not change runtime billing behavior, pricing data, tests, APIs, persisted state, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4405 passed)

Closes #23582
