### PR TITLE
refactor: retire video artifact posters switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -134,20 +134,6 @@ async function artifactActor(
   return { actor, agentId: agent.agentId, runnerGroup, objectStore };
 }
 
-async function setVideoArtifactPosters(
-  actor: ApiTestUser,
-  enabled: boolean,
-): Promise<void> {
-  if (!actor.orgId) {
-    throw new Error("Expected video preview test actor to have an org");
-  }
-  await updateFeatureSwitchesForUser(
-    context,
-    { ...actor, orgId: actor.orgId },
-    { [FeatureSwitchKey.VideoArtifactPosters]: enabled },
-  );
-}
-
 async function sendChatRun(
   actor: ApiTestUser,
   body: {
@@ -310,38 +296,8 @@ async function createRunUploadedFile(args: {
 }
 
 describe("video Artifact previews", () => {
-  it("leaves video preview empty when immediate posters are disabled", async () => {
-    const owner = await artifactActor(
-      "Artifacts API disabled video preview agent",
-    );
-    await setVideoArtifactPosters(owner.actor, false);
-    const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
-
-    const videoArtifact = await createRunUploadedFile({
-      owner,
-      prompt: "upload video without poster generation",
-      filename: "poster-disabled.mp4",
-      contentType: "video/mp4",
-    });
-    await flushWaitUntilForTest();
-
-    expect(frameRequests).toHaveLength(0);
-    expect(
-      owner.objectStore.puts.some((put) => {
-        return put.key.endsWith("/poster-v2.jpg");
-      }),
-    ).toBeFalsy();
-    const response = await chat.listArtifacts(owner.actor);
-    const artifact = response.artifacts.find((item) => {
-      return item.fileId === videoArtifact.fileId;
-    });
-    expect(artifact).toBeDefined();
-    expect(artifact).not.toHaveProperty("previewImageUrl");
-  }, 180_000);
-
   it("generates a poster immediately for an ordinary video upload", async () => {
     const owner = await artifactActor("Artifacts API video preview agent");
-    await setVideoArtifactPosters(owner.actor, true);
     const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
 
     const videoArtifact = await createRunUploadedFile({
@@ -378,7 +334,6 @@ describe("video Artifact previews", () => {
     const owner = await artifactActor(
       "Artifacts API concurrent video preview agent",
     );
-    await setVideoArtifactPosters(owner.actor, true);
     mockCloudflareVideoFrame(owner.actor.userId);
     owner.objectStore.rejectNextImmutablePutAsExisting();
 
@@ -399,7 +354,6 @@ describe("video Artifact previews", () => {
 
   it("leaves video preview empty when media frame extraction fails", async () => {
     const owner = await artifactActor("Artifacts API video preview fail agent");
-    await setVideoArtifactPosters(owner.actor, true);
     const frameRequests = mockCloudflareVideoFrame(owner.actor.userId, 415);
 
     const videoArtifact = await createRunUploadedFile({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -1042,9 +1042,6 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
   it("generates a poster immediately for a Slack video Artifact", async () => {
     const { orgId, userId, runId } = await seedRunScoped();
-    await updateFeatureSwitchesForUser(context, actorFor({ orgId, userId }), {
-      [FeatureSwitchKey.VideoArtifactPosters]: true,
-    });
     const fileId = `F-${randomUUID().slice(0, 8)}`;
     const permalink = `https://slack.example/files/${fileId}`;
     context.mocks.slack.files.info.mockResolvedValue({

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -1,6 +1,4 @@
 import { command } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { eq } from "drizzle-orm";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { z } from "zod";
@@ -15,7 +13,6 @@ import { putImmutableS3Object } from "../external/s3";
 import { tapError } from "../utils";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 const log = logger("artifacts:preview");
 
@@ -276,50 +273,18 @@ export const scheduleArtifactPreviewRender$ = command(
   },
 );
 
-export interface VideoArtifactPreviewRenderArgs extends RenderArtifactPreviewArgs {
-  readonly orgId: string;
-}
-
-const renderVideoArtifactPreviewIfEnabled$ = command(
-  async (
-    { get, set },
-    args: VideoArtifactPreviewRenderArgs,
-    signal: AbortSignal,
-  ): Promise<boolean> => {
-    const overrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {
-        orgId: args.orgId,
-        userId: args.userId,
-        overrides,
-      })
-    ) {
-      return false;
-    }
-    return await set(renderAndStoreArtifactPreview$, args, signal);
-  },
-);
-
 /**
- * Fire-and-forget a video poster render when the owner's feature switch is
- * enabled. The switch lookup stays in the detached task so Artifact creation
- * never waits on poster eligibility or rendering.
+ * Fire-and-forget a video poster render on a detached signal via waitUntil, so
+ * Artifact creation never waits on poster rendering.
  */
 export const scheduleVideoArtifactPreviewRender$ = command(
-  ({ set }, args: VideoArtifactPreviewRenderArgs | null): void => {
+  ({ set }, args: RenderArtifactPreviewArgs | null): void => {
     if (!args) {
       return;
     }
     waitUntil(
       tapError(
-        set(
-          renderVideoArtifactPreviewIfEnabled$,
-          args,
-          new AbortController().signal,
-        ),
+        set(renderAndStoreArtifactPreview$, args, new AbortController().signal),
         (error) => {
           log.warn("Failed to render video artifact preview", {
             artifactId: args.id,

--- a/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
+++ b/turbo/apps/api/src/signals/services/run-uploaded-files.service.ts
@@ -13,7 +13,7 @@ import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
 import {
   scheduleVideoArtifactPreviewRender$,
-  type VideoArtifactPreviewRenderArgs,
+  type RenderArtifactPreviewArgs,
 } from "./artifact-preview.service";
 
 interface RecordWebUploadedFileArgs {
@@ -84,16 +84,14 @@ function videoArtifactPreviewArgs(
   args: {
     readonly runId: string;
     readonly userId: string;
-    readonly orgId: string | null | undefined;
     readonly url: string | null;
     readonly contentType: string | null;
   },
   row: RecordedUploadedFile | undefined,
-): VideoArtifactPreviewRenderArgs | null {
+): RenderArtifactPreviewArgs | null {
   if (
     !row ||
     row.previewImageUrl ||
-    !args.orgId ||
     !args.url ||
     !args.contentType?.startsWith("video/")
   ) {
@@ -103,7 +101,6 @@ function videoArtifactPreviewArgs(
     id: row.id,
     runId: args.runId,
     userId: args.userId,
-    orgId: args.orgId,
     url: args.url,
     contentType: args.contentType,
   };
@@ -286,7 +283,6 @@ export const recordWebUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -375,7 +371,6 @@ export const recordTelegramUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -502,7 +497,6 @@ export const recordGithubUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -569,7 +563,6 @@ export const recordFeishuUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -636,7 +629,6 @@ export const recordTeamsUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -714,7 +706,6 @@ export const recordAgentPhoneUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },
@@ -792,7 +783,6 @@ export const recordSlackUploadedFile$ = command(
         {
           runId: args.runId,
           userId: args.userId,
-          orgId: args.orgId,
           url: args.url,
           contentType: args.contentType,
         },

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -13,9 +13,6 @@ describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
-      true,
-    );
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -75,7 +75,6 @@ export enum FeatureSwitchKey {
   StrapiIntegration = "strapiIntegration",
   Artifacts = "artifacts",
   HostedArtifactVersions = "hostedArtifactVersions",
-  VideoArtifactPosters = "videoArtifactPosters",
   ImageStyleR2 = "imageStyleR2",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -453,12 +453,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.VideoArtifactPosters]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Generate poster images asynchronously when video artifacts are recorded.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ImageStyleR2]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Retire the globally enabled `VideoArtifactPosters` feature switch.
- Run video artifact poster generation directly without feature-switch override lookups.
- Remove obsolete disabled-switch coverage while retaining poster success, concurrency, and extraction-failure coverage.

## Verification

- Passed `pnpm -F @vm0/core lint`
- Passed `pnpm -F api lint` (existing repository test warnings only)
- Passed `pnpm -F @vm0/core check-types`
- Passed `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- Passed `pnpm exec prettier --check` on all changed files
- Passed `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1` (24 tests)
- API poster integration tests could not start because this environment has no PostgreSQL cluster or `DATABASE_URL`; `scripts/prepare.sh` confirmed the same setup limitation.
