### PR TITLE
refactor: remove image style r2 feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -4558,7 +4558,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, website.runId);
   }, 90_000);
 
-  it("uses R2 by default and preserves GitHub fallback through the user feature switch", async () => {
+  it("uses R2 for archive-backed styles and GitHub for styles without archives", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const style = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
@@ -4583,32 +4583,6 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
     expect(defaultR2Prompt).toContain("--compile --style-source r2");
     await cancelChatRun(actor, defaultR2Run.runId);
-
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ImageStyleR2]: false },
-    );
-
-    const githubRun = await sendChatRun(actor, {
-      agentId,
-      prompt: "draw a flower shop",
-      generationTemplate: {
-        type: "illustration",
-        selection: { illustrationStyleId: style.illustrationStyleId },
-      },
-    });
-    const githubPrompt =
-      (await api.readRun(actor, githubRun.runId)).appendSystemPrompt ?? "";
-    expect(githubPrompt).toContain(
-      "Style source: vm0-ai/vm0-skills@main:illustration-template/ink-storefront",
-    );
-    expect(githubPrompt).not.toContain("private R2 registry resource");
-    expect(githubPrompt).not.toContain("--style-source r2");
-    await cancelChatRun(actor, githubRun.runId);
 
     const githubOnlyRun = await sendChatRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -144,12 +144,14 @@ describe("buildGenerationTemplatePrompt", () => {
       `- Style description: ${imageStyle.description}`,
     );
     expect(result.prompt).toContain(
-      `zero generate image --provider built-in --style ${item.illustrationStyleId} --prompt "<user request>" --compile`,
+      `zero generate image --provider built-in --style ${item.illustrationStyleId} --prompt "<user request>" --compile --style-source r2`,
     );
-    expect(result.prompt).toContain("Style source: vm0-ai/vm0-skills@main:");
+    expect(result.prompt).toContain(
+      `Style source: private R2 registry resource ${imageStyle.id}`,
+    );
     expect(result.prompt).toContain("Follow the returned packet completely");
     expect(result.prompt).toContain(
-      "If the source is unavailable, stop without generating",
+      "If the R2 source is unavailable, stop without generating; do not fall back to GitHub.",
     );
     expect(result.prompt).toContain("--compiled-prompt");
     expect(result.prompt).toContain("resolved compatible CLI options");

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -69,17 +69,8 @@ type GenerationTemplatePromptResult =
       readonly message: string;
     };
 
-interface BuildGenerationTemplatePromptOptions {
-  /**
-   * When true, archive-enabled image styles resolve through private R2.
-   * When false, the existing vm0-skills GitHub source remains unchanged.
-   */
-  readonly imageStyleR2Enabled?: boolean;
-}
-
 export function buildGenerationTemplatePrompt(
   generationTemplate: GenerationTemplateInput | null | undefined,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (!generationTemplate) {
     return { status: "resolved", prompt: "" };
@@ -89,10 +80,7 @@ export function buildGenerationTemplatePrompt(
     return buildVideoGenerationTemplatePrompt(generationTemplate);
   }
   if (generationTemplate.type === "illustration") {
-    return buildIllustrationGenerationTemplatePrompt(
-      generationTemplate,
-      options,
-    );
+    return buildIllustrationGenerationTemplatePrompt(generationTemplate);
   }
   if (generationTemplate.type === "workflow") {
     return buildWorkflowGenerationTemplatePrompt(generationTemplate);
@@ -120,14 +108,13 @@ function stripGenerationTemplateContext(prompt: string): string {
 
 export function buildGenerationTemplatesPrompt(
   generationTemplates: readonly GenerationTemplateInput[],
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (generationTemplates.length === 0) {
     return { status: "resolved", prompt: "" };
   }
   const details: string[] = [];
   for (const [index, generationTemplate] of generationTemplates.entries()) {
-    const built = buildGenerationTemplatePrompt(generationTemplate, options);
+    const built = buildGenerationTemplatePrompt(generationTemplate);
     if (built.status === "invalid") {
       return built;
     }
@@ -302,7 +289,6 @@ function buildVideoGenerationTemplatePrompt(
 
 function buildIllustrationGenerationTemplatePrompt(
   generationTemplate: IllustrationGenerationTemplateInput,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   const imageStyle = findImageStyle(
     generationTemplate.selection.illustrationStyleId,
@@ -310,8 +296,7 @@ function buildIllustrationGenerationTemplatePrompt(
   if (!imageStyle) {
     return { status: "invalid", message: "Unknown generation image style" };
   }
-  const useR2 =
-    options?.imageStyleR2Enabled === true && hasR2Archive(imageStyle);
+  const useR2 = hasR2Archive(imageStyle);
   const styleSource = useR2
     ? `private R2 registry resource ${imageStyle.id}`
     : imageStyle.source.repo && imageStyle.source.ref

--- a/turbo/apps/api/src/signals/routes/thread-generation-template.ts
+++ b/turbo/apps/api/src/signals/routes/thread-generation-template.ts
@@ -14,19 +14,14 @@ import {
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;
   readonly explicitTemplates?: readonly GenerationTemplateRequest[];
-  readonly imageStyleR2Enabled?: boolean;
 }): string {
   if (args.explicitTemplates && args.explicitTemplates.length > 0) {
-    const built = buildGenerationTemplatesPrompt(args.explicitTemplates, {
-      imageStyleR2Enabled: args.imageStyleR2Enabled,
-    });
+    const built = buildGenerationTemplatesPrompt(args.explicitTemplates);
     return built.status === "resolved" ? built.prompt : "";
   }
   if (!args.explicit) {
     return "";
   }
-  const built = buildGenerationTemplatePrompt(args.explicit, {
-    imageStyleR2Enabled: args.imageStyleR2Enabled,
-  });
+  const built = buildGenerationTemplatePrompt(args.explicit);
   return built.status === "resolved" ? built.prompt : "";
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -277,7 +277,6 @@ function shouldTouchThreadSortFromNormalSend(
 interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
   readonly userMessageInlineTemplatesEnabled: boolean;
-  readonly imageStyleR2Enabled: boolean;
 }
 
 interface RuntimeNormalSendBody extends Omit<NormalSendBody, "userMessage"> {
@@ -1024,10 +1023,6 @@ async function resolveNormalSendFeatureSwitches(
     ),
     userMessageInlineTemplatesEnabled: isFeatureEnabled(
       FeatureSwitchKey.StructuredPromptInlineTemplates,
-      context,
-    ),
-    imageStyleR2Enabled: isFeatureEnabled(
-      FeatureSwitchKey.ImageStyleR2,
       context,
     ),
   };
@@ -2410,7 +2405,6 @@ const prepareNormalSend$ = command(
         runtimeBody.userMessageGenerationTemplates.length > 0
           ? runtimeBody.userMessageGenerationTemplates
           : undefined,
-      imageStyleR2Enabled: featureSwitches.imageStyleR2Enabled,
     });
     const persistedExplicitSelection =
       await maybePersistTimedExplicitModelFirstSelection(args, db);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2412,7 +2412,6 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
   readonly userMessageProjection:
     | ReturnType<typeof projectUserMessage>
     | undefined;
-  readonly imageStyleR2Enabled: boolean;
   readonly inlineTemplatesEnabled: boolean;
 }) {
   return measureChatCallbackPreCreateTiming(
@@ -2427,7 +2426,6 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
         explicitTemplates: args.inlineTemplatesEnabled
           ? args.userMessageProjection?.generationTemplates
           : undefined,
-        imageStyleR2Enabled: args.imageStyleR2Enabled,
       });
     },
   );
@@ -2496,10 +2494,6 @@ async function buildCreateQueuedChatRunInput(
     await resolveQueuedMessageGenerationTemplatePrompt({
       input: args,
       userMessageProjection,
-      imageStyleR2Enabled: isFeatureEnabled(
-        FeatureSwitchKey.ImageStyleR2,
-        featureSwitchContext,
-      ),
       inlineTemplatesEnabled,
     });
   const computerUseHostGrant = await measureChatCallbackPreCreateTiming(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,7 +12,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
     );
@@ -138,7 +137,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HostedArtifactVersions]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(
       staffOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
@@ -174,7 +172,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ImageStyleR2]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(
       otherOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
@@ -256,10 +253,6 @@ describe("user-overridable switches", () => {
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
       FeatureSwitchKey.ComposerConnectorPermissions,
     );
-    expect(getUserOverridableFeatureSwitchKeys()).toContain(
-      FeatureSwitchKey.ImageStyleR2,
-    );
-
     expect(
       filterUserOverridableFeatureSwitchOverrides({
         [FeatureSwitchKey.ComposerUploadPopover]: true,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -76,7 +76,6 @@ export enum FeatureSwitchKey {
   Artifacts = "artifacts",
   HostedArtifactVersions = "hostedArtifactVersions",
   VideoArtifactPosters = "videoArtifactPosters",
-  ImageStyleR2 = "imageStyleR2",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ComposerConnectorPermissions = "composerConnectorPermissions",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -459,12 +459,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Generate poster images asynchronously when video artifacts are recorded.",
     enabled: true,
   },
-  [FeatureSwitchKey.ImageStyleR2]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Resolve archive-enabled image styles from private R2 packages. When off, image style authoring continues reading vm0-skills from GitHub.",
-    enabled: true,
-  },
   [FeatureSwitchKey.OrgPlanEntitlementReads]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove the globally enabled `ImageStyleR2` feature switch and its API plumbing.
- Route archive-backed image styles through private R2 unconditionally while keeping GitHub sources for styles without archives.
- Update feature-switch, prompt-generation, and chat integration coverage for the permanent routing behavior.

## Verification

- `pnpm exec prettier --write` on all changed files
- `pnpm turbo run lint --filter=@vm0/core --filter=api --concurrency=1`
- Core and dependency type checks passed; the API workspace check hit the environment's default V8 heap limit, then passed with `node --max-old-space-size=3072 ./node_modules/typescript/bin/tsc --noEmit` from `turbo/apps/api`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/generation-template-prompt.test.ts` — 11 passed
- Targeted `chat-messages.bdd.test.ts` R2 routing case — 1 passed
