### PR TITLE
fix(platform): use standard inputs for chat header automation fields

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -471,6 +471,10 @@ describe("chat lifecycle", () => {
     expect(within(dialog).getByLabelText("Thread ID value")).toHaveValue(
       "gmail-thread-1",
     );
+    // The field and operator cells are fixed for a thread-scoped automation, so
+    // they must not look editable next to the value cell.
+    expect(within(dialog).getByLabelText("Thread ID field")).toBeDisabled();
+    expect(within(dialog).getByLabelText("Thread ID operator")).toBeDisabled();
     await fill(
       within(dialog).getByLabelText("Thread ID value"),
       "gmail-thread-2",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1549,12 +1549,7 @@ function HeaderGmailNewMessageAutomationEditForm({
             readOnly
             disabled
           />
-          <Input
-            aria-label="Thread ID operator"
-            value="Is"
-            readOnly
-            disabled
-          />
+          <Input aria-label="Thread ID operator" value="Is" readOnly disabled />
           <Input
             name="threadId"
             aria-label="Thread ID value"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1321,9 +1321,6 @@ function HeaderWorkflowAutomationEditDialog({
   );
 }
 
-const HEADER_AUTOMATION_FIELD_CLASS =
-  "h-9 w-full rounded-md border border-border/60 bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary disabled:opacity-60";
-
 function localDateTimeInputValue(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -1427,13 +1424,12 @@ function HeaderScheduleAutomationEditForm({
       {schedule.type === "once" ? (
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
           Run at
-          <input
+          <Input
             name="atTime"
             aria-label="Run at"
             type="datetime-local"
             defaultValue={localDateTimeInputValue(schedule.atTime)}
             disabled={saving}
-            className={HEADER_AUTOMATION_FIELD_CLASS}
           />
           <span>Displays in {displayTimezone}</span>
         </label>
@@ -1441,12 +1437,11 @@ function HeaderScheduleAutomationEditForm({
       {schedule.type === "cron" ? (
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
           Cron expression
-          <input
+          <Input
             name="cronExpression"
             aria-label="Cron expression"
             defaultValue={schedule.cronExpression}
             disabled={saving}
-            className={HEADER_AUTOMATION_FIELD_CLASS}
           />
           <span>Runs in {schedule.timezone}</span>
         </label>
@@ -1548,25 +1543,24 @@ function HeaderGmailNewMessageAutomationEditForm({
     >
       {automation.eventConfig.threadId ? (
         <div className="grid grid-cols-3 gap-2">
-          <input
+          <Input
             aria-label="Thread ID field"
             value="Thread ID"
             readOnly
-            className={HEADER_AUTOMATION_FIELD_CLASS}
+            disabled
           />
-          <input
+          <Input
             aria-label="Thread ID operator"
             value="Is"
             readOnly
-            className={HEADER_AUTOMATION_FIELD_CLASS}
+            disabled
           />
-          <input
+          <Input
             name="threadId"
             aria-label="Thread ID value"
             defaultValue={automation.eventConfig.threadId}
             disabled={saving}
             required
-            className={HEADER_AUTOMATION_FIELD_CLASS}
           />
         </div>
       ) : null}
@@ -1574,7 +1568,7 @@ function HeaderGmailNewMessageAutomationEditForm({
         {GMAIL_TEXT_FIELDS.map(({ field, label }) => {
           return (
             <div key={field} className="grid grid-cols-3 gap-2">
-              <input
+              <Input
                 name={`${field}Contains`}
                 aria-label={`${label} contains`}
                 defaultValue={gmailMatcherDefaultValue(
@@ -1584,9 +1578,8 @@ function HeaderGmailNewMessageAutomationEditForm({
                 )}
                 disabled={saving}
                 placeholder={`${label} contains`}
-                className={HEADER_AUTOMATION_FIELD_CLASS}
               />
-              <input
+              <Input
                 name={`${field}ContainsAny`}
                 aria-label={`${label} contains any`}
                 defaultValue={gmailMatcherDefaultValue(
@@ -1596,9 +1589,8 @@ function HeaderGmailNewMessageAutomationEditForm({
                 )}
                 disabled={saving}
                 placeholder={`${label} contains any`}
-                className={HEADER_AUTOMATION_FIELD_CLASS}
               />
-              <input
+              <Input
                 name={`${field}DoesNotContain`}
                 aria-label={`${label} does not contain`}
                 defaultValue={gmailMatcherDefaultValue(
@@ -1608,7 +1600,6 @@ function HeaderGmailNewMessageAutomationEditForm({
                 )}
                 disabled={saving}
                 placeholder={`${label} does not contain`}
-                className={HEADER_AUTOMATION_FIELD_CLASS}
               />
             </div>
           );
@@ -1676,14 +1667,13 @@ function HeaderGmailLabelAutomationEditForm({
     >
       <label className="flex flex-col gap-1 text-xs text-muted-foreground">
         Label name
-        <input
+        <Input
           name="labelName"
           aria-label="Label name"
           required
           defaultValue={automation.eventConfig.labelName}
           disabled={saving}
           placeholder="Support"
-          className={HEADER_AUTOMATION_FIELD_CLASS}
         />
       </label>
       <DialogFooter>


### PR DESCRIPTION
## What

The Gmail automation editors in the chat thread header built all nine of their text fields from raw `<input>` elements styled by a local `HEADER_AUTOMATION_FIELD_CLASS` constant (`zero-chat-thread-page.tsx:1324`) — a near-copy of the `FIELD_CLASS` the workflow detail page used.

Both diverge from the `Input` primitive on `rounded-md` vs `rounded-lg`, `border-border/60` vs `border-[0.7px] border-[hsl(var(--gray-400))]`, `bg-background` vs `bg-input`, and `px-2.5` vs `px-3 py-2`. The result: the *same* Gmail automation condition looked different depending on whether you opened it from the workflow detail page or from the chat header.

### The Thread ID row was the worst case

`zero-chat-thread-page.tsx:1547` rendered three identically styled boxes:

| cell | before | interactive? |
|---|---|---|
| field | `<input value="Thread ID" readOnly>` | no |
| operator | `<input value="Is" readOnly>` | no |
| value | `<input name="threadId">` | **yes** |

Three boxes that look the same, two of which do nothing when clicked, with nothing on screen distinguishing them. Compare `workflow-detail-page.tsx:5322`, which builds the same field/operator/value row from `Select` + `Select` + `Input` — there the two choosers are obviously dropdowns and the value is obviously a text box.

## User-visible impact

- Automation fields in the chat header now match the ones on the workflow detail page and pick up the standard focus ring and disabled styling.
- The two fixed Thread ID cells are now visibly non-interactive instead of masquerading as editable fields.

## Implementation notes

- All nine call sites render `Input`; `HEADER_AUTOMATION_FIELD_CLASS` is deleted.
- The two fixed Thread ID cells keep `readOnly` (so React does not warn about a `value` without `onChange`) and additionally take `disabled`, which is what applies `Input`'s `disabled:opacity-50 disabled:cursor-not-allowed`.
- Neither fixed cell has a `name`, so they were never part of the submitted `FormData` — payloads are unchanged. `aria-label`s are preserved, so the existing `getByLabelText("Thread ID value")` assertions still resolve.

## Follow-up, deliberately not in this PR

The complete fix is to reuse the workflow detail page's condition row component so the chat header gets real `Select` controls and a remove button rather than disabled text boxes. That is a structural refactor and wants its own review.

## Verification

Relying on the PR pipeline for lint, types, and tests, per the repo's PR convention.

Found by the daily UI consistency audit workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)