### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1357,14 +1357,24 @@ def event_type(record):
     return record.get("payload", {}).get("type")
 
 
-def normalize_probe_root(value, root):
+def normalize_probe_input(value, root):
     if isinstance(value, str):
         return value.replace(str(root), "$PROBE_ROOT")
     if isinstance(value, list):
-        return [normalize_probe_root(item, root) for item in value]
+        return [normalize_probe_input(item, root) for item in value]
     if isinstance(value, dict):
+        # Synthetic context messages receive fresh IDs on each resume.
+        # Preserve the field while ignoring its non-semantic random value.
         return {
-            key: normalize_probe_root(item, root)
+            key: (
+                "$MESSAGE_ID"
+                if (
+                    key == "id"
+                    and isinstance(item, str)
+                    and item.startswith("msg_")
+                )
+                else normalize_probe_input(item, root)
+            )
             for key, item in value.items()
         }
     return value
@@ -1428,8 +1438,8 @@ def probe_current_codex(
         session_id,
         port,
     )
-    full_input = normalize_probe_root(full_request["input"], full_root)
-    candidate_input = normalize_probe_root(
+    full_input = normalize_probe_input(full_request["input"], full_root)
+    candidate_input = normalize_probe_input(
         candidate_request["input"],
         candidate_root,
     )

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -114,7 +114,7 @@ CACHE_TMP_TAR=""
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
 CLAUDE_CODE_VERSION="2.1.220"
-CODEX_CLI_VERSION="0.145.0"
+CODEX_CLI_VERSION="0.146.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update the Codex CLI pin in the reusable RootFS template from `0.145.0` to `0.146.0`.
- Keep the compact-generation compatibility probe strict while normalizing per-resume `msg_*` values that Codex `0.146.0` now generates for synthetic context messages. The probe still compares ID field presence, message ordering, roles, and content.
- Keep the remaining RootFS package and tool pins unchanged after checking their current stable or LTS releases.

## Verification

- Confirmed `@openai/codex@0.146.0` is published on npm under the stable `latest` tag.
- Ran the embedded compact-generation probe successfully with Codex `0.145.0` and `0.146.0`.
- `git diff --check`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- `bash -n crates/runner/scripts/build-template.sh`
- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm check-types`
- `cargo fmt --all -- --check`
- GitHub Actions completed without failures on head `5d1fdd0245`, including `check`, `coverage`, `runner-build`, and all four `runner-behavior` lanes.

The local `cargo test -p runner cmd::build::scripts::tests` attempt reached the final runner test-binary link and was then killed by the 4 GB sandbox before tests started. The hosted Crates workflow completed successfully.
