### PR TITLE
perf(python): reuse connected endpoint ip evidence

### DIFF
--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -1,8 +1,21 @@
 """Read-only helpers for mitmproxy connection endpoint shapes."""
 
 import ipaddress
+from dataclasses import dataclass
 
 _ADDRESS_PAIR_LENGTH = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectedIpEndpoint:
+    """Parsed connected IP with its original endpoint text.
+
+    This value records IP screening performed by this module. It is not proof of TLS identity,
+    destination ownership, authorization, or public routability.
+    """
+
+    address: tuple[str, int]
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
 def server_address(server: object) -> tuple[str, int] | None:
@@ -33,15 +46,15 @@ def address_pair(address: object) -> tuple[str, int] | None:
     return host, port
 
 
-def authoritative_connected_endpoint(endpoint: object) -> tuple[str, int] | None:
-    """Return an endpoint that supplies acceptable connected IP evidence.
+def authoritative_connected_endpoint(endpoint: object) -> ConnectedIpEndpoint | None:
+    """Return parsed evidence from an acceptable connected IP endpoint.
 
     The endpoint must have an ``address_pair`` shape and its host must parse as an IPv4 or IPv6
     literal. DNS names, malformed endpoints, loopback addresses, and unspecified addresses return
     ``None``. Other parsed IP address categories are not filtered: ``authoritative`` describes
-    connected endpoint evidence, not public routability. Accepted inputs return their first
-    ``(host, port)`` pair. Additional tuple elements are discarded, while the host and port values
-    themselves are not normalized.
+    connected endpoint evidence, not public routability. Accepted inputs retain their first
+    original ``(host, port)`` pair alongside the parsed IP. Additional tuple elements are
+    discarded, while the host and port values themselves are not normalized.
     """
     endpoint_pair = address_pair(endpoint)
     if endpoint_pair is None:
@@ -53,7 +66,7 @@ def authoritative_connected_endpoint(endpoint: object) -> tuple[str, int] | None
         return None
     if endpoint_ip.is_loopback or endpoint_ip.is_unspecified:
         return None
-    return endpoint_pair
+    return ConnectedIpEndpoint(address=endpoint_pair, ip=endpoint_ip)
 
 
 def connected_ip_destination_endpoint(
@@ -61,7 +74,7 @@ def connected_ip_destination_endpoint(
     *,
     port: int,
     extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
-) -> tuple[str, int] | None:
+) -> ConnectedIpEndpoint | None:
     """Resolve connected IP evidence for ``port`` using fail-closed precedence.
 
     Check ``server.peername`` and then ``server.address``. The first authoritative primary
@@ -75,15 +88,15 @@ def connected_ip_destination_endpoint(
     """
     peername = authoritative_connected_endpoint(server_peername(server))
     if peername is not None:
-        return peername if peername[1] == port else None
+        return peername if peername.address[1] == port else None
 
     address = authoritative_connected_endpoint(server_address(server))
     if address is not None:
-        return address if address[1] == port else None
+        return address if address.address[1] == port else None
 
     for extra_endpoint in extra_endpoints:
         endpoint = authoritative_connected_endpoint(extra_endpoint)
-        if endpoint is not None and endpoint[1] == port:
+        if endpoint is not None and endpoint.address[1] == port:
             return endpoint
 
     return None

--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -15,7 +15,7 @@ class ConnectedIpEndpoint:
     """
 
     address: tuple[str, int]
-    ip: ipaddress.IPv4Address | ipaddress.IPv6Address
+    parsed_ip: ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
 def server_address(server: object) -> tuple[str, int] | None:
@@ -66,7 +66,7 @@ def authoritative_connected_endpoint(endpoint: object) -> ConnectedIpEndpoint | 
         return None
     if endpoint_ip.is_loopback or endpoint_ip.is_unspecified:
         return None
-    return ConnectedIpEndpoint(address=endpoint_pair, ip=endpoint_ip)
+    return ConnectedIpEndpoint(address=endpoint_pair, parsed_ip=endpoint_ip)
 
 
 def connected_ip_destination_endpoint(

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -792,7 +792,7 @@ def _public_destination_connected_runtime_hosts(
     )
     return (
         _public_destination_runtime_host_classification(
-            connected_endpoint[0] if connected_endpoint is not None else None,
+            connected_endpoint.address[0] if connected_endpoint is not None else None,
             classifications,
         ),
     )

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -100,11 +100,12 @@ def _connected_verified_tls_destination_endpoint(
     # mitmproxy verifies the upstream certificate against server.sni when
     # ssl_insecure is false. At this point the connected IP is authenticated as
     # the same host we plan to bind, so CDN/Anycast DNS drift does not matter.
-    return connection_endpoints.connected_ip_destination_endpoint(
+    connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
         server,
         port=port,
         extra_endpoints=extra_endpoints,
     )
+    return connected_endpoint.address if connected_endpoint is not None else None
 
 
 def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -100,28 +100,28 @@ def _connection_id(connection: object) -> str | None:
     return None
 
 
-def _endpoint_matches(
-    left: connection_endpoints.ConnectedIpEndpoint,
-    right: tuple[str, int],
+def _connected_endpoint_matches_address(
+    connected_endpoint: connection_endpoints.ConnectedIpEndpoint,
+    binding_address: tuple[str, int],
 ) -> bool:
-    if left.address == right:
+    if connected_endpoint.address == binding_address:
         return True
-    right_host, right_port = right
-    if left.address[1] != right_port:
+    binding_host, binding_port = binding_address
+    if connected_endpoint.address[1] != binding_port:
         return False
     try:
-        right_ip = ipaddress.ip_address(right_host)
+        binding_ip = ipaddress.ip_address(binding_host)
     except ValueError:
         return False
-    return left.ip == right_ip
+    return connected_endpoint.parsed_ip == binding_ip
 
 
-def _endpoint_matches_any(
-    endpoint: connection_endpoints.ConnectedIpEndpoint,
+def _connected_endpoint_matches_any_binding(
+    connected_endpoint: connection_endpoints.ConnectedIpEndpoint,
     bindings: tuple[UpstreamDestinationBinding, ...],
 ) -> bool:
     return any(
-        _endpoint_matches(endpoint, binding.original_address)
+        _connected_endpoint_matches_address(connected_endpoint, binding.original_address)
         for binding in bindings
         if binding.original_address is not None
     )
@@ -335,7 +335,10 @@ def _server_binding_matches_current_destination(
         return (
             binding.original_address is not None
             and connected_endpoint is not None
-            and _endpoint_matches(connected_endpoint, binding.original_address)
+            and _connected_endpoint_matches_address(
+                connected_endpoint,
+                binding.original_address,
+            )
         )
     return _address_matches(binding.host, binding.port, getattr(server, "address", None))
 
@@ -375,7 +378,10 @@ def _client_binding_connected_endpoint(
         port=port,
         extra_endpoints=(connection_endpoints.connection_sockname(client),),
     )
-    if connected_endpoint is None or not _endpoint_matches_any(connected_endpoint, bindings):
+    if connected_endpoint is None or not _connected_endpoint_matches_any_binding(
+        connected_endpoint,
+        bindings,
+    ):
         return None
     return connected_endpoint.address
 

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -100,28 +100,24 @@ def _connection_id(connection: object) -> str | None:
     return None
 
 
-def _endpoint_ip_key(host: str) -> str | None:
-    try:
-        return str(ipaddress.ip_address(host))
-    except ValueError:
-        return None
-
-
-def _endpoint_matches(left: object, right: tuple[str, int]) -> bool:
-    left_pair = connection_endpoints.address_pair(left)
-    if left_pair is None:
-        return False
-    left_host, left_port = left_pair
+def _endpoint_matches(
+    left: connection_endpoints.ConnectedIpEndpoint,
+    right: tuple[str, int],
+) -> bool:
+    if left.address == right:
+        return True
     right_host, right_port = right
-    if left_port != right_port:
+    if left.address[1] != right_port:
         return False
-    left_key = _endpoint_ip_key(left_host)
-    right_key = _endpoint_ip_key(right_host)
-    return left_key is not None and left_key == right_key
+    try:
+        right_ip = ipaddress.ip_address(right_host)
+    except ValueError:
+        return False
+    return left.ip == right_ip
 
 
 def _endpoint_matches_any(
-    endpoint: object,
+    endpoint: connection_endpoints.ConnectedIpEndpoint,
     bindings: tuple[UpstreamDestinationBinding, ...],
 ) -> bool:
     return any(
@@ -243,15 +239,15 @@ def refresh_server_binding_connected_address_if_matching(
         return False
     if binding.host != destination.host or binding.port != destination.port:
         return False
-    connected_pair = connection_endpoints.authoritative_connected_endpoint(connected_address)
-    if connected_pair is None:
+    connected_endpoint = connection_endpoints.authoritative_connected_endpoint(connected_address)
+    if connected_endpoint is None:
         return False
 
     refreshed_binding = UpstreamDestinationBinding(
         host=binding.host,
         port=binding.port,
         kinds=binding.kinds | frozenset((kind,)),
-        original_address=connected_pair,
+        original_address=connected_endpoint.address,
     )
     _bindings_by_server_id[server_id] = refreshed_binding
     _associate_server_with_client(server_id, client)
@@ -381,7 +377,7 @@ def _client_binding_connected_endpoint(
     )
     if connected_endpoint is None or not _endpoint_matches_any(connected_endpoint, bindings):
         return None
-    return connected_endpoint
+    return connected_endpoint.address
 
 
 def diagnostic_snapshot_for_flow(

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
@@ -20,6 +20,7 @@ from tests.upstream_connection_helpers import (
     bind_flow_upstream,
     mark_connected_tls_upstream,
     seed_server_binding,
+    track_normalized_binding_ip_parses,
 )
 
 
@@ -242,7 +243,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_when_upstrea
 
 
 async def test_matching_sni_and_host_allows_connected_firewall_auth_with_early_binding(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -263,6 +264,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_early_b
         kinds=frozenset(("connector_auth",)),
         original_address=("140.82.112.5", 443),
     )
+    binding_ip_parses = track_normalized_binding_ip_parses(monkeypatch)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -275,6 +277,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_early_b
     assert flow.server_conn.address == ("140.82.112.5", 443)
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     assert flow.request.headers["Authorization"] == "Bearer x"
+    assert binding_ip_parses == [("140.82.112.5",)]
 
 
 async def test_matching_sni_and_host_allows_connected_firewall_auth_after_retargeting(

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -30,6 +30,7 @@ from tests.requestheaders_helpers import (
 from tests.upstream_connection_helpers import (
     mark_connected_tls_upstream,
     seed_server_binding,
+    track_normalized_binding_ip_parses,
 )
 
 
@@ -601,6 +602,60 @@ async def test_firewall_allow_prior_client_binding_endpoint_mismatch_blocks(
         ]
         is False
     )
+
+
+async def test_firewall_allow_prior_client_binding_scan_parses_live_endpoint_once(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.99",
+        sni="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    flow.server_conn.peername = ("203.0.113.99", 443)
+    flow.server_conn.address = ("api.github.com", 443)
+    flow.server_conn.state = connection.ConnectionState.OPEN
+    for index in range(8):
+        prior_server = connection.Server(address=(f"198.18.20.{index + 1}", 443))
+        seed_server_binding(
+            prior_server,
+            client=flow.client_conn,
+            host="api.github.com",
+            port=443,
+            kinds=frozenset(("connector_auth",)),
+            original_address=prior_server.address,
+        )
+    binding_ip_parses = track_normalized_binding_ip_parses(monkeypatch)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+        _assert_no_request_stream(flow)
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
+    assert binding_ip_parses
+    for parses in binding_ip_parses:
+        assert len(parses) == 9
+        assert parses.count("203.0.113.99") == 1
 
 
 async def test_firewall_allow_prior_client_binding_endpoint_match_still_requires_tls(

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -1,7 +1,9 @@
 """Shared helpers for upstream mitmproxy test state."""
 
+import ipaddress
 from typing import cast
 
+import pytest
 from mitmproxy import certs, connection, http
 
 import upstream_destination_binding
@@ -10,6 +12,52 @@ import upstream_destination_binding
 _NO_CONNECTED_CLIENT_SOCKNAME = ("", 0)
 # Admission only checks that mitmproxy recorded at least one upstream certificate.
 _TLS_CERTIFICATE_PROOF = cast(certs.Cert, object())
+
+
+def track_normalized_binding_ip_parses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str | bytes | int, ...]]:
+    """Track IP parses performed inside each normalized binding match."""
+    binding_ip_parses: list[tuple[str | bytes | int, ...]] = []
+    active_ip_parses: list[str | bytes | int] | None = None
+    flow_matches_normalized_destination = (
+        upstream_destination_binding.flow_matches_normalized_destination
+    )
+    parse_ip_address = ipaddress.ip_address
+
+    def track_flow_matches_normalized_destination(
+        flow: http.HTTPFlow,
+        *,
+        destination: upstream_destination_binding.NormalizedUpstreamDestination,
+        allowed_kinds: frozenset[upstream_destination_binding.BindingKind],
+    ) -> bool:
+        nonlocal active_ip_parses
+        current_ip_parses: list[str | bytes | int] = []
+        active_ip_parses = current_ip_parses
+        try:
+            return flow_matches_normalized_destination(
+                flow,
+                destination=destination,
+                allowed_kinds=allowed_kinds,
+            )
+        finally:
+            binding_ip_parses.append(tuple(current_ip_parses))
+            active_ip_parses = None
+
+    def track_ip_address(
+        address: str | bytes | int,
+    ) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+        if active_ip_parses is not None:
+            active_ip_parses.append(address)
+        return parse_ip_address(address)
+
+    monkeypatch.setattr(
+        upstream_destination_binding,
+        "flow_matches_normalized_destination",
+        track_flow_matches_normalized_destination,
+    )
+    monkeypatch.setattr(ipaddress, "ip_address", track_ip_address)
+    return binding_ip_parses
 
 
 def seed_server_binding(


### PR DESCRIPTION
## Summary

- carry the original connected endpoint pair and its parsed IP through endpoint validation
- reuse the parsed live IP across direct and prior-client binding comparisons
- fast-path exact endpoint pairs while preserving equivalent IPv6 matching
- retain existing public-destination, TLS, endpoint precedence, and fail-closed behavior
- add real-flow parse-count coverage for exact direct and eight-candidate fallback paths

The exact direct-path probe now performs one IP parse instead of three. On the pinned Python 3.14.0 environment, the local 5 × 20,000-call median changed from 3.596 µs/check on the baseline to 1.687 µs/check with this implementation.

## Exclusions

- no parsed IP stored in bindings
- no module-level or cross-request cache
- no authorization, TLS, binding-kind, endpoint precedence, or public-routability policy changes
- no dependency, API, protocol, persisted-state, database, environment, or deployment-contract changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_connection_endpoints.py tests/test_request_handler_api_admission.py tests/test_request_headers_api_admission.py tests/test_request_handler_connector_admission.py tests/test_request_headers_connector_admission.py tests/test_request_handler_builtin_host_policy.py tests/test_request_handler_public_destination.py` (151 passed)
- `uv run --no-sync python -m pytest tests/ -q` (4,437 passed)

Closes #23661
