### PR TITLE
refactor(api): build model rankings with drizzle ctes

### DIFF
--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,5 +1,17 @@
 import { command } from "ccstate";
-import { and, eq, gt, gte, inArray, lt, or, sql, sum } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  lt,
+  or,
+  sql,
+  sum,
+  type SQLWrapper,
+} from "drizzle-orm";
 import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -7,12 +19,11 @@ import {
   VM0_MODEL_ALIAS_TO_MODEL,
   VM0_MODEL_TO_PROVIDER,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { z } from "zod";
 
 import {
-  executeRawRows,
-  pgInt8ToSafeIntegerSchema,
-} from "../../lib/db-raw-rows";
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { type Db, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 
@@ -38,24 +49,6 @@ interface ModelRankingResult {
   readonly windowEnd: Date;
   readonly rows: readonly ModelRankingRow[];
 }
-
-const modelRankingSqlRowSchema = z
-  .object({
-    model: z.string(),
-    input_tokens: pgInt8ToSafeIntegerSchema,
-    output_tokens: pgInt8ToSafeIntegerSchema,
-    total_tokens: pgInt8ToSafeIntegerSchema,
-    previous_total_tokens: pgInt8ToSafeIntegerSchema,
-  })
-  .transform((row): ModelRankingRow => {
-    return {
-      model: row.model,
-      inputTokens: row.input_tokens,
-      outputTokens: row.output_tokens,
-      totalTokens: row.total_tokens,
-      previousTotalTokens: row.previous_total_tokens,
-    };
-  });
 
 function getModelAliasEntries() {
   return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
@@ -146,7 +139,19 @@ function modelStatModelExpression() {
       return sql`WHEN ${eq(modelColumn, alias)} THEN ${model}`;
     }),
     sql` `,
-  )} ELSE ${modelColumn} END`;
+  )} ELSE ${sql`${modelColumn}`} END`.mapWith(pgTextDecoder);
+}
+
+function modelStatWindowSum(value: SQLWrapper, start: string, end: string) {
+  return sql`COALESCE(
+    ${sum(value)} FILTER (
+      WHERE ${and(
+        gte(modelStat.hourStart, sql`${start}::timestamp`),
+        lt(modelStat.hourStart, sql`${end}::timestamp`),
+      )}
+    ),
+    0
+  )::bigint`.mapWith(pgInt8ToSafeIntegerDecoder);
 }
 
 async function replaceModelStats(
@@ -273,51 +278,55 @@ async function selectModelRankings(
   const previousStartParam = utcTimestampParam(previousStart);
   const previousEndParam = utcTimestampParam(previousEnd);
 
-  const rows = await executeRawRows(
-    db,
-    sql`
-      WITH current_period AS (
-      SELECT
-        ${modelExpr} AS model,
-        COALESCE(${sum(
+  const rankingPeriods = db.$with("ranking_periods").as(
+    db
+      .select({
+        model: modelExpr.as("ranking_model"),
+        inputTokens: modelStatWindowSum(
           sql`${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}`,
-        )}, 0)::bigint AS input_tokens,
-        COALESCE(${sum(modelStat.outputTokens)}, 0)::bigint AS output_tokens,
-        COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS total_tokens
-      FROM ${modelStat}
-      WHERE ${and(
-        gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`),
-        lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
-        inArray(modelStat.model, modelStatsModelIds),
-      )}
-      GROUP BY 1
-    ),
-    previous_period AS (
-      SELECT
-        ${modelExpr} AS model,
-        COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS previous_total_tokens
-      FROM ${modelStat}
-      WHERE ${and(
-        gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
-        lt(modelStat.hourStart, sql`${previousEndParam}::timestamp`),
-        inArray(modelStat.model, modelStatsModelIds),
-      )}
-      GROUP BY 1
-    )
-    SELECT
-      current_period.model,
-      current_period.input_tokens,
-      current_period.output_tokens,
-      current_period.total_tokens,
-      COALESCE(previous_period.previous_total_tokens, 0)::bigint AS previous_total_tokens
-    FROM current_period
-    LEFT JOIN previous_period ON previous_period.model = current_period.model
-    WHERE current_period.total_tokens > 0
-    ORDER BY current_period.total_tokens DESC
-      LIMIT 50
-    `,
-    modelRankingSqlRowSchema,
+          windowStartParam,
+          windowEndParam,
+        ).as("input_tokens"),
+        outputTokens: modelStatWindowSum(
+          modelStat.outputTokens,
+          windowStartParam,
+          windowEndParam,
+        ).as("output_tokens"),
+        totalTokens: modelStatWindowSum(
+          modelStat.totalTokens,
+          windowStartParam,
+          windowEndParam,
+        ).as("total_tokens"),
+        previousTotalTokens: modelStatWindowSum(
+          modelStat.totalTokens,
+          previousStartParam,
+          previousEndParam,
+        ).as("previous_total_tokens"),
+      })
+      .from(modelStat)
+      .where(
+        and(
+          gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
+          lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
+          inArray(modelStat.model, modelStatsModelIds),
+        ),
+      )
+      .groupBy(sql`1`),
   );
+
+  const rows: ModelRankingRow[] = await db
+    .with(rankingPeriods)
+    .select({
+      model: rankingPeriods.model,
+      inputTokens: rankingPeriods.inputTokens,
+      outputTokens: rankingPeriods.outputTokens,
+      totalTokens: rankingPeriods.totalTokens,
+      previousTotalTokens: rankingPeriods.previousTotalTokens,
+    })
+    .from(rankingPeriods)
+    .where(gt(rankingPeriods.totalTokens, sql`0`))
+    .orderBy(desc(rankingPeriods.totalTokens))
+    .limit(50);
 
   return {
     period,

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -1465,6 +1465,43 @@ const queryBuilderCases = {
   ],
   readValid: [
     {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            WITH ranking_periods AS (
+              SELECT id
+              FROM literal_model_stats
+            )
+            SELECT id
+            FROM ranking_periods
+            LIMIT 50
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const modelStatsRelation: SQL;
+        await executeRawRows(
+          db,
+          sql\`
+            WITH ranking_periods AS (
+              SELECT id
+              FROM \${modelStatsRelation}
+            )
+            SELECT id
+            FROM ranking_periods
+            LIMIT 50
+          \`,
+          rowSchema,
+        );
+      `,
+    },
+    {
       code: `${schemaPreamble}
         import { eq, sql } from "drizzle-orm";
         async function executeRawRows(...args: unknown[]) { return args; }
@@ -2242,6 +2279,48 @@ const queryBuilderCases = {
     },
   ],
   readInvalid: [
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { gte, sql, sum } from "drizzle-orm";
+        await executeRawRows(
+          db,
+          sql\`
+            WITH ranking_periods AS (
+              SELECT
+                \${runs.threadId} AS thread_id,
+                COALESCE(\${sum(runs.id)}, 0)::bigint AS total
+              FROM \${runs}
+              WHERE \${gte(runs.id, 0)}
+              GROUP BY 1
+            ),
+            previous_period AS (
+              SELECT
+                \${runs.threadId} AS thread_id,
+                COALESCE(\${sum(runs.id)}, 0)::bigint AS previous_total
+              FROM \${runs}
+              WHERE \${gte(runs.id, 0)}
+              GROUP BY 1
+            ),
+            visible_rankings AS (
+              SELECT thread_id, total
+              FROM ranking_periods
+              WHERE total > 0
+            )
+            SELECT
+              visible_rankings.thread_id,
+              visible_rankings.total,
+              previous_period.previous_total
+            FROM visible_rankings
+            LEFT JOIN previous_period
+              ON previous_period.thread_id = visible_rankings.thread_id
+            ORDER BY visible_rankings.total DESC
+            LIMIT 50
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "composedCteQueryBuilder" }],
+    },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { eq, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -130,7 +130,7 @@ export const preferDrizzleApis = createRule({
       crossJoinLateral:
         "Use Drizzle crossJoinLateral(...) for this equivalent lateral join.",
       composedCteQueryBuilder:
-        "Use Drizzle $with(...), select(), joins, grouping, ordering, and set-operation builders for this complete locally composed read query.",
+        "Use Drizzle $with(...), select(), joins, grouping, ordering, and set-operation builders for this complete read CTE query.",
       deleteQueryBuilder:
         "Use Drizzle delete(...).where(...) for this complete schema-backed delete query.",
       emptyFragment:

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -3232,18 +3232,27 @@ function isScalarCteProjection(
   return hasGuaranteedOneRow && referenced.size === ctes.size;
 }
 
+interface BuilderRelationPolicy {
+  readonly allowedLiteralRelations?: ReadonlySet<string>;
+  readonly requireTableMarkers: boolean;
+}
+
 function builderRelation(
   value: unknown,
   markers: ReadonlyMap<string, SqlMarker>,
-  requireTableMarkers = false,
+  policy?: BuilderRelationPolicy,
 ): boolean {
   const range = rangeVarPayload(value);
   if (range !== undefined) {
     const marker = markers.get(range.relname);
     return (
       validRelationAlias(range.alias) &&
-      (marker === undefined ||
-        (requireTableMarkers ? marker.isTable : marker.isWrapper))
+      (marker === undefined
+        ? policy?.allowedLiteralRelations === undefined ||
+          policy.allowedLiteralRelations.has(range.relname)
+        : policy?.requireTableMarkers === true
+          ? marker.isTable
+          : marker.isWrapper)
     );
   }
   const join = recordProperty(value, "JoinExpr");
@@ -3254,9 +3263,9 @@ function builderRelation(
     join.rarg !== undefined &&
     join.quals !== undefined &&
     hasOnlyKeys(join, new Set(["jointype", "larg", "quals", "rarg"])) &&
-    builderRelation(join.larg, markers, requireTableMarkers) &&
+    builderRelation(join.larg, markers, policy) &&
     rangeVarPayload(join.rarg) !== undefined &&
-    builderRelation(join.rarg, markers, requireTableMarkers)
+    builderRelation(join.rarg, markers, policy)
   );
 }
 
@@ -3277,6 +3286,7 @@ function isBuilderReadSelect(
   markers: ReadonlyMap<string, SqlMarker>,
   allowUnionAll: boolean,
   allowWithClause: boolean,
+  relationPolicy?: BuilderRelationPolicy,
 ): boolean {
   if (select.op === "SETOP_UNION") {
     if (
@@ -3308,8 +3318,8 @@ function isBuilderReadSelect(
       return false;
     }
     return (
-      isBuilderReadSelect(select.larg, markers, true, false) &&
-      isBuilderReadSelect(select.rarg, markers, true, false)
+      isBuilderReadSelect(select.larg, markers, true, false, relationPolicy) &&
+      isBuilderReadSelect(select.rarg, markers, true, false, relationPolicy)
     );
   }
   if (
@@ -3328,7 +3338,7 @@ function isBuilderReadSelect(
     targetValues(select) === undefined ||
     !Array.isArray(select.fromClause) ||
     select.fromClause.length !== 1 ||
-    !builderRelation(select.fromClause[0], markers)
+    !builderRelation(select.fromClause[0], markers, relationPolicy)
   ) {
     return false;
   }
@@ -3350,13 +3360,12 @@ function isBuilderReadSelect(
         isSupportedNumericLimit(select.limitCount, markers);
 }
 
-function isComposedReadCte(
+function isBuilderReadCte(
   select: Record<string, unknown>,
   markers: ReadonlyMap<string, SqlMarker>,
   hasLocalExpansion: boolean,
 ): boolean {
   if (
-    !hasLocalExpansion ||
     ![...markers.values()].every((marker) => {
       return marker.isBoundScalar || marker.isWrapper;
     })
@@ -3368,6 +3377,10 @@ function isComposedReadCte(
     return false;
   }
   const names = new Set<string>();
+  const directRelationPolicy: BuilderRelationPolicy = {
+    allowedLiteralRelations: names,
+    requireTableMarkers: true,
+  };
   for (const item of withClause.ctes) {
     const cte = commonTableExpression(item);
     const body = recordProperty(cte?.ctequery, "SelectStmt");
@@ -3375,13 +3388,25 @@ function isComposedReadCte(
       cte === undefined ||
       body === undefined ||
       names.has(cte.ctename) ||
-      !isBuilderReadSelect(body, markers, false, false)
+      !isBuilderReadSelect(
+        body,
+        markers,
+        false,
+        false,
+        hasLocalExpansion ? undefined : directRelationPolicy,
+      )
     ) {
       return false;
     }
     names.add(cte.ctename);
   }
-  return isBuilderReadSelect(select, markers, true, true);
+  return isBuilderReadSelect(
+    select,
+    markers,
+    true,
+    true,
+    hasLocalExpansion ? undefined : directRelationPolicy,
+  );
 }
 
 function isStructuredScalarSelect(
@@ -3421,7 +3446,9 @@ function isStructuredScalarSelect(
     targetValues(inner) !== undefined &&
     Array.isArray(inner.fromClause) &&
     inner.fromClause.length === 1 &&
-    builderRelation(inner.fromClause[0], markers, true) &&
+    builderRelation(inner.fromClause[0], markers, {
+      requireTableMarkers: true,
+    }) &&
     inner.whereClause !== undefined &&
     isLimitOne(inner.limitCount)
   );
@@ -3444,7 +3471,7 @@ function readQueryCapability(
   if (context !== "statement") {
     return undefined;
   }
-  if (isComposedReadCte(select, parsed.markers, hasLocalExpansion)) {
+  if (isBuilderReadCte(select, parsed.markers, hasLocalExpansion)) {
     return "composed-cte";
   }
   if (isScalarCteProjection(select, parsed.markers)) {


### PR DESCRIPTION
## Summary

- recognize conventional direct read CTEs only when base relations are real
  Drizzle tables and unmarked relations are CTEs declared by the same supported
  statement
- build model rankings with one typed Drizzle CTE over the combined current and
  previous windows instead of two raw aggregation branches and a left join
- preserve runtime text and safe-integer validation with dedicated Drizzle
  decoders, and add type-aware positive and ownership-safety lint coverage

## Correctness and performance

- the rollback probe returned the same 19 normalized rows and values for the
  exact-base and candidate queries
- the candidate remains one statement, round trip, and snapshot; parameters
  decreased from 114 to 66
- representative PostgreSQL work changed from two `GroupAggregate` branches
  plus a left join to one `GroupAggregate`; shared hits changed from 1338 to
  1337 and execution time from 1.116 ms to 0.718 ms in the verification sample
- five alternating API ESLint pairs measured final-candidate median wall time
  at 31.286 s versus 31.466 s for the exact base (-0.57%), and aggregate peak
  RSS at 3,443,612 KiB versus 3,415,524 KiB (+0.82%)

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules test`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts`
- `pnpm knip`
- pre-commit full Turbo type checking
- `git diff --check`

## Scope

No schema migration, persisted-data rewrite, API or protocol change, feature
switch, compatibility shim, extra query, or extra round trip is introduced.
The model-stat write query and the usage-record factory work in #23572 remain
out of scope.

Closes #23571

Parent: #23047
