### PR TITLE
refactor(api): replace redundant sql column wrappers

### DIFF
--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -40,10 +40,7 @@ import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { resolveTestOrgId$, testUserId$ } from "../services/cli-auth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "../services/zero-chat-event-type.service";
+import { chatEventTypeIn } from "../services/zero-chat-event-type.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -572,7 +569,7 @@ function slackPendingChatEventRows(db: ReadonlyDb, teamId: string) {
     .select({
       id: chatMessages.id,
       chatThreadId: chatMessages.chatThreadId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       triggerSource: chatMessages.triggerSource,
       createdAt: chatMessages.createdAt,
     })

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -128,10 +128,7 @@ import {
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { resolveChatThreadSession } from "../services/chat-session-continuity.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "../services/zero-chat-event-type.service";
+import { chatEventTypeIn } from "../services/zero-chat-event-type.service";
 import { bestEffort, tapError } from "../utils";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -469,7 +466,7 @@ async function resolveClientEventId(
     .select({
       chatThreadId: chatMessages.chatThreadId,
       threadUserId: chatThreads.userId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       runId: chatMessages.runId,
       revokesEventId: chatMessages.revokesEventId,
@@ -826,7 +823,7 @@ async function getLatestRunsByThreadId(
   const messageRows = await db
     .select({
       runId: chatMessages.runId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       attachFiles: chatMessages.attachFiles,
@@ -1628,7 +1625,7 @@ function appendUnassociatedUserMessage(params: {
       .select({
         chatThreadId: chatMessages.chatThreadId,
         threadUserId: chatThreads.userId,
-        eventType: chatEventTypeSql().as("event_type"),
+        eventType: chatMessages.eventType,
         content: chatMessages.content,
         runId: chatMessages.runId,
         revokesEventId: chatMessages.revokesEventId,
@@ -1753,7 +1750,7 @@ function appendRecallUserMessage(params: {
 
     const [existingRevoker] = await tx
       .select({
-        eventType: chatEventTypeSql().as("event_type"),
+        eventType: chatMessages.eventType,
         content: chatMessages.content,
         createdAt: chatMessages.createdAt,
       })
@@ -1905,7 +1902,7 @@ function appendInterruptUserMessage(params: {
   return params.db.transaction(async (tx) => {
     const [existingInterrupter] = await tx
       .select({
-        eventType: chatEventTypeSql().as("event_type"),
+        eventType: chatMessages.eventType,
         content: chatMessages.content,
         createdAt: chatMessages.createdAt,
       })

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -20,10 +20,7 @@ import {
 import { alias } from "drizzle-orm/pg-core";
 
 import type { Db } from "../external/db";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 type ChatQueueReadDb = Pick<Db, "select">;
 type ChatQueueDistinctReadDb = Pick<Db, "select" | "selectDistinct">;
@@ -70,7 +67,7 @@ export async function listPendingChatQueueEvents(
     .select({
       id: chatMessages.id,
       chatThreadId: chatMessages.chatThreadId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       runId: chatMessages.runId,
       createdAt: chatMessages.createdAt,
     })
@@ -123,7 +120,7 @@ export async function loadPendingChatQueueEvent(
     .select({
       id: chatMessages.id,
       chatThreadId: chatMessages.chatThreadId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       createdAt: chatMessages.createdAt,
     })
     .from(chatMessages)
@@ -173,7 +170,7 @@ export async function loadChatAutomationIntakePause(
 ): Promise<ChatAutomationIntakePause | null> {
   const rows = await db
     .select({
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       createdAt: chatMessages.createdAt,
       pauseReason: chatMessages.error,
     })

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -135,10 +135,7 @@ import {
   resolveModelFirstProviderAdmission,
   type ModelFirstPin,
 } from "./zero-model-selection.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 const log = logger("callback:chat");
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -2010,7 +2007,7 @@ async function getLatestRunsByThreadId(
   const messageRows = await db
     .select({
       runId: chatMessages.runId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       attachFiles: chatMessages.attachFiles,

--- a/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
@@ -44,10 +44,7 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 const GITHUB_API_BASE = "https://api.github.com";
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
@@ -619,7 +616,7 @@ async function collectUnreadChatThreads(args: {
   for (const row of rows) {
     const messages = await args.db
       .select({
-        eventType: chatEventTypeSql().as("event_type"),
+        eventType: chatMessages.eventType,
         content: chatMessages.content,
         userMessage: chatMessages.userMessage,
         createdAt: chatMessages.createdAt,

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -112,8 +112,8 @@ export function runnerSessionAffinityPollPriority(args: {
   );
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
   const targetGenerationRunId = sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
-  const sessionId = sql`${runnerJobQueue.cliAgentSessionId}`;
-  const profile = sql`${runnerJobQueue.profile}`;
+  const sessionId = runnerJobQueue.cliAgentSessionId;
+  const profile = runnerJobQueue.profile;
   const exactCondition = reusableSandboxCondition({
     sessionId,
     profile,

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -72,10 +72,7 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { loadWorkflowVolumeFiles } from "./zero-workflow-volume.service";
 
 const RATE_LIMIT_MS = 24 * 60 * 60 * 1000;
@@ -751,7 +748,7 @@ async function collectConversationMessages(
   for (const thread of threads) {
     const rows = await runtime.db
       .select({
-        eventType: chatEventTypeSql().as("event_type"),
+        eventType: chatMessages.eventType,
         content: chatMessages.content,
         userMessage: chatMessages.userMessage,
         createdAt: chatMessages.createdAt,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
@@ -1,10 +1,6 @@
 import type { ChatEventType } from "@vm0/api-contracts/contracts/chat-events";
 import { chatMessages } from "@vm0/db/schema/chat-message";
-import { inArray, sql, type SQL } from "drizzle-orm";
-
-export function chatEventTypeSql() {
-  return sql`${chatMessages.eventType}`.mapWith(chatMessages.eventType);
-}
+import { inArray, type SQL } from "drizzle-orm";
 
 export function chatEventTypeIn(eventTypes: readonly ChatEventType[]): SQL {
   return inArray(chatMessages.eventType, [...eventTypes]);

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -10,7 +10,6 @@ import { eq, isNotNull, sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { chatEventTypeSql } from "./zero-chat-event-type.service";
 
 type ChatEventInsert = typeof chatMessages.$inferInsert;
 type ChatEventWriteTransaction = Parameters<
@@ -377,7 +376,7 @@ export async function replaceChatEvent(
     .select({
       chatThreadId: chatMessages.chatThreadId,
       createdAt: chatMessages.createdAt,
-      eventType: chatEventTypeSql(),
+      eventType: chatMessages.eventType,
     })
     .from(chatMessages)
     .where(eq(chatMessages.id, eventId))

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -22,10 +22,7 @@ import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
 import type { Db } from "../external/db";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { visibleChatEventCondition } from "./zero-chat-message-shared.service";
 import {
   projectUserMessage,
@@ -204,7 +201,7 @@ async function loadSelectedIncompleteRounds(
   const rows = await db
     .select({
       runId: chatMessages.runId,
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       attachFiles: chatMessages.attachFiles,

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -25,10 +25,7 @@ import {
   visibleChatEventCondition,
 } from "./zero-chat-message-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { queuedUserMessageExists } from "./zero-chat-queued-message.service";
 import {
   projectUserMessage,
@@ -86,7 +83,7 @@ async function loadThinkingContextMessages(args: {
 }): Promise<ThinkingContextMessage[]> {
   const rows = await args.db
     .select({
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       createdAt: chatMessages.createdAt,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -119,10 +119,7 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 
 export { insertAssistantEventMessages$ };
 
@@ -299,7 +296,7 @@ function effectiveChatMessageRunId() {
 const eventColumns = {
   id: chatMessages.id,
   chatThreadId: chatMessages.chatThreadId,
-  eventType: chatEventTypeSql().as("event_type"),
+  eventType: chatMessages.eventType,
   content: chatMessages.content,
   userMessage: chatMessages.userMessage,
   thinking: chatMessages.thinking,
@@ -463,7 +460,7 @@ function selectChatEventsWithMetadata(db: Pick<Db, "select">) {
 const searchMessageColumns = {
   messageId: chatMessages.id,
   chatThreadId: chatMessages.chatThreadId,
-  eventType: chatEventTypeSql().as("event_type"),
+  eventType: chatMessages.eventType,
   content: chatMessages.content,
   userMessage: chatMessages.userMessage,
   createdAt: chatMessages.createdAt,
@@ -474,7 +471,9 @@ const searchMessageColumns = {
 
 const searchContextMessageColumns = {
   ...searchMessageColumns,
-  eventType: chatEventTypeSql().as("context_event_type"),
+  eventType: sql`${chatMessages.eventType}`
+    .mapWith(chatMessages.eventType)
+    .as("context_event_type"),
 } as const;
 
 function escapeLikePattern(value: string): string {

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -30,10 +30,7 @@ import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { safeJsonParse, tapError } from "../utils";
-import {
-  chatEventTypeIn,
-  chatEventTypeSql,
-} from "./zero-chat-event-type.service";
+import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { visibleChatEventCondition } from "./zero-chat-message-shared.service";
 import {
   RECOMMENDED_FOLLOWUP_LIMIT,
@@ -269,7 +266,7 @@ async function getLatestTitleContextMessages(
 
   const rows = await db
     .select({
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       createdAt: chatMessages.createdAt,
@@ -464,7 +461,7 @@ async function getLatestFollowupContextMessages(
 ): Promise<ChatCompletionContextMessage[]> {
   const rows = await db
     .select({
-      eventType: chatEventTypeSql().as("event_type"),
+      eventType: chatMessages.eventType,
       content: chatMessages.content,
       userMessage: chatMessages.userMessage,
       createdAt: chatMessages.createdAt,

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -213,9 +213,7 @@ function threadedUsageRecordWith(db: Db, runs: UsageRecordRuns) {
         runId: sql`NULL::text`
           .mapWith(nullableDriverValueDecoder(pgTextDecoder))
           .as("run_id"),
-        title: sql`${chatThreads.title}`
-          .mapWith(nullableDriverValueDecoder(pgTextDecoder))
-          .as("title"),
+        title: chatThreads.title,
         credits: safeIntegerSum(runs.credits).as("credits"),
         tokens: safeIntegerSum(runs.tokens).as("tokens"),
         lastActivity: max(runs.createdAt)

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -194,7 +194,7 @@ export function mergedRunCreditsCharged(
 }
 
 export function mergedRunModel(events: FinalizedUsageRunTotalsSubquery) {
-  return sql`${events.model}`.mapWith(nullableTextDecoder).as("model");
+  return events.model;
 }
 
 function finalizedUsageTokenSum(

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -682,7 +682,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         }
         db.select({
           direct: sql\`\${users.name}\`.mapWith(users.name),
-          mapped: sql\`\${users.name}\`.mapWith(users.name),
           sameAlias: sql\`\${users.name}\`.mapWith(users.name).as("name"),
           selectedName: sql\`\${selectedUsers.name}\`.mapWith(selectedUsers.name),
           localName: localName.mapWith(users.name),
@@ -700,7 +699,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         });
       `,
       errors: [
-        { messageId: "directColumn" },
         { messageId: "directColumn" },
         { messageId: "directColumn" },
         { messageId: "directColumn" },

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -689,8 +689,20 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           returnedName: nameSql().mapWith(users.name),
         }).from(users);
         db.select(localSelection).from(selectedUsers);
+        db.selectDistinct({
+          name: sql\`\${users.name}\`.mapWith(users.name),
+        }).from(users);
+        db.selectDistinctOn([users.id], {
+          name: sql\`\${users.name}\`.mapWith(users.name),
+        }).from(users);
+        db.delete(users).returning({
+          name: sql\`\${users.name}\`.mapWith(users.name),
+        });
       `,
       errors: [
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
         { messageId: "directColumn" },
         { messageId: "directColumn" },
         { messageId: "directColumn" },

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -602,8 +602,104 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .innerJoin(users, sql\`true ORDER BY \${users.id}\`);
       `,
     },
+    {
+      name: "column wrappers with material behavior remain valid",
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        declare const importedColumnSql: () => SQL<string>;
+        declare const currentUsers: () => typeof users;
+        const nullableDateDecoder = {
+          mapFromDriverValue(value: unknown): Date | null {
+            return value === null ? null : new Date(String(value));
+          },
+        };
+        db.select({
+          qualified: sql\`CASE
+            WHEN \${eq(users.id, 1)} THEN \${"one"}
+            ELSE \${sql\`\${users.name}\`}
+          END\`.mapWith(users.name),
+          distinctAlias: sql\`\${users.name}\`
+            .mapWith(users.name)
+            .as("context_name"),
+          customDecoder: sql\`\${users.name}\`.mapWith(String).as("name"),
+          precisionDecoder: sql\`\${users.id}\`.mapWith(Number).as("id"),
+          imported: importedColumnSql(),
+          dynamic: sql\`\${currentUsers().name}\`.mapWith(currentUsers().name),
+        }).from(users);
+        db.select({
+          deletedAt: sql\`\${users.deletedAt}\`
+            .mapWith(nullableDateDecoder)
+            .as("deleted_at"),
+        }).from(users).unionAll(
+          db.select({ deletedAt: users.deletedAt }).from(users),
+        );
+        db.select()
+          .from(users)
+          .where(eq(sql\`\${users.name}\`, "encoded value"));
+        export function exportedColumnSql() {
+          return sql\`\${users.name}\`;
+        }
+      `,
+    },
+    {
+      name: "unmapped SQL results retain their noop decoder",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          name: sql\`\${users.name}\`,
+          deletedAt: sql\`\${users.deletedAt}\`,
+        }).from(users);
+      `,
+    },
+    {
+      name: "non-Drizzle wrapper lookalikes remain valid",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const lookalike = {
+          getSQL() {
+            return sql\`\${users.name}\`;
+          },
+        };
+        db.select({ name: sql\`\${lookalike}\` }).from(users);
+      `,
+    },
   ],
   invalid: [
+    {
+      name: "identity column wrappers use direct structured fields",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const selectedUsers = db
+          .select({ name: users.name })
+          .from(users)
+          .as("selected_users");
+        const localName = sql\`\${users.name}\`;
+        const localSelection = {
+          selectedName: sql\`\${selectedUsers.name}\`.mapWith(selectedUsers.name),
+        };
+        function nameSql() {
+          return sql\`\${users.name}\`;
+        }
+        db.select({
+          direct: sql\`\${users.name}\`.mapWith(users.name),
+          mapped: sql\`\${users.name}\`.mapWith(users.name),
+          sameAlias: sql\`\${users.name}\`.mapWith(users.name).as("name"),
+          selectedName: sql\`\${selectedUsers.name}\`.mapWith(selectedUsers.name),
+          localName: localName.mapWith(users.name),
+          returnedName: nameSql().mapWith(users.name),
+        }).from(users);
+        db.select(localSelection).from(selectedUsers);
+      `,
+      errors: [
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+        { messageId: "directColumn" },
+      ],
+    },
     {
       code: `${drizzlePreamble}
         import { eq, sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1,6 +1,7 @@
 import {
   AST_NODE_TYPES,
   ESLintUtils,
+  type TSESLint,
   type TSESTree,
 } from "@typescript-eslint/utils";
 import {
@@ -29,6 +30,7 @@ import {
 } from "typescript";
 
 import {
+  getDrizzleColumnMetadata,
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
   isDrizzleSqlTag,
@@ -46,7 +48,10 @@ import {
   type SqlCapabilityChecks,
   type SqlAnalysisFinding,
 } from "../sql-analysis/sql-analysis.ts";
-import { createSqlSourceComposer } from "../sql-analysis/sql-source.ts";
+import {
+  createSqlSourceComposer,
+  type SqlSource,
+} from "../sql-analysis/sql-source.ts";
 import { createRule } from "../utils.ts";
 
 const PREDICATE_HELPERS = new Set([
@@ -129,6 +134,8 @@ export const preferDrizzleApis = createRule({
         "Use Drizzle crossJoin(...) for this equivalent inner join on true.",
       crossJoinLateral:
         "Use Drizzle crossJoinLateral(...) for this equivalent lateral join.",
+      directColumn:
+        "Select the Drizzle column directly instead of using an identity SQL wrapper.",
       composedCteQueryBuilder:
         "Use Drizzle $with(...), select(), joins, grouping, ordering, and set-operation builders for this complete read CTE query.",
       deleteQueryBuilder:
@@ -168,7 +175,9 @@ export const preferDrizzleApis = createRule({
     const structuralCallInspections: Array<() => void> = [];
     const structuredScalarCandidates =
       new Set<TSESTree.TaggedTemplateExpression>();
+    const directColumnCandidates = new Set<TSESTree.TaggedTemplateExpression>();
     const structuredSelectionCalls: TSESTree.CallExpression[] = [];
+    const reportedDirectColumnSelections = new WeakSet<TSESTree.Node>();
     const reportedStructuralFindings = new WeakMap<
       TSESTree.Node,
       Set<string>
@@ -642,7 +651,9 @@ export const preferDrizzleApis = createRule({
       return [];
     }
 
-    function transparentNode(node: TSESTree.Node): TSESTree.Node | undefined {
+    function transparentNode(
+      node: TSESTree.Node,
+    ): TSESTree.Expression | undefined {
       if (
         node.type === AST_NODE_TYPES.TSAsExpression ||
         node.type === AST_NODE_TYPES.TSTypeAssertion ||
@@ -792,6 +803,259 @@ export const preferDrizzleApis = createRule({
         : [];
     }
 
+    function structuredFieldRoots(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): readonly TSESTree.Expression[] {
+      if (visited.has(node)) {
+        return [];
+      }
+      visited.add(node);
+      const transparent = transparentNode(node);
+      if (transparent !== undefined) {
+        return structuredFieldRoots(transparent, visited);
+      }
+      if (node.type === AST_NODE_TYPES.ObjectExpression) {
+        return node.properties.flatMap((property) => {
+          return property.type === AST_NODE_TYPES.SpreadElement
+            ? structuredFieldRoots(property.argument, visited)
+            : structuredFieldRoots(property.value, visited);
+        });
+      }
+      if (node.type === AST_NODE_TYPES.ArrayExpression) {
+        return node.elements.flatMap((element) => {
+          return element === null
+            ? []
+            : element.type === AST_NODE_TYPES.SpreadElement
+              ? structuredFieldRoots(element.argument, visited)
+              : structuredFieldRoots(element, visited);
+        });
+      }
+      const initializer = localSelectionInitializer(node);
+      if (
+        initializer?.type === AST_NODE_TYPES.ObjectExpression ||
+        initializer?.type === AST_NODE_TYPES.ArrayExpression
+      ) {
+        return structuredFieldRoots(initializer, visited);
+      }
+      const returned = localSelectionReturn(node);
+      if (
+        returned?.type === AST_NODE_TYPES.ObjectExpression ||
+        returned?.type === AST_NODE_TYPES.ArrayExpression
+      ) {
+        return structuredFieldRoots(returned, visited);
+      }
+      return isSqlCompositionExpression(node) ? [node] : [];
+    }
+
+    function isSqlCompositionExpression(
+      node: TSESTree.Node,
+    ): node is TSESTree.Expression {
+      return (
+        node.type === AST_NODE_TYPES.CallExpression ||
+        node.type === AST_NODE_TYPES.ChainExpression ||
+        node.type === AST_NODE_TYPES.ConditionalExpression ||
+        node.type === AST_NODE_TYPES.Identifier ||
+        node.type === AST_NODE_TYPES.TaggedTemplateExpression ||
+        node.type === AST_NODE_TYPES.TSAsExpression ||
+        node.type === AST_NODE_TYPES.TSNonNullExpression ||
+        node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        node.type === AST_NODE_TYPES.TSTypeAssertion
+      );
+    }
+
+    function localDirectColumnInitializer(
+      node: TSESTree.Expression,
+    ): TSESTree.Expression | undefined {
+      if (node.type !== AST_NODE_TYPES.Identifier) {
+        return undefined;
+      }
+      let scope: TSESLint.Scope.Scope | null =
+        context.sourceCode.getScope(node);
+      while (scope !== null) {
+        const variable = scope.variables.find((candidate) => {
+          return candidate.name === node.name;
+        });
+        if (variable !== undefined) {
+          const declarations = variable.defs.filter((definition) => {
+            return definition.node.type === AST_NODE_TYPES.VariableDeclarator;
+          });
+          const declaration = declarations[0]?.node;
+          return declarations.length === 1 &&
+            declaration?.type === AST_NODE_TYPES.VariableDeclarator &&
+            declaration.id.type === AST_NODE_TYPES.Identifier &&
+            declaration.init !== null &&
+            declaration.parent.kind === "const"
+            ? declaration.init
+            : undefined;
+        }
+        scope = scope.upper;
+      }
+      return undefined;
+    }
+
+    function composeDirectColumnSource(
+      node: TSESTree.Expression,
+      visited: Set<TSESTree.Node>,
+    ): SqlSource | null {
+      if (visited.has(node)) {
+        return null;
+      }
+      visited.add(node);
+      if (sqlSourceComposer.couldCompose(node)) {
+        const source = sqlSourceComposer.compose(node);
+        if (source !== null) {
+          return source;
+        }
+      }
+      const initializer = localDirectColumnInitializer(node);
+      return initializer !== undefined &&
+        isSqlCompositionExpression(initializer)
+        ? composeDirectColumnSource(initializer, visited)
+        : null;
+    }
+
+    function columnMetadata(node: TSESTree.Expression) {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return getDrizzleColumnMetadata(
+        checker,
+        checker.getTypeAtLocation(tsNode),
+        tsNode,
+      );
+    }
+
+    // Identity-wrapper linting intentionally recognizes only normal stable
+    // identifier/property access. Calls, computed access, and other unusual
+    // metaprogramming stay opaque even when their static type resembles a
+    // Drizzle column.
+    function isConventionalColumnExpression(
+      node: TSESTree.Expression,
+    ): boolean {
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        return true;
+      }
+      return (
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        !node.computed &&
+        !node.optional &&
+        node.property.type === AST_NODE_TYPES.Identifier &&
+        (node.object.type === AST_NODE_TYPES.Identifier ||
+          (node.object.type === AST_NODE_TYPES.MemberExpression &&
+            isConventionalColumnExpression(node.object)))
+      );
+    }
+
+    function isSameColumnExpression(
+      left: TSESTree.Expression,
+      right: TSESTree.Expression,
+    ): boolean {
+      const leftMetadata = columnMetadata(left);
+      const rightMetadata = columnMetadata(right);
+      return (
+        isConventionalColumnExpression(left) &&
+        isConventionalColumnExpression(right) &&
+        leftMetadata !== undefined &&
+        rightMetadata !== undefined &&
+        leftMetadata.databaseName === rightMetadata.databaseName &&
+        leftMetadata.tableName === rightMetadata.tableName &&
+        context.sourceCode.getText(left) === context.sourceCode.getText(right)
+      );
+    }
+
+    function unwrapDirectColumnResult(node: TSESTree.Expression): {
+      readonly alias: string | undefined;
+      readonly mapWith: TSESTree.Expression | undefined;
+      readonly source: TSESTree.Expression;
+    } | null {
+      let current = node;
+      let alias: string | undefined;
+      let mapWith: TSESTree.Expression | undefined;
+      while (true) {
+        const transparent = transparentNode(current);
+        if (transparent !== undefined) {
+          current = transparent;
+          continue;
+        }
+        if (
+          current.type !== AST_NODE_TYPES.CallExpression ||
+          current.callee.type !== AST_NODE_TYPES.MemberExpression ||
+          !isDrizzleResultWrapper(current)
+        ) {
+          return { alias, mapWith, source: current };
+        }
+        const method = memberName(current.callee);
+        const argument = current.arguments[0];
+        if (
+          method === "as" &&
+          alias === undefined &&
+          argument?.type === AST_NODE_TYPES.Literal &&
+          typeof argument.value === "string"
+        ) {
+          alias = argument.value;
+        } else if (
+          method === "mapWith" &&
+          mapWith === undefined &&
+          argument !== undefined &&
+          argument.type !== AST_NODE_TYPES.SpreadElement
+        ) {
+          mapWith = argument;
+        } else {
+          return null;
+        }
+        current = current.callee.object;
+      }
+    }
+
+    function inspectDirectColumnSelection(node: TSESTree.Expression): void {
+      const result = unwrapDirectColumnResult(node);
+      if (result === null) {
+        return;
+      }
+      const source = composeDirectColumnSource(
+        result.source,
+        new Set<TSESTree.Node>(),
+      );
+      const variant = source?.variants[0];
+      if (
+        source === null ||
+        source.variants.length !== 1 ||
+        variant === undefined ||
+        ![...source.expandedTemplates].every((template) => {
+          return isDrizzleSqlTag(checker, services, template.tag);
+        })
+      ) {
+        return;
+      }
+      const expressions = variant.chunks.filter((chunk) => {
+        return chunk.kind === "expression";
+      });
+      const expression = expressions[0];
+      if (
+        expressions.length !== 1 ||
+        expression === undefined ||
+        expression.depth !== 0 ||
+        variant.chunks.some((chunk) => {
+          return chunk.kind === "literal" && chunk.text !== "";
+        })
+      ) {
+        return;
+      }
+      const metadata = columnMetadata(expression.expression);
+      if (
+        !isConventionalColumnExpression(expression.expression) ||
+        metadata === undefined ||
+        (result.alias !== undefined &&
+          result.alias !== metadata.databaseName) ||
+        result.mapWith === undefined ||
+        !isSameColumnExpression(expression.expression, result.mapWith) ||
+        reportedDirectColumnSelections.has(node)
+      ) {
+        return;
+      }
+      reportedDirectColumnSelections.add(node);
+      context.report({ node, messageId: "directColumn" });
+    }
+
     function inspectStructuredSelectionCall(
       node: TSESTree.CallExpression,
     ): void {
@@ -817,7 +1081,10 @@ export const preferDrizzleApis = createRule({
     }
 
     function inspectStructuredSelections(): void {
-      if (structuredScalarCandidates.size === 0) {
+      if (
+        structuredScalarCandidates.size === 0 &&
+        directColumnCandidates.size === 0
+      ) {
         return;
       }
       for (const call of structuredSelectionCalls) {
@@ -841,9 +1108,19 @@ export const preferDrizzleApis = createRule({
         ) {
           continue;
         }
-        const roots = structuredScalarRoots(fields, new Set<TSESTree.Node>());
-        for (const root of roots) {
-          reportAnalysis(root, "structured-selection");
+        if (directColumnCandidates.size > 0) {
+          for (const field of structuredFieldRoots(
+            fields,
+            new Set<TSESTree.Node>(),
+          )) {
+            inspectDirectColumnSelection(field);
+          }
+        }
+        if (structuredScalarCandidates.size > 0) {
+          const roots = structuredScalarRoots(fields, new Set<TSESTree.Node>());
+          for (const root of roots) {
+            reportAnalysis(root, "structured-selection");
+          }
         }
       }
     }
@@ -1583,6 +1860,15 @@ export const preferDrizzleApis = createRule({
           /\bLIMIT\s+1\s*\)\s*$/iu.test(literalSource)
         ) {
           structuredScalarCandidates.add(node);
+        }
+        if (
+          node.quasi.expressions.length === 1 &&
+          node.quasi.quasis.length === 2 &&
+          node.quasi.quasis.every((quasi) => {
+            return (quasi.value.cooked ?? quasi.value.raw) === "";
+          })
+        ) {
+          directColumnCandidates.add(node);
         }
         const firstQuasi = node.quasi.quasis[0];
         const isExactEmpty =

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1041,6 +1041,9 @@ export const preferDrizzleApis = createRule({
         return;
       }
       const metadata = columnMetadata(expression.expression);
+      // A bare SQL result uses noopDecoder, so selecting the column directly
+      // is equivalent only when the wrapper explicitly uses that same column
+      // as its result decoder.
       if (
         !isConventionalColumnExpression(expression.expression) ||
         metadata === undefined ||

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1,7 +1,6 @@
 import {
   AST_NODE_TYPES,
   ESLintUtils,
-  type TSESLint,
   type TSESTree,
 } from "@typescript-eslint/utils";
 import {
@@ -864,54 +863,11 @@ export const preferDrizzleApis = createRule({
       );
     }
 
-    function localDirectColumnInitializer(
-      node: TSESTree.Expression,
-    ): TSESTree.Expression | undefined {
-      if (node.type !== AST_NODE_TYPES.Identifier) {
-        return undefined;
-      }
-      let scope: TSESLint.Scope.Scope | null =
-        context.sourceCode.getScope(node);
-      while (scope !== null) {
-        const variable = scope.variables.find((candidate) => {
-          return candidate.name === node.name;
-        });
-        if (variable !== undefined) {
-          const declarations = variable.defs.filter((definition) => {
-            return definition.node.type === AST_NODE_TYPES.VariableDeclarator;
-          });
-          const declaration = declarations[0]?.node;
-          return declarations.length === 1 &&
-            declaration?.type === AST_NODE_TYPES.VariableDeclarator &&
-            declaration.id.type === AST_NODE_TYPES.Identifier &&
-            declaration.init !== null &&
-            declaration.parent.kind === "const"
-            ? declaration.init
-            : undefined;
-        }
-        scope = scope.upper;
-      }
-      return undefined;
-    }
-
     function composeDirectColumnSource(
       node: TSESTree.Expression,
-      visited: Set<TSESTree.Node>,
     ): SqlSource | null {
-      if (visited.has(node)) {
-        return null;
-      }
-      visited.add(node);
-      if (sqlSourceComposer.couldCompose(node)) {
-        const source = sqlSourceComposer.compose(node);
-        if (source !== null) {
-          return source;
-        }
-      }
-      const initializer = localDirectColumnInitializer(node);
-      return initializer !== undefined &&
-        isSqlCompositionExpression(initializer)
-        ? composeDirectColumnSource(initializer, visited)
+      return sqlSourceComposer.couldCompose(node)
+        ? sqlSourceComposer.compose(node)
         : null;
     }
 
@@ -1011,10 +967,7 @@ export const preferDrizzleApis = createRule({
       if (result === null) {
         return;
       }
-      const source = composeDirectColumnSource(
-        result.source,
-        new Set<TSESTree.Node>(),
-      );
+      const source = composeDirectColumnSource(result.source);
       const variant = source?.variants[0];
       if (
         source === null ||


### PR DESCRIPTION
## Summary

- replace the proven runner, chat-event-type, finalized-model, and usage-record title pass-through wrappers with direct Drizzle fields
- preserve the material `context_event_type` derived-column alias while removing the redundant event-type helper
- extend `api/prefer-drizzle-apis` to diagnose complete structured-selection pass-throughs only when they use the exact same column decoder

The lint deliberately leaves bare ``sql`${column}``` results, distinct aliases, custom decoders, nested SQL, predicates, opaque factories, and unusual composition alone. A bare SQL result uses Drizzle's `noopDecoder`, so it is not assumed to be equivalent to selecting a decoded column directly.

This changes no schema, persisted data, API or runner protocol, feature switch, or deployment compatibility contract.

## Equivalence evidence

- runner-affinity full-query SQL and parameters are byte-identical
- chat event, finalized model, and title queries only remove asserted same-name projections; parameter shape is unchanged
- the material `context_event_type` projection remains explicitly mapped and aliased
- five warm alternating API ESLint measurements:
  - baseline median: 33,467.38 ms / 3,402,128 KiB
  - candidate median: 29,382.47 ms / 3,403,956 KiB
  - delta: -12.21% wall time / +0.05% peak RSS

## Validation

- `pnpm format`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-apis.test.ts --silent=passed-only` (211 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected API integration tests (8 files, 158 passed)
- runner same-session affinity integration test (1 passed)
- `pnpm knip --workspace api --workspace @vm0/eslint-rules`
- pre-commit full Knip and Turbo type checks
- `git diff --check`

Closes #23680

Parent: #23047
