### PR TITLE
feat(platform): open chat browser from thread header

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -165,6 +165,7 @@ export interface ChatThreadSignals {
   browserSessionCardSignalsById$: Computed<
     ReadonlyMap<string, BrowserSessionSignals>
   >;
+  latestBrowserSessionSignals$: Computed<BrowserSessionSignals | null>;
   hasEvents$: Computed<Promise<boolean>>;
   hasNewEvents$: Computed<Promise<boolean>>;
   hasQueuedEvents$: Computed<Promise<boolean>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2100,9 +2100,29 @@ function createLatestEventSignals(
       );
     },
   );
+  const latestBrowserSessionSignals$ = computed(
+    (get): BrowserSessionSignals | null => {
+      const events = get(rawEvents$);
+      for (let eventIndex = events.length - 1; eventIndex >= 0; eventIndex--) {
+        const blocks = events[eventIndex]!.blocks;
+        for (
+          let blockIndex = blocks.length - 1;
+          blockIndex >= 0;
+          blockIndex--
+        ) {
+          const block = blocks[blockIndex]!;
+          if (block.type === "browser-session") {
+            return block.signals;
+          }
+        }
+      }
+      return null;
+    },
+  );
   return {
     latestRunFinishCreatedAt$,
     latestAssistantTextCreatedAt$,
+    latestBrowserSessionSignals$,
   };
 }
 
@@ -4338,6 +4358,7 @@ function publicChatThreadEventSignals(
     artifactSignalsForUrl: events.artifactSignalsForUrl,
     mailDraftCardSignalsById$: events.mailDraftCardSignalsById$,
     browserSessionCardSignalsById$: events.browserSessionCardSignalsById$,
+    latestBrowserSessionSignals$: events.latestBrowserSessionSignals$,
     hasEvents$: events.hasEvents$,
     hasNewEvents$: events.hasNewEvents$,
     hasQueuedEvents$: events.hasQueuedEvents$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -291,6 +291,98 @@ function menuItemByText(text: string): HTMLElement {
 }
 
 describe("thread-owned utility sidebar", () => {
+  it("opens the latest browser session from the thread header", async () => {
+    const firstBrowserId = "c0000000-0000-4000-a000-000000000051";
+    const latestBrowserId = "c0000000-0000-4000-a000-000000000052";
+    const browsers = new Map<string, ZeroBrowserSession>([
+      [
+        firstBrowserId,
+        {
+          id: firstBrowserId,
+          name: "First browser",
+          status: "suspended",
+          viewerUrl: `https://app.vm0.ai/browsers/${firstBrowserId}`,
+          liveUrl: null,
+          proxyCountryCode: null,
+          timeoutMinutes: 240,
+          maxCredits: 500,
+          grossCredits: 2,
+          creditsCharged: 2,
+          idleExpiresAt: null,
+          suspendedAt: "2026-03-10T00:05:00.000Z",
+          suspensionReason: "idle",
+          createdAt: "2026-03-10T00:00:00.000Z",
+          updatedAt: "2026-03-10T00:05:00.000Z",
+        },
+      ],
+      [
+        latestBrowserId,
+        {
+          id: latestBrowserId,
+          name: "Latest browser",
+          status: "active",
+          viewerUrl: `https://app.vm0.ai/browsers/${latestBrowserId}`,
+          liveUrl: "https://live.browser-use.com/?wss=latest-browser",
+          proxyCountryCode: null,
+          timeoutMinutes: 240,
+          maxCredits: 500,
+          grossCredits: 3,
+          creditsCharged: 3,
+          idleExpiresAt: "2026-03-10T00:20:00.000Z",
+          suspendedAt: null,
+          suspensionReason: null,
+          createdAt: "2026-03-10T00:10:00.000Z",
+          updatedAt: "2026-03-10T00:10:00.000Z",
+        },
+      ],
+    ]);
+    context.mocks.api(zeroBrowserContract.get, ({ params, respond }) => {
+      const browser = browsers.get(params.browserId);
+      if (!browser) {
+        throw new Error(`Unexpected browser ${params.browserId}`);
+      }
+      return respond(200, { browser });
+    });
+    context.mocks.api(zeroBrowserContract.leaseById, ({ params, respond }) => {
+      const browser = browsers.get(params.browserId);
+      if (!browser) {
+        throw new Error(`Unexpected browser ${params.browserId}`);
+      }
+      return respond(200, { browser });
+    });
+    setupChatThread({
+      messages: [
+        {
+          id: "msg-first-browser",
+          role: "assistant",
+          content: `[First browser](/browsers/${firstBrowserId})`,
+          runId: "run-first-browser",
+          seqId: 1,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          id: "msg-latest-browser",
+          role: "assistant",
+          content: `[Latest browser](/browsers/${latestBrowserId})`,
+          runId: "run-latest-browser",
+          seqId: 2,
+          createdAt: "2026-03-10T00:10:00Z",
+        },
+      ],
+    });
+
+    const button = await screen.findByLabelText("Open browser");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    click(button);
+
+    const frame = await screen.findByTitle("Live browser: Latest browser");
+    expect(frame).toHaveAttribute(
+      "src",
+      "https://live.browser-use.com/?wss=latest-browser",
+    );
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("opens the thread-scoped catalog list", async () => {
     const requestedThreadIds: (string | undefined)[] = [];
     context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -30,6 +30,7 @@ import {
   IconHandStop,
   IconPhoto,
   IconChartLine,
+  IconBrowser,
   IconPlayerPlay,
   IconVideo,
   IconCopy,
@@ -194,6 +195,7 @@ import { pauseChatThreadGoal$ } from "../../signals/chat-page/chat-goal.ts";
 import {
   activeThreadSidebar$,
   openThreadAutomations$,
+  openThreadBrowserSession$,
 } from "../../signals/chat-page/thread-sidebar-coordinator.ts";
 import type { ThreadSidebarSignals } from "../../signals/chat-page/thread-sidebar.ts";
 import {
@@ -444,6 +446,46 @@ export function AutomationMenuButton({
     </TooltipProvider>
   );
 }
+
+function BrowserMenuButton({ thread }: { thread: ChatThreadSignals }) {
+  const browserSession = useGet(thread.latestBrowserSessionSignals$);
+  const sidebarTarget = useGet(thread.sidebar.target$);
+  const openBrowserSidebar = useSet(openThreadBrowserSession$);
+
+  if (!browserSession) {
+    return null;
+  }
+
+  const open =
+    sidebarTarget?.type === "browser" &&
+    sidebarTarget.browserSessionId === browserSession.browserId;
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-150",
+              open
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground/70 hover:bg-accent hover:text-foreground",
+            )}
+            aria-label="Open browser"
+            aria-pressed={open}
+            onClick={() => {
+              openBrowserSidebar(browserSession.browserId);
+            }}
+          >
+            <IconBrowser size={18} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open browser</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const threadTitle = useGet(thread.threadTitle$)?.trim() ?? "";
   const threadTitleEmoji = useGet(thread.threadTitleEmoji$);
@@ -480,6 +522,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
         <AutomationMenuButton key={thread.threadId} thread={thread} />
+        <BrowserMenuButton thread={thread} />
         <ArtifactsButton thread={thread} />
       </div>
     </header>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -30,7 +30,7 @@ import {
   IconHandStop,
   IconPhoto,
   IconChartLine,
-  IconBrowser,
+  IconWorld,
   IconPlayerPlay,
   IconVideo,
   IconCopy,
@@ -477,7 +477,7 @@ function BrowserMenuButton({ thread }: { thread: ChatThreadSignals }) {
               openBrowserSidebar(browserSession.browserId);
             }}
           >
-            <IconBrowser size={18} />
+            <IconWorld size={18} stroke={1.5} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Open browser</TooltipContent>


### PR DESCRIPTION
## Summary

- Show a browser icon in the chat thread header when the thread event history contains a managed browser session.
- Open the existing thread-owned browser sidebar from the header and reflect its selected state with the same interaction styling as Automation and Artifacts.
- Select the latest browser session by event order so older history backfills cannot replace the header target.

## User impact

Users can reopen a thread browser directly from the top-right chat actions without finding its original message card. Threads without a browser session keep the existing header unchanged.

## Verification

- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx --maxWorkers=4 --silent=passed-only (16 tests passed)
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- git diff --check
- PR preview browser verification pending via pr-verify