### PR TITLE
fix(usage): distinguish people search from web search

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -994,7 +994,11 @@ describe("POST /api/zero/image-io/generate", () => {
               kind: "image",
               credits: creditsCharged,
               providers: [
-                { provider: IMAGE_IO_MODEL, credits: creditsCharged },
+                {
+                  provider: IMAGE_IO_MODEL,
+                  credits: creditsCharged,
+                  usageKinds: [{ kind: "image", credits: creditsCharged }],
+                },
               ],
             },
           ],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-people-search";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { zeroWebSearchContract } from "@vm0/api-contracts/contracts/zero-web-search";
 import { HttpResponse, http, type JsonBodyType } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -24,6 +25,7 @@ import { now } from "../../external/time";
 import type { RouteEntry } from "../../route-entry";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { zeroPeopleSearchRoutes } from "../zero-people-search";
+import { zeroWebSearchRoutes } from "../zero-web-search";
 import {
   createBddApi,
   expectApiError,
@@ -34,6 +36,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const PERPLEXITY_AGENT_URL = "https://api.perplexity.ai/v1/agent";
+const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
 const MAX_PROVIDER_RESPONSE_BYTES = 512 * 1024;
 
 const peopleSearchRoutes: readonly RouteEntry[] = [
@@ -68,6 +71,10 @@ function client() {
   return setupAppWithRoutes({ context, routes: peopleSearchRoutes });
 }
 
+function webSearchClient() {
+  return setupAppWithRoutes({ context, routes: zeroWebSearchRoutes });
+}
+
 async function bootstrapOnboarding(actor: ApiTestUser): Promise<void> {
   const completed = await createBddApi(context).completeOnboarding(actor);
   expect(completed.status).toBe(200);
@@ -95,6 +102,18 @@ async function seedPeopleSearchPricing(): Promise<void> {
       provider: "perplexity",
       category: "request",
       unitPrice: 20,
+      unitSize: 1,
+    },
+  ]);
+}
+
+async function seedWebSearchPricing(): Promise<void> {
+  await seedUsagePricingRows([
+    {
+      kind: "web-search",
+      provider: "perplexity",
+      category: "request",
+      unitPrice: 5,
       unitSize: 1,
     },
   ]);
@@ -196,6 +215,22 @@ function providerResponse(args?: {
         search_people: { invocation: args?.invocation ?? 1 },
       },
     },
+  };
+}
+
+function webSearchProviderResponse() {
+  return {
+    id: "search-request-id",
+    server_time: "2026-07-14T10:00:00Z",
+    results: [
+      {
+        title: "AI regulation update",
+        url: "https://example.com/update",
+        snippet: "A relevant public-web excerpt.",
+        date: "2026-07-13",
+        last_updated: "2026-07-14",
+      },
+    ],
   };
 }
 
@@ -717,7 +752,7 @@ describe("zero people-search route", () => {
     expect(afterCredits).toBe(beforeCredits);
   });
 
-  it("attributes usage to a run", async () => {
+  it("preserves People Search and Web Search attribution for one run", async () => {
     const actor = createBddApi(context).user();
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
@@ -728,6 +763,7 @@ describe("zero people-search route", () => {
     await api.ensureOrgModelProvider(actor);
     await fundActor(actor);
     await seedPeopleSearchPricing();
+    await seedWebSearchPricing();
     configureProvider();
     const compose = await api.createCompose(actor, {
       version: "1.0",
@@ -744,10 +780,14 @@ describe("zero people-search route", () => {
     });
     const token = api.zeroTokenForRunWithCapabilities(actor, run.runId, [
       "people-search:read",
+      "web-search:read",
     ]);
     server.use(
       http.post(PERPLEXITY_AGENT_URL, () => {
         return HttpResponse.json(providerResponse());
+      }),
+      http.post(PERPLEXITY_SEARCH_URL, () => {
+        return HttpResponse.json(webSearchProviderResponse());
       }),
     );
 
@@ -755,6 +795,13 @@ describe("zero people-search route", () => {
       client()(zeroPeopleSearchContract).search({
         headers: { authorization: `Bearer ${token}` },
         body: defaultRequest(),
+      }),
+      [200],
+    );
+    await accept(
+      webSearchClient()(zeroWebSearchContract).search({
+        headers: { authorization: `Bearer ${token}` },
+        body: { query: "latest AI regulation", limit: 5 },
       }),
       [200],
     );
@@ -777,15 +824,19 @@ describe("zero people-search route", () => {
 
     expect(usageRow?.breakdown).toContainEqual({
       kind: "other",
-      credits: 20,
+      credits: 25,
       providers: [
         {
           provider: "perplexity",
-          credits: 20,
+          credits: 25,
           usageKinds: [
             {
               kind: "people-search",
               credits: 20,
+            },
+            {
+              kind: "web-search",
+              credits: 5,
             },
           ],
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-people-search.test.ts
@@ -782,6 +782,12 @@ describe("zero people-search route", () => {
         {
           provider: "perplexity",
           credits: 20,
+          usageKinds: [
+            {
+              kind: "people-search",
+              credits: 20,
+            },
+          ],
         },
       ],
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -19,6 +19,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
+  insertUsageEvent$,
   materializeHourlyUsage$,
   readUsageStorageCounts$,
 } from "./helpers/zero-usage-insight";
@@ -409,7 +410,13 @@ describe("GET /api/zero/usage/record", () => {
       {
         kind: "connector",
         credits: 250,
-        providers: [{ provider: connectorProvider, credits: 250 }],
+        providers: [
+          {
+            provider: connectorProvider,
+            credits: 250,
+            usageKinds: [{ kind: "connector", credits: 250 }],
+          },
+        ],
       },
     ]);
     expect(response.body.rows[0]?.member).toBeNull();
@@ -424,7 +431,13 @@ describe("GET /api/zero/usage/record", () => {
       {
         kind: "model",
         credits: 50,
-        providers: [{ provider: model, credits: 50 }],
+        providers: [
+          {
+            provider: model,
+            credits: 50,
+            usageKinds: [{ kind: "model", credits: 50 }],
+          },
+        ],
       },
     ]);
 
@@ -489,12 +502,24 @@ describe("GET /api/zero/usage/record", () => {
           {
             kind: "model",
             credits: 50,
-            providers: [{ provider: model, credits: 50 }],
+            providers: [
+              {
+                provider: model,
+                credits: 50,
+                usageKinds: [{ kind: "model", credits: 50 }],
+              },
+            ],
           },
           {
             kind: "connector",
             credits: 20,
-            providers: [{ provider: connectorProvider, credits: 20 }],
+            providers: [
+              {
+                provider: connectorProvider,
+                credits: 20,
+                usageKinds: [{ kind: "connector", credits: 20 }],
+              },
+            ],
           },
         ],
       }),
@@ -616,12 +641,24 @@ describe("GET /api/zero/usage/record", () => {
       {
         kind: "image",
         credits: 30,
-        providers: [{ provider: imageProvider, credits: 30 }],
+        providers: [
+          {
+            provider: imageProvider,
+            credits: 30,
+            usageKinds: [{ kind: "image", credits: 30 }],
+          },
+        ],
       },
       {
         kind: "connector",
         credits: 100,
-        providers: [{ provider: connectorProvider, credits: 100 }],
+        providers: [
+          {
+            provider: connectorProvider,
+            credits: 100,
+            usageKinds: [{ kind: "connector", credits: 100 }],
+          },
+        ],
       },
     ]);
 
@@ -825,17 +862,96 @@ describe("GET /api/zero/usage/record", () => {
       {
         kind: "model",
         credits: 150,
-        providers: [{ provider: model, credits: 150 }],
+        providers: [
+          {
+            provider: model,
+            credits: 150,
+            usageKinds: [{ kind: "model", credits: 150 }],
+          },
+        ],
       },
       {
         kind: "image",
         credits: 120,
-        providers: [{ provider: imageProvider, credits: 120 }],
+        providers: [
+          {
+            provider: imageProvider,
+            credits: 120,
+            usageKinds: [{ kind: "image", credits: 120 }],
+          },
+        ],
       },
       {
         kind: "connector",
         credits: 20,
-        providers: [{ provider: connectorProvider, credits: 20 }],
+        providers: [
+          {
+            provider: connectorProvider,
+            credits: 20,
+            usageKinds: [{ kind: "connector", credits: 20 }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves raw usage kinds that share a provider", async () => {
+    const fixture = await entitledRecordActor();
+    if (!fixture.actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const run = await createUnthreadedRun(fixture.actor, {
+      prompt: "Use People Search and Web Search",
+      triggerSource: "cli",
+    });
+    const processedAt = nowDate();
+
+    for (const [kind, creditsCharged] of [
+      ["people-search", 20],
+      ["web-search", 5],
+    ] as const) {
+      await store.set(
+        insertUsageEvent$,
+        {
+          orgId: fixture.actor.orgId,
+          userId: fixture.actor.userId,
+          runId: run.runId,
+          kind,
+          provider: "perplexity",
+          category: "request",
+          quantity: 1,
+          status: "processed",
+          creditsCharged,
+          processedAt,
+        },
+        context.signal,
+      );
+    }
+
+    mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.rows).toHaveLength(1);
+    expect(response.body.rows[0]?.breakdown).toStrictEqual([
+      {
+        kind: "other",
+        credits: 25,
+        providers: [
+          {
+            provider: "perplexity",
+            credits: 25,
+            usageKinds: [
+              { kind: "people-search", credits: 20 },
+              { kind: "web-search", credits: 5 },
+            ],
+          },
+        ],
       },
     ]);
   });
@@ -911,7 +1027,13 @@ describe("GET /api/zero/usage/record", () => {
       {
         kind: "other",
         credits: 6,
-        providers: [{ provider: "google-maps", credits: 6 }],
+        providers: [
+          {
+            provider: "google-maps",
+            credits: 6,
+            usageKinds: [{ kind: "maps", credits: 6 }],
+          },
+        ],
       },
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -19,7 +19,6 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
-  insertUsageEvent$,
   materializeHourlyUsage$,
   readUsageStorageCounts$,
 } from "./helpers/zero-usage-insight";
@@ -889,67 +888,6 @@ describe("GET /api/zero/usage/record", () => {
             provider: connectorProvider,
             credits: 20,
             usageKinds: [{ kind: "connector", credits: 20 }],
-          },
-        ],
-      },
-    ]);
-  });
-
-  it("preserves raw usage kinds that share a provider", async () => {
-    const fixture = await entitledRecordActor();
-    if (!fixture.actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-    const run = await createUnthreadedRun(fixture.actor, {
-      prompt: "Use People Search and Web Search",
-      triggerSource: "cli",
-    });
-    const processedAt = nowDate();
-
-    for (const [kind, creditsCharged] of [
-      ["people-search", 20],
-      ["web-search", 5],
-    ] as const) {
-      await store.set(
-        insertUsageEvent$,
-        {
-          orgId: fixture.actor.orgId,
-          userId: fixture.actor.userId,
-          runId: run.runId,
-          kind,
-          provider: "perplexity",
-          category: "request",
-          quantity: 1,
-          status: "processed",
-          creditsCharged,
-          processedAt,
-        },
-        context.signal,
-      );
-    }
-
-    mocks.clerk.session(fixture.actor.userId, fixture.actor.orgId);
-    const response = await accept(
-      apiClient().get({
-        query: { range: "7d", tz: "UTC" },
-        headers: authHeaders(),
-      }),
-      [200],
-    );
-
-    expect(response.body.rows).toHaveLength(1);
-    expect(response.body.rows[0]?.breakdown).toStrictEqual([
-      {
-        kind: "other",
-        credits: 25,
-        providers: [
-          {
-            provider: "perplexity",
-            credits: 25,
-            usageKinds: [
-              { kind: "people-search", credits: 20 },
-              { kind: "web-search", credits: 5 },
-            ],
           },
         ],
       },

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -93,8 +93,18 @@ interface UsageRecordIntermediateRow extends UsageRecordRow {
 interface UsageRecordBreakdownSqlRow {
   readonly rowKey: string;
   readonly kind: UsageRecordKind;
+  readonly usageKind: string;
   readonly provider: string;
   readonly credits: number;
+}
+
+interface UsageRecordProviderAccumulator {
+  readonly provider: string;
+  credits: number;
+  readonly usageKinds: {
+    readonly kind: string;
+    readonly credits: number;
+  }[];
 }
 
 function tokenExpr(usage: FinalizedUsageRelation) {
@@ -462,6 +472,7 @@ async function queryUsageRecordBreakdown(
         runId: usage.runId,
         userId: usage.userId,
         kind: usageKindExpr(usage).as("kind"),
+        usageKind: sql`${usage.kind}`.mapWith(pgTextDecoder).as("usage_kind"),
         provider: sql`COALESCE(NULLIF(${usage.provider}, ''), 'unknown')`
           .mapWith(pgTextDecoder)
           .as("provider"),
@@ -495,6 +506,7 @@ async function queryUsageRecordBreakdown(
       .select({
         rowKey: rowKey.as("row_key"),
         kind: usageRows.kind,
+        usageKind: usageRows.usageKind,
         provider: usageRows.provider,
         credits: usageRows.credits,
       })
@@ -505,6 +517,7 @@ async function queryUsageRecordBreakdown(
     .select({
       rowKey: keyed.rowKey,
       kind: keyed.kind,
+      usageKind: keyed.usageKind,
       provider: keyed.provider,
       credits: sql`${sum(keyed.credits)}::bigint`
         .mapWith(pgInt8ToSafeIntegerDecoder)
@@ -512,20 +525,34 @@ async function queryUsageRecordBreakdown(
     })
     .from(keyed)
     .where(inArray(keyed.rowKey, [...rowKeys]))
-    .groupBy(keyed.rowKey, keyed.kind, keyed.provider)
+    .groupBy(keyed.rowKey, keyed.kind, keyed.usageKind, keyed.provider)
     .having(gt(sum(keyed.credits), sql`0`))
-    .orderBy(asc(keyed.rowKey), asc(keyed.kind), asc(keyed.provider));
+    .orderBy(
+      asc(keyed.rowKey),
+      asc(keyed.kind),
+      asc(keyed.provider),
+      asc(keyed.usageKind),
+    );
 
   const byRow = new Map<
     string,
-    Map<UsageRecordKind, UsageRecordBreakdownSqlRow[]>
+    Map<UsageRecordKind, Map<string, UsageRecordProviderAccumulator>>
   >();
   for (const row of rows) {
-    const kind = row.kind;
     const kinds = byRow.get(row.rowKey) ?? new Map();
-    const providers = kinds.get(kind) ?? [];
-    providers.push(row);
-    kinds.set(kind, providers);
+    const providers = kinds.get(row.kind) ?? new Map();
+    const provider = providers.get(row.provider) ?? {
+      provider: row.provider,
+      credits: 0,
+      usageKinds: [],
+    };
+    provider.credits += row.credits;
+    provider.usageKinds.push({
+      kind: row.usageKind,
+      credits: row.credits,
+    });
+    providers.set(row.provider, provider);
+    kinds.set(row.kind, providers);
     byRow.set(row.rowKey, kinds);
   }
 
@@ -539,16 +566,10 @@ async function queryUsageRecordBreakdown(
       "connector",
       "other",
     ] as const) {
-      const providerRows = kindMap.get(kind) ?? [];
-      if (providerRows.length === 0) {
+      const providers = Array.from(kindMap.get(kind)?.values() ?? []);
+      if (providers.length === 0) {
         continue;
       }
-      const providers = providerRows.map((row) => {
-        return {
-          provider: row.provider,
-          credits: row.credits,
-        };
-      });
       breakdown.push({
         kind,
         credits: providers.reduce((sum, provider) => {

--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -4,13 +4,14 @@ const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   scrape: "Web Fetch",
   maps: "Maps",
   "web-search": "Web Search",
+  "people-search": "People Search",
   finance: "Finance",
   weather: "Weather",
 };
 
-// Chat usage keeps the managed usage kind, while Settings currently groups
-// these kinds under `other` and only retains the provider. Keep the provider
-// aliases here so both surfaces show the same product-facing capability name.
+// Current Settings responses retain raw usage kinds inside each provider.
+// Keep provider aliases for older APIs that only return the provider so app
+// and API promotions can serve different versions safely.
 const MANAGED_USAGE_PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   firecrawl: "Web Fetch",
   "google-maps": "Maps",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -309,7 +309,7 @@ describe("chat lifecycle", () => {
           runId: "run-usage-folded-managed-api",
           usage: {
             version: 1,
-            totalCredits: 180,
+            totalCredits: 216,
             settledAt: "2026-06-09T10:00:03Z",
             breakdown: [
               {
@@ -324,6 +324,11 @@ describe("chat lifecycle", () => {
               },
               {
                 kind: "web-search",
+                credits: 36,
+                providers: [{ provider: "perplexity", credits: 36 }],
+              },
+              {
+                kind: "people-search",
                 credits: 36,
                 providers: [{ provider: "perplexity", credits: 36 }],
               },
@@ -364,16 +369,17 @@ describe("chat lifecycle", () => {
       screen.queryByText("Inspecting managed API results."),
     ).not.toBeInTheDocument();
 
-    const managedApiCredit = await screen.findByLabelText("Credit usage 180");
+    const managedApiCredit = await screen.findByLabelText("Credit usage 216");
     click(managedApiCredit);
 
     await waitFor(() => {
       expect(screen.getByText("Web Fetch")).toBeInTheDocument();
       expect(screen.getByText("Maps")).toBeInTheDocument();
       expect(screen.getByText("Web Search")).toBeInTheDocument();
+      expect(screen.getByText("People Search")).toBeInTheDocument();
       expect(screen.getByText("Finance")).toBeInTheDocument();
       expect(screen.getByText("Weather")).toBeInTheDocument();
-      expect(screen.getAllByText("36")).toHaveLength(5);
+      expect(screen.getAllByText("36")).toHaveLength(6);
       expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();
       expect(screen.queryByText("Google Maps")).not.toBeInTheDocument();
       expect(screen.queryByText("Perplexity")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -28,7 +28,14 @@ function usageRows(): UsageRecordRow[] {
           providers: [
             { provider: "firecrawl", credits: 180 },
             { provider: "google-maps", credits: 200 },
-            { provider: "perplexity", credits: 200 },
+            {
+              provider: "perplexity",
+              credits: 200,
+              usageKinds: [
+                { kind: "people-search", credits: 80 },
+                { kind: "web-search", credits: 120 },
+              ],
+            },
             { provider: "apidojo", credits: 200 },
             { provider: "google-weather", credits: 200 },
           ],
@@ -196,6 +203,19 @@ describe("personal usage settings", () => {
       expect(screen.getAllByText("Web Search").length).toBeGreaterThanOrEqual(
         1,
       );
+      expect(
+        screen.getAllByText("People Search").length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getAllByText("People Search").some((element) => {
+          return element.parentElement?.textContent === "People Search80";
+        }),
+      ).toBe(true);
+      expect(
+        screen.getAllByText("Web Search").some((element) => {
+          return element.parentElement?.textContent === "Web Search120";
+        }),
+      ).toBe(true);
       expect(screen.getAllByText("Finance").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Weather").length).toBeGreaterThanOrEqual(1);
       expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -210,12 +210,12 @@ describe("personal usage settings", () => {
         screen.getAllByText("People Search").some((element) => {
           return element.parentElement?.textContent === "People Search80";
         }),
-      ).toBe(true);
+      ).toBeTruthy();
       expect(
         screen.getAllByText("Web Search").some((element) => {
           return element.parentElement?.textContent === "Web Search120";
         }),
-      ).toBe(true);
+      ).toBeTruthy();
       expect(screen.getAllByText("Finance").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Weather").length).toBeGreaterThanOrEqual(1);
       expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -242,23 +242,29 @@ function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
                   {meta.label} - {segment.credits.toLocaleString()}
                 </div>
                 <div className="mt-1 flex flex-col gap-0.5">
-                  {segment.providers.map((provider) => {
-                    return (
-                      <div
-                        key={provider.provider}
-                        className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
-                      >
-                        <span className="truncate">
-                          {getCreditUsageDisplayName(
-                            segment.kind,
-                            provider.provider,
-                          )}
-                        </span>
-                        <span className="shrink-0 tabular-nums">
-                          {provider.credits.toLocaleString()}
-                        </span>
-                      </div>
-                    );
+                  {segment.providers.flatMap((provider) => {
+                    const usageKinds =
+                      provider.usageKinds && provider.usageKinds.length > 0
+                        ? provider.usageKinds
+                        : [{ kind: segment.kind, credits: provider.credits }];
+                    return usageKinds.map((usageKind) => {
+                      return (
+                        <div
+                          key={`${provider.provider}:${usageKind.kind}`}
+                          className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
+                        >
+                          <span className="truncate">
+                            {getCreditUsageDisplayName(
+                              usageKind.kind,
+                              provider.provider,
+                            )}
+                          </span>
+                          <span className="shrink-0 tabular-nums">
+                            {usageKind.credits.toLocaleString()}
+                          </span>
+                        </div>
+                      );
+                    });
                   })}
                 </div>
               </TooltipContent>

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -47,6 +47,15 @@ export type UsageRecordKind = z.infer<typeof usageRecordKindSchema>;
 const usageRecordProviderBreakdownSchema = z.object({
   provider: z.string(),
   credits: z.number(),
+  // Optional while app and API promotions can serve different versions.
+  usageKinds: z
+    .array(
+      z.object({
+        kind: z.string(),
+        credits: z.number(),
+      }),
+    )
+    .optional(),
 });
 
 const usageRecordKindBreakdownSchema = z.object({


### PR DESCRIPTION
## Summary

- preserve raw usage kinds inside each provider in the Settings usage-record API
- render People Search and Web Search as separate tooltip entries even when both are billed through Perplexity
- keep the existing coarse usage categories and a provider-based fallback for mixed app/API deployments

## User impact

Settings now attributes `people-search` credits to **People Search** instead of folding them into **Web Search**. Existing charts and totals are unchanged.

## Implementation

- add an optional provider-level `usageKinds` breakdown to the usage-record contract
- aggregate API rows by coarse kind, provider, and raw usage kind while preserving provider totals
- prefer raw usage-kind labels in the Settings tooltip and retain the legacy provider fallback
- cover one run calling the production People Search and Web Search endpoints plus the rendered Settings, chat, and image-generation usage surfaces

## Exclusions

- no database migration or historical data rewrite
- no changes to the coarse `model`, `image`, `video`, `connector`, and `other` categories

## Validation

- `pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F @vm0/app lint`
- `DATABASE_URL=<test-db-url> pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-record.test.ts src/signals/routes/__tests__/zero-people-search.test.ts --maxWorkers=2 --silent=passed-only` (25 tests)
- `DATABASE_URL=<test-db-url> pnpm -F api exec vitest run src/signals/routes/__tests__/zero-image-io-generate.test.ts --maxWorkers=1 --silent=passed-only` (20 tests)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx --maxWorkers=1 --silent=passed-only` (4 tests)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx --maxWorkers=1 --silent=passed-only` (20 tests)
- Prettier checks for all changed files
- `git diff --check`

Closes #23608
