### PR TITLE
docs(guest-agent): document claude result status

### DIFF
--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -19,10 +19,28 @@ pub struct ClaudeResultSummary {
 }
 
 /// Semantic status derived from Claude Code's terminal `type=result` event.
+///
+/// This describes only the event's recognized semantic evidence. It is
+/// independent of the CLI process exit status and the outcome of any later
+/// post-result cleanup. When the event contains conflicting evidence,
+/// recognized error evidence takes precedence over recognized success evidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaudeResultStatus {
+    /// The event contains recognized success evidence (`is_error` is `false` or
+    /// `subtype` is `"success"`) and no recognized error evidence.
     Success,
+
+    /// The event contains recognized error evidence (`is_error` is `true` or
+    /// `subtype` is `"error"`).
+    ///
+    /// This status takes precedence over [`Self::Success`] when both kinds of
+    /// evidence are present.
     Error,
+
+    /// The event contains neither recognized success nor recognized error
+    /// evidence.
+    ///
+    /// This status does not assert either success or failure.
     Unknown,
 }
 


### PR DESCRIPTION
## Summary

- document the recognized `is_error` and `subtype` evidence for every `ClaudeResultStatus` variant
- clarify that error evidence wins when terminal result fields conflict
- distinguish semantic result-event status from CLI process exit and post-result cleanup outcomes

## Scope

- documentation only
- no status derivation, runtime behavior, public signature, schema, or protocol changes

## Validation

- `cargo fmt --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent`

Closes #23640
