### PR TITLE
perf(python): fast-path ascii hostname labels

### DIFF
--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -12,7 +12,8 @@ normalization steps are implementation details, not a complete WHATWG/IDNA API.
 
 from unicodedata import bidirectional, category, normalize
 
-_ASCII_MAX = 0x7F
+_ASCII_SPACE = " "
+_ASCII_DELETE = "\x7f"
 _IPV4_MAX_OCTET = 255
 _IPV4_HEX_PREFIX_LENGTH = 2
 _IPV4_MIN_PARTS = 1
@@ -51,6 +52,7 @@ _BIDI_RTL_END_CLASSES = _BIDI_RTL_CLASSES | frozenset((_BIDI_ARABIC_NUMBER, _BID
 _BIDI_ARABIC_NUMBER_END_CLASSES = _BIDI_RTL_CLASSES | frozenset((_BIDI_ARABIC_NUMBER,))
 _FORBIDDEN_NORMALIZED_LABEL_CHARS = frozenset("#%,/:<>?@[\\]^|[]")
 _FORBIDDEN_NORMALIZED_LABEL_DOTS = frozenset(".\u3002\uff0e\uff61")
+_FORBIDDEN_ASCII_LABEL_CHARS = _FORBIDDEN_NORMALIZED_LABEL_CHARS | frozenset((".",))
 _GREEK_CAPITAL_SIGMA = "\u03a3"
 _GREEK_COMBINING_YPOGEGRAMMENI = "\u0345"
 _GREEK_SMALL_IOTA = "\u03b9"
@@ -123,7 +125,7 @@ class UnsafeIdnaCompatibilityMappingError(UnicodeError):
 
 
 def _is_ascii(value: str) -> bool:
-    return all(ord(char) <= _ASCII_MAX for char in value)
+    return value.isascii()
 
 
 def _is_ipv4_number_component(value: str) -> bool:
@@ -389,9 +391,17 @@ def _has_invalid_alabel(ascii_host: str) -> bool:
 def _normalize_label(label: str) -> str:
     if not label:
         raise UnicodeError("empty IDNA label")
-    normalized_label = _normalize_label_text(label)
-    _validate_normalized_label_text(normalized_label)
-    ascii_label = label.lower() if _is_ascii(label) else _encode_unicode_label(label)
+    if _is_ascii(label):
+        if any(
+            char <= _ASCII_SPACE or char == _ASCII_DELETE or char in _FORBIDDEN_ASCII_LABEL_CHARS
+            for char in label
+        ):
+            raise UnicodeError("invalid IDNA label")
+        ascii_label = label.lower()
+    else:
+        normalized_label = _normalize_label_text(label)
+        _validate_normalized_label_text(normalized_label)
+        ascii_label = _encode_unicode_label(label)
     if len(ascii_label) > _DNS_LABEL_MAX_LENGTH:
         raise UnicodeError("IDNA label too long")
     if not _is_valid_alabel(ascii_label):

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -1,0 +1,74 @@
+"""Shared hostname identity policy tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+import host_normalization
+from host_normalization import normalize_idna_hostname, normalize_idna_label
+
+
+def test_ascii_hostname_bypasses_unicode_pipeline():
+    with (
+        patch.object(
+            host_normalization,
+            "normalize",
+            wraps=host_normalization.normalize,
+        ) as unicode_normalize,
+        patch.object(
+            host_normalization,
+            "category",
+            wraps=host_normalization.category,
+        ) as unicode_category,
+        patch.object(
+            host_normalization,
+            "bidirectional",
+            wraps=host_normalization.bidirectional,
+        ) as unicode_bidirectional,
+    ):
+        normalized = normalize_idna_hostname("API.GITHUB.COM")
+
+    assert normalized == "api.github.com"
+    unicode_normalize.assert_not_called()
+    unicode_category.assert_not_called()
+    unicode_bidirectional.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        pytest.param("API", "api", id="mixed-case"),
+        pytest.param("A" * 63, "a" * 63, id="maximum-length"),
+        pytest.param(
+            "!\"$&'()*+-;=_`{}~",
+            "!\"$&'()*+-;=_`{}~",
+            id="permissive-punctuation",
+        ),
+        pytest.param("XN--BCHER-KVA", "xn--bcher-kva", id="canonical-alabel"),
+    ],
+)
+def test_ascii_label_contract(label, expected):
+    assert normalize_idna_label(label) == expected
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_message"),
+    [
+        pytest.param("", "empty IDNA label", id="empty"),
+        pytest.param(".", "invalid IDNA label", id="dot"),
+        pytest.param("a#b", "invalid IDNA label", id="forbidden-punctuation"),
+        pytest.param("a b", "invalid IDNA label", id="space"),
+        pytest.param("a\tb", "invalid IDNA label", id="whitespace"),
+        pytest.param("a\x00b", "invalid IDNA label", id="control"),
+        pytest.param("a\x7fb", "invalid IDNA label", id="delete"),
+        pytest.param("A" * 64, "IDNA label too long", id="over-maximum-length"),
+        pytest.param("xn--a", "invalid IDNA A-label", id="invalid-alabel"),
+        pytest.param("#" * 64, "invalid IDNA label", id="validation-precedes-length"),
+    ],
+)
+def test_rejects_invalid_ascii_label(label, expected_message):
+    with pytest.raises(UnicodeError) as exc_info:
+        normalize_idna_label(label)
+
+    assert type(exc_info.value) is UnicodeError
+    assert str(exc_info.value) == expected_message

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 
 import host_normalization
-from host_normalization import normalize_idna_hostname, normalize_idna_label
 
 
 def test_ascii_hostname_bypasses_unicode_pipeline():
@@ -26,7 +25,7 @@ def test_ascii_hostname_bypasses_unicode_pipeline():
             wraps=host_normalization.bidirectional,
         ) as unicode_bidirectional,
     ):
-        normalized = normalize_idna_hostname("API.GITHUB.COM")
+        normalized = host_normalization.normalize_idna_hostname("API.GITHUB.COM")
 
     assert normalized == "api.github.com"
     unicode_normalize.assert_not_called()
@@ -48,7 +47,7 @@ def test_ascii_hostname_bypasses_unicode_pipeline():
     ],
 )
 def test_ascii_label_contract(label, expected):
-    assert normalize_idna_label(label) == expected
+    assert host_normalization.normalize_idna_label(label) == expected
 
 
 @pytest.mark.parametrize(
@@ -68,7 +67,7 @@ def test_ascii_label_contract(label, expected):
 )
 def test_rejects_invalid_ascii_label(label, expected_message):
     with pytest.raises(UnicodeError) as exc_info:
-        normalize_idna_label(label)
+        host_normalization.normalize_idna_label(label)
 
     assert type(exc_info.value) is UnicodeError
     assert str(exc_info.value) == expected_message

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -162,6 +162,7 @@ tests must not resolve a different mitmproxy version from production.
 | `test_firewall_rewrite_forwarding.py`                   | Firewall auth URL rewrite forwarding behavior                                                                        |
 | `test_firewall_rewrite_safety.py`                       | Firewall auth URL rewrite fail-closed and safety behavior                                                            |
 | `test_auth_query_injection.py`                          | Firewall auth query injection and query rewrite behavior                                                             |
+| `test_host_normalization.py`                            | Shared hostname identity, ASCII fast-path, IDNA, and label-boundary contracts                                        |
 | `test_url_utils.py`                                     | Rewrite URL, path, query, and auth-base URL utility cases                                                            |
 | `test_url_utils_trusted_authority.py`                   | Trusted request authority success and URL reconstruction                                                             |
 | `test_url_utils_trusted_authority_rejection.py`         | Trusted request authority rejection matrices                                                                         |


### PR DESCRIPTION
## Summary

- fast-path ordinary ASCII labels inside the shared hostname identity policy
- preserve empty, invalid-character, control, length, and canonical A-label behavior
- keep non-ASCII normalization, unsafe compatibility mapping, bidi, IPv4-like, dot, and trailing-dot paths unchanged
- add public-policy coverage for Unicode-operation bypass and ASCII boundary contracts
- document the new focused test suite

## Performance

A deterministic probe matched the previous result or exception type and message for all 116,522 tested ASCII cases.

On the committed Python 3.14.0 environment, a paired `timeit.repeat` benchmark used five runs of 50,000 hostname normalizations:

| Host | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `api.github.com` | 11.03 us | 2.21 us | 80.0% |
| `subdomain.with-four.labels.com` | 15.42 us | 2.74 us | 82.3% |
| `xn--r8jz45g.xn--q9jyb4c` | 31.99 us | 22.98 us | 28.2% |

The A-label path intentionally retains Unicode round-trip validation.

## Compatibility

- no API, runner/backend protocol, queue payload, dependency, environment, schema, migration, persisted-data, or generated-artifact changes
- no cache or retained normalization state
- the addon remains a single runner-artifact deployment and rollback is a normal code revert

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_host_normalization.py` — 15 passed
- `uv run --no-sync python -m pytest tests/` — 4420 passed
- `scripts/check-file-size.sh crates/runner/mitm-addon/src/host_normalization.py crates/runner/mitm-addon/tests/test_host_normalization.py docs/testing/mitm-addon-testing.md`

Closes #23592
