### PR TITLE
test(runner): cover workspace gc deletion retries

### DIFF
--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::future::Future;
 use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::time::SystemTime;
 
 use nix::fcntl::Flock;
@@ -14,6 +16,13 @@ use super::GC_MIN_AGE;
 use super::filesystem::{GcDirStatus, dir_stats, gc_path_dir_status};
 use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_lock_after_probe};
 use super::report::{GcReport, human_bytes};
+
+type RemoveDirAllFuture<'a> = Pin<Box<dyn Future<Output = std::io::Result<()>> + 'a>>;
+type RemoveDirAllFn = for<'a> fn(&'a Path) -> RemoveDirAllFuture<'a>;
+
+fn real_remove_dir_all(path: &Path) -> RemoveDirAllFuture<'_> {
+    Box::pin(tokio::fs::remove_dir_all(path))
+}
 
 #[derive(Default)]
 pub(super) struct WorkspaceGcSummary {
@@ -289,6 +298,27 @@ async fn gc_workspace_orphans_with_candidates(
     workspace_age_reference: SystemTime,
     dry_run: bool,
 ) -> RunnerResult<WorkspaceGcSummary> {
+    gc_workspace_orphans_with_candidates_and_remove(
+        candidates,
+        firecrackers,
+        live_runner_base_dirs,
+        process_discovery_uncertain,
+        workspace_age_reference,
+        dry_run,
+        real_remove_dir_all,
+    )
+    .await
+}
+
+async fn gc_workspace_orphans_with_candidates_and_remove(
+    candidates: Vec<DeadRunnerBaseDirLockCandidate>,
+    firecrackers: &[crate::process::FirecrackerProcessInfo],
+    live_runner_base_dirs: &HashSet<PathBuf>,
+    process_discovery_uncertain: bool,
+    workspace_age_reference: SystemTime,
+    dry_run: bool,
+    remove_dir_all: RemoveDirAllFn,
+) -> RunnerResult<WorkspaceGcSummary> {
     if process_discovery_uncertain {
         warn!("workspace gc: process discovery is incomplete; skipping workspace orphan cleanup");
         return Ok(WorkspaceGcSummary::default());
@@ -331,9 +361,14 @@ async fn gc_workspace_orphans_with_candidates(
             continue;
         }
 
-        let (cleaned, freed, lock_decision) =
-            gc_workspace_orphans_in_base_dir(base_dir, &active, workspace_age_reference, dry_run)
-                .await;
+        let (cleaned, freed, lock_decision) = gc_workspace_orphans_in_base_dir(
+            base_dir,
+            &active,
+            workspace_age_reference,
+            dry_run,
+            remove_dir_all,
+        )
+        .await;
         summary.workspaces_cleaned += cleaned;
         summary.bytes_freed += freed;
 
@@ -371,6 +406,7 @@ async fn gc_workspace_orphans_in_base_dir(
     active: &HashSet<PathBuf>,
     workspace_age_reference: SystemTime,
     dry_run: bool,
+    remove_dir_all: RemoveDirAllFn,
 ) -> (u32, u64, BaseDirLockDecision) {
     match gc_path_dir_status(base_dir).await {
         Ok(GcDirStatus::RealDir(_)) => {}
@@ -480,7 +516,7 @@ async fn gc_workspace_orphans_in_base_dir(
                 human_bytes(size)
             );
         } else {
-            match tokio::fs::remove_dir_all(&path).await {
+            match remove_dir_all(&path).await {
                 Ok(()) => {
                     info!(
                         "removed orphaned workspace {} ({})",

--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -29,6 +29,10 @@ fn write_base_dir_lock(home: &HomePaths, base_dir: &Path) -> PathBuf {
     lock_path
 }
 
+fn failing_remove_dir_all(_path: &Path) -> RemoveDirAllFuture<'_> {
+    Box::pin(async { Err(std::io::Error::other("injected workspace removal failure")) })
+}
+
 fn firecracker_with_base_dir(
     pid: u32,
     sandbox_id: &str,
@@ -315,6 +319,61 @@ async fn gc_workspace_orphans_deletes_old_orphan() {
     assert_eq!(summary.workspaces_cleaned, 1);
     assert!(summary.bytes_freed > 0 || cfg!(target_os = "macos"));
     assert_eq!(summary.base_dir_locks_removed, 1);
+}
+
+#[tokio::test]
+async fn gc_workspace_orphans_retries_after_workspace_removal_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let base_dir = dir.path().join("runner-data");
+    let workspace = base_dir.join("workspaces").join("run-old");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(workspace.join("cow.img"), vec![0u8; 4096]).unwrap();
+    set_mtime(&workspace, old_gc_time());
+    let lock_path = write_base_dir_lock(&home, &base_dir);
+
+    let failed = gc_workspace_orphans_with_candidates_and_remove(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+        failing_remove_dir_all,
+    )
+    .await
+    .unwrap();
+
+    assert!(workspace.exists(), "failed cleanup must keep the workspace");
+    assert_eq!(failed.workspaces_cleaned, 0);
+    assert_eq!(failed.bytes_freed, 0);
+    assert_eq!(failed.base_dir_locks_removed, 0);
+    assert!(
+        lock_path.exists(),
+        "failed cleanup must keep the retry lock"
+    );
+
+    let retried = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(retried.workspaces_cleaned, 1);
+    assert!(retried.bytes_freed > 0 || cfg!(target_os = "macos"));
+    assert_eq!(retried.base_dir_locks_removed, 1);
+    assert!(
+        !workspace.exists(),
+        "retry should remove the orphaned workspace"
+    );
+    assert!(!lock_path.exists(), "retry should remove the base-dir lock");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a private workspace-removal operation boundary while keeping normal GC paths bound to `tokio::fs::remove_dir_all`
- cover a deterministic orphan deletion failure through real candidate discovery and a real base-directory lock
- verify a later GC pass rediscovers the retained lock, removes the workspace, and reports successful cleanup

## Scope

This changes testability only. Workspace selection, age checks, dry-run behavior, logging, accounting, lock decisions, and production filesystem behavior are unchanged. There are no API, protocol, persisted-state, migration, or deployment compatibility changes.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner gc_workspace_orphans_retries_after_workspace_removal_failure`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::workspaces::tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2864 passed, 14 ignored; guest inventory passed)
- staged Rust pre-commit hooks

Closes #23645
