### PR TITLE
fix(platform): make initial thread sidebar selection immediate

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -33,7 +33,10 @@ import {
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
 import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
-import { autoOpenThreadSidebar$ } from "./thread-sidebar-coordinator.ts";
+import {
+  autoOpenInitialThreadSidebar$,
+  autoOpenThreadSidebar$,
+} from "./thread-sidebar-coordinator.ts";
 import {
   createComposerConnectorAuthorizationSignals,
   type ComposerConnectorAuthorizationSignals,
@@ -210,6 +213,7 @@ const resolvePaneThread$ = command(
       set(loadDraft$, thread, isNew, signal),
       set(setupChatThreadInitScroll$, thread, signal),
       set(thread.subscribeChatThread$, signal),
+      set(autoOpenInitialThreadSidebar$, thread, signal),
       set(autoOpenThreadSidebar$, thread, signal),
     ]);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -153,6 +153,7 @@ export interface ChatThreadSignals {
   // -- Paged messages (sole rendering path) --------------------------------
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
+  indexedDbMessagesInitialized$: Computed<Promise<void>>;
   visibleRenderedChatGroups$: Computed<Promise<GroupedChatMessageGroup[]>>;
   visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
   sidebarAutoOpenCandidate$: Computed<

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -13,6 +13,7 @@ import {
   onRef,
   onRejection,
   resetSignal,
+  settle,
   setLoop,
   withCleanup,
 } from "../utils.ts";
@@ -2415,6 +2416,7 @@ function createInitializeIndexedDbMessages({
   persistentMessages$: PersistentChatMessages$;
   registerBodyBlocks: BodyBlocksRenderer;
 }) {
+  const initialized = Promise.withResolvers<void>();
   const mergeIndexedDbMessages$ = command(
     ({ set }, messages: ChatEvent[]): void => {
       const registeredMessages = messages.map((message) => {
@@ -2430,15 +2432,28 @@ function createInitializeIndexedDbMessages({
     },
   );
 
-  return command(async ({ set }, signal: AbortSignal): Promise<void> => {
-    const indexedDbMessages = await set(
-      loadIndexedDbChatEvents$,
-      threadId,
-      signal,
-    );
-    signal.throwIfAborted();
-    set(mergeIndexedDbMessages$, indexedDbMessages);
-  });
+  const initializeIndexedDbMessages$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      const result = await settle(
+        set(loadIndexedDbChatEvents$, threadId, signal),
+        signal,
+      );
+      if (result.ok) {
+        set(mergeIndexedDbMessages$, result.value);
+      }
+      initialized.resolve(undefined);
+      if (!result.ok) {
+        throw result.error;
+      }
+    },
+  );
+
+  return {
+    indexedDbMessagesInitialized$: computed(() => {
+      return initialized.promise;
+    }),
+    initializeIndexedDbMessages$,
+  };
 }
 
 function createMailDraftCardSignalsById(
@@ -2580,7 +2595,7 @@ function createPagedMessages(
     registerBodyBlocks,
     artifactCardSignals,
   );
-  const initializeIndexedDbMessages$ = createInitializeIndexedDbMessages({
+  const indexedDbMessages = createInitializeIndexedDbMessages({
     artifactCardSignals,
     threadId,
     persistentMessages$: persistentChatMessages$,
@@ -2603,7 +2618,7 @@ function createPagedMessages(
   );
 
   return {
-    initializeIndexedDbMessages$,
+    ...indexedDbMessages,
     mergePersistentMessages$,
     ...latestMessageSignals,
     appendOptimisticMessage$,
@@ -2769,6 +2784,7 @@ function createLoadMoreRenderedChatGroupsWithPrependScroll(
 interface RunTrackingDeps {
   threadId: string;
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
+  initialAutoOpenDecisionCompleted$: Computed<Promise<void>>;
   initializeIndexedDbMessages$: Command<Promise<void>, [AbortSignal]>;
   mergePersistentMessages$: Command<void, [ChatEvent[]]>;
   syncRemoteMessages$: Command<Promise<void>, [AbortSignal]>;
@@ -2959,6 +2975,7 @@ function createMarkThreadReadIfNeeded({
 
 function createOnSubscribedCommand({
   threadId,
+  initialAutoOpenDecisionCompleted$,
   syncRemoteMessages$,
   settleMessageSync$,
   reloadArtifacts$,
@@ -2968,6 +2985,7 @@ function createOnSubscribedCommand({
 }: Pick<
   RunTrackingDeps,
   | "threadId"
+  | "initialAutoOpenDecisionCompleted$"
   | "syncRemoteMessages$"
   | "settleMessageSync$"
   | "reloadArtifacts$"
@@ -2981,6 +2999,8 @@ function createOnSubscribedCommand({
   const hasSubscribed$ = state(false);
   return command(async ({ get, set }, signal: AbortSignal) => {
     L.debug("subscribeChatThread$ catchup start", { threadId });
+    await get(initialAutoOpenDecisionCompleted$);
+    signal.throwIfAborted();
     set(reloadArtifacts$);
     if (get(hasSubscribed$)) {
       set(reloadMailDrafts$);
@@ -3038,6 +3058,7 @@ function createReceiveSyncedEventsCommand({
 function createRunTracking({
   threadId,
   latestRunFinishCreatedAt$,
+  initialAutoOpenDecisionCompleted$,
   initializeIndexedDbMessages$,
   mergePersistentMessages$,
   syncRemoteMessages$,
@@ -3067,6 +3088,7 @@ function createRunTracking({
 
   const onSubscribed$ = createOnSubscribedCommand({
     threadId,
+    initialAutoOpenDecisionCompleted$,
     syncRemoteMessages$,
     settleMessageSync$,
     reloadArtifacts$,
@@ -4313,6 +4335,7 @@ function publicChatThreadMessageSignals(
     latestAssistantTextCreatedAt$: messages.latestAssistantTextCreatedAt$,
     visibleRenderedChatGroups$: messages.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: messages.visibleRenderedChatGroupsReady$,
+    indexedDbMessagesInitialized$: messages.indexedDbMessagesInitialized$,
     sidebarAutoOpenCandidate$: messages.sidebarAutoOpenCandidate$,
     messageImageGroups$: messages.messageImageGroups$,
     artifactSignalsForUrl: messages.artifactSignalsForUrl,
@@ -4422,6 +4445,8 @@ export function createChatThreadSignals(
   const runTracking = createRunTracking({
     threadId,
     latestRunFinishCreatedAt$: messages.latestRunFinishCreatedAt$,
+    initialAutoOpenDecisionCompleted$:
+      threadOwned.sidebar.initialAutoOpenDecisionCompleted$,
     initializeIndexedDbMessages$: messages.initializeIndexedDbMessages$,
     mergePersistentMessages$: messages.mergePersistentMessages$,
     syncRemoteMessages$: messages.syncRemoteMessages$,

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-auto-open.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-auto-open.ts
@@ -126,7 +126,7 @@ function orderedThreadSidebarAutoOpenCandidates(
   groups: readonly GroupedChatMessageGroup[],
 ): ThreadSidebarAutoOpenCandidateSource[] {
   const running: ThreadSidebarAutoOpenCandidateSource[] = [];
-  const completed: ThreadSidebarAutoOpenCandidateSource[] = [];
+  let latestCompleted: ThreadSidebarAutoOpenCandidateSource[] | undefined;
   for (let groupIndex = groups.length - 1; groupIndex >= 0; groupIndex--) {
     const group = groups[groupIndex];
     if (!group) {
@@ -136,10 +136,17 @@ function orderedThreadSidebarAutoOpenCandidates(
     if (!state) {
       continue;
     }
-    const target = state === "running" ? running : completed;
-    target.push(...autoOpenCandidatesInGroup(group));
+    if (state === "running") {
+      running.push(...autoOpenCandidatesInGroup(group));
+      continue;
+    }
+    if (latestCompleted === undefined) {
+      // An empty newest completed group intentionally blocks fallback to
+      // cards from older completed runs.
+      latestCompleted = autoOpenCandidatesInGroup(group);
+    }
   }
-  return [...running, ...completed];
+  return [...running, ...(latestCompleted ?? [])];
 }
 
 function candidateFromSource(

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -16,6 +16,7 @@ import {
   threadSidebarAutoOpenCandidateKey,
   type ThreadSidebarAutoOpenCandidate,
 } from "./thread-sidebar-auto-open.ts";
+import { settle } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Page-level coordinator for the thread-owned utility sidebar. Sidebar state
@@ -34,6 +35,7 @@ export const activeThreadSidebar$ = computed(
   ): {
     readonly thread: ChatThreadSignals;
     readonly target: ThreadSidebarTarget;
+    readonly animateEntry: boolean;
   } | null => {
     for (const thread of [get(currentLeftThread$), get(currentRightThread$)]) {
       if (!thread) {
@@ -41,7 +43,11 @@ export const activeThreadSidebar$ = computed(
       }
       const target = get(thread.sidebar.target$);
       if (target) {
-        return { thread, target };
+        return {
+          thread,
+          target,
+          animateEntry: get(thread.sidebar.animateEntry$),
+        };
       }
     }
     return null;
@@ -80,14 +86,12 @@ function targetFromAutoOpenCandidate(
   };
 }
 
-export const autoOpenThreadSidebar$ = command(
+const autoOpenThreadSidebarFromCurrentMessages$ = command(
   async (
     { get, set },
     thread: ChatThreadSignals,
     signal: AbortSignal,
   ): Promise<void> => {
-    await get(thread.hasNewMessages$);
-    signal.throwIfAborted();
     if (
       !get(chatThreadSidebarAutoOpenEnabled$) ||
       typeof window === "undefined" ||
@@ -124,6 +128,37 @@ export const autoOpenThreadSidebar$ = command(
       return;
     }
     set(openOnThread$, thread, targetFromAutoOpenCandidate(candidate));
+  },
+);
+
+export const autoOpenInitialThreadSidebar$ = command(
+  async (
+    { get, set },
+    thread: ChatThreadSignals,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await get(thread.indexedDbMessagesInitialized$);
+    signal.throwIfAborted();
+    const result = await settle(
+      set(autoOpenThreadSidebarFromCurrentMessages$, thread, signal),
+      signal,
+    );
+    set(thread.sidebar.enableEntryAnimations$);
+    if (!result.ok) {
+      throw result.error;
+    }
+  },
+);
+
+export const autoOpenThreadSidebar$ = command(
+  async (
+    { get, set },
+    thread: ChatThreadSignals,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await get(thread.hasNewMessages$);
+    signal.throwIfAborted();
+    await set(autoOpenThreadSidebarFromCurrentMessages$, thread, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -55,6 +55,14 @@ export interface ThreadSidebarSignals {
   readonly target$: Computed<ThreadSidebarTarget | null>;
   readonly open$: Command<void, [ThreadSidebarTarget]>;
   readonly close$: Command<void, []>;
+  /**
+   * Whether the current sidebar session should animate into the split layout.
+   * The first local-message auto-open captures `false`; later opens capture
+   * `true` after that initial decision completes.
+   */
+  readonly animateEntry$: Computed<boolean>;
+  readonly initialAutoOpenDecisionCompleted$: Computed<Promise<void>>;
+  readonly enableEntryAnimations$: Command<void, []>;
   readonly editingAutomationId$: Computed<string | null>;
   readonly setEditingAutomationId$: Command<void, [string | null]>;
   /**
@@ -88,9 +96,12 @@ export function createThreadSidebarSignals(
   threadId: string,
 ): ThreadSidebarSignals {
   const internalTarget$ = state<ThreadSidebarTarget | null>(null);
+  const internalEntryAnimationsEnabled$ = state(false);
+  const internalAnimateEntry$ = state(false);
   const internalFullscreen$ = state(false);
   const internalEditingAutomationId$ = state<string | null>(null);
   const internalClaimedAutoOpenCandidateKey$ = state<string | null>(null);
+  const initialAutoOpenDecision = Promise.withResolvers<void>();
   const resetSession$ = resetSignal();
 
   const artifactCatalog = createArtifactCatalogSignals({
@@ -112,6 +123,9 @@ export function createThreadSidebarSignals(
 
   const open$ = command(({ get, set }, target: ThreadSidebarTarget) => {
     const current = get(internalTarget$);
+    if (current === null) {
+      set(internalAnimateEntry$, get(internalEntryAnimationsEnabled$));
+    }
     if (current?.type !== target.type) {
       set(internalFullscreen$, false);
     }
@@ -126,6 +140,7 @@ export function createThreadSidebarSignals(
     // while keeping the cached catalog pages for the next open.
     set(resetSession$);
     set(internalTarget$, null);
+    set(internalAnimateEntry$, false);
     set(internalFullscreen$, false);
     set(internalEditingAutomationId$, null);
   });
@@ -154,6 +169,16 @@ export function createThreadSidebarSignals(
     }),
     open$,
     close$,
+    animateEntry$: computed((get) => {
+      return get(internalAnimateEntry$);
+    }),
+    initialAutoOpenDecisionCompleted$: computed(() => {
+      return initialAutoOpenDecision.promise;
+    }),
+    enableEntryAnimations$: command(({ set }) => {
+      set(internalEntryAnimationsEnabled$, true);
+      initialAutoOpenDecision.resolve(undefined);
+    }),
     editingAutomationId$: computed((get) => {
       return get(internalEditingAutomationId$);
     }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -624,6 +624,12 @@ describe("thread-owned utility sidebar", () => {
         runningUrl,
       );
     });
+    expect(screen.getByTestId("chat-thread-sidebar-pane")).toHaveClass(
+      "animate-in",
+      "fade-in",
+      "duration-[180ms]",
+      "transition-[flex-basis,width]",
+    );
   });
 
   it("auto-opens a browser card from a running run", async () => {
@@ -746,6 +752,64 @@ describe("thread-owned utility sidebar", () => {
         completedUrl,
       );
     });
+  });
+
+  it("does not auto-open a card from an older completed run when the latest completed run has no card", async () => {
+    const olderCompletedUrl = "https://older-completed-deck.sites.vm7.io";
+    context.mocks.browser.matchMedia((query) => {
+      return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
+    });
+
+    setupChatThread({
+      autoOpenEnabled: true,
+      messages: [
+        {
+          id: "msg-older-completed-card",
+          role: "assistant",
+          content: `[Older completed deck](${olderCompletedUrl})`,
+          runId: "run-older-completed",
+          seqId: 1,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          id: "msg-older-completed-finish",
+          role: "assistant",
+          content: null,
+          runId: "run-older-completed",
+          runLifecycleEvent: "completed",
+          seqId: 2,
+          createdAt: "2026-03-10T00:00:01Z",
+        },
+        {
+          id: "msg-latest-completed-user",
+          role: "user",
+          content: "Summarize the completed work",
+          runId: "run-latest-completed",
+          seqId: 3,
+          createdAt: "2026-03-10T00:00:02Z",
+        },
+        {
+          id: "msg-latest-completed-response",
+          role: "assistant",
+          content: "Latest run completed without a sidebar card.",
+          runId: "run-latest-completed",
+          seqId: 4,
+          createdAt: "2026-03-10T00:00:03Z",
+        },
+        {
+          id: "msg-latest-completed-finish",
+          role: "assistant",
+          content: null,
+          runId: "run-latest-completed",
+          runLifecycleEvent: "completed",
+          seqId: 5,
+          createdAt: "2026-03-10T00:00:04Z",
+        },
+      ],
+    });
+
+    await screen.findByText("Latest run completed without a sidebar card.");
+    expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
   });
 
   it("skips deleted, reconnect-required, and unavailable cards before falling back", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -624,12 +624,6 @@ describe("thread-owned utility sidebar", () => {
         runningUrl,
       );
     });
-    expect(screen.getByTestId("chat-thread-sidebar-pane")).toHaveClass(
-      "animate-in",
-      "fade-in",
-      "duration-[180ms]",
-      "transition-[flex-basis,width]",
-    );
   });
 
   it("auto-opens a browser card from a running run", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -170,7 +170,7 @@ describe("zero chat thread IndexedDB fallback", () => {
     await clearCachedChatData();
   });
 
-  it("auto-opens a cached card before remote catch-up without entry animation", async () => {
+  it("shows cached messages and their sidebar before remote catch-up", async () => {
     const cachedUrl = "https://cached-initial-deck.sites.vm7.io";
     prepareDefaultAgent();
     mockCurrentThreadDetail();
@@ -221,10 +221,9 @@ describe("zero chat thread IndexedDB fallback", () => {
         "src",
         cachedUrl,
       );
-      expect(screen.getByTestId("chat-thread-sidebar-pane")).not.toHaveClass(
-        "animate-in",
-        "transition-[flex-basis,width]",
-      );
+      await expect(
+        screen.findByText("Cached initial deck"),
+      ).resolves.toBeInTheDocument();
     } finally {
       if (!releaseCatchUp.settled()) {
         releaseCatchUp.resolve();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -1,10 +1,12 @@
 import { screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  chatThreadArtifactsContract,
   chatThreadByIdContract,
   chatThreadEventsContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockOrganization, mockUser } from "../../../__tests__/mock-auth.ts";
@@ -19,6 +21,7 @@ import {
   chatIdb$,
   openChatIdb,
 } from "../../../signals/external/chat-idb-store.ts";
+import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "../../../signals/chat-page/chat-thread-sidebar-layout.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
 vi.mock("idb", async () => {
@@ -46,7 +49,11 @@ async function primeRuntimeChatDb(): Promise<
   return await context.store.get(chatIdb$);
 }
 
-function setupChatPage(): void {
+function setupChatPage({
+  autoOpenEnabled = false,
+}: {
+  readonly autoOpenEnabled?: boolean;
+} = {}): void {
   detachedSetupPage({
     context,
     path: `/chats/${THREAD_ID}`,
@@ -54,6 +61,9 @@ function setupChatPage(): void {
     org: {
       activeOrg: { id: IDB_ORG_ID, name: "Default Org" },
       memberships: [{ id: IDB_ORG_ID }],
+    },
+    featureSwitches: {
+      [FeatureSwitchKey.ChatThreadSidebarAutoOpen]: autoOpenEnabled,
     },
   });
 }
@@ -158,6 +168,69 @@ describe("zero chat thread IndexedDB fallback", () => {
 
   afterEach(async () => {
     await clearCachedChatData();
+  });
+
+  it("auto-opens a cached card before remote catch-up without entry animation", async () => {
+    const cachedUrl = "https://cached-initial-deck.sites.vm7.io";
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+    context.mocks.browser.matchMedia((query) => {
+      return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
+    });
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, { runs: [] });
+    });
+
+    const runtimeDb = await primeRuntimeChatDb();
+    await runtimeDb.put(CHAT_MESSAGES_STORE, {
+      id: "00000000-0000-4000-8000-000000000091",
+      threadId: THREAD_ID,
+      eventType: "output.message",
+      content: `[Cached initial deck](${cachedUrl})`,
+      runId: "run-cached-initial",
+      seqId: 1,
+      createdAt: "2026-03-10T00:00:01Z",
+    });
+    await runtimeDb.put(CHAT_MESSAGES_STORE, {
+      id: "00000000-0000-4000-8000-000000000092",
+      threadId: THREAD_ID,
+      eventType: "run.completed",
+      content: null,
+      runId: "run-cached-initial",
+      runLifecycleEvent: "completed",
+      seqId: 2,
+      createdAt: "2026-03-10T00:00:02Z",
+    });
+
+    const catchUpRequested = context.mocks.deferred<void>();
+    const releaseCatchUp = context.mocks.deferred<void>();
+    context.mocks.api(chatThreadEventsContract.list, async ({ respond }) => {
+      catchUpRequested.resolve();
+      await releaseCatchUp.promise;
+      return respond(200, { events: [], hasHistoryBefore: false });
+    });
+
+    try {
+      setupChatPage({ autoOpenEnabled: true });
+      await catchUpRequested.promise;
+
+      const sidebar = await screen.findByTestId("artifact-sidebar");
+      expect(sidebar).toBeInTheDocument();
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "src",
+        cachedUrl,
+      );
+      expect(screen.getByTestId("chat-thread-sidebar-pane")).not.toHaveClass(
+        "animate-in",
+        "transition-[flex-basis,width]",
+      );
+    } finally {
+      if (!releaseCatchUp.settled()) {
+        releaseCatchUp.resolve();
+      }
+      runtimeDb.close();
+    }
   });
 
   it("falls back to remote messages when IndexedDB has no cached events", async () => {

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-sidebar-shell.tsx
@@ -18,6 +18,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 function chatThreadSidebarLayout(
   width: number | null,
   resizing: boolean,
+  animateEntry: boolean,
 ): { style: CSSProperties; transition: string } {
   const widthValue =
     width === null
@@ -25,9 +26,10 @@ function chatThreadSidebarLayout(
       : `clamp(${CHAT_THREAD_SIDEBAR_MIN_WIDTH}px, ${width}px, calc(100% - ${CHAT_THREAD_SIDEBAR_MIN_THREAD_WIDTH}px))`;
   return {
     style: { "--chat-thread-sidebar-width": widthValue } as CSSProperties,
-    transition: resizing
-      ? ""
-      : "transition-[flex-basis,width] duration-[240ms] ease",
+    transition:
+      resizing || !animateEntry
+        ? ""
+        : "transition-[flex-basis,width] duration-[240ms] ease",
   };
 }
 
@@ -62,16 +64,19 @@ function ChatThreadSidebarResizeHandle() {
 
 export function ChatThreadSidebarShell({
   children,
+  animateEntry,
   open,
   sidebar,
 }: {
   readonly children: ReactNode;
+  readonly animateEntry: boolean;
   readonly open: boolean;
   readonly sidebar: ReactNode;
 }) {
   const { style, transition } = chatThreadSidebarLayout(
     useGet(chatThreadSidebarWidth$),
     useGet(chatThreadSidebarResizing$),
+    animateEntry,
   );
 
   return (
@@ -89,9 +94,11 @@ export function ChatThreadSidebarShell({
       </div>
       {open && <ChatThreadSidebarResizeHandle />}
       <div
+        data-testid="chat-thread-sidebar-pane"
         className={cn(
           "flex min-h-0 min-w-0 overflow-hidden",
           transition,
+          open && animateEntry && "animate-in fade-in duration-[180ms] ease",
           open
             ? "flex-1 basis-0 xl:w-[var(--chat-thread-sidebar-width)] xl:flex-none xl:basis-[var(--chat-thread-sidebar-width)]"
             : "pointer-events-none w-0 flex-none basis-0",

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -1025,7 +1025,7 @@ function MailDraftDetail({
       aria-label="Email details"
       data-chat-thread-container-id={signals.threadId}
       data-testid="mail-draft-sidebar"
-      className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0 animate-in fade-in slide-in-from-right-2 duration-[180ms] ease"
+      className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0"
     >
       <MailDraftDetails close={close} draft={draft} signals={signals} />
       <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-border/60 px-4 py-3">

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -169,7 +169,6 @@ function ThreadArtifactsPanel({ thread }: { thread: ChatThreadSignals }) {
         fullscreen
           ? THREAD_SIDEBAR_FULLSCREEN_CLASSNAME
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
-        "animate-in fade-in duration-[180ms] ease",
       )}
     >
       <ThreadSidebarHeader

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -435,7 +435,6 @@ function ArtifactSidebarSurface({
               ARTIFACT_FULLSCREEN_DEFAULT_LAYER_CLASSNAME,
             )
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
-        "animate-in fade-in duration-[180ms] ease",
       )}
       data-testid="artifact-sidebar"
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1698,7 +1698,7 @@ function HeaderAutomationSidebar({
   return (
     <aside
       aria-label="Automations"
-      className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0 animate-in fade-in slide-in-from-right-2 duration-[180ms] ease"
+      className="flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0"
       data-testid="automation-sidebar"
     >
       <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
@@ -1816,6 +1816,7 @@ export function ZeroChatThreadPage() {
   return (
     <>
       <ChatThreadSidebarShell
+        animateEntry={activeThreadSidebar?.animateEntry ?? true}
         open={activeThreadSidebar !== null}
         sidebar={
           activeThreadSidebar ? (


### PR DESCRIPTION
## Summary

- resolve the initial utility-sidebar candidate immediately after cached IndexedDB messages merge, before remote message catch-up
- suppress the sidebar fade and width transitions for that first decision, then restore entry animations for subsequent opens
- stop completed-run fallback at the newest successful run so an older card does not reopen when the latest completed run has none
- centralize sidebar entry animation in the shared shell for consistent artifact, email draft, and automation behavior

## User impact

Opening or switching to a cached chat thread with a sidebar card now presents the split view immediately instead of rendering messages first and popping the sidebar in later. A latest completed run without a card also keeps the thread in single-column mode instead of falling back to an older run's card.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx --maxWorkers=1` (15 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx --maxWorkers=1` (3 passed)

Local authenticated browser verification was unavailable because the checkout does not have `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW`; the page-level tests cover the production bootstrap path.
