### PR TITLE
fix(runner): separate mitmdump discovery from exit wait

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -226,9 +226,7 @@ pub async fn run_benchmark(
     factory.shutdown().await;
     runtime.shutdown().await;
     drop(resource_locks);
-    if let Err(e) = mitm.stop().await {
-        warn!(error = %e, "proxy stop failed");
-    }
+    let proxy_stop_result = mitm.stop().await;
     remove_benchmark_live_runner_instance(&live_runner_instance_handle, "complete").await;
 
     // 5. Log timing summary (always, even on error)
@@ -238,8 +236,8 @@ pub async fn run_benchmark(
         guest_restore_ms,
         exec_ms,
     } = timing;
-    match &result {
-        Ok(exec_result) => {
+    match (&result, &proxy_stop_result) {
+        (Ok(exec_result), Ok(())) => {
             let exit_code = benchmark_exit_code(exec_result);
             info!(
                 proxy_ms,
@@ -254,9 +252,14 @@ pub async fn run_benchmark(
                 "benchmark complete"
             );
         }
-        Err(e) => {
+        (Ok(_), Err(e)) | (Err(e), _) => {
             info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, workspace_mount_ms = ?workspace_mount_ms, guest_restore_ms = ?guest_restore_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
         }
+    }
+    if result.is_err()
+        && let Err(e) = &proxy_stop_result
+    {
+        warn!(error = %e, "proxy stop also failed after benchmark execution failure");
     }
 
     let exec_result = result?;
@@ -266,7 +269,8 @@ pub async fn run_benchmark(
     let stderr = std::io::stderr();
     write_benchmark_exec_output(&mut stdout.lock(), &mut stderr.lock(), &exec_result);
 
-    // 7. Propagate exit code
+    // 7. Propagate cleanup failure before a successful guest exit code
+    proxy_stop_result?;
     Ok(ExitCode::from(benchmark_exit_code(&exec_result)))
 }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -236,8 +236,17 @@ pub async fn run_benchmark(
         guest_restore_ms,
         exec_ms,
     } = timing;
-    match (&result, &proxy_stop_result) {
-        (Ok(exec_result), Ok(())) => {
+    let proxy_stop_would_be_primary = match &result {
+        Ok(exec_result) => benchmark_exit_code(exec_result) == 0,
+        Err(_) => false,
+    };
+    let primary_proxy_stop_error = if proxy_stop_would_be_primary {
+        proxy_stop_result.as_ref().err()
+    } else {
+        None
+    };
+    match (&result, primary_proxy_stop_error) {
+        (Ok(exec_result), None) => {
             let exit_code = benchmark_exit_code(exec_result);
             info!(
                 proxy_ms,
@@ -252,13 +261,11 @@ pub async fn run_benchmark(
                 "benchmark complete"
             );
         }
-        (Ok(_), Err(e)) | (Err(e), _) => {
+        (Ok(_), Some(e)) | (Err(e), _) => {
             info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, workspace_mount_ms = ?workspace_mount_ms, guest_restore_ms = ?guest_restore_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
         }
     }
-    if result.is_err()
-        && let Err(e) = &proxy_stop_result
-    {
+    if !proxy_stop_would_be_primary && let Err(e) = &proxy_stop_result {
         warn!(error = %e, "proxy stop also failed after benchmark execution failure");
     }
 
@@ -270,8 +277,11 @@ pub async fn run_benchmark(
     write_benchmark_exec_output(&mut stdout.lock(), &mut stderr.lock(), &exec_result);
 
     // 7. Propagate cleanup failure before a successful guest exit code
-    proxy_stop_result?;
-    Ok(ExitCode::from(benchmark_exit_code(&exec_result)))
+    let exit_code = benchmark_exit_code(&exec_result);
+    if exit_code == 0 {
+        proxy_stop_result?;
+    }
+    Ok(ExitCode::from(exit_code))
 }
 
 fn benchmark_exit_code(exec_result: &ExecResult) -> u8 {

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -17,6 +17,7 @@ pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{
     ProcessStatRead, read_cmdline, read_cwd, read_process_stat, read_process_stat_checked,
+    read_process_stat_checked_blocking,
 };
 pub(crate) use self::types::process_stat_is_live;
 pub use self::types::{

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -189,6 +189,13 @@ pub(crate) async fn read_process_stat_checked(pid: u32) -> ProcessStatRead {
     classify_process_stat_read(tokio::fs::read(&path).await)
 }
 
+/// Blocking variant for callers that already run a complete procfs traversal
+/// on a blocking thread.
+pub(crate) fn read_process_stat_checked_blocking(pid: u32) -> ProcessStatRead {
+    let path = format!("/proc/{pid}/stat");
+    classify_process_stat_read(std::fs::read(&path))
+}
+
 /// Read `/proc/{pid}/stat` and extract process facts.
 pub(crate) async fn read_process_stat(pid: u32) -> Option<ProcessStat> {
     match read_process_stat_checked(pid).await {

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -854,6 +854,62 @@ wait "$!"
         std::fs::set_permissions(path, perms).unwrap();
     }
 
+    fn write_graceful_parent_with_descendant_mitmdump(path: &Path) {
+        std::fs::write(
+            path,
+            r#"#!/usr/bin/env python3
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+Path(f"{sys.argv[0]}.env").write_text(
+    f"{os.environ['TMPDIR']}\n{os.environ['VM0_MITMDUMP_RUNTIME_DIR']}\n",
+    encoding="utf-8",
+)
+port = None
+ready_path = None
+usage_state_id = None
+previous = None
+for argument in sys.argv[1:]:
+    if previous == "--listen-port":
+        port = int(argument)
+    if argument.startswith("vm0_addon_ready_path="):
+        ready_path = Path(argument.removeprefix("vm0_addon_ready_path="))
+    if argument.startswith("vm0_usage_state_id="):
+        usage_state_id = argument.removeprefix("vm0_usage_state_id=")
+    previous = argument
+
+descendant_pid = os.fork()
+if descendant_pid == 0:
+    for handled in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+        signal.signal(handled, signal.SIG_IGN)
+    Path(f"{sys.argv[0]}.descendant").write_text(
+        str(os.getpid()), encoding="utf-8"
+    )
+    while True:
+        time.sleep(60)
+
+signal.signal(signal.SIGTERM, lambda _signum, _frame: sys.exit(0))
+ready_path.parent.mkdir(parents=True, exist_ok=True)
+ready_path.write_text(usage_state_id, encoding="utf-8")
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(1)
+while True:
+    connection, _ = sock.accept()
+    connection.close()
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
     fn write_forking_failing_mitmdump(path: &Path) {
         std::fs::write(
             path,
@@ -1601,6 +1657,37 @@ exit 42
         let child = restart.spawn().await.unwrap();
         proxy.complete_restart(child);
         proxy.kill_now().await.unwrap();
+        assert_no_launch_dirs(&runtime_dir).await;
+    }
+
+    #[tokio::test]
+    async fn graceful_stop_kills_descendant_after_parent_exits_cleanly() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
+        let fake_mitmdump = dir.path().join("graceful-parent-mitmdump");
+        write_graceful_parent_with_descendant_mitmdump(&fake_mitmdump);
+        let config = test_proxy_config(dir.path(), &home, fake_mitmdump.clone());
+        let runtime_dir = config.runtime_dir.clone();
+        let (mut proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
+        proxy.start().await.unwrap();
+
+        let descendant_path = fake_mitmdump.with_extension("descendant");
+        wait_for_file(&descendant_path).await;
+        let descendant_pid: u32 = std::fs::read_to_string(&descendant_path)
+            .unwrap()
+            .parse()
+            .unwrap();
+        let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
+        let launch_path = PathBuf::from(environment.lines().next().unwrap());
+
+        proxy.stop().await.unwrap();
+
+        assert!(
+            wait_for_pid_absent(descendant_pid).await,
+            "graceful stop left forked descendant {descendant_pid} alive"
+        );
+        assert!(!launch_path.exists(), "graceful stop left launch directory");
         assert_no_launch_dirs(&runtime_dir).await;
     }
 

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use nix::fcntl::Flock;
 use nix::sys::signal::Signal;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::process::{ProcessStat, ProcessStatRead, process_stat_is_live};
@@ -19,12 +19,26 @@ pub(super) const RUNTIME_MARKER_ENV: &str = "VM0_MITMDUMP_RUNTIME_DIR";
 const RUNTIME_MARKER_PREFIX: &[u8] = b"VM0_MITMDUMP_RUNTIME_DIR=";
 const LAUNCH_PREFIX: &str = "launch-";
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
-const PROCESS_SCAN_INTERVAL: Duration = Duration::from_millis(20);
+const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Clone, Copy)]
 struct ProcessIdentity {
     pid: u32,
     starttime: u64,
+}
+
+#[derive(Clone)]
+struct ProcessObservation {
+    identity: ProcessIdentity,
+    stat: ProcessStat,
+    command: String,
+}
+
+struct ProcessSnapshot {
+    processes: Vec<ProcessObservation>,
+    elapsed: Duration,
+    examined: usize,
+    same_uid: usize,
 }
 
 /// Serializes owners of the runner-local proxy resources and scopes every
@@ -177,155 +191,191 @@ impl MitmdumpRuntime {
     }
 
     async fn terminate_marked_processes(&self, exact_path: Option<&Path>) -> RunnerResult<()> {
-        let deadline = tokio::time::Instant::now() + PROCESS_EXIT_TIMEOUT;
+        let target = exact_path.unwrap_or(&self.root);
         let mut consecutive_empty_scans = 0u8;
         loop {
-            let processes = self.scan_marked_processes(exact_path).await?;
-            if processes.is_empty() {
+            let snapshot = self.scan_marked_processes(exact_path).await?;
+            log_process_snapshot(target, &snapshot);
+            if snapshot.processes.is_empty() {
                 consecutive_empty_scans += 1;
                 if consecutive_empty_scans == 2 {
                     return Ok(());
                 }
             } else {
                 consecutive_empty_scans = 0;
-                for process in processes {
-                    signal_stable_process(process).await?;
+                for process in &snapshot.processes {
+                    signal_stable_process(process.identity).await?;
                 }
+                wait_for_process_exit(target, &snapshot).await?;
             }
-            if tokio::time::Instant::now() >= deadline {
-                let target = exact_path.unwrap_or(&self.root);
-                return Err(RunnerError::Internal(format!(
-                    "timed out terminating mitmdump processes using {}",
-                    target.display()
-                )));
-            }
-            tokio::time::sleep(PROCESS_SCAN_INTERVAL).await;
+            tokio::time::sleep(PROCESS_EXIT_POLL_INTERVAL).await;
         }
     }
 
     async fn scan_marked_processes(
         &self,
         exact_path: Option<&Path>,
-    ) -> RunnerResult<Vec<ProcessIdentity>> {
-        let expected_uid = nix::unistd::geteuid().as_raw();
-        let mut entries = tokio::fs::read_dir("/proc").await.map_err(|error| {
-            RunnerError::Internal(format!("scan /proc for mitmdump runtime owners: {error}"))
-        })?;
-        let mut processes = Vec::new();
-        let mut seen = HashSet::new();
-        loop {
-            let entry = entries.next_entry().await.map_err(|error| {
+    ) -> RunnerResult<ProcessSnapshot> {
+        let root = self.root.clone();
+        let exact_path = exact_path.map(Path::to_path_buf);
+        tokio::task::spawn_blocking(move || scan_marked_processes(&root, exact_path.as_deref()))
+            .await
+            .map_err(|error| {
                 RunnerError::Internal(format!(
-                    "read /proc entry for mitmdump runtime owners: {error}"
+                    "join mitmdump runtime owner discovery task: {error}"
                 ))
-            })?;
-            let Some(entry) = entry else {
-                break;
-            };
-            let Some(pid) = entry
-                .file_name()
-                .to_str()
-                .and_then(|name| name.parse::<u32>().ok())
-            else {
-                continue;
-            };
-            let metadata = match entry.metadata().await {
-                Ok(metadata) => metadata,
-                Err(error) if process_disappeared(&error) => continue,
-                Err(error) => {
-                    return Err(RunnerError::Internal(format!(
-                        "inspect /proc/{pid} for mitmdump runtime owner: {error}"
-                    )));
-                }
-            };
-            if metadata.uid() != expected_uid {
-                continue;
-            }
-            let Some(environ) = read_process_environ(pid).await? else {
-                continue;
-            };
-            let Some(marker) = runtime_marker(&environ) else {
-                continue;
-            };
-            let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker));
-            if !self.is_launch_path(marker_path)
-                || exact_path.is_some_and(|expected| marker_path != expected)
-            {
-                continue;
-            }
-            let before = match crate::process::read_process_stat_checked(pid).await {
-                ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
-                ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
-                ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
-                ProcessStatRead::Unreadable(error) => {
-                    return Err(RunnerError::Internal(format!(
-                        "read /proc/{pid}/stat for mitmdump runtime owner: {error}"
-                    )));
-                }
-                ProcessStatRead::Invalid => {
-                    return Err(RunnerError::Internal(format!(
-                        "parse /proc/{pid}/stat for mitmdump runtime owner"
-                    )));
-                }
-            };
-            let Some(rechecked_environ) = read_process_environ(pid).await? else {
-                continue;
-            };
-            if runtime_marker(&rechecked_environ) != Some(marker) {
-                continue;
-            }
-            let after = match crate::process::read_process_stat_checked(pid).await {
-                ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
-                ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
-                ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
-                ProcessStatRead::Unreadable(error) => {
-                    return Err(RunnerError::Internal(format!(
-                        "recheck /proc/{pid}/stat for mitmdump runtime owner: {error}"
-                    )));
-                }
-                ProcessStatRead::Invalid => {
-                    return Err(RunnerError::Internal(format!(
-                        "reparse /proc/{pid}/stat for mitmdump runtime owner"
-                    )));
-                }
-            };
-            if !same_process(&before, &after) || !seen.insert((pid, after.starttime)) {
-                continue;
-            }
-            processes.push(ProcessIdentity {
-                pid,
-                starttime: after.starttime,
-            });
-        }
-        Ok(processes)
+            })?
     }
 
     fn is_launch_path(&self, path: &Path) -> bool {
-        path.parent() == Some(self.root.as_path())
-            && path
-                .file_name()
-                .is_some_and(|name| name.as_bytes().starts_with(LAUNCH_PREFIX.as_bytes()))
+        is_launch_path(&self.root, path)
     }
 }
 
-async fn read_process_environ(pid: u32) -> RunnerResult<Option<Vec<u8>>> {
-    match tokio::fs::read(format!("/proc/{pid}/environ")).await {
+fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult<ProcessSnapshot> {
+    let started = std::time::Instant::now();
+    let expected_uid = nix::unistd::geteuid().as_raw();
+    let entries = std::fs::read_dir("/proc").map_err(|error| {
+        RunnerError::Internal(format!("scan /proc for mitmdump runtime owners: {error}"))
+    })?;
+    let mut processes = Vec::new();
+    let mut seen = HashSet::new();
+    let mut examined = 0usize;
+    let mut same_uid = 0usize;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            RunnerError::Internal(format!(
+                "read /proc entry for mitmdump runtime owners: {error}"
+            ))
+        })?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        examined += 1;
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(error) if process_disappeared(&error) => continue,
+            Err(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "inspect /proc/{pid} for mitmdump runtime owner: {error}"
+                )));
+            }
+        };
+        if metadata.uid() != expected_uid {
+            continue;
+        }
+        same_uid += 1;
+        let Some(environ) = read_process_environ(pid)? else {
+            continue;
+        };
+        let Some(marker) = runtime_marker(&environ) else {
+            continue;
+        };
+        let marker_path = Path::new(std::ffi::OsStr::from_bytes(marker));
+        if !is_launch_path(root, marker_path)
+            || exact_path.is_some_and(|expected| marker_path != expected)
+        {
+            continue;
+        }
+        let before = match crate::process::read_process_stat_checked_blocking(pid) {
+            ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
+            ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+            ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
+            ProcessStatRead::Unreadable(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "read /proc/{pid}/stat for mitmdump runtime owner: {error}"
+                )));
+            }
+            ProcessStatRead::Invalid => {
+                return Err(RunnerError::Internal(format!(
+                    "parse /proc/{pid}/stat for mitmdump runtime owner"
+                )));
+            }
+        };
+        let Some(rechecked_environ) = read_process_environ(pid)? else {
+            continue;
+        };
+        if runtime_marker(&rechecked_environ) != Some(marker) {
+            continue;
+        }
+        let Some(command) = read_process_comm(pid)? else {
+            continue;
+        };
+        let after = match crate::process::read_process_stat_checked_blocking(pid) {
+            ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
+            ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
+            ProcessStatRead::Unreadable(error) if process_disappeared(&error) => continue,
+            ProcessStatRead::Unreadable(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "recheck /proc/{pid}/stat for mitmdump runtime owner: {error}"
+                )));
+            }
+            ProcessStatRead::Invalid => {
+                return Err(RunnerError::Internal(format!(
+                    "reparse /proc/{pid}/stat for mitmdump runtime owner"
+                )));
+            }
+        };
+        if !same_process(&before, &after) || !seen.insert((pid, after.starttime)) {
+            continue;
+        }
+        processes.push(ProcessObservation {
+            identity: ProcessIdentity {
+                pid,
+                starttime: after.starttime,
+            },
+            stat: after,
+            command,
+        });
+    }
+    Ok(ProcessSnapshot {
+        processes,
+        elapsed: started.elapsed(),
+        examined,
+        same_uid,
+    })
+}
+
+fn read_process_environ(pid: u32) -> RunnerResult<Option<Vec<u8>>> {
+    match std::fs::read(format!("/proc/{pid}/environ")) {
         Ok(environ) => Ok(Some(environ)),
         Err(error) if process_disappeared(&error) => Ok(None),
-        Err(error) if process_comm_is_mitmdump(pid).await? => Err(RunnerError::Internal(format!(
+        Err(error) if process_comm_is_mitmdump(pid)? => Err(RunnerError::Internal(format!(
             "read /proc/{pid}/environ for mitmdump runtime owner: {error}"
         ))),
         Err(_) => Ok(None),
     }
 }
 
-async fn process_comm_is_mitmdump(pid: u32) -> RunnerResult<bool> {
+fn process_comm_is_mitmdump(pid: u32) -> RunnerResult<bool> {
     let path = format!("/proc/{pid}/comm");
-    match tokio::fs::read(&path).await {
+    match std::fs::read(&path) {
         Ok(comm) => Ok(comm.strip_suffix(b"\n").unwrap_or(&comm) == b"mitmdump"),
         Err(error) if process_disappeared(&error) => Ok(false),
         Err(error) => Err(RunnerError::Internal(format!(
             "read {path} after an unreadable process environment: {error}"
+        ))),
+    }
+}
+
+fn read_process_comm(pid: u32) -> RunnerResult<Option<String>> {
+    let path = format!("/proc/{pid}/comm");
+    match std::fs::read(&path) {
+        Ok(comm) => {
+            let comm = comm.strip_suffix(b"\n").unwrap_or(&comm);
+            let command = String::from_utf8_lossy(comm)
+                .chars()
+                .flat_map(char::escape_default)
+                .collect();
+            Ok(Some(command))
+        }
+        Err(error) if process_disappeared(&error) => Ok(None),
+        Err(error) => Err(RunnerError::Internal(format!(
+            "read {path} for mitmdump runtime owner: {error}"
         ))),
     }
 }
@@ -342,6 +392,117 @@ fn runtime_marker(environ: &[u8]) -> Option<&[u8]> {
 
 fn same_process(before: &ProcessStat, after: &ProcessStat) -> bool {
     before.pgid == after.pgid && before.starttime == after.starttime
+}
+
+fn is_launch_path(root: &Path, path: &Path) -> bool {
+    path.parent() == Some(root)
+        && path
+            .file_name()
+            .is_some_and(|name| name.as_bytes().starts_with(LAUNCH_PREFIX.as_bytes()))
+}
+
+fn log_process_snapshot(target: &Path, snapshot: &ProcessSnapshot) {
+    let elapsed_ms = snapshot.elapsed.as_millis();
+    let matched = snapshot.processes.len();
+    debug!(
+        target = %target.display(),
+        elapsed_ms,
+        examined = snapshot.examined,
+        same_uid = snapshot.same_uid,
+        matched,
+        "scanned for mitmdump runtime owners"
+    );
+    if snapshot.elapsed >= PROCESS_EXIT_TIMEOUT {
+        warn!(
+            target = %target.display(),
+            elapsed_ms,
+            examined = snapshot.examined,
+            same_uid = snapshot.same_uid,
+            matched,
+            "mitmdump process discovery exceeded the process-exit budget"
+        );
+    }
+}
+
+async fn wait_for_process_exit(target: &Path, snapshot: &ProcessSnapshot) -> RunnerResult<()> {
+    let deadline = tokio::time::Instant::now() + PROCESS_EXIT_TIMEOUT;
+    let mut remaining = snapshot.processes.clone();
+    loop {
+        let mut live = Vec::new();
+        for process in &remaining {
+            if let Some(observation) = observe_stable_process(process).await? {
+                live.push(observation);
+            }
+        }
+        if live.is_empty() {
+            return Ok(());
+        }
+        remaining = live;
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err(process_exit_timeout_error(target, snapshot, &remaining));
+        }
+        tokio::time::sleep_until(std::cmp::min(deadline, now + PROCESS_EXIT_POLL_INTERVAL)).await;
+    }
+}
+
+async fn observe_stable_process(
+    process: &ProcessObservation,
+) -> RunnerResult<Option<ProcessObservation>> {
+    match crate::process::read_process_stat_checked(process.identity.pid).await {
+        ProcessStatRead::Found(stat)
+            if process_stat_is_live(&stat) && stat.starttime == process.identity.starttime =>
+        {
+            Ok(Some(ProcessObservation {
+                identity: process.identity,
+                stat,
+                command: process.command.clone(),
+            }))
+        }
+        ProcessStatRead::Found(_) | ProcessStatRead::Missing => Ok(None),
+        ProcessStatRead::Unreadable(error) if process_disappeared(&error) => Ok(None),
+        ProcessStatRead::Unreadable(error) => Err(RunnerError::Internal(format!(
+            "read /proc/{}/stat while waiting for mitmdump cleanup: {error}",
+            process.identity.pid
+        ))),
+        ProcessStatRead::Invalid => Err(RunnerError::Internal(format!(
+            "parse /proc/{}/stat while waiting for mitmdump cleanup",
+            process.identity.pid
+        ))),
+    }
+}
+
+fn process_exit_timeout_error(
+    target: &Path,
+    snapshot: &ProcessSnapshot,
+    remaining: &[ProcessObservation],
+) -> RunnerError {
+    let processes = remaining
+        .iter()
+        .map(|process| {
+            format!(
+                "pid={} state={} ppid={} pgid={} starttime={} command={:?}",
+                process.identity.pid,
+                process.stat.state,
+                process.stat.ppid,
+                process.stat.pgid,
+                process.identity.starttime,
+                process.command
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    RunnerError::Internal(format!(
+        "timed out waiting for signalled mitmdump processes using {}: \
+         discovery_elapsed_ms={}, examined={}, same_uid={}, matched={}; remaining=[{}]",
+        target.display(),
+        snapshot.elapsed.as_millis(),
+        snapshot.examined,
+        snapshot.same_uid,
+        snapshot.processes.len(),
+        processes
+    ))
 }
 
 async fn signal_stable_process(process: ProcessIdentity) -> RunnerResult<()> {

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -206,7 +206,7 @@ impl MitmdumpRuntime {
                 for process in &snapshot.processes {
                     signal_stable_process(process.identity).await?;
                 }
-                wait_for_process_exit(target, &snapshot).await?;
+                wait_for_processes_exit(target, &snapshot).await?;
             }
             tokio::time::sleep(PROCESS_EXIT_POLL_INTERVAL).await;
         }
@@ -302,9 +302,6 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
         if runtime_marker(&rechecked_environ) != Some(marker) {
             continue;
         }
-        let Some(command) = read_process_comm(pid)? else {
-            continue;
-        };
         let after = match crate::process::read_process_stat_checked_blocking(pid) {
             ProcessStatRead::Found(stat) if process_stat_is_live(&stat) => stat,
             ProcessStatRead::Found(_) | ProcessStatRead::Missing => continue,
@@ -323,6 +320,7 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
         if !same_process(&before, &after) || !seen.insert((pid, after.starttime)) {
             continue;
         }
+        let command = read_process_comm(pid);
         processes.push(ProcessObservation {
             identity: ProcessIdentity {
                 pid,
@@ -362,21 +360,14 @@ fn process_comm_is_mitmdump(pid: u32) -> RunnerResult<bool> {
     }
 }
 
-fn read_process_comm(pid: u32) -> RunnerResult<Option<String>> {
+fn read_process_comm(pid: u32) -> String {
     let path = format!("/proc/{pid}/comm");
     match std::fs::read(&path) {
         Ok(comm) => {
             let comm = comm.strip_suffix(b"\n").unwrap_or(&comm);
-            let command = String::from_utf8_lossy(comm)
-                .chars()
-                .flat_map(char::escape_default)
-                .collect();
-            Ok(Some(command))
+            String::from_utf8_lossy(comm).into_owned()
         }
-        Err(error) if process_disappeared(&error) => Ok(None),
-        Err(error) => Err(RunnerError::Internal(format!(
-            "read {path} for mitmdump runtime owner: {error}"
-        ))),
+        Err(_) => "<unavailable>".to_string(),
     }
 }
 
@@ -424,7 +415,7 @@ fn log_process_snapshot(target: &Path, snapshot: &ProcessSnapshot) {
     }
 }
 
-async fn wait_for_process_exit(target: &Path, snapshot: &ProcessSnapshot) -> RunnerResult<()> {
+async fn wait_for_processes_exit(target: &Path, snapshot: &ProcessSnapshot) -> RunnerResult<()> {
     let deadline = tokio::time::Instant::now() + PROCESS_EXIT_TIMEOUT;
     let mut remaining = snapshot.processes.clone();
     loop {


### PR DESCRIPTION
## Summary

- run each mitmdump owner discovery snapshot in one blocking procfs traversal
  and keep discovery time outside the process-exit deadline
- signal stable `(pid, starttime)` identities once, poll only those identities,
  and report safe scan and survivor facts on a genuine timeout
- make a successful guest benchmark return its normal-path proxy cleanup error
  after output and other teardown complete
- cover graceful direct-parent exit with a surviving marker-inheriting
  descendant using real processes and filesystem state

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner`
- new descendant regression test repeated 10 times locally

## Scope

This keeps the existing exact environment marker, UID checks, process start-time
validation, runtime lock, crash reconciliation, and fail-closed launch
preservation. It does not change the cleanup timeout, mitmproxy packaging,
production service shutdown policy, or add cgroup management.

Closes #23659
