### PR TITLE
test(python): cover invalid model pricing unit sizes

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -41,7 +41,7 @@ def signed_raw_usage_pricing_headers(pricing: str) -> dict[str, str]:
 def signed_usage_pricing_headers(
     unit_prices: dict[str, object] | None = None,
     *,
-    unit_size: int = 1_000_000,
+    unit_size: object = 1_000_000,
     issued_at: object | None = None,
 ) -> dict[str, str]:
     if unit_prices is None:

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -126,23 +126,39 @@ class TestReportModelProviderUsage:
         }
 
     @pytest.mark.parametrize(
-        "unit_prices",
+        ("unit_size", "unit_prices"),
         [
-            {
-                category: price
-                for category, price in _MODEL_USAGE_UNIT_PRICES.items()
-                if category != "tokens.output"
-            },
-            {**_MODEL_USAGE_UNIT_PRICES, "tokens.unknown": 19},
-            {**_MODEL_USAGE_UNIT_PRICES, "tokens.output": True},
+            (
+                100,
+                {
+                    category: price
+                    for category, price in _MODEL_USAGE_UNIT_PRICES.items()
+                    if category != "tokens.output"
+                },
+            ),
+            (100, {**_MODEL_USAGE_UNIT_PRICES, "tokens.unknown": 19}),
+            (100, {**_MODEL_USAGE_UNIT_PRICES, "tokens.output": True}),
+            (0, _MODEL_USAGE_UNIT_PRICES),
+            (-1, _MODEL_USAGE_UNIT_PRICES),
+            (True, _MODEL_USAGE_UNIT_PRICES),
+            ("100", _MODEL_USAGE_UNIT_PRICES),
         ],
-        ids=["partial", "extra", "invalid"],
+        ids=[
+            "partial-prices",
+            "extra-price",
+            "invalid-price",
+            "zero-unit-size",
+            "negative-unit-size",
+            "boolean-unit-size",
+            "numeric-string-unit-size",
+        ],
     )
     def test_rejects_malformed_model_pricing_atomically(
         self,
         real_flow,
         usage_webhook_api,
-        unit_prices,
+        unit_size: object,
+        unit_prices: dict[str, object],
     ):
         flow = real_flow(with_response=False, host="model.vm0.ai")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0-model"
@@ -158,7 +174,7 @@ class TestReportModelProviderUsage:
         flow.request.headers["authorization"] = "Bearer proxy-secret"
         flow.response = tutils.tresp(
             status_code=200,
-            headers=header_map(signed_usage_pricing_headers(unit_prices, unit_size=100)),
+            headers=header_map(signed_usage_pricing_headers(unit_prices, unit_size=unit_size)),
         )
 
         mitm_addon.responseheaders(flow)
@@ -167,7 +183,7 @@ class TestReportModelProviderUsage:
 
         # Exercise the primitive metadata boundary independently of signed ingestion.
         flow.metadata[metadata_keys.MODEL_USAGE_PRICING] = {
-            "unitSize": 100,
+            "unitSize": unit_size,
             "unitPrices": unit_prices,
         }
 

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -35,6 +35,8 @@ def _fix_pricing_clock(monkeypatch: pytest.MonkeyPatch) -> None:
 def _signed_pricing_flow(
     real_flow: RealFlowFactory,
     issued_at: object,
+    *,
+    unit_size: object = 1_000_000,
 ) -> http.HTTPFlow:
     flow = real_flow(with_response=False, host="model.vm0.ai")
     flow.request.headers["authorization"] = "Bearer proxy-secret"
@@ -42,7 +44,7 @@ def _signed_pricing_flow(
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
     flow.response = tutils.tresp(
         status_code=200,
-        headers=header_map(signed_usage_pricing_headers(issued_at=issued_at)),
+        headers=header_map(signed_usage_pricing_headers(issued_at=issued_at, unit_size=unit_size)),
     )
     return flow
 
@@ -270,6 +272,27 @@ class TestResponseHeadersHandler:
     ) -> None:
         _fix_pricing_clock(monkeypatch)
         flow = _signed_pricing_flow(real_flow, issued_at)
+
+        mitm_addon.responseheaders(flow)
+
+        assert metadata_keys.MODEL_USAGE_PRICING not in flow.metadata
+        assert flow.response is not None
+        assert "x-vm0-usage-pricing" not in flow.response.headers
+        assert "x-vm0-usage-pricing-signature" not in flow.response.headers
+
+    @pytest.mark.parametrize(
+        "unit_size",
+        [0, -1, True, "1000000"],
+        ids=["zero", "negative", "boolean", "numeric-string"],
+    )
+    def test_rejects_and_strips_invalid_signed_model_usage_pricing_unit_size(
+        self,
+        real_flow: RealFlowFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        unit_size: object,
+    ) -> None:
+        _fix_pricing_clock(monkeypatch)
+        flow = _signed_pricing_flow(real_flow, _FIXED_TIME, unit_size=unit_size)
 
         mitm_addon.responseheaders(flow)
 


### PR DESCRIPTION
## Summary

- cover zero, negative, Boolean, and numeric-string `unitSize` values through the real signed response-header hook
- verify rejected schedules install no pricing metadata and strip both private pricing headers
- extend final usage reporting coverage so the same malformed primitive metadata remains reportable without runner-calculated `grossCredits`

## Scope

- test code only; no production behavior, protocol, API, schema, persistence, migration, or rollout changes
- retain the existing Auto retirement compatibility reader unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused pricing integration tests: 65 passed
- mutation check: both zero-unit-size cases failed when the positive-value predicate was temporarily removed, then passed after restoring production source
- `uv run --no-sync python -m pytest tests/`: 4,444 passed
- `git diff --check`

Closes #23665
