### PR TITLE
fix(runner): prevent jsonl flush acknowledgement starvation

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -211,6 +211,7 @@ def configure(updated: set[str]) -> None:
         ready_path = ctx.options.vm0_addon_ready_path
         usage_state_id = ctx.options.vm0_usage_state_id
         if ready_path and usage_state_id:
+            runner_flush_lifecycle.start_runner_jsonl_flush_worker()
             Path(ready_path).write_text(usage_state_id, encoding="utf-8")
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1528,15 +1528,16 @@ def _handle_error(flow: http.HTTPFlow) -> None:
 def done():
     """Flush pending usage reports and forwarding workers before mitmproxy exits.
 
-    The runner flush lifecycle waits for any active SIGUSR1 worker, drains
-    accepted requests, and closes admission before this hook shuts down the
-    usage executor. Any retryable outcome retained by those completed workers
-    is then retried synchronously before the remaining workers and JSONL writer
-    stop. Auth.base forwarding does not need to finish running work
-    during shutdown, so its worker shutdown stops new forwards and best-effort
-    closes active upstream sockets without waiting for slow upstream responses.
-    JSONL writer shutdown is also bounded and best-effort; if it times out,
-    process shutdown continues with accepted log entries possibly still pending.
+    The runner flush lifecycle waits for any active SIGUSR1 usage worker,
+    drains accepted usage requests, and closes admission before this hook shuts
+    down the usage executor. It also performs a final JSONL marker observation
+    and joins the marker watcher before the JSONL writer stops. Any retryable
+    usage outcome retained by completed workers is then retried synchronously.
+    Auth.base forwarding does not need to finish running work during shutdown,
+    so its worker shutdown stops new forwards and best-effort closes active
+    upstream sockets without waiting for slow upstream responses. JSONL writer
+    shutdown is also bounded and best-effort; if it times out, process shutdown
+    continues with accepted log entries possibly still pending.
     """
     try:
         runner_flush_lifecycle.drain_and_close()

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -1,4 +1,4 @@
-"""Runner-triggered usage and JSONL flush lifecycle owner."""
+"""Runner-triggered usage flush and JSONL marker-watcher lifecycle owner."""
 
 import json
 import os
@@ -24,8 +24,8 @@ _UsageFlushPhase = Literal["running", "draining", "closed"]
 # - Rust performs a bounded wait for the acknowledged snapshot to have zero
 #   flows, buffered events, and reports before stopping the proxy.
 # - Rust may also write `jsonl-flush-request` for a concrete network log path.
-#   This addon drains accepted JSONL writes for that path and acknowledges with
-#   `jsonl-flush-state` before the runner uploads the file.
+#   An addon-owned watcher independently drains accepted JSONL writes for that
+#   path and acknowledges with `jsonl-flush-state` before Rust uploads the file.
 #
 # Keep this in sync with usage/counters.py and the Rust wait path in
 # crates/runner/src/proxy/flush.rs plus crates/runner/src/cmd/start/mod.rs.
@@ -40,10 +40,14 @@ _usage_flush_signal_lock = threading.Lock()
 # changes the phase before waiting for that lock and becomes the sole draining owner.
 _usage_flush_phase: _UsageFlushPhase = "running"
 _jsonl_flush_state_write_lock = threading.Lock()
+_jsonl_flush_worker_lock = threading.Lock()
+_jsonl_flush_stop = threading.Event()
+_jsonl_flush_worker: threading.Thread | None = None
 _last_jsonl_flush_request_id: str | None = None
 _JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
 _JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
 RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
+RUNNER_JSONL_FLUSH_POLL_SECONDS = 0.1
 
 
 def handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
@@ -51,7 +55,7 @@ def handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
 
     Keep this handler minimal: it may interrupt mitmproxy's event loop, so it
     only records that work is needed and lets the background worker perform
-    file I/O, usage flushing, and JSONL flushing.
+    file I/O and usage flushing.
     """
     global _usage_flush_requested
 
@@ -83,6 +87,7 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
 def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
     global _last_jsonl_flush_request_id, _usage_flush_phase, _usage_flush_requested
 
+    _stop_runner_jsonl_flush_worker()
     acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
     if not acquired:
         raise AssertionError("runner usage flush worker did not stop")
@@ -92,6 +97,56 @@ def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
         _last_jsonl_flush_request_id = None
     finally:
         _usage_flush_signal_lock.release()
+
+
+def start_runner_jsonl_flush_worker() -> None:
+    """Start the addon-owned JSONL marker watcher once."""
+    global _jsonl_flush_worker
+
+    with _jsonl_flush_worker_lock:
+        if _usage_flush_phase != "running":
+            return
+        if _jsonl_flush_worker is not None and _jsonl_flush_worker.is_alive():
+            return
+
+        _jsonl_flush_stop.clear()
+        worker = threading.Thread(
+            target=_run_runner_jsonl_flush_worker,
+            name="runner-jsonl-flush",
+            daemon=True,
+        )
+        worker.start()
+        _jsonl_flush_worker = worker
+
+
+def stop_runner_jsonl_flush_worker_for_tests() -> None:
+    _stop_runner_jsonl_flush_worker()
+
+
+def _run_runner_jsonl_flush_worker() -> None:
+    """Observe current-generation JSONL markers independently of usage."""
+    while True:
+        _flush_jsonl_for_runner_request()
+        if _jsonl_flush_stop.wait(RUNNER_JSONL_FLUSH_POLL_SECONDS):
+            _flush_jsonl_for_runner_request()
+            return
+
+
+def _stop_runner_jsonl_flush_worker() -> None:
+    global _jsonl_flush_worker
+
+    with _jsonl_flush_worker_lock:
+        worker = _jsonl_flush_worker
+        if worker is None:
+            return
+        _jsonl_flush_stop.set()
+
+    if worker is not threading.current_thread():
+        worker.join()
+
+    with _jsonl_flush_worker_lock:
+        if _jsonl_flush_worker is worker:
+            _jsonl_flush_worker = None
 
 
 def _start_usage_flush_worker() -> None:
@@ -140,7 +195,6 @@ def _drain_runner_usage_flush_requests() -> None:
     while _usage_flush_requested:
         _usage_flush_requested = False
         _flush_usage_for_runner_request()
-        _flush_jsonl_for_runner_request()
 
 
 def _flush_usage_for_runner_request() -> None:
@@ -251,12 +305,15 @@ def drain_and_close() -> None:
     global _usage_flush_phase
 
     _usage_flush_phase = "draining"
-    with _usage_flush_signal_lock:
-        try:
-            usage.flush_usage_events(trigger="shutdown")
-            _drain_runner_usage_flush_requests()
-        finally:
-            # Close request admission while still owning the lock, then consume
-            # any request recorded immediately before this cutoff.
-            _usage_flush_phase = "closed"
-            _drain_runner_usage_flush_requests()
+    try:
+        with _usage_flush_signal_lock:
+            try:
+                usage.flush_usage_events(trigger="shutdown")
+                _drain_runner_usage_flush_requests()
+            finally:
+                # Close request admission while still owning the lock, then consume
+                # any request recorded immediately before this cutoff.
+                _usage_flush_phase = "closed"
+                _drain_runner_usage_flush_requests()
+    finally:
+        _stop_runner_jsonl_flush_worker()

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -141,8 +141,7 @@ def _stop_runner_jsonl_flush_worker() -> None:
             return
         _jsonl_flush_stop.set()
 
-    if worker is not threading.current_thread():
-        worker.join()
+    worker.join()
 
     with _jsonl_flush_worker_lock:
         if _jsonl_flush_worker is worker:

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -14,7 +14,7 @@ from mitmproxy import ctx
 import logging_utils
 import usage
 
-_UsageFlushPhase = Literal["running", "draining", "closed"]
+_RunnerFlushPhase = Literal["running", "draining", "closed"]
 
 # Runner-triggered flush protocols:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -38,7 +38,7 @@ _usage_flush_requested: bool = False
 _usage_flush_signal_lock = threading.Lock()
 # Running workers own requests under the lock. During shutdown, drain_and_close()
 # changes the phase before waiting for that lock and becomes the sole draining owner.
-_usage_flush_phase: _UsageFlushPhase = "running"
+_runner_flush_phase: _RunnerFlushPhase = "running"
 _jsonl_flush_state_write_lock = threading.Lock()
 _jsonl_flush_worker_lock = threading.Lock()
 _jsonl_flush_stop = threading.Event()
@@ -60,7 +60,7 @@ def handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
     global _usage_flush_requested
 
     del signum
-    if _usage_flush_phase == "closed":
+    if _runner_flush_phase == "closed":
         return
     _usage_flush_requested = True
     _start_usage_flush_worker()
@@ -85,14 +85,14 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
 
 
 def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
-    global _last_jsonl_flush_request_id, _usage_flush_phase, _usage_flush_requested
+    global _last_jsonl_flush_request_id, _runner_flush_phase, _usage_flush_requested
 
     _stop_runner_jsonl_flush_worker()
     acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
     if not acquired:
         raise AssertionError("runner usage flush worker did not stop")
     try:
-        _usage_flush_phase = "running"
+        _runner_flush_phase = "running"
         _usage_flush_requested = False
         _last_jsonl_flush_request_id = None
     finally:
@@ -104,7 +104,7 @@ def start_runner_jsonl_flush_worker() -> None:
     global _jsonl_flush_worker
 
     with _jsonl_flush_worker_lock:
-        if _usage_flush_phase != "running":
+        if _runner_flush_phase != "running":
             return
         if _jsonl_flush_worker is not None and _jsonl_flush_worker.is_alive():
             return
@@ -151,11 +151,11 @@ def _stop_runner_jsonl_flush_worker() -> None:
 
 def _start_usage_flush_worker() -> None:
     """Start one flush worker, coalescing repeated signals while active."""
-    if _usage_flush_phase != "running":
+    if _runner_flush_phase != "running":
         return
     if not _usage_flush_signal_lock.acquire(blocking=False):
         return
-    if _usage_flush_phase != "running":
+    if _runner_flush_phase != "running":
         _usage_flush_signal_lock.release()
         return
 
@@ -302,9 +302,9 @@ def _write_jsonl_flush_state(
 
 def drain_and_close() -> None:
     """Drain accepted runner flush requests and close further admission."""
-    global _usage_flush_phase
+    global _runner_flush_phase
 
-    _usage_flush_phase = "draining"
+    _runner_flush_phase = "draining"
     try:
         with _usage_flush_signal_lock:
             try:
@@ -313,7 +313,7 @@ def drain_and_close() -> None:
             finally:
                 # Close request admission while still owning the lock, then consume
                 # any request recorded immediately before this cutoff.
-                _usage_flush_phase = "closed"
+                _runner_flush_phase = "closed"
                 _drain_runner_usage_flush_requests()
     finally:
         _stop_runner_jsonl_flush_worker()

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -52,9 +52,9 @@ def _reset_module_state() -> Iterator[None]:
     lookups in module-level dicts.  Without a reset, earlier tests leak
     entries that change later tests' behaviour.
 
-    The usage buffer owns a background timer in production, and the runner
-    flush signal owns a background worker that can touch usage and JSONL state,
-    so tests reset them around each case to avoid cross-test callbacks.
+    The usage buffer owns a background timer in production, while runner flush
+    handling owns a usage signal worker and a JSONL marker watcher, so tests
+    reset them around each case to avoid cross-test callbacks.
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -1,6 +1,7 @@
 """Tests for mitm addon configuration hooks."""
 
 import importlib.util
+import json
 import sys
 import uuid
 from collections.abc import Sequence
@@ -11,6 +12,7 @@ from unittest.mock import patch
 import pytest
 from mitmproxy.addonmanager import Loader
 
+import logging_utils
 import mitm_addon
 import platform_api
 import runner_flush_lifecycle
@@ -145,21 +147,44 @@ class TestAddonConfiguration:
         state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         assert state["usageStateId"] == "runner-usage-state-id"
 
-    def test_configure_writes_addon_ready_marker_with_usage_state_id(self, tmp_path):
+    def test_configure_starts_jsonl_watcher_before_addon_ready(self, tmp_path):
         ready_path = tmp_path / "addon-ready"
+        log_path = tmp_path / "network.jsonl"
+        (tmp_path / "jsonl-flush-request").write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-usage-state-id",
+                    "flushRequestId": "jsonl-request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                    "path": str(log_path),
+                }
+            )
+        )
 
         with (
             patch.object(mitm_addon, "__file__", _addon_file_path(tmp_path)),
+            patch.object(runner_flush_lifecycle, "__file__", str(tmp_path / "runner_flush.py")),
             patch.object(
                 mitm_addon.ctx,
                 "options",
                 _Options(addon_ready_path=str(ready_path)),
                 create=True,
             ),
+            patch.object(logging_utils, "flush_log_path", return_value=True) as flush_log_path,
         ):
             mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
+            mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
+            runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
 
         assert ready_path.read_text(encoding="utf-8") == "runner-usage-state-id"
+        state = json.loads((tmp_path / "jsonl-flush-state").read_text())
+        assert state["flushRequestId"] == "jsonl-request-1"
+        assert state["path"] == str(log_path)
+        assert state["pending"] == 0
+        flush_log_path.assert_called_once_with(
+            str(log_path),
+            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+        )
 
     def test_configure_writes_fallback_pending_state_id_when_usage_state_id_is_empty(
         self, tmp_path

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -149,11 +149,6 @@ class TestDoneHook:
                 "_flush_usage_for_runner_request",
                 side_effect=flush_usage_for_runner_request,
             ),
-            patch.object(
-                runner_flush_lifecycle,
-                "_flush_jsonl_for_runner_request",
-                side_effect=lambda: calls.append("flush:jsonl"),
-            ),
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
@@ -167,9 +162,7 @@ class TestDoneHook:
         assert calls == [
             "flush:shutdown",
             "flush:runner",
-            "flush:jsonl",
             "flush:runner",
-            "flush:jsonl",
             "shutdown:True",
             "auth-base:shutdown:False",
             "jsonl:shutdown",
@@ -211,10 +204,6 @@ class TestDoneHook:
                 runner_flush_lifecycle,
                 "_flush_usage_for_runner_request",
             ) as flush_runner_usage,
-            patch.object(
-                runner_flush_lifecycle,
-                "_flush_jsonl_for_runner_request",
-            ) as flush_runner_jsonl,
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
@@ -227,7 +216,6 @@ class TestDoneHook:
 
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         flush_runner_usage.assert_called_once_with()
-        flush_runner_jsonl.assert_called_once_with()
         mock_executor.shutdown.assert_called_once_with(wait=True)
         shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -1,11 +1,13 @@
-"""Tests for runner-triggered usage flush hooks."""
+"""Tests for runner-triggered usage and JSONL flush lifecycles."""
 
 import json
 import multiprocessing
 import os
 import signal
 import threading
+import time
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -31,6 +33,32 @@ _PROCESS_EXIT_TIMEOUT_SECONDS = 5
 
 def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
     runner_flush_lifecycle.wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout=timeout)
+
+
+def wait_for_jsonl_flush_state(
+    files: "RunnerUsageFlushFiles",
+    *,
+    flush_request_id: str = _DEFAULT_JSONL_FLUSH_REQUEST_ID,
+    pending: int | None = None,
+    timeout: float = 1.0,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            state = json.loads(files.jsonl_flush_state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            state = None
+        if (
+            isinstance(state, dict)
+            and state.get("flushRequestId") == flush_request_id
+            and (pending is None or state.get("pending") == pending)
+        ):
+            return state
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(f"JSONL flush state did not acknowledge {flush_request_id}")
+        time.sleep(min(0.005, remaining))
 
 
 def record_stranded_runner_usage_flush_signal() -> None:
@@ -146,6 +174,16 @@ def runner_usage_flush_files(tmp_path: Path) -> Iterator[RunnerUsageFlushFiles]:
         usage.set_pending_path("")
 
 
+@contextmanager
+def running_jsonl_flush_worker(files: RunnerUsageFlushFiles) -> Iterator[None]:
+    with patch.object(runner_flush_lifecycle, "__file__", str(files.lifecycle_file)):
+        runner_flush_lifecycle.start_runner_jsonl_flush_worker()
+        try:
+            yield
+        finally:
+            runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
+
+
 class _InstrumentedFlushOwnerLock:
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -244,7 +282,7 @@ class TestRunnerUsageFlushSignal:
         release_shutdown_flush = threading.Event()
         calls: list[str] = []
         runner_usage_flush_files.write_usage_flush_request()
-        log_path = runner_usage_flush_files.write_jsonl_flush_request()
+        log_path = runner_usage_flush_files.network_log_path
 
         def flush_usage_events(*, trigger: str) -> int:
             calls.append(f"flush:{trigger}")
@@ -286,6 +324,7 @@ class TestRunnerUsageFlushSignal:
             patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
         ):
             try:
+                runner_flush_lifecycle.start_runner_jsonl_flush_worker()
                 done_thread.start()
                 wait_for_event(
                     shutdown_flush_started,
@@ -295,9 +334,12 @@ class TestRunnerUsageFlushSignal:
                 )
 
                 runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
+                runner_usage_flush_files.write_jsonl_flush_request(log_path=log_path)
+                state = wait_for_jsonl_flush_state(runner_usage_flush_files)
+                assert state["path"] == str(log_path)
+                assert state["pending"] == 0
                 state_before_release = json.loads(runner_usage_flush_files.pending_path.read_text())
                 assert "flushRequestId" not in state_before_release
-                assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
 
                 release_shutdown_flush.set()
                 done_thread.join_and_raise(timeout=1)
@@ -353,24 +395,20 @@ class TestRunnerUsageFlushSignal:
             flush_request_id="request-1",
         )
 
-    def test_signal_handler_acknowledges_jsonl_flush_request(
+    def test_jsonl_watcher_acknowledges_flush_request(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
             patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
+            running_jsonl_flush_worker(runner_usage_flush_files),
         ):
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
+            state = wait_for_jsonl_flush_state(runner_usage_flush_files)
 
         entry = json.loads(log_path.read_text().strip())
         assert entry["action"] == "ALLOW"
-        state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
         assert state == {
             "pid": state["pid"],
             "usageStateId": "runner-state",
@@ -386,13 +424,10 @@ class TestRunnerUsageFlushSignal:
         runner_usage_flush_files.write_jsonl_flush_request(flush_request_id="../jsonl-request-1")
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
+            running_jsonl_flush_worker(runner_usage_flush_files),
         ):
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
+            pass
 
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
@@ -413,7 +448,7 @@ class TestRunnerUsageFlushSignal:
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
 
-    def test_jsonl_flush_failure_writes_pending_state(
+    def test_jsonl_flush_exception_writes_pending_state(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
@@ -426,8 +461,7 @@ class TestRunnerUsageFlushSignal:
             patch.object(logging_utils, "flush_log_path", side_effect=RuntimeError("secret")),
             patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
         ):
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
+            runner_flush_lifecycle._flush_jsonl_for_runner_request()
 
         state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
         assert state == {
@@ -467,90 +501,75 @@ class TestRunnerUsageFlushSignal:
                 "RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS",
                 0.01,
             ),
+            patch.object(
+                logging_utils,
+                "flush_log_path",
+                wraps=logging_utils.flush_log_path,
+            ) as flush_log_path,
             patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
         ):
             try:
                 logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
                 assert append_started.wait(timeout=1)
 
-                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-                wait_for_usage_flush_worker_to_stop()
-
-                state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
-                assert state == {
-                    "pid": state["pid"],
-                    "usageStateId": "runner-state",
-                    "updatedAtMs": state["updatedAtMs"],
-                    "flushRequestId": "jsonl-request-1",
-                    "path": str(log_path),
-                    "pending": 1,
-                }
-
-                with patch.object(logging_utils, "flush_log_path") as retry_flush:
-                    runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-                    wait_for_usage_flush_worker_to_stop()
-
-                retry_flush.assert_not_called()
+                runner_flush_lifecycle.start_runner_jsonl_flush_worker()
+                state = wait_for_jsonl_flush_state(runner_usage_flush_files)
+                runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
             finally:
+                runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
                 release_append.set()
                 jsonl_writer.reset_for_tests()
 
+        assert state == {
+            "pid": state["pid"],
+            "usageStateId": "runner-state",
+            "updatedAtMs": state["updatedAtMs"],
+            "flushRequestId": "jsonl-request-1",
+            "path": str(log_path),
+            "pending": 1,
+        }
+        flush_log_path.assert_called_once_with(str(log_path), timeout=0.01)
         log.warn.assert_called_once_with("JSONL flush did not complete before timeout")
 
-    def test_signal_handler_does_not_reprocess_acknowledged_jsonl_flush_request(
+    def test_jsonl_watcher_does_not_reprocess_acknowledged_request(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
             patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            running_jsonl_flush_worker(runner_usage_flush_files),
         ):
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
+            wait_for_jsonl_flush_state(runner_usage_flush_files)
 
         flush_log_path.assert_called_once_with(
             str(log_path),
             timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
         )
 
-    def test_jsonl_flush_failure_is_retryable(
+    def test_jsonl_flush_exception_is_retried_by_watcher(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
             patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
-        ):
-            with patch.object(
+            patch.object(
                 logging_utils,
                 "flush_log_path",
-                side_effect=RuntimeError("flush failed"),
-            ) as failed_flush:
-                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-                wait_for_usage_flush_worker_to_stop()
+                side_effect=(RuntimeError("flush failed"), True),
+            ) as flush_log_path,
+            running_jsonl_flush_worker(runner_usage_flush_files),
+        ):
+            state = wait_for_jsonl_flush_state(runner_usage_flush_files, pending=0)
 
-            with patch.object(logging_utils, "flush_log_path") as retry_flush:
-                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-                wait_for_usage_flush_worker_to_stop()
-
-        failed_flush.assert_called_once_with(
-            str(log_path),
-            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
-        )
-        retry_flush.assert_called_once_with(
-            str(log_path),
-            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
-        )
-        state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
+        assert flush_log_path.call_count == 2
+        for flush_call in flush_log_path.call_args_list:
+            assert flush_call.args == (str(log_path),)
+            assert flush_call.kwargs == {
+                "timeout": runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS
+            }
         assert state["pending"] == 0
 
     def test_jsonl_flush_acknowledgement_write_failure_is_retryable(
@@ -577,36 +596,18 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
-            ),
-            patch.object(
                 logging_utils,
                 "flush_log_path",
                 wraps=logging_utils.flush_log_path,
             ) as flush_log_path,
             patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
+            patch.object(Path, "replace", new=fail_first_state_replace),
+            running_jsonl_flush_worker(runner_usage_flush_files),
         ):
-            with patch.object(Path, "replace", new=fail_first_state_replace):
-                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-                wait_for_usage_flush_worker_to_stop()
+            state = wait_for_jsonl_flush_state(runner_usage_flush_files)
 
-            assert failure_injected
-            flush_log_path.assert_called_once_with(
-                str(log_path),
-                timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
-            )
-            assert not state_path.exists()
-            assert not tmp_state_path.exists()
-
-            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
-
+        assert failure_injected
         assert flush_log_path.call_count == 2
-        flush_log_path.assert_called_with(
-            str(log_path),
-            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
-        )
-        state = json.loads(state_path.read_text())
         assert state == {
             "pid": state["pid"],
             "usageStateId": "runner-state",
@@ -616,6 +617,67 @@ class TestRunnerUsageFlushSignal:
             "pending": 0,
         }
         assert not tmp_state_path.exists()
+
+    def test_jsonl_watcher_acknowledges_rapid_sequential_paths(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        first_path = runner_usage_flush_files.write_jsonl_flush_request()
+        second_path = runner_usage_flush_files.tmp_path / "network-2.jsonl"
+
+        with (
+            patch.object(logging_utils, "flush_log_path", return_value=True) as flush_log_path,
+            running_jsonl_flush_worker(runner_usage_flush_files),
+        ):
+            first_state = wait_for_jsonl_flush_state(runner_usage_flush_files)
+            runner_usage_flush_files.write_jsonl_flush_request(
+                flush_request_id="jsonl-request-2",
+                log_path=second_path,
+            )
+            second_state = wait_for_jsonl_flush_state(
+                runner_usage_flush_files,
+                flush_request_id="jsonl-request-2",
+            )
+
+        assert first_state["path"] == str(first_path)
+        assert first_state["pending"] == 0
+        assert second_state["path"] == str(second_path)
+        assert second_state["pending"] == 0
+        assert [flush_call.args for flush_call in flush_log_path.call_args_list] == [
+            (str(first_path),),
+            (str(second_path),),
+        ]
+
+    def test_jsonl_watcher_rejects_previous_usage_generation(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        runner_usage_flush_files.write_jsonl_flush_request()
+        marker = json.loads(runner_usage_flush_files.jsonl_flush_request_path.read_text())
+        marker["usageStateId"] = "previous-runner-state"
+        runner_usage_flush_files.jsonl_flush_request_path.write_text(json.dumps(marker))
+
+        with (
+            patch.object(logging_utils, "flush_log_path") as flush_log_path,
+            running_jsonl_flush_worker(runner_usage_flush_files),
+        ):
+            pass
+
+        flush_log_path.assert_not_called()
+        assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
+
+    def test_jsonl_watcher_final_observation_processes_published_marker(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        with patch.object(
+            runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
+        ):
+            runner_flush_lifecycle.start_runner_jsonl_flush_worker()
+            log_path = runner_usage_flush_files.write_jsonl_flush_request()
+            runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
+
+        state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
+        assert state["flushRequestId"] == _DEFAULT_JSONL_FLUSH_REQUEST_ID
+        assert state["path"] == str(log_path)
+        assert state["pending"] == 0
 
     def test_runner_flush_failure_warns_without_error_text(self):
         log = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -97,7 +97,7 @@ def _run_signal_while_legacy_request_flag_lock_is_held(tmp_path: str) -> None:
             "_usage_flush_requested",
             legacy_request_flag,
         ),
-        patch.object(runner_flush_lifecycle, "_usage_flush_phase", "draining"),
+        patch.object(runner_flush_lifecycle, "_runner_flush_phase", "draining"),
     ):
         signal.signal(
             runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -676,7 +676,7 @@ async fn run_start_with_home(
         log_paths,
         network_log_manager,
         network_log_drain,
-        mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
+        mitm_jsonl_flush: Some(mitm.jsonl_flush_handle()),
         network_policy_refresh,
         session_history_cpu: SessionHistoryCpuPool::for_host_cpus(host_cpus),
         session_history_probe: SessionHistoryProbe::default(),

--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -73,20 +73,18 @@ write_jsonl_flush_state() {
   now_ms="$(date +%s%3N)"
   printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"flushRequestId":"%s","path":"%s","pending":0}' "$$" "$state_id" "$now_ms" "$flush_id" "$path" > "$jsonl_state"
 }
-handle_flush_request() {
-  write_pending_snapshot
-  write_jsonl_flush_state
-}
 mkfifo "$fifo"
 exec 3<>"$fifo"
-# Match the addon lifecycle: the signal handler only wakes the worker. File I/O
-# runs outside the trap, and every queued wake reads the latest request markers.
+# Match the addon lifecycle: SIGUSR1 only wakes usage work, while the JSONL
+# marker watcher progresses independently.
 trap 'printf "\n" >&3' USR1
 trap 'exit 0' TERM
 echo ready
 while true; do
-  read -r _ <&3 || true
-  handle_flush_request
+  if read -r -t 0.05 _ <&3; then
+    write_pending_snapshot
+  fi
+  write_jsonl_flush_state
 done
 "#,
     )
@@ -174,10 +172,7 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     install_usage_flush_child(&mut config).await;
     let addon_dir = config.paths.base_dir.join("mitm-addon");
     config.proxy.mitm.set_addon_dir_for_test(addon_dir.clone());
-    let mitm_jsonl_flush = config
-        .proxy
-        .mitm
-        .jsonl_flush_handle(config.usage_flush_tx.clone());
+    let mitm_jsonl_flush = config.proxy.mitm.jsonl_flush_handle();
     let write_started = Arc::new(tokio::sync::Notify::new());
     let release_write = Arc::new(tokio::sync::Semaphore::new(0));
     let network_log_manager =

--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex as AsyncMutex, mpsc};
+use tokio::sync::Mutex as AsyncMutex;
 use tracing::{error, warn};
 use uuid::Uuid;
 
@@ -32,9 +32,6 @@ const USAGE_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Poll interval when waiting for a single JSONL path flush.
 const JSONL_FLUSH_POLL: Duration = Duration::from_millis(50);
-
-/// Minimum interval between repeated JSONL flush signals while the addon is not ready.
-const JSONL_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
@@ -156,6 +153,7 @@ impl From<&JsonlFlushState> for JsonlFlushSnapshot {
 enum FlushReadiness<S> {
     Ready,
     NotReady {
+        phase: &'static str,
         not_ready: String,
         snapshot: Option<S>,
     },
@@ -163,9 +161,11 @@ enum FlushReadiness<S> {
 
 enum FlushWaitFailure<S> {
     RequestFailed {
+        phase: &'static str,
         not_ready: String,
     },
     TimedOut {
+        phase: &'static str,
         not_ready: String,
         snapshot: Option<S>,
     },
@@ -176,7 +176,6 @@ pub struct MitmJsonlFlushHandle {
     pub(super) addon_dir: PathBuf,
     pub(super) usage_state: Arc<Mutex<UsageFlushTarget>>,
     pub(super) request_lock: Arc<AsyncMutex<()>>,
-    pub(super) request_flush_tx: mpsc::Sender<()>,
 }
 
 pub(super) fn now_millis() -> u64 {
@@ -241,21 +240,7 @@ impl MitmJsonlFlushHandle {
                 return false;
             }
         };
-        if !self.request_flush() {
-            warn!(path = %path.display(), "failed to request JSONL flush");
-            return false;
-        }
-        wait_jsonl_flush_requesting(&self.addon_dir, JSONL_FLUSH_TIMEOUT, &request, || {
-            self.request_flush()
-        })
-        .await
-    }
-
-    fn request_flush(&self) -> bool {
-        match self.request_flush_tx.try_send(()) {
-            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => true,
-            Err(mpsc::error::TrySendError::Closed(())) => false,
-        }
+        wait_jsonl_flush(&self.addon_dir, JSONL_FLUSH_TIMEOUT, &request).await
     }
 }
 
@@ -429,12 +414,11 @@ pub async fn wait_usage_flush_requesting(
     request: &UsageFlushRequest,
     request_flush: impl FnMut() -> bool,
 ) -> bool {
-    match wait_flush_requesting(
+    match wait_flush(
         addon_dir,
         "usage-pending",
         timeout,
         USAGE_FLUSH_POLL,
-        USAGE_FLUSH_REQUEST_INTERVAL,
         |content| match parse_usage_pending_state(content) {
             Ok(state) => {
                 let snapshot = Some(UsagePendingSnapshot::from(&state));
@@ -443,6 +427,7 @@ pub async fn wait_usage_flush_requesting(
                         FlushReadiness::Ready
                     }
                     Ok(()) => FlushReadiness::NotReady {
+                        phase: "pending_delivery",
                         not_ready: format!(
                             "pending flows={} buffered={} reports={}",
                             state.flows, state.buffered, state.reports
@@ -450,27 +435,30 @@ pub async fn wait_usage_flush_requesting(
                         snapshot,
                     },
                     Err(not_ready) => FlushReadiness::NotReady {
+                        phase: "state_validation",
                         not_ready,
                         snapshot,
                     },
                 }
             }
             Err(not_ready) => FlushReadiness::NotReady {
+                phase: "state_read",
                 not_ready,
                 snapshot: None,
             },
         },
-        request_flush,
+        Some((USAGE_FLUSH_REQUEST_INTERVAL, request_flush)),
     )
     .await
     {
         Ok(()) => true,
-        Err(FlushWaitFailure::RequestFailed { not_ready }) => {
+        Err(FlushWaitFailure::RequestFailed { phase, not_ready }) => {
             error!(
                 r#type = "usage_underbilling",
                 reason = "usage_flush_request_failed",
                 underbilling_class = "risk",
                 component = "runner",
+                phase,
                 not_ready = %not_ready,
                 request_usage_state_id = %request.core.expected_usage_state_id,
                 request_id = %request.core.flush_request_id,
@@ -479,6 +467,7 @@ pub async fn wait_usage_flush_requesting(
             false
         }
         Err(FlushWaitFailure::TimedOut {
+            phase,
             not_ready,
             snapshot,
         }) => {
@@ -489,6 +478,7 @@ pub async fn wait_usage_flush_requesting(
                         reason = "usage_flush_timeout",
                         underbilling_class = "risk",
                         component = "runner",
+                        phase,
                         timeout_secs = timeout.as_secs(),
                         not_ready = %not_ready,
                         pid = snapshot.pid,
@@ -507,6 +497,7 @@ pub async fn wait_usage_flush_requesting(
                         reason = "usage_flush_timeout",
                         underbilling_class = "risk",
                         component = "runner",
+                        phase,
                         timeout_secs = timeout.as_secs(),
                         not_ready = %not_ready,
                         request_usage_state_id = %request.core.expected_usage_state_id,
@@ -520,40 +511,57 @@ pub async fn wait_usage_flush_requesting(
     }
 }
 
-async fn wait_flush_requesting<S>(
+async fn wait_flush<S, F>(
     addon_dir: &Path,
     state_file_name: &str,
     timeout: Duration,
     poll_interval: Duration,
-    repeat_request_interval: Duration,
     mut evaluate_state: impl FnMut(&str) -> FlushReadiness<S>,
-    mut request_flush: impl FnMut() -> bool,
-) -> Result<(), FlushWaitFailure<S>> {
+    mut repeat_request: Option<(Duration, F)>,
+) -> Result<(), FlushWaitFailure<S>>
+where
+    F: FnMut() -> bool,
+{
     let path = addon_dir.join(state_file_name);
     let started_at = tokio::time::Instant::now();
     let deadline = started_at + timeout;
-    let mut next_flush_request_at = started_at + repeat_request_interval;
+    let mut next_flush_request_at = repeat_request
+        .as_ref()
+        .map(|(repeat_request_interval, _)| started_at + *repeat_request_interval);
     loop {
-        let (not_ready, snapshot) = match read_addon_state_file(&path).await {
+        let (phase, not_ready, snapshot) = match read_addon_state_file(&path).await {
             Ok(Some(content)) => match evaluate_state(&content) {
                 FlushReadiness::Ready => return Ok(()),
                 FlushReadiness::NotReady {
+                    phase,
                     not_ready,
                     snapshot,
-                } => (not_ready, snapshot),
+                } => (phase, not_ready, snapshot),
             },
-            Ok(None) => (format!("cannot read {}: not found", path.display()), None),
-            Err(e) => (format!("cannot read {}: {e}", path.display()), None),
+            Ok(None) => (
+                "state_read",
+                format!("cannot read {}: not found", path.display()),
+                None,
+            ),
+            Err(e) => (
+                "state_read",
+                format!("cannot read {}: {e}", path.display()),
+                None,
+            ),
         };
         let now = tokio::time::Instant::now();
-        if now >= next_flush_request_at {
+        if let Some(next_request_at) = next_flush_request_at.as_mut()
+            && let Some((repeat_request_interval, request_flush)) = repeat_request.as_mut()
+            && now >= *next_request_at
+        {
             if !request_flush() {
-                return Err(FlushWaitFailure::RequestFailed { not_ready });
+                return Err(FlushWaitFailure::RequestFailed { phase, not_ready });
             }
-            next_flush_request_at = now + repeat_request_interval;
+            *next_request_at = now + *repeat_request_interval;
         }
         if now >= deadline {
             return Err(FlushWaitFailure::TimedOut {
+                phase,
                 not_ready,
                 snapshot,
             });
@@ -562,68 +570,71 @@ async fn wait_flush_requesting<S>(
     }
 }
 
-#[cfg(test)]
 async fn wait_jsonl_flush(
     addon_dir: &Path,
     timeout: Duration,
     request: &JsonlFlushRequest,
 ) -> bool {
-    wait_jsonl_flush_requesting(addon_dir, timeout, request, || true).await
-}
-
-async fn wait_jsonl_flush_requesting(
-    addon_dir: &Path,
-    timeout: Duration,
-    request: &JsonlFlushRequest,
-    request_flush: impl FnMut() -> bool,
-) -> bool {
-    match wait_flush_requesting(
+    match wait_flush::<_, fn() -> bool>(
         addon_dir,
         "jsonl-flush-state",
         timeout,
         JSONL_FLUSH_POLL,
-        JSONL_FLUSH_REQUEST_INTERVAL,
         |content| match parse_jsonl_flush_state(content) {
             Ok(state) => {
                 let snapshot = Some(JsonlFlushSnapshot::from(&state));
                 match validate_jsonl_flush_state(&state, request, now_millis()) {
                     Ok(()) if state.pending == 0 => FlushReadiness::Ready,
                     Ok(()) => FlushReadiness::NotReady {
+                        phase: "path_drain",
                         not_ready: format!("pending writes={}", state.pending),
                         snapshot,
                     },
                     Err(not_ready) => FlushReadiness::NotReady {
+                        phase: "state_validation",
                         not_ready,
                         snapshot,
                     },
                 }
             }
             Err(not_ready) => FlushReadiness::NotReady {
+                phase: "state_read",
                 not_ready,
                 snapshot: None,
             },
         },
-        request_flush,
+        None,
     )
     .await
     {
         Ok(()) => true,
-        Err(FlushWaitFailure::RequestFailed { not_ready }) => {
+        Err(FlushWaitFailure::RequestFailed { phase, not_ready }) => {
             warn!(
+                phase,
                 reason = %not_ready,
-                "JSONL flush request failed, proceeding with network log upload"
+                expected_request_id = %request.core.flush_request_id,
+                expected_usage_state_id = %request.core.expected_usage_state_id,
+                expected_path = %request.path,
+                expected_requested_at_ms = request.core.requested_at_ms,
+                "JSONL flush wait stopped, proceeding with network log upload"
             );
             false
         }
         Err(FlushWaitFailure::TimedOut {
+            phase,
             not_ready,
             snapshot,
         }) => {
             match snapshot {
                 Some(snapshot) => {
                     warn!(
+                        phase,
                         timeout_secs = timeout.as_secs(),
                         reason = %not_ready,
+                        expected_request_id = %request.core.flush_request_id,
+                        expected_usage_state_id = %request.core.expected_usage_state_id,
+                        expected_path = %request.path,
+                        expected_requested_at_ms = request.core.requested_at_ms,
                         pid = snapshot.pid,
                         usage_state_id = %snapshot.usage_state_id,
                         updated_at_ms = snapshot.updated_at_ms,
@@ -635,8 +646,13 @@ async fn wait_jsonl_flush_requesting(
                 }
                 None => {
                     warn!(
+                        phase,
                         timeout_secs = timeout.as_secs(),
                         reason = %not_ready,
+                        expected_request_id = %request.core.flush_request_id,
+                        expected_usage_state_id = %request.core.expected_usage_state_id,
+                        expected_path = %request.path,
+                        expected_requested_at_ms = request.core.requested_at_ms,
                         "JSONL flush timed out, proceeding with network log upload"
                     );
                 }
@@ -696,11 +712,35 @@ mod tests {
         );
     }
 
+    fn assert_jsonl_expected_fields(event: &CapturedEvent, path: &Path, phase: &str) {
+        assert_event_field(event, "phase", phase);
+        assert_event_field(event, "expected_request_id", "jsonl-request-test");
+        assert_event_field(event, "expected_usage_state_id", "state-test");
+        assert_event_field(event, "expected_path", &path.to_string_lossy());
+        assert_event_field(event, "expected_requested_at_ms", "1770000000000");
+    }
+
     fn usage_target() -> UsageFlushTarget {
         UsageFlushTarget {
             expected_usage_state_id: "state-test".to_string(),
             usage_state_started_at_ms: 1_770_000_000_000,
         }
+    }
+
+    async fn wait_for_jsonl_request(addon_dir: &Path, expected_path: &Path) -> serde_json::Value {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Ok(content) = std::fs::read_to_string(addon_dir.join("jsonl-flush-request"))
+                    && let Ok(marker) = serde_json::from_str::<serde_json::Value>(&content)
+                    && marker["path"] == expected_path.to_string_lossy().as_ref()
+                {
+                    return marker;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("JSONL flush request was not published")
     }
 
     fn usage_request() -> UsageFlushRequest {
@@ -936,67 +976,6 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn wait_jsonl_flush_requests_flush_when_pending() {
-        let dir = tempfile::tempdir().unwrap();
-        let log_path = dir.path().join("network.jsonl");
-        let request = jsonl_request(&log_path);
-        let path = dir.path().join("jsonl-flush-state");
-        std::fs::write(&path, jsonl_state(&log_path, 1)).unwrap();
-        let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-        let p = path.clone();
-        let l = log_path.clone();
-        let requests = std::sync::Arc::clone(&request_count);
-        let flushed =
-            wait_jsonl_flush_requesting(dir.path(), Duration::from_secs(5), &request, || {
-                requests.fetch_add(1, Ordering::SeqCst);
-                std::fs::write(&p, jsonl_state(&l, 0)).unwrap();
-                true
-            })
-            .await;
-
-        assert!(flushed);
-        assert_eq!(request_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn wait_jsonl_flush_request_failure_at_deadline_logs_warning() {
-        let dir = tempfile::tempdir().unwrap();
-        let log_path = dir.path().join("network.jsonl");
-        let request = jsonl_request(&log_path);
-        std::fs::write(
-            dir.path().join("jsonl-flush-state"),
-            jsonl_state(&log_path, 1),
-        )
-        .unwrap();
-        let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-
-        let requests = std::sync::Arc::clone(&request_count);
-        let (flushed, events) = capture_async_log_events(wait_jsonl_flush_requesting(
-            dir.path(),
-            JSONL_FLUSH_REQUEST_INTERVAL,
-            &request,
-            || {
-                requests.fetch_add(1, Ordering::SeqCst);
-                false
-            },
-        ))
-        .await;
-
-        assert!(!flushed);
-        assert_eq!(request_count.load(Ordering::SeqCst), 1);
-        assert_eq!(events.len(), 1, "captured events: {events:#?}");
-        let event = &events[0];
-        assert_eq!(event.level, Level::WARN);
-        assert_event_field(
-            event,
-            "message",
-            "JSONL flush request failed, proceeding with network log upload",
-        );
-        assert_event_field(event, "reason", "pending writes=1");
-    }
-
-    #[tokio::test(start_paused = true)]
     async fn wait_jsonl_flush_timeout_logs_snapshot_fields() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("network.jsonl");
@@ -1024,6 +1003,7 @@ mod tests {
             "JSONL flush timed out, proceeding with network log upload",
         );
         assert_event_field(event, "reason", "pending writes=2");
+        assert_jsonl_expected_fields(event, &log_path, "path_drain");
         assert_event_field(event, "pid", "1234");
         assert_event_field(event, "flush_request_id", "jsonl-request-test");
         let log_path_string = log_path.to_string_lossy().to_string();
@@ -1058,6 +1038,7 @@ mod tests {
             event_field(event, "reason").starts_with("state file is not valid JSONL flush JSON:"),
             "event={event:#?}"
         );
+        assert_jsonl_expected_fields(event, &log_path, "state_read");
         assert_event_missing_field(event, "pid");
         assert_event_missing_field(event, "path");
         assert_event_missing_field(event, "pending");
@@ -1096,6 +1077,7 @@ mod tests {
             "reason",
             "JSONL flush path does not match current request",
         );
+        assert_jsonl_expected_fields(event, &log_path, "state_validation");
         assert_event_field(event, "pid", "1234");
         assert_event_field(event, "flush_request_id", "jsonl-request-test");
         let other_path_string = other_path.to_string_lossy().to_string();
@@ -1104,26 +1086,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn jsonl_flush_handle_writes_request_and_sends_flush_signal() {
+    async fn jsonl_flush_handle_completes_without_usage_channel() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("network.jsonl");
-        let (tx, mut rx) = mpsc::channel(1);
         let usage_state = Arc::new(Mutex::new(usage_target()));
         let handle = MitmJsonlFlushHandle {
             addon_dir: dir.path().to_path_buf(),
             usage_state,
             request_lock: Arc::new(AsyncMutex::new(())),
-            request_flush_tx: tx,
         };
 
         let d = dir.path().to_path_buf();
         let l = log_path.clone();
         let waiter = tokio::spawn(async move { handle.flush_path(&l).await });
 
-        rx.recv().await.unwrap();
-        let marker: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(d.join("jsonl-flush-request")).unwrap())
-                .unwrap();
+        let marker = wait_for_jsonl_request(&d, &log_path).await;
         let state = serde_json::json!({
             "pid": 1234,
             "usageStateId": "state-test",
@@ -1142,23 +1119,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let first_log_path = dir.path().join("network-a.jsonl");
         let second_log_path = dir.path().join("network-b.jsonl");
-        let (tx, mut rx) = mpsc::channel(1);
         let handle = MitmJsonlFlushHandle {
             addon_dir: dir.path().to_path_buf(),
             usage_state: Arc::new(Mutex::new(usage_target())),
             request_lock: Arc::new(AsyncMutex::new(())),
-            request_flush_tx: tx,
         };
 
         let first_handle = handle.clone();
         let first_path = first_log_path.clone();
         let first = tokio::spawn(async move { first_handle.flush_path(&first_path).await });
 
-        rx.recv().await.unwrap();
-        let first_marker: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
-        )
-        .unwrap();
+        let first_marker = wait_for_jsonl_request(dir.path(), &first_log_path).await;
         assert_eq!(
             first_marker["path"],
             first_log_path.to_string_lossy().to_string()
@@ -1168,7 +1139,14 @@ mod tests {
         let second_path = second_log_path.clone();
         let second = tokio::spawn(async move { second_handle.flush_path(&second_path).await });
         tokio::task::yield_now().await;
-        assert!(rx.try_recv().is_err());
+        let marker_while_first_is_pending: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            marker_while_first_is_pending["path"],
+            first_log_path.to_string_lossy().to_string()
+        );
 
         let first_state = serde_json::json!({
             "pid": 1234,
@@ -1185,11 +1163,7 @@ mod tests {
         .unwrap();
         assert!(first.await.unwrap());
 
-        rx.recv().await.unwrap();
-        let second_marker: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
-        )
-        .unwrap();
+        let second_marker = wait_for_jsonl_request(dir.path(), &second_log_path).await;
         assert_eq!(
             second_marker["path"],
             second_log_path.to_string_lossy().to_string()
@@ -1217,18 +1191,13 @@ mod tests {
         let second_log_path = dir.path().join("network-b.jsonl");
         let (mut proxy, _crash_rx) = MitmProxy::noop();
         proxy.set_addon_dir_for_test(dir.path().to_path_buf());
-        let (tx, mut rx) = mpsc::channel(1);
-        let first_handle = proxy.jsonl_flush_handle(tx.clone());
-        let second_handle = proxy.jsonl_flush_handle(tx);
+        let first_handle = proxy.jsonl_flush_handle();
+        let second_handle = proxy.jsonl_flush_handle();
 
         let first_path = first_log_path.clone();
         let first = tokio::spawn(async move { first_handle.flush_path(&first_path).await });
 
-        rx.recv().await.unwrap();
-        let first_marker: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
-        )
-        .unwrap();
+        let first_marker = wait_for_jsonl_request(dir.path(), &first_log_path).await;
         assert_eq!(
             first_marker["path"],
             first_log_path.to_string_lossy().to_string()
@@ -1237,7 +1206,14 @@ mod tests {
         let second_path = second_log_path.clone();
         let second = tokio::spawn(async move { second_handle.flush_path(&second_path).await });
         tokio::task::yield_now().await;
-        assert!(rx.try_recv().is_err());
+        let marker_while_first_is_pending: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            marker_while_first_is_pending["path"],
+            first_log_path.to_string_lossy().to_string()
+        );
 
         let first_state = serde_json::json!({
             "pid": 1234,
@@ -1254,11 +1230,7 @@ mod tests {
         .unwrap();
         assert!(first.await.unwrap());
 
-        rx.recv().await.unwrap();
-        let second_marker: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
-        )
-        .unwrap();
+        let second_marker = wait_for_jsonl_request(dir.path(), &second_log_path).await;
         assert_eq!(
             second_marker["path"],
             second_log_path.to_string_lossy().to_string()

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -46,8 +46,8 @@
 //!
 //! Addon-side details live in `crates/runner/mitm-addon/src/mitm_addon.py`
 //! (mitmproxy hook orchestration),
-//! `crates/runner/mitm-addon/src/runner_flush_lifecycle.py` (SIGUSR1 worker and
-//! request handling),
+//! `crates/runner/mitm-addon/src/runner_flush_lifecycle.py` (SIGUSR1 usage
+//! worker and JSONL marker watcher),
 //! `crates/runner/mitm-addon/src/usage/counters.py` (`usage-pending`),
 //! `crates/runner/mitm-addon/src/registry.py` (registry loading), and
 //! `crates/runner/mitm-addon/src/jsonl_writer.py` (accepted-write flush

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -192,12 +192,11 @@ impl MitmProxy {
     }
 
     /// Create a cloneable handle for asking the addon to flush accepted JSONL writes.
-    pub fn jsonl_flush_handle(&self, request_flush_tx: mpsc::Sender<()>) -> MitmJsonlFlushHandle {
+    pub fn jsonl_flush_handle(&self) -> MitmJsonlFlushHandle {
         MitmJsonlFlushHandle {
             addon_dir: self.config.addon_dir.clone(),
             usage_state: Arc::clone(&self.usage_flush_state),
             request_lock: Arc::clone(&self.jsonl_flush_request_lock),
-            request_flush_tx,
         }
     }
 


### PR DESCRIPTION
## Summary

- start an addon-owned JSONL flush marker watcher before publishing addon readiness
- keep SIGUSR1 and the capacity-one runner channel scoped to usage flushes
- have Rust publish each JSONL request and wait directly for the matching acknowledgement
- preserve request serialization and generation/path validation while adding actionable timeout diagnostics

## Compatibility

- no database schema, migration, product data, public API, queue payload, or persisted-state format changes
- usage flush delivery and billing shutdown semantics remain unchanged
- JSONL request and acknowledgement files retain their existing formats

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner`

Closes #23590
