### PR TITLE
refactor(runner): retire legacy template warm naming

### DIFF
--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -91,11 +91,6 @@ async fn try_delete_orphan_rootfs(
     Some(rootfs_size)
 }
 
-fn template_warm_hash(name: &str) -> Option<&str> {
-    name.strip_prefix(TEMPLATE_WARM_DIR_PREFIX)
-        .filter(|hash| !hash.is_empty())
-}
-
 /// Try to delete an abandoned `runner build --warm-rootfs-cache` working dir.
 ///
 /// The directory intentionally lives under `images/` so the warm download/build
@@ -456,7 +451,10 @@ async fn gc_nested_images_with_protected_refs_and_readers(
             }
         }
 
-        if let Some(template_hash) = template_warm_hash(&rootfs_hash) {
+        if let Some(template_hash) = rootfs_hash
+            .strip_prefix(TEMPLATE_WARM_DIR_PREFIX)
+            .filter(|hash| !hash.is_empty())
+        {
             if let Some(freed_bytes) =
                 gc_template_warm_dir(home, &rootfs_path, &rootfs_hash, template_hash, dry_run).await
             {

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -93,10 +93,6 @@ async fn try_delete_orphan_rootfs(
 
 fn template_warm_hash(name: &str) -> Option<&str> {
     name.strip_prefix(TEMPLATE_WARM_DIR_PREFIX)
-        .or_else(|| {
-            name.strip_prefix("template-")
-                .and_then(|rest| rest.strip_suffix(".warm.tmp"))
-        })
         .filter(|hash| !hash.is_empty())
 }
 

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -139,14 +139,6 @@ async fn gc_nested_images_empty_dir_returns_zero() {
     assert_eq!(freed, 0);
 }
 
-#[test]
-fn template_warm_hash_accepts_only_current_names() {
-    assert_eq!(template_warm_hash("template-warm-abc123"), Some("abc123"));
-    assert_eq!(template_warm_hash("template-abc123.warm.tmp"), None);
-    assert_eq!(template_warm_hash("template-warm-"), None);
-    assert_eq!(template_warm_hash("rootfs-hash"), None);
-}
-
 #[tokio::test]
 async fn gc_nested_images_keeps_locked_current_template_warm_dir() {
     use std::fs::FileTimes;
@@ -170,6 +162,34 @@ async fn gc_nested_images_keeps_locked_current_template_warm_dir() {
 
     assert_eq!(freed, 0);
     assert!(warm_dir.exists(), "active warm rootfs dir must survive GC");
+}
+
+#[tokio::test]
+async fn gc_nested_images_does_not_treat_legacy_name_as_template_warm_dir() {
+    use std::fs::FileTimes;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let legacy_dir = home.images_dir().join("template-abc123.warm.tmp");
+    std::fs::create_dir_all(&legacy_dir).unwrap();
+    std::fs::write(legacy_dir.join("template.ext4"), b"partial").unwrap();
+
+    let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    std::fs::File::open(&legacy_dir)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(old_time))
+        .unwrap();
+
+    let lock_file = lock::open_lock_file(&home.template_lock("abc123")).unwrap();
+    let _held = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+    let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
+
+    assert!(
+        !legacy_dir.exists(),
+        "the retired name must not be protected by the template lock"
+    );
+    assert!(freed > 0);
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -140,12 +140,9 @@ async fn gc_nested_images_empty_dir_returns_zero() {
 }
 
 #[test]
-fn template_warm_hash_accepts_current_and_legacy_names() {
+fn template_warm_hash_accepts_only_current_names() {
     assert_eq!(template_warm_hash("template-warm-abc123"), Some("abc123"));
-    assert_eq!(
-        template_warm_hash("template-abc123.warm.tmp"),
-        Some("abc123")
-    );
+    assert_eq!(template_warm_hash("template-abc123.warm.tmp"), None);
     assert_eq!(template_warm_hash("template-warm-"), None);
     assert_eq!(template_warm_hash("rootfs-hash"), None);
 }
@@ -176,48 +173,6 @@ async fn gc_nested_images_keeps_locked_current_template_warm_dir() {
 }
 
 #[tokio::test]
-async fn gc_nested_images_keeps_locked_template_warm_dir() {
-    use std::fs::FileTimes;
-
-    let dir = tempfile::tempdir().unwrap();
-    let home = test_home(dir.path());
-    let warm_dir = home.images_dir().join("template-abc123.warm.tmp");
-    std::fs::create_dir_all(&warm_dir).unwrap();
-    std::fs::write(warm_dir.join("template.ext4"), b"partial").unwrap();
-
-    let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    std::fs::File::open(&warm_dir)
-        .unwrap()
-        .set_times(FileTimes::new().set_modified(old_time))
-        .unwrap();
-
-    let lock_file = lock::open_lock_file(&home.template_lock("abc123")).unwrap();
-    let _held = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
-
-    let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
-
-    assert_eq!(freed, 0);
-    assert!(warm_dir.exists(), "active warm rootfs dir must survive GC");
-}
-
-#[tokio::test]
-async fn gc_nested_images_keeps_recent_template_warm_dir() {
-    let dir = tempfile::tempdir().unwrap();
-    let home = test_home(dir.path());
-    let warm_dir = home.images_dir().join("template-abc123.warm.tmp");
-    std::fs::create_dir_all(&warm_dir).unwrap();
-    std::fs::write(warm_dir.join("template.ext4"), b"partial").unwrap();
-
-    let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
-
-    assert_eq!(freed, 0);
-    assert!(
-        warm_dir.exists(),
-        "recent warm rootfs dir must survive the GC grace window"
-    );
-}
-
-#[tokio::test]
 async fn gc_nested_images_keeps_recent_current_template_warm_dir() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
@@ -232,31 +187,6 @@ async fn gc_nested_images_keeps_recent_current_template_warm_dir() {
         warm_dir.exists(),
         "recent warm rootfs dir must survive the GC grace window"
     );
-}
-
-#[tokio::test]
-async fn gc_nested_images_removes_stale_template_warm_dir() {
-    use std::fs::FileTimes;
-
-    let dir = tempfile::tempdir().unwrap();
-    let home = test_home(dir.path());
-    let warm_dir = home.images_dir().join("template-abc123.warm.tmp");
-    std::fs::create_dir_all(&warm_dir).unwrap();
-    std::fs::write(warm_dir.join("template.ext4"), b"partial").unwrap();
-
-    let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    std::fs::File::open(&warm_dir)
-        .unwrap()
-        .set_times(FileTimes::new().set_modified(old_time))
-        .unwrap();
-
-    let freed = gc_nested_images(&home, Some(0), false).await.unwrap();
-
-    assert!(
-        !warm_dir.exists(),
-        "stale warm rootfs dir should be removed"
-    );
-    assert!(freed > 0);
 }
 
 #[tokio::test]
@@ -282,6 +212,34 @@ async fn gc_nested_images_removes_stale_current_template_warm_dir() {
         "stale warm rootfs dir should be removed"
     );
     assert!(freed > 0);
+}
+
+#[tokio::test]
+async fn gc_nested_images_dry_run_reports_stale_current_template_warm_dir() {
+    use std::fs::FileTimes;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let warm_dir = home.images_dir().join("template-warm-abc123");
+    std::fs::create_dir_all(&warm_dir).unwrap();
+    std::fs::write(warm_dir.join("attempt-old.tmp"), b"partial").unwrap();
+
+    let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    std::fs::File::open(&warm_dir)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(old_time))
+        .unwrap();
+
+    let (expected_size, _) = dir_stats(&warm_dir).await;
+    assert!(expected_size > 0, "test fixture must have non-zero size");
+
+    let freed = gc_nested_images(&home, Some(0), true).await.unwrap();
+
+    assert!(
+        warm_dir.exists(),
+        "dry-run must preserve the warm directory"
+    );
+    assert_eq!(freed, expected_size);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- recognize only `template-warm-<hash>` as template warm staging in image GC
- remove duplicate legacy lock, age, and stale-removal fixtures
- cover current warm-directory dry-run retention and exact byte reporting

## Behavior and compatibility

Current warm directories keep the existing symlink checks, template locking, grace period, deletion, dry-run, and accounting behavior. The retired `template-<hash>.warm.tmp` name is no longer mapped to a template lock; any residual directory can only follow the existing generic rootfs path.

All supported and rollback-capable runner releases already use the current producer format, and production GC has converged. This PR does not change the producer, unknown/rootfs directory classification, schemas, persisted data, APIs, serialized payloads, protocols, or deployment configuration.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::images::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`

Closes #23649
