### PR TITLE
fix(mitm-addon): report retained counts after failed flushes

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -14,6 +14,8 @@ Dropped retained batches always emit ``usage_underbilling`` with
 ``reason=retry_budget_exhausted`` and ``underbilling_class=confirmed``.
 Shutdown-retained batches emit ``usage_underbilling`` with
 ``reason=shutdown_retained_without_retry`` and ``underbilling_class=risk``.
+Failed shutdown admission remains an ordinary error record; its separate
+retained-only summary emits the shutdown underbilling signal.
 
 Operators should use ``retained_source_event_count`` and
 ``retained_webhook_batch_count`` for retained work, and
@@ -122,7 +124,11 @@ def _log_flush_summaries(
                 **extra,
             )
             continue
-        if trigger == "shutdown" and retained_webhook_batch_count:
+        if (
+            phase in ("enqueued", "retained")
+            and trigger == "shutdown"
+            and retained_webhook_batch_count
+        ):
             message = "Usage event buffer retained shutdown batches without retry"
             log_usage_underbilling(
                 summary.proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -294,9 +294,15 @@ class UsageEventBuffer:
             if pending_flush is None:
                 return flushed_batch_count
 
+            started_at = time.monotonic()
             try:
-                admission_result = self._enqueue_pending_flush(pending_flush, trigger)
+                admission_result = self._enqueue_pending_flush(
+                    pending_flush,
+                    trigger,
+                    started_at=started_at,
+                )
             except _BatchEnqueueError as exc:
+                duration_ms = _elapsed_ms(started_at)
                 with self._lock:
                     retain_result = self._state.complete_admission(
                         pending_flush, exc.admission_result
@@ -309,10 +315,13 @@ class UsageEventBuffer:
                     trigger,
                     pending_flush,
                     retain_result,
+                    duration_ms,
+                    exc.original,
                     timer_to_start,
                 )
                 raise exc.original from exc
-            except Exception:
+            except Exception as exc:
+                duration_ms = _elapsed_ms(started_at)
                 with self._lock:
                     retain_result = self._state.fail_enqueue(pending_flush, flush_generation)
                     timer_to_start = self._prepare_failed_flush_retention_locked(
@@ -323,6 +332,8 @@ class UsageEventBuffer:
                     trigger,
                     pending_flush,
                     retain_result,
+                    duration_ms,
+                    exc,
                     timer_to_start,
                 )
                 raise
@@ -362,8 +373,22 @@ class UsageEventBuffer:
         trigger: UsageFlushTrigger,
         pending_flush: _PendingFlush,
         retain_result: _RetainBatchesResult,
+        duration_ms: int,
+        error: Exception,
         timer_to_start: _TimerHandle | None,
     ) -> None:
+        _apply_retained_batch_counts(
+            pending_flush.summaries,
+            retain_result.retained_batches,
+        )
+        _log_flush_summaries(
+            "failed",
+            trigger,
+            pending_flush.flush_sequence,
+            pending_flush.summaries,
+            duration_ms=duration_ms,
+            error_type=type(error).__name__,
+        )
         if retain_result.dropped_batches:
             _log_dropped_batches(
                 trigger,
@@ -382,47 +407,32 @@ class UsageEventBuffer:
         self,
         pending_flush: _PendingFlush,
         trigger: UsageFlushTrigger,
+        *,
+        started_at: float,
     ) -> _BatchAdmissionResult:
-        started_at = time.monotonic()
-        try:
-            _log_flush_summaries(
-                "started", trigger, pending_flush.flush_sequence, pending_flush.summaries
-            )
-            admission_result = _enqueue_batches(
-                pending_flush.batches,
-                (
-                    self._enqueue_webhook
-                    if self._enqueue_webhook is not None
-                    else enqueue_webhook_delivery
-                ),
-                lambda pending_batch: self._make_delivery_outcome_callback(
-                    pending_flush, pending_batch
-                ),
-            )
-            _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
-            _log_flush_summaries(
-                "enqueued",
-                trigger,
-                pending_flush.flush_sequence,
-                pending_flush.summaries,
-                duration_ms=_elapsed_ms(started_at),
-            )
-            return admission_result
-        except Exception as exc:
-            error_type = (
-                type(exc.original).__name__
-                if isinstance(exc, _BatchEnqueueError)
-                else type(exc).__name__
-            )
-            _log_flush_summaries(
-                "failed",
-                trigger,
-                pending_flush.flush_sequence,
-                pending_flush.summaries,
-                duration_ms=_elapsed_ms(started_at),
-                error_type=error_type,
-            )
-            raise
+        _log_flush_summaries(
+            "started", trigger, pending_flush.flush_sequence, pending_flush.summaries
+        )
+        admission_result = _enqueue_batches(
+            pending_flush.batches,
+            (
+                self._enqueue_webhook
+                if self._enqueue_webhook is not None
+                else enqueue_webhook_delivery
+            ),
+            lambda pending_batch: self._make_delivery_outcome_callback(
+                pending_flush, pending_batch
+            ),
+        )
+        _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
+        _log_flush_summaries(
+            "enqueued",
+            trigger,
+            pending_flush.flush_sequence,
+            pending_flush.summaries,
+            duration_ms=_elapsed_ms(started_at),
+        )
+        return admission_result
 
     def _make_delivery_outcome_callback(
         self,

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -159,6 +159,94 @@ def test_flush_logs_failure_without_token(tmp_path):
     assert entries[1]["level"] == "error"
     assert entries[1]["message"] == "Usage event buffer flush failed"
     assert entries[1]["error_type"] == "RuntimeError"
+    assert entries[1]["retained_webhook_batch_count"] == 1
+    assert entries[1]["retained_source_event_count"] == 1
     assert isinstance(entries[1]["duration_ms"], int)
     assert entries[1]["duration_ms"] >= 0
+    assert "secret-token" not in json.dumps(entries)
+
+
+def test_flush_logs_only_unfinished_batch_after_partial_failure(tmp_path):
+    attempted_runs: list[str] = []
+
+    def fail_second_enqueue(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+    ) -> bool:
+        del url, sandbox_token, path, log_type
+        attempted_runs.append(payload["runId"])
+        if payload["runId"] == "run-2":
+            raise OSError("secret-token")
+        return True
+
+    enqueue = RecordingEnqueue(side_effect=fail_second_enqueue)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    for run_id, source_key in (("run-1", "source-1"), ("run-2", "source-2")):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "secret-token",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+
+    with pytest.raises(OSError, match="secret-token"):
+        usage.flush_usage_events(trigger="test")
+
+    assert attempted_runs == ["run-1", "run-2"]
+    entries = flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "failed"]
+    failed_entry = entries[1]
+    assert failed_entry["level"] == "error"
+    assert failed_entry["error_type"] == "OSError"
+    assert failed_entry["source_event_count"] == 2
+    assert failed_entry["webhook_batch_count"] == 2
+    assert failed_entry["retained_webhook_batch_count"] == 1
+    assert failed_entry["retained_source_event_count"] == 1
+    assert "secret-token" not in json.dumps(entries)
+
+
+def test_flush_failure_excludes_retry_budget_drop_from_retained_counts(tmp_path):
+    def fail_enqueue(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+    ) -> bool:
+        del url, sandbox_token, payload, path, log_type
+        raise OSError("secret-token")
+
+    usage.reset_usage_buffer_for_tests(
+        enqueue_webhook=RecordingEnqueue(side_effect=fail_enqueue),
+        max_retained_batch_retries=0,
+    )
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "secret-token",
+        "run-1",
+        [event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+
+    with pytest.raises(OSError, match="secret-token"):
+        usage.flush_usage_events(trigger="test")
+
+    entries = flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "failed", "dropped"]
+    failed_entry = entries[1]
+    assert failed_entry["source_event_count"] == 1
+    assert failed_entry["webhook_batch_count"] == 1
+    assert failed_entry["retained_webhook_batch_count"] == 0
+    assert failed_entry["retained_source_event_count"] == 0
+    dropped_entry = entries[2]
+    assert dropped_entry["type"] == "usage_underbilling"
+    assert dropped_entry["reason"] == "retry_budget_exhausted"
+    assert dropped_entry["dropped_webhook_batch_count"] == 1
+    assert dropped_entry["dropped_source_event_count"] == 1
     assert "secret-token" not in json.dumps(entries)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -538,18 +538,22 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
         reports=0,
         flush_request_id="shutdown-retained",
     )
-    retained_entries = [
-        entry
-        for entry in flush_log_entries(proxy_log_path)
-        if entry.get("reason") == "shutdown_retained_without_retry"
-    ]
-    assert len(retained_entries) == 1
-    assert retained_entries[0]["level"] == "error"
-    assert retained_entries[0]["type"] == "usage_underbilling"
-    assert retained_entries[0]["underbilling_class"] == "risk"
-    assert retained_entries[0]["component"] == "mitm_addon"
-    assert retained_entries[0]["retained_source_event_count"] == 1
-    assert retained_entries[0]["retained_webhook_batch_count"] == 1
+    entries = flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "failed", "retained"]
+    failed_entry = entries[1]
+    assert failed_entry["type"] == "usage_event_buffer_flush"
+    assert failed_entry["retained_source_event_count"] == 1
+    assert failed_entry["retained_webhook_batch_count"] == 1
+    retained_entry = entries[2]
+    assert retained_entry["level"] == "error"
+    assert retained_entry["type"] == "usage_underbilling"
+    assert retained_entry["reason"] == "shutdown_retained_without_retry"
+    assert retained_entry["underbilling_class"] == "risk"
+    assert retained_entry["component"] == "mitm_addon"
+    assert retained_entry["source_event_count"] == 1
+    assert retained_entry["webhook_batch_count"] == 1
+    assert retained_entry["retained_source_event_count"] == 1
+    assert retained_entry["retained_webhook_batch_count"] == 1
 
     enqueue.side_effect = None
     enqueue.clear()
@@ -606,17 +610,23 @@ def test_shutdown_partial_enqueue_failure_retains_unfinished_without_reschedulin
         reports=0,
         flush_request_id="shutdown-partial-retained",
     )
-    retained_entries = [
-        entry
-        for entry in flush_log_entries(proxy_log_path)
-        if entry.get("reason") == "shutdown_retained_without_retry"
-    ]
-    assert len(retained_entries) == 1
-    assert retained_entries[0]["level"] == "error"
-    assert retained_entries[0]["type"] == "usage_underbilling"
-    assert retained_entries[0]["trigger"] == "shutdown"
-    assert retained_entries[0]["retained_source_event_count"] == 1
-    assert retained_entries[0]["retained_webhook_batch_count"] == 1
+    entries = flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "failed", "retained"]
+    failed_entry = entries[1]
+    assert failed_entry["type"] == "usage_event_buffer_flush"
+    assert failed_entry["source_event_count"] == 2
+    assert failed_entry["webhook_batch_count"] == 2
+    assert failed_entry["retained_source_event_count"] == 1
+    assert failed_entry["retained_webhook_batch_count"] == 1
+    retained_entry = entries[2]
+    assert retained_entry["level"] == "error"
+    assert retained_entry["type"] == "usage_underbilling"
+    assert retained_entry["trigger"] == "shutdown"
+    assert retained_entry["reason"] == "shutdown_retained_without_retry"
+    assert retained_entry["source_event_count"] == 1
+    assert retained_entry["webhook_batch_count"] == 1
+    assert retained_entry["retained_source_event_count"] == 1
+    assert retained_entry["retained_webhook_batch_count"] == 1
 
     enqueue.side_effect = None
     enqueue.clear()


### PR DESCRIPTION
## Summary

- emit failed usage-flush summaries after admission state determines the batches actually retained
- preserve enqueue-duration semantics and original exception propagation
- keep shutdown failures separate from the single retained-only underbilling signal
- cover full, partial, retry-exhausted, and shutdown exception logging through public buffer entry points

## Scope

This changes structured logging only. It does not change usage payloads, retry state, delivery
callbacks, idempotency keys, timers, record fields, persisted data, APIs, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_logging.py -v`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_flush_failures.py -v`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_timer_shutdown.py -v`
- `uv run --no-sync python -m pytest tests/` (4418 passed)

Closes #23591
