### PR TITLE
fix(runner): bound decoded websocket messages

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -14,9 +14,9 @@ test = [
     "h2>=4.3.0",
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
-    # Keep tests on the exact runtime version from crates/runner/src/deps.rs.
+    # Keep tests on the exact standalone runtime and its release-locked wsproto.
     "mitmproxy==12.2.3",
-    "wsproto>=1.2",
+    "wsproto==1.3.2",
     "zstandard>=0.25.0",
 ]
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -130,7 +130,7 @@ class _AuthBaseBodyCheck:
 
 def load(loader: Loader) -> None:
     """Register custom options for the addon."""
-    mitmproxy_compat.install_request_end_stream_bridge()
+    mitmproxy_compat.install_runtime_compatibility()
     signal.signal(
         runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
         runner_flush_lifecycle.handle_runner_usage_flush_signal,

--- a/crates/runner/mitm-addon/src/mitmproxy_compat.py
+++ b/crates/runner/mitm-addon/src/mitmproxy_compat.py
@@ -1,27 +1,42 @@
 """Version-locked bridges for mitmproxy state that public hooks omit."""
 
+import wsproto
 from mitmproxy import http, version
 from mitmproxy.proxy import layer
 from mitmproxy.proxy.layers.http import HttpStream
 from mitmproxy.proxy.layers.http._events import RequestHeaders
 from mitmproxy.proxy.layers.http._hooks import HttpRequestHeadersHook
 
+import websocket_framing
+
 # Keep this synchronized with ``crates/runner/src/deps.rs`` and the Python
-# test dependencies. Re-audit the private imports and generator behavior before
-# accepting another version.
+# test dependencies. Re-audit the private imports, generators, and WebSocket
+# extension behavior before accepting another version.
 _SUPPORTED_MITMPROXY_VERSION = "12.2.3"
+_SUPPORTED_WSPROTO_VERSION = "1.3.2"
 _BRIDGE_MARKER_ATTRIBUTE = "_vm0_request_end_stream_bridge"
 _REQUEST_END_STREAM_METADATA = "_vm0_request_end_stream"
 
 
-def install_request_end_stream_bridge() -> None:
-    """Expose RequestHeaders.end_stream to the matching public hook once."""
+def install_runtime_compatibility() -> None:
+    """Install all exact-version mitmproxy compatibility adaptations."""
     if version.VERSION != _SUPPORTED_MITMPROXY_VERSION:
         raise RuntimeError(
-            "VM0's request framing bridge requires mitmproxy "
+            "VM0's runtime compatibility layer requires mitmproxy "
             f"{_SUPPORTED_MITMPROXY_VERSION}; found {version.VERSION}"
         )
+    if wsproto.__version__ != _SUPPORTED_WSPROTO_VERSION:
+        raise RuntimeError(
+            "VM0's runtime compatibility layer requires wsproto "
+            f"{_SUPPORTED_WSPROTO_VERSION}; found {wsproto.__version__}"
+        )
 
+    _install_request_end_stream_bridge()
+    websocket_framing.install_websocket_framing()
+
+
+def _install_request_end_stream_bridge() -> None:
+    """Expose RequestHeaders.end_stream to the matching public hook once."""
     current_handler = HttpStream.state_wait_for_request_headers
     if hasattr(current_handler, _BRIDGE_MARKER_ATTRIBUTE):
         return

--- a/crates/runner/mitm-addon/src/websocket_framing.py
+++ b/crates/runner/mitm-addon/src/websocket_framing.py
@@ -1,0 +1,283 @@
+"""Bound decoded WebSocket messages before mitmproxy's addon hooks."""
+
+from __future__ import annotations
+
+import zlib
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import cast
+
+import wsproto
+from mitmproxy import connection
+from mitmproxy.proxy import commands
+from mitmproxy.proxy.layers import websocket
+from wsproto import events
+from wsproto.extensions import Extension, PerMessageDeflate
+from wsproto.frame_protocol import CloseReason, FrameDecoder, FrameProtocol, Opcode, RsvBits
+
+MAX_DECODED_MESSAGE_BYTES = 16 * 1024 * 1024
+MAX_MESSAGE_DATA_FRAMES = 8_192
+
+_EMPTY_DEFLATE_BLOCK = b"\x00\x00\xff\xff"
+_CONNECTION_MARKER_ATTRIBUTE = "_vm0_bounded_websocket_framing"
+_ORIGINAL_WEBSOCKET_CONNECTION = websocket.WebsocketConnection
+
+
+@dataclass
+class _MessageBudget:
+    max_decoded_bytes: int
+    max_data_frames: int
+    decoded_bytes: int = 0
+    data_frames: int = 0
+
+    @property
+    def remaining_bytes(self) -> int:
+        return self.max_decoded_bytes - self.decoded_bytes
+
+    def reserve_bytes(self, size: int) -> bool:
+        if size > self.remaining_bytes:
+            return False
+        self.decoded_bytes += size
+        return True
+
+    def reserve_frame(self) -> bool:
+        if self.data_frames >= self.max_data_frames:
+            return False
+        self.data_frames += 1
+        return True
+
+    def reset(self) -> None:
+        self.decoded_bytes = 0
+        self.data_frames = 0
+
+
+class _DecodedMessageLimit(Extension):
+    """Count decoded data after negotiated inbound extensions run."""
+
+    name = "vm0-decoded-message-limit"
+
+    def __init__(self, budget: _MessageBudget) -> None:
+        self._budget = budget
+        self._opcode: Opcode | None = None
+        self._frame_started = False
+
+    def enabled(self) -> bool:
+        return True
+
+    def offer(self) -> bool:
+        return False
+
+    def frame_inbound_header(
+        self,
+        proto: FrameDecoder | FrameProtocol,
+        opcode: Opcode,
+        rsv: RsvBits,
+        payload_length: int,
+    ) -> RsvBits:
+        self._opcode = opcode
+        return RsvBits(False, False, False)
+
+    def frame_inbound_payload_data(
+        self,
+        proto: FrameDecoder | FrameProtocol,
+        data: bytes,
+    ) -> bytes | CloseReason:
+        opcode = self._opcode
+        if opcode is None:
+            raise RuntimeError("WebSocket payload arrived without a frame header")
+        if opcode.iscontrol():
+            return data
+
+        if not self._frame_started:
+            self._frame_started = True
+            if not self._budget.reserve_frame():
+                return CloseReason.MESSAGE_TOO_BIG
+
+        if not self._budget.reserve_bytes(len(data)):
+            return CloseReason.MESSAGE_TOO_BIG
+        return data
+
+    def frame_inbound_complete(
+        self,
+        proto: FrameDecoder | FrameProtocol,
+        fin: bool,
+    ) -> None:
+        opcode = self._opcode
+        if opcode is None:
+            raise RuntimeError("WebSocket frame completed without a frame header")
+        is_control = opcode.iscontrol()
+        self._opcode = None
+        self._frame_started = False
+        if fin and not is_control:
+            self._budget.reset()
+
+    def clear(self) -> None:
+        self._opcode = None
+        self._frame_started = False
+        self._budget.reset()
+
+
+class _BoundedPerMessageDeflate(PerMessageDeflate):
+    """Apply the shared decoded-message budget while inflating input."""
+
+    def __init__(self, source: PerMessageDeflate, budget: _MessageBudget) -> None:
+        super().__init__(
+            client_no_context_takeover=source.client_no_context_takeover,
+            client_max_window_bits=source.client_max_window_bits,
+            server_no_context_takeover=source.server_no_context_takeover,
+            server_max_window_bits=source.server_max_window_bits,
+        )
+        if not source.enabled():
+            raise RuntimeError("mitmproxy passed a disabled permessage-deflate extension")
+        self.finalize(self.name)
+        self._budget = budget
+
+    def _discard_inbound_state(self) -> None:
+        self._decompressor = None
+        self._inbound_is_compressible = None
+        self._inbound_compressed = None
+        self._budget.reset()
+
+    def clear(self) -> None:
+        self._compressor = None
+        self._discard_inbound_state()
+
+    def _decompress_bounded(self, data: bytes) -> bytes | CloseReason:
+        decompressor = self._decompressor
+        if decompressor is None:
+            raise RuntimeError("compressed WebSocket data arrived without a decompressor")
+        remaining = self._budget.remaining_bytes
+        try:
+            decoded = decompressor.decompress(data, remaining + 1)
+        except zlib.error:
+            self._discard_inbound_state()
+            return CloseReason.INVALID_FRAME_PAYLOAD_DATA
+
+        if len(decoded) > remaining or decompressor.unconsumed_tail:
+            self._discard_inbound_state()
+            return CloseReason.MESSAGE_TOO_BIG
+        return decoded
+
+    def frame_inbound_payload_data(
+        self,
+        proto: FrameDecoder | FrameProtocol,
+        data: bytes,
+    ) -> bytes | CloseReason:
+        if not self._inbound_compressed or not self._inbound_is_compressible:
+            return data
+        return self._decompress_bounded(bytes(data))
+
+    def frame_inbound_complete(
+        self,
+        proto: FrameDecoder | FrameProtocol,
+        fin: bool,
+    ) -> bytes | CloseReason | None:
+        if not fin:
+            return None
+        if not self._inbound_is_compressible:
+            self._inbound_compressed = None
+            return None
+        if not self._inbound_compressed:
+            self._inbound_compressed = None
+            return None
+
+        decoded = self._decompress_bounded(_EMPTY_DEFLATE_BLOCK)
+        if isinstance(decoded, CloseReason):
+            return decoded
+        if not self._budget.reserve_bytes(len(decoded)):
+            self._discard_inbound_state()
+            return CloseReason.MESSAGE_TOO_BIG
+
+        if proto.client:
+            no_context_takeover = self.server_no_context_takeover
+        else:
+            no_context_takeover = self.client_no_context_takeover
+        if no_context_takeover:
+            self._decompressor = None
+
+        self._inbound_compressed = None
+        return decoded
+
+
+class _BoundedWebsocketConnection(_ORIGINAL_WEBSOCKET_CONNECTION):
+    """Pinned mitmproxy connection with bounded inbound message state."""
+
+    def __init__(
+        self,
+        connection_type: wsproto.ConnectionType,
+        extensions: list[Extension] | None = None,
+        trailing_data: bytes = b"",
+        *,
+        conn: connection.Connection,
+    ) -> None:
+        budget = _MessageBudget(
+            max_decoded_bytes=MAX_DECODED_MESSAGE_BYTES,
+            max_data_frames=MAX_MESSAGE_DATA_FRAMES,
+        )
+        bounded_extensions: list[Extension] = []
+        bounded_deflates: list[_BoundedPerMessageDeflate] = []
+        for extension in extensions or []:
+            if isinstance(extension, PerMessageDeflate):
+                bounded_deflate = _BoundedPerMessageDeflate(extension, budget)
+                bounded_extensions.append(bounded_deflate)
+                bounded_deflates.append(bounded_deflate)
+            else:
+                bounded_extensions.append(extension)
+
+        message_limit = _DecodedMessageLimit(budget)
+        bounded_extensions.append(message_limit)
+        super().__init__(
+            connection_type,
+            bounded_extensions,
+            trailing_data,
+            conn=conn,
+        )
+        self._vm0_message_limit = message_limit
+        self._vm0_bounded_deflates = bounded_deflates
+        self.frame_buf = [self._mutable_fragment()]
+
+    @staticmethod
+    def _mutable_fragment(data: bytes = b"") -> bytes:
+        # mitmproxy types frame_buf as list[bytes], but bytearray is accepted by
+        # bytes.join and makes its existing ``frame_buf[-1] += data`` mutate.
+        return cast(bytes, bytearray(data))
+
+    def _ensure_mutable_fragment(self) -> None:
+        if not self.frame_buf:
+            self.frame_buf.append(self._mutable_fragment())
+        elif isinstance(self.frame_buf[-1], bytes):
+            self.frame_buf[-1] = self._mutable_fragment(self.frame_buf[-1])
+
+    def _clear_partial_state(self) -> None:
+        self.frame_buf = [self._mutable_fragment()]
+        self._vm0_message_limit.clear()
+        for extension in self._vm0_bounded_deflates:
+            extension.clear()
+
+    def events(self) -> Generator[events.Event, None, None]:
+        try:
+            for event in super().events():
+                if isinstance(event, events.CloseConnection):
+                    self._clear_partial_state()
+                yield event
+                self._ensure_mutable_fragment()
+        finally:
+            self._ensure_mutable_fragment()
+
+    def send2(self, event: events.Event) -> commands.SendData:
+        if isinstance(event, events.CloseConnection):
+            self._clear_partial_state()
+        return super().send2(event)
+
+
+setattr(_BoundedWebsocketConnection, _CONNECTION_MARKER_ATTRIBUTE, True)
+
+
+def install_websocket_framing() -> None:
+    """Install the pinned connection class once."""
+    current_connection = websocket.WebsocketConnection
+    if hasattr(current_connection, _CONNECTION_MARKER_ATTRIBUTE):
+        return
+    if current_connection is not _ORIGINAL_WEBSOCKET_CONNECTION:
+        raise RuntimeError("mitmproxy WebsocketConnection has an incompatible shape")
+    websocket.WebsocketConnection = _BoundedWebsocketConnection

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -129,7 +129,22 @@ class TestAddonConfiguration:
 
         with (
             patch.object(mitm_addon.mitmproxy_compat.version, "VERSION", "12.2.4"),
-            pytest.raises(RuntimeError, match=r"requires mitmproxy 12\.2\.3; found 12\.2\.4"),
+            pytest.raises(
+                RuntimeError,
+                match=r"runtime compatibility layer requires mitmproxy 12\.2\.3; found 12\.2\.4",
+            ),
+        ):
+            mitm_addon.load(loader)
+
+    def test_load_rejects_unreviewed_wsproto_version(self):
+        loader = Loader(_RecordingMaster())
+
+        with (
+            patch.object(mitm_addon.mitmproxy_compat.wsproto, "__version__", "1.3.3"),
+            pytest.raises(
+                RuntimeError,
+                match=r"runtime compatibility layer requires wsproto 1\.3\.2; found 1\.3\.3",
+            ),
         ):
             mitm_addon.load(loader)
 

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
@@ -1,0 +1,470 @@
+"""WebSocket framing integration tests through mitmproxy's real hook pipeline."""
+
+import weakref
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+from unittest.mock import patch
+
+import pytest
+import wsproto
+import wsproto.events
+import wsproto.extensions
+from mitmproxy import connection, http
+from mitmproxy.addons.proxyserver import Proxyserver
+from mitmproxy.proxy import commands, events
+from mitmproxy.proxy.commands import StartHook
+from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.layers import websocket
+from mitmproxy.test import taddons
+from mitmproxy.websocket import WebSocketData
+from wsproto.connection import Connection as WsprotoConnection
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import websocket_framing
+
+_CLIENT_IP = "10.200.0.5"
+_HOST = "websocket.example.com"
+
+
+@dataclass
+class _RunningWebSocket:
+    layer: websocket.WebsocketLayer
+    flow: http.HTTPFlow
+    client: connection.Client
+    server: connection.Server
+
+
+class _ZlibDecompressor(Protocol):
+    def decompress(self, data: bytes, /, max_length: int = 0) -> bytes: ...
+
+    @property
+    def unconsumed_tail(self) -> bytes: ...
+
+
+@dataclass
+class _DecompressionStats:
+    max_lengths: list[int] = field(default_factory=list)
+    output_sizes: list[int] = field(default_factory=list)
+    instances: list[weakref.ReferenceType["_TrackingDecompressor"]] = field(default_factory=list)
+
+
+class _TrackingDecompressor:
+    def __init__(self, inner: _ZlibDecompressor, stats: _DecompressionStats) -> None:
+        self._inner = inner
+        self._stats = stats
+
+    def decompress(self, data: bytes, /, max_length: int = 0) -> bytes:
+        decoded = self._inner.decompress(data, max_length)
+        self._stats.max_lengths.append(max_length)
+        self._stats.output_sizes.append(len(decoded))
+        return decoded
+
+    @property
+    def unconsumed_tail(self) -> bytes:
+        return self._inner.unconsumed_tail
+
+
+def _track_zlib_decompression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _DecompressionStats:
+    real_decompressobj = zlib.decompressobj
+    stats = _DecompressionStats()
+
+    def tracking_decompressobj(
+        wbits: int = zlib.MAX_WBITS,
+        zdict: bytes | None = None,
+    ) -> _TrackingDecompressor:
+        if zdict is None:
+            inner = real_decompressobj(wbits)
+        else:
+            inner = real_decompressobj(wbits, zdict=zdict)
+        tracked = _TrackingDecompressor(inner, stats)
+        stats.instances.append(weakref.ref(tracked))
+        return tracked
+
+    monkeypatch.setattr(websocket_framing.zlib, "decompressobj", tracking_decompressobj)
+    return stats
+
+
+async def _handle_event(
+    addon_context: taddons.context,
+    running: _RunningWebSocket,
+    event: events.Event,
+) -> list[commands.Command]:
+    observed: list[commands.Command] = []
+    pending = [event]
+    while pending:
+        emitted = list(running.layer.handle_event(pending.pop(0)))
+        observed.extend(emitted)
+        for command in emitted:
+            if isinstance(command, StartHook):
+                await addon_context.master.addons.invoke_addon(mitm_addon, command)
+                pending.append(events.HookCompleted(command, None))
+    return observed
+
+
+async def _start_websocket(
+    addon_context: taddons.context,
+    *,
+    compression: bool = False,
+    run_id: str | None = None,
+) -> _RunningWebSocket:
+    client = connection.Client(
+        peername=(_CLIENT_IP, 12345),
+        sockname=("127.0.0.1", 8080),
+        state=connection.ConnectionState.OPEN,
+    )
+    context = Context(client, addon_context.options)
+    context.server.address = (_HOST, 443)
+    context.server.state = connection.ConnectionState.OPEN
+
+    flow = http.HTTPFlow(context.client, context.server)
+    flow.request = http.Request.make(
+        "GET",
+        f"https://{_HOST}/socket",
+        headers={
+            "Connection": "upgrade",
+            "Upgrade": "websocket",
+            "Sec-WebSocket-Version": "13",
+        },
+    )
+    response_headers = {
+        "Connection": "upgrade",
+        "Upgrade": "websocket",
+    }
+    if compression:
+        response_headers["Sec-WebSocket-Extensions"] = "permessage-deflate"
+    flow.response = http.Response.make(101, headers=response_headers)
+    flow.websocket = WebSocketData()
+    if run_id is not None:
+        flow.metadata[metadata_keys.VM_RUN_ID] = run_id
+
+    running = _RunningWebSocket(
+        layer=websocket.WebsocketLayer(context, flow),
+        flow=flow,
+        client=context.client,
+        server=context.server,
+    )
+    start_commands = await _handle_event(addon_context, running, events.Start())
+    assert sum(isinstance(command, websocket.WebsocketStartHook) for command in start_commands) == 1
+    return running
+
+
+def _peer(*, from_client: bool, compression: bool = False) -> WsprotoConnection:
+    extensions: list[wsproto.extensions.Extension] = []
+    if compression:
+        permessage_deflate = wsproto.extensions.PerMessageDeflate()
+        permessage_deflate.finalize(permessage_deflate.name)
+        extensions.append(permessage_deflate)
+    connection_type = (
+        wsproto.ConnectionType.CLIENT if from_client else wsproto.ConnectionType.SERVER
+    )
+    return WsprotoConnection(connection_type, extensions)
+
+
+def _message_event(
+    content: bytes | str,
+    *,
+    message_finished: bool = True,
+) -> wsproto.events.Message:
+    if isinstance(content, str):
+        return wsproto.events.TextMessage(content, message_finished=message_finished)
+    return wsproto.events.BytesMessage(content, message_finished=message_finished)
+
+
+def _source_connection(
+    running: _RunningWebSocket,
+    *,
+    from_client: bool,
+) -> connection.Connection:
+    return running.client if from_client else running.server
+
+
+def _message_hooks(observed: list[commands.Command]) -> list[websocket.WebsocketMessageHook]:
+    return [command for command in observed if isinstance(command, websocket.WebsocketMessageHook)]
+
+
+def _data_sends(observed: list[commands.Command]) -> list[commands.SendData]:
+    return [
+        command
+        for command in observed
+        if isinstance(command, commands.SendData) and command.data[0] & 0x0F != 0x08
+    ]
+
+
+@pytest.mark.parametrize(
+    ("from_client", "content"),
+    [
+        (True, b"client-binary"),
+        (False, "server-text"),
+    ],
+)
+async def test_decoded_message_limit_applies_to_both_directions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    from_client: bool,
+    content: bytes | str,
+) -> None:
+    encoded_size = len(content.encode() if isinstance(content, str) else content)
+    monkeypatch.setattr(websocket_framing, "MAX_DECODED_MESSAGE_BYTES", encoded_size)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        running = await _start_websocket(addon_context)
+        peer = _peer(from_client=from_client)
+
+        accepted = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                _source_connection(running, from_client=from_client),
+                peer.send(_message_event(content)),
+            ),
+        )
+        rejected = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                _source_connection(running, from_client=from_client),
+                peer.send(_message_event(b"x" * (encoded_size + 1))),
+            ),
+        )
+
+    assert len(_message_hooks(accepted)) == 1
+    assert len(_data_sends(accepted)) == 1
+    assert running.flow.websocket is not None
+    assert [message.content for message in running.flow.websocket.messages] == [
+        content.encode() if isinstance(content, str) else content
+    ]
+    assert _message_hooks(rejected) == []
+    assert _data_sends(rejected) == []
+    assert running.flow.websocket.close_code == 1009
+    assert not running.flow.live
+
+
+async def test_read_split_message_reuses_mutable_fragment(
+    tmp_path: Path,
+) -> None:
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        running = await _start_websocket(addon_context)
+        wire = _peer(from_client=False).send(_message_event(b"split-across-reads"))
+
+        await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(running.server, wire[:6]),
+        )
+        fragment = running.layer.server_ws.frame_buf[-1]
+        first_identity = id(fragment)
+        assert isinstance(fragment, bytearray)
+
+        await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(running.server, wire[6:12]),
+        )
+        assert id(running.layer.server_ws.frame_buf[-1]) == first_identity
+
+        completed = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(running.server, wire[12:]),
+        )
+
+    assert len(_message_hooks(completed)) == 1
+    assert running.flow.websocket is not None
+    assert running.flow.websocket.messages[-1].content == b"split-across-reads"
+
+
+async def test_fragmented_message_limits_ignore_interleaved_control_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(websocket_framing, "MAX_DECODED_MESSAGE_BYTES", 2)
+    monkeypatch.setattr(websocket_framing, "MAX_MESSAGE_DATA_FRAMES", 2)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        accepted = await _start_websocket(addon_context)
+        accepted_peer = _peer(from_client=False)
+        first = await _handle_event(
+            addon_context,
+            accepted,
+            events.DataReceived(
+                accepted.server,
+                accepted_peer.send(_message_event(b"a", message_finished=False)),
+            ),
+        )
+        ping = await _handle_event(
+            addon_context,
+            accepted,
+            events.DataReceived(
+                accepted.server,
+                accepted_peer.send(wsproto.events.Ping(payload=b"still-open")),
+            ),
+        )
+        final = await _handle_event(
+            addon_context,
+            accepted,
+            events.DataReceived(accepted.server, accepted_peer.send(_message_event(b"b"))),
+        )
+
+        rejected = await _start_websocket(addon_context)
+        rejected_peer = _peer(from_client=False)
+        for _ in range(2):
+            observed = await _handle_event(
+                addon_context,
+                rejected,
+                events.DataReceived(
+                    rejected.server,
+                    rejected_peer.send(_message_event(b"", message_finished=False)),
+                ),
+            )
+            assert _message_hooks(observed) == []
+        over_limit = await _handle_event(
+            addon_context,
+            rejected,
+            events.DataReceived(rejected.server, rejected_peer.send(_message_event(b""))),
+        )
+
+        byte_rejected = await _start_websocket(addon_context)
+        byte_rejected_peer = _peer(from_client=False)
+        byte_prefix = await _handle_event(
+            addon_context,
+            byte_rejected,
+            events.DataReceived(
+                byte_rejected.server,
+                byte_rejected_peer.send(_message_event(b"a", message_finished=False)),
+            ),
+        )
+        byte_over_limit = await _handle_event(
+            addon_context,
+            byte_rejected,
+            events.DataReceived(
+                byte_rejected.server,
+                byte_rejected_peer.send(_message_event(b"bb")),
+            ),
+        )
+
+    assert first == []
+    assert any(isinstance(command, commands.SendData) for command in ping)
+    assert len(_message_hooks(final)) == 1
+    assert accepted.flow.websocket is not None
+    assert accepted.flow.websocket.messages[-1].content == b"ab"
+    assert _message_hooks(over_limit) == []
+    assert _data_sends(over_limit) == []
+    assert rejected.flow.websocket is not None
+    assert rejected.flow.websocket.close_code == 1009
+    assert rejected.flow.websocket.messages == []
+    assert byte_prefix == []
+    assert _message_hooks(byte_over_limit) == []
+    assert _data_sends(byte_over_limit) == []
+    assert byte_rejected.flow.websocket is not None
+    assert byte_rejected.flow.websocket.close_code == 1009
+    assert byte_rejected.flow.websocket.messages == []
+
+
+async def test_compression_preserves_context_takeover_and_is_connection_local(
+    tmp_path: Path,
+) -> None:
+    original_permessage_deflate = wsproto.extensions.PerMessageDeflate
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        running = await _start_websocket(addon_context, compression=True)
+        peer = _peer(from_client=False, compression=True)
+        first = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                running.server,
+                peer.send(_message_event(b"shared-prefix-" * 32)),
+            ),
+        )
+        second = await _handle_event(
+            addon_context,
+            running,
+            events.DataReceived(
+                running.server,
+                peer.send(_message_event(b"shared-prefix-" * 32 + b"second")),
+            ),
+        )
+
+    assert wsproto.extensions.PerMessageDeflate is original_permessage_deflate
+    assert len(_message_hooks(first)) == 1
+    assert len(_message_hooks(second)) == 1
+    assert running.flow.websocket is not None
+    assert [message.content for message in running.flow.websocket.messages] == [
+        b"shared-prefix-" * 32,
+        b"shared-prefix-" * 32 + b"second",
+    ]
+
+
+@pytest.mark.parametrize("from_client", [True, False])
+async def test_compressed_overflow_is_bounded_and_does_not_affect_another_flow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    from_client: bool,
+) -> None:
+    decoded_limit = 4 * 1024
+    monkeypatch.setattr(websocket_framing, "MAX_DECODED_MESSAGE_BYTES", decoded_limit)
+    stats = _track_zlib_decompression(monkeypatch)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        rejected = await _start_websocket(
+            addon_context,
+            compression=True,
+            run_id="run-rejected",
+        )
+        compressed_peer = _peer(from_client=from_client, compression=True)
+        overflow = await _handle_event(
+            addon_context,
+            rejected,
+            events.DataReceived(
+                _source_connection(rejected, from_client=from_client),
+                compressed_peer.send(_message_event(b"x" * (1024 * 1024))),
+            ),
+        )
+
+        healthy = await _start_websocket(addon_context, run_id="run-healthy")
+        healthy_peer = _peer(from_client=False)
+        delivered = await _handle_event(
+            addon_context,
+            healthy,
+            events.DataReceived(
+                healthy.server,
+                healthy_peer.send(_message_event(b"healthy")),
+            ),
+        )
+
+    assert stats.max_lengths
+    assert all(0 < max_length <= decoded_limit + 1 for max_length in stats.max_lengths)
+    assert max(stats.output_sizes) <= decoded_limit + 1
+    assert all(instance() is None for instance in stats.instances)
+    assert _message_hooks(overflow) == []
+    assert _data_sends(overflow) == []
+    assert rejected.flow.websocket is not None
+    assert rejected.flow.websocket.close_code == 1009
+    assert rejected.flow.websocket.messages == []
+    rejected_source = rejected.layer.client_ws if from_client else rejected.layer.server_ws
+    assert sum(len(fragment) for fragment in rejected_source.frame_buf) == 0
+    assert len(_message_hooks(delivered)) == 1
+    assert len(_data_sends(delivered)) == 1
+    assert healthy.flow.websocket is not None
+    assert healthy.flow.websocket.timestamp_end is None
+    assert healthy.flow.websocket.messages[-1].content == b"healthy"

--- a/crates/runner/mitm-addon/uv.lock
+++ b/crates/runner/mitm-addon/uv.lock
@@ -591,7 +591,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.8" },
-    { name = "wsproto", specifier = ">=1.2" },
+    { name = "wsproto", specifier = "==1.3.2" },
     { name = "zstandard", specifier = ">=0.25.0" },
 ]
 test = [
@@ -600,7 +600,7 @@ test = [
     { name = "mitmproxy", specifier = "==12.2.3" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "wsproto", specifier = ">=1.2" },
+    { name = "wsproto", specifier = "==1.3.2" },
     { name = "zstandard", specifier = ">=0.25.0" },
 ]
 

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1085,6 +1085,7 @@ exit 42
             "terminal_usage.py",
             "upstream_admission.py",
             "url_utils.py",
+            "websocket_framing.py",
             "websocket_retention.py",
             "logging_utils.py",
             "usage/__init__.py",

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -109,6 +109,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_request_headers_connector_admission.py`           | Requestheaders connector destination admission, TLS evidence, and binding                                            |
 | `test_request_headers_firewall_auth.py`                 | Requestheaders stream-safe firewall auth, connector intent, fallback, and cancellation cleanup                       |
 | `test_mitmproxy_request_framing.py`                     | HTTP/2 request framing through mitmproxy's state machine and real addon hook dispatch                                |
+| `test_mitmproxy_websocket_framing.py`                   | Decoded WebSocket message bounds through mitmproxy's state machine and real addon hook dispatch                      |
 | `test_request_handler_usage_tracking.py`                | Request-hook billable usage tracking lifecycle                                                                       |
 | `test_response_headers_handler.py`                      | Response-header hook stream setup                                                                                    |
 | `test_response_handler_connector_diagnostics.py`        | Response-hook connector diagnostic replacement and streaming lifecycle                                               |


### PR DESCRIPTION
## Summary

- cap every proxied WebSocket direction at 16 MiB of decoded data and 8,192 data frames per logical message before mitmproxy creates a completed message
- bound `permessage-deflate` output with `decompress(..., max_length)` across payload and RFC 7692 trailer processing, then close only the offending flow with code 1009
- keep incomplete frame accumulation mutable to avoid repeated prefix copies across transport reads
- pin and startup-gate mitmproxy 12.2.3 with its release-locked wsproto 1.3.2 private contract
- add real mitmproxy state-machine coverage for both directions, fragmentation, read splitting, control-frame interleaving, compression, state release, and independent-flow survival

The implementation keeps the adaptation inside mitmproxy's replaced `WebsocketConnection`. Mutable-buffer maintenance and terminal cleanup run through its `events()` and `send2()` methods, avoiding an additional wrapper around mitmproxy's relay command generator.

## Scope

This changes only runner-local proxy behavior. It adds no API, database, queue, persisted-state, configuration, or deployment-order dependency. Messages below both limits retain existing compression, addon hook, usage, forwarding, and retention behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,413 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2,865 passed, 14 ignored)
- verified the official arm64 mitmproxy 12.2.3 archive checksum and loaded the addon successfully with the standalone binary

Closes #23589
