### PR TITLE
docs(runner): correct host oom probe contract

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1952,7 +1952,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let exit = match result {
         Ok(exit) => exit,
         Err(e) => {
-            // Sandbox crashed — check host dmesg for cgroup OOM kill of the
+            // Sandbox crashed — check host dmesg for OOM evidence naming the
             // firecracker process before propagating a generic error.
             if let Some(host_process_pid) = sandbox.host_process_pid()
                 && check_host_oom(host_process_pid).await
@@ -1962,9 +1962,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     pid = host_process_pid,
                     "host OOM kill detected for firecracker"
                 );
-                let error = "Firecracker VM killed by host OOM killer \
-                             (cgroup memory limit exceeded)"
-                    .to_string();
+                let error = "Firecracker VM killed by host OOM killer".to_string();
                 telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
                 return Ok(AgentExecutionResult::failure(1, error, None)
                     .with_resource_failure_kind(ResourceFailureKind::HostMemoryOomKilled));

--- a/crates/runner/src/executor/diagnostics/oom.rs
+++ b/crates/runner/src/executor/diagnostics/oom.rs
@@ -8,10 +8,11 @@ pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
     lower.contains("out of memory") || lower.contains("oom-kill") || lower.contains("oom_reaper")
 }
 
-/// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
-/// Reads the entire ring buffer (~512KB) directly — no shell wrapper needed
-/// since the pure function handles filtering.  Times out after 5s to avoid
-/// blocking if sudo hangs.
+/// Checks host `dmesg` output for OOM evidence naming a specific Firecracker process.
+///
+/// Invokes `dmesg` directly under the runner's current privileges and times out
+/// after five seconds. Returns `false` when the command exits unsuccessfully,
+/// cannot be started, or times out.
 pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::process::Command::new("dmesg").output().await
@@ -36,9 +37,13 @@ pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
     }
 }
 
-/// Returns true if host dmesg output contains an OOM kill record for the
-/// given firecracker PID.  Checks that the character after the PID is not
-/// a digit to avoid prefix matches (e.g. pid=1234 must not match pid=12345).
+/// Returns `true` when host `dmesg` output contains the case-sensitive
+/// `oom-kill` marker and an exact `task=firecracker,pid=<pid>` token.
+///
+/// The marker and task token are searched independently across the output, so
+/// this does not validate a memory-cgroup constraint. The character after the
+/// PID must not be a digit, avoiding prefix matches such as `pid=1234` matching
+/// `pid=12345`.
 pub(in crate::executor) fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
     if !dmesg.contains("oom-kill") {
         return false;

--- a/crates/runner/src/executor/diagnostics/oom.rs
+++ b/crates/runner/src/executor/diagnostics/oom.rs
@@ -12,7 +12,7 @@ pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
 ///
 /// Invokes `dmesg` directly under the runner's current privileges and times out
 /// after five seconds. Returns `false` when the command exits unsuccessfully,
-/// cannot be started, or times out.
+/// execution fails, or the operation times out.
 pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::process::Command::new("dmesg").output().await
@@ -38,12 +38,12 @@ pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
 }
 
 /// Returns `true` when host `dmesg` output contains the case-sensitive
-/// `oom-kill` marker and an exact `task=firecracker,pid=<pid>` token.
+/// `oom-kill` marker and the `task=firecracker,pid=<pid>` substring.
 ///
-/// The marker and task token are searched independently across the output, so
-/// this does not validate a memory-cgroup constraint. The character after the
-/// PID must not be a digit, avoiding prefix matches such as `pid=1234` matching
-/// `pid=12345`.
+/// The two substrings are searched independently across the full output and
+/// need not occur in the same log record. The predicate does not require a
+/// memory-cgroup constraint marker. The character after the PID must not be a
+/// digit, avoiding prefix matches such as `pid=1234` matching `pid=12345`.
 pub(in crate::executor) fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
     if !dmesg.contains("oom-kill") {
         return false;


### PR DESCRIPTION
## Summary

- document the host OOM probe's direct `dmesg` invocation, five-second timeout, and false-on-command-failure behavior
- describe the independent `oom-kill` and Firecracker PID substring searches, PID boundary, and memory-cgroup evidence limitation
- remove the unsupported cgroup-limit claim from the caller comment and human-readable failure text

## Scope

- preserves the OOM matcher, command execution, timeout, control flow, telemetry, and `HostMemoryOomKilled` classification
- does not change APIs, protocols, persisted data, migrations, performance, or deployment behavior
- adds no tests because runtime behavior is unchanged and existing runner diagnostics tests already cover the documented predicate

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2,865 passed; 14 ignored)
- `git diff --check`
- pre-commit workspace Rust formatting, Clippy, rustdoc, file-size, and commitlint hooks

Closes #23585
