### PR TITLE
fix(vsock): retain guest transport until host disconnect

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -494,7 +494,6 @@ impl ConnectionDispatcher {
                 }) {
                     log("WARN", &format!("Failed to send shutdown_ack: {e}"));
                 }
-                log("INFO", "Shutdown complete, exiting");
                 Ok(DispatchOutcome::Shutdown)
             }
         }
@@ -637,6 +636,18 @@ fn handle_connection_with_outcome(
                 return Err(session.failure(error));
             }
             Err(DecodeWithError::Visitor(DecodeDispatchError::Shutdown)) => {
+                // Shutdown is terminal, so ignore all later frames while
+                // retaining the transport until the host has observed the ACK
+                // or abandoned its bounded graceful-shutdown attempt.
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(_) => {}
+                        Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                        Err(_) => break,
+                    }
+                }
+                log("INFO", "Shutdown complete, exiting");
                 return Ok(ConnectionEnd::Shutdown);
             }
         }

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -81,8 +81,9 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
     assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
     assert_eq!(ack.seq, 10);
 
-    let report = done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert_run_still_running(&done_rx, EXPECTED_RECONNECT_ATTEMPTS + 1);
     drop(shutdown_stream);
+    let report = done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
     drop(listener);
     assert_eq!(report, Ok(()));
     handle.join().unwrap().unwrap();

--- a/crates/vsock-guest/tests/connection/shutdown.rs
+++ b/crates/vsock-guest/tests/connection/shutdown.rs
@@ -43,7 +43,7 @@ fn run_exits_after_shutdown_even_when_ack_write_fails() {
 }
 
 #[test]
-fn run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect() {
+fn run_sends_shutdown_ack_and_waits_for_disconnect() {
     use std::os::unix::net::UnixListener;
     use std::sync::mpsc;
 
@@ -69,14 +69,17 @@ fn run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect() {
     assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
     assert_eq!(ack.seq, 42);
 
-    let finished_before_disconnect = done_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+    assert_eq!(
+        done_rx.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout),
+        "run() should retain the connection after MSG_SHUTDOWN_ACK",
+    );
     drop(host_stream);
 
+    done_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("run() should exit after host disconnect");
     let result = handle.join().unwrap();
-    assert!(
-        finished_before_disconnect,
-        "run() should exit after MSG_SHUTDOWN without waiting for host disconnect",
-    );
     assert!(
         result.is_ok(),
         "shutdown should stop run() cleanly: {result:?}"
@@ -103,12 +106,16 @@ fn shutdown_rejects_non_empty_payload_without_exiting() {
 }
 
 #[test]
-fn shutdown_ignores_later_frames_in_same_read_buffer() {
+fn shutdown_ignores_same_buffer_and_later_frames() {
     let (handle, mut host_stream) = start_guest_connection();
     let path = unique_tmp_path("shutdown-followed-by-write-file", ".txt");
+    let later_path = unique_tmp_path("shutdown-followed-by-later-write-file", ".txt");
     let write_payload =
         vsock_proto::encode_write_file(path.as_str(), b"should-not-write", false, false)
             .expect("encode write_file");
+    let later_write_payload =
+        vsock_proto::encode_write_file(later_path.as_str(), b"should-not-write", false, false)
+            .expect("encode later write_file");
 
     let mut batch = vsock_proto::encode(MSG_SHUTDOWN, 50, &[]).unwrap();
     batch.extend_from_slice(&vsock_proto::encode(MSG_WRITE_FILE, 51, &write_payload).unwrap());
@@ -118,7 +125,11 @@ fn shutdown_ignores_later_frames_in_same_read_buffer() {
     assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
     assert_eq!(ack.seq, 50);
 
+    host_stream
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE, 52, &later_write_payload).unwrap())
+        .unwrap();
     drop(host_stream);
     join_guest_connection(handle);
     assert!(!Path::new(path.as_str()).exists());
+    assert!(!Path::new(later_path.as_str()).exists());
 }

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -197,15 +197,28 @@ async fn shutdown_cancels_blocked_write_helper_before_connection_exit() {
     assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
     assert_eq!(ack.seq, 21);
 
-    join_raw_guest_connection(guest);
-    let mut trailing = [0u8; 1];
-    assert_eq!(
-        stream
-            .read(&mut trailing)
-            .expect("read shutdown stream EOF"),
-        0,
-        "no write result may follow shutdown acknowledgement"
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pid_alive(pid) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("shutdown helper should be reaped before host disconnect");
+    assert!(
+        !guest.is_finished(),
+        "guest connection should remain active until host disconnect"
     );
+
+    stream.set_nonblocking(true).unwrap();
+    let mut trailing = [0u8; 1];
+    let trailing_read = stream.read(&mut trailing);
+    assert!(
+        matches!(&trailing_read, Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+        "no write result or connection close may follow shutdown acknowledgement: {trailing_read:?}"
+    );
+
+    drop(stream);
+    join_raw_guest_connection(guest);
     assert!(
         !pid_alive(pid),
         "shutdown helper pid {pid} should be reaped"


### PR DESCRIPTION
## Summary

- keep the guest transport alive after `MSG_SHUTDOWN_ACK` until the host
  disconnects, preventing guest process and VM teardown from racing ACK receipt
- make the post-shutdown connection state terminal: discard later frames and
  return without reconnecting after host EOF or transport failure
- preserve active-operation cancellation and ACK-write-failure behavior with
  public socket and blocked-write integration coverage

## Explicit exclusions

- no new vsock message, payload, timeout, or host-side success classification
- no changes to `guest-init`, Firecracker lifecycle, API, persistence,
  configuration, or deployment sequencing
- host close before a valid ACK remains a graceful-shutdown failure

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc stop_`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --no-deps`
- repository pre-commit `cargo-fmt`, `cargo-doc`, `cargo-clippy`, file-size, and
  commit-message hooks

Closes #23595
