### PR TITLE
fix(ci): preserve balloon results across ssh interruptions

### DIFF
--- a/.github/scripts/runner-behavior-balloon-remote.sh
+++ b/.github/scripts/runner-behavior-balloon-remote.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+
+BIN_DIR=$1; JOB_REF=$2
+RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-balloon"
+SVC="${JOB_REF}-balloon"
+GROUP="vm0/balloon-${JOB_REF}"
+SUBMIT_PID=""
+ALLOC_PID=""
+
+fail() {
+  echo "FAIL: $1"
+  echo "--- Diagnostics ---"
+  echo "Balloon stats:"
+  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics 2>/dev/null \
+    | jq . 2>/dev/null || echo "(unavailable)"
+  echo "Host dmesg (last 10 lines):"
+  sudo dmesg | tail -10 2>/dev/null || true
+  exit 1
+}
+
+cleanup() {
+  echo "--- Cleanup ---"
+  if [ -n "$ALLOC_PID" ]; then
+    kill "$ALLOC_PID" 2>/dev/null || true
+  fi
+  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+  if [ -n "$ALLOC_PID" ]; then
+    wait "$ALLOC_PID" 2>/dev/null || true
+  fi
+  if [ -n "$SUBMIT_PID" ]; then
+    kill "$SUBMIT_PID" 2>/dev/null || true
+    wait "$SUBMIT_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Clean up any residual transient unit from a previous CI run.
+# stop() returns Ok when no service exists, so any non-zero exit is
+# a real cleanup failure.
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
+  || fail "failed to stop residual balloon service"
+
+# Start transient runner service
+echo "--- Starting runner ---"
+sudo "$BIN_DIR/runner" service start --name "$SVC" \
+  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true \
+  || fail "failed to start balloon service"
+
+# Submit a long-running job in background (keeps sandbox alive during tests)
+echo "--- Submitting long-running job ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 360 && echo done' &
+SUBMIT_PID=$!
+
+# Helper: fail fast if the keepalive job exits before the balloon
+# assertions finish. Otherwise a dead sandbox can look like
+# actual_mib=0 and produce misleading follow-on failures.
+ensure_submit_running() {
+  if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
+    wait "$SUBMIT_PID" 2>/dev/null || true
+    SUBMIT_PID=""
+    fail "keepalive submit exited before balloon test completed"
+  fi
+}
+
+# Wait for sandbox control socket. Socket and api.sock paths use
+# sandbox_id (distinct from run_id after #9552). `runner exec`
+# resolves its CLI arg against sandbox_id sock dirs, so SANDBOX_ID
+# is what we need here.
+echo "--- Waiting for sandbox control socket ---"
+for _ in $(seq 1 60); do
+  ensure_submit_running
+  SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
+    "$RUNNER_DIR/status.json" 2>/dev/null)
+  [ -n "$SANDBOX_ID" ] && [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] && break
+  SANDBOX_ID=""
+  sleep 1
+done
+[ -z "$SANDBOX_ID" ] && fail "control socket not found after 60s"
+echo "Found sandbox: $SANDBOX_ID"
+
+API_SOCK="/run/vm0/sock/$SANDBOX_ID/api.sock"
+
+# Keep these recovery expectations aligned with balloon.rs: the controller
+# polls every 5 seconds and inflates only when free_memory is above 384 MiB.
+INFLATE_FREE_BOUNDARY_MIB=384
+CONTROLLER_OBSERVATION_SECONDS=12
+RECOVERY_POLL_SECONDS=2
+RECOVERY_TIMEOUT_SECONDS=60
+
+# Helper: read current balloon actual_mib (returns 0 if VM is dead)
+balloon_mib() {
+  local val
+  val=$(sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
+    | jq -r '.actual_mib // 0' 2>/dev/null)
+  echo "${val:-0}"
+}
+
+# Helper: read a validated target/actual/free-memory snapshot from one
+# Firecracker response. The controller also truncates free_memory to MiB.
+balloon_snapshot() {
+  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
+    | jq -er '
+      [.target_mib, .actual_mib, .free_memory] as $values
+      | select(all($values[]; type == "number" and . >= 0 and . == floor))
+      | [
+          $values[0],
+          $values[1],
+          ($values[2] / 1048576 | floor)
+        ]
+      | @tsv
+    ' 2>/dev/null
+}
+
+# Helper: read guest MemAvailable in kB.
+guest_avail_kb() {
+  local output
+  local val
+  output=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- grep MemAvailable /proc/meminfo 2>/dev/null) || return 1
+  val=$(printf '%s\n' "$output" | awk '/^MemAvailable:/ { print $2; exit }')
+  case "$val" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  echo "$val"
+}
+
+# Helper: check if VM is still alive
+vm_alive() {
+  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/ >/dev/null 2>&1
+}
+
+# Test 1: idle inflate — balloon controller gradually reclaims idle guest memory
+# With per-tick cap (256 MiB), balloon inflates over multiple ticks.
+echo "--- Test 1: balloon idle inflate ---"
+ACTUAL=0
+for _ in $(seq 1 30); do
+  ensure_submit_running
+  ACTUAL=$(balloon_mib)
+  [ "${ACTUAL:-0}" -gt 0 ] && break
+  sleep 1
+done
+[ "$ACTUAL" -gt 0 ] || fail "balloon did not inflate: actual_mib=$ACTUAL"
+echo "PASS: balloon idle inflate (actual_mib=$ACTUAL)"
+
+# Wait for balloon to stabilize (enters hysteresis band)
+echo "--- Waiting for balloon to stabilize ---"
+PREV=0
+STABLE_COUNT=0
+for _ in $(seq 1 30); do
+  ensure_submit_running
+  vm_alive || fail "VM exited during balloon stabilization"
+  ACTUAL=$(balloon_mib)
+  if [ "$ACTUAL" -eq "$PREV" ] && [ "$ACTUAL" -gt 0 ]; then
+    STABLE_COUNT=$((STABLE_COUNT + 1))
+    [ "$STABLE_COUNT" -ge 2 ] && break
+  else
+    STABLE_COUNT=0
+  fi
+  PREV=$ACTUAL
+  sleep 3
+done
+INFLATE_MIB=$ACTUAL
+[ "$INFLATE_MIB" -gt 0 ] || fail "balloon stabilized at zero; VM may have exited"
+echo "Balloon stabilized at ${INFLATE_MIB} MiB"
+
+# Verify guest-side: MemAvailable decreased
+ensure_submit_running
+AVAIL=$(guest_avail_kb) || fail "failed to read guest MemAvailable"
+[ "$AVAIL" -gt 0 ] || fail "guest MemAvailable unavailable"
+[ "$AVAIL" -lt 1536000 ] || fail "MemAvailable too high after balloon: ${AVAIL}kB (expected < 1536000kB)"
+echo "PASS: guest MemAvailable reduced (${AVAIL}kB)"
+
+# Test 2: deflate under memory pressure — allocate anonymous memory
+# in the guest to push available below deflate threshold (192 MiB).
+# Scale the allocator down when the idle balloon state already leaves
+# limited guest headroom; otherwise the allocator can starve the
+# keepalive job and mask the assertion as "cancelled by user".
+# Trailing `# BALLOON_ALLOC_MARKER` is a unique string pkill can
+# match on to terminate the guest-side allocator below.
+echo "--- Test 2: balloon deflate under memory pressure ---"
+MAX_PRESSURE_ALLOC_MIB=300
+MIN_PRESSURE_REMAINING_MIB=128
+MIN_PRESSURE_AVAIL_KB=$(( MIN_PRESSURE_REMAINING_MIB * 1024 ))
+ensure_submit_running
+PRE_PRESSURE_AVAIL_KB=$(guest_avail_kb) || fail "failed to read guest MemAvailable before pressure allocation"
+if [ "$PRE_PRESSURE_AVAIL_KB" -le "$MIN_PRESSURE_AVAIL_KB" ]; then
+  fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need > ${MIN_PRESSURE_AVAIL_KB}kB)"
+fi
+PRE_PRESSURE_AVAIL_MIB=$(( PRE_PRESSURE_AVAIL_KB / 1024 ))
+PRESSURE_ALLOC_MIB=$(( PRE_PRESSURE_AVAIL_MIB - MIN_PRESSURE_REMAINING_MIB ))
+if [ "$PRESSURE_ALLOC_MIB" -gt "$MAX_PRESSURE_ALLOC_MIB" ]; then
+  PRESSURE_ALLOC_MIB=$MAX_PRESSURE_ALLOC_MIB
+fi
+[ "$PRESSURE_ALLOC_MIB" -gt 0 ] || fail "pressure allocation would be zero: ${PRE_PRESSURE_AVAIL_KB}kB available"
+echo "Pre-pressure guest MemAvailable: ${PRE_PRESSURE_AVAIL_KB}kB; allocating ${PRESSURE_ALLOC_MIB}MiB"
+sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "import ctypes,time; b=bytearray(${PRESSURE_ALLOC_MIB}*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER" &
+ALLOC_PID=$!
+
+# Wait for balloon to deflate (actual_mib decreases)
+DEFLATED=0
+for _ in $(seq 1 30); do
+  ensure_submit_running
+  vm_alive || fail "VM exited during balloon deflate test"
+  ACTUAL=$(balloon_mib)
+  if [ "$ACTUAL" -lt "$INFLATE_MIB" ]; then
+    DEFLATED=1
+    break
+  fi
+  sleep 2
+done
+[ "$DEFLATED" -eq 1 ] || fail "balloon did not deflate: actual_mib=$ACTUAL (was $INFLATE_MIB)"
+DEFLATE_MIB=$ACTUAL
+echo "PASS: balloon deflated from ${INFLATE_MIB} to ${DEFLATE_MIB} MiB"
+
+# Test 3: re-inflate after pressure released — kill the host-side
+# exec first (prevents further output), then kill the guest-side
+# allocator. The host kill does NOT propagate to the guest process
+# because vsock-guest spawns it independently.
+echo "--- Test 3: balloon re-inflate after pressure release ---"
+kill "$ALLOC_PID" 2>/dev/null || true
+wait "$ALLOC_PID" 2>/dev/null || true
+ALLOC_PID=""
+
+# Verify VM survived the memory pressure test
+vm_alive || fail "VM crashed during memory pressure test"
+
+# Kill guest-side allocator — Test 2 passing means the controller has
+# already returned memory to the guest, enough for pkill exec.
+sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- pkill -f '[B]ALLOON_ALLOC_MARKER' 2>/dev/null || true
+
+# A failed runner exec must not masquerade as allocator absence, so probe
+# through a guest command that reports state while always exiting successfully.
+ALLOCATOR_STOPPED=0
+for _ in $(seq 1 5); do
+  if ! ALLOCATOR_STATE=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- \
+    sh -c 'pgrep -f "[B]ALLOON_ALLOC_MARKER" >/dev/null; status=$?; if [ "$status" -eq 0 ]; then printf "running\n"; elif [ "$status" -eq 1 ]; then printf "stopped\n"; else exit "$status"; fi' \
+    2>/dev/null); then
+    fail "failed to verify guest pressure allocator state"
+  fi
+  case "$ALLOCATOR_STATE" in
+    stopped)
+      ALLOCATOR_STOPPED=1
+      break
+      ;;
+    running)
+      sleep 1
+      ;;
+    *)
+      fail "unexpected guest pressure allocator state: $ALLOCATOR_STATE"
+      ;;
+  esac
+done
+[ "$ALLOCATOR_STOPPED" -eq 1 ] || fail "guest pressure allocator remained running"
+
+# Accept either realized re-inflation or a stable state inside the controller's
+# hysteresis band. Both sides must persist for a complete observation window so
+# a single boundary crossing cannot determine the result.
+RECOVERY_DEADLINE=$(( SECONDS + RECOVERY_TIMEOUT_SECONDS ))
+HIGH_FREE_SINCE=""
+LOW_FREE_SINCE=""
+TARGET_RAISED=0
+RECOVERY_RESULT=""
+LAST_TARGET=$DEFLATE_MIB
+LAST_ACTUAL=$DEFLATE_MIB
+LAST_FREE_MIB=""
+while [ "$SECONDS" -lt "$RECOVERY_DEADLINE" ]; do
+  ensure_submit_running
+  vm_alive || fail "VM exited during balloon re-inflate test"
+
+  if ! SNAPSHOT=$(balloon_snapshot); then
+    fail "failed to read valid balloon recovery statistics"
+  fi
+  IFS=$'\t' read -r LAST_TARGET LAST_ACTUAL LAST_FREE_MIB <<< "$SNAPSHOT"
+  echo "Recovery snapshot: target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB"
+
+  if [ "$LAST_TARGET" -gt "$DEFLATE_MIB" ]; then
+    TARGET_RAISED=1
+  fi
+  if [ "$LAST_ACTUAL" -gt "$DEFLATE_MIB" ]; then
+    RECOVERY_RESULT="re-inflated"
+    break
+  fi
+
+  NOW=$SECONDS
+  if [ "$LAST_FREE_MIB" -gt "$INFLATE_FREE_BOUNDARY_MIB" ]; then
+    LOW_FREE_SINCE=""
+    if [ -z "$HIGH_FREE_SINCE" ]; then
+      HIGH_FREE_SINCE=$NOW
+    fi
+    if [ "$TARGET_RAISED" -eq 0 ] \
+      && [ $(( NOW - HIGH_FREE_SINCE )) -ge "$CONTROLLER_OBSERVATION_SECONDS" ]; then
+      fail "balloon controller did not respond above inflate boundary: target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB boundary=${INFLATE_FREE_BOUNDARY_MIB}MiB"
+    fi
+  else
+    HIGH_FREE_SINCE=""
+    if [ -z "$LOW_FREE_SINCE" ]; then
+      LOW_FREE_SINCE=$NOW
+    fi
+    if [ $(( NOW - LOW_FREE_SINCE )) -ge "$CONTROLLER_OBSERVATION_SECONDS" ] \
+      && [ "$LAST_TARGET" -eq "$LAST_ACTUAL" ]; then
+      RECOVERY_RESULT="hysteresis-settled"
+      break
+    fi
+  fi
+
+  sleep "$RECOVERY_POLL_SECONDS"
+done
+
+case "$RECOVERY_RESULT" in
+  re-inflated)
+    echo "PASS: balloon re-inflated from ${DEFLATE_MIB} to ${LAST_ACTUAL} MiB (target=${LAST_TARGET}MiB free=${LAST_FREE_MIB}MiB)"
+    ;;
+  hysteresis-settled)
+    echo "PASS: balloon settled inside inflate hysteresis (deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB boundary=${INFLATE_FREE_BOUNDARY_MIB}MiB)"
+    ;;
+  *)
+    if [ "$TARGET_RAISED" -eq 1 ]; then
+      fail "balloon target increase was not realized before timeout: deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB:-unknown}MiB"
+    fi
+    fail "balloon recovery did not reach a stable outcome: deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB:-unknown}MiB"
+    ;;
+esac
+
+# Stop transient service
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
+  || fail "failed to stop balloon service"
+kill "$SUBMIT_PID" 2>/dev/null || true
+wait "$SUBMIT_PID" 2>/dev/null || true
+trap - EXIT
+
+echo "=== Balloon test passed ==="

--- a/.github/scripts/runner-behavior-balloon.sh
+++ b/.github/scripts/runner-behavior-balloon.sh
@@ -1,7 +1,302 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REMOTE_WORKER="$SCRIPT_DIR/runner-behavior-balloon-remote.sh"
 REMOTE="${METAL_USER}@${HOST}"
+
+case "${GITHUB_RUN_ID:-}" in
+  ''|*[!0-9]*)
+    echo "GITHUB_RUN_ID must be numeric" >&2
+    exit 2
+    ;;
+esac
+case "${GITHUB_RUN_ATTEMPT:-}" in
+  ''|*[!0-9]*)
+    echo "GITHUB_RUN_ATTEMPT must be numeric" >&2
+    exit 2
+    ;;
+esac
+
+EXECUTION_KEY="balloon-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+REMOTE_DIR="/tmp/vm0-runner-behavior/${EXECUTION_KEY}"
+REMOTE_WORKER_PATH="${REMOTE_DIR}/worker.sh"
+REMOTE_LOG="${REMOTE_DIR}/output.log"
+REMOTE_STATUS="${REMOTE_DIR}/status"
+REMOTE_UNIT="vm0-ci-${EXECUTION_KEY}"
+SSH_ATTEMPTS=3
+RESULT_POLL_SECONDS=2
+RESULT_TIMEOUT_SECONDS=270
+
+LOCAL_LOG=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/balloon-result.XXXXXX")
+REMOTE_STAGED=0
+REMOTE_MAY_BE_STARTED=0
+REMOTE_DONE=0
+
+cleanup() {
+  rm -f "$LOCAL_LOG"
+
+  if [ "$REMOTE_STAGED" -eq 1 ]; then
+    if [ "$REMOTE_MAY_BE_STARTED" -eq 1 ]; then
+      if [ "$REMOTE_DONE" -eq 1 ]; then
+        return
+      fi
+      ssh "$REMOTE" bash -s -- "$REMOTE_DIR" "$REMOTE_UNIT" <<'REMOTE_ABORT' >/dev/null 2>&1 || true
+set -euo pipefail
+REMOTE_DIR=$1
+UNIT=$2
+sudo systemctl stop "${UNIT}.service" 2>/dev/null || true
+rm -rf -- "$REMOTE_DIR"
+REMOTE_ABORT
+    else
+      # REMOTE_DIR is derived exclusively from validated numeric workflow IDs.
+      # shellcheck disable=SC2029
+      ssh "$REMOTE" "rm -rf -- '${REMOTE_DIR}'" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+stage_worker() {
+  local attempt
+  local status
+
+  for attempt in $(seq 1 "$SSH_ATTEMPTS"); do
+    status=0
+    # REMOTE_DIR is derived exclusively from validated numeric workflow IDs.
+    # shellcheck disable=SC2029
+    ssh "$REMOTE" "set -eu
+umask 077
+mkdir -p '${REMOTE_DIR}'
+tmp=\$(mktemp '${REMOTE_DIR}/worker.XXXXXX')
+trap 'rm -f \"\$tmp\"' EXIT
+cat > \"\$tmp\"
+chmod 700 \"\$tmp\"
+mv \"\$tmp\" '${REMOTE_WORKER_PATH}'
+trap - EXIT" < "$REMOTE_WORKER" || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$status" -ne 255 ] || [ "$attempt" -eq "$SSH_ATTEMPTS" ]; then
+      return "$status"
+    fi
+
+    echo "Transient SSH failure while staging balloon worker; retrying (${attempt}/${SSH_ATTEMPTS})" >&2
+    sleep "$attempt"
+  done
+}
+
+launch_once() {
+  ssh "$REMOTE" bash -s -- \
+    "$REMOTE_DIR" "$REMOTE_WORKER_PATH" "$REMOTE_LOG" "$REMOTE_STATUS" \
+    "$REMOTE_UNIT" "$BIN_DIR" "$JOB_REF" <<'REMOTE_LAUNCH'
+set -euo pipefail
+REMOTE_DIR=$1
+WORKER=$2
+LOG=$3
+STATUS_FILE=$4
+UNIT=$5
+BIN_DIR=$6
+JOB_REF=$7
+
+exec 9>"${REMOTE_DIR}/launch.lock"
+flock 9
+
+if [ -f "$STATUS_FILE" ]; then
+  exit 0
+fi
+
+LOAD_STATE=$(sudo systemctl show "${UNIT}.service" \
+  --property=LoadState --value 2>/dev/null || true)
+if [ "$LOAD_STATE" = "loaded" ]; then
+  ACTIVE_STATE=$(sudo systemctl show "${UNIT}.service" \
+    --property=ActiveState --value)
+  case "$ACTIVE_STATE" in
+    active|activating|deactivating)
+      exit 0
+      ;;
+    *)
+      echo "durable balloon unit stopped without publishing a result: ${ACTIVE_STATE}" >&2
+      exit 1
+      ;;
+  esac
+fi
+if [ -n "$LOAD_STATE" ] && [ "$LOAD_STATE" != "not-found" ]; then
+  echo "unexpected durable balloon unit load state: ${LOAD_STATE}" >&2
+  exit 1
+fi
+
+REMOTE_UID=$(id -u)
+REMOTE_GID=$(id -g)
+REMOTE_HOME=$HOME
+REMOTE_PWD=$PWD
+
+sudo systemd-run \
+  --quiet \
+  --collect \
+  --service-type=exec \
+  --unit="$UNIT" \
+  --uid="$REMOTE_UID" \
+  --gid="$REMOTE_GID" \
+  --working-directory="$REMOTE_PWD" \
+  --setenv="HOME=${REMOTE_HOME}" \
+  /bin/bash -c '
+    worker=$1
+    log=$2
+    status_file=$3
+    bin_dir=$4
+    job_ref=$5
+
+    "$worker" "$bin_dir" "$job_ref" > "$log" 2>&1
+    worker_status=$?
+    printf "%s\n" "$worker_status" > "${status_file}.tmp"
+    mv "${status_file}.tmp" "$status_file"
+    exit "$worker_status"
+  ' balloon-result-wrapper "$WORKER" "$LOG" "$STATUS_FILE" "$BIN_DIR" "$JOB_REF"
+REMOTE_LAUNCH
+}
+
+launch_worker() {
+  local attempt
+  local status
+
+  for attempt in $(seq 1 "$SSH_ATTEMPTS"); do
+    status=0
+    launch_once || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$status" -ne 255 ] || [ "$attempt" -eq "$SSH_ATTEMPTS" ]; then
+      return "$status"
+    fi
+
+    echo "Lost SSH launch response; checking the same durable execution (${attempt}/${SSH_ATTEMPTS})" >&2
+    sleep "$attempt"
+  done
+}
+
+read_remote_state() {
+  ssh "$REMOTE" bash -s -- "$REMOTE_STATUS" "$REMOTE_UNIT" <<'REMOTE_STATE'
+set -euo pipefail
+STATUS_FILE=$1
+UNIT=$2
+
+if [ -f "$STATUS_FILE" ]; then
+  STATUS=$(<"$STATUS_FILE")
+  printf 'done:%s\n' "$STATUS"
+  exit 0
+fi
+
+LOAD_STATE=$(sudo systemctl show "${UNIT}.service" \
+  --property=LoadState --value 2>/dev/null || true)
+if [ -z "$LOAD_STATE" ] || [ "$LOAD_STATE" = "not-found" ]; then
+  echo "absent"
+  exit 0
+fi
+if [ "$LOAD_STATE" != "loaded" ]; then
+  printf 'invalid-load:%s\n' "$LOAD_STATE"
+  exit 0
+fi
+
+ACTIVE_STATE=$(sudo systemctl show "${UNIT}.service" \
+  --property=ActiveState --value)
+case "$ACTIVE_STATE" in
+  active|activating|deactivating)
+    echo "pending"
+    ;;
+  *)
+    printf 'stopped:%s\n' "$ACTIVE_STATE"
+    ;;
+esac
+REMOTE_STATE
+}
+
+read_remote_state_with_retry() {
+  local attempt
+  local state
+  local status
+
+  for attempt in $(seq 1 "$SSH_ATTEMPTS"); do
+    status=0
+    state=$(read_remote_state) || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      printf '%s\n' "$state"
+      return 0
+    fi
+    if [ "$status" -ne 255 ] || [ "$attempt" -eq "$SSH_ATTEMPTS" ]; then
+      return "$status"
+    fi
+
+    echo "Transient SSH failure while observing balloon result; retrying (${attempt}/${SSH_ATTEMPTS})" >&2
+    sleep "$attempt"
+  done
+}
+
+fetch_remote_log() {
+  local attempt
+  local status
+
+  for attempt in $(seq 1 "$SSH_ATTEMPTS"); do
+    status=0
+    # REMOTE_LOG is derived exclusively from validated numeric workflow IDs.
+    # shellcheck disable=SC2029
+    ssh "$REMOTE" "cat -- '${REMOTE_LOG}'" > "$LOCAL_LOG" || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$status" -ne 255 ] || [ "$attempt" -eq "$SSH_ATTEMPTS" ]; then
+      return "$status"
+    fi
+
+    echo "Transient SSH failure while retrieving balloon log; retrying (${attempt}/${SSH_ATTEMPTS})" >&2
+    sleep "$attempt"
+  done
+}
+
+remove_remote_result() {
+  ssh "$REMOTE" bash -s -- "$REMOTE_DIR" "$REMOTE_UNIT" <<'REMOTE_REMOVE'
+set -euo pipefail
+REMOTE_DIR=$1
+UNIT=$2
+
+for _ in $(seq 1 20); do
+  LOAD_STATE=$(sudo systemctl show "${UNIT}.service" \
+    --property=LoadState --value 2>/dev/null || true)
+  if [ -z "$LOAD_STATE" ] || [ "$LOAD_STATE" = "not-found" ]; then
+    rm -rf -- "$REMOTE_DIR"
+    exit 0
+  fi
+  sleep 0.25
+done
+
+echo "durable balloon unit was not collected" >&2
+exit 1
+REMOTE_REMOVE
+}
+
+remove_remote_result_with_retry() {
+  local attempt
+  local status
+
+  for attempt in $(seq 1 "$SSH_ATTEMPTS"); do
+    status=0
+    remove_remote_result || status=$?
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$status" -ne 255 ] || [ "$attempt" -eq "$SSH_ATTEMPTS" ]; then
+      return "$status"
+    fi
+
+    echo "Transient SSH failure while removing balloon result; retrying (${attempt}/${SSH_ATTEMPTS})" >&2
+    sleep "$attempt"
+  done
+}
 
 echo "=== Generating config ==="
 # shellcheck disable=SC2029
@@ -16,334 +311,75 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --api-url https://not-a-real-server.test \
   --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
+echo "=== Staging durable balloon test ==="
+REMOTE_STAGED=1
+stage_worker
+
 echo "=== Running balloon test ==="
-ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
-BIN_DIR=$1; JOB_REF=$2
-RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-balloon"
-SVC="${JOB_REF}-balloon"
-GROUP="vm0/balloon-${JOB_REF}"
-SUBMIT_PID=""
-ALLOC_PID=""
+REMOTE_MAY_BE_STARTED=1
+launch_worker
 
-fail() {
-  echo "FAIL: $1"
-  echo "--- Diagnostics ---"
-  echo "Balloon stats:"
-  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics 2>/dev/null \
-    | jq . 2>/dev/null || echo "(unavailable)"
-  echo "Host dmesg (last 10 lines):"
-  sudo dmesg | tail -10 2>/dev/null || true
-  exit 1
-}
-
-cleanup() {
-  echo "--- Cleanup ---"
-  if [ -n "$ALLOC_PID" ]; then
-    kill "$ALLOC_PID" 2>/dev/null || true
-  fi
-  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
-  if [ -n "$ALLOC_PID" ]; then
-    wait "$ALLOC_PID" 2>/dev/null || true
-  fi
-  if [ -n "$SUBMIT_PID" ]; then
-    kill "$SUBMIT_PID" 2>/dev/null || true
-    wait "$SUBMIT_PID" 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT
-
-# Clean up any residual transient unit from a previous CI run.
-# stop() returns Ok when no service exists, so any non-zero exit is
-# a real cleanup failure.
-sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
-  || fail "failed to stop residual balloon service"
-
-# Start transient runner service
-echo "--- Starting runner ---"
-sudo "$BIN_DIR/runner" service start --name "$SVC" \
-  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true \
-  || fail "failed to start balloon service"
-
-# Submit a long-running job in background (keeps sandbox alive during tests)
-echo "--- Submitting long-running job ---"
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 360 && echo done' &
-SUBMIT_PID=$!
-
-# Helper: fail fast if the keepalive job exits before the balloon
-# assertions finish. Otherwise a dead sandbox can look like
-# actual_mib=0 and produce misleading follow-on failures.
-ensure_submit_running() {
-  if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
-    wait "$SUBMIT_PID" 2>/dev/null || true
-    SUBMIT_PID=""
-    fail "keepalive submit exited before balloon test completed"
-  fi
-}
-
-# Wait for sandbox control socket. Socket and api.sock paths use
-# sandbox_id (distinct from run_id after #9552). `runner exec`
-# resolves its CLI arg against sandbox_id sock dirs, so SANDBOX_ID
-# is what we need here.
-echo "--- Waiting for sandbox control socket ---"
-for i in $(seq 1 60); do
-  ensure_submit_running
-  SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
-    "$RUNNER_DIR/status.json" 2>/dev/null)
-  [ -n "$SANDBOX_ID" ] && [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] && break
-  SANDBOX_ID=""
-  sleep 1
-done
-[ -z "$SANDBOX_ID" ] && fail "control socket not found after 60s"
-echo "Found sandbox: $SANDBOX_ID"
-
-API_SOCK="/run/vm0/sock/$SANDBOX_ID/api.sock"
-
-# Keep these recovery expectations aligned with balloon.rs: the controller
-# polls every 5 seconds and inflates only when free_memory is above 384 MiB.
-INFLATE_FREE_BOUNDARY_MIB=384
-CONTROLLER_OBSERVATION_SECONDS=12
-RECOVERY_POLL_SECONDS=2
-RECOVERY_TIMEOUT_SECONDS=60
-
-# Helper: read current balloon actual_mib (returns 0 if VM is dead)
-balloon_mib() {
-  local val
-  val=$(sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
-    | jq -r '.actual_mib // 0' 2>/dev/null)
-  echo "${val:-0}"
-}
-
-# Helper: read a validated target/actual/free-memory snapshot from one
-# Firecracker response. The controller also truncates free_memory to MiB.
-balloon_snapshot() {
-  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
-    | jq -er '
-      [.target_mib, .actual_mib, .free_memory] as $values
-      | select(all($values[]; type == "number" and . >= 0 and . == floor))
-      | [
-          $values[0],
-          $values[1],
-          ($values[2] / 1048576 | floor)
-        ]
-      | @tsv
-    ' 2>/dev/null
-}
-
-# Helper: read guest MemAvailable in kB.
-guest_avail_kb() {
-  local output
-  local val
-  output=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- grep MemAvailable /proc/meminfo 2>/dev/null) || return 1
-  val=$(printf '%s\n' "$output" | awk '/^MemAvailable:/ { print $2; exit }')
-  case "$val" in
-    ''|*[!0-9]*) return 1 ;;
-  esac
-  echo "$val"
-}
-
-# Helper: check if VM is still alive
-vm_alive() {
-  sudo curl -sf --unix-socket "$API_SOCK" http://localhost/ >/dev/null 2>&1
-}
-
-# Test 1: idle inflate — balloon controller gradually reclaims idle guest memory
-# With per-tick cap (256 MiB), balloon inflates over multiple ticks.
-echo "--- Test 1: balloon idle inflate ---"
-ACTUAL=0
-for i in $(seq 1 30); do
-  ensure_submit_running
-  ACTUAL=$(balloon_mib)
-  [ "${ACTUAL:-0}" -gt 0 ] && break
-  sleep 1
-done
-[ "$ACTUAL" -gt 0 ] || fail "balloon did not inflate: actual_mib=$ACTUAL"
-echo "PASS: balloon idle inflate (actual_mib=$ACTUAL)"
-
-# Wait for balloon to stabilize (enters hysteresis band)
-echo "--- Waiting for balloon to stabilize ---"
-PREV=0
-STABLE_COUNT=0
-for i in $(seq 1 30); do
-  ensure_submit_running
-  vm_alive || fail "VM exited during balloon stabilization"
-  ACTUAL=$(balloon_mib)
-  if [ "$ACTUAL" -eq "$PREV" ] && [ "$ACTUAL" -gt 0 ]; then
-    STABLE_COUNT=$((STABLE_COUNT + 1))
-    [ "$STABLE_COUNT" -ge 2 ] && break
-  else
-    STABLE_COUNT=0
-  fi
-  PREV=$ACTUAL
-  sleep 3
-done
-INFLATE_MIB=$ACTUAL
-[ "$INFLATE_MIB" -gt 0 ] || fail "balloon stabilized at zero; VM may have exited"
-echo "Balloon stabilized at ${INFLATE_MIB} MiB"
-
-# Verify guest-side: MemAvailable decreased
-ensure_submit_running
-AVAIL=$(guest_avail_kb) || fail "failed to read guest MemAvailable"
-[ "$AVAIL" -gt 0 ] || fail "guest MemAvailable unavailable"
-[ "$AVAIL" -lt 1536000 ] || fail "MemAvailable too high after balloon: ${AVAIL}kB (expected < 1536000kB)"
-echo "PASS: guest MemAvailable reduced (${AVAIL}kB)"
-
-# Test 2: deflate under memory pressure — allocate anonymous memory
-# in the guest to push available below deflate threshold (192 MiB).
-# Scale the allocator down when the idle balloon state already leaves
-# limited guest headroom; otherwise the allocator can starve the
-# keepalive job and mask the assertion as "cancelled by user".
-# Trailing `# BALLOON_ALLOC_MARKER` is a unique string pkill can
-# match on to terminate the guest-side allocator below.
-echo "--- Test 2: balloon deflate under memory pressure ---"
-MAX_PRESSURE_ALLOC_MIB=300
-MIN_PRESSURE_REMAINING_MIB=128
-MIN_PRESSURE_AVAIL_KB=$(( MIN_PRESSURE_REMAINING_MIB * 1024 ))
-ensure_submit_running
-PRE_PRESSURE_AVAIL_KB=$(guest_avail_kb) || fail "failed to read guest MemAvailable before pressure allocation"
-if [ "$PRE_PRESSURE_AVAIL_KB" -le "$MIN_PRESSURE_AVAIL_KB" ]; then
-  fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need > ${MIN_PRESSURE_AVAIL_KB}kB)"
-fi
-PRE_PRESSURE_AVAIL_MIB=$(( PRE_PRESSURE_AVAIL_KB / 1024 ))
-PRESSURE_ALLOC_MIB=$(( PRE_PRESSURE_AVAIL_MIB - MIN_PRESSURE_REMAINING_MIB ))
-if [ "$PRESSURE_ALLOC_MIB" -gt "$MAX_PRESSURE_ALLOC_MIB" ]; then
-  PRESSURE_ALLOC_MIB=$MAX_PRESSURE_ALLOC_MIB
-fi
-[ "$PRESSURE_ALLOC_MIB" -gt 0 ] || fail "pressure allocation would be zero: ${PRE_PRESSURE_AVAIL_KB}kB available"
-echo "Pre-pressure guest MemAvailable: ${PRE_PRESSURE_AVAIL_KB}kB; allocating ${PRESSURE_ALLOC_MIB}MiB"
-sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "import ctypes,time; b=bytearray(${PRESSURE_ALLOC_MIB}*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER" &
-ALLOC_PID=$!
-
-# Wait for balloon to deflate (actual_mib decreases)
-DEFLATED=0
-for i in $(seq 1 30); do
-  ensure_submit_running
-  vm_alive || fail "VM exited during balloon deflate test"
-  ACTUAL=$(balloon_mib)
-  if [ "$ACTUAL" -lt "$INFLATE_MIB" ]; then
-    DEFLATED=1
-    break
-  fi
-  sleep 2
-done
-[ "$DEFLATED" -eq 1 ] || fail "balloon did not deflate: actual_mib=$ACTUAL (was $INFLATE_MIB)"
-DEFLATE_MIB=$ACTUAL
-echo "PASS: balloon deflated from ${INFLATE_MIB} to ${DEFLATE_MIB} MiB"
-
-# Test 3: re-inflate after pressure released — kill the host-side
-# exec first (prevents further output), then kill the guest-side
-# allocator. The host kill does NOT propagate to the guest process
-# because vsock-guest spawns it independently.
-echo "--- Test 3: balloon re-inflate after pressure release ---"
-kill "$ALLOC_PID" 2>/dev/null || true
-wait "$ALLOC_PID" 2>/dev/null || true
-ALLOC_PID=""
-
-# Verify VM survived the memory pressure test
-vm_alive || fail "VM crashed during memory pressure test"
-
-# Kill guest-side allocator — Test 2 passing means the controller has
-# already returned memory to the guest, enough for pkill exec.
-sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- pkill -f '[B]ALLOON_ALLOC_MARKER' 2>/dev/null || true
-
-# A failed runner exec must not masquerade as allocator absence, so probe
-# through a guest command that reports state while always exiting successfully.
-ALLOCATOR_STOPPED=0
-for i in $(seq 1 5); do
-  if ! ALLOCATOR_STATE=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- \
-    sh -c 'pgrep -f "[B]ALLOON_ALLOC_MARKER" >/dev/null; status=$?; if [ "$status" -eq 0 ]; then printf "running\n"; elif [ "$status" -eq 1 ]; then printf "stopped\n"; else exit "$status"; fi' \
-    2>/dev/null); then
-    fail "failed to verify guest pressure allocator state"
-  fi
-  case "$ALLOCATOR_STATE" in
-    stopped)
-      ALLOCATOR_STOPPED=1
+DEADLINE=$(( SECONDS + RESULT_TIMEOUT_SECONDS ))
+POLL_COUNT=0
+REMOTE_RESULT=""
+while [ "$SECONDS" -lt "$DEADLINE" ]; do
+  STATE=$(read_remote_state_with_retry)
+  case "$STATE" in
+    done:*)
+      REMOTE_RESULT=${STATE#done:}
+      REMOTE_DONE=1
       break
       ;;
-    running)
-      sleep 1
+    pending)
+      POLL_COUNT=$(( POLL_COUNT + 1 ))
+      if [ "$POLL_COUNT" -eq 1 ] || [ $(( POLL_COUNT % 15 )) -eq 0 ]; then
+        echo "Waiting for durable balloon result"
+      fi
+      ;;
+    absent)
+      echo "durable balloon unit disappeared without publishing a result" >&2
+      exit 1
+      ;;
+    stopped:*)
+      echo "durable balloon unit stopped without publishing a result: ${STATE#stopped:}" >&2
+      exit 1
+      ;;
+    invalid-load:*)
+      echo "unexpected durable balloon unit load state: ${STATE#invalid-load:}" >&2
+      exit 1
       ;;
     *)
-      fail "unexpected guest pressure allocator state: $ALLOCATOR_STATE"
+      echo "unexpected durable balloon state: $STATE" >&2
+      exit 1
       ;;
   esac
-done
-[ "$ALLOCATOR_STOPPED" -eq 1 ] || fail "guest pressure allocator remained running"
-
-# Accept either realized re-inflation or a stable state inside the controller's
-# hysteresis band. Both sides must persist for a complete observation window so
-# a single boundary crossing cannot determine the result.
-RECOVERY_DEADLINE=$(( SECONDS + RECOVERY_TIMEOUT_SECONDS ))
-HIGH_FREE_SINCE=""
-LOW_FREE_SINCE=""
-TARGET_RAISED=0
-RECOVERY_RESULT=""
-LAST_TARGET=$DEFLATE_MIB
-LAST_ACTUAL=$DEFLATE_MIB
-LAST_FREE_MIB=""
-while [ "$SECONDS" -lt "$RECOVERY_DEADLINE" ]; do
-  ensure_submit_running
-  vm_alive || fail "VM exited during balloon re-inflate test"
-
-  if ! SNAPSHOT=$(balloon_snapshot); then
-    fail "failed to read valid balloon recovery statistics"
-  fi
-  IFS=$'\t' read -r LAST_TARGET LAST_ACTUAL LAST_FREE_MIB <<< "$SNAPSHOT"
-  echo "Recovery snapshot: target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB"
-
-  if [ "$LAST_TARGET" -gt "$DEFLATE_MIB" ]; then
-    TARGET_RAISED=1
-  fi
-  if [ "$LAST_ACTUAL" -gt "$DEFLATE_MIB" ]; then
-    RECOVERY_RESULT="re-inflated"
-    break
-  fi
-
-  NOW=$SECONDS
-  if [ "$LAST_FREE_MIB" -gt "$INFLATE_FREE_BOUNDARY_MIB" ]; then
-    LOW_FREE_SINCE=""
-    if [ -z "$HIGH_FREE_SINCE" ]; then
-      HIGH_FREE_SINCE=$NOW
-    fi
-    if [ "$TARGET_RAISED" -eq 0 ] \
-      && [ $(( NOW - HIGH_FREE_SINCE )) -ge "$CONTROLLER_OBSERVATION_SECONDS" ]; then
-      fail "balloon controller did not respond above inflate boundary: target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB boundary=${INFLATE_FREE_BOUNDARY_MIB}MiB"
-    fi
-  else
-    HIGH_FREE_SINCE=""
-    if [ -z "$LOW_FREE_SINCE" ]; then
-      LOW_FREE_SINCE=$NOW
-    fi
-    if [ $(( NOW - LOW_FREE_SINCE )) -ge "$CONTROLLER_OBSERVATION_SECONDS" ] \
-      && [ "$LAST_TARGET" -eq "$LAST_ACTUAL" ]; then
-      RECOVERY_RESULT="hysteresis-settled"
-      break
-    fi
-  fi
-
-  sleep "$RECOVERY_POLL_SECONDS"
+  sleep "$RESULT_POLL_SECONDS"
 done
 
-case "$RECOVERY_RESULT" in
-  re-inflated)
-    echo "PASS: balloon re-inflated from ${DEFLATE_MIB} to ${LAST_ACTUAL} MiB (target=${LAST_TARGET}MiB free=${LAST_FREE_MIB}MiB)"
-    ;;
-  hysteresis-settled)
-    echo "PASS: balloon settled inside inflate hysteresis (deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB}MiB boundary=${INFLATE_FREE_BOUNDARY_MIB}MiB)"
-    ;;
-  *)
-    if [ "$TARGET_RAISED" -eq 1 ]; then
-      fail "balloon target increase was not realized before timeout: deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB:-unknown}MiB"
-    fi
-    fail "balloon recovery did not reach a stable outcome: deflated=${DEFLATE_MIB}MiB target=${LAST_TARGET}MiB actual=${LAST_ACTUAL}MiB free=${LAST_FREE_MIB:-unknown}MiB"
+if [ -z "$REMOTE_RESULT" ]; then
+  echo "durable balloon test did not finish within ${RESULT_TIMEOUT_SECONDS}s" >&2
+  if fetch_remote_log; then
+    cat "$LOCAL_LOG"
+  fi
+  exit 1
+fi
+
+case "$REMOTE_RESULT" in
+  ''|*[!0-9]*)
+    echo "invalid durable balloon exit status: $REMOTE_RESULT" >&2
+    exit 1
     ;;
 esac
+if [ "$REMOTE_RESULT" -gt 255 ]; then
+  echo "invalid durable balloon exit status: $REMOTE_RESULT" >&2
+  exit 1
+fi
 
-# Stop transient service
-sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
-  || fail "failed to stop balloon service"
-kill "$SUBMIT_PID" 2>/dev/null || true
-wait "$SUBMIT_PID" 2>/dev/null || true
-trap - EXIT
+fetch_remote_log
+cat "$LOCAL_LOG"
+remove_remote_result_with_retry
+REMOTE_STAGED=0
 
-echo "=== Balloon test passed ==="
-REMOTE_SCRIPT
+# Preserve the worker status as the script's final command while still allowing
+# ShellCheck to analyze the EXIT trap handler.
+(exit "$REMOTE_RESULT")

--- a/.github/scripts/runner-behavior-balloon.sh
+++ b/.github/scripts/runner-behavior-balloon.sh
@@ -117,14 +117,23 @@ if [ "$LOAD_STATE" = "loaded" ]; then
       exit 0
       ;;
     *)
+      if [ -f "$STATUS_FILE" ]; then
+        exit 0
+      fi
       echo "durable balloon unit stopped without publishing a result: ${ACTIVE_STATE}" >&2
       exit 1
       ;;
   esac
 fi
 if [ -n "$LOAD_STATE" ] && [ "$LOAD_STATE" != "not-found" ]; then
+  if [ -f "$STATUS_FILE" ]; then
+    exit 0
+  fi
   echo "unexpected durable balloon unit load state: ${LOAD_STATE}" >&2
   exit 1
+fi
+if [ -f "$STATUS_FILE" ]; then
+  exit 0
 fi
 
 REMOTE_UID=$(id -u)

--- a/.github/scripts/runner-behavior-balloon.sh
+++ b/.github/scripts/runner-behavior-balloon.sh
@@ -135,6 +135,7 @@ REMOTE_PWD=$PWD
 sudo systemd-run \
   --quiet \
   --collect \
+  --expand-environment=no \
   --service-type=exec \
   --unit="$UNIT" \
   --uid="$REMOTE_UID" \
@@ -148,8 +149,9 @@ sudo systemd-run \
     bin_dir=$4
     job_ref=$5
 
-    "$worker" "$bin_dir" "$job_ref" > "$log" 2>&1
-    worker_status=$?
+    set -euo pipefail
+    worker_status=0
+    "$worker" "$bin_dir" "$job_ref" > "$log" 2>&1 || worker_status=$?
     printf "%s\n" "$worker_status" > "${status_file}.tmp"
     mv "${status_file}.tmp" "$status_file"
     exit "$worker_status"
@@ -183,19 +185,31 @@ set -euo pipefail
 STATUS_FILE=$1
 UNIT=$2
 
-if [ -f "$STATUS_FILE" ]; then
+emit_result_if_ready() {
+  if [ ! -f "$STATUS_FILE" ]; then
+    return 1
+  fi
   STATUS=$(<"$STATUS_FILE")
   printf 'done:%s\n' "$STATUS"
+}
+
+if emit_result_if_ready; then
   exit 0
 fi
 
 LOAD_STATE=$(sudo systemctl show "${UNIT}.service" \
   --property=LoadState --value 2>/dev/null || true)
 if [ -z "$LOAD_STATE" ] || [ "$LOAD_STATE" = "not-found" ]; then
+  if emit_result_if_ready; then
+    exit 0
+  fi
   echo "absent"
   exit 0
 fi
 if [ "$LOAD_STATE" != "loaded" ]; then
+  if emit_result_if_ready; then
+    exit 0
+  fi
   printf 'invalid-load:%s\n' "$LOAD_STATE"
   exit 0
 fi
@@ -207,6 +221,9 @@ case "$ACTIVE_STATE" in
     echo "pending"
     ;;
   *)
+    if emit_result_if_ready; then
+      exit 0
+    fi
     printf 'stopped:%s\n' "$ACTIVE_STATE"
     ;;
 esac
@@ -337,14 +354,23 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
       fi
       ;;
     absent)
+      if fetch_remote_log; then
+        cat "$LOCAL_LOG"
+      fi
       echo "durable balloon unit disappeared without publishing a result" >&2
       exit 1
       ;;
     stopped:*)
+      if fetch_remote_log; then
+        cat "$LOCAL_LOG"
+      fi
       echo "durable balloon unit stopped without publishing a result: ${STATE#stopped:}" >&2
       exit 1
       ;;
     invalid-load:*)
+      if fetch_remote_log; then
+        cat "$LOCAL_LOG"
+      fi
       echo "unexpected durable balloon unit load state: ${STATE#invalid-load:}" >&2
       exit 1
       ;;

--- a/.github/scripts/tests/runner-behavior-balloon-test.sh
+++ b/.github/scripts/tests/runner-behavior-balloon-test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DRIVER="$REPO_ROOT/.github/scripts/runner-behavior-balloon.sh"
+REMOTE_WORKER="$REPO_ROOT/.github/scripts/runner-behavior-balloon-remote.sh"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "expected ${file} to contain: ${expected}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_value() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  actual=$(<"$file")
+  if [ "$actual" != "$expected" ]; then
+    echo "expected ${file} to contain ${expected}; got ${actual}" >&2
+    exit 1
+  fi
+}
+
+tmp=$(mktemp -d)
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+fake_bin="$tmp/bin"
+state_dir="$tmp/state"
+runner_temp="$tmp/runner-temp"
+mkdir -p "$fake_bin" "$state_dir" "$runner_temp"
+
+cat > "$fake_bin/ssh" <<'FAKE_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+increment() {
+  local name="$1"
+  local file="$FAKE_SSH_STATE_DIR/$name"
+  local value=0
+
+  if [ -f "$file" ]; then
+    value=$(<"$file")
+  fi
+  value=$((value + 1))
+  printf '%s\n' "$value" > "$file"
+  printf '%s\n' "$value"
+}
+
+if [ "$#" -eq 2 ] && [[ "$2" == *"runner config"* ]]; then
+  increment config-count >/dev/null
+  exit 0
+fi
+
+if [ "$#" -eq 2 ] && [[ "$2" == *"worker.XXXXXX"* ]]; then
+  cmp - "$EXPECTED_REMOTE_WORKER"
+  increment stage-count >/dev/null
+  exit 0
+fi
+
+if [ "$#" -eq 2 ] && [[ "$2" == "cat -- "* ]]; then
+  increment fetch-count >/dev/null
+  printf '%s\n' "durable balloon output"
+  exit 0
+fi
+
+if [ "$#" -eq 11 ] && [ "$2" = "bash" ] && [ "$3" = "-s" ]; then
+  cat > "$FAKE_SSH_STATE_DIR/launch-script"
+  launch_attempt=$(increment launch-attempt-count)
+  if [ ! -f "$FAKE_SSH_STATE_DIR/started" ]; then
+    touch "$FAKE_SSH_STATE_DIR/started"
+    increment execution-count >/dev/null
+  fi
+  if [ "$launch_attempt" -eq 1 ]; then
+    exit 255
+  fi
+  exit 0
+fi
+
+if [ "$#" -eq 6 ] && [ "$2" = "bash" ] && [ "$3" = "-s" ]; then
+  case "$5" in
+    */status)
+      cat > "$FAKE_SSH_STATE_DIR/state-script"
+      state_attempt=$(increment state-attempt-count)
+      case "$state_attempt" in
+        1)
+          exit 255
+          ;;
+        2)
+          echo "pending"
+          ;;
+        *)
+          echo "done:37"
+          ;;
+      esac
+      exit 0
+      ;;
+    *)
+      cat > "$FAKE_SSH_STATE_DIR/remove-script"
+      increment remove-count >/dev/null
+      exit 0
+      ;;
+  esac
+fi
+
+echo "unexpected ssh invocation: $*" >&2
+exit 2
+FAKE_SSH
+chmod +x "$fake_bin/ssh"
+
+cat > "$fake_bin/sleep" <<'FAKE_SLEEP'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_SLEEP_INVOCATIONS"
+FAKE_SLEEP
+chmod +x "$fake_bin/sleep"
+
+status=0
+PATH="$fake_bin:$PATH" \
+  FAKE_SLEEP_INVOCATIONS="$state_dir/sleep-invocations" \
+  FAKE_SSH_STATE_DIR="$state_dir" \
+  EXPECTED_REMOTE_WORKER="$REMOTE_WORKER" \
+  RUNNER_TEMP="$runner_temp" \
+  METAL_USER="metal" \
+  HOST="runner.example.test" \
+  BIN_DIR="/opt/vm0" \
+  JOB_REF="behavior-a" \
+  DEFAULT_ROOTFS_HASH="rootfs" \
+  DEFAULT_SNAPSHOT_HASH="snapshot" \
+  OFFICIAL_RUNNER_SECRET="test-secret" \
+  GITHUB_RUN_ID="30429172938" \
+  GITHUB_RUN_ATTEMPT="1" \
+  bash "$DRIVER" > "$state_dir/stdout" 2> "$state_dir/stderr" || status=$?
+
+[ "$status" -eq 37 ] || {
+  echo "expected driver to propagate exit 37; got ${status}" >&2
+  cat "$state_dir/stdout" >&2
+  cat "$state_dir/stderr" >&2
+  exit 1
+}
+
+assert_value "$state_dir/config-count" "1"
+assert_value "$state_dir/stage-count" "1"
+assert_value "$state_dir/launch-attempt-count" "2"
+assert_value "$state_dir/execution-count" "1"
+assert_value "$state_dir/state-attempt-count" "3"
+assert_value "$state_dir/fetch-count" "1"
+assert_value "$state_dir/remove-count" "1"
+assert_contains "$state_dir/launch-script" "flock 9"
+assert_contains "$state_dir/launch-script" "systemd-run"
+assert_contains "$state_dir/launch-script" "--collect"
+assert_contains "$state_dir/stdout" "durable balloon output"
+assert_contains "$state_dir/stderr" "Lost SSH launch response"
+assert_contains "$state_dir/stderr" "Transient SSH failure while observing balloon result"
+
+if find "$runner_temp" -mindepth 1 -print -quit | grep -q .; then
+  echo "expected driver to remove its local result file" >&2
+  find "$runner_temp" -mindepth 1 -print >&2
+  exit 1
+fi
+
+echo "runner-behavior-balloon-test: ok"

--- a/.github/scripts/tests/runner-behavior-balloon-test.sh
+++ b/.github/scripts/tests/runner-behavior-balloon-test.sh
@@ -327,10 +327,16 @@ for _ in 1 2; do
         "success-unit" "/opt/vm0" "behavior-a"
   )
   for _ in $(seq 1 100); do
-    [ -f "$success_status" ] && break
+    if [ -f "$success_status" ] \
+      && [ -f "$success_command_status" ] \
+      && [ ! -e "$success_active" ]; then
+      break
+    fi
     /bin/sleep 0.01
   done
   test -f "$success_status"
+  test -f "$success_command_status"
+  test ! -e "$success_active"
 done
 assert_value "$success_count" "1"
 assert_value "$success_status" "0"

--- a/.github/scripts/tests/runner-behavior-balloon-test.sh
+++ b/.github/scripts/tests/runner-behavior-balloon-test.sh
@@ -29,6 +29,20 @@ assert_value() {
   fi
 }
 
+assert_count() {
+  local file="$1"
+  local expected="$2"
+  local value="$3"
+  local actual
+
+  actual=$(grep -Fc -- "$value" "$file" || true)
+  if [ "$actual" -ne "$expected" ]; then
+    echo "expected ${file} to contain ${value} ${expected} time(s); got ${actual}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 tmp=$(mktemp -d)
 cleanup() {
   rm -rf "$tmp"
@@ -64,22 +78,41 @@ fi
 
 if [ "$#" -eq 2 ] && [[ "$2" == *"worker.XXXXXX"* ]]; then
   cmp - "$EXPECTED_REMOTE_WORKER"
+  mkdir -p "$FAKE_REMOTE_DIR"
+  cat > "$FAKE_REMOTE_WORKER" <<'FAKE_REMOTE_WORKER_SCRIPT'
+#!/usr/bin/env bash
+while [ ! -f "$FAKE_WORKER_RELEASE" ]; do
+  /bin/sleep 0.01
+done
+echo "durable balloon output"
+exit 37
+FAKE_REMOTE_WORKER_SCRIPT
+  chmod +x "$FAKE_REMOTE_WORKER"
   increment stage-count >/dev/null
   exit 0
 fi
 
 if [ "$#" -eq 2 ] && [[ "$2" == "cat -- "* ]]; then
   increment fetch-count >/dev/null
-  printf '%s\n' "durable balloon output"
+  [ -f "$FAKE_REMOTE_STATUS" ]
+  [ ! -e "${FAKE_REMOTE_STATUS}.tmp" ]
+  touch "$FAKE_SSH_STATE_DIR/atomic-status-observed"
+  cat "$FAKE_REMOTE_LOG"
   exit 0
 fi
 
 if [ "$#" -eq 11 ] && [ "$2" = "bash" ] && [ "$3" = "-s" ]; then
   cat > "$FAKE_SSH_STATE_DIR/launch-script"
   launch_attempt=$(increment launch-attempt-count)
-  if [ ! -f "$FAKE_SSH_STATE_DIR/started" ]; then
-    touch "$FAKE_SSH_STATE_DIR/started"
-    increment execution-count >/dev/null
+  launch_status=0
+  (
+    cd "$FAKE_REMOTE_CWD"
+    HOME="$FAKE_REMOTE_HOME" bash "$FAKE_SSH_STATE_DIR/launch-script" \
+      "$FAKE_REMOTE_DIR" "$FAKE_REMOTE_WORKER" "$FAKE_REMOTE_LOG" \
+      "$FAKE_REMOTE_STATUS" "$9" "${10}" "${11}"
+  ) || launch_status=$?
+  if [ "$launch_status" -ne 0 ]; then
+    exit "$launch_status"
   fi
   if [ "$launch_attempt" -eq 1 ]; then
     exit 255
@@ -92,28 +125,21 @@ if [ "$#" -eq 6 ] && [ "$2" = "bash" ] && [ "$3" = "-s" ]; then
     */status)
       cat > "$FAKE_SSH_STATE_DIR/state-script"
       state_attempt=$(increment state-attempt-count)
-      case "$state_attempt" in
-        1)
-          exit 255
-          ;;
-        2)
-          echo "pending"
-          ;;
-        *)
-          echo "done:37"
-          ;;
-      esac
-      exit 0
+      if [ "$state_attempt" -eq 1 ]; then
+        exit 255
+      fi
+      bash "$FAKE_SSH_STATE_DIR/state-script" "$FAKE_REMOTE_STATUS" "$6"
       ;;
     *)
       cat > "$FAKE_SSH_STATE_DIR/remove-script"
       increment remove-count >/dev/null
-      exit 0
+      bash "$FAKE_SSH_STATE_DIR/remove-script" "$FAKE_REMOTE_DIR" "$6"
       ;;
   esac
+  exit 0
 fi
 
-echo "unexpected ssh invocation: $*" >&2
+echo "unexpected ssh invocation ($# args): $*" >&2
 exit 2
 FAKE_SSH
 chmod +x "$fake_bin/ssh"
@@ -122,6 +148,10 @@ cat > "$fake_bin/sleep" <<'FAKE_SLEEP'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$FAKE_SLEEP_INVOCATIONS"
+if [ "$*" = "2" ]; then
+  touch "$FAKE_WORKER_RELEASE"
+fi
+/bin/sleep 0.01
 FAKE_SLEEP
 chmod +x "$fake_bin/sleep"
 
@@ -136,12 +166,30 @@ cat > "$fake_bin/systemctl" <<'FAKE_SYSTEMCTL'
 #!/usr/bin/env bash
 set -euo pipefail
 
-case " $* " in
-  *" --property=LoadState "*)
+case "${FAKE_SYSTEMCTL_MODE:-runtime}: $*" in
+  "runtime: "*" stop "*)
+    touch "$FAKE_WORKER_RELEASE"
+    rm -f "$FAKE_SYSTEMD_ACTIVE"
+    ;;
+  "runtime: "*" --property=LoadState "*)
+    if [ -f "$FAKE_SYSTEMD_ACTIVE" ]; then
+      echo "loaded"
+    else
+      echo "not-found"
+    fi
+    ;;
+  "runtime: "*" --property=ActiveState "*)
+    if [ -f "$FAKE_SYSTEMD_ACTIVE" ]; then
+      echo "active"
+    else
+      echo "inactive"
+    fi
+    ;;
+  "publication-race: "*" --property=LoadState "*)
     printf '37\n' > "$RACE_STATUS_FILE"
     echo "loaded"
     ;;
-  *" --property=ActiveState "*)
+  "publication-race: "*" --property=ActiveState "*)
     echo "inactive"
     ;;
   *)
@@ -155,15 +203,58 @@ chmod +x "$fake_bin/systemctl"
 cat > "$fake_bin/systemd-run" <<'FAKE_SYSTEMD_RUN'
 #!/usr/bin/env bash
 set -euo pipefail
-touch "$REPLAY_MARKER"
+
+count=0
+if [ -f "$FAKE_SYSTEMD_RUN_COUNT_FILE" ]; then
+  count=$(<"$FAKE_SYSTEMD_RUN_COUNT_FILE")
+fi
+printf '%s\n' "$((count + 1))" > "$FAKE_SYSTEMD_RUN_COUNT_FILE"
+printf '%s\n' "$@" > "$FAKE_SYSTEMD_RUN_ARGS_FILE"
+
+while [ "$#" -gt 0 ] && [ "$1" != "/bin/bash" ]; do
+  shift
+done
+if [ "$#" -eq 0 ]; then
+  echo "systemd-run command not found" >&2
+  exit 2
+fi
+
+touch "$FAKE_SYSTEMD_ACTIVE"
+(
+  exec 9>&-
+  command_status=0
+  "$@" || command_status=$?
+  printf '%s\n' "$command_status" > "$FAKE_SYSTEMD_COMMAND_STATUS_FILE"
+  rm -f "$FAKE_SYSTEMD_ACTIVE"
+) &
 FAKE_SYSTEMD_RUN
 chmod +x "$fake_bin/systemd-run"
+
+fake_remote_dir="$state_dir/remote"
+fake_remote_worker="$fake_remote_dir/worker.sh"
+fake_remote_log="$fake_remote_dir/output.log"
+fake_remote_status="$fake_remote_dir/status"
+fake_remote_home="$state_dir/home"
+fake_remote_cwd="$state_dir/cwd"
+mkdir -p "$fake_remote_home" "$fake_remote_cwd"
 
 status=0
 PATH="$fake_bin:$PATH" \
   FAKE_SLEEP_INVOCATIONS="$state_dir/sleep-invocations" \
   FAKE_SSH_STATE_DIR="$state_dir" \
   EXPECTED_REMOTE_WORKER="$REMOTE_WORKER" \
+  FAKE_REMOTE_DIR="$fake_remote_dir" \
+  FAKE_REMOTE_WORKER="$fake_remote_worker" \
+  FAKE_REMOTE_LOG="$fake_remote_log" \
+  FAKE_REMOTE_STATUS="$fake_remote_status" \
+  FAKE_REMOTE_HOME="$fake_remote_home" \
+  FAKE_REMOTE_CWD="$fake_remote_cwd" \
+  FAKE_WORKER_RELEASE="$state_dir/release-worker" \
+  FAKE_SYSTEMCTL_MODE="runtime" \
+  FAKE_SYSTEMD_ACTIVE="$state_dir/systemd-active" \
+  FAKE_SYSTEMD_RUN_COUNT_FILE="$state_dir/execution-count" \
+  FAKE_SYSTEMD_RUN_ARGS_FILE="$state_dir/systemd-run-args" \
+  FAKE_SYSTEMD_COMMAND_STATUS_FILE="$state_dir/systemd-command-status" \
   RUNNER_TEMP="$runner_temp" \
   METAL_USER="metal" \
   HOST="runner.example.test" \
@@ -190,16 +281,66 @@ assert_value "$state_dir/execution-count" "1"
 assert_value "$state_dir/state-attempt-count" "3"
 assert_value "$state_dir/fetch-count" "1"
 assert_value "$state_dir/remove-count" "1"
+assert_value "$state_dir/systemd-command-status" "37"
+test -f "$state_dir/atomic-status-observed"
+test ! -e "$fake_remote_dir"
+test ! -e "$state_dir/systemd-active"
 assert_contains "$state_dir/launch-script" "flock 9"
-assert_contains "$state_dir/launch-script" "systemd-run"
-assert_contains "$state_dir/launch-script" "--collect"
-assert_contains "$state_dir/launch-script" "--expand-environment=no"
-assert_contains "$state_dir/stdout" "durable balloon output"
+assert_contains "$state_dir/systemd-run-args" "--collect"
+assert_contains "$state_dir/systemd-run-args" "--expand-environment=no"
+assert_contains "$state_dir/systemd-run-args" "--uid=$(id -u)"
+assert_contains "$state_dir/systemd-run-args" "--gid=$(id -g)"
+assert_contains "$state_dir/systemd-run-args" "--working-directory=$fake_remote_cwd"
+assert_contains "$state_dir/systemd-run-args" "--setenv=HOME=$fake_remote_home"
+assert_count "$state_dir/stdout" "1" "durable balloon output"
 assert_contains "$state_dir/stderr" "Lost SSH launch response"
 assert_contains "$state_dir/stderr" "Transient SSH failure while observing balloon result"
 
+success_dir="$state_dir/success"
+success_worker="$success_dir/worker.sh"
+success_log="$success_dir/output.log"
+success_status="$success_dir/status"
+success_active="$success_dir/active"
+success_count="$success_dir/execution-count"
+success_args="$success_dir/systemd-run-args"
+success_command_status="$success_dir/command-status"
+mkdir -p "$success_dir"
+cat > "$success_worker" <<'SUCCESS_WORKER'
+#!/usr/bin/env bash
+echo "successful balloon output"
+SUCCESS_WORKER
+chmod +x "$success_worker"
+
+for _ in 1 2; do
+  (
+    cd "$fake_remote_cwd"
+    HOME="$fake_remote_home" \
+      FAKE_SYSTEMCTL_MODE="runtime" \
+      FAKE_SYSTEMD_ACTIVE="$success_active" \
+      FAKE_SYSTEMD_RUN_COUNT_FILE="$success_count" \
+      FAKE_SYSTEMD_RUN_ARGS_FILE="$success_args" \
+      FAKE_SYSTEMD_COMMAND_STATUS_FILE="$success_command_status" \
+      FAKE_WORKER_RELEASE="$success_dir/release-worker" \
+      PATH="$fake_bin:$PATH" \
+      bash "$state_dir/launch-script" \
+        "$success_dir" "$success_worker" "$success_log" "$success_status" \
+        "success-unit" "/opt/vm0" "behavior-a"
+  )
+  for _ in $(seq 1 100); do
+    [ -f "$success_status" ] && break
+    /bin/sleep 0.01
+  done
+  test -f "$success_status"
+done
+assert_value "$success_count" "1"
+assert_value "$success_status" "0"
+assert_value "$success_command_status" "0"
+test ! -e "${success_status}.tmp"
+assert_count "$success_log" "1" "successful balloon output"
+
 race_status="$state_dir/race-status"
-RACE_STATUS_FILE="$race_status" PATH="$fake_bin:$PATH" \
+FAKE_SYSTEMCTL_MODE="publication-race" RACE_STATUS_FILE="$race_status" \
+  PATH="$fake_bin:$PATH" \
   bash "$state_dir/state-script" "$race_status" "race-unit" \
   > "$state_dir/race-state"
 assert_value "$state_dir/race-state" "done:37"
@@ -209,7 +350,11 @@ launch_race_status="$launch_race_dir/status"
 replay_marker="$launch_race_dir/replayed"
 mkdir -p "$launch_race_dir"
 launch_race_result=0
-RACE_STATUS_FILE="$launch_race_status" REPLAY_MARKER="$replay_marker" \
+FAKE_SYSTEMCTL_MODE="publication-race" RACE_STATUS_FILE="$launch_race_status" \
+  FAKE_SYSTEMD_ACTIVE="$launch_race_dir/active" \
+  FAKE_SYSTEMD_RUN_COUNT_FILE="$replay_marker" \
+  FAKE_SYSTEMD_RUN_ARGS_FILE="$launch_race_dir/args" \
+  FAKE_SYSTEMD_COMMAND_STATUS_FILE="$launch_race_dir/command-status" \
   PATH="$fake_bin:$PATH" \
   bash "$state_dir/launch-script" \
     "$launch_race_dir" "$launch_race_dir/worker.sh" \

--- a/.github/scripts/tests/runner-behavior-balloon-test.sh
+++ b/.github/scripts/tests/runner-behavior-balloon-test.sh
@@ -152,6 +152,13 @@ esac
 FAKE_SYSTEMCTL
 chmod +x "$fake_bin/systemctl"
 
+cat > "$fake_bin/systemd-run" <<'FAKE_SYSTEMD_RUN'
+#!/usr/bin/env bash
+set -euo pipefail
+touch "$REPLAY_MARKER"
+FAKE_SYSTEMD_RUN
+chmod +x "$fake_bin/systemd-run"
+
 status=0
 PATH="$fake_bin:$PATH" \
   FAKE_SLEEP_INVOCATIONS="$state_dir/sleep-invocations" \
@@ -196,6 +203,26 @@ RACE_STATUS_FILE="$race_status" PATH="$fake_bin:$PATH" \
   bash "$state_dir/state-script" "$race_status" "race-unit" \
   > "$state_dir/race-state"
 assert_value "$state_dir/race-state" "done:37"
+
+launch_race_dir="$state_dir/launch-race"
+launch_race_status="$launch_race_dir/status"
+replay_marker="$launch_race_dir/replayed"
+mkdir -p "$launch_race_dir"
+launch_race_result=0
+RACE_STATUS_FILE="$launch_race_status" REPLAY_MARKER="$replay_marker" \
+  PATH="$fake_bin:$PATH" \
+  bash "$state_dir/launch-script" \
+    "$launch_race_dir" "$launch_race_dir/worker.sh" \
+    "$launch_race_dir/output.log" "$launch_race_status" \
+    "race-unit" "/opt/vm0" "behavior-a" || launch_race_result=$?
+if [ "$launch_race_result" -ne 0 ]; then
+  echo "expected launch retry to accept the concurrently published result" >&2
+  exit 1
+fi
+if [ -e "$replay_marker" ]; then
+  echo "expected launch retry not to replay a completed worker" >&2
+  exit 1
+fi
 
 if find "$runner_temp" -mindepth 1 -print -quit | grep -q .; then
   echo "expected driver to remove its local result file" >&2

--- a/.github/scripts/tests/runner-behavior-balloon-test.sh
+++ b/.github/scripts/tests/runner-behavior-balloon-test.sh
@@ -125,6 +125,33 @@ printf '%s\n' "$*" >> "$FAKE_SLEEP_INVOCATIONS"
 FAKE_SLEEP
 chmod +x "$fake_bin/sleep"
 
+cat > "$fake_bin/sudo" <<'FAKE_SUDO'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$@"
+FAKE_SUDO
+chmod +x "$fake_bin/sudo"
+
+cat > "$fake_bin/systemctl" <<'FAKE_SYSTEMCTL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case " $* " in
+  *" --property=LoadState "*)
+    printf '37\n' > "$RACE_STATUS_FILE"
+    echo "loaded"
+    ;;
+  *" --property=ActiveState "*)
+    echo "inactive"
+    ;;
+  *)
+    echo "unexpected systemctl invocation: $*" >&2
+    exit 2
+    ;;
+esac
+FAKE_SYSTEMCTL
+chmod +x "$fake_bin/systemctl"
+
 status=0
 PATH="$fake_bin:$PATH" \
   FAKE_SLEEP_INVOCATIONS="$state_dir/sleep-invocations" \
@@ -159,9 +186,16 @@ assert_value "$state_dir/remove-count" "1"
 assert_contains "$state_dir/launch-script" "flock 9"
 assert_contains "$state_dir/launch-script" "systemd-run"
 assert_contains "$state_dir/launch-script" "--collect"
+assert_contains "$state_dir/launch-script" "--expand-environment=no"
 assert_contains "$state_dir/stdout" "durable balloon output"
 assert_contains "$state_dir/stderr" "Lost SSH launch response"
 assert_contains "$state_dir/stderr" "Transient SSH failure while observing balloon result"
+
+race_status="$state_dir/race-status"
+RACE_STATUS_FILE="$race_status" PATH="$fake_bin:$PATH" \
+  bash "$state_dir/state-script" "$race_status" "race-unit" \
+  > "$state_dir/race-state"
+assert_value "$state_dir/race-state" "done:37"
 
 if find "$runner_temp" -mindepth 1 -print -quit | grep -q .; then
   echo "expected driver to remove its local result file" >&2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -276,7 +276,8 @@ jobs:
             .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
-            .github/scripts/tests/cloudflare-ssh-proxy-test.sh
+            .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
+            .github/scripts/tests/runner-behavior-balloon-test.sh
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.
           .github/scripts/check-workflow-shell-compatibility.sh


### PR DESCRIPTION
## Summary

- run the balloon behavior test in a transient systemd unit instead of tying its lifetime to one foreground SSH channel
- persist the remote log and exit status, then retrieve them through short retryable SSH observations
- guard the stable execution identity with `flock` so an ambiguous launch response cannot start the test twice
- add an integration test that injects launch and observation disconnects and verifies single execution plus exact exit-status propagation

## Scope

This changes only the balloon runner-behavior scenario. It does not add generic retries for arbitrary stateful SSH commands or change the balloon assertions themselves.

## Validation

- `bash -n .github/scripts/runner-behavior-balloon.sh .github/scripts/runner-behavior-balloon-remote.sh .github/scripts/tests/runner-behavior-balloon-test.sh`
- workflow ShellCheck command from `.github/workflows/security.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `bash .github/scripts/tests/runner-behavior-balloon-test.sh`
- `actionlint`
- `pnpm exec prettier --check ../.github/workflows/security.yml`
- dev-11 systemd smoke test for preserved UID, GID, HOME, working directory, durable log, and nonzero status

Closes #23686
