### PR TITLE
feat(connectors): route strava oauth through the app callback

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1482,6 +1482,7 @@ describe("connectors page", () => {
     ["notion", "Notion"],
     ["sentry", "Sentry"],
     ["server-authored-oauth", "Server-authored OAuth"],
+    ["strava", "Strava"],
     ["vercel", "Vercel"],
   ] as const)(
     "starts %s OAuth with the app callback",

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -12,7 +12,6 @@ const LEGACY_CALLBACK_CONNECTOR_REFS: ReadonlySet<string> = new Set([
   "outlook-calendar",
   "outlook-mail",
   "slack",
-  "strava",
   "todoist",
   "xero",
 ]);


### PR DESCRIPTION
## Summary

- Remove `strava` from `LEGACY_CALLBACK_CONNECTOR_REFS` now that the Strava OAuth app accepts the App callback URL.
- Extend the connectors-page `it.each` so Strava is covered by the same assertion as every other App-callback connector.

## User impact

Connecting Strava now completes OAuth through the dedicated App callback page at `/connectors/strava/callback` instead of `<web>/api/connectors/strava/callback`, matching the redirect URI configured on the Strava side.

## Implementation notes

- Since #23392 inverted this module, the set is a denylist and `isConnectorAppOauthCallbackEnabled` returns `!has(ref)`. Enabling a connector therefore means deleting its line, not adding one.
- The same helper gates both sides — `turbo/apps/api/src/signals/routes/connector-oauth-origin.ts` (authoritative for `redirect_uri`) and `turbo/apps/platform/src/signals/zero-page/settings/connectors.ts` (decides whether to send `callbackTarget: "app"`) — so one deletion moves the whole flow.
- Strava is `auth-code` with `callbackOrigin: "web"` in `provider-capabilities.ts`, so it takes the App callback path once un-denylisted. #23392 removed the `callbackOrigin === "web"` condition from the API gate, which now only checks `callbackTarget === "app" && isConnectorAppOauthCallbackEnabled(ref)`.
- Rollout is safe in both cross-version pairings. New frontend + old backend: the frontend sends `callbackTarget: "app"`, the old backend still has `strava` denylisted and returns the legacy URL, so the flow completes over the old path. Old frontend + new backend: no `callbackTarget` is sent, so the legacy path is used. The API independently re-checks its own copy of the list and owns the `redirect_uri`, so no unregistered redirect can reach the provider mid-rollout.

## Verification

- `zero-connectors-page.test.tsx` asserts `body.callbackTarget === "app"` and the resulting auth-window navigation per connector, so this row fails if `strava` is still denylisted — the change is locked in rather than merely accompanied by a test.
- Existing API coverage of the mechanism is unchanged: `uses App callbacks by default outside the legacy callback list` and `keeps denylisted API-origin callbacks on the API`. No per-ref API test is added; the additions here are data, not new mechanism.
- Per the repo's PR preference, full local vitest was not run; the PR pipeline covers it.

## Remaining connectors

`LEGACY_CALLBACK_CONNECTOR_REFS` still holds 11 refs, each blocked on its own provider-side redirect URI registration: `airtable`, `asana`, `cloudflare`, `gumroad`, `microsoft-365`, `monday`, `outlook-calendar`, `outlook-mail`, `slack`, `todoist`, `xero`.

`microsoft-365`, `outlook-calendar`, and `outlook-mail` share `MICROSOFT_OAUTH_CLIENT_ID`, so one Azure app registration unblocks all three. `cloudflare` is the only one whose `callbackOrigin` is `api` rather than `web`, so enabling it moves the callback from the API origin to the App origin.
