### PR TITLE
fix(platform): open chat sidebar before mark-read completes

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -153,11 +153,21 @@ const receiveSyncedEventsInVisibleThreads$ = command(
 
     await Promise.all(
       visibleThreads.map(async (thread) => {
-        await set(thread.receiveSyncedEvents$, events, signal);
-        signal.throwIfAborted();
-        if (events.length > 0) {
-          await set(autoOpenThreadSidebar$, thread, signal);
+        // Receiving merges the new events before it awaits read-state work, so
+        // start it first and let sidebar selection proceed from that projection.
+        const receiveEventsPromise = set(
+          thread.receiveSyncedEvents$,
+          events,
+          signal,
+        );
+        if (events.length === 0) {
+          await receiveEventsPromise;
+          return;
         }
+        await Promise.all([
+          receiveEventsPromise,
+          set(autoOpenThreadSidebar$, thread, signal),
+        ]);
       }),
     );
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -10,6 +10,7 @@ import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
   chatThreadEventsContract,
+  chatThreadMarkReadContract,
   chatThreadsContract,
   type ChatThreadArtifactFile,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -905,13 +906,27 @@ describe("thread-owned utility sidebar", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("auto-opens a sidebar card received from background sync", async () => {
+  it("auto-opens a background-synced sidebar card before mark-read completes", async () => {
     const syncedUrl = "https://synced-presentation.sites.vm7.io";
+    const markReadStarted = Promise.withResolvers<void>();
+    const finishMarkRead = Promise.withResolvers<void>();
     context.mocks.browser.matchMedia((query) => {
       return query === CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY;
     });
+    context.mocks.api(
+      chatThreadMarkReadContract.markRead,
+      async ({ respond }) => {
+        markReadStarted.resolve();
+        await finishMarkRead.promise;
+        return respond(200, {
+          lastReadAt: "2026-03-10T00:00:05Z",
+          unreads: [],
+        });
+      },
+    );
     const fixture = setupChatThread({
       autoOpenEnabled: true,
+      messages: [],
     });
 
     await waitFor(() => {
@@ -923,7 +938,7 @@ describe("thread-owned utility sidebar", () => {
         role: "user",
         content: "Build a presentation",
         runId: "run-synced",
-        seqId: 3,
+        seqId: 1,
         createdAt: "2026-03-10T00:00:03Z",
       },
       {
@@ -931,17 +946,30 @@ describe("thread-owned utility sidebar", () => {
         role: "assistant",
         content: `[Synced presentation](${syncedUrl})`,
         runId: "run-synced",
-        seqId: 4,
+        seqId: 2,
         createdAt: "2026-03-10T00:00:04Z",
+      },
+      {
+        id: "msg-synced-finish",
+        role: "assistant",
+        content: null,
+        runId: "run-synced",
+        runLifecycleEvent: "completed",
+        seqId: 3,
+        createdAt: "2026-03-10T00:00:05Z",
       },
     ]);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
-        "src",
-        syncedUrl,
-      );
-    });
+    await markReadStarted.promise;
+    try {
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("artifact-sidebar-body-html"),
+        ).toHaveAttribute("src", syncedUrl);
+      });
+    } finally {
+      finishMarkRead.resolve();
+    }
   });
 
   it("does not reopen the same auto-opened card after the user closes it", async () => {


### PR DESCRIPTION
## Summary

- Start background event receiving before sidebar candidate selection so the newly merged message projection is immediately available.
- Await sidebar auto-open alongside the remaining receive lifecycle under the same realtime owner and `AbortSignal`.
- Add a page-level regression test that holds the mark-read response open and verifies the sidebar appears first.

## User impact

Chat messages with openable cards can reveal their sidebar as soon as their events are merged instead of waiting for the thread mark-read network round trip.

## Verification

- `npx --yes prettier@3.8.1 --check turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx`
- `git diff --check`
- Targeted Vitest was not run locally because the fresh checkout does not include `node_modules`; the PR pipeline will run the repository checks.
