### PR TITLE
refactor: remove org plan entitlement reads switch

### DIFF
--- a/turbo/apps/api/src/signals/services/org-plan-entitlement-read.service.ts
+++ b/turbo/apps/api/src/signals/services/org-plan-entitlement-read.service.ts
@@ -1,12 +1,8 @@
-import { orgTierSchema } from "@vm0/api-contracts/contracts/orgs";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
 import { eq } from "drizzle-orm";
 
 import type { Db } from "../external/db";
-import { ORG_PLAN_ENTITLEMENT_TIER_VALUES } from "./org-plan-entitlement-tier-values";
 
 type ReadDb = Pick<Db, "select">;
 
@@ -59,61 +55,35 @@ function runtimeStatusForEntitlement(
   }
 }
 
-function capabilitiesForTier(tierValue: string): OrgPlanCapabilities {
-  const tier = orgTierSchema.parse(tierValue);
-  return {
-    status: tier === "pro-suspend" ? "suspended" : "active",
-    ...ORG_PLAN_ENTITLEMENT_TIER_VALUES[tier],
-  };
-}
-
-export function orgPlanEntitlementReadsEnabled(orgId: string): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.OrgPlanEntitlementReads, { orgId });
-}
-
 export async function loadOrgPlanCapabilities(
   db: ReadDb,
   orgId: string,
   options?: { readonly forUpdate?: boolean },
 ): Promise<OrgPlanCapabilities | null> {
-  if (orgPlanEntitlementReadsEnabled(orgId)) {
-    const query = db
-      .select(CAPABILITY_SELECTION)
-      .from(orgPlanEntitlements)
-      .where(eq(orgPlanEntitlements.orgId, orgId))
-      .limit(1);
-    const [capabilities] = options?.forUpdate
-      ? await query.for("update")
-      : await query;
-    if (!capabilities) {
-      const orgQuery = db
-        .select({ orgId: orgMetadata.orgId })
-        .from(orgMetadata)
-        .where(eq(orgMetadata.orgId, orgId))
-        .limit(1);
-      const [org] = options?.forUpdate
-        ? await orgQuery.for("update")
-        : await orgQuery;
-      if (!org) {
-        return null;
-      }
-      throw new Error(`Missing org plan entitlement for ${orgId}`);
-    }
-    return {
-      ...capabilities,
-      status: runtimeStatusForEntitlement(capabilities.status),
-    };
-  }
-
   const query = db
-    .select({ tier: orgMetadata.tier })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
+    .select(CAPABILITY_SELECTION)
+    .from(orgPlanEntitlements)
+    .where(eq(orgPlanEntitlements.orgId, orgId))
     .limit(1);
-  const [org] = options?.forUpdate ? await query.for("update") : await query;
-  if (!org) {
-    return null;
+  const [capabilities] = options?.forUpdate
+    ? await query.for("update")
+    : await query;
+  if (!capabilities) {
+    const orgQuery = db
+      .select({ orgId: orgMetadata.orgId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+    const [org] = options?.forUpdate
+      ? await orgQuery.for("update")
+      : await orgQuery;
+    if (!org) {
+      return null;
+    }
+    throw new Error(`Missing org plan entitlement for ${orgId}`);
   }
-
-  return capabilitiesForTier(org.tier);
+  return {
+    ...capabilities,
+    status: runtimeStatusForEntitlement(capabilities.status),
+  };
 }

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -6,7 +6,6 @@ import {
   and,
   eq,
   exists,
-  inArray,
   isNotNull,
   isNull,
   lt,
@@ -21,10 +20,7 @@ import { nowDate } from "../external/time";
 import { tapError } from "../utils";
 import { logger } from "../../lib/log";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
-import {
-  loadOrgPlanCapabilities,
-  orgPlanEntitlementReadsEnabled,
-} from "./org-plan-entitlement-read.service";
+import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 
 const L = logger("CreditRecharge");
 
@@ -105,7 +101,7 @@ async function resolvePaymentMethod(
  * Atomically claims the recharge slot via UPDATE … RETURNING with a
  * WHERE clause that filters on:
  *  - autoRechargeEnabled = true
- *  - plan entitlement allows auto-recharge (or legacy tier fallback)
+ *  - plan entitlement allows auto-recharge
  *  - stripeCustomerId / threshold / amount NOT NULL
  *  - credits <= threshold
  *  - pendingAt IS NULL OR pendingAt < now() - 10 minutes
@@ -131,19 +127,17 @@ export const triggerAutoRecharge$ = command(
       return;
     }
 
-    const planEligibility = orgPlanEntitlementReadsEnabled(orgId)
-      ? exists(
-          writeDb
-            .select({ orgId: orgPlanEntitlements.orgId })
-            .from(orgPlanEntitlements)
-            .where(
-              and(
-                eq(orgPlanEntitlements.orgId, orgId),
-                eq(orgPlanEntitlements.autoRechargeAllowed, true),
-              ),
-            ),
-        )
-      : inArray(orgMetadata.tier, ["pro", "team", "custom"]);
+    const planEligibility = exists(
+      writeDb
+        .select({ orgId: orgPlanEntitlements.orgId })
+        .from(orgPlanEntitlements)
+        .where(
+          and(
+            eq(orgPlanEntitlements.orgId, orgId),
+            eq(orgPlanEntitlements.autoRechargeAllowed, true),
+          ),
+        ),
+    );
 
     const clearPendingFlag = async (): Promise<void> => {
       await writeDb

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -143,7 +143,6 @@ describe("getAllFeatureStates", () => {
     expect(
       staffOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
     ).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );
@@ -179,7 +178,6 @@ describe("getAllFeatureStates", () => {
     expect(
       otherOrgStates[FeatureSwitchKey.StructuredPromptInlineTemplates],
     ).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       false,
     );
@@ -227,9 +225,6 @@ describe("user-overridable switches", () => {
       FeatureSwitchKey.WorkflowConnectorReadiness,
     );
     expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
-      FeatureSwitchKey.OrgPlanEntitlementReads,
-    );
-    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
       FeatureSwitchKey.ZeroMailReplyFollowUp,
     );
     expect(getUserOverridableFeatureSwitchKeys()).toContain(
@@ -264,7 +259,6 @@ describe("user-overridable switches", () => {
       filterUserOverridableFeatureSwitchOverrides({
         [FeatureSwitchKey.ComposerUploadPopover]: true,
         [FeatureSwitchKey.WorkflowConnectorReadiness]: true,
-        [FeatureSwitchKey.OrgPlanEntitlementReads]: true,
         [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
         [FeatureSwitchKey.ZeroMailReplyFollowUp]: true,
         [FeatureSwitchKey.BrazilianPortugueseLocale]: true,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -77,7 +77,6 @@ export enum FeatureSwitchKey {
   HostedArtifactVersions = "hostedArtifactVersions",
   VideoArtifactPosters = "videoArtifactPosters",
   ImageStyleR2 = "imageStyleR2",
-  OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ComposerConnectorPermissions = "composerConnectorPermissions",
   ThreeColumnNav = "threeColumnNav",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -465,13 +465,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Resolve archive-enabled image styles from private R2 packages. When off, image style authoring continues reading vm0-skills from GitHub.",
     enabled: true,
   },
-  [FeatureSwitchKey.OrgPlanEntitlementReads]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Read runtime plan capability limits from org_plan_entitlements instead of deriving them from org_metadata.tier.",
-    enabled: true,
-    userOverridable: false,
-  },
   [FeatureSwitchKey.WorkflowConnectorReadiness]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- remove the fully enabled `orgPlanEntitlementReads` feature switch
- make `org_plan_entitlements` the only runtime capability read path while preserving the missing-entitlement integrity check
- remove the legacy `org_metadata.tier` fallback from atomic auto-recharge eligibility

## Testing

- `pnpm format`
- `pnpm -F @vm0/core lint`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest run packages/core/src/__tests__/feature-switch.test.ts apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only`
