### PR TITLE
feat(api): admit morning briefs through the chat thread queue

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -17,7 +17,7 @@ import { zeroMorningBriefContract } from "@vm0/api-contracts/contracts/zero-morn
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
 import { Cron } from "croner";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
@@ -38,6 +38,14 @@ import { mockGoogleCalendarConnectorOAuth } from "./helpers/api-bdd-workflows";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { holdOrgAdmissionLockFixture } from "../../../test-fixtures/chat-messages";
+import {
+  insertOldFormatQueuedUserMessageFixture,
+  insertQueuedWebUserMessageFixture,
+  pauseMorningBriefAutomationIntakeFixture,
+  readMorningBriefDeliveryFixture,
+  readMorningBriefQueuedParamsFixture,
+} from "../../../test-fixtures/morning-brief";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -56,7 +64,6 @@ const webhooks = createWebhookCallbackApi(context);
 const connectors = createConnectorBddApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 const routeMocks = createZeroRouteMocks(context);
-
 const CRON_SECRET = "test-morning-brief-cron-secret";
 const TIMEZONE = "Asia/Shanghai";
 // Anchor on the next 7:00 local strictly after the real clock: runner job
@@ -337,11 +344,9 @@ async function setupMorningBriefActor(
   return { actor: orgActor, runnerGroup, gmailAfterSeconds };
 }
 
-async function findMorningBriefThreadOrNull(scenario: Scenario): Promise<{
-  readonly threadId: string;
-  readonly runId: string;
-  readonly chatMessage: string;
-} | null> {
+async function findMorningBriefThreadIdOrNull(
+  scenario: Scenario,
+): Promise<string | null> {
   routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
   const threadEvents = await accept(
     setupApp({ context })(chatThreadsContract).events({
@@ -356,22 +361,42 @@ async function findMorningBriefThreadOrNull(scenario: Scenario): Promise<{
   if (!thread) {
     return null;
   }
+  return thread.chatThreadId;
+}
+
+async function readMorningBriefThreadEvents(
+  scenario: Scenario,
+  threadId: string,
+) {
   const messages = await accept(
     setupApp({ context })(chatThreadEventsContract).list({
       headers: actorHeaders(),
-      params: { threadId: thread.chatThreadId },
+      params: { threadId },
       query: { limit: 50 },
     }),
     [200],
   );
-  const runMessage = messages.body.events.find((message) => {
+  return messages.body.events;
+}
+
+async function findMorningBriefThreadOrNull(scenario: Scenario): Promise<{
+  readonly threadId: string;
+  readonly runId: string;
+  readonly chatMessage: string;
+} | null> {
+  const threadId = await findMorningBriefThreadIdOrNull(scenario);
+  if (!threadId) {
+    return null;
+  }
+  const messages = await readMorningBriefThreadEvents(scenario, threadId);
+  const runMessage = messages.find((message) => {
     return message.eventType === "input.prompt" && message.runId !== undefined;
   });
   if (!runMessage?.runId || runMessage.content === null) {
     throw new Error("Expected the Morning Brief run message");
   }
   return {
-    threadId: thread.chatThreadId,
+    threadId,
     runId: runMessage.runId,
     chatMessage: runMessage.content,
   };
@@ -575,11 +600,62 @@ describe("cron execute morning briefs", () => {
     await executeMorningBriefsCron();
 
     // The run lands in the fixed Morning Brief thread through the chat queue.
-    const { runId, chatMessage } = await findMorningBriefThread(scenario);
+    const { threadId, runId, chatMessage } =
+      await findMorningBriefThread(scenario);
 
     // The thread shows only the member-facing line, with no signed URL.
     expect(chatMessage).toBe(`Generate my Morning Brief for ${BRIEF_DATE}.`);
     expect(chatMessage).not.toContain("# Run facts");
+    const delivery = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(delivery).toStrictEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        status: "running",
+        runId,
+        inputKey: expect.stringContaining("/input.json"),
+        outputKey: expect.stringContaining("/output.json"),
+      }),
+    );
+    if (!delivery) {
+      throw new Error("Expected the admitted Morning Brief delivery");
+    }
+    const queuedParams = await readMorningBriefQueuedParamsFixture({
+      messageId: delivery.id,
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+    });
+    expect(queuedParams).toStrictEqual(
+      expect.objectContaining({
+        version: 1,
+        prompt: expect.stringContaining("# Run facts"),
+        appendSystemPrompt: expect.stringContaining(
+          "Begin exactly with `Good morning.`",
+        ),
+        morningBriefDelivery: {
+          deliveryId: delivery.id,
+          internalKind: "morning-brief:email",
+          secret: expect.any(String),
+          payload: { deliveryId: delivery.id },
+        },
+      }),
+    );
+    const threadMessages = await readMorningBriefThreadEvents(
+      scenario,
+      threadId,
+    );
+    expect(
+      threadMessages.filter((message) => {
+        return (
+          message.eventType === "input.prompt" &&
+          message.content === chatMessage &&
+          message.runId !== undefined
+        );
+      }),
+    ).toHaveLength(1);
 
     // The agent uploads output.json and the run completes.
     mockUploadedBriefOutput(VALID_OUTPUT);
@@ -868,7 +944,8 @@ describe("cron execute morning briefs", () => {
     await drainOutbox();
     expect(sentMorningBriefEmails()).toHaveLength(1);
 
-    // Repeat triggers on the same local date reset the delivery and resend.
+    // Repeat triggers on the same local date return the admitted delivery
+    // without enqueueing a second message or sending a second email.
     routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
     const second = await accept(
       morningBriefTriggerClient().trigger({
@@ -878,17 +955,276 @@ describe("cron execute morning briefs", () => {
       [200],
     );
     await flushWaitUntilForTest();
-    mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(
-      scenario,
-      second.body.runId,
-      0,
-      `morning-brief-cli-${triggered.body.runId}`,
-    );
     await drainOutbox();
-    expect(sentMorningBriefEmails()).toHaveLength(2);
+    expect(second.body.runId).toBe(triggered.body.runId);
+    expect(sentMorningBriefEmails()).toHaveLength(1);
+    const thread = await findMorningBriefThread(scenario);
+    const events = await readMorningBriefThreadEvents(
+      scenario,
+      thread.threadId,
+    );
+    expect(
+      events.filter((event) => {
+        return (
+          event.eventType === "input.prompt" &&
+          event.content === `Generate my Morning Brief for ${BRIEF_DATE}.` &&
+          event.runId !== undefined
+        );
+      }),
+    ).toHaveLength(1);
     clearMockNow();
   });
+
+  it("keeps a queued brief and a concurrent user message in FIFO order", async () => {
+    context.mocks.resend.send.mockResolvedValue({
+      data: { id: "resend-fifo" },
+      error: null,
+    });
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    mockNow(AFTER_SEVEN_LOCAL);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.actor.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const briefRequest = morningBriefTriggerClient().trigger({
+      headers: actorHeaders(),
+      body: {},
+    });
+
+    let threadId: string | null = null;
+    await expect
+      .poll(async () => {
+        threadId = await findMorningBriefThreadIdOrNull(scenario);
+        return threadId;
+      })
+      .not.toBeNull();
+    if (!threadId) {
+      throw new Error("Expected the queued Morning Brief thread");
+    }
+    const queuedThreadId = threadId;
+    await expect
+      .poll(async () => {
+        const events = await readMorningBriefThreadEvents(
+          scenario,
+          queuedThreadId,
+        );
+        return events.some((event) => {
+          return (
+            event.eventType === "input.prompt" &&
+            event.content === `Generate my Morning Brief for ${BRIEF_DATE}.` &&
+            event.runId === undefined
+          );
+        });
+      })
+      .toBe(true);
+
+    const userPrompt = "Add the budget review to today's priorities.";
+    await insertQueuedWebUserMessageFixture({
+      threadId: queuedThreadId,
+      content: userPrompt,
+      createdAt: new Date(AFTER_SEVEN_LOCAL + 1000),
+    });
+    await expect
+      .poll(async () => {
+        const events = await readMorningBriefThreadEvents(
+          scenario,
+          queuedThreadId,
+        );
+        return events.some((event) => {
+          return (
+            event.eventType === "input.prompt" && event.content === userPrompt
+          );
+        });
+      })
+      .toBe(true);
+
+    admissionLock.release();
+    const brief = await accept(briefRequest, [200]);
+    await admissionLock.done;
+
+    mockUploadedBriefOutput(VALID_OUTPUT);
+    await completeMorningBriefRun(scenario, brief.body.runId, 0);
+    await drainOutbox();
+
+    let userRunId: string | null = null;
+    await expect
+      .poll(async () => {
+        const events = await readMorningBriefThreadEvents(
+          scenario,
+          queuedThreadId,
+        );
+        const claimed = events.filter((event) => {
+          return (
+            event.eventType === "input.prompt" &&
+            event.runId !== undefined &&
+            (event.content === `Generate my Morning Brief for ${BRIEF_DATE}.` ||
+              event.content === userPrompt)
+          );
+        });
+        userRunId =
+          claimed.find((event) => {
+            return event.content === userPrompt;
+          })?.runId ?? null;
+        return claimed.map((event) => {
+          return event.content;
+        });
+      })
+      .toStrictEqual([
+        `Generate my Morning Brief for ${BRIEF_DATE}.`,
+        userPrompt,
+      ]);
+    if (!userRunId) {
+      throw new Error("Expected the concurrent user message run");
+    }
+    expect(userRunId).not.toBe(brief.body.runId);
+    await completeMorningBriefRun(scenario, userRunId, 0);
+    clearMockNow();
+  }, 90_000);
+
+  it("admits a queued brief while workflow automation intake is paused", async () => {
+    context.mocks.resend.send.mockResolvedValue({
+      data: { id: "resend-paused" },
+      error: null,
+    });
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    mockNow(AFTER_SEVEN_LOCAL);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.actor.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const briefRequest = morningBriefTriggerClient().trigger({
+      headers: actorHeaders(),
+      body: {},
+    });
+    let threadId: string | null = null;
+    await expect
+      .poll(async () => {
+        threadId = await findMorningBriefThreadIdOrNull(scenario);
+        return threadId;
+      })
+      .not.toBeNull();
+    if (!threadId) {
+      throw new Error("Expected the queued Morning Brief thread");
+    }
+    const queuedThreadId = threadId;
+    await expect
+      .poll(async () => {
+        const events = await readMorningBriefThreadEvents(
+          scenario,
+          queuedThreadId,
+        );
+        return events.some((event) => {
+          return (
+            event.eventType === "input.prompt" && event.runId === undefined
+          );
+        });
+      })
+      .toBe(true);
+
+    await pauseMorningBriefAutomationIntakeFixture(queuedThreadId);
+    const pausedEvents = await readMorningBriefThreadEvents(
+      scenario,
+      queuedThreadId,
+    );
+    expect(pausedEvents).toContainEqual(
+      expect.objectContaining({
+        eventType: "queue.automation_paused",
+      }),
+    );
+
+    admissionLock.release();
+    const triggered = await accept(briefRequest, [200]);
+    await admissionLock.done;
+    const thread = await findMorningBriefThread(scenario);
+    expect(thread.runId).toBe(triggered.body.runId);
+    mockUploadedBriefOutput(VALID_OUTPUT);
+    await completeMorningBriefRun(scenario, triggered.body.runId, 0);
+    await drainOutbox();
+    clearMockNow();
+  }, 90_000);
+
+  it("drains an old-format queued params payload without new delivery fields", async () => {
+    context.mocks.resend.send.mockResolvedValue({
+      data: { id: "resend-old-format" },
+      error: null,
+    });
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    mockNow(AFTER_SEVEN_LOCAL);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const triggered = await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [200],
+    );
+    const thread = await findMorningBriefThread(scenario);
+
+    const displayContent = "Legacy queued Morning Brief display text.";
+    const realPrompt = "Legacy queued Morning Brief execution prompt.";
+    const appendSystemPrompt = "Legacy Morning Brief system instructions.";
+    const messageId = await insertOldFormatQueuedUserMessageFixture({
+      threadId: thread.threadId,
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      content: displayContent,
+      prompt: realPrompt,
+      appendSystemPrompt,
+    });
+    const oldParams = await readMorningBriefQueuedParamsFixture({
+      messageId,
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+    });
+    expect(oldParams).toStrictEqual({
+      version: 1,
+      prompt: realPrompt,
+      appendSystemPrompt,
+    });
+
+    mockUploadedBriefOutput(VALID_OUTPUT);
+    await completeMorningBriefRun(scenario, triggered.body.runId, 0);
+    await drainOutbox();
+    const events = await readMorningBriefThreadEvents(
+      scenario,
+      thread.threadId,
+    );
+    const claimed = events.find((event) => {
+      return (
+        event.eventType === "input.prompt" &&
+        event.content === displayContent &&
+        event.runId !== undefined
+      );
+    });
+    if (!claimed?.runId) {
+      throw new Error("Expected the old-format queue item to drain");
+    }
+    const runInput = await completeMorningBriefRun(scenario, claimed.runId, 0);
+    expect(runInput.prompt).toBe(realPrompt);
+    expect(runInput.appendSystemPrompt).toContain(appendSystemPrompt);
+    clearMockNow();
+  }, 90_000);
 
   it("sends no email when the uploaded brief output is invalid", async () => {
     context.mocks.resend.send.mockResolvedValue({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -194,6 +194,7 @@ import type {
 } from "./chat-session-continuity.service";
 import {
   claimQueueFirstRunAssociation,
+  recordQueueFirstClaimedRun,
   type QueueFirstRunAssociation,
   type QueueFirstRunClaimResult,
 } from "./zero-chat-queued-message.service";
@@ -5511,6 +5512,12 @@ async function commitFailedLaunch(args: {
         runnerGroup: undefined,
         error: message,
       });
+      if (queueFirstClaim) {
+        await recordQueueFirstClaimedRun(tx, {
+          claim: queueFirstClaim,
+          runId: args.identity.runId,
+        });
+      }
       return {
         kind: "failed",
         createdAt,
@@ -5783,6 +5790,12 @@ async function commitQueuedPreparedLaunch(
     status: "queued",
     runnerGroup: payload.runnerGroup,
   });
+  if (queueFirstClaim) {
+    await recordQueueFirstClaimedRun(tx, {
+      claim: queueFirstClaim,
+      runId: run.id,
+    });
+  }
   await args.timing.measure(
     "api_dispatch_persist_custom_connector_auth_refs",
     "nested",
@@ -5847,6 +5860,12 @@ async function commitPendingPreparedLaunch(
     status: "pending",
     runnerGroup: payload.runnerGroup,
   });
+  if (queueFirstClaim) {
+    await recordQueueFirstClaimedRun(tx, {
+      claim: queueFirstClaim,
+      runId: run.id,
+    });
+  }
   const runnerJobCreatedAt = await args.timing.measure(
     "api_dispatch_persist_runner_job_queue",
     "top_level",

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2537,7 +2537,10 @@ async function buildCreateQueuedChatRunInput(
       });
     },
   );
-  const prompt = sourceParams?.prompt ?? userMessageProjection.agentPrompt;
+  const prompt =
+    args.queuedMessage.triggerSource === "workflow-schedule"
+      ? (sourceParams?.prompt ?? userMessageProjection.agentPrompt)
+      : userMessageProjection.agentPrompt;
 
   return {
     orgId: args.agent.orgId,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -224,7 +224,7 @@ export class ChatCallbackPreCreateTimingCollector {
 
   flush(
     runId: string,
-    triggerSource: "web" | "slack" | "feishu" | "teams" = "web",
+    triggerSource: QueuedUserMessage["triggerSource"] = "web",
   ): void {
     if (this.flushed) {
       return;
@@ -255,7 +255,7 @@ export class ChatCallbackPreCreateTimingCollector {
 function flushChatCallbackTimingOnRejection(args: {
   readonly timing: ChatCallbackPreCreateTimingCollector;
   readonly getRunId: () => string | null;
-  readonly triggerSource: "web" | "slack" | "feishu" | "teams";
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
 }): (error: unknown) => void {
   return () => {
     const runId = args.getRunId();
@@ -526,7 +526,7 @@ interface CreateQueuedChatRunInput {
     readonly hostId: string;
     readonly displayName: string;
   } | null;
-  readonly triggerSource: "web" | "slack" | "feishu" | "teams";
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly realAgentInPreview?: boolean;
   readonly slackDelivery?: {
     readonly channelId: string;
@@ -535,6 +535,12 @@ interface CreateQueuedChatRunInput {
   };
   readonly feishuDelivery?: FeishuDeliveryTarget;
   readonly teamsDelivery?: TeamsDeliveryTarget;
+  readonly morningBriefDelivery?: {
+    readonly deliveryId: string;
+    readonly internalKind: "morning-brief:email";
+    readonly secret: string;
+    readonly payload: unknown;
+  };
   readonly apiStartTime?: number;
   readonly userInfoExtras?: {
     readonly slackDisplayName?: string;
@@ -641,6 +647,15 @@ function buildQueuedCreateZeroRunArgs(
     selectedModelOverride: input.modelPin.selectedModel ?? undefined,
     codexServiceTier: input.codexServiceTier,
     callbacks: [
+      ...(input.morningBriefDelivery
+        ? [
+            {
+              internalKind: input.morningBriefDelivery.internalKind,
+              secret: input.morningBriefDelivery.secret,
+              payload: input.morningBriefDelivery.payload,
+            },
+          ]
+        : []),
       {
         internalKind: "chat" as const,
         secret: generateCallbackSecret(),
@@ -697,6 +712,11 @@ function buildQueuedCreateZeroRunArgs(
       kind: "user_message" as const,
       threadId: input.threadId,
       messageId: input.queuedMessage.id,
+      ...(input.morningBriefDelivery
+        ? {
+            morningBriefDeliveryId: input.morningBriefDelivery.deliveryId,
+          }
+        : {}),
     },
     zeroRunModelPin: {
       modelProvider: input.effectiveModelProvider ?? null,
@@ -1927,7 +1947,7 @@ function formatPriorRunMessage(
 
 function buildChatPriorRunsContext(
   runs: readonly PriorRun[],
-  triggerSource: "web" | "slack" | "feishu" | "teams",
+  triggerSource: QueuedUserMessage["triggerSource"],
   inlineTemplatesEnabled: boolean,
 ): string {
   if (runs.length === 0) {
@@ -1961,7 +1981,9 @@ function buildChatPriorRunsContext(
           ? "Feishu"
           : triggerSource === "teams"
             ? "Microsoft Teams"
-            : "Web Chat"
+            : triggerSource === "workflow-schedule"
+              ? "Morning Brief"
+              : "Web Chat"
     } Run Context`,
     "The current CLI session is fresh, so recent visible chat rounds are provided here for continuity.",
     "Use these messages as context for the user's current request.",
@@ -1975,7 +1997,7 @@ function buildChatPriorRunsContext(
 async function getLatestRunsByThreadId(
   db: Db,
   threadId: string,
-  triggerSource: "web" | "slack" | "feishu" | "teams",
+  triggerSource: QueuedUserMessage["triggerSource"],
   limit: number,
 ): Promise<PriorRun[]> {
   const runRows = await db
@@ -2130,7 +2152,7 @@ async function buildQueuedPriorContext(args: {
   readonly threadId: string;
   readonly startNewSession: boolean;
   readonly incompleteContext: string;
-  readonly triggerSource: "web" | "slack" | "feishu" | "teams";
+  readonly triggerSource: QueuedUserMessage["triggerSource"];
   readonly inlineTemplatesEnabled: boolean;
 }): Promise<string> {
   if (!args.startNewSession || args.incompleteContext.length > 0) {
@@ -2515,7 +2537,7 @@ async function buildCreateQueuedChatRunInput(
       });
     },
   );
-  const prompt = userMessageProjection.agentPrompt;
+  const prompt = sourceParams?.prompt ?? userMessageProjection.agentPrompt;
 
   return {
     orgId: args.agent.orgId,
@@ -2541,6 +2563,7 @@ async function buildCreateQueuedChatRunInput(
     slackDelivery: sourceParams?.slackDelivery,
     feishuDelivery: sourceParams?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
+    morningBriefDelivery: sourceParams?.morningBriefDelivery,
     apiStartTime: sourceParams?.apiStartTime,
     userInfoExtras: sourceParams?.userInfoExtras,
   };

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -7,13 +7,16 @@ import {
   morningBriefSchedules,
 } from "@vm0/db/schema/morning-brief";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
 import { and, asc, eq, isNotNull, lte } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
+import {
+  publishChatThreadMessageCreatedSafely,
+  publishThreadListChanged,
+} from "../external/realtime";
 import { nowDate } from "../external/time";
 import {
   generatePresignedGetUrl,
@@ -21,9 +24,9 @@ import {
   putS3Object,
 } from "../external/s3";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { settle } from "../utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   collectMorningBriefInput,
   type MorningBriefInput,
@@ -33,13 +36,11 @@ import {
   morningBriefLocalDate,
   nextMorningBriefRunAt,
 } from "./morning-brief-schedule.service";
+import { insertChatEvent } from "./zero-chat-event.service";
+import { touchChatThreadLastMessageAt } from "./zero-chat-message-shared.service";
+import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-message.service";
+import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveDefaultAgent } from "./zero-email-common.service";
-import {
-  postRunUserMessage,
-  resolveRunChatThreadModelContext,
-} from "./zero-chat-run-message.service";
-import type { ModelFirstPin } from "./zero-model-selection.service";
-import { createZeroRun$ } from "./zero-runs-create.service";
 import { createAutomationChatThread } from "./zero-workflow-user-automation-thread.service";
 
 const log = logger("api:morning-brief");
@@ -392,98 +393,51 @@ async function ensureMorningBriefChatThread(
   });
 }
 
-interface MorningBriefModelContext {
-  readonly modelPin: ModelFirstPin;
-  readonly effectiveModelProvider: string | null | undefined;
-  readonly cliAgentType: string | null;
-  readonly codexServiceTier: "fast" | undefined;
-}
-
-async function resolveMorningBriefModelContext(
-  db: Db,
-  claimed: ClaimedMorningBrief,
-  chatThreadId: string,
-): Promise<MorningBriefModelContext | null> {
-  const { row, deliveryId, currentTime } = claimed;
-  const modelContext = await resolveRunChatThreadModelContext({
-    db,
-    orgId: row.orgId,
-    userId: row.userId,
-    threadId: chatThreadId,
-  });
-  if ("status" in modelContext) {
-    // Credit / provider admission problems skip silently by design; the
-    // schedule already points at tomorrow 7:00.
-    await markDeliveryFailed(
-      db,
-      deliveryId,
-      modelContext.body.error.message,
-      currentTime,
-    );
-    return null;
-  }
-  const { pin, providerAdmission, runCodexServiceTier } = modelContext;
-  if (providerAdmission.error) {
-    await markDeliveryFailed(
-      db,
-      deliveryId,
-      providerAdmission.error.body.error.message,
-      currentTime,
-    );
-    return null;
-  }
-  return {
-    modelPin: pin,
-    effectiveModelProvider: providerAdmission.effectiveModelProvider,
-    cliAgentType: providerAdmission.cliAgentType,
-    codexServiceTier: runCodexServiceTier,
-  };
-}
-
-async function recordMorningBriefRunStart(
+async function persistMorningBriefQueueEvent(
   db: Db,
   args: {
     readonly claimed: ClaimedMorningBrief;
     readonly staged: StagedMorningBriefInput;
-    readonly model: MorningBriefModelContext;
     readonly chatThreadId: string;
-    readonly runId: string;
-    readonly runStatus: string;
     readonly chatMessage: string;
+    readonly encryptedParams: string;
   },
 ): Promise<void> {
-  const { claimed, staged, model } = args;
-  // The thread shows the member-facing line; the run-facts prompt with its
-  // signed URLs stays on the run.
-  await postRunUserMessage({
-    db,
-    threadId: args.chatThreadId,
-    userId: claimed.row.userId,
-    runId: args.runId,
-    prompt: args.chatMessage,
-    appendQueueMarker: args.runStatus === "queued",
+  const { claimed, staged } = args;
+  await db.transaction(async (tx) => {
+    const inserted = await insertChatEvent(tx, {
+      id: claimed.deliveryId,
+      chatThreadId: args.chatThreadId,
+      eventType: "input.prompt",
+      content: args.chatMessage,
+      userMessage: createUserMessageDocument({ text: args.chatMessage }),
+      runId: null,
+      triggerSource: "workflow-schedule",
+      encryptedParams: args.encryptedParams,
+      createdAt: claimed.currentTime,
+    });
+    if (!inserted) {
+      throw new Error("Failed to enqueue the morning brief message");
+    }
+    await touchChatThreadLastMessageAt(
+      tx,
+      args.chatThreadId,
+      inserted.createdAt,
+      inserted.id,
+    );
+    const [delivery] = await tx
+      .update(morningBriefDeliveries)
+      .set({
+        inputKey: staged.inputKey,
+        outputKey: staged.outputKey,
+        updatedAt: claimed.currentTime,
+      })
+      .where(eq(morningBriefDeliveries.id, claimed.deliveryId))
+      .returning({ id: morningBriefDeliveries.id });
+    if (!delivery) {
+      throw new Error("Morning brief delivery disappeared before enqueue");
+    }
   });
-
-  await db
-    .update(zeroRuns)
-    .set({
-      modelProvider: model.effectiveModelProvider,
-      modelProviderId: model.modelPin.modelProviderId,
-      modelProviderCredentialScope: model.modelPin.modelProviderCredentialScope,
-      selectedModel: model.modelPin.selectedModel,
-    })
-    .where(eq(zeroRuns.id, args.runId));
-
-  await db
-    .update(morningBriefDeliveries)
-    .set({
-      status: "running",
-      runId: args.runId,
-      inputKey: staged.inputKey,
-      outputKey: staged.outputKey,
-      updatedAt: claimed.currentTime,
-    })
-    .where(eq(morningBriefDeliveries.id, claimed.deliveryId));
 }
 
 const startMorningBriefRun$ = command(
@@ -495,7 +449,7 @@ const startMorningBriefRun$ = command(
       readonly apiStartTime: number;
     },
     signal: AbortSignal,
-  ): Promise<{ readonly runId: string } | "skipped"> => {
+  ): Promise<{ readonly runId: string | null } | "skipped"> => {
     const db = set(writeDb$);
     const { claimed, staged } = args;
     const { row, timezone, briefDate, deliveryId, currentTime } = claimed;
@@ -520,16 +474,6 @@ const startMorningBriefRun$ = command(
     );
     signal.throwIfAborted();
 
-    const model = await resolveMorningBriefModelContext(
-      db,
-      claimed,
-      chatThreadId,
-    );
-    signal.throwIfAborted();
-    if (!model) {
-      return "skipped";
-    }
-
     const chatMessage = buildMorningBriefChatMessage(briefDate);
     const runPrompt = buildMorningBriefRunPrompt({
       briefDate,
@@ -539,88 +483,58 @@ const startMorningBriefRun$ = command(
       inputUrl: staged.inputUrl,
       outputUrl: staged.outputUrl,
     });
-    const callbacks: {
-      readonly internalKind: InternalRunCallbackKind;
-      readonly secret: string;
-      readonly payload: unknown;
-    }[] = [
+    const encryptedParams = await encryptQueuedUserMessageRunParams(
       {
-        internalKind: "morning-brief:email",
-        secret: generateCallbackSecret(),
-        payload: { deliveryId },
-      },
-      {
-        internalKind: "chat",
-        secret: generateCallbackSecret(),
-        payload: { threadId: chatThreadId, agentId },
-      },
-    ];
-
-    const result = await set(
-      createZeroRun$,
-      {
-        auth: {
-          orgId: row.orgId,
-          orgRole: "member",
-          userId: row.userId,
-          tokenType: "session",
-        },
-        body: {
-          prompt: runPrompt,
-          agentId,
-          ...(model.effectiveModelProvider
-            ? { modelProvider: model.effectiveModelProvider }
-            : {}),
-        },
-        apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-schedule",
-        chatThreadId,
-        modelProviderId: model.modelPin.modelProviderId ?? undefined,
-        modelProviderCredentialScope:
-          model.modelPin.modelProviderCredentialScope ?? undefined,
-        selectedModelOverride: model.modelPin.selectedModel ?? undefined,
-        threadSessionRoute: {
-          selectedModel: model.modelPin.selectedModel,
-          modelProvider: model.effectiveModelProvider ?? null,
-          cliAgentType: model.cliAgentType,
-        },
-        codexServiceTier: model.codexServiceTier,
+        version: 1,
+        prompt: runPrompt,
         appendSystemPrompt: buildMorningBriefAppendSystemPrompt({
           briefDate,
           timezone,
           inputUrl: staged.inputUrl,
           outputUrl: staged.outputUrl,
         }),
-        callbacks,
+        morningBriefDelivery: {
+          deliveryId,
+          internalKind: "morning-brief:email",
+          secret: generateCallbackSecret(),
+          payload: { deliveryId },
+        },
+        apiStartTime: args.apiStartTime,
+      },
+      { orgId: row.orgId, userId: row.userId },
+    );
+    signal.throwIfAborted();
+
+    await persistMorningBriefQueueEvent(db, {
+      claimed,
+      staged,
+      chatThreadId,
+      chatMessage,
+      encryptedParams,
+    });
+    signal.throwIfAborted();
+    await publishChatThreadMessageCreatedSafely(row.userId, chatThreadId);
+    signal.throwIfAborted();
+    await publishThreadListChanged(row.userId);
+    signal.throwIfAborted();
+
+    await set(
+      drainChatThreadQueueForThread$,
+      {
+        chatThreadId,
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
       },
       signal,
     );
     signal.throwIfAborted();
 
-    if (result.status !== 201) {
-      await markDeliveryFailed(
-        db,
-        deliveryId,
-        result.body.error.message,
-        currentTime,
-      );
-      signal.throwIfAborted();
-      return "skipped";
-    }
-
-    await recordMorningBriefRunStart(db, {
-      claimed,
-      staged,
-      model,
-      chatThreadId,
-      runId: result.body.runId,
-      runStatus: result.body.status,
-      chatMessage,
-    });
+    const [delivery] = await db
+      .select({ runId: morningBriefDeliveries.runId })
+      .from(morningBriefDeliveries)
+      .where(eq(morningBriefDeliveries.id, deliveryId))
+      .limit(1);
     signal.throwIfAborted();
-
-    return { runId: result.body.runId };
+    return { runId: delivery?.runId ?? null };
   },
 );
 
@@ -661,6 +575,11 @@ const processDueMorningBrief$ = command(
 
 type ManualMorningBriefAdmission =
   | { readonly kind: "ok"; readonly claimed: ClaimedMorningBrief }
+  | {
+      readonly kind: "duplicate";
+      readonly runId: string | null;
+      readonly briefDate: string;
+    }
   | { readonly kind: "forbidden" }
   | { readonly kind: "bad_request"; readonly message: string };
 
@@ -740,23 +659,26 @@ async function admitManualMorningBrief(
       createdAt: currentTime,
       updatedAt: currentTime,
     })
-    .onConflictDoUpdate({
-      target: [
-        morningBriefDeliveries.orgId,
-        morningBriefDeliveries.userId,
-        morningBriefDeliveries.briefDate,
-      ],
-      set: {
-        status: "collecting",
-        runId: null,
-        error: null,
-        updatedAt: currentTime,
-      },
-    })
+    .onConflictDoNothing()
     .returning({ id: morningBriefDeliveries.id });
   signal.throwIfAborted();
   if (!delivery) {
-    throw new Error("Expected the morning brief delivery upsert to return");
+    const [existing] = await db
+      .select({ runId: morningBriefDeliveries.runId })
+      .from(morningBriefDeliveries)
+      .where(
+        and(
+          eq(morningBriefDeliveries.orgId, args.orgId),
+          eq(morningBriefDeliveries.userId, args.userId),
+          eq(morningBriefDeliveries.briefDate, briefDate),
+        ),
+      )
+      .limit(1);
+    return {
+      kind: "duplicate",
+      runId: existing?.runId ?? null,
+      briefDate,
+    };
   }
 
   return {
@@ -786,8 +708,8 @@ type TriggerMorningBriefResult =
 
 /**
  * Testing entry point behind the manualMorningBrief feature switch: runs the
- * full collect → run pipeline for the caller immediately, reusing (and
- * resetting) today's delivery row so repeated manual triggers work.
+ * full collect → queue pipeline for the caller immediately. The same
+ * once-per-local-date delivery guard used by cron deduplicates repeats.
  */
 export const triggerMorningBriefNow$ = command(
   async (
@@ -808,6 +730,18 @@ export const triggerMorningBriefNow$ = command(
       currentTime,
       signal,
     );
+    if (admission.kind === "duplicate") {
+      return admission.runId
+        ? {
+            kind: "ok",
+            runId: admission.runId,
+            briefDate: admission.briefDate,
+          }
+        : {
+            kind: "bad_request",
+            message: "Morning brief is already queued for today",
+          };
+    }
     if (admission.kind !== "ok") {
       return admission;
     }
@@ -826,10 +760,13 @@ export const triggerMorningBriefNow$ = command(
       { claimed, staged, apiStartTime: args.apiStartTime },
       signal,
     );
-    if (started === "skipped") {
+    if (started === "skipped" || !started.runId) {
       return {
         kind: "bad_request",
-        message: "Morning brief run could not be started",
+        message:
+          started === "skipped"
+            ? "Morning brief run could not be started"
+            : "Morning brief is queued behind another message",
       };
     }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -519,17 +519,14 @@ export async function claimQueueFirstRunAssociation(
         return { kind: "lost" };
       }
 
-      if (args.morningBriefDeliveryId) {
-        const [delivery] = await db
-          .select({ runId: morningBriefDeliveries.runId })
-          .from(morningBriefDeliveries)
-          .where(eq(morningBriefDeliveries.id, args.morningBriefDeliveryId))
-          .for("update")
-          .limit(1);
-        if (!delivery || delivery.runId !== null) {
-          outcome = "lost";
-          return { kind: "lost" };
-        }
+      if (
+        !(await lockUnclaimedMorningBriefDelivery(
+          db,
+          args.morningBriefDeliveryId,
+        ))
+      ) {
+        outcome = "lost";
+        return { kind: "lost" };
       }
 
       const claimed = await appendClaimedUserMessage(db, {
@@ -555,6 +552,22 @@ export async function claimQueueFirstRunAssociation(
       return { queue_first_claim_result: outcome };
     },
   );
+}
+
+async function lockUnclaimedMorningBriefDelivery(
+  db: DbTransaction,
+  deliveryId: string | undefined,
+): Promise<boolean> {
+  if (!deliveryId) {
+    return true;
+  }
+  const [delivery] = await db
+    .select({ runId: morningBriefDeliveries.runId })
+    .from(morningBriefDeliveries)
+    .where(eq(morningBriefDeliveries.id, deliveryId))
+    .for("update")
+    .limit(1);
+  return delivery?.runId === null;
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -7,6 +7,7 @@ import {
   type ChatMessageUserMessage,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { and, eq, exists, isNull, notExists, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
@@ -46,6 +47,7 @@ const queuedUserMessageTriggerSourceSchema = z.enum([
   "slack",
   "feishu",
   "teams",
+  "workflow-schedule",
 ]);
 
 const queuedUserMessageRunParamsSchema = z.object({
@@ -73,6 +75,14 @@ const queuedUserMessageRunParamsSchema = z.object({
     })
     .optional(),
   teamsDelivery: teamsDeliveryTargetSchema.optional(),
+  morningBriefDelivery: z
+    .object({
+      deliveryId: z.string(),
+      internalKind: z.literal("morning-brief:email"),
+      secret: z.string(),
+      payload: z.unknown(),
+    })
+    .optional(),
   apiStartTime: z.number().optional(),
   userInfoExtras: z
     .object({
@@ -108,7 +118,12 @@ export interface QueuedUserMessage {
   readonly modelProviderType: string | null;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
   readonly selectedModel: string | null;
-  readonly triggerSource: "web" | "slack" | "feishu" | "teams";
+  readonly triggerSource:
+    | "web"
+    | "slack"
+    | "feishu"
+    | "teams"
+    | "workflow-schedule";
   readonly encryptedParams: string | null;
 }
 
@@ -117,6 +132,7 @@ export type QueueFirstRunAssociation =
       readonly kind: "user_message";
       readonly threadId: string;
       readonly messageId: string;
+      readonly morningBriefDeliveryId?: string;
     }
   | {
       readonly kind: "workflow_event";
@@ -135,7 +151,11 @@ export type QueueFirstRunAssociation =
     };
 
 export type QueueFirstRunClaimResult =
-  | { readonly kind: "claimed"; readonly createdAt: Date }
+  | {
+      readonly kind: "claimed";
+      readonly createdAt: Date;
+      readonly morningBriefDeliveryId?: string;
+    }
   | { readonly kind: "lost" };
 
 /**
@@ -499,6 +519,19 @@ export async function claimQueueFirstRunAssociation(
         return { kind: "lost" };
       }
 
+      if (args.morningBriefDeliveryId) {
+        const [delivery] = await db
+          .select({ runId: morningBriefDeliveries.runId })
+          .from(morningBriefDeliveries)
+          .where(eq(morningBriefDeliveries.id, args.morningBriefDeliveryId))
+          .for("update")
+          .limit(1);
+        if (!delivery || delivery.runId !== null) {
+          outcome = "lost";
+          return { kind: "lost" };
+        }
+      }
+
       const claimed = await appendClaimedUserMessage(db, {
         threadId: args.threadId,
         messageId: args.messageId,
@@ -510,12 +543,51 @@ export async function claimQueueFirstRunAssociation(
       }
 
       outcome = "claimed";
-      return { kind: "claimed", createdAt: claimed.createdAt };
+      return {
+        kind: "claimed",
+        createdAt: claimed.createdAt,
+        ...(args.morningBriefDeliveryId
+          ? { morningBriefDeliveryId: args.morningBriefDeliveryId }
+          : {}),
+      };
     },
     () => {
       return { queue_first_claim_result: outcome };
     },
   );
+}
+
+/**
+ * Finish queue-claim side effects that reference the newly inserted run row.
+ * The caller invokes this in the same final-admission transaction immediately
+ * after run persistence so the delivery foreign key and queue claim commit
+ * atomically.
+ */
+export async function recordQueueFirstClaimedRun(
+  db: DbTransaction,
+  args: {
+    readonly claim: Extract<
+      QueueFirstRunClaimResult,
+      { readonly kind: "claimed" }
+    >;
+    readonly runId: string;
+  },
+): Promise<void> {
+  if (!args.claim.morningBriefDeliveryId) {
+    return;
+  }
+  const [delivery] = await db
+    .update(morningBriefDeliveries)
+    .set({
+      status: "running",
+      runId: args.runId,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(morningBriefDeliveries.id, args.claim.morningBriefDeliveryId))
+    .returning({ id: morningBriefDeliveries.id });
+  if (!delivery) {
+    throw new Error("Failed to record the admitted morning brief run");
+  }
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -1,7 +1,4 @@
-import {
-  chatMessages,
-  type ChatMessageGoalSnapshot,
-} from "@vm0/db/schema/chat-message";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -13,13 +10,9 @@ import {
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
-import { nowDate } from "../external/time";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { insertChatEvent } from "./zero-chat-event.service";
-import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
-import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import {
   resolvePersistedChatThreadModel,
   type ResolvedPersistedChatThreadModel,
@@ -79,50 +72,6 @@ export async function resolveRunChatThreadModelContext(params: {
     return badRequestMessage("Chat thread not found");
   }
   return resolved;
-}
-
-/**
- * Post a run's prompt as a user chat message into its linked
- * thread and publish realtime signals so the client surfaces the run.
- */
-export async function postRunUserMessage(params: {
-  readonly db: Db;
-  readonly threadId: string;
-  readonly userId: string;
-  readonly runId: string;
-  readonly prompt: string;
-  readonly appendQueueMarker: boolean;
-  readonly runGroupId?: string;
-  readonly goalSnapshot?: ChatMessageGoalSnapshot;
-}): Promise<void> {
-  const goalSnapshot = params.goalSnapshot
-    ? {
-        objectiveBrief: nonEmptyGoalObjectiveBrief(
-          params.goalSnapshot.objectiveBrief,
-        ),
-      }
-    : undefined;
-  await params.db.transaction(async (tx): Promise<void> => {
-    const inserted = await insertChatEvent(tx, {
-      chatThreadId: params.threadId,
-      eventType: "input.prompt",
-      content: params.prompt,
-      userMessage: createUserMessageDocument({ text: params.prompt }),
-      runId: params.runId,
-      runGroupId: params.runGroupId,
-      goalSnapshot,
-    });
-    if (!params.appendQueueMarker) {
-      return;
-    }
-    await appendQueuedRunAssistantMarker(tx, {
-      chatThreadId: params.threadId,
-      runId: params.runId,
-      runGroupId: params.runGroupId,
-      createdAfter: inserted?.createdAt ?? nowDate(),
-    });
-  });
-  await publishRunUserMessageSignals(params.userId, params.threadId);
 }
 
 async function publishRunUserMessageSignals(

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from "node:crypto";
+
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "../lib/db";
+import {
+  decryptQueuedUserMessageRunParams,
+  encryptQueuedUserMessageRunParams,
+} from "../signals/services/zero-chat-queued-message.service";
+import { insertChatEvent } from "../signals/services/zero-chat-event.service";
+import { touchChatThreadLastMessageAt } from "../signals/services/zero-chat-message-shared.service";
+import { createUserMessageDocument } from "../signals/services/zero-chat-user-message.service";
+
+export async function readMorningBriefDeliveryFixture(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly briefDate: string;
+}) {
+  const [delivery] = await db()
+    .select({
+      id: morningBriefDeliveries.id,
+      status: morningBriefDeliveries.status,
+      runId: morningBriefDeliveries.runId,
+      inputKey: morningBriefDeliveries.inputKey,
+      outputKey: morningBriefDeliveries.outputKey,
+    })
+    .from(morningBriefDeliveries)
+    .where(
+      and(
+        eq(morningBriefDeliveries.orgId, args.orgId),
+        eq(morningBriefDeliveries.userId, args.userId),
+        eq(morningBriefDeliveries.briefDate, args.briefDate),
+      ),
+    )
+    .limit(1);
+  return delivery ?? null;
+}
+
+export async function readMorningBriefQueuedParamsFixture(args: {
+  readonly messageId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  const [message] = await db()
+    .select({ encryptedParams: chatMessages.encryptedParams })
+    .from(chatMessages)
+    .where(eq(chatMessages.id, args.messageId))
+    .limit(1);
+  return await decryptQueuedUserMessageRunParams(
+    message?.encryptedParams ?? null,
+    { orgId: args.orgId, userId: args.userId },
+  );
+}
+
+/**
+ * Appends the production automation-pause control event to a dedicated brief
+ * thread. The workflow queue API intentionally has no resource for this
+ * non-automation thread, so the acceptance test uses the event writer.
+ */
+export async function pauseMorningBriefAutomationIntakeFixture(
+  threadId: string,
+): Promise<void> {
+  await db().transaction(async (tx) => {
+    await insertChatEvent(tx, {
+      chatThreadId: threadId,
+      eventType: "queue.automation_paused",
+      runId: null,
+      pauseReason: "Morning Brief queue acceptance test",
+    });
+  });
+}
+
+/**
+ * Appends a normal web user message without invoking a drain. Product sends
+ * persist this same event before draining, but cannot pause at that boundary.
+ */
+export async function insertQueuedWebUserMessageFixture(args: {
+  readonly threadId: string;
+  readonly content: string;
+  readonly createdAt: Date;
+}): Promise<string> {
+  const messageId = randomUUID();
+  await db().transaction(async (tx) => {
+    const inserted = await insertChatEvent(tx, {
+      id: messageId,
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      content: args.content,
+      userMessage: createUserMessageDocument({ text: args.content }),
+      runId: null,
+      triggerSource: "web",
+      createdAt: args.createdAt,
+    });
+    if (!inserted) {
+      throw new Error("Expected the queued web user message fixture");
+    }
+    await touchChatThreadLastMessageAt(
+      tx,
+      args.threadId,
+      inserted.createdAt,
+      inserted.id,
+    );
+  });
+  return messageId;
+}
+
+/**
+ * Inserts the pre-Morning-Brief-extension queued params shape. No product API
+ * can create an integration queue item with a historical encrypted payload.
+ */
+export async function insertOldFormatQueuedUserMessageFixture(args: {
+  readonly threadId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly content: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt: string;
+}): Promise<string> {
+  const messageId = randomUUID();
+  const encryptedParams = await encryptQueuedUserMessageRunParams(
+    {
+      version: 1,
+      prompt: args.prompt,
+      appendSystemPrompt: args.appendSystemPrompt,
+    },
+    { orgId: args.orgId, userId: args.userId },
+  );
+  await db().transaction(async (tx) => {
+    const inserted = await insertChatEvent(tx, {
+      id: messageId,
+      chatThreadId: args.threadId,
+      eventType: "input.prompt",
+      content: args.content,
+      userMessage: createUserMessageDocument({ text: args.content }),
+      runId: null,
+      triggerSource: "workflow-schedule",
+      encryptedParams,
+    });
+    if (!inserted) {
+      throw new Error("Expected the old-format queued message fixture");
+    }
+    await touchChatThreadLastMessageAt(
+      tx,
+      args.threadId,
+      inserted.createdAt,
+      inserted.id,
+    );
+  });
+  return messageId;
+}


### PR DESCRIPTION
## Summary

- enqueue cron and manual Morning Brief deliveries as queued `input.prompt` user messages on the canonical brief thread, then admit them through the shared chat-thread drain
- preserve the existing visible brief message while carrying the real prompt and system instructions in encrypted queued-message params
- materialize the Morning Brief email callback during claim and record the admitted run ID on `morning_brief_deliveries` in the same final-admission transaction
- preserve FIFO user-message behavior, automation-pause non-interaction, once-per-local-date delivery deduplication, and canonical session binding

## Rolling deploy

This is a single internal-trigger cutover. The encrypted queued-message format changes only through additive optional fields (`morningBriefDelivery` and the newly accepted Morning Brief trigger source). Existing payloads without the new fields continue to parse and drain. During a rolling deploy, an old instance that encounters a new-format payload will not crash; unknown optional delivery fields may be dropped, which is acceptable for the brief's dedicated thread during the short overlap window.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts --silent=passed-only` (9 tests)
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`

Closes #23700
Parent: #23182
Parallel sibling: #23683