### PR TITLE
fix(platform): center personal profile modal in settings

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -93,6 +93,15 @@ export const openSettingsUserProfile$ = command(
     }
     const props = {
       apiKeysProps: { hide: true },
+      appearance: {
+        elements: {
+          modalBackdrop: {
+            position: "absolute",
+            width: "100%",
+            height: "100%",
+          },
+        },
+      },
       getContainer: () => {
         return container;
       },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -667,6 +667,15 @@ describe("zero sidebar account menu", () => {
       expect(clerkProfileModals).toHaveLength(1);
       expect(mockedClerk.openUserProfile).toHaveBeenCalledWith({
         apiKeysProps: { hide: true },
+        appearance: {
+          elements: {
+            modalBackdrop: {
+              position: "absolute",
+              width: "100%",
+              height: "100%",
+            },
+          },
+        },
         getContainer: expect.any(Function),
       });
     });


### PR DESCRIPTION
## Summary

- size the Clerk UserProfile backdrop against its Settings portal container instead of the viewport
- preserve the existing Settings focus isolation while centering the profile modal
- extend the page-level Settings regression coverage for the scoped backdrop positioning

## User impact

The Personal information Manage modal now opens centered within Settings instead of appearing shifted down and to the right.

## Verification

- Prettier 3.8.1 on the changed files
- `pnpm -F @vm0/app lint` (passed with existing Oxlint warnings)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx -t "keeps the user profile inside settings and changes debug capture"`
- Browser/dev-server verification not run per repository preference
