### PR TITLE
refactor(api): build usage record queries with drizzle ctes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -775,6 +775,17 @@ describe("GET /api/zero/usage/record", () => {
     );
     expect(secondPage.body.rows).toHaveLength(1);
     expect(secondPage.body.rows[0]?.threadId).toBe(expectedThreadIds[2]);
+
+    const emptyPage = await accept(
+      apiClient().get({
+        query: { page: 3, pageSize: 2 },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(emptyPage.body.rows).toStrictEqual([]);
+    expect(emptyPage.body.pagination.total).toBe(3);
+    expect(emptyPage.body.totalCredits).toBe(30);
   });
 
   it("returns kind and provider breakdowns for each usage row", async () => {

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { and, count, eq, inArray, sql, type SQL } from "drizzle-orm";
 import {
   type UsageRecordKind,
   type UsageRecordRow,
@@ -9,13 +8,33 @@ import {
   usageRecordKindSchema,
   usageRecordSourceSchema,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
-import { z } from "zod";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  max,
+  notInArray,
+  sql,
+  sum,
+  type SQLWrapper,
+} from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
 
 import {
-  executeRawRows,
-  pgInt8ToSafeIntegerSchema,
-  pgTimestampWithoutTimezoneToDateSchema,
-} from "../../lib/db-raw-rows";
+  nullableDriverValueDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import {
@@ -50,6 +69,10 @@ const PASSTHROUGH_TRIGGER_SOURCES = [
   "cli",
   "agent",
 ] as const;
+const usageRecordKindDecoder = zodEnumDriverValueDecoder(usageRecordKindSchema);
+const usageRecordSourceDecoder = zodEnumDriverValueDecoder(
+  usageRecordSourceSchema,
+);
 
 interface UsageRecordArgs {
   readonly userId: string;
@@ -67,70 +90,36 @@ interface UsageRecordIntermediateRow extends UsageRecordRow {
   readonly userId: string;
 }
 
-const usageRecordSqlRowSchema = z
-  .object({
-    row_key: z.string(),
-    source: usageRecordSourceSchema,
-    user_id: z.string(),
-    thread_id: z.string().nullable(),
-    run_id: z.string().nullable(),
-    title: z.string().nullable(),
-    credits: pgInt8ToSafeIntegerSchema,
-    tokens: pgInt8ToSafeIntegerSchema,
-    last_activity: pgTimestampWithoutTimezoneToDateSchema,
-  })
-  .transform((row): UsageRecordIntermediateRow => {
-    return {
-      rowKey: row.row_key,
-      source: row.source,
-      userId: row.user_id,
-      threadId: row.thread_id,
-      runId: row.run_id,
-      title: row.title,
-      credits: row.credits,
-      tokens: row.tokens,
-      breakdown: [],
-      member: null,
-      lastActivityAt: row.last_activity.toISOString(),
-    };
-  });
-
-const usageRecordTotalsSqlRowSchema = z.object({
-  total: pgInt8ToSafeIntegerSchema,
-  total_credits: pgInt8ToSafeIntegerSchema,
-});
-
-const usageRecordBreakdownSqlRowSchema = z.object({
-  row_key: z.string(),
-  kind: usageRecordKindSchema,
-  provider: z.string(),
-  credits: pgInt8ToSafeIntegerSchema,
-});
-type UsageRecordBreakdownSqlRow = z.output<
-  typeof usageRecordBreakdownSqlRowSchema
->;
+interface UsageRecordBreakdownSqlRow {
+  readonly rowKey: string;
+  readonly kind: UsageRecordKind;
+  readonly provider: string;
+  readonly credits: number;
+}
 
 function tokenExpr(usage: FinalizedUsageRelation) {
   return sql`CASE WHEN ${and(
     eq(usage.kind, MODEL_USAGE_KIND),
     inArray(usage.category, MODEL_TOKEN_CATEGORIES),
-  )} THEN ${usage.quantity} ELSE 0 END`;
+  )} THEN ${usage.quantity} ELSE 0 END::bigint`.mapWith(
+    pgInt8ToSafeIntegerDecoder,
+  );
 }
 
 function sourceExpr() {
-  const passthroughList = sql.join(
-    PASSTHROUGH_TRIGGER_SOURCES.map((source) => {
-      return sql`${source}`;
-    }),
-    sql`, `,
-  );
   return sql`
     CASE
-      WHEN zr.trigger_source = 'web' THEN 'chat'
-      WHEN zr.trigger_source IN ('workflow-schedule', 'workflow-event') THEN 'automation'
-      WHEN zr.trigger_source IN (${passthroughList}) THEN zr.trigger_source
+      WHEN ${eq(zeroRuns.triggerSource, sql`'web'`)} THEN 'chat'
+      WHEN ${inArray(
+        zeroRuns.triggerSource,
+        sql`('workflow-schedule', 'workflow-event')`,
+      )} THEN 'automation'
+      WHEN ${inArray(
+        zeroRuns.triggerSource,
+        PASSTHROUGH_TRIGGER_SOURCES,
+      )} THEN ${zeroRuns.triggerSource}
       ELSE 'other'
-    END`;
+    END`.mapWith(usageRecordSourceDecoder);
 }
 
 function usageKindExpr(usage: FinalizedUsageRelation) {
@@ -138,11 +127,169 @@ function usageKindExpr(usage: FinalizedUsageRelation) {
     CASE
       WHEN ${inArray(usage.kind, USAGE_RECORD_KINDS)} THEN ${usage.kind}
       ELSE 'other'
-    END`;
+    END`.mapWith(usageRecordKindDecoder);
 }
 
 function usageCreditsExpr(usage: FinalizedUsageRelation) {
-  return sql`${usage.creditsCharged} + ${usage.allowanceUnits}`;
+  return sql`${usage.creditsCharged} + ${usage.allowanceUnits}::bigint`.mapWith(
+    pgInt8ToSafeIntegerDecoder,
+  );
+}
+
+function safeIntegerSum(value: SQLWrapper) {
+  return sql`COALESCE(${sum(value)}, 0)::bigint`.mapWith(
+    pgInt8ToSafeIntegerDecoder,
+  );
+}
+
+function usageRecordRunsWith(
+  db: Db,
+  userId: string | null,
+  orgId: string,
+  period: UsagePeriod | null,
+) {
+  const usage = buildFinalizedUsageRelation(period ?? undefined);
+  const usageRows = db.$with("usage_rows").as(
+    db
+      .select({
+        runId: usage.runId,
+        userId: usage.userId,
+        credits: usageCreditsExpr(usage).as("credits"),
+        tokens: tokenExpr(usage).as("tokens"),
+      })
+      .from(usage)
+      .where(
+        and(
+          eq(usage.orgId, orgId),
+          userId === null ? undefined : eq(usage.userId, userId),
+        ),
+      ),
+  );
+  const runs = db.$with("runs").as(
+    db
+      .select({
+        runId: usageRows.runId,
+        userId: usageRows.userId,
+        credits: usageRows.credits,
+        tokens: usageRows.tokens,
+        source: sourceExpr().as("source"),
+        chatThreadId: zeroRuns.chatThreadId,
+        summary: zeroRuns.summary,
+        prompt: agentRuns.prompt,
+        createdAt: agentRuns.createdAt,
+      })
+      .from(usageRows)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, usageRows.runId))
+      .innerJoin(agentRuns, eq(agentRuns.id, usageRows.runId)),
+  );
+  return { usageRows, runs };
+}
+
+type UsageRecordRuns = ReturnType<typeof usageRecordRunsWith>["runs"];
+
+function threadedUsageRecordWith(db: Db, runs: UsageRecordRuns) {
+  return db.$with("threaded").as(
+    db
+      .select({
+        rowKey:
+          sql`CONCAT(${runs.source}, ':thread:', ${runs.chatThreadId}::text, ':user:', ${runs.userId})`
+            .mapWith(pgTextDecoder)
+            .as("row_key"),
+        source: runs.source,
+        userId: runs.userId,
+        threadId: sql`${runs.chatThreadId}::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("thread_id"),
+        runId: sql`NULL::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("run_id"),
+        title: sql`${chatThreads.title}`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("title"),
+        credits: safeIntegerSum(runs.credits).as("credits"),
+        tokens: safeIntegerSum(runs.tokens).as("tokens"),
+        lastActivity: max(runs.createdAt)
+          .mapWith(agentRuns.createdAt)
+          .as("last_activity"),
+      })
+      .from(runs)
+      .leftJoin(chatThreads, eq(chatThreads.id, runs.chatThreadId))
+      .where(
+        and(
+          isNotNull(runs.chatThreadId),
+          inArray(runs.source, [...THREADED_SOURCES]),
+        ),
+      )
+      .groupBy(runs.source, runs.userId, runs.chatThreadId, chatThreads.title),
+  );
+}
+
+function deletedThreadedUsageRecordWith(db: Db, runs: UsageRecordRuns) {
+  return db.$with("deleted_threaded").as(
+    db
+      .select({
+        rowKey:
+          sql`CONCAT(${runs.source}, ':deleted-thread:user:', ${runs.userId})`
+            .mapWith(pgTextDecoder)
+            .as("row_key"),
+        source: runs.source,
+        userId: runs.userId,
+        threadId: sql`NULL::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("thread_id"),
+        runId: sql`NULL::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("run_id"),
+        title: sql`'Deleted chats'::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("title"),
+        credits: safeIntegerSum(runs.credits).as("credits"),
+        tokens: safeIntegerSum(runs.tokens).as("tokens"),
+        lastActivity: max(runs.createdAt)
+          .mapWith(agentRuns.createdAt)
+          .as("last_activity"),
+      })
+      .from(runs)
+      .where(
+        and(
+          isNull(runs.chatThreadId),
+          inArray(runs.source, [...THREADED_SOURCES]),
+        ),
+      )
+      .groupBy(runs.source, runs.userId),
+  );
+}
+
+function unthreadedUsageRecordWith(db: Db, runs: UsageRecordRuns) {
+  return db.$with("unthreaded").as(
+    db
+      .select({
+        rowKey:
+          sql`CONCAT(${runs.source}, ':run:', ${runs.runId}::text, ':user:', ${runs.userId})`
+            .mapWith(pgTextDecoder)
+            .as("row_key"),
+        source: runs.source,
+        userId: runs.userId,
+        threadId: sql`NULL::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("thread_id"),
+        runId: sql`${runs.runId}::text`
+          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+          .as("run_id"),
+        title:
+          sql`LEFT(COALESCE(NULLIF(${max(runs.summary)}, ''), ${max(runs.prompt)}), 120)`
+            .mapWith(nullableDriverValueDecoder(pgTextDecoder))
+            .as("title"),
+        credits: safeIntegerSum(runs.credits).as("credits"),
+        tokens: safeIntegerSum(runs.tokens).as("tokens"),
+        lastActivity: max(runs.createdAt)
+          .mapWith(agentRuns.createdAt)
+          .as("last_activity"),
+      })
+      .from(runs)
+      .where(notInArray(runs.source, [...THREADED_SOURCES]))
+      .groupBy(runs.runId, runs.source, runs.userId),
+  );
 }
 
 // Per-source usage for one user in one org. `record` is the shared CTE so the
@@ -151,172 +298,148 @@ function usageCreditsExpr(usage: FinalizedUsageRelation) {
 // NULL, collapse to one synthetic row per source/user. Everything else is one
 // row per run.
 function recordWith(
+  db: Db,
   userId: string | null,
   orgId: string,
   period: UsagePeriod | null,
-): SQL {
-  const threadedSourceList = sql.join(
-    THREADED_SOURCES.map((source) => {
-      return sql`${source}`;
-    }),
-    sql`, `,
+) {
+  const { usageRows, runs } = usageRecordRunsWith(db, userId, orgId, period);
+  const threaded = threadedUsageRecordWith(db, runs);
+  const deletedThreaded = deletedThreadedUsageRecordWith(db, runs);
+  const unthreaded = unthreadedUsageRecordWith(db, runs);
+  const record = db.$with("record").as(
+    unionAll(
+      db
+        .select({
+          rowKey: threaded.rowKey,
+          source: threaded.source,
+          userId: threaded.userId,
+          threadId: threaded.threadId,
+          runId: threaded.runId,
+          title: threaded.title,
+          credits: threaded.credits,
+          tokens: threaded.tokens,
+          lastActivity: threaded.lastActivity,
+        })
+        .from(threaded),
+      db
+        .select({
+          rowKey: deletedThreaded.rowKey,
+          source: deletedThreaded.source,
+          userId: deletedThreaded.userId,
+          threadId: deletedThreaded.threadId,
+          runId: deletedThreaded.runId,
+          title: deletedThreaded.title,
+          credits: deletedThreaded.credits,
+          tokens: deletedThreaded.tokens,
+          lastActivity: deletedThreaded.lastActivity,
+        })
+        .from(deletedThreaded),
+      db
+        .select({
+          rowKey: unthreaded.rowKey,
+          source: unthreaded.source,
+          userId: unthreaded.userId,
+          threadId: unthreaded.threadId,
+          runId: unthreaded.runId,
+          title: unthreaded.title,
+          credits: unthreaded.credits,
+          tokens: unthreaded.tokens,
+          lastActivity: unthreaded.lastActivity,
+        })
+        .from(unthreaded),
+    ),
   );
-  const usage = buildFinalizedUsageRelation(period ?? undefined);
-  const userPredicate =
-    userId === null ? sql.empty() : sql`AND ${eq(usage.userId, userId)}`;
-  return sql`
-    WITH usage_rows AS (
-      SELECT
-        ${usage.runId} AS run_id,
-        ${usage.userId} AS user_id,
-        ${usageCreditsExpr(usage)}::bigint AS credits,
-        ${tokenExpr(usage)}::bigint AS tokens
-      FROM ${usage}
-      WHERE ${usage.orgId} = ${orgId}
-        ${userPredicate}
-    ),
-    runs AS (
-      SELECT
-        ur.run_id,
-        ur.user_id,
-        ur.credits,
-        ur.tokens,
-        ${sourceExpr()} AS source,
-        zr.chat_thread_id,
-        zr.summary,
-        ar.prompt,
-        ar.created_at
-      FROM usage_rows ur
-      INNER JOIN zero_runs zr ON zr.id = ur.run_id
-      INNER JOIN agent_runs ar ON ar.id = ur.run_id
-    ),
-    threaded AS (
-      SELECT
-        CONCAT(r.source, ':thread:', r.chat_thread_id::text, ':user:', r.user_id) AS row_key,
-        r.source,
-        r.user_id,
-        r.chat_thread_id::text AS thread_id,
-        NULL::text AS run_id,
-        ct.title AS title,
-        COALESCE(SUM(r.credits), 0)::bigint AS credits,
-        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
-        MAX(r.created_at) AS last_activity
-      FROM runs r
-      LEFT JOIN chat_threads ct ON ct.id = r.chat_thread_id
-      WHERE r.chat_thread_id IS NOT NULL
-        AND r.source IN (${threadedSourceList})
-      GROUP BY r.source, r.user_id, r.chat_thread_id, ct.title
-    ),
-    deleted_threaded AS (
-      SELECT
-        CONCAT(r.source, ':deleted-thread:user:', r.user_id) AS row_key,
-        r.source,
-        r.user_id,
-        NULL::text AS thread_id,
-        NULL::text AS run_id,
-        'Deleted chats'::text AS title,
-        COALESCE(SUM(r.credits), 0)::bigint AS credits,
-        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
-        MAX(r.created_at) AS last_activity
-      FROM runs r
-      WHERE r.chat_thread_id IS NULL
-        AND r.source IN (${threadedSourceList})
-      GROUP BY r.source, r.user_id
-    ),
-    unthreaded AS (
-      SELECT
-        CONCAT(r.source, ':run:', r.run_id::text, ':user:', r.user_id) AS row_key,
-        r.source,
-        r.user_id,
-        NULL::text AS thread_id,
-        r.run_id::text AS run_id,
-        LEFT(COALESCE(NULLIF(MAX(r.summary), ''), MAX(r.prompt)), 120) AS title,
-        COALESCE(SUM(r.credits), 0)::bigint AS credits,
-        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
-        MAX(r.created_at) AS last_activity
-      FROM runs r
-      WHERE r.source NOT IN (${threadedSourceList})
-      GROUP BY r.run_id, r.source, r.user_id
-    ),
-    record AS (
-      SELECT * FROM threaded
-      UNION ALL
-      SELECT * FROM deleted_threaded
-      UNION ALL
-      SELECT * FROM unthreaded
-    )`;
+  return { usageRows, runs, threaded, deletedThreaded, unthreaded, record };
 }
+
+type UsageRecordRelations = ReturnType<typeof recordWith>;
 
 async function queryUsageRecordRows(
   db: Db,
-  recordCte: SQL,
+  relations: UsageRecordRelations,
   sourceFilter: UsageRecordSource | undefined,
   pageSize: number,
   offset: number,
 ): Promise<UsageRecordIntermediateRow[]> {
-  const where =
-    sourceFilter === undefined
-      ? sql.empty()
-      : sql`WHERE source = ${sourceFilter}`;
-  return await executeRawRows(
-    db,
-    sql`
-      ${recordCte}
-      SELECT row_key, source, user_id, thread_id, run_id, title, credits, tokens, last_activity
-      FROM record
-      ${where}
-      ORDER BY last_activity DESC, row_key
-      LIMIT ${pageSize} OFFSET ${offset}
-    `,
-    usageRecordSqlRowSchema,
-  );
+  const rows = await db
+    .with(
+      relations.usageRows,
+      relations.runs,
+      relations.threaded,
+      relations.deletedThreaded,
+      relations.unthreaded,
+      relations.record,
+    )
+    .select({
+      rowKey: relations.record.rowKey,
+      source: relations.record.source,
+      userId: relations.record.userId,
+      threadId: relations.record.threadId,
+      runId: relations.record.runId,
+      title: relations.record.title,
+      credits: relations.record.credits,
+      tokens: relations.record.tokens,
+      lastActivity: relations.record.lastActivity,
+    })
+    .from(relations.record)
+    .where(
+      sourceFilter === undefined
+        ? undefined
+        : eq(relations.record.source, sourceFilter),
+    )
+    .orderBy(desc(relations.record.lastActivity), asc(relations.record.rowKey))
+    .limit(pageSize)
+    .offset(offset);
+  return rows.map((row): UsageRecordIntermediateRow => {
+    return {
+      rowKey: row.rowKey,
+      source: row.source,
+      userId: row.userId,
+      threadId: row.threadId,
+      runId: row.runId,
+      title: row.title,
+      credits: row.credits,
+      tokens: row.tokens,
+      breakdown: [],
+      member: null,
+      lastActivityAt: row.lastActivity.toISOString(),
+    };
+  });
 }
 
 async function queryUsageRecordTotals(
   db: Db,
-  recordCte: SQL,
+  relations: UsageRecordRelations,
   sourceFilter: UsageRecordSource | undefined,
 ): Promise<{ total: number; totalCredits: number }> {
-  const where =
-    sourceFilter === undefined
-      ? sql.empty()
-      : sql`WHERE source = ${sourceFilter}`;
-  const rows = await executeRawRows(
-    db,
-    sql`
-      ${recordCte}
-      SELECT ${count()}::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
-      FROM record ${where}
-    `,
-    usageRecordTotalsSqlRowSchema,
-  );
+  const rows = await db
+    .with(
+      relations.usageRows,
+      relations.runs,
+      relations.threaded,
+      relations.deletedThreaded,
+      relations.unthreaded,
+      relations.record,
+    )
+    .select({
+      total: sql`${count()}::bigint`
+        .mapWith(pgInt8ToSafeIntegerDecoder)
+        .as("total"),
+      totalCredits: safeIntegerSum(relations.record.credits).as(
+        "total_credits",
+      ),
+    })
+    .from(relations.record)
+    .where(
+      sourceFilter === undefined
+        ? undefined
+        : eq(relations.record.source, sourceFilter),
+    );
   return {
     total: rows[0]?.total ?? 0,
-    totalCredits: rows[0]?.total_credits ?? 0,
+    totalCredits: rows[0]?.totalCredits ?? 0,
   };
-}
-
-function rowKeyExpr() {
-  const threadedSourceList = sql.join(
-    THREADED_SOURCES.map((source) => {
-      return sql`${source}`;
-    }),
-    sql`, `,
-  );
-  return sql`
-    CASE
-      WHEN ${and(
-        sql`chat_thread_id IS NOT NULL`,
-        sql`source IN (${threadedSourceList})`,
-      )}
-        THEN CONCAT(source, ':thread:', chat_thread_id::text, ':user:', user_id)
-      WHEN ${and(
-        sql`chat_thread_id IS NULL`,
-        sql`source IN (${threadedSourceList})`,
-      )}
-        THEN CONCAT(source, ':deleted-thread:user:', user_id)
-      ELSE CONCAT(source, ':run:', run_id::text, ':user:', user_id)
-    END`;
 }
 
 async function queryUsageRecordBreakdown(
@@ -331,51 +454,67 @@ async function queryUsageRecordBreakdown(
   }
 
   const usage = buildFinalizedUsageRelation(period ?? undefined);
-  const userPredicate =
-    userId === null ? sql.empty() : sql`AND ${eq(usage.userId, userId)}`;
-  const rowKeyList = sql.join(
-    rowKeys.map((rowKey) => {
-      return sql`${rowKey}`;
-    }),
-    sql`, `,
-  );
-  const sourceSql = sourceExpr();
-  const kindSql = usageKindExpr(usage);
-
-  const rows = await executeRawRows(
-    db,
-    sql`
-      WITH usage_rows AS (
-        SELECT
-          ${sourceSql} AS source,
-          zr.chat_thread_id,
-          ${usage.runId} AS run_id,
-          ${usage.userId} AS user_id,
-          ${kindSql} AS kind,
-          COALESCE(NULLIF(${usage.provider}, ''), 'unknown') AS provider,
-          ${usageCreditsExpr(usage)}::bigint AS credits
-        FROM ${usage}
-        INNER JOIN zero_runs zr ON zr.id = ${usage.runId}
-        WHERE ${usage.orgId} = ${orgId}
-          ${userPredicate}
+  const usageRows = db.$with("usage_rows").as(
+    db
+      .select({
+        source: sourceExpr().as("source"),
+        chatThreadId: zeroRuns.chatThreadId,
+        runId: usage.runId,
+        userId: usage.userId,
+        kind: usageKindExpr(usage).as("kind"),
+        provider: sql`COALESCE(NULLIF(${usage.provider}, ''), 'unknown')`
+          .mapWith(pgTextDecoder)
+          .as("provider"),
+        credits: usageCreditsExpr(usage).as("credits"),
+      })
+      .from(usage)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, usage.runId))
+      .where(
+        and(
+          eq(usage.orgId, orgId),
+          userId === null ? undefined : eq(usage.userId, userId),
+        ),
       ),
-      keyed AS (
-        SELECT
-          ${rowKeyExpr()} AS row_key,
-          kind,
-          provider,
-          credits
-        FROM usage_rows
-      )
-      SELECT row_key, kind, provider, SUM(credits)::bigint AS credits
-      FROM keyed
-      WHERE row_key IN (${rowKeyList})
-      GROUP BY row_key, kind, provider
-      HAVING SUM(credits) > 0
-      ORDER BY row_key, kind, provider
-    `,
-    usageRecordBreakdownSqlRowSchema,
   );
+  const rowKey = sql`
+    CASE
+      WHEN ${and(
+        isNotNull(usageRows.chatThreadId),
+        inArray(usageRows.source, [...THREADED_SOURCES]),
+      )}
+        THEN CONCAT(${usageRows.source}, ':thread:', ${usageRows.chatThreadId}::text, ':user:', ${usageRows.userId})
+      WHEN ${and(
+        isNull(usageRows.chatThreadId),
+        inArray(usageRows.source, [...THREADED_SOURCES]),
+      )}
+        THEN CONCAT(${usageRows.source}, ':deleted-thread:user:', ${usageRows.userId})
+      ELSE CONCAT(${usageRows.source}, ':run:', ${usageRows.runId}::text, ':user:', ${usageRows.userId})
+    END`.mapWith(pgTextDecoder);
+  const keyed = db.$with("keyed").as(
+    db
+      .select({
+        rowKey: rowKey.as("row_key"),
+        kind: usageRows.kind,
+        provider: usageRows.provider,
+        credits: usageRows.credits,
+      })
+      .from(usageRows),
+  );
+  const rows: UsageRecordBreakdownSqlRow[] = await db
+    .with(usageRows, keyed)
+    .select({
+      rowKey: keyed.rowKey,
+      kind: keyed.kind,
+      provider: keyed.provider,
+      credits: sql`${sum(keyed.credits)}::bigint`
+        .mapWith(pgInt8ToSafeIntegerDecoder)
+        .as("credits"),
+    })
+    .from(keyed)
+    .where(inArray(keyed.rowKey, [...rowKeys]))
+    .groupBy(keyed.rowKey, keyed.kind, keyed.provider)
+    .having(gt(sum(keyed.credits), sql`0`))
+    .orderBy(asc(keyed.rowKey), asc(keyed.kind), asc(keyed.provider));
 
   const byRow = new Map<
     string,
@@ -383,11 +522,11 @@ async function queryUsageRecordBreakdown(
   >();
   for (const row of rows) {
     const kind = row.kind;
-    const kinds = byRow.get(row.row_key) ?? new Map();
+    const kinds = byRow.get(row.rowKey) ?? new Map();
     const providers = kinds.get(kind) ?? [];
     providers.push(row);
     kinds.set(kind, providers);
-    byRow.set(row.row_key, kinds);
+    byRow.set(row.rowKey, kinds);
   }
 
   const breakdownByRow = new Map<string, UsageRecordRow["breakdown"]>();
@@ -463,12 +602,12 @@ export const zeroUsageRecord$ = command(
     const userId = args.scope === "mine" ? args.userId : null;
     const offset = (args.page - 1) * args.pageSize;
     const queryPeriod = period ? normalizeFinalizedUsagePeriod(period) : null;
-    const recordCte = recordWith(userId, args.orgId, queryPeriod);
+    const relations = recordWith(db, userId, args.orgId, queryPeriod);
 
     signal.throwIfAborted();
     const rows = await queryUsageRecordRows(
       db,
-      recordCte,
+      relations,
       args.source,
       args.pageSize,
       offset,
@@ -486,7 +625,7 @@ export const zeroUsageRecord$ = command(
     signal.throwIfAborted();
     const { total, totalCredits } = await queryUsageRecordTotals(
       db,
-      recordCte,
+      relations,
       args.source,
     );
     signal.throwIfAborted();

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -1577,19 +1577,6 @@ const queryBuilderCases = {
             )
           \`;
         }
-        function unionRows(userId: number) {
-          return sql\`
-            WITH rows AS (
-              SELECT run_id
-              FROM usage_event
-              WHERE user_id = \${userId}
-              UNION ALL
-              SELECT run_id
-              FROM archived_usage_event
-              WHERE user_id = \${userId}
-            )
-          \`;
-        }
         function deletingRows(userId: number) {
           return sql\`
             WITH rows AS (
@@ -1610,7 +1597,7 @@ const queryBuilderCases = {
           \`;
         }
         function statefulRows(userId: number) {
-          const selectedUserId = userId;
+          let selectedUserId = userId;
           return sql\`
             WITH rows AS (
               SELECT run_id
@@ -1628,11 +1615,6 @@ const queryBuilderCases = {
         await executeRawRows(
           db,
           sql\`\${materializedRows(threadId)} SELECT run_id FROM rows\`,
-          rowSchema,
-        );
-        await executeRawRows(
-          db,
-          sql\`\${unionRows(threadId)} SELECT run_id FROM rows\`,
           rowSchema,
         );
         await executeRawRows(
@@ -2279,6 +2261,57 @@ const queryBuilderCases = {
     },
   ],
   readInvalid: [
+    {
+      code: `${rawRowsImport}${schemaPreamble}
+        import { eq, gt, sql, sum } from "drizzle-orm";
+
+        function recordWith(userId: number) {
+          const live = sql\`
+            live AS (
+              SELECT
+                \${runs.threadId} AS thread_id,
+                \${sum(runs.id)} AS total
+              FROM \${runs}
+              WHERE \${eq(runs.threadId, userId)}
+              GROUP BY \${runs.threadId}
+              HAVING \${gt(sum(runs.id), 0)}
+            )
+          \`;
+          const archived = sql\`
+            archived AS (
+              SELECT
+                \${runs.threadId} AS thread_id,
+                \${sum(runs.id)} AS total
+              FROM \${runs}
+              WHERE \${eq(runs.threadId, userId)}
+              GROUP BY \${runs.threadId}
+            )
+          \`;
+          const record = sql\`
+            record AS (
+              SELECT thread_id, total
+              FROM live
+              UNION ALL
+              SELECT thread_id, total
+              FROM archived
+            )
+          \`;
+          return sql\`WITH \${live}, \${archived}, \${record}\`;
+        }
+
+        await executeRawRows(
+          db,
+          sql\`
+            \${recordWith(threadId)}
+            SELECT thread_id, total
+            FROM record
+            ORDER BY total DESC
+          \`,
+          rowSchema,
+        );
+      `,
+      errors: [{ messageId: "composedCteQueryBuilder" }],
+    },
     {
       code: `${rawRowsImport}${schemaPreamble}
         import { gte, sql, sum } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -3272,6 +3272,7 @@ function builderRelation(
 const BUILDER_READ_SELECT_KEYS = new Set([
   "fromClause",
   "groupClause",
+  "havingClause",
   "limitCount",
   "limitOption",
   "op",
@@ -3391,7 +3392,7 @@ function isBuilderReadCte(
       !isBuilderReadSelect(
         body,
         markers,
-        false,
+        true,
         false,
         hasLocalExpansion ? undefined : directRelationPolicy,
       )

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
@@ -20,6 +20,7 @@ import {
   isTypeAssertionExpression,
   isVariableDeclaration,
   isVariableDeclarationList,
+  isVariableStatement,
   NodeFlags,
   type Node,
   type Symbol as TypeScriptSymbol,
@@ -463,7 +464,7 @@ export function createSqlSourceComposer(
       !isFunctionDeclaration(declaration) ||
       declaration.getSourceFile() !== tsCallee.getSourceFile() ||
       declaration.body === undefined ||
-      declaration.body.statements.length !== 1 ||
+      declaration.body.statements.length === 0 ||
       declaration.parameters.length !== node.arguments.length
     ) {
       return null;
@@ -486,7 +487,8 @@ export function createSqlSourceComposer(
       }
       parameters.push(symbol);
     }
-    const statement = declaration.body.statements[0];
+    const statements = declaration.body.statements;
+    const statement = statements[statements.length - 1];
     if (
       statement === undefined ||
       !isReturnStatement(statement) ||
@@ -494,11 +496,39 @@ export function createSqlSourceComposer(
     ) {
       return null;
     }
+    // Model only the conventional straight-line helper shape. Mutation,
+    // control flow, destructuring, and non-final returns remain opaque.
+    const localInitializers: Node[] = [];
+    for (const leadingStatement of statements.slice(0, -1)) {
+      if (
+        !isVariableStatement(leadingStatement) ||
+        (leadingStatement.declarationList.flags & NodeFlags.Const) === 0 ||
+        leadingStatement.declarationList.declarations.length === 0
+      ) {
+        return null;
+      }
+      for (const localDeclaration of leadingStatement.declarationList
+        .declarations) {
+        if (
+          !isIdentifier(localDeclaration.name) ||
+          localDeclaration.initializer === undefined
+        ) {
+          return null;
+        }
+        const initializer = services.tsNodeToESTreeNodeMap.get(
+          localDeclaration.initializer,
+        );
+        if (!isComposableExpression(initializer)) {
+          return null;
+        }
+        localInitializers.push(localDeclaration.initializer);
+      }
+    }
+    const parameterSet = new Set(parameters);
     if (
-      !parametersAppearInComposablePositions(
-        statement.expression,
-        new Set(parameters),
-      )
+      [...localInitializers, statement.expression].some((expression) => {
+        return !parametersAppearInComposablePositions(expression, parameterSet);
+      })
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary

- build usage-record rows, totals, and breakdowns with typed Drizzle CTE/query builders and explicit result decoders
- extend `prefer-drizzle-apis` composition analysis for conventional `const` declarations, `HAVING`, and CTE `UNION ALL`
- cover pagination beyond the final page and the corresponding lint regression shape

## Behavior and compatibility

- preserves row, optional breakdown, and total statement order; independent snapshots; source mapping; grouping; pagination; and response shape
- introduces no schema, persisted-data, public API, runner protocol, feature-switch, migration, or deployment-compatibility change

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules test`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-record.test.ts`
- `pnpm knip`
- exact-base/candidate SQL and parameter comparison plus a real-data differential probe
- real-data `EXPLAIN (ANALYZE, BUFFERS)` comparison
- five-pair API ESLint wall-time/RSS gate (elapsed -2.90%, RSS +0.46%)

Closes #23572

Parent: #23047
