### PR TITLE
refactor(runner): retire legacy registry tmp cleanup

### DIFF
--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -107,7 +107,6 @@ async fn write_registry_with_reserve(
             path.display()
         )));
     }
-    remove_legacy_registry_tmp(path).await?;
     crate::state_file::write_private_atomic(path, &content).await
 }
 
@@ -135,18 +134,6 @@ fn fail_closed_capacity_bytes(value: &ProxyRegistry) -> RunnerResult<u64> {
                     RunnerError::Internal("proxy registry fail-closed reserve overflow".to_string())
                 })
         })
-}
-
-async fn remove_legacy_registry_tmp(path: &Path) -> RunnerResult<()> {
-    let tmp = path.with_extension("json.tmp");
-    match tokio::fs::remove_file(&tmp).await {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(RunnerError::Internal(format!(
-            "remove stale registry tmp {}: {e}",
-            tmp.display()
-        ))),
-    }
 }
 
 /// Lightweight, cloneable handle for proxy registry operations.
@@ -540,48 +527,6 @@ mod tests {
                 .mode()
                 & 0o777,
             0o600
-        );
-    }
-
-    #[tokio::test]
-    async fn write_registry_removes_stale_fixed_tmp_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry_path = dir.path().join("proxy-registry.json");
-        let legacy_tmp = registry_path.with_extension("json.tmp");
-        std::fs::write(&legacy_tmp, b"stale").unwrap();
-        let empty = ProxyRegistry {
-            vms: HashMap::new(),
-            updated_at: 0,
-        };
-
-        write_registry(&registry_path, &empty).await.unwrap();
-
-        assert!(
-            !legacy_tmp.exists(),
-            "stale fixed registry tmp was not removed"
-        );
-        read_registry(&registry_path).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn write_registry_removes_stale_fixed_tmp_symlink_without_following_it() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry_path = dir.path().join("proxy-registry.json");
-        let legacy_tmp = registry_path.with_extension("json.tmp");
-        let outside = dir.path().join("outside-target");
-        std::fs::write(&outside, b"outside").unwrap();
-        std::os::unix::fs::symlink(&outside, &legacy_tmp).unwrap();
-        let empty = ProxyRegistry {
-            vms: HashMap::new(),
-            updated_at: 0,
-        };
-
-        write_registry(&registry_path, &empty).await.unwrap();
-
-        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
-        assert!(
-            std::fs::symlink_metadata(&legacy_tmp).is_err(),
-            "stale fixed registry tmp symlink was not removed"
         );
     }
 


### PR DESCRIPTION
## Summary

- stop inspecting and unlinking the retired fixed proxy registry staging path before current registry writes
- remove the compatibility helper and its two dedicated tests after the supported rollback set converged on unique atomic staging
- keep current atomic writes, locking, capacity checks, permissions, registry format, and target-path defenses unchanged

## Compatibility

All runner releases in the supported production rollback set contain the unique state-file writer and cannot recreate the retired fixed path. A dormant legacy file may remain unused; this PR does not add a new cleanup or migration contract.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner proxy::registry::tests` (17 passed)
- `cargo test -p runner` (2,863 passed, 14 ignored)
- repository pre-commit hooks, including workspace Rust formatting, Clippy, and documentation checks

Closes #23647
