### PR TITLE
test(python): cover rtl idna rejection branches

### DIFF
--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
@@ -364,6 +364,27 @@ class TestTrustedAuthorityRejection:
             ),
             pytest.param(
                 443,
+                "\u05d0a\u05d0.example",
+                "invalid_authority",
+                "https://api.github.com/repos",
+                id="rtl-ltr-rtl",
+            ),
+            pytest.param(
+                443,
+                "\u05d01\u0662.example",
+                "invalid_authority",
+                "https://api.github.com/repos",
+                id="rtl-european-arabic-number-mixing",
+            ),
+            pytest.param(
+                443,
+                "\u05d0-.example",
+                "invalid_authority",
+                "https://api.github.com/repos",
+                id="rtl-invalid-terminal-class",
+            ),
+            pytest.param(
+                443,
                 "\u0754\u3d20.example",
                 "invalid_authority",
                 "https://api.github.com/repos",


### PR DESCRIPTION
## Summary

- add trusted-authority integration cases for RTL/LTR/RTL mixing, RTL European/Arabic-number mixing, and invalid RTL terminal classes
- assert that each malformed hostname is rejected as `invalid_authority` before it can become a canonical A-label
- keep the source reviewable with explicit Unicode escapes and reuse the existing real-flow rejection matrix

## Scope

This is a test-only change. It does not modify production behavior, APIs, runner protocols, persisted state, dependencies, configuration, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_url_utils_trusted_authority_rejection.py` — 93 passed
- three focused in-memory mutation probes — each corresponding test failed as expected with `authority_mismatch` instead of `invalid_authority`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4,408 passed

Closes #23593
