### PR TITLE
fix(platform): use the alert primitive for artifact catalog error state

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -556,4 +556,19 @@ describe("artifact catalog page", () => {
       screen.findByText("No artifacts found"),
     ).resolves.toBeInTheDocument();
   });
+
+  it("announces an alert when the catalog fails to load", async () => {
+    context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
+      return respond(403, {
+        error: { code: "FORBIDDEN", message: "Transient catalog failure" },
+      });
+    });
+
+    setupArtifactCatalogPage();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Could not load artifacts. Try again later.",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -13,7 +13,8 @@ import {
 } from "@tabler/icons-react";
 import { r2ImageTransformUrl } from "@vm0/core";
 import { useGet, useLoadable, useSet } from "ccstate-react";
-import { Alert, AlertDescription, cn } from "@vm0/ui";
+import { cn } from "@vm0/ui";
+import { Alert, AlertDescription } from "@vm0/ui/components/ui/alert";
 
 import {
   artifactCatalog$,

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@tabler/icons-react";
 import { r2ImageTransformUrl } from "@vm0/core";
 import { useGet, useLoadable, useSet } from "ccstate-react";
-import { cn } from "@vm0/ui";
+import { Alert, AlertDescription, cn } from "@vm0/ui";
 
 import {
   artifactCatalog$,
@@ -221,13 +221,12 @@ export function ArtifactCatalogSkeleton() {
 
 export function ArtifactCatalogError() {
   return (
-    <div
-      role="alert"
-      className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
-    >
+    <Alert variant="destructive">
       <IconAlertTriangle size={16} stroke={1.5} aria-hidden />
-      Could not load artifacts. Try again later.
-    </div>
+      <AlertDescription>
+        Could not load artifacts. Try again later.
+      </AlertDescription>
+    </Alert>
   );
 }
 


### PR DESCRIPTION
## What

The artifacts catalog rendered its load-failure banner as a hand-rolled `div`, bypassing the `Alert` primitive that already exists in `@vm0/ui` and is already used by `workflow-detail-page` and `zero-settings-tab`.

`views/artifacts-page/artifact-catalog-page.tsx:226` (before):

```
border border-destructive/30  bg-destructive/5  px-4 py-3
```

`Alert variant="destructive"` (`packages/ui/src/components/ui/alert.tsx:13`):

```
border-red-200  bg-red-50  px-4 py-3.5
```

So the same "something failed to load" state showed a different red and a different vertical padding depending on which page you were on.

## User-visible impact

The artifacts error banner now matches every other error banner in the product — same red, same padding, same radius. No copy change.

## Implementation notes

- Replaced the hand-rolled markup with `Alert` + `AlertDescription`.
- `Alert` sets `role="alert"` internally, so the accessibility semantics of the previous markup are preserved rather than duplicated.
- The `IconAlertTriangle` child is positioned by `Alert`'s own `[&>svg]` rules, which is why the explicit flex/gap wrapper is no longer needed.

## Verification

Relying on the PR pipeline for lint, types, and tests. The catalog test suite asserts on the error message text and not on the container's classes, so no test update was required.

Found by the daily UI consistency audit workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)