### PR TITLE
test(e2e): verify artifact head before continuation

### DIFF
--- a/e2e/helpers/storage-fixtures.bash
+++ b/e2e/helpers/storage-fixtures.bash
@@ -114,6 +114,16 @@ seed_storage_fixture() (
         --slurpfile files "$files_json" \
         '{storageName: $storageName, storageOwner: $storageOwner, versionId: $versionId, files: $files[0]}' > "$commit_payload"
 
-    e2e_api_curl "/api/test/storage-fixture/commit" -X POST --data-binary "@$commit_payload" >/dev/null
+    local commit_response
+    commit_response="$(e2e_api_curl "/api/test/storage-fixture/commit" -X POST --data-binary "@$commit_payload")"
+    if ! jq -e --arg versionId "$version_id" '
+        .success == true
+        and .versionId == $versionId
+        and .headVersionId == $versionId
+    ' <<< "$commit_response" >/dev/null; then
+        echo "# Storage fixture commit did not acknowledge HEAD $version_id" >&2
+        jq -c '{success, versionId, headVersionId}' <<< "$commit_response" >&2 || true
+        return 1
+    fi
     printf '%s\n' "$version_id"
 )

--- a/e2e/tests/03-runner/t06-vm0-agent-session.bats
+++ b/e2e/tests/03-runner/t06-vm0-agent-session.bats
@@ -187,6 +187,8 @@ teardown_file() {
     echo "updated-content" > testfile.txt
     run seed_storage_fixture artifact "$artifact_name" .
     assert_success
+    local updated_version_id="$output"
+    echo "# Updated artifact HEAD: $updated_version_id"
 
     # -- Step 4: Continue from session with templateVars (was t06-3d) --
     echo "# Continuing from session..."

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2264,6 +2264,27 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     const customArtifactName = `bdd-phase3-artifact-${randomUUID().slice(0, 8)}`;
     const customArtifactMountPath = "/phase3-writeback";
+    const pinnedArtifactName = `bdd-phase3-pinned-${randomUUID().slice(0, 8)}`;
+    const pinnedArtifactMountPath = "/phase3-pinned";
+    const pinnedArtifactFile = storageTextFile(
+      "pinned.txt",
+      `canonical pinned Storage ${pinnedArtifactName}`,
+    );
+    const preparedPinnedArtifact = await storages.prepareStorage(actor, {
+      storageName: pinnedArtifactName,
+      storageOwner: "user",
+      files: [pinnedArtifactFile],
+    });
+    const committedPinnedArtifact = await storages.commitStorage(actor, {
+      storageName: pinnedArtifactName,
+      storageOwner: "user",
+      versionId: preparedPinnedArtifact.versionId,
+      files: [pinnedArtifactFile],
+    });
+    expect(committedPinnedArtifact).toMatchObject({
+      versionId: preparedPinnedArtifact.versionId,
+      headVersionId: preparedPinnedArtifact.versionId,
+    });
     const composeName = `bdd-storage-persistence-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
       version: "1",
@@ -2290,6 +2311,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         {
           name: customArtifactName,
           mountPath: customArtifactMountPath,
+        },
+        {
+          name: pinnedArtifactName,
+          version: preparedPinnedArtifact.versionId,
+          mountPath: pinnedArtifactMountPath,
         },
       ],
       additionalVolumes: [
@@ -2333,6 +2359,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     if (!initialCustomArtifact) {
       throw new Error("Expected the custom canonical writeback mount");
     }
+    const initialPinnedArtifact = initialManifest.storageMounts.find(
+      (mount) => {
+        return mount.name === pinnedArtifactName;
+      },
+    );
+    if (!initialPinnedArtifact) {
+      throw new Error("Expected the pinned canonical writeback mount");
+    }
 
     const memoryFile = storageTextFile(
       "MEMORY.md",
@@ -2349,22 +2383,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       versionId: preparedMemory.versionId,
       files: [memoryFile],
     });
-    const customArtifactFile = storageTextFile(
-      "checkpoint.txt",
-      `canonical custom writeback ${initialRun.runId}`,
-    );
-    const preparedCustomArtifact = await storages.prepareStorage(actor, {
-      storageName: customArtifactName,
-      storageOwner: "user",
-      files: [customArtifactFile],
-    });
-    await storages.commitStorage(actor, {
-      storageName: customArtifactName,
-      storageOwner: "user",
-      versionId: preparedCustomArtifact.versionId,
-      files: [customArtifactFile],
-    });
-
     const historyHash = createHash("sha256")
       .update(`canonical storage history ${initialRun.runId}`)
       .digest("hex");
@@ -2385,12 +2403,22 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           },
           {
             name: initialCustomArtifact.name,
-            version: preparedCustomArtifact.versionId,
+            version: initialCustomArtifact.versionId,
             mountPath: initialCustomArtifact.mountPath,
             ...(initialCustomArtifact.missingRootPolicy === undefined
               ? {}
               : {
                   missingRootPolicy: initialCustomArtifact.missingRootPolicy,
+                }),
+          },
+          {
+            name: initialPinnedArtifact.name,
+            version: initialPinnedArtifact.versionId,
+            mountPath: initialPinnedArtifact.mountPath,
+            ...(initialPinnedArtifact.missingRootPolicy === undefined
+              ? {}
+              : {
+                  missingRootPolicy: initialPinnedArtifact.missingRootPolicy,
                 }),
           },
         ],
@@ -2418,6 +2446,48 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       checkpoint_canonical: true,
     });
 
+    const customArtifactFile = storageTextFile(
+      "checkpoint.txt",
+      `canonical custom writeback ${initialRun.runId}`,
+    );
+    const preparedCustomArtifact = await storages.prepareStorage(actor, {
+      storageName: customArtifactName,
+      storageOwner: "user",
+      files: [customArtifactFile],
+    });
+    const committedCustomArtifact = await storages.commitStorage(actor, {
+      storageName: customArtifactName,
+      storageOwner: "user",
+      versionId: preparedCustomArtifact.versionId,
+      files: [customArtifactFile],
+    });
+    expect(committedCustomArtifact).toMatchObject({
+      versionId: preparedCustomArtifact.versionId,
+      headVersionId: preparedCustomArtifact.versionId,
+    });
+    const newerPinnedArtifactFile = storageTextFile(
+      "pinned.txt",
+      `newer pinned Storage ${initialRun.runId}`,
+    );
+    const preparedNewerPinnedArtifact = await storages.prepareStorage(actor, {
+      storageName: pinnedArtifactName,
+      storageOwner: "user",
+      files: [newerPinnedArtifactFile],
+    });
+    expect(preparedNewerPinnedArtifact.versionId).not.toBe(
+      preparedPinnedArtifact.versionId,
+    );
+    const committedNewerPinnedArtifact = await storages.commitStorage(actor, {
+      storageName: pinnedArtifactName,
+      storageOwner: "user",
+      versionId: preparedNewerPinnedArtifact.versionId,
+      files: [newerPinnedArtifactFile],
+    });
+    expect(committedNewerPinnedArtifact).toMatchObject({
+      versionId: preparedNewerPinnedArtifact.versionId,
+      headVersionId: preparedNewerPinnedArtifact.versionId,
+    });
+
     const sessionRun = await api.createDirectRun(actor, {
       sessionId: initialRun.sessionId,
       prompt: "continue canonical storage session",
@@ -2442,6 +2512,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           storageId: initialCustomArtifact.storageId,
           versionId: preparedCustomArtifact.versionId,
           mountPath: customArtifactMountPath,
+          writeback: true,
+        }),
+        expect.objectContaining({
+          name: pinnedArtifactName,
+          storageId: initialPinnedArtifact.storageId,
+          versionId: preparedPinnedArtifact.versionId,
+          mountPath: pinnedArtifactMountPath,
           writeback: true,
         }),
       ]),

--- a/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-storage-fixture.ts
@@ -7,7 +7,7 @@ import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { command } from "ccstate";
 import { and, desc, eq } from "drizzle-orm";
 
-import { notFound } from "../../lib/error";
+import { conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -158,8 +158,9 @@ async function commitStorageState(
   if (!storage) {
     return notFound("Storage fixture commit target not found");
   }
-  const response = await set(
-    commitStorageUploadForStorage$,
+  const response = await commitFixtureStorage(
+    set,
+    db,
     {
       storageId: storage.id,
       versionId: body.versionId,
@@ -168,10 +169,54 @@ async function commitStorageState(
     },
     signal,
   );
-  signal.throwIfAborted();
   return response.status === 200
     ? actionOk({ committed: response.body })
     : response;
+}
+
+async function commitFixtureStorage(
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  db: Db,
+  input: {
+    readonly storageId: string;
+    readonly versionId: string;
+    readonly files: StorageStateAction<"commit">["files"];
+    readonly message?: string;
+  },
+  signal: AbortSignal,
+) {
+  const response = await set(
+    commitStorageUploadForStorage$,
+    {
+      storageId: input.storageId,
+      versionId: input.versionId,
+      files: input.files,
+      message: input.message,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (response.status !== 200) {
+    return response;
+  }
+
+  const [storage] = await db
+    .select({ headVersionId: storages.headVersionId })
+    .from(storages)
+    .where(eq(storages.id, input.storageId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (storage?.headVersionId !== input.versionId) {
+    return conflict("Storage fixture HEAD changed before acknowledgement");
+  }
+
+  return {
+    status: 200 as const,
+    body: {
+      ...response.body,
+      headVersionId: storage.headVersionId,
+    },
+  };
 }
 
 async function listStorageState(
@@ -316,8 +361,9 @@ const commit$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
   signal.throwIfAborted();
 
-  return await set(
-    commitStorageUploadForStorage$,
+  return await commitFixtureStorage(
+    set,
+    db,
     {
       storageId,
       versionId: bodyResult.data.versionId,

--- a/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-storage-fixture.ts
@@ -24,6 +24,7 @@ const prepareResponseSchema = z.object({
 const commitResponseSchema = z.object({
   success: z.literal(true),
   versionId: z.string(),
+  headVersionId: z.string(),
   storageName: z.string(),
   size: z.number(),
   fileCount: z.number(),


### PR DESCRIPTION
## Summary

- return the post-commit Storage HEAD from the preview fixture endpoint and reject mismatched acknowledgements
- require the runner E2E fixture helper to verify the prepared, committed, and observed versions before continuing a session
- extend API integration coverage so an unpinned artifact follows a HEAD advanced after completion while an explicitly pinned artifact stays fixed

## Scope

This does not change the production Storage protocol, session protocol, runner payloads, or database schema. It does not add retries, sleeps, locks, or speculative production ordering logic.

## Validation

- `bash -n e2e/helpers/storage-fixtures.bash e2e/tests/03-runner/t06-vm0-agent-session.bats`
- `shellcheck -x e2e/helpers/storage-fixtures.bash`
- `pnpm --filter @vm0/api-contracts --filter api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/api-contracts exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'persists canonical mounts across session continuation' --maxWorkers=1 --silent=passed-only`

The local full API suite completed 2,443 tests and failed four existing fixed-staff-org entitlement tests. The same cross-file Stripe-customer collision was reproduced from a clean `origin/main` worktree.

Closes #23615
