### PR TITLE
refactor(platform): retire chat history backfill progress switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -1,6 +1,5 @@
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   chatThreadEventsContract,
   type ChatEventResponse,
@@ -99,9 +98,6 @@ describe("chat history backfill loading", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatHistoryBackfillProgress]: true,
-      },
     });
 
     await waitFor(() => {
@@ -136,25 +132,5 @@ describe("chat history backfill loading", () => {
         document.querySelector("[data-history-backfill-skeleton]"),
       ).toBeNull();
     });
-  });
-
-  it("stays hidden during backfill when the feature switch is off", async () => {
-    const { finalHistoryPage, beforeSeqIds } = mockPagedHistory();
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatHistoryBackfillProgress]: false,
-      },
-    });
-
-    await waitFor(() => {
-      expect(beforeSeqIds).toContain(GATED_BEFORE_SEQ_ID);
-    });
-    expect(
-      document.querySelector("[data-history-backfill-skeleton]"),
-    ).toBeNull();
-    finalHistoryPage.resolve();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2783,11 +2783,8 @@ function ChatHistoryBackfillSkeleton({
 }: {
   thread: ChatThreadSignals;
 }) {
-  const featureSwitches = useGet(featureSwitch$);
-  const enabled =
-    featureSwitches[FeatureSwitchKey.ChatHistoryBackfillProgress] ?? false;
   const progress = useLastResolved(thread.historyBackfillProgress$);
-  if (!enabled || progress === null || progress === undefined) {
+  if (progress === null || progress === undefined) {
     return null;
   }
   return (

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -16,9 +16,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.ChatHistoryBackfillProgress, {}),
-    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -81,6 +81,5 @@ export enum FeatureSwitchKey {
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ComposerConnectorPermissions = "composerConnectorPermissions",
   ThreeColumnNav = "threeColumnNav",
-  ChatHistoryBackfillProgress = "chatHistoryBackfillProgress",
   ChatThreadSidebarAutoOpen = "chatThreadSidebarAutoOpen",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -389,12 +389,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatHistoryBackfillProgress]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Chat message skeletons above the first visible message while older history loads.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ThreeColumnNav]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove the fully rolled-out `chatHistoryBackfillProgress` key from the feature-switch enum and registry.
- Keep chat history backfill skeletons always active whenever older history is still loading, preserving the globally enabled behavior.
- Delete obsolete feature-switch overrides, the disabled-state branch, and its unreachable test while retaining always-on behavior coverage.

## Verification

- `pnpm exec prettier --write packages/core/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx` (1 test passed)
- `pnpm exec knip --workspace @vm0/core --workspace @vm0/app`
