### PR TITLE
fix(browser): auto-reload cards and sidebar after session changes

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -296,6 +296,10 @@ Once an instance is reclaimed the card shows the suspended state and keeps the
 stable `/browsers/:browserId` link. The viewer's resume action, and
 `zero browser use` in a later run, start a new provider instance from the saved
 profile: cookies and storage come back, the previous pages and tabs do not.
+Resume and reclamation publish a user-scoped realtime event carrying the
+logical browser ID. Each open thread subscribes once and reloads only the
+matching shared card signals, so repeated cards and the sidebar move between
+live and suspended state together.
 Logical browsers remain scoped to their chat threads, while every thread for the
 same user in the same organization uses one shared login profile. Multiple
 threads may run provider instances with that profile in parallel. The API

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -1,4 +1,5 @@
 import Ably from "ably";
+import type { BrowserSessionChangedPayload } from "@vm0/api-contracts/contracts/realtime";
 import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
@@ -212,6 +213,29 @@ export async function publishConnectorPermissionUpdatedSafely(
     publishUserSignal([userId], "connectorPermissionUpdated"),
     (error) => {
       L.warn("Failed to publish connector permission updated signal", {
+        error,
+      });
+    },
+  );
+}
+
+/**
+ * Notify the user's open chat surfaces that one managed browser changed
+ * lifecycle state. The payload identifies the logical browser so each
+ * thread-scoped card registry only reloads the matching shared signals.
+ *
+ * Best-effort: a failed publish must not fail browser resume or reclamation.
+ */
+export async function publishBrowserSessionChangedSafely(
+  userId: string,
+  browserId: string,
+): Promise<void> {
+  const payload: BrowserSessionChangedPayload = { browserId };
+  await tapError(
+    publishUserSignal([userId], "browserSessionChanged", payload),
+    (error) => {
+      L.warn("Failed to publish browser session changed signal", {
+        browserId,
         error,
       });
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -1093,6 +1093,7 @@ describe("zero browser route", () => {
       settled: 0,
       errors: 1,
     });
+    context.mocks.ably.publish.mockClear();
     const reclaimed = await reconcileBrowsers();
     expect(reclaimed.body).toMatchObject({
       stopped: 1,
@@ -1100,6 +1101,10 @@ describe("zero browser route", () => {
       errors: 0,
     });
     expect(providerStops).toBe(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "browserSessionChanged",
+      { browserId },
+    );
     await flushWaitUntilForTest();
 
     routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
@@ -1160,6 +1165,7 @@ describe("zero browser route", () => {
     ).toBe(0);
 
     // The viewer can restore a reclaimed browser without a live run.
+    context.mocks.ably.publish.mockClear();
     const resumed = await accept(
       client().resumeById({
         headers: { authorization: "Bearer clerk-session" },
@@ -1175,6 +1181,10 @@ describe("zero browser route", () => {
       idleExpiresAt: isoAt(26 * MINUTE_MS),
     });
     expect(providerCreates).toBe(2);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "browserSessionChanged",
+      { browserId },
+    );
 
     mockNow(STARTED_AT_MS + 20 * MINUTE_MS);
     const viewerLease = await accept(

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -36,6 +36,7 @@ import { z } from "zod";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
+import { publishBrowserSessionChangedSafely } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
 import {
@@ -762,7 +763,7 @@ async function markBrowserResumableIfSettled(
   if ((pending?.count ?? 0) !== 0) {
     return;
   }
-  await db
+  const [suspended] = await db
     .update(browserSessions)
     .set({
       status: "suspended",
@@ -774,7 +775,14 @@ async function markBrowserResumableIfSettled(
         eq(browserSessions.id, browserId),
         eq(browserSessions.status, "stopping"),
       ),
-    );
+    )
+    .returning({
+      id: browserSessions.id,
+      userId: browserSessions.userId,
+    });
+  if (suspended) {
+    await publishBrowserSessionChangedSafely(suspended.userId, suspended.id);
+  }
   signal.throwIfAborted();
 }
 
@@ -1239,7 +1247,7 @@ async function claimStartedProviderInstance(
     readonly pricing: BrowserPricing;
   },
 ) {
-  return await db.transaction(async (tx) => {
+  const claimed = await db.transaction(async (tx) => {
     await lockBrowserThread(tx, args.context.chatThreadId);
     const [current] = await tx
       .select()
@@ -1294,6 +1302,13 @@ async function claimStartedProviderInstance(
       .where(eq(browserSessions.id, current.id));
     return { kind: "active" as const, instance };
   });
+  if (claimed.kind === "active" && args.browser.status === "resuming") {
+    await publishBrowserSessionChangedSafely(
+      args.browser.userId,
+      args.browser.id,
+    );
+  }
+  return claimed;
 }
 
 async function createAndClaimProviderInstance(

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -3,11 +3,13 @@ import {
   zeroBrowserContract,
   type ZeroBrowserSession,
 } from "@vm0/api-contracts/contracts/zero-browser";
+import { browserSessionChangedPayloadSchema } from "@vm0/api-contracts/contracts/realtime";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { pageSignal$ } from "../page-signal.ts";
+import { setAblyPayloadLoop$ } from "../realtime.ts";
 import { onRef, settle, setLoop } from "../utils.ts";
 import {
   getOrCreateCardSignals,
@@ -31,6 +33,7 @@ export interface BrowserSessionSignals extends BrowserSessionDescriptor {
   readonly session$: Computed<Promise<ZeroBrowserSession | null>>;
   readonly panelSession$: Computed<Promise<ZeroBrowserSession | null>>;
   readonly resuming$: Computed<boolean>;
+  readonly reload$: Command<void, []>;
   readonly reloadPanel$: Command<void, []>;
   readonly resume$: Command<Promise<void>, [AbortSignal]>;
   // Attach to the visible panel container: the lease heartbeat lives exactly as
@@ -45,6 +48,7 @@ export interface BrowserSessionCardSignalsRegistry {
   register(descriptor: BrowserSessionDescriptor): BrowserSessionSignals;
   resolve(resourceKey: string): BrowserSessionSignals;
   entries(): ReadonlyMap<string, BrowserSessionSignals>;
+  readonly subscribe$: Command<Promise<void>, [AbortSignal]>;
 }
 
 export function parseBrowserSessionUrl(
@@ -100,33 +104,20 @@ export function createBrowserSessionSignals(
   descriptor: BrowserSessionDescriptor,
 ): BrowserSessionSignals {
   const target = { browserId: descriptor.browserId, chatThreadId: threadId };
-
-  // The card state is loaded once. Only the panel follows the live session,
-  // because only the panel can act on it.
-  const session$ = computed(async (get) => {
-    return await fetchBrowserSession(
-      get(zeroClient$),
-      target,
-      get(pageSignal$),
-    );
-  });
-
-  const panelReloadVersion$ = state(0);
-  const panelOverride$ = state<ZeroBrowserSession | null | undefined>(
+  const reloadVersion$ = state(0);
+  const sessionOverride$ = state<ZeroBrowserSession | null | undefined>(
     undefined,
   );
-  const panelSession$ = computed(
-    async (get): Promise<ZeroBrowserSession | null> => {
-      get(panelReloadVersion$);
-      const override = get(panelOverride$);
-      return override === undefined
-        ? await fetchBrowserSession(get(zeroClient$), target, get(pageSignal$))
-        : override;
-    },
-  );
-  const reloadPanel$ = command(({ set }) => {
-    set(panelOverride$, undefined);
-    set(panelReloadVersion$, (version) => {
+  const session$ = computed(async (get): Promise<ZeroBrowserSession | null> => {
+    get(reloadVersion$);
+    const override = get(sessionOverride$);
+    return override === undefined
+      ? await fetchBrowserSession(get(zeroClient$), target, get(pageSignal$))
+      : override;
+  });
+  const reload$ = command(({ set }) => {
+    set(sessionOverride$, undefined);
+    set(reloadVersion$, (version) => {
       return version + 1;
     });
   });
@@ -150,10 +141,10 @@ export function createBrowserSessionSignals(
     );
     set(resumingState$, false);
     if (resumed.ok) {
-      set(panelOverride$, resumed.value.body.browser);
+      set(sessionOverride$, resumed.value.body.browser);
       return;
     }
-    set(reloadPanel$);
+    set(reload$);
   });
 
   const keepAliveRef$ = onRef(
@@ -177,7 +168,7 @@ export function createBrowserSessionSignals(
             }
             // The browser was reclaimed while the panel was hidden or idle. Stop
             // the heartbeat and let the panel offer a resume instead.
-            set(reloadPanel$);
+            set(reload$);
             return true;
           },
           LEASE_HEARTBEAT_INTERVAL_MS,
@@ -191,11 +182,12 @@ export function createBrowserSessionSignals(
     ...descriptor,
     threadId,
     session$,
-    panelSession$,
+    panelSession$: session$,
     resuming$: computed((get) => {
       return get(resumingState$);
     }),
-    reloadPanel$,
+    reload$,
+    reloadPanel$: reload$,
     resume$,
     keepAliveRef$,
   };
@@ -214,6 +206,39 @@ export function createBrowserSessionCardSignalsRegistry(
 ): BrowserSessionCardSignalsRegistry {
   const signalsByResourceKey = new Map<string, BrowserSessionSignals>();
   const signalsByBrowserId = new Map<string, BrowserSessionSignals>();
+  const reloadAll$ = command(({ set }, _signal: AbortSignal): boolean => {
+    for (const signals of signalsByBrowserId.values()) {
+      set(signals.reload$);
+    }
+    return false;
+  });
+  const onBrowserSessionChanged$ = command(
+    ({ set }, payload: unknown, _signal: AbortSignal): boolean => {
+      const parsed = browserSessionChangedPayloadSchema.safeParse(payload);
+      if (!parsed.success) {
+        return false;
+      }
+      const signals = signalsByBrowserId.get(parsed.data.browserId);
+      if (signals) {
+        set(signals.reload$);
+      }
+      return false;
+    },
+  );
+  const subscribe$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      await set(
+        setAblyPayloadLoop$,
+        {
+          topic: "browserSessionChanged",
+          loopCommand$: onBrowserSessionChanged$,
+          catchUpCommand$: reloadAll$,
+          options: { runOnSubscribe: true },
+        },
+        signal,
+      );
+    },
+  );
   return {
     register(descriptor) {
       const shared = getOrCreateCardSignals(
@@ -237,5 +262,6 @@ export function createBrowserSessionCardSignalsRegistry(
     entries() {
       return signalsByBrowserId;
     },
+    subscribe$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2611,6 +2611,7 @@ function createPagedEvents(
     mailDraftCardSignalsById$,
     reloadMailDrafts$: mailDraftCardSignals.reload$,
     browserSessionCardSignalsById$,
+    subscribeBrowserSessions$: browserSessionCardSignals.subscribe$,
     artifactSignalsForUrl: (url: string): ArtifactSignals | undefined => {
       return artifactCardSignals.find(url);
     },
@@ -2770,6 +2771,7 @@ interface RunTrackingDeps {
   settleEventSync$: Command<Promise<void>, []>;
   reloadArtifacts$: Command<void, []>;
   reloadMailDrafts$: Command<void, []>;
+  subscribeBrowserSessions$: Command<Promise<void>, [AbortSignal]>;
   reloadComposerWorkflows$: Command<Promise<void>, [AbortSignal]>;
   autoScroll$: Command<void, []>;
   automationSignals: Pick<
@@ -3044,6 +3046,7 @@ function createRunTracking({
   settleEventSync$,
   reloadArtifacts$,
   reloadMailDrafts$,
+  subscribeBrowserSessions$,
   reloadComposerWorkflows$,
   autoScroll$,
   automationSignals,
@@ -3104,6 +3107,7 @@ function createRunTracking({
     await Promise.all([
       set(markThreadReadIfNeeded$, signal),
       set(subscribeComputerUseHostsChanged$, signal),
+      set(subscribeBrowserSessions$, signal),
       set(
         dataSource.subscribeRealtime$,
         {
@@ -4428,6 +4432,7 @@ export function createChatThreadSignals(
     settleEventSync$: events.settleEventSync$,
     reloadArtifacts$: artifact.reloadArtifacts$,
     reloadMailDrafts$: events.reloadMailDrafts$,
+    subscribeBrowserSessions$: events.subscribeBrowserSessions$,
     reloadComposerWorkflows$: composer.workflowComposer.reloadWorkflows$,
     autoScroll$: scrollSignals.autoScroll$,
     automationSignals: threadOwned,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3708,7 +3708,7 @@ describe("chat event action cards", () => {
     const browserId = "c0000000-0000-4000-a000-000000000081";
     const liveUrl =
       "https://live.browser-use.com/?wss=test-browser-session-token";
-    const browser: ZeroBrowserSession = {
+    let browser: ZeroBrowserSession = {
       id: browserId,
       name: "booking",
       status: "active",
@@ -3788,6 +3788,58 @@ describe("chat event action cards", () => {
     expect(frame.closest("[data-browser-session-sidebar]")).not.toBeNull();
     await waitFor(() => {
       expect(leaseRequests).toBeGreaterThan(0);
+    });
+    await waitFor(() => {
+      expect(hasSubscription("browserSessionChanged")).toBeTruthy();
+    });
+
+    browser = {
+      ...browser,
+      status: "suspended",
+      liveUrl: null,
+      creditsCharged: 12,
+      idleExpiresAt: null,
+      suspendedAt: "2026-07-24T10:12:00.000Z",
+      suspensionReason: "idle",
+      updatedAt: "2026-07-24T10:12:00.000Z",
+    };
+    triggerAblyEvent("browserSessionChanged", { browserId });
+
+    await waitFor(() => {
+      for (const card of cards) {
+        expect(card).toHaveAttribute(
+          "data-browser-session-status",
+          "suspended",
+        );
+        expect(card).toHaveTextContent("12 credits charged");
+      }
+      expect(screen.getByText("Browser suspended")).toBeInTheDocument();
+      expect(
+        document.querySelector('iframe[title="Live browser: booking"]'),
+      ).toBeNull();
+    });
+
+    const resumedLiveUrl =
+      "https://live.browser-use.com/?wss=resumed-browser-session-token";
+    browser = {
+      ...browser,
+      status: "active",
+      liveUrl: resumedLiveUrl,
+      idleExpiresAt: "2026-07-24T10:22:00.000Z",
+      suspendedAt: null,
+      suspensionReason: null,
+      updatedAt: "2026-07-24T10:12:01.000Z",
+    };
+    triggerAblyEvent("browserSessionChanged", { browserId });
+
+    await waitFor(() => {
+      for (const card of cards) {
+        expect(card).toHaveAttribute("data-browser-session-status", "active");
+      }
+      expect(screen.getByTitle("Live browser: booking")).toHaveAttribute(
+        "src",
+        resumedLiveUrl,
+      );
     });
     expect(
       queryAllByRoleFast("link").find((link) => {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -745,7 +745,9 @@ export {
 
 export {
   ablyTokenRequestSchema,
+  browserSessionChangedPayloadSchema,
   connectorChangedPayloadSchema,
+  type BrowserSessionChangedPayload,
   type ConnectorChangedPayload,
   runnerRealtimeTokenContract,
   type RunnerRealtimeTokenContract,

--- a/turbo/packages/api-contracts/src/contracts/realtime.ts
+++ b/turbo/packages/api-contracts/src/contracts/realtime.ts
@@ -14,6 +14,14 @@ export type ConnectorChangedPayload = z.infer<
   typeof connectorChangedPayloadSchema
 >;
 
+export const browserSessionChangedPayloadSchema = z.object({
+  browserId: z.uuid(),
+});
+
+export type BrowserSessionChangedPayload = z.infer<
+  typeof browserSessionChangedPayloadSchema
+>;
+
 /**
  * Ably token request schema (matches Ably SDK's TokenRequest type)
  */


### PR DESCRIPTION
## Summary

- publish a best-effort user-scoped `browserSessionChanged` signal when a resumed browser becomes active or a reclaimed browser becomes suspended
- subscribe once per open chat thread and reload only the shared signals for the matching `browserId`
- keep repeated browser cards and the sidebar on one session resource, with reconnect catch-up refreshes

## User impact

Browser cards and the live sidebar now update automatically after browser resume and stop/reclamation, including lifecycle changes initiated from another client.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm knip --workspace api --workspace @vm0/app --workspace @vm0/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts --maxWorkers=1`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx -t "renders trusted browser universal links as fixed cards that open the live sidebar" --maxWorkers=1`