### PR TITLE
fix(platform): prevent standalone pwa root overscroll with the keyboard open

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -90,7 +90,7 @@ describe("platform entrypoint safe area behavior", () => {
       /#root\s*{[\s\S]*box-sizing:\s*border-box;[\s\S]*background-color:\s*hsl\(var\(--background\)\);[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab-raw\)\s+var\(--sal\);/,
     );
     expect(globalCss).toMatch(
-      /@media\s*\(display-mode:\s*standalone\)\s*{[\s\S]*#root\s*{\s*position:\s*absolute;\s*overflow-y:\s*auto;\s*}/,
+      /@media\s*\(display-mode:\s*standalone\)\s*{[\s\S]*#root\s*{\s*position:\s*absolute;\s*overflow-y:\s*hidden;\s*}/,
     );
     expect(globalCss.indexOf("position: absolute;")).toBeGreaterThan(
       globalCss.indexOf("position: fixed;"),

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -102,10 +102,12 @@ body {
 
 @media (display-mode: standalone) {
   /* Keep editable content in document coordinates. iOS can paint a stale
-     caret when a focused editor is inside a fixed-position ancestor. */
+     caret when a focused editor is inside a fixed-position ancestor. Keep
+     keyboard-reserve scrolling programmatic so touch gestures cannot move
+     the app shell into the reserved space. */
   #root {
     position: absolute;
-    overflow-y: auto;
+    overflow-y: hidden;
   }
 
   #root::after {


### PR DESCRIPTION
## Summary

- keep the standalone app root in document coordinates for iOS caret stability
- make keyboard-reserve scrolling programmatic-only so touch gestures cannot drag the app shell into reserved whitespace
- update the safe-area CSS contract to lock in the root overflow behavior

## User impact

Focusing the chat composer in an installed iOS PWA no longer exposes the root keyboard reserve as manually scrollable blank space. The existing VisualViewport settle logic, reserve, and composer `scrollIntoView` behavior remain unchanged, while message history continues to use its nested scroll container.

## Verification

- `pnpm exec prettier --check apps/platform/src/views/css/index.css apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts --maxWorkers=1 --silent=passed-only` (4 tests passed)
- Not run: local browser or device verification; CI, preview, and real-device validation remain