### PR TITLE
feat(zero): enable zero finance for all users

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -176,19 +176,19 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(token)?.capabilities).toContain("web-search:read");
   });
 
-  it("grants finance capability from user feature switch overrides", () => {
+  it("grants finance capability by default and respects explicit opt-out", () => {
     const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
-    const overrideToken = generateZeroToken(
+    const disabledToken = generateZeroToken(
       "user_zero",
       "run_zero",
       "org_zero",
-      { [FeatureSwitchKey.ZeroFinance]: true },
+      { [FeatureSwitchKey.ZeroFinance]: false },
     );
 
-    expect(verifyZeroToken(defaultToken)?.capabilities).not.toContain(
+    expect(verifyZeroToken(defaultToken)?.capabilities).toContain(
       "finance:read",
     );
-    expect(verifyZeroToken(overrideToken)?.capabilities).toContain(
+    expect(verifyZeroToken(disabledToken)?.capabilities).not.toContain(
       "finance:read",
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8875,7 +8875,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
     );
     expect(claim.appendSystemPrompt ?? "").toContain("zero web-search --help");
-    expect(claim.appendSystemPrompt ?? "").not.toContain("zero finance --help");
+    expect(claim.appendSystemPrompt ?? "").toContain("zero finance --help");
     expect(claim.appendSystemPrompt ?? "").toContain("zero scrape --help");
     expect(claim.appendSystemPrompt ?? "").toContain(
       "zero people-search <query>",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8631,9 +8631,6 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await bdd.readMe(actor);
     await api.grantProEntitlement(actor);
     await api.ensureOrgModelProvider(actor);
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ZeroFinance]: true,
-    });
     const agent = await bdd.createAgent(actor, {
       displayName: "Research Bot",
       description: "Finds release details",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-finance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-finance.test.ts
@@ -35,23 +35,6 @@ function client() {
   return setupApp({ context });
 }
 
-async function financeEnabledActor(): Promise<ApiTestUser> {
-  const actor = createBddApi(context).user();
-  if (!actor.orgId) {
-    throw new Error("Zero Finance test actor must belong to an organization");
-  }
-  await updateFeatureSwitchesForUser(
-    context,
-    {
-      userId: actor.userId,
-      orgId: actor.orgId,
-      ...(actor.orgRole ? { orgRole: actor.orgRole } : {}),
-    },
-    { [FeatureSwitchKey.ZeroFinance]: true },
-  );
-  return actor;
-}
-
 async function fundActor(actor: ApiTestUser): Promise<void> {
   await createRunsApi(context).grantProEntitlement(actor);
 }
@@ -73,6 +56,18 @@ function configureProvider(): void {
 describe("zero finance routes", () => {
   it("rejects requests when the feature switch is disabled", async () => {
     const actor = createBddApi(context).user();
+    if (!actor.orgId) {
+      throw new Error("Zero Finance test actor must belong to an organization");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        userId: actor.userId,
+        orgId: actor.orgId,
+        ...(actor.orgRole ? { orgRole: actor.orgRole } : {}),
+      },
+      { [FeatureSwitchKey.ZeroFinance]: false },
+    );
     let providerRequests = 0;
     configureProvider();
     server.use(
@@ -128,7 +123,7 @@ describe("zero finance routes", () => {
   });
 
   it("maps all operations to APIDojo and charges one credit each", async () => {
-    const actor = await financeEnabledActor();
+    const actor = createBddApi(context).user();
     await fundActor(actor);
     configureProvider();
     const beforeCredits = await credits(actor);
@@ -216,7 +211,7 @@ describe("zero finance routes", () => {
   });
 
   it("does not charge credits when APIDojo fails", async () => {
-    const actor = await financeEnabledActor();
+    const actor = createBddApi(context).user();
     await fundActor(actor);
     configureProvider();
     const beforeCredits = await credits(actor);
@@ -243,7 +238,7 @@ describe("zero finance routes", () => {
   });
 
   it("returns not configured without calling APIDojo", async () => {
-    const actor = await financeEnabledActor();
+    const actor = createBddApi(context).user();
     let providerRequests = 0;
     mockEnv("ZERO_FINANCE_APIDOJO_TOKEN", undefined);
     server.use(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,6 +12,7 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ZeroFinance, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.ImageStyleR2, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.VideoArtifactPosters, {})).toBe(
       true,
@@ -156,7 +157,7 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ZeroFinance]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ZeroFinance]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ZeroBrowser]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.LanguagePreference]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -245,8 +245,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Enable the managed APIDojo-backed Zero Finance API and finance:read ZERO_TOKEN capability.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `ZeroFinance` globally and remove the staff-only organization allowlist
- grant `finance:read` and expose managed finance commands by default while preserving explicit user opt-out behavior
- update feature-switch, token, API route, and runner-context coverage to exercise the global rollout

## Verification

- `pnpm --filter @vm0/core lint`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed
- `pnpm --filter api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- `pnpm --filter api exec vitest run src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/zero-finance.test.ts` — 20 passed
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "injects agent identity, tool hints, and user info into the runner context"` — blocked before the changed assertions by the existing local queue-harness `404 Job not found in queue`; the PR pipeline will validate this integration path
