### PR TITLE
fix(browser): log bounded malformed provider cost values

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -404,7 +404,7 @@ describe("zero browser route", () => {
     );
   });
 
-  it("logs provider validation issues without exposing invalid values", async () => {
+  it("logs bounded cost diagnostics without exposing other provider values", async () => {
     const { runs, chat, actor, agent } = await setupBrowserScenario();
     const sent = await chat.requestSendEvent(
       actor,
@@ -425,7 +425,10 @@ describe("zero browser route", () => {
         ["browser:read", "browser:write"],
       )}`,
     };
-    const privateProviderValue = "private-provider-value";
+    const invalidBrowserCost = "-0.001";
+    const oversizedProxyCost = "1".repeat(160);
+    const privateProviderValue =
+      "https://provider.invalid/private-provider-value";
     server.use(
       http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
         const body = z
@@ -437,9 +440,13 @@ describe("zero browser route", () => {
       }),
       http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
         return HttpResponse.json(
-          providerBrowser(randomUUID(), {
-            browserCost: privateProviderValue,
-          }),
+          {
+            ...providerBrowser(randomUUID(), {
+              browserCost: invalidBrowserCost,
+              proxyCost: oversizedProxyCost,
+            }),
+            liveUrl: privateProviderValue,
+          },
           { status: 201 },
         );
       }),
@@ -462,20 +469,36 @@ describe("zero browser route", () => {
     expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
       "Managed browser provider returned an invalid response",
       expect.objectContaining({
-        validationIssueCount: 1,
-        validationIssues: [
+        validationIssueCount: 3,
+        validationIssues: expect.arrayContaining([
           expect.objectContaining({
             path: "browserCost",
             code: "invalid_format",
             message: expect.any(String),
+            providerValueType: "string",
+            providerValueLength: invalidBrowserCost.length,
+            providerValuePreview: invalidBrowserCost,
           }),
-        ],
+          expect.objectContaining({
+            path: "proxyCost",
+            code: "too_big",
+            message: expect.any(String),
+            providerValueType: "string",
+            providerValueLength: oversizedProxyCost.length,
+            providerValuePreview: oversizedProxyCost.slice(0, 128),
+          }),
+          expect.objectContaining({
+            path: "liveUrl",
+            code: "custom",
+            message: expect.any(String),
+          }),
+        ]),
         validationIssuesOmitted: 0,
       }),
     );
-    expect(
-      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
-    ).not.toContain(privateProviderValue);
+    const logged = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(logged).not.toContain(oversizedProxyCost);
+    expect(logged).not.toContain(privateProviderValue);
   });
 
   it("isolates profiles across concurrent thread browser sessions", async () => {

--- a/turbo/apps/api/src/signals/services/browser-use.service.ts
+++ b/turbo/apps/api/src/signals/services/browser-use.service.ts
@@ -71,6 +71,10 @@ const browserUseSessionSchema = z.object({
 
 export type BrowserUseSession = z.infer<typeof browserUseSessionSchema>;
 
+function parseBrowserUseSession(body: unknown): BrowserUseSession {
+  return browserUseSessionSchema.parse(body, { reportInput: true });
+}
+
 export class BrowserUseProviderError extends Error {
   readonly status: 502 | 503;
   readonly code: string;
@@ -250,7 +254,7 @@ export async function createBrowserUseSession(
     },
     signal,
   );
-  return browserUseSessionSchema.parse(body);
+  return parseBrowserUseSession(body);
 }
 
 export async function getBrowserUseSession(
@@ -262,7 +266,7 @@ export async function getBrowserUseSession(
     { method: "GET" },
     signal,
   );
-  return browserUseSessionSchema.parse(body);
+  return parseBrowserUseSession(body);
 }
 
 export async function stopBrowserUseSession(
@@ -277,5 +281,5 @@ export async function stopBrowserUseSession(
     },
     signal,
   );
-  return browserUseSessionSchema.parse(body);
+  return parseBrowserUseSession(body);
 }

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -63,6 +63,12 @@ const PROVIDER_CLEANUP_TIMEOUT_MS = 30_000;
 const PROVIDER_START_LIFECYCLE_TIMEOUT_MS = 90_000;
 const STRANDED_START_GRACE_MS = 60_000;
 const MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG = 10;
+const MAX_PROVIDER_VALUE_PREVIEW_CHARS = 128;
+const PROVIDER_VALUE_DIAGNOSTIC_FIELDS = [
+  "browserCost",
+  "proxyCost",
+  "proxyUsedMb",
+] as const;
 const IDLE_LEASE_MS = ZERO_BROWSER_IDLE_LEASE_MINUTES * 60_000;
 const OWNED_BROWSER_STATUSES = [
   "creating",
@@ -184,6 +190,47 @@ function conflict(message: string, code = "BROWSER_CONFLICT") {
   return serviceError(409, code, message);
 }
 
+interface ProviderValueDiagnostic {
+  readonly providerValueType: string;
+  readonly providerValueLength?: number;
+  readonly providerValuePreview?: string;
+}
+
+function providerValueDiagnostic(
+  path: readonly PropertyKey[],
+  value: unknown,
+): ProviderValueDiagnostic | null {
+  const field = path.length === 1 ? path[0] : undefined;
+  if (
+    typeof field !== "string" ||
+    !PROVIDER_VALUE_DIAGNOSTIC_FIELDS.some((candidate) => {
+      return candidate === field;
+    })
+  ) {
+    return null;
+  }
+  const providerValueType =
+    value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+  const previewValue =
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+      ? String(value)
+      : null;
+  if (previewValue === null) {
+    return { providerValueType };
+  }
+  const characters = Array.from(previewValue);
+  return {
+    providerValueType,
+    providerValueLength: characters.length,
+    providerValuePreview: characters
+      .slice(0, MAX_PROVIDER_VALUE_PREVIEW_CHARS)
+      .join(""),
+  };
+}
+
 function providerFailure(error: unknown): BrowserServiceError {
   if (error instanceof BrowserUseProviderError) {
     return serviceError(error.status, error.code, error.message);
@@ -195,6 +242,7 @@ function providerFailure(error: unknown): BrowserServiceError {
       validationIssues: error.issues
         .slice(0, MAX_PROVIDER_VALIDATION_ISSUES_TO_LOG)
         .map((issue) => {
+          const diagnostic = providerValueDiagnostic(issue.path, issue.input);
           return {
             path:
               issue.path.length === 0
@@ -202,6 +250,7 @@ function providerFailure(error: unknown): BrowserServiceError {
                 : issue.path.map(String).join("."),
             code: issue.code,
             message: issue.message,
+            ...diagnostic,
           };
         }),
       validationIssuesOmitted: Math.max(


### PR DESCRIPTION
## Summary

- Capture Zod issue inputs when Browser Use session responses fail validation.
- Add value type, character length, and a 128-character preview only for `browserCost`, `proxyCost`, and `proxyUsedMb`.
- Keep the existing 502 response unchanged and continue omitting values from all other provider fields.
- Cover negative costs, oversized previews, and non-cost value redaction in the route integration test.

## User impact

Future Axiom warnings will show the bounded malformed cost representation, making upstream Browser Use schema mismatches diagnosable without logging the full provider response or connection URLs.

## Verification

- `npx -y prettier@3.8.1 --check` on all changed files
- Targeted Oxlint and ESLint on all changed files
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts -t "logs bounded cost diagnostics without exposing other provider values"`

The full route test file also ran locally: the modified test and three other cases passed; four unrelated runner-queue cases returned `404 Job not found in queue`. CI remains the source of truth for the complete suite.
