### PR TITLE
test(python): cover bracketed ipv4 host rejection

### DIFF
--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
@@ -524,6 +524,8 @@ class TestTrustedAuthorityRejection:
     @pytest.mark.parametrize(
         "host_header",
         [
+            pytest.param("[127.0.0.1]", id="bracketed-ipv4"),
+            pytest.param("[127.0.0.1]:443", id="bracketed-ipv4-default-port"),
             pytest.param("0177.0.0.1", id="octal-ipv4"),
             pytest.param("127。0。0。1", id="ideographic-dot-ipv4"),
             pytest.param("127.0.0.1。", id="trailing-ideographic-dot-ipv4"),


### PR DESCRIPTION
## Summary

- cover bracketed IPv4 Host authorities with and without an explicit HTTPS default port
- verify both forms remain `invalid_authority` with the trusted IPv4 SNI fallback URL
- keep the change test-only by extending the existing noncanonical IPv4 authority matrix

## Scope

- no production parser, request-hook, API, schema, dependency, configuration, documentation, or deployment-contract changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_url_utils_trusted_authority_rejection.py` — 95 passed
- controlled removal of the parsed-address IPv6 guard — both new cases failed as expected, then passed after exact restoration
- `uv run --no-sync python -m pytest -q tests/` — 4438 passed
- `lefthook run pre-commit`

Closes #23666
