### PR TITLE
test(runner): avoid executing temporary agent scripts

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -488,20 +488,21 @@ fn agent_start_command_reports_non_file_agent_on_stderr() {
 
 #[test]
 fn agent_start_command_keeps_agent_stderr_merged_into_stdout() {
-    let dir = tempfile::tempdir().unwrap();
-    let agent_path = dir.path().join("guest-agent");
-    fs::write(
-        &agent_path,
-        "#!/bin/sh\nprintf 'agent stdout\\n'\nprintf 'agent stderr\\n' >&2\n",
-    )
-    .unwrap();
-    fs::set_permissions(&agent_path, fs::Permissions::from_mode(0o755)).unwrap();
-
-    let output = Command::new("sh")
+    let mut child = Command::new("sh")
         .arg("-c")
-        .arg(build_agent_start_command(agent_path.to_str().unwrap()))
-        .output()
+        .arg(build_agent_start_command("/bin/sh"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"printf 'agent stdout\\n'\nprintf 'agent stderr\\n' >&2\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
 
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(


### PR DESCRIPTION
## Summary

- make the agent stderr merge integration test independent of executable temporary mounts
- execute the existing /bin/sh and feed the test program through stdin while preserving the real exec and stderr redirection path
- leave the production agent start command unchanged

## Root cause

The test created and executed a script under the process temporary directory. When that filesystem is mounted with noexec, the shell exits with code 126 even though the script has mode 0755.

## Testing

- TMPDIR=/dev/shm cargo test --manifest-path crates/Cargo.toml -p runner --bin runner agent_start_command_ -- --nocapture
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps
- cargo test --manifest-path crates/Cargo.toml -p runner --all-features