### PR TITLE
chore(rust): update displaydoc to 0.2.7

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1015,13 +1015,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update `displaydoc` from 0.2.6 to 0.2.7.
- Update `displaydoc`'s procedural-macro parser dependency from `syn` 2.0.119 to 3.0.3.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because `crypto-common` 0.1.7 pins it exactly to `=0.14.7`.

## Manual version bumps

- None.

## Validation

- `cargo test --workspace --exclude runner`
- `cargo test -p runner`
