### PR TITLE
docs(rust): document guest archive extraction outcomes

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -5,7 +5,23 @@ use guest_common::log_warn;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
-/// Extract a gzip-compressed tar archive into `target_path`.
+/// Extract a gzip-compressed tar archive into an existing target directory.
+///
+/// Accepted entries are unpacked sequentially and directly into `target_path`.
+/// Extraction is non-atomic and does not roll back entries written before a
+/// later error. Entries rejected by the path and link safety checks, and link
+/// targets or sources that are missing or unreadable for non-transport reasons,
+/// are logged and skipped. Consequently, `Ok(())` means that all accepted
+/// entries were processed, not that every archive entry was unpacked.
+///
+/// # Errors
+///
+/// The target is canonicalized before entries are read, so `target_path` must
+/// already exist. A canonicalization failure, an unreadable archive entry or
+/// entry path, or a failure to unpack an accepted entry terminates extraction.
+/// Terminating archive errors are retriable when the source recorded an HTTP
+/// body-read failure; otherwise they are fatal. Files written before an error
+/// remain in the target directory.
 pub(crate) fn extract_tar_gz(
     source: ArchiveSource,
     target_path: &str,

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -875,6 +875,11 @@ fn record_remote_archive_attribution(
     );
 }
 
+/// Download and extract an archive, retrying retriable failures.
+///
+/// Every attempt uses the same `target_path`. The retry loop neither clears the
+/// target nor rolls back files written by a failed extraction attempt, so later
+/// attempts run against any filesystem state left by earlier ones.
 fn download_with_retry(
     url: &str,
     target_path: &str,


### PR DESCRIPTION
## Summary

- document that guest archive extraction requires an existing target and mutates it sequentially without rollback
- distinguish warning-and-skip entries from terminal extraction errors and clarify safe-subset success
- document that retriable attempts reuse the same target path without per-attempt cleanup

## Scope

Documentation only. This does not change extraction, retry, cleanup, error classification, logging, security policy, schemas, persisted data, APIs, or protocols.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-download --all-targets --all-features`
- `cargo doc -p guest-download --all-features --no-deps --document-private-items`
- `cargo test -p guest-download`
- pre-commit workspace Rust formatting, Clippy, and documentation checks

Closes #23641
