### PR TITLE
fix(platform): recover 401 requests without unauthorized toasts

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -258,7 +258,8 @@ All HTTP calls via `zeroClient$` must use the `accept` utility function. This is
 
 `accept` takes a ts-rest call promise and a **required non-empty** array of accepted status codes. It returns a type-narrowed result containing only the accepted status codes. Any response **not** in the accept list is automatically:
 
-1. Shown as a `toast.error` (with the server's error message)
+1. Shown as a `toast.error` (with the server's error message), except for 401
+   responses handled by the authenticated client's sign-in recovery
 2. Thrown as an `ApiError` (so the calling code stops executing)
 
 ```typescript
@@ -273,7 +274,8 @@ export const inviteMember$ = command(
       [200],
     );
     // result type is narrowed to { status: 200, body: OrgMessageResponse }
-    // If status was 400/401/403/500 → toast + throw already happened, we never reach here
+    // If status was 400/403/500 → toast + throw already happened.
+    // A 401 redirects to sign-in without an error toast.
     toast.success(`Invitation sent to ${email}`);
     set(refreshOrgMembers$);
   },
@@ -317,7 +319,7 @@ export const getAgent$ = computed(async (get) => {
 
 ### Fail fast for background fetches
 
-For `computed` (background data fetching), call `accept` directly and let errors propagate. `accept` already handles API errors by showing the server message and throwing an `ApiError`; application code should not catch or replace that error handling.
+For `computed` (background data fetching), call `accept` directly and let errors propagate. `accept` already handles API errors by showing the server message (except for 401 responses owned by sign-in recovery) and throwing an `ApiError`; application code should not catch or replace that error handling.
 
 ```typescript
 export const billingStatus$ = computed(async (get) => {
@@ -329,7 +331,7 @@ export const billingStatus$ = computed(async (get) => {
 
 ### View layer: use loadables for state
 
-When `accept` throws, `useLoadable` / `useLoadableSet` transitions to `{ state: 'hasError', error: ApiError }`. Views should use loadable state for loading, disabled, and success UI. Do not catch errors in the view layer, do not show replacement toasts, and do not add application-level error handling around API failures; `accept` already handled the error and the flow should fail fast.
+When `accept` throws, `useLoadable` / `useLoadableSet` transitions to `{ state: 'hasError', error: ApiError }`. Views should use loadable state for loading, disabled, and success UI. Do not catch errors in the view layer, do not show replacement toasts, and do not add application-level error handling around API failures; `accept` and the authenticated client already handled the error and the flow should fail fast.
 
 ```typescript
 function ScheduleForm() {

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -1,5 +1,6 @@
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { isAbortError, onRejection } from "../signals/utils.ts";
+import { isNetworkRequestError } from "./network-error.ts";
 
 class ApiError extends Error {
   readonly code: string;
@@ -39,22 +40,14 @@ function requestErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Request failed";
 }
 
-function isNetworkRequestError(error: unknown): boolean {
-  return (
-    error instanceof TypeError &&
-    (error.message === "Failed to fetch" ||
-      error.message === "Load failed" ||
-      error.message.startsWith("NetworkError"))
-  );
-}
-
 interface AcceptOptions {
   readonly showErrorToast?: boolean;
 }
 
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
- * Otherwise throws an `ApiError` and, by default, shows a toast.
+ * Otherwise throws an `ApiError` and, by default, shows a toast. A 401 is
+ * never toasted because the authenticated clients own sign-in recovery.
  *
  * Browser network failures propagate without showing their raw error message.
  *
@@ -86,7 +79,7 @@ async function accept<
     return result as Extract<T, { status: S }>;
   }
   const { message, code } = extractError(result.body, result.status);
-  if (showErrorToast) {
+  if (showErrorToast && result.status !== 401) {
     toast.error(message);
   }
   throw new ApiError(message, code, result.status);

--- a/turbo/apps/platform/src/lib/network-error.ts
+++ b/turbo/apps/platform/src/lib/network-error.ts
@@ -1,0 +1,8 @@
+export function isNetworkRequestError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    (error.message === "Failed to fetch" ||
+      error.message === "Load failed" ||
+      error.message.startsWith("NetworkError"))
+  );
+}

--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -42,8 +42,8 @@ export function initSentry(): void {
         return null;
       }
 
-      // ApiError thrown by accept() — surfaced to users via toast
-      // notifications and not actionable in Sentry.
+      // ApiError thrown by accept() — surfaced through toast notifications or
+      // authentication recovery and not actionable in Sentry.
       const original = hint?.originalException;
       if (original instanceof ApiError) {
         return null;

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { HttpResponse } from "msw";
 import {
   addClientCapabilityToVersion,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
@@ -6,7 +7,11 @@ import {
 } from "@vm0/api-contracts/contracts/client-headers";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 
-import { clearMockedAuth, mockUser } from "../../__tests__/mock-auth.ts";
+import {
+  clearMockedAuth,
+  mockedClerk,
+  mockUser,
+} from "../../__tests__/mock-auth.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { fetch$ } from "../fetch.ts";
@@ -14,6 +19,7 @@ import {
   forceUpgradeDialogOpen$,
   listenForceUpgradeDialog$,
 } from "../force-upgrade.ts";
+import { setRootSignal$ } from "../root-signal.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
@@ -146,6 +152,83 @@ describe("api client headers", () => {
     expect(first.requestId).toMatch(UUID_REGEX);
     expect(second.requestId).toMatch(UUID_REGEX);
     expect(second.requestId).not.toBe(first.requestId);
+  });
+
+  it("retries fetch$ auth recovery network failures without redirecting", async () => {
+    mockSignedInUser();
+    context.store.set(setRootSignal$, context.signal);
+    let requests = 0;
+    let forcedTokenRefreshes = 0;
+    context.mocks.http.get("*/api/zero/auth-recovery-test", () => {
+      requests += 1;
+      if (requests === 1) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "UNAUTHORIZED",
+              message: "Unauthorized",
+            },
+          },
+          { status: 401 },
+        );
+      }
+      if (requests === 2) {
+        return HttpResponse.error();
+      }
+      return HttpResponse.json({ recovered: true });
+    });
+    mockedClerk.sessionGetToken.mockImplementation((options) => {
+      if (options?.skipCache) {
+        forcedTokenRefreshes += 1;
+        if (forcedTokenRefreshes === 1) {
+          return Promise.reject(
+            Object.assign(new Error("Clerk is offline"), {
+              code: "clerk_offline",
+            }),
+          );
+        }
+        if (forcedTokenRefreshes === 2) {
+          return Promise.reject(new TypeError("Failed to fetch"));
+        }
+        return Promise.resolve("fresh-token");
+      }
+      return Promise.resolve("test-token");
+    });
+
+    const response = await getFetchForTest()("/api/zero/auth-recovery-test");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ recovered: true });
+    expect(requests).toBe(3);
+    expect(forcedTokenRefreshes).toBe(3);
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+  });
+
+  it("redirects fetch$ when the fresh-token replay remains unauthorized", async () => {
+    mockSignedInUser();
+    context.store.set(setRootSignal$, context.signal);
+    let requests = 0;
+    context.mocks.http.get("*/api/zero/auth-recovery-test", () => {
+      requests += 1;
+      return HttpResponse.json(
+        {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Unauthorized",
+          },
+        },
+        { status: 401 },
+      );
+    });
+    mockedClerk.sessionGetToken.mockImplementation((options) => {
+      return Promise.resolve(options?.skipCache ? "fresh-token" : "test-token");
+    });
+
+    const response = await getFetchForTest()("/api/zero/auth-recovery-test");
+
+    expect(response.status).toBe(401);
+    expect(requests).toBe(2);
+    expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
   });
 
   it("forwards the captured omby preview bypass to vm6 API requests", async () => {

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -11,8 +11,10 @@ import {
 import { IN_VITEST } from "../env.ts";
 import { addCapturedPreviewBypassHeader } from "../lib/preview-bypass-cookie.ts";
 import {
+  authRecoverySignal,
   fetchFreshToken,
   handleUnauthorizedRedirect,
+  retryAuthRecoveryOperation,
   type ClerkLike,
 } from "./auth-retry.ts";
 import { addClientHeaders } from "./client-headers.ts";
@@ -21,6 +23,7 @@ import { reportForceUpgradeResponse } from "./force-upgrade.ts";
 interface AuthedClientOptions {
   readonly baseUrl: string;
   readonly getClerk: () => Promise<ClerkLike>;
+  readonly getRootSignal: () => AbortSignal;
   readonly getUnauthorizedRedirectSuppressionUntil?: () => number;
   readonly resolvePath?: (
     path: string,
@@ -44,7 +47,10 @@ export function createAuthedContractClient<T extends AppRouter>(
         ? await options.resolvePath(args.path, { method: args.route.method })
         : args.path;
 
-      const requestWithToken = (token: string | null) => {
+      const requestWithToken = (
+        token: string | null,
+        signal: AbortSignal | null | undefined = args.fetchOptions?.signal,
+      ) => {
         const headers = new Headers(args.headers);
         if (token) {
           headers.set("Authorization", `Bearer ${token}`);
@@ -53,7 +59,11 @@ export function createAuthedContractClient<T extends AppRouter>(
         addCapturedPreviewBypassHeader(headers, options.baseUrl);
         return trpcRestFetchApi({
           ...args,
-          fetchOptions: { ...args.fetchOptions, credentials: "include" },
+          fetchOptions: {
+            ...args.fetchOptions,
+            credentials: "include",
+            signal,
+          },
           headers,
           path,
         });
@@ -62,11 +72,17 @@ export function createAuthedContractClient<T extends AppRouter>(
       let response = await requestWithToken(initialToken);
 
       if (response.status === 401) {
-        const refreshResult = await fetchFreshToken(clerk, initialToken);
+        const recoverySignal = authRecoverySignal(
+          options.getRootSignal(),
+          args.fetchOptions?.signal,
+        );
+        const refreshResult = await fetchFreshToken(clerk, recoverySignal);
         if (refreshResult.status === "refreshed") {
-          response = await requestWithToken(refreshResult.token);
+          response = await retryAuthRecoveryOperation(() => {
+            return requestWithToken(refreshResult.token, recoverySignal);
+          }, recoverySignal);
         }
-        if (response.status === 401 && refreshResult.status !== "offline") {
+        if (response.status === 401) {
           handleUnauthorizedRedirect(
             clerk,
             options.getUnauthorizedRedirectSuppressionUntil?.() ?? 0,

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -18,6 +18,7 @@ import {
 } from "./api-base.ts";
 import { createAuthedContractClient } from "./api-client-base.ts";
 import { unauthorizedRedirectSuppressionUntil$ } from "./auth-retry.ts";
+import { rootSignal$ } from "./root-signal.ts";
 
 /**
  * Type alias for the factory function returned by `get(zeroClient$)`.
@@ -74,6 +75,9 @@ export const zeroClient$ = computed((get) => {
       baseUrl: resolveApiBase(),
       getClerk: () => {
         return get(clerk$);
+      },
+      getRootSignal: () => {
+        return get(rootSignal$);
       },
       getUnauthorizedRedirectSuppressionUntil: () => {
         return get(unauthorizedRedirectSuppressionUntil$);

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -2,15 +2,16 @@
  * Auth retry helpers shared by `fetch$` (signals/fetch.ts) and
  * `zeroClient$` (signals/api-client.ts).
  *
- * On a 401 response we force-refresh the Clerk JWT and replay the request
- * once before falling back to `clerk.redirectToSignIn()`. This covers the
- * common PWA case where `session.getToken()` returned a cached token that
- * expired between fetch and server-side validation (see issue #8883).
+ * On a 401 response we force-refresh the Clerk JWT and replay the request.
+ * Network failures during either recovery step retry with fibonacci backoff.
+ * Only an explicit 401 after recovery falls back to
+ * `clerk.redirectToSignIn()`.
  */
 import { command, computed, state } from "ccstate";
 import type { Clerk } from "@clerk/clerk-js";
+import { isNetworkRequestError } from "../lib/network-error.ts";
 import { now } from "../lib/time.ts";
-import { detach, Reason, settle } from "./utils";
+import { detach, Reason, retryWithFibonacciBackoff } from "./utils";
 
 export type ClerkLike = Pick<Clerk, "session" | "redirectToSignIn">;
 
@@ -18,8 +19,7 @@ const AUTH_TRANSITION_REDIRECT_SUPPRESSION_MS = 30_000;
 
 type FreshTokenResult =
   | { readonly status: "refreshed"; readonly token: string }
-  | { readonly status: "unavailable" }
-  | { readonly status: "offline" };
+  | { readonly status: "unavailable" };
 
 const unauthorizedRedirectSuppressionUntilState$ = state(0);
 
@@ -44,10 +44,9 @@ function isUnauthorizedRedirectSuppressed(suppressionUntil: number): boolean {
 }
 
 /**
- * Force-refresh the Clerk session token. Clerk performs bounded transient
- * retries internally. Once those retries determine the browser is offline,
- * preserve the session and let the next API action retry after connectivity
- * returns instead of redirecting to sign-in.
+ * Force-refresh the Clerk session token. Network failures retry until the
+ * request's owning signal aborts, so a temporarily offline browser does not
+ * turn into a sign-in redirect.
  *
  * Concurrent 401s may each trigger their own refresh, but Clerk's FAPI
  * internally dedups in-flight token requests, so the extra traffic is
@@ -55,28 +54,53 @@ function isUnauthorizedRedirectSuppressed(suppressionUntil: number): boolean {
  */
 export async function fetchFreshToken(
   clerk: ClerkLike,
-  staleToken: string | null,
+  signal: AbortSignal,
 ): Promise<FreshTokenResult> {
-  if (!clerk.session) {
+  signal.throwIfAborted();
+  const session = clerk.session;
+  if (!session) {
     return { status: "unavailable" };
   }
-  const tokenResult = await settle(clerk.session.getToken({ skipCache: true }));
-  if (!tokenResult.ok) {
-    const { error } = tokenResult;
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "clerk_offline"
-    ) {
-      return { status: "offline" };
-    }
-    throw error;
-  }
-  if (!tokenResult.value || tokenResult.value === staleToken) {
+  const token = await retryAuthRecoveryOperation(() => {
+    return session.getToken({ skipCache: true });
+  }, signal);
+  if (!token) {
     return { status: "unavailable" };
   }
-  return { status: "refreshed", token: tokenResult.value };
+  return { status: "refreshed", token };
+}
+
+function isClerkOfflineError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "clerk_offline"
+  );
+}
+
+function isAuthRecoveryNetworkError(error: unknown): boolean {
+  return isClerkOfflineError(error) || isNetworkRequestError(error);
+}
+
+export function retryAuthRecoveryOperation<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  return retryWithFibonacciBackoff(
+    operation,
+    isAuthRecoveryNetworkError,
+    signal,
+  );
+}
+
+export function authRecoverySignal(
+  rootSignal: AbortSignal,
+  requestSignal: AbortSignal | null | undefined,
+): AbortSignal {
+  return requestSignal
+    ? AbortSignal.any([rootSignal, requestSignal])
+    : rootSignal;
 }
 
 export function handleUnauthorizedRedirect(

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -7,6 +7,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
 import { createAuthedContractClient } from "../api-client-base.ts";
 import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
 export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
@@ -21,6 +22,9 @@ const apiFeatureSwitchClient$ = computed((get) => {
     baseUrl: resolveApiBaseForTarget("api"),
     getClerk: () => {
       return get(clerk$);
+    },
+    getRootSignal: () => {
+      return get(rootSignal$);
     },
     getUnauthorizedRedirectSuppressionUntil: () => {
       return get(unauthorizedRedirectSuppressionUntil$);

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -2,13 +2,16 @@ import { computed } from "ccstate";
 import { addCapturedPreviewBypassHeader } from "../lib/preview-bypass-cookie.ts";
 import { clerk$ } from "./auth.ts";
 import {
+  authRecoverySignal,
   fetchFreshToken,
   handleUnauthorizedRedirect,
+  retryAuthRecoveryOperation,
   unauthorizedRedirectSuppressionUntil$,
 } from "./auth-retry.ts";
 import { resolveApiBase, resolveOAuthApiBase } from "./api-base.ts";
 import { addClientHeaders } from "./client-headers.ts";
 import { reportForceUpgradeResponse } from "./force-upgrade.ts";
+import { rootSignal$ } from "./root-signal.ts";
 
 /**
  * OAuth navigation uses the direct API in preview/development so those
@@ -104,7 +107,10 @@ export const fetch$ = computed((get) => {
     const clerk = await get(clerk$);
     const initialToken = (await clerk.session?.getToken()) ?? null;
 
-    const performFetch = async (token: string | null): Promise<Response> => {
+    const performFetch = async (
+      token: string | null,
+      signal?: AbortSignal,
+    ): Promise<Response> => {
       // Clone Request inputs so the body stream is available for retry.
       const requestInput = url instanceof Request ? url.clone() : url;
 
@@ -160,6 +166,9 @@ export const fetch$ = computed((get) => {
       const finalHeaders = new Headers(finalInit.headers);
       addCapturedPreviewBypassHeader(finalHeaders, finalUrl);
       finalInit.headers = finalHeaders;
+      if (signal) {
+        finalInit.signal = signal;
+      }
 
       return await fetch(finalUrl, finalInit);
     };
@@ -167,11 +176,17 @@ export const fetch$ = computed((get) => {
     let response = await performFetch(initialToken);
 
     if (response.status === 401) {
-      const refreshResult = await fetchFreshToken(clerk, initialToken);
+      const recoverySignal = authRecoverySignal(
+        get(rootSignal$),
+        options?.signal ?? (url instanceof Request ? url.signal : undefined),
+      );
+      const refreshResult = await fetchFreshToken(clerk, recoverySignal);
       if (refreshResult.status === "refreshed") {
-        response = await performFetch(refreshResult.token);
+        response = await retryAuthRecoveryOperation(async () => {
+          return await performFetch(refreshResult.token, recoverySignal);
+        }, recoverySignal);
       }
-      if (response.status === 401 && refreshResult.status !== "offline") {
+      if (response.status === 401) {
         handleUnauthorizedRedirect(
           clerk,
           get(unauthorizedRedirectSuppressionUntil$),

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -346,6 +346,53 @@ const FIB_DELAYS_MS = [
 ] as const;
 
 const MAX_LOOP_COUNT_IN_TEST = 100;
+
+function fibonacciRetryDelayMs(retryIndex: number): number {
+  return (
+    FIB_DELAYS_MS[Math.min(retryIndex, FIB_DELAYS_MS.length - 1)] ?? 60_000
+  );
+}
+
+async function waitForFibonacciRetry(
+  retryIndex: number,
+  signal: AbortSignal,
+): Promise<void> {
+  const delayMs = fibonacciRetryDelayMs(retryIndex);
+  await (IN_VITEST
+    ? delay(0, { signal: AbortSignal.any([]) })
+    : delay(delayMs, { signal }));
+  signal.throwIfAborted();
+}
+
+/**
+ * Retry one async operation with fibonacci backoff while `shouldRetry`
+ * classifies its rejection as transient. Resolves on the first successful
+ * attempt and rejects when the signal aborts or an error is not retryable.
+ */
+export async function retryWithFibonacciBackoff<T>(
+  operation: () => Promise<T>,
+  shouldRetry: (error: unknown) => boolean,
+  signal: AbortSignal,
+): Promise<T> {
+  let retryIndex = 0;
+  while (true) {
+    if (IN_VITEST && retryIndex > MAX_LOOP_COUNT_IN_TEST) {
+      throw new Error(
+        `retryWithFibonacciBackoff: infinite retry detected — exceeded ${MAX_LOOP_COUNT_IN_TEST} attempts in test`,
+      );
+    }
+    const result = await settle(runRetriedLoad(operation), signal);
+    if (result.ok) {
+      return result.value;
+    }
+    if (!shouldRetry(result.error)) {
+      throw result.error;
+    }
+    await waitForFibonacciRetry(retryIndex, signal);
+    retryIndex++;
+  }
+}
+
 /**
  * Run `loopBody` in a loop with `interval` between iterations.
  * Transient (non-abort) errors trigger fibonacci backoff retries.
@@ -389,16 +436,13 @@ export async function setLoop(
       if (options.retryTransientErrors === false) {
         throw error;
       }
-      const backoff =
-        FIB_DELAYS_MS[Math.min(fibIndex, FIB_DELAYS_MS.length - 1)] ?? 60_000;
+      const backoff = fibonacciRetryDelayMs(fibIndex);
       L.warn(
         `setLoop: transient error (attempt ${fibIndex + 1}), retrying in ${backoff}ms`,
         error,
       );
+      await waitForFibonacciRetry(fibIndex, signal);
       fibIndex++;
-      await (IN_VITEST
-        ? delay(0, { signal: AbortSignal.any([]) })
-        : delay(backoff, { signal }));
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -10,7 +10,6 @@ import {
   zeroPersonalModelProvidersMainContract,
 } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { toast } from "@vm0/ui/components/ui/sonner";
 
 import {
   click,
@@ -929,7 +928,6 @@ describe("zero sidebar account menu", () => {
   });
 
   it("redirects without a toast when the fresh-token request remains unauthorized", async () => {
-    const toastError = vi.spyOn(toast, "error");
     mockAdminAccountSidebar();
     context.mocks.data.personalModelProviders([
       connectedPersonalCodexProvider(),
@@ -967,8 +965,7 @@ describe("zero sidebar account menu", () => {
       expect(modelProviderRequests).toBe(2);
       expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
     });
-    expect(toastError).not.toHaveBeenCalledWith("Unauthorized");
-    toastError.mockRestore();
+    expect(screen.queryByText("Unauthorized")).not.toBeInTheDocument();
   });
 
   it("suppresses global sign-in redirects during add-account auth transitions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
@@ -9,6 +10,7 @@ import {
   zeroPersonalModelProvidersMainContract,
 } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 import {
   click,
@@ -859,34 +861,45 @@ describe("zero sidebar account menu", () => {
     });
   });
 
-  it("keeps the session active when a token refresh detects offline state", async () => {
+  it("retries auth recovery network failures before replaying the request", async () => {
     mockAdminAccountSidebar();
-    context.mocks.data.personalModelProviders([
-      connectedPersonalCodexProvider(),
-    ]);
+    const provider = connectedPersonalCodexProvider();
+    context.mocks.data.personalModelProviders([provider]);
 
     let modelProviderRequests = 0;
     let forcedTokenRefreshes = 0;
-    context.mocks.api(
-      zeroPersonalModelProvidersMainContract.list,
-      ({ respond }) => {
-        modelProviderRequests += 1;
-        return respond(401, {
-          error: {
-            code: "UNAUTHORIZED",
-            message: "Unauthorized",
+    context.mocks.http.get("*/api/zero/me/model-providers", () => {
+      modelProviderRequests += 1;
+      if (modelProviderRequests === 1) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "UNAUTHORIZED",
+              message: "Unauthorized",
+            },
           },
-        });
-      },
-    );
+          { status: 401 },
+        );
+      }
+      if (modelProviderRequests === 2) {
+        return HttpResponse.error();
+      }
+      return HttpResponse.json({ modelProviders: [provider] });
+    });
     mockedClerk.sessionGetToken.mockImplementation((options) => {
       if (options?.skipCache) {
         forcedTokenRefreshes += 1;
-        return Promise.reject(
-          Object.assign(new Error("Clerk is offline"), {
-            code: "clerk_offline",
-          }),
-        );
+        if (forcedTokenRefreshes === 1) {
+          return Promise.reject(
+            Object.assign(new Error("Clerk is offline"), {
+              code: "clerk_offline",
+            }),
+          );
+        }
+        if (forcedTokenRefreshes === 2) {
+          return Promise.reject(new TypeError("Failed to fetch"));
+        }
+        return Promise.resolve("fresh-token");
       }
       return Promise.resolve("test-token");
     });
@@ -903,10 +916,59 @@ describe("zero sidebar account menu", () => {
     });
 
     await waitFor(() => {
-      expect(modelProviderRequests).toBe(1);
-      expect(forcedTokenRefreshes).toBe(1);
+      expect(modelProviderRequests).toBe(3);
+      expect(forcedTokenRefreshes).toBe(3);
     });
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+
+    const menu = await openAccountMenu();
+    const panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(
+      within(panel).getByRole("heading", { name: "Codex" }),
+    ).toBeInTheDocument();
+  });
+
+  it("redirects without a toast when the fresh-token request remains unauthorized", async () => {
+    const toastError = vi.spyOn(toast, "error");
+    mockAdminAccountSidebar();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
+
+    let modelProviderRequests = 0;
+    context.mocks.api(
+      zeroPersonalModelProvidersMainContract.list,
+      ({ respond }) => {
+        modelProviderRequests += 1;
+        return respond(401, {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Unauthorized",
+          },
+        });
+      },
+    );
+    mockedClerk.sessionGetToken.mockImplementation((options) => {
+      return Promise.resolve(options?.skipCache ? "fresh-token" : "test-token");
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    await waitFor(() => {
+      expect(modelProviderRequests).toBe(2);
+      expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
+    });
+    expect(toastError).not.toHaveBeenCalledWith("Unauthorized");
+    toastError.mockRestore();
   });
 
   it("suppresses global sign-in redirects during add-account auth transitions", async () => {


### PR DESCRIPTION
## Summary

- keep `accept()` fail-fast for `401` responses while suppressing their user-facing error toast
- force-refresh the Clerk token after an initial `401`, then replay both typed-client and `fetch$` requests
- retry Clerk offline errors and browser fetch failures with Fibonacci backoff until the owning request or app root is aborted
- redirect to sign-in only for confirmed unauthorized recovery outcomes, never for transient network failures

## User impact

Users no longer see an Unauthorized toast or get sent to sign-in because connectivity dropped during token recovery. Sessions that remain unauthorized after a fresh-token replay still redirect to sign-in.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types` (11 packages passed before the API process reached the default 2 GB Node heap limit)
- `env NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx`
- `pnpm --filter @vm0/app exec vitest run src/signals/__tests__/api-client-headers.test.ts`
- `pnpm --filter @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts`
