### PR TITLE
feat(platform): localize connectors and authorization flows

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -355,6 +355,86 @@
     "loading": "Loading authentication",
     "toggleTheme": "Toggle theme"
   },
+  "authorization": {
+    "browser": {
+      "description": "Zero will use an isolated cloud browser profile for this chat thread. Enabling it disconnects Computer Use for the thread.",
+      "enable": "Enable for this thread",
+      "enabled": "Cloud browser enabled",
+      "linkExpires": "Link expires {{date}}.",
+      "title": "Enable cloud browser",
+      "unavailableDescription": "This cloud browser authorization link is invalid, expired, or not available for this workspace.",
+      "unavailableTitle": "Authorization link unavailable"
+    },
+    "computerUse": {
+      "authorize": "Authorize",
+      "authorized": "Authorized",
+      "checkingCompatibility": "Checking compatibility",
+      "description": "Choose an online computer for Zero to use in {{source}}.",
+      "downloadMac": "Download for macOS",
+      "lastSeen": "Last seen {{date}}",
+      "linkExpires": "Link expires {{date}}.",
+      "macRequirement": "Requires an Apple silicon Mac with macOS 14 or newer. Intel Macs aren't supported.",
+      "noHostsDescription": "Open Zero Computer Use on your Mac and refresh this page when it comes online.",
+      "noHostsTitle": "No online computers",
+      "sources": {
+        "chat": "this chat thread",
+        "slack": "this Slack thread",
+        "teams": "this Teams thread"
+      },
+      "title": "Authorize computer use",
+      "unavailableDescription": "This Computer Use authorization link is invalid, expired, or not available for this workspace.",
+      "unavailableTitle": "Authorization link unavailable",
+      "unsupportedIntelMac": "Requires an Apple silicon Mac"
+    },
+    "permission": {
+      "confirm": "Confirm",
+      "duration": "Duration",
+      "durationLabel": "Permission duration",
+      "durationOptions": {
+        "always": "Always",
+        "oneHour": "1 hour",
+        "sevenDays": "7 days",
+        "twentyFourHours": "24 hours"
+      },
+      "errors": {
+        "agentNotFound": "Agent not found",
+        "loadAgent": "Failed to load agent",
+        "loadGrants": "Failed to load permission grants",
+        "loadMetadata": "Failed to load permission metadata",
+        "missingAgentId": "Missing agent ID in URL parameters",
+        "missingPermission": "Missing permission in URL parameters",
+        "unknownAction": "Unknown permission action: {{action}}",
+        "unknownConnector": "Unknown connector: {{connector}}",
+        "unknownPermission": "Unknown permission: {{permission}}",
+        "updateFailed": "Couldn't update permissions"
+      },
+      "expiration": {
+        "expired": "Expired",
+        "inDays_one": "Expires in {{count}} day",
+        "inDays_other": "Expires in {{count}} days",
+        "inHours_one": "Expires in {{count}} hour",
+        "inHours_other": "Expires in {{count}} hours",
+        "lessThanHour": "Expires in less than 1 hour",
+        "lessThanHourShort": "< 1 hour",
+        "prefix": "Expires in "
+      },
+      "greeting": "Hey {{userName}}, you're updating your permissions for {{targetName}}.",
+      "result": {
+        "alreadyAllowedDescription": "Your connector permission grant is already allowed",
+        "alreadyAllowedTitle": "Already allowed",
+        "alreadyDeniedDescription": "Your connector permission grant is already denied",
+        "alreadyDeniedTitle": "Already denied",
+        "deniedDescription": "Your connector permission grant has been denied",
+        "deniedTitle": "Permissions denied",
+        "updatedDescription": "Your connector permission grant has been updated",
+        "updatedTitle": "Permissions updated"
+      },
+      "saving": "Saving...",
+      "unknownEndpoints": "Unknown endpoints",
+      "userFallback": "there",
+      "wouldLike": "Would like to"
+    }
+  },
   "browserSession": {
     "close": "Close live browser",
     "creditsCharged_one": "{{formattedCount}} credit charged",
@@ -384,6 +464,680 @@
     "unavailable": {
       "description": "This browser does not belong to this chat or has been removed.",
       "title": "Browser unavailable"
+    }
+  },
+  "connectors": {
+    "access": {
+      "accessFor": "{{action}} {{connector}} access for {{agent}}",
+      "accessUpdated": "{{connector}} access updated",
+      "clearSearch": "Clear agent search",
+      "description": "Choose which agents can use this connector.",
+      "loading": "Loading agents...",
+      "managePermissions": "Manage permissions",
+      "managePermissionsFor": "Manage {{connector}} permissions for {{agent}}",
+      "noAgents": "No agents found",
+      "noMatchingAgents": "No agents matching \"{{search}}\"",
+      "permissionsUpdated": "Permissions updated",
+      "search": "Find agents",
+      "title": "Manage {{connector}} access",
+      "unnamedAgent": "Unnamed"
+    },
+    "actions": {
+      "apply": "Apply",
+      "authorize": "Authorize",
+      "cancel": "Cancel",
+      "close": "Close",
+      "closeWindow": "Close window",
+      "connect": "Connect",
+      "connecting": "Connecting...",
+      "create": "Create",
+      "creating": "Creating…",
+      "delete": "Delete",
+      "deleting": "Deleting…",
+      "disconnect": "Disconnect",
+      "disconnecting": "Disconnecting...",
+      "grant": "Grant",
+      "reconnect": "Reconnect",
+      "rename": "Rename",
+      "revoke": "Revoke",
+      "save": "Save",
+      "saving": "Saving...",
+      "savingEllipsis": "Saving…",
+      "tryAgain": "Try again",
+      "uninstall": "Uninstall",
+      "uninstalling": "Uninstalling..."
+    },
+    "callback": {
+      "connected": "{{connector}} connected",
+      "connectedAs": "Connected as {{username}}. You can close this window.",
+      "connectedDescription": "Your account has been connected. You can close this window.",
+      "connecting": "Connecting {{connector}}…",
+      "connectingDescription": "Please wait while we finish connecting your account.",
+      "errorDescription": "{{error}} Close this window and try again.",
+      "errorFallback": "An error occurred during connection.",
+      "failed": "Connection failed",
+      "failedTitle": "Couldn’t connect {{connector}}",
+      "finishing": "Finishing the secure connection",
+      "success": "Connected"
+    },
+    "card": {
+      "accessFor": "{{action}} {{connector}} access",
+      "authorized": "Authorized",
+      "connectAria": "Connect {{connector}}",
+      "connected": "Connected",
+      "connecting": "Connecting…",
+      "connectionExpired": "Connection expired",
+      "connectToContinue": "Connect this account to continue",
+      "managePermissions": "Manage permissions",
+      "managePermissionsFor": "Manage {{connector}} permissions",
+      "optional": "Optional",
+      "required": "Required",
+      "reviewPermissions": "Review permissions",
+      "updatePermissions": "Update permissions"
+    },
+    "catalog": {
+      "access": {
+        "add": "Add access",
+        "manage": "Manage {{connector}} access",
+        "usedBy": "Used by "
+      },
+      "categories": {
+        "ai": {
+          "label": "AI",
+          "menu": "AI"
+        },
+        "aiAgentApps": {
+          "label": "Agent Platforms and AI Apps",
+          "menu": "Agent Platforms"
+        },
+        "aiGeneralModels": {
+          "label": "General Models and Reasoning",
+          "menu": "General Models"
+        },
+        "aiImageVideo": {
+          "label": "Image / Video Generation",
+          "menu": "Image / Video"
+        },
+        "aiMemoryTracingEval": {
+          "label": "Memory / Tracing / Evaluation",
+          "menu": "Memory / Tracing"
+        },
+        "aiVoiceAudio": {
+          "label": "Voice / Audio",
+          "menu": "Voice / Audio"
+        },
+        "communicationCollaboration": {
+          "label": "Communication and Collaboration",
+          "menu": "Communication"
+        },
+        "dataAutomationInfrastructure": {
+          "label": "Data, Automation, and Infrastructure",
+          "menu": "Data and Automation"
+        },
+        "docsFilesKnowledge": {
+          "label": "Docs, Files, and Knowledge",
+          "menu": "Documents"
+        },
+        "engineeringTeamExecution": {
+          "label": "Engineering and Team Execution",
+          "menu": "Engineering"
+        },
+        "marketingContentGrowth": {
+          "label": "Marketing, Content, and Growth",
+          "menu": "Marketing"
+        },
+        "meetingsScheduling": {
+          "label": "Meetings and Scheduling",
+          "menu": "Meetings"
+        },
+        "salesCrmBusinessOperations": {
+          "label": "Sales, CRM, and Business Operations",
+          "menu": "Sales and Business"
+        }
+      },
+      "categoriesAria": "Connector categories",
+      "description": "Connect third-party services for your agents to use.",
+      "empty": {
+        "agent": "No connectors for this agent",
+        "connected": "No connected connectors",
+        "matching": "{{message}} matching \"{{search}}\"",
+        "notConnected": "No connectors left to connect",
+        "search": "No connectors matching \"{{search}}\""
+      },
+      "filters": {
+        "agents": "Agents",
+        "all": "All",
+        "aria": "Filter connectors",
+        "connected": "Connected",
+        "notConnected": "Not connected",
+        "status": "Status"
+      },
+      "iconUnavailable": "Connector icon unavailable",
+      "newConnector": "New connector",
+      "noConnectorsAlt": "No connectors",
+      "otherCategory": "Other",
+      "search": "Find connectors",
+      "tabs": {
+        "builtin": "Built-in",
+        "custom": "Custom"
+      },
+      "title": "Connectors",
+      "unnamedAgent": "Unnamed"
+    },
+    "connectDialog": {
+      "connectedAs": "Connected as {{username}}",
+      "device": {
+        "checking": "Checking for approval...",
+        "connect": "Connect {{connector}}",
+        "copyThenOpen": "Copy this code, then open the verification page to approve access.",
+        "description": "Open the provider's verification page, then enter this verification code to approve access.",
+        "intro": "Connect to get a verification code, then use it on the provider's verification page to approve access.",
+        "openPage": "Open verification page",
+        "selectOption": "Select {{option}}",
+        "starting": "Starting...",
+        "startingConnection": "Starting connection...",
+        "verificationCode": "Verification code",
+        "waiting": "Waiting for approval. Keep this dialog open."
+      },
+      "external": {
+        "code": "Code",
+        "complete": "Complete connection",
+        "description": "Open {{connector}} sign-in, then paste the code displayed by {{connector}}.",
+        "open": "Open {{connector}} sign-in",
+        "start": "Start {{connector}} sign-in"
+      },
+      "noAuth": {
+        "enable": "Enable {{connector}}",
+        "enabling": "Enabling..."
+      },
+      "noMethod": "No connection method is available.",
+      "or": "or",
+      "progress": {
+        "connecting": "Connecting...",
+        "savingPermissions": "Saving permissions..."
+      },
+      "unavailable": {
+        "description": "This connector has available connection methods, but none of them can be configured from this dialog yet.",
+        "title": "Connection methods unavailable"
+      }
+    },
+    "custom": {
+      "connect": {
+        "description": "Your secret is encrypted at rest and injected into outbound requests by the firewall. It's never exposed to the agent as an environment variable.",
+        "secret": "Secret",
+        "title": "Connect {{connector}}"
+      },
+      "create": {
+        "displayName": "Display name",
+        "headerName": "Header name",
+        "headerTemplate": "Header template",
+        "headerTemplateHint": "(must contain {{placeholder}})",
+        "prefixes": "Prefixes",
+        "prefixesHint": "(one per line, https only)",
+        "title": "New custom connector"
+      },
+      "delete": {
+        "description": "This removes the connector and every member's stored secret for it. Agents authorized for this connector will lose access immediately. This can't be undone.",
+        "title": "Delete {{connector}}?"
+      },
+      "emptyAdmin": "No custom connectors yet. Create one to register an API for every member to use.",
+      "emptyMember": "Your org hasn't registered any custom connectors yet.",
+      "moreOptions": "More options",
+      "rename": {
+        "displayName": "Display name",
+        "title": "Rename custom connector"
+      },
+      "statusConnected": "Connected",
+      "toasts": {
+        "connected": "Connected",
+        "created": "Created \"{{connector}}\"",
+        "deleted": "Custom connector deleted",
+        "disconnected": "Disconnected",
+        "renamed": "Renamed to \"{{connector}}\""
+      }
+    },
+    "customProposal": {
+      "configure": "Configure {{connector}}",
+      "descriptionAgent": "Saving will connect your values and authorize {{agent}}.",
+      "descriptionUser": "Saving will connect this custom connector for your account.",
+      "invalid": "This custom connector proposal link is invalid or expired.",
+      "requestScope": "Request scope",
+      "returnToChat": "Return to the chat and reply ACK so the agent can verify the connector.",
+      "saved": "Saved",
+      "savedToast": "{{connector}} saved",
+      "targetFallback": "this agent",
+      "update": "Update {{connector}}"
+    },
+    "directed": {
+      "authorizeAgent": "Authorize {{agent}}",
+      "authorized": "{{connector}} authorized",
+      "connected": "{{connector}} connected",
+      "needsConnector": "{{agent}} needs {{connector}} to proceed",
+      "reconnecting": "Reconnecting..."
+    },
+    "expiration": {
+      "inDays_one": "Expires in {{count}} day",
+      "inDays_other": "Expires in {{count}} days",
+      "inHours_one": "Expires in {{count}} hour",
+      "inHours_other": "Expires in {{count}} hours",
+      "lessThanHour": "Expires in less than 1 hour"
+    },
+    "permissions": {
+      "actions": {
+        "allow": "Allow",
+        "deny": "Deny",
+        "mixed": "Mixed"
+      },
+      "allowDuration": {
+        "always": "Allow always",
+        "oneHour": "Allow for 1h",
+        "sevenDays": "Allow for 7d",
+        "twentyFourHours": "Allow for 24h"
+      },
+      "allowOptions": "{{permission}} allow options",
+      "always": "Always",
+      "clearSearch": "Clear permission search",
+      "descriptionAgent": "Configure which actions this agent is allowed to perform via this connector.",
+      "descriptionWorkflow": "Configure which actions this workflow is allowed to perform via this connector.",
+      "find": "Find permissions",
+      "findPlaceholder": "Find permissions...",
+      "forTarget": "for {{target}}",
+      "loadError": "Failed to load permission metadata",
+      "loading": "Loading permissions...",
+      "metadataMissing": "No permission metadata found for {{connector}}",
+      "noResults": "No results for “{{search}}”",
+      "otherEndpoints": "Other endpoints",
+      "otherEndpointsDescription": "API endpoints not matched by any permission above",
+      "permissions": "Permissions",
+      "restore": "Restore",
+      "scopeReview": {
+        "added": "New permissions",
+        "description": "The required permissions for this connector have changed. Please review and reconnect to apply the update.",
+        "failed": "Failed to load scope changes.",
+        "loading": "Loading scope changes...",
+        "removed": "Removed permissions",
+        "title": "{{connector}} permissions update"
+      },
+      "selectAll": "Select all",
+      "showMore_one": "Show more ({{count}})",
+      "showMore_other": "Show more ({{count}})",
+      "title": "{{connector}} permissions"
+    },
+    "providerConnect": {
+      "agentphone": {
+        "back": "Back to {{brandName}}",
+        "connectDescription": "Link this phone number to your {{brandName}} account so you can interact with Zero from text messages.",
+        "connectTitle": "Connect phone number",
+        "errorFallback": "We couldn't connect this phone number. Try again from your text messages.",
+        "incompleteDescription": "Open a fresh /connect link from your text messages.",
+        "incompleteTitle": "Connect link is incomplete",
+        "invalidSignature": "The signature on this link is not valid.",
+        "invalidTimestamp": "The timestamp on this link is not valid.",
+        "invalidTitle": "Connect link is invalid",
+        "risk": "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.",
+        "successDescription": "{{phone}} is connected. Send a text message to start chatting with Zero.",
+        "successTitle": "Phone number connected"
+      },
+      "common": {
+        "backToSettings": "Back to settings",
+        "checkingTitle": "Checking account status...",
+        "connectionFailed": "Connection failed",
+        "invalidLink": "Invalid link",
+        "verifying": "Please wait while we verify your connection."
+      },
+      "feishu": {
+        "back": "Back to Feishu settings",
+        "checkingTitle": "Checking account status…",
+        "connectDescription": "Link your {{brandName}} account to this Feishu bot so you can work with your agent directly from Feishu.",
+        "connectTitle": "Connect to Feishu",
+        "errorFallback": "We couldn't connect Feishu. Open a fresh connect link and try again.",
+        "invalidDescription": "Open a fresh connect link from Feishu and try again.",
+        "open": "Open Feishu",
+        "successDescription": "You're connected. Send a message in Feishu to start chatting.",
+        "successDescriptionNamed": "You're connected to {{bot}}. Send a message in Feishu to start chatting.",
+        "successTitle": "Connected to Feishu!"
+      },
+      "github": {
+        "accountFallback": "this GitHub account",
+        "alreadyDescription": "You're already connected as {{account}}. Mention your agent in GitHub issues or pull requests to start chatting.",
+        "alreadyTitle": "Already connected to GitHub",
+        "back": "Back to workflows",
+        "checkingConnectionDescription": "Please wait while we check your GitHub connection.",
+        "checkingConnectionTitle": "Checking connection...",
+        "checkingSession": "Please wait while we verify your {{brandName}} session.",
+        "connectDescription": "Link your {{brandName}} account to {{account}} so GitHub mentions can run your agents from issues and pull requests.",
+        "connectTitle": "Connect to GitHub",
+        "errorFallback": "We couldn't connect GitHub. Try again from GitHub.",
+        "invalidInstallation": "The GitHub installation on this link is not valid.",
+        "invalidSignature": "The signature on this link is not valid.",
+        "invalidTimestamp": "The timestamp on this link is not valid.",
+        "invalidTitle": "Connect link is invalid",
+        "invalidUser": "The GitHub user on this link is not valid.",
+        "invalidUsername": "The GitHub username on this link is not valid.",
+        "linkIncomplete": "Open a fresh GitHub connect link and try again.",
+        "linkIncompleteTitle": "Connect link is incomplete",
+        "notInstalledDescription": "Ask an organization admin to install GitHub before connecting your account.",
+        "notInstalledTitle": "GitHub is not installed",
+        "refresh": "Refresh this page and try again.",
+        "signInButton": "Sign in to {{brandName}}",
+        "signInCheckFailed": "Couldn't check sign-in",
+        "signInDescription": "Use your {{brandName}} account before connecting this GitHub user.",
+        "signInTitle": "Sign in to continue",
+        "successDescription": "You're connected as {{account}}. Mention your agent in GitHub issues or pull requests to start chatting.",
+        "successTitle": "Connected to GitHub!",
+        "wrongOrganizationDescription": "Your active organization doesn't match this GitHub installation. Switch to the correct organization and open the link again.",
+        "wrongOrganizationTitle": "Switch organization"
+      },
+      "slack": {
+        "connectDescription": "Link your account to this Slack workspace so you can interact with your agent directly from Slack.",
+        "connectTitle": "Connect to Slack",
+        "invalidDescription": "This page is meant to be opened from a Slack connect link.",
+        "open": "Open Slack",
+        "successDescription": "Mention @Zero in any channel or send a DM to start chatting.",
+        "successDescriptionWorkspace": "You're connected to {{workspace}}. Mention @Zero in any channel or send a DM to start chatting.",
+        "successTitle": "Connected to Slack!"
+      },
+      "teams": {
+        "connectDescription": "Link your Teams account so you can interact with your agent directly from Microsoft Teams.",
+        "connectDescriptionNamed": "{{displayName}}, link your Teams account so you can interact with your agent directly from Microsoft Teams.",
+        "connectTitle": "Connect Microsoft Teams",
+        "invalidDescription": "This page is meant to be opened from a Microsoft Teams connect link.",
+        "open": "Open Teams",
+        "successDescription": "You are connected to {{team}}. Mention @Zero in Teams to start chatting.",
+        "successTitle": "Connected to Microsoft Teams"
+      },
+      "telegram": {
+        "alreadyDescription": "You're already connected. Send a message in Telegram to start chatting.",
+        "alreadyDescriptionNamed": "You're already connected to {{bot}}. Send a message in Telegram to start chatting.",
+        "alreadyTitle": "Already connected to Telegram",
+        "back": "Back to Telegram settings",
+        "botFallback": "this bot",
+        "checkingConnectionDescription": "Please wait while we check your Telegram connection.",
+        "checkingConnectionTitle": "Checking connection...",
+        "checkingDomain": "Checking domain status...",
+        "checkingSession": "Please wait while we verify your {{brandName}} session.",
+        "connectDescription": "Link your account to this Telegram bot so you can interact with your agent directly from Telegram.",
+        "connectTitle": "Connect to Telegram",
+        "continue": "Continue with Telegram",
+        "domainDescription": "Telegram web login is not enabled for {{bot}}.",
+        "domainIn": "In ",
+        "domainInstructionsAfter": ", choose the bot, then set the domain to:",
+        "domainKeepOpen": "Keep this page open after saving the domain. You can also connect from Telegram with /connect.",
+        "domainSend": ", send ",
+        "domainTitle": "Set Telegram login domain",
+        "errorFallback": "We couldn't connect Telegram. Try again from Telegram.",
+        "invalidSignature": "The signature on this link is not valid.",
+        "invalidTimestamp": "The timestamp on this link is not valid.",
+        "invalidTitle": "Connect link is invalid",
+        "invalidUser": "The Telegram user on this link is not valid.",
+        "invalidUsername": "The Telegram username on this link is not valid.",
+        "linkIncomplete": "Open a fresh /connect link from Telegram and try again.",
+        "linkIncompleteTitle": "Connect link is incomplete",
+        "open": "Open Telegram",
+        "openBotFather": "Open BotFather",
+        "refresh": "Refresh this page and try again.",
+        "signInButton": "Sign in to {{brandName}}",
+        "signInCheckFailed": "Couldn't check sign-in",
+        "signInDescription": "Use your {{brandName}} account before connecting this Telegram user.",
+        "signInTitle": "Sign in to continue",
+        "successDescription": "You're connected to {{bot}}. Send a message in Telegram to start chatting.",
+        "successTitle": "Connected to Telegram!"
+      }
+    },
+    "providerSettings": {
+      "agentphone": {
+        "authorizedSender": "Authorized sender",
+        "connectAria": "Connect phone",
+        "connectDescription": "Enter your phone number. We will text a verification link that connects this workspace.",
+        "connectTitle": "Connect phone",
+        "copyAria": "Copy {{phone}}",
+        "copyError": "Failed to copy phone number",
+        "copySuccess": "Phone number copied",
+        "description": "Text-message access to Zero",
+        "destination": "iMessage or SMS to",
+        "normalized": "We will text {{phone}}.",
+        "options": "Phone options",
+        "phoneLabel": "Phone",
+        "phoneNumber": "Phone number",
+        "risk": "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.",
+        "sending": "Sending...",
+        "sendVerification": "Send verification",
+        "verificationSent": "Verification text sent to {{phone}}. Open the link in that text to finish connecting."
+      },
+      "errors": {
+        "agentphonePhone": "Enter a phone number with country code, like +1 555 555 1212.",
+        "githubAuthorizationWindow": "Failed to open authorization window",
+        "telegramDomain": "Domain is not visible to Telegram yet. Check BotFather and try again.",
+        "telegramPrivacy": "Privacy mode still appears to be on. Turn it off in BotFather, then try again."
+      },
+      "feishu": {
+        "addBot": "Add bot",
+        "addDialogDescription": "Create an enterprise custom app, enable its bot, and complete these steps in the Feishu developer console.",
+        "addDialogTitle": "Add a Feishu bot",
+        "agentDescription": "Choose the agent that should handle messages sent to this bot.",
+        "backToIntegrations": "Back to integrations",
+        "botFallback": "Feishu bot",
+        "botIconAlt": "{{bot}} bot icon",
+        "bots": "Feishu bots",
+        "callbackStatusVerified": "Callback verified",
+        "callbackStatusWaiting": "Waiting for callback",
+        "configured": "Configured",
+        "copied": "{{label}} copied",
+        "copy": "Copy",
+        "create": {
+          "descriptionAfter": ", create an enterprise custom app named {{brandName}}, upload the {{brandName}} icon, then add the Bot capability.",
+          "descriptionBefore": "In the ",
+          "downloadIcon": "Download the {{brandName}} icon",
+          "iconAlt": "{{brandName}} app icon",
+          "iconHint": ", or use any icon you prefer.",
+          "iconTitle": "{{brandName}} app icon",
+          "imageAlt": "Feishu app creation form with the app name, icon, and Create button highlighted",
+          "title": "Create an enterprise custom app"
+        },
+        "credentials": {
+          "description": "Copy the App ID and App Secret from Credentials & Basic Information.",
+          "imageAlt": "Feishu app creation result showing where to find the App ID and App Secret",
+          "title": "Add the app credentials"
+        },
+        "defaultAgent": "Default agent",
+        "defaultAgentAria": "Default agent for {{appId}}",
+        "dialogAdminRequired": "An organization admin must configure the app. You can connect your own account from the Feishu bot list after setup is complete.",
+        "emptyAdmin": "Add a custom app to route Feishu messages to an agent.",
+        "emptyMember": "Ask an organization admin to add a Feishu bot.",
+        "emptyTitle": "No Feishu bots yet",
+        "events": {
+          "callbackLabel": "Callback URL",
+          "continue": "Continue after Feishu verifies the callback URL and the message event is subscribed.",
+          "description": "Open Event Configuration. Under Subscription mode, select “Send notifications to developer's server”. Then open Callback Configuration and paste the callback URL. After Feishu verifies it, add the “Receive message v1” event.",
+          "requestAlt": "Feishu Event Configuration screen with the Request URL field highlighted",
+          "requestLabel": "Add the callback request URL",
+          "subscriptionAlt": "Feishu Event Configuration screen with the subscription mode edit control highlighted",
+          "subscriptionLabel": "Select the event subscription mode",
+          "title": "Configure event delivery"
+        },
+        "faq": {
+          "approvalAnswer": "If availability is set to All members, a Feishu administrator must approve the release. Feishu sends the approval request to an administrator in a direct message, and the app remains pending until an administrator completes the review.",
+          "approvalQuestion": "Why is publishing the app waiting for approval?",
+          "challengeAnswer": "This usually means the Encrypt Key or Verification Token saved during the Tokens step is incorrect. Return to the Tokens step, enter both values from Event Configuration → Encryption Strategy again, save them, and retry the Request URL.",
+          "challengeQuestion": "Why does Feishu show \"Challenge code didn't get a response\"?",
+          "title": "Setup FAQ"
+        },
+        "guide": {
+          "next": "Show next Feishu guide image",
+          "previous": "Show previous Feishu guide image",
+          "show": "Show Feishu guide image {{number}}"
+        },
+        "loadError": "Couldn't load Feishu settings.",
+        "manage": "Manage",
+        "manageDialogTitle": "Manage Feishu bot",
+        "moreOptions": "More options for {{bot}}",
+        "pageDescription": "Manage bot routing for this workspace",
+        "publish": {
+          "allMembersAlt": "Feishu availability settings with All members selected",
+          "allMembersLabel": "Make the app available to all members",
+          "createVersionAlt": "Feishu Version Management page with the Create a version button highlighted",
+          "createVersionLabel": "Create an app version",
+          "description": "Create and publish an app version, then edit its availability settings and select All members. The app can only be used by other members of your organization after you grant them access.",
+          "editAvailabilityAlt": "Feishu version details page with the availability settings edit action highlighted",
+          "editAvailabilityLabel": "Edit the availability settings",
+          "title": "Publish the app"
+        },
+        "redirect": {
+          "descriptionAfter": ", open Development Configuration → Security Settings. Add the URL below under Redirect URLs so workspace members can connect their Feishu account to {{brandName}}.",
+          "descriptionBefore": "In the ",
+          "imageAlt": "Feishu Security Settings page showing where to add an OAuth redirect URL",
+          "label": "OAuth redirect URL",
+          "title": "Configure the OAuth redirect URL"
+        },
+        "reviewGuide": "Review guide",
+        "reviewGuideDescription": "Review the completed setup steps for this Feishu bot.",
+        "reviewGuideTitle": "Feishu review guide",
+        "routeDescription": "Route Feishu messages to agents",
+        "selectAgent": "Select an agent",
+        "setupIncomplete": "Setup incomplete",
+        "steps": {
+          "back": "Back",
+          "checking": "Checking…",
+          "close": "Close",
+          "create": "Create",
+          "credentials": "Credentials",
+          "done": "Done",
+          "events": "Events",
+          "next": "Next",
+          "publish": "Publish",
+          "redirect": "Redirect",
+          "tokens": "Tokens",
+          "verify": "Verify and continue",
+          "verifying": "Verifying…",
+          "waiting": "Waiting for callback"
+        },
+        "tokens": {
+          "descriptionAfter": ", select the app you just created, and enter its configuration page. Open Event Configuration → Encryption Strategy, then copy the Encrypt Key and Verification Token.",
+          "descriptionBefore": "Open the ",
+          "imageAlt": "Feishu Encryption Strategy screen showing the Encrypt Key and Verification Token",
+          "title": "Add the event verification tokens"
+        },
+        "uninstallDescription": "This uninstalls {{bot}} from the workspace and disconnects every {{brandName}} account using it. This action cannot be undone.",
+        "uninstallTargetFallback": "this bot",
+        "uninstallTitle": "Uninstall Feishu bot?"
+      },
+      "telegram": {
+        "addBot": "Add bot",
+        "addDescription": "Complete each BotFather step, then create the workspace bot.",
+        "adding": "Adding...",
+        "addTitle": "Add Telegram bot",
+        "agentAria": "Default agent for {{bot}}",
+        "backToIntegrations": "Back to integrations",
+        "botFallback": "Telegram bot",
+        "bots": "Telegram bots",
+        "botToken": "Bot token",
+        "checking": "Checking...",
+        "copied": "copied!",
+        "copyAria": "Copy {{value}}",
+        "copyTitle": "Click to copy",
+        "create": {
+          "description": "{{brandName}} will register this bot and configure its webhook. After setup, mention the bot in a group or send it a DM to talk with the selected agent.",
+          "descriptionNamed": "{{brandName}} will register {{bot}} and configure its webhook. After setup, mention the bot in a group or send it a DM to talk with the selected agent.",
+          "title": "Ready to create the integration"
+        },
+        "defaultAgent": "Default agent",
+        "disconnectAria": "Disconnect {{bot}}",
+        "domain": {
+          "detected": "Domain detected",
+          "instructionAfter": ", choose this bot, and set the domain to ",
+          "instructionEnd": ". Telegram uses this domain to allow the connect flow for this bot.",
+          "instructionStart": "In {{botFather}}, send ",
+          "title": "Set the Telegram login domain"
+        },
+        "emptyDescription": "Add a bot token to start routing Telegram messages to an agent.",
+        "emptyTitle": "No Telegram bots yet",
+        "invalidTokenDescription": "Reinstall the bot with a fresh token from BotFather.",
+        "loadError": "Couldn't load Telegram settings.",
+        "moreOptions": "More options for {{bot}}",
+        "newBotToken": "New bot token",
+        "notConnected": "Not connected",
+        "officialBot": "Zero official bot",
+        "officialDescription": "Official bot provided by {{brandName}}.",
+        "officialMissing": "Official bot configuration is missing.",
+        "pageDescription": "Manage bot routing for this workspace",
+        "privacy": {
+          "instructionAfter": ", choose this bot, then disable privacy mode. This lets the agent read group context around mentions and replies.",
+          "instructionStart": "In {{botFather}}, send ",
+          "off": "Privacy mode is off",
+          "title": "Optional: turn off privacy mode"
+        },
+        "registerAria": "Register Telegram bot",
+        "reinstall": "Reinstall",
+        "reinstallDescription": "Paste the fresh BotFather token for {{bot}}. The token must belong to this same bot.",
+        "reinstalling": "Reinstalling...",
+        "reinstallTargetFallback": "this bot",
+        "reinstallTitle": "Reinstall Telegram bot",
+        "selectAgent": "Select agent",
+        "steps": {
+          "back": "Back",
+          "create": "Create",
+          "domain": "Domain",
+          "next": "Next",
+          "privacy": "Privacy",
+          "token": "Token"
+        },
+        "token": {
+          "instructionAfter": ", choose a name and username, then paste the token below.",
+          "open": "Open ",
+          "send": ", send ",
+          "title": "Create a bot token in BotFather",
+          "verified": "Token verified"
+        },
+        "tokenInvalid": "Token invalid",
+        "uninstallAria": "Uninstall {{bot}}",
+        "uninstallDescription": "This removes {{bot}} from the workspace and disconnects Telegram access for users who use it. This action cannot be undone.",
+        "uninstallTargetFallback": "this bot",
+        "uninstallTitle": "Uninstall Telegram bot?"
+      },
+      "toasts": {
+        "agentphoneConnected": "AgentPhone connected",
+        "agentphoneDisconnected": "AgentPhone disconnected",
+        "agentphoneVerificationSent": "Verification text sent",
+        "feishuBotInstalled": "Feishu bot installed successfully",
+        "feishuBotUninstalled": "Feishu bot uninstalled",
+        "feishuConnected": "Feishu connected successfully",
+        "feishuDisconnected": "Disconnected from Feishu",
+        "slackConnected": "Slack connected successfully",
+        "slackDisconnected": "Disconnected from Slack",
+        "slackInstalled": "Slack installed successfully",
+        "slackPermissionsUpdated": "Permissions updated",
+        "slackUninstalled": "Slack workspace uninstalled",
+        "slackUpdated": "Slack updated",
+        "teamsConnected": "Microsoft Teams connected successfully",
+        "teamsDisconnected": "Disconnected from Microsoft Teams",
+        "teamsInstalled": "Microsoft Teams installed successfully",
+        "teamsUninstalled": "Microsoft Teams integration uninstalled",
+        "teamsUpdated": "Microsoft Teams updated",
+        "telegramAgentUpdated": "Default agent updated",
+        "telegramBotAdded": "Telegram bot added",
+        "telegramBotReinstalled": "Telegram bot reinstalled",
+        "telegramBotUninstalled": "Telegram bot uninstalled",
+        "telegramDisconnected": "Telegram account disconnected",
+        "telegramUpdatingAgent": "Updating default agent..."
+      },
+      "works": {
+        "connected": "Connected",
+        "connectedDetail": "Connected ({{detail}})"
+      }
+    },
+    "redirect": {
+      "back": "Back to {{brandName}}",
+      "errorDescription": "Return to {{brandName}} and try connecting again.",
+      "errorStatus": "Unable to start the connection",
+      "errorTitle": "Couldn’t open {{connector}}",
+      "mobileWarning": "The {{connector}} app may not support this OAuth link. Please complete this connection in the {{brandName}} web app on a computer.",
+      "preparing": "Preparing a secure connection",
+      "redirectDescription": "You’ll continue on {{connector}} to authorize {{brandName}}.",
+      "redirectTitle": "Redirecting to {{connector}}…"
+    },
+    "toasts": {
+      "connected": "{{connector}} connected",
+      "disconnected": "{{connector}} disconnected"
     }
   },
   "lifecycle": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -366,6 +366,88 @@
     "loading": "Carregando autenticação",
     "toggleTheme": "Alternar tema"
   },
+  "authorization": {
+    "browser": {
+      "description": "O Zero usará um perfil isolado de navegador na nuvem para esta conversa. Ao ativá-lo, o Computer Use será desconectado da conversa.",
+      "enable": "Ativar para esta conversa",
+      "enabled": "Navegador na nuvem ativado",
+      "linkExpires": "O link expira em {{date}}.",
+      "title": "Ativar navegador na nuvem",
+      "unavailableDescription": "Este link de autorização do navegador na nuvem é inválido, expirou ou não está disponível para este workspace.",
+      "unavailableTitle": "Link de autorização indisponível"
+    },
+    "computerUse": {
+      "authorize": "Autorizar",
+      "authorized": "Autorizado",
+      "checkingCompatibility": "Verificando compatibilidade",
+      "description": "Escolha um computador online para o Zero usar {{source}}.",
+      "downloadMac": "Baixar para macOS",
+      "lastSeen": "Visto pela última vez em {{date}}",
+      "linkExpires": "O link expira em {{date}}.",
+      "macRequirement": "Requer um Mac com Apple silicon e macOS 14 ou mais recente. Macs com Intel não são compatíveis.",
+      "noHostsDescription": "Abra o Zero Computer Use no Mac e atualize esta página quando ele ficar online.",
+      "noHostsTitle": "Nenhum computador online",
+      "sources": {
+        "chat": "nesta conversa",
+        "slack": "nesta conversa do Slack",
+        "teams": "nesta conversa do Teams"
+      },
+      "title": "Autorizar uso do computador",
+      "unavailableDescription": "Este link de autorização do Computer Use é inválido, expirou ou não está disponível para este workspace.",
+      "unavailableTitle": "Link de autorização indisponível",
+      "unsupportedIntelMac": "Requer um Mac com Apple silicon"
+    },
+    "permission": {
+      "confirm": "Confirmar",
+      "duration": "Duração",
+      "durationLabel": "Duração da permissão",
+      "durationOptions": {
+        "always": "Sempre",
+        "oneHour": "1 hora",
+        "sevenDays": "7 dias",
+        "twentyFourHours": "24 horas"
+      },
+      "errors": {
+        "agentNotFound": "Agente não encontrado",
+        "loadAgent": "Não foi possível carregar o agente",
+        "loadGrants": "Não foi possível carregar as concessões de permissão",
+        "loadMetadata": "Não foi possível carregar os metadados de permissão",
+        "missingAgentId": "O ID do agente não está nos parâmetros da URL",
+        "missingPermission": "A permissão não está nos parâmetros da URL",
+        "unknownAction": "Ação de permissão desconhecida: {{action}}",
+        "unknownConnector": "Conector desconhecido: {{connector}}",
+        "unknownPermission": "Permissão desconhecida: {{permission}}",
+        "updateFailed": "Não foi possível atualizar as permissões"
+      },
+      "expiration": {
+        "expired": "Expirada",
+        "inDays_one": "Expira em {{count}} dia",
+        "inDays_many": "Expira em {{count}} dias",
+        "inDays_other": "Expira em {{count}} dias",
+        "inHours_one": "Expira em {{count}} hora",
+        "inHours_many": "Expira em {{count}} horas",
+        "inHours_other": "Expira em {{count}} horas",
+        "lessThanHour": "Expira em menos de 1 hora",
+        "lessThanHourShort": "< 1 hora",
+        "prefix": "Expira em "
+      },
+      "greeting": "Olá, {{userName}}. Você está atualizando suas permissões para {{targetName}}.",
+      "result": {
+        "alreadyAllowedDescription": "Sua concessão de permissão do conector já está permitida",
+        "alreadyAllowedTitle": "Já permitido",
+        "alreadyDeniedDescription": "Sua concessão de permissão do conector já está negada",
+        "alreadyDeniedTitle": "Já negado",
+        "deniedDescription": "Sua concessão de permissão do conector foi negada",
+        "deniedTitle": "Permissões negadas",
+        "updatedDescription": "Sua concessão de permissão do conector foi atualizada",
+        "updatedTitle": "Permissões atualizadas"
+      },
+      "saving": "Salvando...",
+      "unknownEndpoints": "Endpoints desconhecidos",
+      "userFallback": "você",
+      "wouldLike": "Gostaria de"
+    }
+  },
   "browserSession": {
     "close": "Fechar navegador ao vivo",
     "creditsCharged_one": "{{formattedCount}} crédito cobrado",
@@ -397,6 +479,683 @@
     "unavailable": {
       "description": "Este navegador não pertence a este chat ou foi removido.",
       "title": "Navegador indisponível"
+    }
+  },
+  "connectors": {
+    "access": {
+      "accessFor": "{{action}} acesso ao {{connector}} para {{agent}}",
+      "accessUpdated": "Acesso ao {{connector}} atualizado",
+      "clearSearch": "Limpar busca de agentes",
+      "description": "Escolha quais agentes podem usar este conector.",
+      "loading": "Carregando agentes...",
+      "managePermissions": "Gerenciar permissões",
+      "managePermissionsFor": "Gerenciar permissões do {{connector}} para {{agent}}",
+      "noAgents": "Nenhum agente encontrado",
+      "noMatchingAgents": "Nenhum agente correspondente a \"{{search}}\"",
+      "permissionsUpdated": "Permissões atualizadas",
+      "search": "Buscar agentes",
+      "title": "Gerenciar acesso ao {{connector}}",
+      "unnamedAgent": "Sem nome"
+    },
+    "actions": {
+      "apply": "Aplicar",
+      "authorize": "Autorizar",
+      "cancel": "Cancelar",
+      "close": "Fechar",
+      "closeWindow": "Fechar janela",
+      "connect": "Conectar",
+      "connecting": "Conectando...",
+      "create": "Criar",
+      "creating": "Criando…",
+      "delete": "Excluir",
+      "deleting": "Excluindo…",
+      "disconnect": "Desconectar",
+      "disconnecting": "Desconectando...",
+      "grant": "Conceder",
+      "reconnect": "Reconectar",
+      "rename": "Renomear",
+      "revoke": "Revogar",
+      "save": "Salvar",
+      "saving": "Salvando...",
+      "savingEllipsis": "Salvando…",
+      "tryAgain": "Tentar novamente",
+      "uninstall": "Desinstalar",
+      "uninstalling": "Desinstalando..."
+    },
+    "callback": {
+      "connected": "{{connector}} conectado",
+      "connectedAs": "Conectado como {{username}}. Você pode fechar esta janela.",
+      "connectedDescription": "Sua conta foi conectada. Você pode fechar esta janela.",
+      "connecting": "Conectando {{connector}}…",
+      "connectingDescription": "Aguarde enquanto terminamos de conectar sua conta.",
+      "errorDescription": "{{error}} Feche esta janela e tente novamente.",
+      "errorFallback": "Ocorreu um erro durante a conexão.",
+      "failed": "Falha na conexão",
+      "failedTitle": "Não foi possível conectar {{connector}}",
+      "finishing": "Finalizando a conexão segura",
+      "success": "Conectado"
+    },
+    "card": {
+      "accessFor": "{{action}} acesso ao {{connector}}",
+      "authorized": "Autorizado",
+      "connectAria": "Conectar {{connector}}",
+      "connected": "Conectado",
+      "connecting": "Conectando…",
+      "connectionExpired": "A conexão expirou",
+      "connectToContinue": "Conecte esta conta para continuar",
+      "managePermissions": "Gerenciar permissões",
+      "managePermissionsFor": "Gerenciar permissões do {{connector}}",
+      "optional": "Opcional",
+      "required": "Obrigatório",
+      "reviewPermissions": "Revisar permissões",
+      "updatePermissions": "Atualizar permissões"
+    },
+    "catalog": {
+      "access": {
+        "add": "Adicionar acesso",
+        "manage": "Gerenciar acesso ao {{connector}}",
+        "usedBy": "Usado por "
+      },
+      "categories": {
+        "ai": {
+          "label": "IA",
+          "menu": "IA"
+        },
+        "aiAgentApps": {
+          "label": "Plataformas de agentes e apps de IA",
+          "menu": "Plataformas de agentes"
+        },
+        "aiGeneralModels": {
+          "label": "Modelos gerais e raciocínio",
+          "menu": "Modelos gerais"
+        },
+        "aiImageVideo": {
+          "label": "Geração de imagens e vídeos",
+          "menu": "Imagens e vídeos"
+        },
+        "aiMemoryTracingEval": {
+          "label": "Memória, rastreamento e avaliação",
+          "menu": "Memória e avaliação"
+        },
+        "aiVoiceAudio": {
+          "label": "Voz e áudio",
+          "menu": "Voz e áudio"
+        },
+        "communicationCollaboration": {
+          "label": "Comunicação e colaboração",
+          "menu": "Comunicação"
+        },
+        "dataAutomationInfrastructure": {
+          "label": "Dados, automação e infraestrutura",
+          "menu": "Dados e automação"
+        },
+        "docsFilesKnowledge": {
+          "label": "Documentos, arquivos e conhecimento",
+          "menu": "Documentos"
+        },
+        "engineeringTeamExecution": {
+          "label": "Engenharia e execução da equipe",
+          "menu": "Engenharia"
+        },
+        "marketingContentGrowth": {
+          "label": "Marketing, conteúdo e crescimento",
+          "menu": "Marketing"
+        },
+        "meetingsScheduling": {
+          "label": "Reuniões e agendamento",
+          "menu": "Reuniões"
+        },
+        "salesCrmBusinessOperations": {
+          "label": "Vendas, CRM e operações de negócios",
+          "menu": "Vendas e negócios"
+        }
+      },
+      "categoriesAria": "Categorias de conectores",
+      "description": "Conecte serviços de terceiros para seus agentes usarem.",
+      "empty": {
+        "agent": "Nenhum conector para este agente",
+        "connected": "Nenhum conector conectado",
+        "matching": "{{message}} correspondente a \"{{search}}\"",
+        "notConnected": "Não há mais conectores para conectar",
+        "search": "Nenhum conector correspondente a \"{{search}}\""
+      },
+      "filters": {
+        "agents": "Agentes",
+        "all": "Todos",
+        "aria": "Filtrar conectores",
+        "connected": "Conectados",
+        "notConnected": "Não conectados",
+        "status": "Status"
+      },
+      "iconUnavailable": "Ícone do conector indisponível",
+      "newConnector": "Novo conector",
+      "noConnectorsAlt": "Nenhum conector",
+      "otherCategory": "Outros",
+      "search": "Buscar conectores",
+      "tabs": {
+        "builtin": "Integrados",
+        "custom": "Personalizados"
+      },
+      "title": "Conectores",
+      "unnamedAgent": "Sem nome"
+    },
+    "connectDialog": {
+      "connectedAs": "Conectado como {{username}}",
+      "device": {
+        "checking": "Verificando a aprovação...",
+        "connect": "Conectar {{connector}}",
+        "copyThenOpen": "Copie este código e abra a página de verificação para aprovar o acesso.",
+        "description": "Abra a página de verificação do provedor e insira este código para aprovar o acesso.",
+        "intro": "Conecte-se para obter um código de verificação e use-o na página de verificação do provedor para aprovar o acesso.",
+        "openPage": "Abrir página de verificação",
+        "selectOption": "Selecionar {{option}}",
+        "starting": "Iniciando...",
+        "startingConnection": "Iniciando conexão...",
+        "verificationCode": "Código de verificação",
+        "waiting": "Aguardando aprovação. Mantenha esta caixa de diálogo aberta."
+      },
+      "external": {
+        "code": "Código",
+        "complete": "Concluir conexão",
+        "description": "Abra o login do {{connector}} e cole o código exibido pelo {{connector}}.",
+        "open": "Abrir login do {{connector}}",
+        "start": "Iniciar login do {{connector}}"
+      },
+      "noAuth": {
+        "enable": "Ativar {{connector}}",
+        "enabling": "Ativando..."
+      },
+      "noMethod": "Nenhum método de conexão está disponível.",
+      "or": "ou",
+      "progress": {
+        "connecting": "Conectando...",
+        "savingPermissions": "Salvando permissões..."
+      },
+      "unavailable": {
+        "description": "Este conector tem métodos de conexão disponíveis, mas nenhum deles pode ser configurado nesta caixa de diálogo.",
+        "title": "Métodos de conexão indisponíveis"
+      }
+    },
+    "custom": {
+      "connect": {
+        "description": "Seu segredo é criptografado em repouso e injetado nas solicitações de saída pelo firewall. Ele nunca é exposto ao agente como uma variável de ambiente.",
+        "secret": "Segredo",
+        "title": "Conectar {{connector}}"
+      },
+      "create": {
+        "displayName": "Nome de exibição",
+        "headerName": "Nome do header",
+        "headerTemplate": "Modelo do header",
+        "headerTemplateHint": "(deve conter {{placeholder}})",
+        "prefixes": "Prefixos",
+        "prefixesHint": "(um por linha, somente https)",
+        "title": "Novo conector personalizado"
+      },
+      "delete": {
+        "description": "Isso remove o conector e o segredo armazenado de cada membro. Os agentes autorizados para este conector perderão o acesso imediatamente. Esta ação não pode ser desfeita.",
+        "title": "Excluir {{connector}}?"
+      },
+      "emptyAdmin": "Ainda não há conectores personalizados. Crie um para registrar uma API que todos os membros possam usar.",
+      "emptyMember": "Sua organização ainda não registrou conectores personalizados.",
+      "moreOptions": "Mais opções",
+      "rename": {
+        "displayName": "Nome de exibição",
+        "title": "Renomear conector personalizado"
+      },
+      "statusConnected": "Conectado",
+      "toasts": {
+        "connected": "Conectado",
+        "created": "\"{{connector}}\" criado",
+        "deleted": "Conector personalizado excluído",
+        "disconnected": "Desconectado",
+        "renamed": "Renomeado para \"{{connector}}\""
+      }
+    },
+    "customProposal": {
+      "configure": "Configurar {{connector}}",
+      "descriptionAgent": "Ao salvar, seus valores serão conectados e {{agent}} será autorizado.",
+      "descriptionUser": "Ao salvar, este conector personalizado será conectado à sua conta.",
+      "invalid": "Este link de proposta de conector personalizado é inválido ou expirou.",
+      "requestScope": "Escopo da solicitação",
+      "returnToChat": "Volte ao chat e responda ACK para que o agente possa verificar o conector.",
+      "saved": "Salvo",
+      "savedToast": "{{connector}} salvo",
+      "targetFallback": "este agente",
+      "update": "Atualizar {{connector}}"
+    },
+    "directed": {
+      "authorizeAgent": "Autorizar {{agent}}",
+      "authorized": "{{connector}} autorizado",
+      "connected": "{{connector}} conectado",
+      "needsConnector": "{{agent}} precisa de {{connector}} para continuar",
+      "reconnecting": "Reconectando..."
+    },
+    "expiration": {
+      "inDays_one": "Expira em {{count}} dia",
+      "inDays_many": "Expira em {{count}} dias",
+      "inDays_other": "Expira em {{count}} dias",
+      "inHours_one": "Expira em {{count}} hora",
+      "inHours_many": "Expira em {{count}} horas",
+      "inHours_other": "Expira em {{count}} horas",
+      "lessThanHour": "Expira em menos de 1 hora"
+    },
+    "permissions": {
+      "actions": {
+        "allow": "Permitir",
+        "deny": "Negar",
+        "mixed": "Misto"
+      },
+      "allowDuration": {
+        "always": "Permitir sempre",
+        "oneHour": "Permitir por 1 h",
+        "sevenDays": "Permitir por 7 dias",
+        "twentyFourHours": "Permitir por 24 h"
+      },
+      "allowOptions": "Opções de permissão para {{permission}}",
+      "always": "Sempre",
+      "clearSearch": "Limpar busca de permissões",
+      "descriptionAgent": "Configure quais ações este agente pode realizar por meio deste conector.",
+      "descriptionWorkflow": "Configure quais ações este fluxo de trabalho pode realizar por meio deste conector.",
+      "find": "Buscar permissões",
+      "findPlaceholder": "Buscar permissões...",
+      "forTarget": "para {{target}}",
+      "loadError": "Falha ao carregar os metadados de permissões",
+      "loading": "Carregando permissões...",
+      "metadataMissing": "Nenhum metadado de permissão encontrado para {{connector}}",
+      "noResults": "Nenhum resultado para “{{search}}”",
+      "otherEndpoints": "Outros endpoints",
+      "otherEndpointsDescription": "Endpoints de API que não correspondem a nenhuma permissão acima",
+      "permissions": "Permissões",
+      "restore": "Restaurar",
+      "scopeReview": {
+        "added": "Novas permissões",
+        "description": "As permissões necessárias para este conector mudaram. Revise-as e reconecte para aplicar a atualização.",
+        "failed": "Falha ao carregar as alterações de escopo.",
+        "loading": "Carregando alterações de escopo...",
+        "removed": "Permissões removidas",
+        "title": "Atualização das permissões de {{connector}}"
+      },
+      "selectAll": "Selecionar tudo",
+      "showMore_one": "Mostrar mais ({{count}})",
+      "showMore_many": "Mostrar mais ({{count}})",
+      "showMore_other": "Mostrar mais ({{count}})",
+      "title": "Permissões de {{connector}}"
+    },
+    "providerConnect": {
+      "agentphone": {
+        "back": "Voltar para {{brandName}}",
+        "connectDescription": "Vincule este número de telefone à sua conta do {{brandName}} para interagir com o Zero por mensagens de texto.",
+        "connectTitle": "Conectar número de telefone",
+        "errorFallback": "Não foi possível conectar este número de telefone. Tente novamente pelas suas mensagens de texto.",
+        "incompleteDescription": "Abra um novo link /connect nas suas mensagens de texto.",
+        "incompleteTitle": "O link de conexão está incompleto",
+        "invalidSignature": "A assinatura deste link não é válida.",
+        "invalidTimestamp": "O carimbo de data e hora deste link não é válido.",
+        "invalidTitle": "O link de conexão não é válido",
+        "risk": "As respostas por SMS e MMS podem não ser entregues de forma confiável. Para uma experiência mais confiável, use o iMessage com este número do AgentPhone.",
+        "successDescription": "{{phone}} está conectado. Envie uma mensagem de texto para começar a conversar com o Zero.",
+        "successTitle": "Número de telefone conectado"
+      },
+      "common": {
+        "backToSettings": "Voltar para as configurações",
+        "checkingTitle": "Verificando o status da conta...",
+        "connectionFailed": "Falha na conexão",
+        "invalidLink": "Link inválido",
+        "verifying": "Aguarde enquanto verificamos sua conexão."
+      },
+      "feishu": {
+        "back": "Voltar para as configurações do Feishu",
+        "checkingTitle": "Verificando o status da conta…",
+        "connectDescription": "Vincule sua conta do {{brandName}} a este bot do Feishu para trabalhar com seu agente diretamente pelo Feishu.",
+        "connectTitle": "Conectar ao Feishu",
+        "errorFallback": "Não foi possível conectar o Feishu. Abra um novo link de conexão e tente novamente.",
+        "invalidDescription": "Abra um novo link de conexão no Feishu e tente novamente.",
+        "open": "Abrir Feishu",
+        "successDescription": "Você está conectado. Envie uma mensagem no Feishu para começar a conversar.",
+        "successDescriptionNamed": "Você está conectado a {{bot}}. Envie uma mensagem no Feishu para começar a conversar.",
+        "successTitle": "Conectado ao Feishu!"
+      },
+      "github": {
+        "accountFallback": "esta conta do GitHub",
+        "alreadyDescription": "Você já está conectado como {{account}}. Mencione seu agente em issues ou pull requests do GitHub para começar a conversar.",
+        "alreadyTitle": "Já conectado ao GitHub",
+        "back": "Voltar para fluxos de trabalho",
+        "checkingConnectionDescription": "Aguarde enquanto verificamos sua conexão com o GitHub.",
+        "checkingConnectionTitle": "Verificando a conexão...",
+        "checkingSession": "Aguarde enquanto verificamos sua sessão do {{brandName}}.",
+        "connectDescription": "Vincule sua conta do {{brandName}} a {{account}} para que menções no GitHub possam executar seus agentes em issues e pull requests.",
+        "connectTitle": "Conectar ao GitHub",
+        "errorFallback": "Não foi possível conectar o GitHub. Tente novamente pelo GitHub.",
+        "invalidInstallation": "A instalação do GitHub neste link não é válida.",
+        "invalidSignature": "A assinatura deste link não é válida.",
+        "invalidTimestamp": "O carimbo de data e hora deste link não é válido.",
+        "invalidTitle": "O link de conexão não é válido",
+        "invalidUser": "O usuário do GitHub neste link não é válido.",
+        "invalidUsername": "O nome de usuário do GitHub neste link não é válido.",
+        "linkIncomplete": "Abra um novo link de conexão do GitHub e tente novamente.",
+        "linkIncompleteTitle": "O link de conexão está incompleto",
+        "notInstalledDescription": "Peça a um administrador da organização para instalar o GitHub antes de conectar sua conta.",
+        "notInstalledTitle": "O GitHub não está instalado",
+        "refresh": "Atualize esta página e tente novamente.",
+        "signInButton": "Entrar no {{brandName}}",
+        "signInCheckFailed": "Não foi possível verificar o login",
+        "signInDescription": "Entre com sua conta do {{brandName}} antes de conectar este usuário do GitHub.",
+        "signInTitle": "Entre para continuar",
+        "successDescription": "Você está conectado como {{account}}. Mencione seu agente em issues ou pull requests do GitHub para começar a conversar.",
+        "successTitle": "Conectado ao GitHub!",
+        "wrongOrganizationDescription": "Sua organização ativa não corresponde a esta instalação do GitHub. Mude para a organização correta e abra o link novamente.",
+        "wrongOrganizationTitle": "Mudar de organização"
+      },
+      "slack": {
+        "connectDescription": "Vincule sua conta a este workspace do Slack para interagir com seu agente diretamente pelo Slack.",
+        "connectTitle": "Conectar ao Slack",
+        "invalidDescription": "Esta página deve ser aberta por um link de conexão do Slack.",
+        "open": "Abrir Slack",
+        "successDescription": "Mencione @Zero em qualquer canal ou envie uma DM para começar a conversar.",
+        "successDescriptionWorkspace": "Você está conectado a {{workspace}}. Mencione @Zero em qualquer canal ou envie uma DM para começar a conversar.",
+        "successTitle": "Conectado ao Slack!"
+      },
+      "teams": {
+        "connectDescription": "Vincule sua conta do Teams para interagir com seu agente diretamente pelo Microsoft Teams.",
+        "connectDescriptionNamed": "{{displayName}}, vincule sua conta do Teams para interagir com seu agente diretamente pelo Microsoft Teams.",
+        "connectTitle": "Conectar o Microsoft Teams",
+        "invalidDescription": "Esta página deve ser aberta por um link de conexão do Microsoft Teams.",
+        "open": "Abrir Teams",
+        "successDescription": "Você está conectado a {{team}}. Mencione @Zero no Teams para começar a conversar.",
+        "successTitle": "Conectado ao Microsoft Teams"
+      },
+      "telegram": {
+        "alreadyDescription": "Você já está conectado. Envie uma mensagem no Telegram para começar a conversar.",
+        "alreadyDescriptionNamed": "Você já está conectado a {{bot}}. Envie uma mensagem no Telegram para começar a conversar.",
+        "alreadyTitle": "Já conectado ao Telegram",
+        "back": "Voltar para as configurações do Telegram",
+        "botFallback": "este bot",
+        "checkingConnectionDescription": "Aguarde enquanto verificamos sua conexão com o Telegram.",
+        "checkingConnectionTitle": "Verificando a conexão...",
+        "checkingDomain": "Verificando o status do domínio...",
+        "checkingSession": "Aguarde enquanto verificamos sua sessão do {{brandName}}.",
+        "connectDescription": "Vincule sua conta a este bot do Telegram para interagir com seu agente diretamente pelo Telegram.",
+        "connectTitle": "Conectar ao Telegram",
+        "continue": "Continuar com o Telegram",
+        "domainDescription": "O login web do Telegram não está ativado para {{bot}}.",
+        "domainIn": "No ",
+        "domainInstructionsAfter": ", escolha o bot e defina o domínio como:",
+        "domainKeepOpen": "Mantenha esta página aberta depois de salvar o domínio. Você também pode se conectar pelo Telegram com /connect.",
+        "domainSend": ", envie ",
+        "domainTitle": "Definir domínio de login do Telegram",
+        "errorFallback": "Não foi possível conectar o Telegram. Tente novamente pelo Telegram.",
+        "invalidSignature": "A assinatura deste link não é válida.",
+        "invalidTimestamp": "O carimbo de data e hora deste link não é válido.",
+        "invalidTitle": "O link de conexão não é válido",
+        "invalidUser": "O usuário do Telegram neste link não é válido.",
+        "invalidUsername": "O nome de usuário do Telegram neste link não é válido.",
+        "linkIncomplete": "Abra um novo link /connect no Telegram e tente novamente.",
+        "linkIncompleteTitle": "O link de conexão está incompleto",
+        "open": "Abrir Telegram",
+        "openBotFather": "Abrir BotFather",
+        "refresh": "Atualize esta página e tente novamente.",
+        "signInButton": "Entrar no {{brandName}}",
+        "signInCheckFailed": "Não foi possível verificar o login",
+        "signInDescription": "Entre com sua conta do {{brandName}} antes de conectar este usuário do Telegram.",
+        "signInTitle": "Entre para continuar",
+        "successDescription": "Você está conectado a {{bot}}. Envie uma mensagem no Telegram para começar a conversar.",
+        "successTitle": "Conectado ao Telegram!"
+      }
+    },
+    "providerSettings": {
+      "agentphone": {
+        "authorizedSender": "Remetente autorizado",
+        "connectAria": "Conectar telefone",
+        "connectDescription": "Digite seu número de telefone. Enviaremos por mensagem um link de verificação que conecta este workspace.",
+        "connectTitle": "Conectar telefone",
+        "copyAria": "Copiar {{phone}}",
+        "copyError": "Falha ao copiar o número de telefone",
+        "copySuccess": "Número de telefone copiado",
+        "description": "Acesso ao Zero por mensagens de texto",
+        "destination": "iMessage ou SMS para",
+        "normalized": "Enviaremos uma mensagem para {{phone}}.",
+        "options": "Opções do telefone",
+        "phoneLabel": "Telefone",
+        "phoneNumber": "Número de telefone",
+        "risk": "As respostas por SMS e MMS podem não ser entregues de forma confiável. Para uma experiência mais confiável, use o iMessage com este número do AgentPhone.",
+        "sending": "Enviando...",
+        "sendVerification": "Enviar verificação",
+        "verificationSent": "Mensagem de verificação enviada para {{phone}}. Abra o link dessa mensagem para concluir a conexão."
+      },
+      "errors": {
+        "agentphonePhone": "Digite um número de telefone com código do país, como +1 555 555 1212.",
+        "githubAuthorizationWindow": "Falha ao abrir a janela de autorização",
+        "telegramDomain": "O domínio ainda não está visível para o Telegram. Verifique o BotFather e tente novamente.",
+        "telegramPrivacy": "O modo de privacidade ainda parece estar ativado. Desative-o no BotFather e tente novamente."
+      },
+      "feishu": {
+        "addBot": "Adicionar bot",
+        "addDialogDescription": "Crie um app personalizado empresarial, ative o bot e conclua estas etapas no console de desenvolvedor do Feishu.",
+        "addDialogTitle": "Adicionar um bot do Feishu",
+        "agentDescription": "Escolha o agente que deve processar as mensagens enviadas a este bot.",
+        "backToIntegrations": "Voltar para integrações",
+        "botFallback": "Bot do Feishu",
+        "botIconAlt": "Ícone do bot {{bot}}",
+        "bots": "Bots do Feishu",
+        "callbackStatusVerified": "Callback verificado",
+        "callbackStatusWaiting": "Aguardando callback",
+        "configured": "Configurado",
+        "copied": "{{label}} copiado",
+        "copy": "Copiar",
+        "create": {
+          "descriptionAfter": ", crie um app personalizado empresarial chamado {{brandName}}, envie o ícone do {{brandName}} e adicione o recurso Bot.",
+          "descriptionBefore": "No ",
+          "downloadIcon": "Baixar o ícone do {{brandName}}",
+          "iconAlt": "Ícone do app {{brandName}}",
+          "iconHint": " ou use qualquer ícone de sua preferência.",
+          "iconTitle": "Ícone do app {{brandName}}",
+          "imageAlt": "Formulário de criação de app do Feishu com o nome, o ícone e o botão Criar destacados",
+          "title": "Criar um app personalizado empresarial"
+        },
+        "credentials": {
+          "description": "Copie o App ID e o App Secret de Credentials & Basic Information.",
+          "imageAlt": "Resultado da criação do app do Feishu mostrando onde encontrar o App ID e o App Secret",
+          "title": "Adicionar as credenciais do app"
+        },
+        "defaultAgent": "Agente padrão",
+        "defaultAgentAria": "Agente padrão para {{appId}}",
+        "dialogAdminRequired": "Um administrador da organização deve configurar o app. Você poderá conectar sua própria conta pela lista de bots do Feishu após a conclusão da configuração.",
+        "emptyAdmin": "Adicione um app personalizado para encaminhar mensagens do Feishu a um agente.",
+        "emptyMember": "Peça a um administrador da organização para adicionar um bot do Feishu.",
+        "emptyTitle": "Ainda não há bots do Feishu",
+        "events": {
+          "callbackLabel": "URL de callback",
+          "continue": "Continue depois que o Feishu verificar a URL de callback e o evento de mensagem estiver inscrito.",
+          "description": "Abra Event Configuration. Em Subscription mode, selecione “Send notifications to developer's server”. Depois, abra Callback Configuration e cole a URL de callback. Após a verificação do Feishu, adicione o evento “Receive message v1”.",
+          "requestAlt": "Tela Event Configuration do Feishu com o campo Request URL destacado",
+          "requestLabel": "Adicionar a URL de solicitação de callback",
+          "subscriptionAlt": "Tela Event Configuration do Feishu com o controle de edição do modo de inscrição destacado",
+          "subscriptionLabel": "Selecionar o modo de inscrição de eventos",
+          "title": "Configurar a entrega de eventos"
+        },
+        "faq": {
+          "approvalAnswer": "Se a disponibilidade estiver definida como All members, um administrador do Feishu deverá aprovar a versão. O Feishu envia a solicitação de aprovação a um administrador por mensagem direta, e o app permanece pendente até a conclusão da revisão.",
+          "approvalQuestion": "Por que a publicação do app está aguardando aprovação?",
+          "challengeAnswer": "Isso geralmente significa que o Encrypt Key ou o Verification Token salvo na etapa Tokens está incorreto. Volte à etapa Tokens, insira novamente os dois valores de Event Configuration → Encryption Strategy, salve-os e tente a Request URL outra vez.",
+          "challengeQuestion": "Por que o Feishu mostra \"Challenge code didn't get a response\"?",
+          "title": "Perguntas frequentes sobre a configuração"
+        },
+        "guide": {
+          "next": "Mostrar a próxima imagem do guia do Feishu",
+          "previous": "Mostrar a imagem anterior do guia do Feishu",
+          "show": "Mostrar a imagem {{number}} do guia do Feishu"
+        },
+        "loadError": "Não foi possível carregar as configurações do Feishu.",
+        "manage": "Gerenciar",
+        "manageDialogTitle": "Gerenciar bot do Feishu",
+        "moreOptions": "Mais opções para {{bot}}",
+        "pageDescription": "Gerencie o encaminhamento dos bots neste workspace",
+        "publish": {
+          "allMembersAlt": "Configurações de disponibilidade do Feishu com All members selecionado",
+          "allMembersLabel": "Disponibilizar o app para todos os membros",
+          "createVersionAlt": "Página Version Management do Feishu com o botão Create a version destacado",
+          "createVersionLabel": "Criar uma versão do app",
+          "description": "Crie e publique uma versão do app, edite as configurações de disponibilidade e selecione All members. Outros membros da organização só poderão usar o app depois que você conceder acesso.",
+          "editAvailabilityAlt": "Página de detalhes da versão do Feishu com a ação de editar as configurações de disponibilidade destacada",
+          "editAvailabilityLabel": "Editar as configurações de disponibilidade",
+          "title": "Publicar o app"
+        },
+        "redirect": {
+          "descriptionAfter": ", abra Development Configuration → Security Settings. Adicione a URL abaixo em Redirect URLs para que os membros do workspace conectem suas contas do Feishu ao {{brandName}}.",
+          "descriptionBefore": "No ",
+          "imageAlt": "Página Security Settings do Feishu mostrando onde adicionar uma URL de redirecionamento OAuth",
+          "label": "URL de redirecionamento OAuth",
+          "title": "Configurar a URL de redirecionamento OAuth"
+        },
+        "reviewGuide": "Revisar guia",
+        "reviewGuideDescription": "Revise as etapas concluídas da configuração deste bot do Feishu.",
+        "reviewGuideTitle": "Guia de revisão do Feishu",
+        "routeDescription": "Encaminhe mensagens do Feishu para agentes",
+        "selectAgent": "Selecionar um agente",
+        "setupIncomplete": "Configuração incompleta",
+        "steps": {
+          "back": "Voltar",
+          "checking": "Verificando…",
+          "close": "Fechar",
+          "create": "Criar",
+          "credentials": "Credenciais",
+          "done": "Concluído",
+          "events": "Eventos",
+          "next": "Avançar",
+          "publish": "Publicar",
+          "redirect": "Redirecionar",
+          "tokens": "Tokens",
+          "verify": "Verificar e continuar",
+          "verifying": "Verificando…",
+          "waiting": "Aguardando callback"
+        },
+        "tokens": {
+          "descriptionAfter": ", selecione o app que você acabou de criar e abra sua página de configuração. Acesse Event Configuration → Encryption Strategy e copie o Encrypt Key e o Verification Token.",
+          "descriptionBefore": "Abra o ",
+          "imageAlt": "Tela Encryption Strategy do Feishu mostrando o Encrypt Key e o Verification Token",
+          "title": "Adicionar os tokens de verificação de eventos"
+        },
+        "uninstallDescription": "Isso desinstala {{bot}} do workspace e desconecta todas as contas do {{brandName}} que o utilizam. Esta ação não pode ser desfeita.",
+        "uninstallTargetFallback": "este bot",
+        "uninstallTitle": "Desinstalar o bot do Feishu?"
+      },
+      "telegram": {
+        "addBot": "Adicionar bot",
+        "addDescription": "Conclua cada etapa no BotFather e crie o bot do workspace.",
+        "adding": "Adicionando...",
+        "addTitle": "Adicionar bot do Telegram",
+        "agentAria": "Agente padrão para {{bot}}",
+        "backToIntegrations": "Voltar para integrações",
+        "botFallback": "Bot do Telegram",
+        "bots": "Bots do Telegram",
+        "botToken": "Token do bot",
+        "checking": "Verificando...",
+        "copied": "copiado!",
+        "copyAria": "Copiar {{value}}",
+        "copyTitle": "Clique para copiar",
+        "create": {
+          "description": "O {{brandName}} registrará este bot e configurará seu webhook. Após a configuração, mencione o bot em um grupo ou envie uma DM para conversar com o agente selecionado.",
+          "descriptionNamed": "O {{brandName}} registrará {{bot}} e configurará seu webhook. Após a configuração, mencione o bot em um grupo ou envie uma DM para conversar com o agente selecionado.",
+          "title": "Tudo pronto para criar a integração"
+        },
+        "defaultAgent": "Agente padrão",
+        "disconnectAria": "Desconectar {{bot}}",
+        "domain": {
+          "detected": "Domínio detectado",
+          "instructionAfter": ", escolha este bot e defina o domínio como ",
+          "instructionEnd": ". O Telegram usa este domínio para permitir o fluxo de conexão deste bot.",
+          "instructionStart": "No {{botFather}}, envie ",
+          "title": "Definir o domínio de login do Telegram"
+        },
+        "emptyDescription": "Adicione um token de bot para encaminhar mensagens do Telegram a um agente.",
+        "emptyTitle": "Ainda não há bots do Telegram",
+        "invalidTokenDescription": "Reinstale o bot com um novo token do BotFather.",
+        "loadError": "Não foi possível carregar as configurações do Telegram.",
+        "moreOptions": "Mais opções para {{bot}}",
+        "newBotToken": "Novo token do bot",
+        "notConnected": "Não conectado",
+        "officialBot": "Bot oficial do Zero",
+        "officialDescription": "Bot oficial fornecido pelo {{brandName}}.",
+        "officialMissing": "A configuração do bot oficial está ausente.",
+        "pageDescription": "Gerencie o encaminhamento dos bots neste workspace",
+        "privacy": {
+          "instructionAfter": ", escolha este bot e desative o modo de privacidade. Isso permite que o agente leia o contexto do grupo em torno de menções e respostas.",
+          "instructionStart": "No {{botFather}}, envie ",
+          "off": "O modo de privacidade está desativado",
+          "title": "Opcional: desativar o modo de privacidade"
+        },
+        "registerAria": "Registrar bot do Telegram",
+        "reinstall": "Reinstalar",
+        "reinstallDescription": "Cole o novo token do BotFather para {{bot}}. O token deve pertencer a este mesmo bot.",
+        "reinstalling": "Reinstalando...",
+        "reinstallTargetFallback": "este bot",
+        "reinstallTitle": "Reinstalar bot do Telegram",
+        "selectAgent": "Selecionar agente",
+        "steps": {
+          "back": "Voltar",
+          "create": "Criar",
+          "domain": "Domínio",
+          "next": "Avançar",
+          "privacy": "Privacidade",
+          "token": "Token"
+        },
+        "token": {
+          "instructionAfter": ", escolha um nome e um nome de usuário e cole o token abaixo.",
+          "open": "Abra ",
+          "send": ", envie ",
+          "title": "Criar um token de bot no BotFather",
+          "verified": "Token verificado"
+        },
+        "tokenInvalid": "Token inválido",
+        "uninstallAria": "Desinstalar {{bot}}",
+        "uninstallDescription": "Isso remove {{bot}} do workspace e desconecta o acesso ao Telegram dos usuários que o utilizam. Esta ação não pode ser desfeita.",
+        "uninstallTargetFallback": "este bot",
+        "uninstallTitle": "Desinstalar o bot do Telegram?"
+      },
+      "toasts": {
+        "agentphoneConnected": "AgentPhone conectado",
+        "agentphoneDisconnected": "AgentPhone desconectado",
+        "agentphoneVerificationSent": "Mensagem de verificação enviada",
+        "feishuBotInstalled": "Bot do Feishu instalado com sucesso",
+        "feishuBotUninstalled": "Bot do Feishu desinstalado",
+        "feishuConnected": "Feishu conectado com sucesso",
+        "feishuDisconnected": "Desconectado do Feishu",
+        "slackConnected": "Slack conectado com sucesso",
+        "slackDisconnected": "Desconectado do Slack",
+        "slackInstalled": "Slack instalado com sucesso",
+        "slackPermissionsUpdated": "Permissões atualizadas",
+        "slackUninstalled": "Workspace do Slack desinstalado",
+        "slackUpdated": "Slack atualizado",
+        "teamsConnected": "Microsoft Teams conectado com sucesso",
+        "teamsDisconnected": "Desconectado do Microsoft Teams",
+        "teamsInstalled": "Microsoft Teams instalado com sucesso",
+        "teamsUninstalled": "Integração do Microsoft Teams desinstalada",
+        "teamsUpdated": "Microsoft Teams atualizado",
+        "telegramAgentUpdated": "Agente padrão atualizado",
+        "telegramBotAdded": "Bot do Telegram adicionado",
+        "telegramBotReinstalled": "Bot do Telegram reinstalado",
+        "telegramBotUninstalled": "Bot do Telegram desinstalado",
+        "telegramDisconnected": "Conta do Telegram desconectada",
+        "telegramUpdatingAgent": "Atualizando o agente padrão..."
+      },
+      "works": {
+        "connected": "Conectado",
+        "connectedDetail": "Conectado ({{detail}})"
+      }
+    },
+    "redirect": {
+      "back": "Voltar para {{brandName}}",
+      "errorDescription": "Volte para {{brandName}} e tente conectar novamente.",
+      "errorStatus": "Não foi possível iniciar a conexão",
+      "errorTitle": "Não foi possível abrir {{connector}}",
+      "mobileWarning": "O app {{connector}} pode não aceitar este link OAuth. Conclua esta conexão no app web do {{brandName}} em um computador.",
+      "preparing": "Preparando uma conexão segura",
+      "redirectDescription": "Você continuará no {{connector}} para autorizar o {{brandName}}.",
+      "redirectTitle": "Redirecionando para {{connector}}…"
+    },
+    "toasts": {
+      "connected": "{{connector}} conectado",
+      "disconnected": "{{connector}} desconectado"
     }
   },
   "lifecycle": {

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -21,6 +21,7 @@ import { setAblyLoop$ } from "../realtime.ts";
 import { retryTransientLoad } from "../utils.ts";
 import { resolveActiveUserPermissionGrantPolicy } from "../user-permission-grants.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
+import { i18n } from "../../i18n/index.ts";
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -85,7 +86,9 @@ export function findPermissionInMetadata(
   if (name === UNKNOWN_PERMISSION_GRANT) {
     return {
       name: UNKNOWN_PERMISSION_GRANT,
-      description: "Unknown endpoints",
+      description: i18n.t(($) => {
+        return $.authorization.permission.unknownEndpoints;
+      }),
     };
   }
   return (

--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 import { now } from "../../lib/time.ts";
+import { i18n } from "../../i18n/index.ts";
 
 const HOUR_MS = 60 * 60 * 1000;
 const MINUTE_MS = 60 * 1000;
@@ -10,22 +11,15 @@ const DAY_MS = 24 * HOUR_MS;
 export const DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN: UserPermissionGrantExpiresIn =
   "1h";
 
-export const USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS: readonly {
-  readonly value: UserPermissionGrantExpiresIn;
-  readonly label: string;
-}[] = [
-  { value: "1h", label: "1 hour" },
-  { value: "24h", label: "24 hours" },
-  { value: "7d", label: "7 days" },
-  { value: "always", label: "Always" },
-];
+export const USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS: readonly UserPermissionGrantExpiresIn[] =
+  ["1h", "24h", "7d", "always"];
 
 export function parseUserPermissionGrantExpiresIn(
   value: string | null,
 ): UserPermissionGrantExpiresIn | null {
   for (const option of USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS) {
-    if (option.value === value) {
-      return option.value;
+    if (option === value) {
+      return option;
     }
   }
   return null;
@@ -65,17 +59,29 @@ export function permissionGrantExpiryText(
   }
   const remainingMs = expiresAtMs - nowMs;
   if (remainingMs <= 0) {
-    return "Expired";
+    return i18n.t(($) => {
+      return $.authorization.permission.expiration.expired;
+    });
   }
   if (remainingMs >= DAY_MS) {
-    const days = Math.ceil(remainingMs / DAY_MS);
-    return `Expires in ${days} day${days === 1 ? "" : "s"}`;
+    return i18n.t(
+      ($) => {
+        return $.authorization.permission.expiration.inDays;
+      },
+      { count: Math.ceil(remainingMs / DAY_MS) },
+    );
   }
   if (remainingMs < HOUR_MS - MINUTE_MS) {
-    return "Expires in less than 1 hour";
+    return i18n.t(($) => {
+      return $.authorization.permission.expiration.lessThanHour;
+    });
   }
-  const hours = Math.ceil(remainingMs / HOUR_MS);
-  return `Expires in ${hours} hour${hours === 1 ? "" : "s"}`;
+  return i18n.t(
+    ($) => {
+      return $.authorization.permission.expiration.inHours;
+    },
+    { count: Math.ceil(remainingMs / HOUR_MS) },
+  );
 }
 
 const internalPermissionGrantExpiresInByScope$ = state<

--- a/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-connect-params.ts
@@ -6,10 +6,8 @@ interface AgentPhoneConnectParams {
   channel?: string;
 }
 
-export const AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE =
-  "SMS and MMS replies may not be delivered reliably. For the most reliable experience, use iMessage with this AgentPhone number.";
-
 interface AgentPhoneConnectParamError {
+  code: "incomplete" | "invalid_signature" | "invalid_timestamp";
   title: string;
   message: string;
 }
@@ -61,11 +59,15 @@ function encodeReturnPath(
   return `/agentphone/connect?${search.toString()}`;
 }
 
-function invalidParams(message: string): ParsedAgentPhoneConnectParams {
+function invalidParams(
+  code: "invalid_signature" | "invalid_timestamp",
+  message: string,
+): ParsedAgentPhoneConnectParams {
   return {
     ok: false,
     returnPath: "/agentphone/connect",
     error: {
+      code,
       title: "Connect link is invalid",
       message,
     },
@@ -86,6 +88,7 @@ export function parseAgentPhoneConnectParams(
       ok: false,
       returnPath: "/agentphone/connect",
       error: {
+        code: "incomplete",
         title: "Connect link is incomplete",
         message: "Open a fresh /connect link from your text messages.",
       },
@@ -93,16 +96,25 @@ export function parseAgentPhoneConnectParams(
   }
 
   if (!/^\d+$/.test(tsRaw)) {
-    return invalidParams("The timestamp on this link is not valid.");
+    return invalidParams(
+      "invalid_timestamp",
+      "The timestamp on this link is not valid.",
+    );
   }
 
   const timestamp = Number(tsRaw);
   if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
-    return invalidParams("The timestamp on this link is not valid.");
+    return invalidParams(
+      "invalid_timestamp",
+      "The timestamp on this link is not valid.",
+    );
   }
 
   if (!/^[0-9a-f]{64}$/i.test(signature)) {
-    return invalidParams("The signature on this link is not valid.");
+    return invalidParams(
+      "invalid_signature",
+      "The signature on this link is not valid.",
+    );
   }
 
   const params: AgentPhoneConnectParams = {

--- a/turbo/apps/platform/src/signals/zero-page/github-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-connect-params.ts
@@ -7,6 +7,13 @@ export interface GithubConnectParams {
 }
 
 interface GithubConnectParamError {
+  code:
+    | "incomplete"
+    | "invalid_installation"
+    | "invalid_signature"
+    | "invalid_timestamp"
+    | "invalid_user"
+    | "invalid_username";
   title: string;
   message: string;
 }
@@ -65,6 +72,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "incomplete",
         title: "Connect link is incomplete",
         message: "Open a fresh GitHub connect link and try again.",
       },
@@ -76,6 +84,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_installation",
         title: "Connect link is invalid",
         message: "The GitHub installation on this link is not valid.",
       },
@@ -87,6 +96,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_user",
         title: "Connect link is invalid",
         message: "The GitHub user on this link is not valid.",
       },
@@ -98,6 +108,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_timestamp",
         title: "Connect link is invalid",
         message: "The timestamp on this link is not valid.",
       },
@@ -110,6 +121,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_timestamp",
         title: "Connect link is invalid",
         message: "The timestamp on this link is not valid.",
       },
@@ -121,6 +133,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_signature",
         title: "Connect link is invalid",
         message: "The signature on this link is not valid.",
       },
@@ -132,6 +145,7 @@ export function parseGithubConnectParams(
       ok: false,
       returnPath: "/github/connect",
       error: {
+        code: "invalid_username",
         title: "Connect link is invalid",
         message: "The GitHub username on this link is not valid.",
       },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -27,7 +27,7 @@ function fallbackCategoryLabel(category: string): string {
       return part.charAt(0).toUpperCase() + part.slice(1);
     })
     .join(" ");
-  return label || "Other";
+  return label;
 }
 
 function sortedCategoryConnectors<
@@ -53,6 +53,7 @@ export function groupConnectorsByCategory<
 >(
   connectors: readonly T[],
   categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined,
+  otherCategoryLabel = "Other",
 ): ConnectorCategoryGroup<T>[] {
   const grouped = new Map<string, T[]>();
 
@@ -91,7 +92,7 @@ export function groupConnectorsByCategory<
     if (groupedCategoryIds.has(category)) {
       continue;
     }
-    const label = fallbackCategoryLabel(category);
+    const label = fallbackCategoryLabel(category) || otherCategoryLabel;
     categorySections.push({
       category,
       label,
@@ -134,9 +135,10 @@ export function groupConnectorsByCategory<
     }
 
     const metadata = groupMetadata.get(section.groupId);
-    const label = metadata?.label ?? fallbackCategoryLabel(section.groupId);
-    const menuLabel =
-      metadata?.menuLabel ?? fallbackCategoryLabel(section.groupId);
+    const fallbackGroupLabel =
+      fallbackCategoryLabel(section.groupId) || otherCategoryLabel;
+    const label = metadata?.label ?? fallbackGroupLabel;
+    const menuLabel = metadata?.menuLabel ?? fallbackGroupLabel;
     groups.push({
       id: section.groupId,
       kind: "group",

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -68,6 +68,7 @@ import { sanitizeTokenInputRecord } from "./token-input.ts";
 import { IN_VITEST } from "../../../env.ts";
 import { connectorRedirectingPath } from "../../connectors-page/connector-redirecting.ts";
 import { isConnectorChangedPayloadFor } from "../../connector-change.ts";
+import { i18n } from "../../../i18n/index.ts";
 
 // TODO(#23619): Rename only with the persisted browser storage key.
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
@@ -330,10 +331,6 @@ export function connectorCurrentConnectionStatus(
   return connector.connectionStatus;
 }
 
-function formatExpiryCountdown(value: number, unit: "day" | "hour"): string {
-  return `Expires in ${value} ${unit}${value === 1 ? "" : "s"}`;
-}
-
 export function connectorExpiryCountdownText(
   connector: PublicConnectorCatalogStatusItem,
   nowMs = now(),
@@ -350,12 +347,24 @@ export function connectorExpiryCountdownText(
   }
   const remainingMs = tokenExpiresAtMs - nowMs;
   if (remainingMs >= DAY_MS) {
-    return formatExpiryCountdown(Math.ceil(remainingMs / DAY_MS), "day");
+    return i18n.t(
+      ($) => {
+        return $.connectors.expiration.inDays;
+      },
+      { count: Math.ceil(remainingMs / DAY_MS) },
+    );
   }
   if (remainingMs < HOUR_MS) {
-    return "Expires in less than 1 hour";
+    return i18n.t(($) => {
+      return $.connectors.expiration.lessThanHour;
+    });
   }
-  return formatExpiryCountdown(Math.ceil(remainingMs / HOUR_MS), "hour");
+  return i18n.t(
+    ($) => {
+      return $.connectors.expiration.inHours;
+    },
+    { count: Math.ceil(remainingMs / HOUR_MS) },
+  );
 }
 
 /**
@@ -869,7 +878,12 @@ const finishConnectorConnection$ = command(
     if (options.toastMessage !== null) {
       toast.success(
         options.toastMessage ??
-          `${options.connectorLabel ?? connectorSlug} connected`,
+          i18n.t(
+            ($) => {
+              return $.connectors.toasts.connected;
+            },
+            { connector: options.connectorLabel ?? connectorSlug },
+          ),
         {
           id: `connector-connected-${connectorSlug}`,
         },
@@ -1134,9 +1148,17 @@ export const disconnectConnector$ = command(
       next.delete(connectorSlug);
       return next;
     });
-    toast.success(`${connectorLabel} disconnected`, {
-      id: `connector-disconnected-${connectorSlug}`,
-    });
+    toast.success(
+      i18n.t(
+        ($) => {
+          return $.connectors.toasts.disconnected;
+        },
+        { connector: connectorLabel },
+      ),
+      {
+        id: `connector-disconnected-${connectorSlug}`,
+      },
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -9,6 +9,7 @@ import {
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { sanitizeTokenInput } from "./token-input.ts";
+import { i18n } from "../../../i18n/index.ts";
 
 const internalReload$ = state(0);
 
@@ -67,7 +68,14 @@ export const createCustomConnector$ = command(
       [201],
     );
     set(bumpReload$);
-    toast.success(`Created "${result.body.displayName}"`);
+    toast.success(
+      i18n.t(
+        ($) => {
+          return $.connectors.custom.toasts.created;
+        },
+        { connector: result.body.displayName },
+      ),
+    );
     return result.body;
   },
 );
@@ -84,7 +92,11 @@ export const deleteCustomConnector$ = command(
       [204],
     );
     set(bumpReload$);
-    toast.success("Custom connector deleted");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.custom.toasts.deleted;
+      }),
+    );
   },
 );
 
@@ -105,7 +117,14 @@ export const renameCustomConnector$ = command(
       [200],
     );
     set(bumpReload$);
-    toast.success(`Renamed to "${result.body.displayName}"`);
+    toast.success(
+      i18n.t(
+        ($) => {
+          return $.connectors.custom.toasts.renamed;
+        },
+        { connector: result.body.displayName },
+      ),
+    );
     return result.body;
   },
 );
@@ -127,7 +146,11 @@ export const setCustomConnectorSecret$ = command(
       [204],
     );
     set(bumpReload$);
-    toast.success("Connected");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.custom.toasts.connected;
+      }),
+    );
   },
 );
 
@@ -143,7 +166,11 @@ export const clearCustomConnectorSecret$ = command(
       [204],
     );
     set(bumpReload$);
-    toast.success("Disconnected");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.custom.toasts.disconnected;
+      }),
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/telegram-connect-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-connect-params.ts
@@ -10,6 +10,12 @@ export interface TelegramConnectParams {
 }
 
 interface TelegramConnectParamError {
+  code:
+    | "incomplete"
+    | "invalid_signature"
+    | "invalid_timestamp"
+    | "invalid_user"
+    | "invalid_username";
   title: string;
   message: string;
 }
@@ -101,6 +107,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "incomplete",
         title: "Connect link is incomplete",
         message: "Open a fresh /connect link from Telegram and try again.",
       },
@@ -121,6 +128,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "incomplete",
         title: "Connect link is incomplete",
         message: "Open a fresh /connect link from Telegram and try again.",
       },
@@ -132,6 +140,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "invalid_user",
         title: "Connect link is invalid",
         message: "The Telegram user on this link is not valid.",
       },
@@ -143,6 +152,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "invalid_timestamp",
         title: "Connect link is invalid",
         message: "The timestamp on this link is not valid.",
       },
@@ -155,6 +165,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "invalid_timestamp",
         title: "Connect link is invalid",
         message: "The timestamp on this link is not valid.",
       },
@@ -166,6 +177,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "invalid_signature",
         title: "Connect link is invalid",
         message: "The signature on this link is not valid.",
       },
@@ -177,6 +189,7 @@ export function parseTelegramConnectParams(
       ok: false,
       returnPath: "/telegram/connect",
       error: {
+        code: "invalid_username",
         title: "Connect link is invalid",
         message: "The Telegram username on this link is not valid.",
       },

--- a/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
@@ -8,6 +8,7 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { i18n } from "../../i18n/index.ts";
 
 const internalReload$ = state(0);
 const internalPhoneForm$ = state("");
@@ -53,7 +54,9 @@ export const agentPhonePhoneFormError$ = computed((get) => {
   }
   return isValidAgentPhoneHandle(get(agentPhonePhoneFormNormalized$))
     ? null
-    : "Enter a phone number with country code, like +1 555 555 1212.";
+    : i18n.t(($) => {
+        return $.connectors.providerSettings.errors.agentphonePhone;
+      });
 });
 
 export const setAgentPhonePhoneForm$ = command(({ set }, value: string) => {
@@ -113,11 +116,19 @@ function toastAgentPhoneStatusChange(
   next: AgentPhoneLinkStatusResponse,
 ): void {
   if (next.linked && !previous.linked) {
-    toast.success("AgentPhone connected");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.agentphoneConnected;
+      }),
+    );
     return;
   }
   if (!next.linked && previous.linked) {
-    toast.success("AgentPhone disconnected");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.agentphoneDisconnected;
+      }),
+    );
   }
 }
 
@@ -165,7 +176,9 @@ export const startAgentPhoneLink$ = command(
     const phoneHandle = get(agentPhonePhoneFormNormalized$);
     if (!isValidAgentPhoneHandle(phoneHandle)) {
       throw new Error(
-        "Enter a phone number with country code, like +1 555 555 1212.",
+        i18n.t(($) => {
+          return $.connectors.providerSettings.errors.agentphonePhone;
+        }),
       );
     }
 
@@ -182,7 +195,11 @@ export const startAgentPhoneLink$ = command(
     );
     signal.throwIfAborted();
     set(reloadAgentPhoneLinkStatus$);
-    toast.success("Verification text sent");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.agentphoneVerificationSent;
+      }),
+    );
     return { phoneHandle, verificationSent: true };
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
@@ -9,6 +9,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { i18n } from "../../i18n/index.ts";
 
 const reload$ = state(0);
 const internalDialogOpen$ = state(false);
@@ -115,7 +116,11 @@ export const disconnectFeishuOrg$ = command(
     set(reload$, (value) => {
       return value + 1;
     });
-    toast.success("Disconnected from Feishu");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.feishuDisconnected;
+      }),
+    );
   },
 );
 
@@ -324,7 +329,11 @@ export const completeFeishuInstallationSetup$ = command(
     set(reload$, (value) => {
       return value + 1;
     });
-    toast.success("Feishu bot installed successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.feishuBotInstalled;
+      }),
+    );
   },
 );
 
@@ -342,7 +351,11 @@ export const uninstallFeishuInstallation$ = command(
     set(reload$, (value) => {
       return value + 1;
     });
-    toast.success("Feishu bot uninstalled");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.feishuBotUninstalled;
+      }),
+    );
   },
 );
 
@@ -364,7 +377,11 @@ export const showFeishuSettingsResult$ = command(() => {
   if (error) {
     toast.error(error);
   } else if (params.get("status") === "connected") {
-    toast.success("Feishu connected successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.feishuConnected;
+      }),
+    );
   } else {
     return;
   }
@@ -397,7 +414,11 @@ export const startFeishuSettingsRealtime$ = command(
           );
         })
       ) {
-        toast.success("Feishu connected successfully");
+        toast.success(
+          i18n.t(($) => {
+            return $.connectors.providerSettings.toasts.feishuConnected;
+          }),
+        );
       }
       return false;
     });

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -8,6 +8,7 @@ import {
 import { now } from "../../lib/time.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
+import { i18n } from "../../i18n/index.ts";
 
 interface GithubIntegrationMissingData extends GithubInstallationNotFoundResponse {
   readonly isInstalled: false;
@@ -67,7 +68,11 @@ function openGithubOAuthWindow(): Pick<Window, "closed" | "location"> {
   const authWindow = window.open("about:blank", "_blank", popupFeatures);
 
   if (!authWindow && !standalone) {
-    throw new Error("Failed to open authorization window");
+    throw new Error(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.errors.githubAuthorizationWindow;
+      }),
+    );
   }
 
   if (authWindow) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -7,6 +7,7 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { i18n } from "../../i18n/index.ts";
 
 const internalReload$ = state(0);
 const internalSlackStatus$ = state<SlackOrgStatus | null>(null);
@@ -40,22 +41,42 @@ function toastSlackStatusChange(
   next: SlackOrgStatus,
 ): void {
   if (next.isConnected && !previous.isConnected) {
-    toast.success("Slack connected successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackConnected;
+      }),
+    );
     return;
   }
   if (next.isInstalled && !previous.isInstalled) {
-    toast.success("Slack installed successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackInstalled;
+      }),
+    );
     return;
   }
   if (!next.isInstalled && previous.isInstalled) {
-    toast.success("Slack workspace uninstalled");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackUninstalled;
+      }),
+    );
     return;
   }
   if (!next.isConnected && previous.isConnected) {
-    toast.success("Disconnected from Slack");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackDisconnected;
+      }),
+    );
     return;
   }
-  toast.success("Slack updated");
+  toast.success(
+    i18n.t(($) => {
+      return $.connectors.providerSettings.toasts.slackUpdated;
+    }),
+  );
 }
 
 /** True when the org-scoped Slack installation has outdated bot scopes (admin-only). */
@@ -135,14 +156,26 @@ export const watchSlackConnection$ = command(
 export const initSlackOrg$ = command((_ctx) => {
   const params = new URLSearchParams(window.location.search);
   if (params.get("updated") === "1") {
-    toast.success("Permissions updated");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackPermissionsUpdated;
+      }),
+    );
     window.history.replaceState({}, "", window.location.pathname);
   } else if (params.get("installed") === "1") {
-    toast.success("Slack installed successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackInstalled;
+      }),
+    );
     window.history.replaceState({}, "", window.location.pathname);
   }
   if (params.get("connected") === "1") {
-    toast.success("Slack connected successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.slackConnected;
+      }),
+    );
     window.history.replaceState({}, "", window.location.pathname);
   }
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-teams.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-teams.ts
@@ -7,6 +7,7 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { i18n } from "../../i18n/index.ts";
 
 const internalReload$ = state(0);
 const internalTeamsStatus$ = state<TeamsConnectStatus | null>(null);
@@ -40,22 +41,42 @@ function toastTeamsStatusChange(
   next: TeamsConnectStatus,
 ): void {
   if (next.isConnected && !previous.isConnected) {
-    toast.success("Microsoft Teams connected successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.teamsConnected;
+      }),
+    );
     return;
   }
   if (next.isInstalled && !previous.isInstalled) {
-    toast.success("Microsoft Teams installed successfully");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.teamsInstalled;
+      }),
+    );
     return;
   }
   if (!next.isInstalled && previous.isInstalled) {
-    toast.success("Microsoft Teams integration uninstalled");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.teamsUninstalled;
+      }),
+    );
     return;
   }
   if (!next.isConnected && previous.isConnected) {
-    toast.success("Disconnected from Microsoft Teams");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.teamsDisconnected;
+      }),
+    );
     return;
   }
-  toast.success("Microsoft Teams updated");
+  toast.success(
+    i18n.t(($) => {
+      return $.connectors.providerSettings.toasts.teamsUpdated;
+    }),
+  );
 }
 
 const showTeamsUninstallDialogState$ = state(false);

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -10,6 +10,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { writeToClipboard } from "./clipboard.ts";
+import { i18n } from "../../i18n/index.ts";
 
 export type TelegramAddSetupStep = "token" | "domain" | "privacy" | "create";
 export type TelegramSetupCheckTarget = "token" | "domain" | "privacy";
@@ -97,9 +98,13 @@ function isTelegramSetupCheckSatisfied(
 
 function getTelegramSetupCheckFailureMessage(target: TelegramSetupCheckTarget) {
   if (target === "domain") {
-    return "Domain is not visible to Telegram yet. Check BotFather and try again.";
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.errors.telegramDomain;
+    });
   }
-  return "Privacy mode still appears to be on. Turn it off in BotFather, then try again.";
+  return i18n.t(($) => {
+    return $.connectors.providerSettings.errors.telegramPrivacy;
+  });
 }
 
 export const telegramBotTokenForm$ = computed((get) => {
@@ -339,7 +344,11 @@ export const registerTelegramBot$ = command(
     );
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Telegram bot added");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramBotAdded;
+      }),
+    );
     return (result as { body: TelegramBotStatus }).body;
   },
 );
@@ -423,7 +432,11 @@ export const reinstallTelegramBot$ = command(
     );
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Telegram bot reinstalled");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramBotReinstalled;
+      }),
+    );
     return (result as { body: TelegramBotStatus }).body;
   },
 );
@@ -436,7 +449,11 @@ export const updateTelegramBotAgent$ = command(
       | { botId: string; selectedAgentId: string | null },
     signal: AbortSignal,
   ): Promise<TelegramBotStatus> => {
-    const toastId = toast.loading("Updating default agent...");
+    const toastId = toast.loading(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramUpdatingAgent;
+      }),
+    );
     signal.addEventListener("abort", () => {
       return toast.dismiss(toastId);
     });
@@ -455,7 +472,12 @@ export const updateTelegramBotAgent$ = command(
     );
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Default agent updated", { id: toastId });
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramAgentUpdated;
+      }),
+      { id: toastId },
+    );
     return result.body;
   },
 );
@@ -473,7 +495,11 @@ export const disconnectTelegramAccount$ = command(
     );
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Telegram account disconnected");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramDisconnected;
+      }),
+    );
   },
 );
 
@@ -490,6 +516,10 @@ export const uninstallTelegramBot$ = command(
     );
     signal.throwIfAborted();
     set(reloadTelegramBots$);
-    toast.success("Telegram bot uninstalled");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.telegramBotUninstalled;
+      }),
+    );
   },
 );

--- a/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
@@ -1,6 +1,7 @@
 import { IconCheck, IconLoader2, IconWorld } from "@tabler/icons-react";
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { Button } from "@vm0/ui/components/ui/button";
 
 import {
@@ -9,27 +10,32 @@ import {
 } from "../../signals/browser-authorization/browser-authorization.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { locale$ } from "../../signals/locale.ts";
 import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
 
-function formatTime(value: string): string {
-  return new Date(value).toLocaleString(undefined, {
+function formatTime(value: string, locale: string): string {
+  return new Date(value).toLocaleString(locale, {
     dateStyle: "medium",
     timeStyle: "short",
   });
 }
 
 function ErrorState() {
+  const { t } = useTranslation();
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center px-4">
       <div className="flex w-[430px] max-w-full flex-col items-center gap-6 rounded-xl border border-border bg-background px-6 py-10 text-center">
         <Vm0LogoLink />
         <div className="flex flex-col gap-2">
           <h1 className="text-lg font-medium text-foreground">
-            Authorization link unavailable
+            {t(($) => {
+              return $.authorization.browser.unavailableTitle;
+            })}
           </h1>
           <p className="text-sm leading-5 text-muted-foreground">
-            This cloud browser authorization link is invalid, expired, or not
-            available for this workspace.
+            {t(($) => {
+              return $.authorization.browser.unavailableDescription;
+            })}
           </p>
         </div>
       </div>
@@ -38,6 +44,8 @@ function ErrorState() {
 }
 
 export function BrowserAuthorizationPage() {
+  const { t } = useTranslation();
+  const locale = useGet(locale$);
   const pageSignal = useGet(pageSignal$);
   const requestLoadable = useLoadable(browserAuthorizationRequest$);
   const [applyLoadable, applyAuthorization] = useLoadableSet(
@@ -73,11 +81,14 @@ export function BrowserAuthorizationPage() {
           </div>
           <div className="flex flex-col gap-2">
             <h1 className="text-lg font-medium text-foreground">
-              Enable cloud browser
+              {t(($) => {
+                return $.authorization.browser.title;
+              })}
             </h1>
             <p className="mx-auto max-w-md text-sm leading-5 text-muted-foreground">
-              Zero will use an isolated cloud browser profile for this chat
-              thread. Enabling it disconnects Computer Use for the thread.
+              {t(($) => {
+                return $.authorization.browser.description;
+              })}
             </p>
           </div>
         </div>
@@ -97,11 +108,22 @@ export function BrowserAuthorizationPage() {
           ) : (
             <IconWorld size={16} />
           )}
-          {enabled ? "Cloud browser enabled" : "Enable for this thread"}
+          {enabled
+            ? t(($) => {
+                return $.authorization.browser.enabled;
+              })
+            : t(($) => {
+                return $.authorization.browser.enable;
+              })}
         </Button>
 
         <div className="border-t border-border pt-5 text-xs text-muted-foreground">
-          Link expires {formatTime(request.expiresAt)}.
+          {t(
+            ($) => {
+              return $.authorization.browser.linkExpires;
+            },
+            { date: formatTime(request.expiresAt, locale) },
+          )}
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
+++ b/turbo/apps/platform/src/views/components/permission-grant-duration-select.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
   cn,
 } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 import {
   parseUserPermissionGrantExpiresIn,
   USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS,
@@ -25,6 +26,7 @@ export function PermissionGrantDurationSelect({
   ariaLabel: string;
   className?: string;
 }) {
+  const { t } = useTranslation();
   return (
     <Select
       value={value}
@@ -44,9 +46,27 @@ export function PermissionGrantDurationSelect({
       </SelectTrigger>
       <SelectContent>
         {USER_PERMISSION_GRANT_EXPIRES_IN_OPTIONS.map((option) => {
+          const label =
+            option === "1h"
+              ? t(($) => {
+                  return $.authorization.permission.durationOptions.oneHour;
+                })
+              : option === "24h"
+                ? t(($) => {
+                    return $.authorization.permission.durationOptions
+                      .twentyFourHours;
+                  })
+                : option === "7d"
+                  ? t(($) => {
+                      return $.authorization.permission.durationOptions
+                        .sevenDays;
+                    })
+                  : t(($) => {
+                      return $.authorization.permission.durationOptions.always;
+                    });
           return (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
+            <SelectItem key={option} value={option}>
+              {label}
             </SelectItem>
           );
         })}

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -12,6 +12,7 @@ import type {
   ComputerUseHost,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
 import { Button } from "@vm0/ui/components/ui/button";
+import { useTranslation } from "react-i18next";
 import {
   applyComputerUseAuthorizationRequest$,
   computerUseAuthorizationRequest$,
@@ -20,16 +21,16 @@ import {
   zeroDesktopDownloadSupportStatus$,
   visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
-  ZERO_DESKTOP_MACOS_REQUIREMENT_LABEL,
-  ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { computerUseIllustrationImg } from "../zero-page/platform-assets.ts";
 import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
+import { locale$ } from "../../signals/locale.ts";
+import { i18n } from "../../i18n/index.ts";
 
-function formatTime(value: string): string {
-  return new Date(value).toLocaleString(undefined, {
+function formatTime(value: string, locale: string): string {
+  return new Date(value).toLocaleString(locale, {
     dateStyle: "medium",
     timeStyle: "short",
   });
@@ -38,13 +39,19 @@ function formatTime(value: string): string {
 function sourceLabel(source: ComputerUseAuthorizationSource): string {
   switch (source) {
     case "chat": {
-      return "this chat thread";
+      return i18n.t(($) => {
+        return $.authorization.computerUse.sources.chat;
+      });
     }
     case "slack": {
-      return "this Slack thread";
+      return i18n.t(($) => {
+        return $.authorization.computerUse.sources.slack;
+      });
     }
     case "teams": {
-      return "this Teams thread";
+      return i18n.t(($) => {
+        return $.authorization.computerUse.sources.teams;
+      });
     }
   }
 }
@@ -62,6 +69,8 @@ function HostOption({
   applied: boolean;
   onAuthorize: () => void;
 }) {
+  const { t } = useTranslation();
+  const locale = useGet(locale$);
   return (
     <div className="flex w-full flex-col gap-3 rounded-lg border border-border bg-background px-3 py-3 text-left sm:flex-row sm:items-center sm:justify-between">
       <div className="flex min-w-0 items-center gap-3">
@@ -73,7 +82,12 @@ function HostOption({
             {host.displayName}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">
-            Last seen {formatTime(host.lastSeenAt)}
+            {t(
+              ($) => {
+                return $.authorization.computerUse.lastSeen;
+              },
+              { date: formatTime(host.lastSeenAt, locale) },
+            )}
           </div>
         </div>
       </div>
@@ -88,10 +102,14 @@ function HostOption({
         {applied ? (
           <>
             <IconCheck size={16} />
-            Authorized
+            {t(($) => {
+              return $.authorization.computerUse.authorized;
+            })}
           </>
         ) : (
-          "Authorize"
+          t(($) => {
+            return $.authorization.computerUse.authorize;
+          })
         )}
       </Button>
     </div>
@@ -99,6 +117,7 @@ function HostOption({
 }
 
 function EmptyHosts() {
+  const { t } = useTranslation();
   const downloadSupportLoadable = useLoadable(
     zeroDesktopDownloadSupportStatus$,
   );
@@ -118,24 +137,33 @@ function EmptyHosts() {
       </div>
       <div className="flex max-w-sm flex-col gap-1">
         <h2 className="text-sm font-medium text-foreground">
-          No online computers
+          {t(($) => {
+            return $.authorization.computerUse.noHostsTitle;
+          })}
         </h2>
         <p className="text-sm leading-5 text-muted-foreground">
-          Open Zero Computer Use on your Mac and refresh this page when it comes
-          online.
+          {t(($) => {
+            return $.authorization.computerUse.noHostsDescription;
+          })}
         </p>
         <p className="text-sm leading-5 text-muted-foreground">
-          {ZERO_DESKTOP_MACOS_REQUIREMENT_LABEL}
+          {t(($) => {
+            return $.authorization.computerUse.macRequirement;
+          })}
         </p>
       </div>
       {downloadSupportStatus === "unsupported-intel-mac" ? (
         <Button type="button" variant="outline" disabled className="h-9">
           <IconAlertTriangle size={16} />
-          {ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL}
+          {t(($) => {
+            return $.authorization.computerUse.unsupportedIntelMac;
+          })}
         </Button>
       ) : downloadSupportStatus === "checking" ? (
         <Button type="button" variant="outline" disabled className="h-9">
-          Checking compatibility
+          {t(($) => {
+            return $.authorization.computerUse.checkingCompatibility;
+          })}
         </Button>
       ) : (
         <a
@@ -145,7 +173,9 @@ function EmptyHosts() {
           className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
         >
           <IconDownload size={16} />
-          Download for macOS
+          {t(($) => {
+            return $.authorization.computerUse.downloadMac;
+          })}
         </a>
       )}
     </div>
@@ -153,17 +183,21 @@ function EmptyHosts() {
 }
 
 function ErrorState() {
+  const { t } = useTranslation();
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center px-4">
       <div className="flex w-[430px] max-w-full flex-col items-center gap-6 rounded-xl border border-border bg-background px-6 py-10 text-center">
         <Vm0LogoLink />
         <div className="flex flex-col gap-2">
           <h1 className="text-lg font-medium text-foreground">
-            Authorization link unavailable
+            {t(($) => {
+              return $.authorization.computerUse.unavailableTitle;
+            })}
           </h1>
           <p className="text-sm leading-5 text-muted-foreground">
-            This Computer Use authorization link is invalid, expired, or not
-            available for this workspace.
+            {t(($) => {
+              return $.authorization.computerUse.unavailableDescription;
+            })}
           </p>
         </div>
       </div>
@@ -172,6 +206,8 @@ function ErrorState() {
 }
 
 export function ComputerUseAuthorizationPage() {
+  const { t } = useTranslation();
+  const locale = useGet(locale$);
   const pageSignal = useGet(pageSignal$);
   const requestLoadable = useLoadable(computerUseAuthorizationRequest$);
   const [applyLoadable, applyAuthorization] = useLoadableSet(
@@ -212,11 +248,17 @@ export function ComputerUseAuthorizationPage() {
           </div>
           <div className="flex flex-col gap-2">
             <h1 className="text-lg font-medium text-foreground">
-              Authorize computer use
+              {t(($) => {
+                return $.authorization.computerUse.title;
+              })}
             </h1>
             <p className="mx-auto max-w-md text-sm leading-5 text-muted-foreground">
-              Choose an online computer for Zero to use in{" "}
-              {sourceLabel(request.source)}.
+              {t(
+                ($) => {
+                  return $.authorization.computerUse.description;
+                },
+                { source: sourceLabel(request.source) },
+              )}
             </p>
           </div>
         </div>
@@ -247,7 +289,12 @@ export function ComputerUseAuthorizationPage() {
 
         <div className="flex flex-col gap-3 border-t border-border pt-5">
           <div className="text-xs text-muted-foreground">
-            Link expires {formatTime(request.expiresAt)}.
+            {t(
+              ($) => {
+                return $.authorization.computerUse.linkExpires;
+              },
+              { date: formatTime(request.expiresAt, locale) },
+            )}
           </div>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { Button } from "@vm0/ui";
 import {
   IconAlertTriangle,
@@ -47,6 +48,7 @@ import {
   runChatActionCallback$,
   type ChatActionCallback,
 } from "../../signals/chat-page/action-callback.ts";
+import { i18n } from "../../i18n/index.ts";
 
 function TargetPill({
   avatarUrl,
@@ -86,7 +88,11 @@ function resolvePermissionGrantTarget({
   agent: PermissionAllowAgent;
 }): { target: PermissionGrantTarget } | { message: string } {
   if (!agent) {
-    return { message: "Agent not found" };
+    return {
+      message: i18n.t(($) => {
+        return $.authorization.permission.errors.agentNotFound;
+      }),
+    };
   }
   return {
     target: {
@@ -167,21 +173,38 @@ function ResultCard({
   expiresAt?: string | null;
   showExpiry: boolean;
 }) {
+  const { t } = useTranslation();
   const allowed = action === "allow";
   const title = alreadyApplied
     ? allowed
-      ? "Already allowed"
-      : "Already denied"
+      ? t(($) => {
+          return $.authorization.permission.result.alreadyAllowedTitle;
+        })
+      : t(($) => {
+          return $.authorization.permission.result.alreadyDeniedTitle;
+        })
     : allowed
-      ? "Permissions updated"
-      : "Permissions denied";
+      ? t(($) => {
+          return $.authorization.permission.result.updatedTitle;
+        })
+      : t(($) => {
+          return $.authorization.permission.result.deniedTitle;
+        });
   const description = alreadyApplied
     ? allowed
-      ? "Your connector permission grant is already allowed"
-      : "Your connector permission grant is already denied"
+      ? t(($) => {
+          return $.authorization.permission.result.alreadyAllowedDescription;
+        })
+      : t(($) => {
+          return $.authorization.permission.result.alreadyDeniedDescription;
+        })
     : allowed
-      ? "Your connector permission grant has been updated"
-      : "Your connector permission grant has been denied";
+      ? t(($) => {
+          return $.authorization.permission.result.updatedDescription;
+        })
+      : t(($) => {
+          return $.authorization.permission.result.deniedDescription;
+        });
   const expiryText = showExpiry
     ? permissionGrantExpiryText(expiresAt ?? null)
     : null;
@@ -240,7 +263,9 @@ function resolveUserName(
   if (user?.username) {
     return user.username;
   }
-  return "there";
+  return i18n.t(($) => {
+    return $.authorization.permission.userFallback;
+  });
 }
 
 function anyLoadableIsLoading(
@@ -261,13 +286,19 @@ function permissionAllowLoadErrorMessage({
   metadataState: string;
 }): string | null {
   if (targetState === "hasError") {
-    return "Failed to load agent";
+    return i18n.t(($) => {
+      return $.authorization.permission.errors.loadAgent;
+    });
   }
   if (grantsState === "hasError") {
-    return "Failed to load permission grants";
+    return i18n.t(($) => {
+      return $.authorization.permission.errors.loadGrants;
+    });
   }
   if (metadataState === "hasError") {
-    return "Failed to load permission metadata";
+    return i18n.t(($) => {
+      return $.authorization.permission.errors.loadMetadata;
+    });
   }
   return null;
 }
@@ -332,6 +363,35 @@ interface ConfirmGrantCardProps {
   actionCallback: ChatActionCallback;
 }
 
+function GrantDurationField({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: UserPermissionGrantExpiresIn;
+  disabled: boolean;
+  onChange: (value: UserPermissionGrantExpiresIn) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/70 px-3 py-2">
+      <span className="text-sm font-medium text-foreground">
+        {t(($) => {
+          return $.authorization.permission.duration;
+        })}
+      </span>
+      <PermissionGrantDurationSelect
+        value={value}
+        onValueChange={onChange}
+        disabled={disabled}
+        ariaLabel={t(($) => {
+          return $.authorization.permission.durationLabel;
+        })}
+      />
+    </div>
+  );
+}
+
 function ConfirmGrantCard({
   target,
   icon,
@@ -345,6 +405,7 @@ function ConfirmGrantCard({
   applyGrant,
   actionCallback,
 }: ConfirmGrantCardProps) {
+  const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const durationScope = `agent\u0000${target.id}\u0000${connectorSlug}\u0000${permission.name}\u0000${action}\u0000${initialExpiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
@@ -393,7 +454,12 @@ function ConfirmGrantCard({
 
         <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
-            {`Hey ${userName}, you're updating your permissions for ${target.displayName}.`}
+            {t(
+              ($) => {
+                return $.authorization.permission.greeting;
+              },
+              { userName, targetName: target.displayName },
+            )}
           </p>
 
           <TargetPill
@@ -402,7 +468,11 @@ function ConfirmGrantCard({
           />
 
           <div className="w-full flex flex-col gap-3">
-            <p className="text-sm font-medium text-foreground">Would like to</p>
+            <p className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.authorization.permission.wouldLike;
+              })}
+            </p>
             <ConnectorPermissionCard
               icon={icon}
               connectorLabel={connectorLabel}
@@ -411,19 +481,13 @@ function ConfirmGrantCard({
             />
           </div>
           {expirationAvailable && (
-            <div className="flex w-full items-center justify-between gap-3 rounded-lg border border-border/70 px-3 py-2">
-              <span className="text-sm font-medium text-foreground">
-                Duration
-              </span>
-              <PermissionGrantDurationSelect
-                value={expiresIn}
-                onValueChange={(value) => {
-                  setExpiresInForScope(durationScope, value);
-                }}
-                disabled={saving}
-                ariaLabel="Permission duration"
-              />
-            </div>
+            <GrantDurationField
+              value={expiresIn}
+              disabled={saving}
+              onChange={(value) => {
+                setExpiresInForScope(durationScope, value);
+              }}
+            />
           )}
         </div>
 
@@ -431,7 +495,11 @@ function ConfirmGrantCard({
           {saveError && (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-destructive">
               <IconAlertTriangle size={16} />
-              <span>Couldn&apos;t update permissions</span>
+              <span>
+                {t(($) => {
+                  return $.authorization.permission.errors.updateFailed;
+                })}
+              </span>
             </div>
           )}
           <Button
@@ -440,7 +508,13 @@ function ConfirmGrantCard({
             disabled={saving}
             className="h-9 w-full rounded-[10px]"
           >
-            {saving ? "Saving..." : "Confirm"}
+            {saving
+              ? t(($) => {
+                  return $.authorization.permission.saving;
+                })
+              : t(($) => {
+                  return $.authorization.permission.confirm;
+                })}
           </Button>
         </div>
       </div>
@@ -505,12 +579,30 @@ function PermissionAllowDoctorPage({
   const metadata =
     metadataLoadable.state === "hasData" ? metadataLoadable.data : null;
   if (!metadata) {
-    return <ErrorMessage message={`Unknown connector: ${connectorSlug}`} />;
+    return (
+      <ErrorMessage
+        message={i18n.t(
+          ($) => {
+            return $.authorization.permission.errors.unknownConnector;
+          },
+          { connector: connectorSlug },
+        )}
+      />
+    );
   }
 
   const focusedPermission = findPermissionInMetadata(metadata, permission);
   if (!focusedPermission) {
-    return <ErrorMessage message={`Unknown permission: ${permission}`} />;
+    return (
+      <ErrorMessage
+        message={i18n.t(
+          ($) => {
+            return $.authorization.permission.errors.unknownPermission;
+          },
+          { permission },
+        )}
+      />
+    );
   }
 
   if (savedGrant && isActiveUserPermissionGrant(savedGrant)) {
@@ -561,6 +653,7 @@ function PermissionAllowDoctorPage({
 }
 
 export function PermissionAllowPage() {
+  const { t } = useTranslation();
   const agentId = useGet(permissionAllowAgentId$);
   const connectorSlug = useGet(permissionAllowConnectorSlug$);
   const permission = useGet(permissionAllowPermission$);
@@ -570,16 +663,35 @@ export function PermissionAllowPage() {
   const actionCallback = useGet(routeChatActionCallback$);
 
   if (!agentId) {
-    return <ErrorMessage message="Missing agent ID in URL parameters" />;
+    return (
+      <ErrorMessage
+        message={t(($) => {
+          return $.authorization.permission.errors.missingAgentId;
+        })}
+      />
+    );
   }
 
   if (!connectorSlug || !permission) {
-    return <ErrorMessage message="Missing permission in URL parameters" />;
+    return (
+      <ErrorMessage
+        message={t(($) => {
+          return $.authorization.permission.errors.missingPermission;
+        })}
+      />
+    );
   }
 
   if (actionParam !== null && action === null) {
     return (
-      <ErrorMessage message={`Unknown permission action: ${actionParam}`} />
+      <ErrorMessage
+        message={t(
+          ($) => {
+            return $.authorization.permission.errors.unknownAction;
+          },
+          { action: actionParam },
+        )}
+      />
     );
   }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -2,8 +2,10 @@ import { connectorsSlugCallbackContract } from "@vm0/api-contracts/contracts/con
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@vm0/connectors/app-oauth-callback";
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { pathname, search } from "../../../signals/location.ts";
@@ -12,6 +14,11 @@ const context = testContext();
 const { set$: setConnectorAppOauthCallbackMetadata$ } = localStorageSignals(
   CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY,
 );
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 describe("connector callback page", () => {
   it("forwards provider parameters and renders a durable success page", async () => {
@@ -51,8 +58,9 @@ describe("connector callback page", () => {
       throw new Error("GitHub connector icon not found");
     }
     expect(connectorIcon).toHaveAttribute("src", githubIcon.url);
-    expect(screen.getByText("octocat")).toBeInTheDocument();
-    expect(screen.getByText(/You can close this window\./)).toBeInTheDocument();
+    expect(
+      screen.getByText("Connected as octocat. You can close this window."),
+    ).toBeInTheDocument();
     expect(observedQuery).toMatchObject({
       code: "oauth-code",
       state: "oauth-state",
@@ -104,6 +112,36 @@ describe("connector callback page", () => {
       expect(pathname()).toBe("/connectors/notion/callback/error");
     });
     expect(search()).toBe("?message=Provider+denied+access");
+  });
+
+  it("localizes connection failures in Portuguese while preserving provider errors", async () => {
+    document.documentElement.lang = "pt-BR";
+    context.mocks.api(
+      connectorsSlugCallbackContract.callback,
+      ({ respond }) => {
+        return respond(200, {
+          status: "error",
+          message: "Provider denied access",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors/notion/callback?error=access_denied",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "Não foi possível conectar NOTION",
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText(/Provider denied access/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Feche esta janela e tente novamente\./),
+    ).toBeInTheDocument();
   });
 
   it("restores a completed result page without replaying the callback", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -1,9 +1,11 @@
 import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -11,6 +13,11 @@ const MOBILE_WARNING =
   "The GitHub app may not support this OAuth link. Please complete this connection in the VM0 web app on a computer.";
 const IPHONE_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1";
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 function backToBrandLink(brandName: "VM0" | "Okou"): HTMLElement {
   const link = queryAllByRoleFast("link").find((candidate) => {
@@ -119,6 +126,25 @@ describe("connector redirecting page", () => {
       screen.getByText("Return to VM0 and try connecting again."),
     ).toBeInTheDocument();
     expect(backToBrandLink("VM0")).toHaveAttribute("href", "/");
+  });
+
+  it("localizes OAuth start failures in Portuguese", async () => {
+    document.documentElement.lang = "pt-BR";
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/redirecting?label=GitHub&status=error",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "Não foi possível abrir GitHub",
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText("Volte para VM0 e tente conectar novamente."),
+    ).toBeInTheDocument();
   });
 
   it("uses Okou copy on an Okou host", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -30,7 +30,7 @@ import type {
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -38,6 +38,8 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { search } from "../../../signals/location.ts";
 import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
@@ -48,6 +50,11 @@ import { submitManualGrant$ } from "../../../signals/zero-page/settings/connecto
 
 const context = testContext();
 const resetAfterManualGrantConnectSignal$ = resetSignal();
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 function createMockAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
@@ -455,6 +462,154 @@ describe("connectors page", () => {
       aiGroup.compareDocumentPosition(engineeringGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("localizes the catalog, reconnect state, and access management in Portuguese", async () => {
+    document.documentElement.lang = "pt-BR";
+    const researchAgentId = "c0000000-0000-4000-a000-000000000001";
+    mockConnectors([
+      { connectorSlug: "github", externalUsername: "octocat" },
+      {
+        connectorSlug: "meta-ads",
+        connectionStatus: "reconnect-required",
+        reconnectReason: "authorization_expired_or_revoked",
+      },
+    ]);
+    context.mocks.data.team([teamAgent(researchAgentId, "Research Agent")]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: ["github"] });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Conectores" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Buscar conectores"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Engenharia e execução da equipe"),
+    ).toBeInTheDocument();
+
+    const metaAdsCard = connectorCardByLabel("Meta Ads");
+    expect(
+      within(metaAdsCard).getByText("A conexão expirou"),
+    ).toBeInTheDocument();
+    click(within(metaAdsCard).getByLabelText("Mais opções"));
+    await waitFor(() => {
+      expect(menuItemByText("Reconectar")).toBeInTheDocument();
+    });
+
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Gerenciar acesso ao GitHub",
+      ),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Gerenciar acesso ao GitHub",
+    });
+    expect(
+      within(dialog).getByText(
+        "Escolha quais agentes podem usar este conector.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText(
+        "Revogar acesso ao GitHub para Research Agent",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("localizes the AI catalog subcategories in Portuguese", async () => {
+    document.documentElement.lang = "pt-BR";
+    mockConnectors([]);
+    mockPublicConnectorStatus(
+      [
+        publicStatusItem({
+          connectorSlug: "openai",
+          label: "OpenAI",
+          category: "ai-image-video",
+          authMethods: [],
+        }),
+        publicStatusItem({
+          connectorSlug: "elevenlabs",
+          label: "ElevenLabs",
+          category: "ai-voice-audio",
+          authMethods: [],
+        }),
+        publicStatusItem({
+          connectorSlug: "langfuse",
+          label: "Langfuse",
+          category: "ai-memory-tracing-eval",
+          authMethods: [],
+        }),
+        publicStatusItem({
+          connectorSlug: "axiom",
+          label: "Axiom",
+          category: "engineering-team-execution",
+          authMethods: [],
+        }),
+      ],
+      {
+        categories: [
+          {
+            id: "ai-image-video",
+            label: "Image / Video Generation",
+            menuLabel: "Image / Video",
+            groupId: "ai",
+          },
+          {
+            id: "ai-voice-audio",
+            label: "Voice / Audio",
+            menuLabel: "Voice / Audio",
+            groupId: "ai",
+          },
+          {
+            id: "ai-memory-tracing-eval",
+            label: "Memory / Tracing / Evaluation",
+            menuLabel: "Memory / Tracing",
+            groupId: "ai",
+          },
+          {
+            id: "engineering-team-execution",
+            label: "Engineering / Team Execution",
+            menuLabel: "Engineering",
+            groupId: null,
+          },
+        ],
+        groups: [{ id: "ai", label: "AI", menuLabel: "AI" }],
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await expect(
+      screen.findByRole("heading", {
+        name: "Geração de imagens e vídeos",
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Voz e áudio" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: "Memória, rastreamento e avaliação",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("connector-category-menu-ai-image-video"),
+    ).toHaveTextContent("Imagens e vídeos");
+    expect(
+      screen.getByTestId("connector-category-menu-ai-memory-tracing-eval"),
+    ).toHaveTextContent("Memória e avaliação");
   });
 
   it("renders connector icons from server-authored catalog descriptors", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-github-connect-page.test.tsx
@@ -58,14 +58,22 @@ describe("zero GitHub connect page", () => {
     await waitFor(() => {
       expect(screen.getByText("Connect to GitHub")).toBeInTheDocument();
     });
-    expect(screen.getByText("@octo-dev")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Link your VM0 account to @octo-dev so GitHub mentions can run your agents from issues and pull requests.",
+      ),
+    ).toBeInTheDocument();
 
     click(buttonByText("Connect"));
 
     await waitFor(() => {
       expect(screen.getByText("Connected to GitHub!")).toBeInTheDocument();
     });
-    expect(screen.getByText("@octo-dev")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You're connected as @octo-dev. Mention your agent in GitHub issues or pull requests to start chatting.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Back to workflows")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-telegram-connect-page.test.tsx
@@ -78,7 +78,11 @@ describe("zero Telegram connect page", () => {
     await waitFor(() => {
       expect(screen.getByText("Connected to Telegram!")).toBeInTheDocument();
     });
-    expect(screen.getByText("@agent_bot")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You're connected to @agent_bot. Send a message in Telegram to start chatting.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Open Telegram")).toBeInTheDocument();
     expect(screen.getByText("Back to Telegram settings")).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -34,6 +34,8 @@ import {
   TooltipTrigger,
 } from "@vm0/ui/components/ui/tooltip";
 import { Input } from "@vm0/ui/components/ui/input";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   agentPhoneLinkStatus$,
@@ -51,7 +53,6 @@ import {
   setAgentPhoneVerificationPhone$,
   startAgentPhoneLink$,
 } from "../../signals/zero-page/zero-agentphone.ts";
-import { AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE } from "../../signals/zero-page/agentphone-connect-params.ts";
 import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
@@ -73,21 +74,35 @@ function PhoneNumberCopyButton({
 }: {
   readonly phoneNumber: string;
 }) {
+  const { t } = useTranslation();
   const formatted = formatAgentPhoneNumber(phoneNumber);
 
   return (
     <button
       type="button"
-      aria-label={`Copy ${formatted}`}
+      aria-label={t(
+        ($) => {
+          return $.connectors.providerSettings.agentphone.copyAria;
+        },
+        { phone: formatted },
+      )}
       className="inline-flex items-center gap-1 rounded font-medium text-foreground transition-colors hover:text-foreground/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
       onClick={() => {
         detach(
           (async () => {
             const copied = await writeToClipboard(phoneNumber);
             if (copied) {
-              toast.success("Phone number copied");
+              toast.success(
+                i18n.t(($) => {
+                  return $.connectors.providerSettings.agentphone.copySuccess;
+                }),
+              );
             } else {
-              toast.error("Failed to copy phone number");
+              toast.error(
+                i18n.t(($) => {
+                  return $.connectors.providerSettings.agentphone.copyError;
+                }),
+              );
             }
           })(),
           Reason.DomCallback,
@@ -107,6 +122,7 @@ function AgentPhoneVerificationStatus({
   readonly verificationPhone: string | null;
   readonly connecting: boolean;
 }) {
+  const { t } = useTranslation();
   if (!verificationPhone) {
     return null;
   }
@@ -123,8 +139,12 @@ function AgentPhoneVerificationStatus({
           <IconCircleCheck size={14} className="shrink-0 text-green-600" />
         )}
         <span>
-          Verification text sent to {verificationPhone}. Open the link in that
-          text to finish connecting.
+          {t(
+            ($) => {
+              return $.connectors.providerSettings.agentphone.verificationSent;
+            },
+            { phone: verificationPhone },
+          )}
         </span>
       </span>
     </div>
@@ -144,6 +164,7 @@ function AgentPhoneConnectActions({
   readonly phoneError: string | null;
   readonly onCancel: () => void;
 }) {
+  const { t } = useTranslation();
   const busy = starting || connecting;
 
   return (
@@ -154,7 +175,9 @@ function AgentPhoneConnectActions({
         disabled={starting}
         onClick={onCancel}
       >
-        Cancel
+        {t(($) => {
+          return $.connectors.actions.cancel;
+        })}
       </Button>
       <Button
         type="submit"
@@ -162,16 +185,49 @@ function AgentPhoneConnectActions({
       >
         {busy ? <IconLoader2 size={14} className="animate-spin" /> : null}
         {starting
-          ? "Sending..."
+          ? t(($) => {
+              return $.connectors.providerSettings.agentphone.sending;
+            })
           : connecting
-            ? "Connecting..."
-            : "Send verification"}
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.providerSettings.agentphone
+                  .sendVerification;
+              })}
       </Button>
     </DialogFooter>
   );
 }
 
+function AgentPhoneConnectIntro() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {t(($) => {
+            return $.connectors.providerSettings.agentphone.connectTitle;
+          })}
+        </DialogTitle>
+        <DialogDescription>
+          {t(($) => {
+            return $.connectors.providerSettings.agentphone.connectDescription;
+          })}
+        </DialogDescription>
+      </DialogHeader>
+      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
+        {t(($) => {
+          return $.connectors.providerSettings.agentphone.risk;
+        })}
+      </div>
+    </>
+  );
+}
+
 function AgentPhoneConnectDialog() {
+  const { t } = useTranslation();
   const open = useGet(agentPhoneConnectDialogOpen$);
   const phoneForm = useGet(agentPhonePhoneForm$);
   const normalizedPhone = useLastResolved(agentPhonePhoneFormNormalized$) ?? "";
@@ -222,22 +278,15 @@ function AgentPhoneConnectDialog() {
   return (
     <Dialog open={open} onOpenChange={close}>
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Connect phone</DialogTitle>
-          <DialogDescription>
-            Enter your phone number. We will text a verification link that
-            connects this workspace.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
-          {AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE}
-        </div>
+        <AgentPhoneConnectIntro />
         <form className="grid gap-3" onSubmit={submit}>
           <label
             htmlFor="agentphone-phone-input"
             className="text-sm font-medium text-foreground"
           >
-            Phone number
+            {t(($) => {
+              return $.connectors.providerSettings.agentphone.phoneNumber;
+            })}
           </label>
           <Input
             id="agentphone-phone-input"
@@ -263,7 +312,12 @@ function AgentPhoneConnectDialog() {
               className="text-xs text-muted-foreground"
               data-testid="agentphone-normalized-phone"
             >
-              We will text {normalizedPhone}.
+              {t(
+                ($) => {
+                  return $.connectors.providerSettings.agentphone.normalized;
+                },
+                { phone: normalizedPhone },
+              )}
             </p>
           ) : null}
           {visiblePhoneError ? (
@@ -290,7 +344,8 @@ function AgentPhoneConnectDialog() {
   );
 }
 
-export function AgentPhoneCard() {
+function AgentPhoneCardActions() {
+  const { t } = useTranslation();
   const statusLoadable = useLastLoadable(agentPhoneLinkStatus$);
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
@@ -302,6 +357,101 @@ export function AgentPhoneCard() {
   const disconnecting = disconnectLoadable.state === "loading";
   const isConnected = status?.linked ?? false;
   const connectedPhone = status?.linked ? status.phoneHandle : null;
+
+  return (
+    <>
+      {isConnected ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                data-testid="agentphone-connected-indicator"
+                className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
+              >
+                <IconCircleCheck className="h-3 w-3 text-green-600" />
+                <span className="min-w-0 truncate">
+                  {connectedPhone ??
+                    t(($) => {
+                      return $.connectors.providerSettings.works.connected;
+                    })}
+                </span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t(($) => {
+                return $.connectors.providerSettings.agentphone
+                  .authorizedSender;
+              })}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+      {status !== null && !isConnected ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 rounded-lg"
+          aria-label={t(($) => {
+            return $.connectors.providerSettings.agentphone.connectAria;
+          })}
+          onClick={() => {
+            setConnectOpen(true);
+          }}
+        >
+          {t(($) => {
+            return $.connectors.actions.connect;
+          })}
+        </Button>
+      ) : null}
+      {isConnected ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label={t(($) => {
+                return $.connectors.providerSettings.agentphone.options;
+              })}
+            >
+              <IconDotsVertical size={16} stroke={1.5} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="flex flex-col gap-0.5 w-40 p-2"
+          >
+            <button
+              type="button"
+              aria-label={t(($) => {
+                return $.connectors.actions.disconnect;
+              })}
+              disabled={disconnecting}
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
+              onClick={() => {
+                return detach(disconnect(pageSignal), Reason.DomCallback);
+              }}
+            >
+              {disconnecting
+                ? t(($) => {
+                    return $.connectors.actions.disconnecting;
+                  })
+                : t(($) => {
+                    return $.connectors.actions.disconnect;
+                  })}
+            </button>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+    </>
+  );
+}
+
+export function AgentPhoneCard() {
+  const { t } = useTranslation();
+  const statusLoadable = useLastLoadable(agentPhoneLinkStatus$);
+  const status =
+    statusLoadable.state === "hasData" ? statusLoadable.data : null;
   const agentPhoneNumber = status?.agentPhoneNumber ?? null;
 
   return (
@@ -314,81 +464,30 @@ export function AgentPhoneCard() {
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div className="flex min-w-0 items-center gap-2">
               <div className="truncate text-sm font-medium text-foreground">
-                Phone
+                {t(($) => {
+                  return $.connectors.providerSettings.agentphone.phoneLabel;
+                })}
               </div>
             </div>
             <div className="truncate text-sm text-muted-foreground">
               {agentPhoneNumber ? (
                 <span className="inline-flex max-w-full items-center gap-1">
-                  <span className="shrink-0">iMessage or SMS to</span>
+                  <span className="shrink-0">
+                    {t(($) => {
+                      return $.connectors.providerSettings.agentphone
+                        .destination;
+                    })}
+                  </span>
                   <PhoneNumberCopyButton phoneNumber={agentPhoneNumber} />
                 </span>
               ) : (
-                "Text-message access to Zero"
+                t(($) => {
+                  return $.connectors.providerSettings.agentphone.description;
+                })
               )}
             </div>
           </div>
-          {isConnected ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    data-testid="agentphone-connected-indicator"
-                    className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
-                  >
-                    <IconCircleCheck className="h-3 w-3 text-green-600" />
-                    <span className="min-w-0 truncate">
-                      {connectedPhone ?? "Connected"}
-                    </span>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Authorized Sender</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : null}
-          {status !== null && !isConnected ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8 shrink-0 gap-1.5 rounded-lg"
-              aria-label="Connect phone"
-              onClick={() => {
-                setConnectOpen(true);
-              }}
-            >
-              Connect
-            </Button>
-          ) : null}
-          {isConnected ? (
-            <Popover>
-              <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  aria-label="Phone options"
-                >
-                  <IconDotsVertical size={16} stroke={1.5} />
-                </button>
-              </PopoverTrigger>
-              <PopoverContent
-                align="end"
-                className="flex flex-col gap-0.5 w-40 p-2"
-              >
-                <button
-                  type="button"
-                  aria-label="Disconnect phone"
-                  disabled={disconnecting}
-                  className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
-                  onClick={() => {
-                    return detach(disconnect(pageSignal), Reason.DomCallback);
-                  }}
-                >
-                  {disconnecting ? "Disconnecting..." : "Disconnect"}
-                </button>
-              </PopoverContent>
-            </Popover>
-          ) : null}
+          <AgentPhoneCardActions />
         </div>
       </div>
       <AgentPhoneConnectDialog />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1,5 +1,6 @@
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { Input } from "@vm0/ui/components/ui/input";
 import { Button } from "@vm0/ui/components/ui/button";
 import { CopyButton } from "@vm0/ui/components/ui/copy-button";
@@ -63,6 +64,7 @@ import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
+import { i18n } from "../../../../i18n/index.ts";
 
 // ---------------------------------------------------------------------------
 // Connected status text helper
@@ -71,10 +73,14 @@ import { ConnectorHelpText } from "./connector-help-text.tsx";
 function connectedStatusText(item: PublicConnectorCatalogStatusItem): string {
   const connectionStatus = connectorCurrentConnectionStatus(item);
   if (connectionStatus === "reconnect-required") {
-    return "Connection expired";
+    return i18n.t(($) => {
+      return $.connectors.card.connectionExpired;
+    });
   }
   if (connectionStatus === "scope-mismatch") {
-    return "Update permissions";
+    return i18n.t(($) => {
+      return $.connectors.card.updatePermissions;
+    });
   }
   const expiryText = connectorExpiryCountdownText(item);
   if (expiryText) {
@@ -82,11 +88,23 @@ function connectedStatusText(item: PublicConnectorCatalogStatusItem): string {
   }
   if (item.connection?.externalUsername) {
     if (item.connection.externalUsername.startsWith("arn:")) {
-      return `Connected as ${item.connection.externalUsername}`;
+      return i18n.t(
+        ($) => {
+          return $.connectors.connectDialog.connectedAs;
+        },
+        { username: item.connection.externalUsername },
+      );
     }
-    return `Connected as @${item.connection.externalUsername}`;
+    return i18n.t(
+      ($) => {
+        return $.connectors.connectDialog.connectedAs;
+      },
+      { username: `@${item.connection.externalUsername}` },
+    );
   }
-  return "Connected";
+  return i18n.t(($) => {
+    return $.connectors.card.connected;
+  });
 }
 
 type PostConnectOptions = {
@@ -260,6 +278,7 @@ function ManualGrantForm({
   submit: SubmitManualGrantFn;
   submitting: boolean;
 }) {
+  const { t } = useTranslation();
   const setFormValue = useSet(setManualGrantFormValue$);
   const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
@@ -324,21 +343,31 @@ function ManualGrantForm({
         disabled={!allFilled || submitting}
         className="w-full"
       >
-        {submitting ? "Saving..." : "Save"}
+        {submitting
+          ? t(($) => {
+              return $.connectors.actions.saving;
+            })
+          : t(($) => {
+              return $.connectors.actions.save;
+            })}
       </Button>
     </form>
   );
 }
 
 function UnavailableConnectMethodsContent() {
+  const { t } = useTranslation();
   return (
     <div className="rounded-md border border-dashed border-border bg-muted/30 p-3">
       <p className="text-sm font-medium text-foreground">
-        Connection methods unavailable
+        {t(($) => {
+          return $.connectors.connectDialog.unavailable.title;
+        })}
       </p>
       <p className="mt-1 text-sm text-muted-foreground">
-        This connector has available connection methods, but none of them can be
-        configured from this dialog yet.
+        {t(($) => {
+          return $.connectors.connectDialog.unavailable.description;
+        })}
       </p>
     </div>
   );
@@ -353,12 +382,22 @@ function getOAuthAuthCodeProgressContent({
 }) {
   // While browser authorization is in progress, only show connecting state.
   if (isPolling) {
-    return <p className="text-sm text-muted-foreground">Connecting...</p>;
+    return (
+      <p className="text-sm text-muted-foreground">
+        {i18n.t(($) => {
+          return $.connectors.connectDialog.progress.connecting;
+        })}
+      </p>
+    );
   }
 
   if (settling) {
     return (
-      <p className="text-sm text-muted-foreground">Saving permissions...</p>
+      <p className="text-sm text-muted-foreground">
+        {i18n.t(($) => {
+          return $.connectors.connectDialog.progress.savingPermissions;
+        })}
+      </p>
     );
   }
 
@@ -378,6 +417,7 @@ function OAuthAuthCodeConnectButton({
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   signal: AbortSignal;
 }) {
+  const { t } = useTranslation();
   return (
     <Button
       variant="outline"
@@ -400,7 +440,13 @@ function OAuthAuthCodeConnectButton({
       }}
       className="w-full"
     >
-      {item.connected ? "Authorize" : "Connect"}
+      {item.connected
+        ? t(($) => {
+            return $.connectors.actions.authorize;
+          })
+        : t(($) => {
+            return $.connectors.actions.connect;
+          })}
     </Button>
   );
 }
@@ -425,12 +471,18 @@ function getOAuthDeviceAuthStatusText(
   >,
 ): string {
   if (!state.approvalOpened) {
-    return "Copy this code, then open the verification page to approve access.";
+    return i18n.t(($) => {
+      return $.connectors.connectDialog.device.copyThenOpen;
+    });
   }
   if (state.status === "polling") {
-    return "Checking for approval...";
+    return i18n.t(($) => {
+      return $.connectors.connectDialog.device.checking;
+    });
   }
-  return "Waiting for approval. Keep this dialog open.";
+  return i18n.t(($) => {
+    return $.connectors.connectDialog.device.waiting;
+  });
 }
 
 function OAuthDeviceAuthCodePanel({
@@ -443,16 +495,22 @@ function OAuthDeviceAuthCodePanel({
   >;
   onOpenVerificationPage: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">
-        Open the provider&apos;s verification page, then enter this verification
-        code to approve access.
+        {t(($) => {
+          return $.connectors.connectDialog.device.description;
+        })}
       </p>
       <div className="rounded-lg border border-border bg-muted/30 p-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <p className="text-xs text-muted-foreground">Verification code</p>
+            <p className="text-xs text-muted-foreground">
+              {t(($) => {
+                return $.connectors.connectDialog.device.verificationCode;
+              })}
+            </p>
             <p
               className="mt-1 break-all font-mono text-2xl font-semibold tracking-normal"
               data-testid="connector-oauth-device-code"
@@ -479,7 +537,9 @@ function OAuthDeviceAuthCodePanel({
         onClick={onOpenVerificationPage}
         data-testid="connector-oauth-device-open"
       >
-        Open verification page
+        {t(($) => {
+          return $.connectors.connectDialog.device.openPage;
+        })}
       </Button>
       <p className="text-xs text-muted-foreground" role="status">
         {getOAuthDeviceAuthStatusText(state)}
@@ -553,6 +613,7 @@ function OAuthDeviceAuthStartOptionsForm({
   values: Record<string, string>;
   setValue: (name: string, value: string) => void;
 }) {
+  const { t } = useTranslation();
   if (startOptions.length === 0) {
     return null;
   }
@@ -580,7 +641,14 @@ function OAuthDeviceAuthStartOptionsForm({
               }}
             >
               <SelectTrigger id={inputId} className="h-9">
-                <SelectValue placeholder={`Select ${option.label}`} />
+                <SelectValue
+                  placeholder={t(
+                    ($) => {
+                      return $.connectors.connectDialog.device.selectOption;
+                    },
+                    { option: option.label },
+                  )}
+                />
               </SelectTrigger>
               <SelectContent>
                 {option.options.map((choice) => {
@@ -599,7 +667,79 @@ function OAuthDeviceAuthStartOptionsForm({
   );
 }
 
+function OAuthDeviceAuthStartContent({
+  connectorSlug,
+  connectorLabel,
+  authMethod,
+  startOptions,
+  values,
+  message,
+  starting,
+  startOptionsFilled,
+  setValue,
+  onStart,
+}: {
+  connectorSlug: ConnectorSlug;
+  connectorLabel: string;
+  authMethod: ConnectorAuthMethodId;
+  startOptions: readonly PublicConnectorCatalogStartOption[];
+  values: Record<string, string>;
+  message?: string;
+  starting: boolean;
+  startOptionsFilled: boolean;
+  setValue: (name: string, value: string) => void;
+  onStart: (event: unknown) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3">
+      {message ? null : (
+        <p className="text-sm text-muted-foreground">
+          {t(($) => {
+            return $.connectors.connectDialog.device.intro;
+          })}
+        </p>
+      )}
+      <OAuthDeviceAuthStartOptionsForm
+        connectorSlug={connectorSlug}
+        authMethod={authMethod}
+        startOptions={startOptions}
+        values={values}
+        setValue={setValue}
+      />
+      {message ? (
+        <p className="text-sm text-destructive" role="alert">
+          {message}
+        </p>
+      ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onStart}
+        disabled={starting || !startOptionsFilled}
+        className="w-full"
+      >
+        {starting
+          ? t(($) => {
+              return $.connectors.connectDialog.device.starting;
+            })
+          : message
+            ? t(($) => {
+                return $.connectors.actions.tryAgain;
+              })
+            : t(
+                ($) => {
+                  return $.connectors.connectDialog.device.connect;
+                },
+                { connector: connectorLabel },
+              )}
+      </Button>
+    </div>
+  );
+}
+
 function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
+  const { t } = useTranslation();
   const state = useGet(connectorOAuthDeviceAuthState$);
   const openVerificationPage = useSet(
     openConnectorOAuthDeviceAuthVerificationPage$,
@@ -661,7 +801,11 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
 
   if (current?.status === "starting") {
     return (
-      <p className="text-sm text-muted-foreground">Starting connection...</p>
+      <p className="text-sm text-muted-foreground">
+        {t(($) => {
+          return $.connectors.connectDialog.device.startingConnection;
+        })}
+      </p>
     );
   }
 
@@ -682,53 +826,33 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
     current?.status === "error"
   ) {
     return (
-      <div className="flex flex-col gap-3">
-        <OAuthDeviceAuthStartOptionsForm
-          connectorSlug={props.item.connectorRef}
-          authMethod={props.authMethod}
-          startOptions={startOptions}
-          values={effectiveStartOptionValues}
-          setValue={setStartOptionValue}
-        />
-        <p className="text-sm text-destructive" role="alert">
-          {current.message}
-        </p>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={start}
-          disabled={starting || !startOptionsFilled}
-          className="w-full"
-        >
-          {starting ? "Starting..." : "Try again"}
-        </Button>
-      </div>
+      <OAuthDeviceAuthStartContent
+        connectorSlug={props.item.connectorRef}
+        connectorLabel={props.item.label}
+        authMethod={props.authMethod}
+        startOptions={startOptions}
+        values={effectiveStartOptionValues}
+        message={current.message}
+        starting={starting}
+        startOptionsFilled={startOptionsFilled}
+        setValue={setStartOptionValue}
+        onStart={start}
+      />
     );
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <p className="text-sm text-muted-foreground">
-        Connect to get a verification code, then use it on the provider&apos;s
-        verification page to approve access.
-      </p>
-      <OAuthDeviceAuthStartOptionsForm
-        connectorSlug={props.item.connectorRef}
-        authMethod={props.authMethod}
-        startOptions={startOptions}
-        values={effectiveStartOptionValues}
-        setValue={setStartOptionValue}
-      />
-      <Button
-        type="button"
-        variant="outline"
-        onClick={start}
-        disabled={starting || !startOptionsFilled}
-        className="w-full"
-      >
-        {starting ? "Starting..." : `Connect ${props.item.label}`}
-      </Button>
-    </div>
+    <OAuthDeviceAuthStartContent
+      connectorSlug={props.item.connectorRef}
+      connectorLabel={props.item.label}
+      authMethod={props.authMethod}
+      startOptions={startOptions}
+      values={effectiveStartOptionValues}
+      starting={starting}
+      startOptionsFilled={startOptionsFilled}
+      setValue={setStartOptionValue}
+      onStart={start}
+    />
   );
 }
 
@@ -752,6 +876,7 @@ function ExternalCodeStartContent({
   starting: boolean;
   onStart: ExternalCodeButtonHandler;
 }) {
+  const { t } = useTranslation();
   const terminalMessage =
     current?.status === "expired" || current?.status === "error"
       ? current.message
@@ -771,7 +896,16 @@ function ExternalCodeStartContent({
         disabled={starting}
         className="w-full"
       >
-        {starting ? "Starting..." : `Start ${connectorLabel} sign-in`}
+        {starting
+          ? t(($) => {
+              return $.connectors.connectDialog.device.starting;
+            })
+          : t(
+              ($) => {
+                return $.connectors.connectDialog.external.start;
+              },
+              { connector: connectorLabel },
+            )}
       </Button>
     </div>
   );
@@ -794,13 +928,18 @@ function ExternalCodePendingContent({
   onCodeChange: (code: string) => void;
   onComplete: ExternalCodeSubmitHandler;
 }) {
+  const { t } = useTranslation();
   return (
     <form className="flex flex-col gap-3" onSubmit={onComplete}>
       {method.description && <ConnectorHelpText text={method.description} />}
       {!method.description && (
         <p className="text-sm text-muted-foreground">
-          Open {connectorLabel} sign-in, then paste the code displayed by{" "}
-          {connectorLabel}.
+          {t(
+            ($) => {
+              return $.connectors.connectDialog.external.description;
+            },
+            { connector: connectorLabel },
+          )}
         </p>
       )}
       <div className="flex items-center gap-2">
@@ -810,7 +949,12 @@ function ExternalCodePendingContent({
           className="min-w-0 flex-1"
           onClick={onOpen}
         >
-          Open {connectorLabel} sign-in
+          {t(
+            ($) => {
+              return $.connectors.connectDialog.external.open;
+            },
+            { connector: connectorLabel },
+          )}
         </Button>
         <CopyButton
           type="button"
@@ -819,7 +963,9 @@ function ExternalCodePendingContent({
         />
       </div>
       <label className="sr-only" htmlFor="connector-external-code-input">
-        Code
+        {t(($) => {
+          return $.connectors.connectDialog.external.code;
+        })}
       </label>
       <Input
         id="connector-external-code-input"
@@ -827,7 +973,9 @@ function ExternalCodePendingContent({
         onChange={(event) => {
           onCodeChange(event.target.value);
         }}
-        placeholder="Code"
+        placeholder={t(($) => {
+          return $.connectors.connectDialog.external.code;
+        })}
         autoComplete="one-time-code"
         data-testid="connector-external-code-input"
       />
@@ -842,13 +990,20 @@ function ExternalCodePendingContent({
         className="w-full"
         data-testid="connector-external-code-complete"
       >
-        {completing ? "Connecting..." : "Complete connection"}
+        {completing
+          ? t(($) => {
+              return $.connectors.actions.connecting;
+            })
+          : t(($) => {
+              return $.connectors.connectDialog.external.complete;
+            })}
       </Button>
     </form>
   );
 }
 
 function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
+  const { t } = useTranslation();
   const state = useGet(connectorExternalCodeState$);
   const setCode = useSet(setConnectorExternalCodeAuthorizationCode$);
   const openAuthorizationPage = useSet(
@@ -891,7 +1046,11 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
 
   if (starting) {
     return (
-      <p className="text-sm text-muted-foreground">Starting connection...</p>
+      <p className="text-sm text-muted-foreground">
+        {t(($) => {
+          return $.connectors.connectDialog.device.startingConnection;
+        })}
+      </p>
     );
   }
 
@@ -948,6 +1107,7 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
 }
 
 function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
+  const { t } = useTranslation();
   const enable = onDomEventFn(async () => {
     await props.connectNoAuthAndSettle(
       {
@@ -976,7 +1136,16 @@ function NoAuthConnectMethodContent(props: ConnectMethodContentProps) {
         disabled={props.noAuthSubmitting}
         className="w-full"
       >
-        {props.noAuthSubmitting ? "Enabling..." : `Enable ${props.item.label}`}
+        {props.noAuthSubmitting
+          ? t(($) => {
+              return $.connectors.connectDialog.noAuth.enabling;
+            })
+          : t(
+              ($) => {
+                return $.connectors.connectDialog.noAuth.enable;
+              },
+              { connector: props.item.label },
+            )}
       </Button>
     </div>
   );
@@ -1021,13 +1190,18 @@ function getConnectMethodContentEntries(
 }
 
 function AuthMethodDivider() {
+  const { t } = useTranslation();
   return (
     <div className="relative py-1">
       <div className="absolute inset-0 flex items-center">
         <span className="w-full zero-border-t" />
       </div>
       <div className="relative flex justify-center text-xs">
-        <span className="bg-background px-2 text-muted-foreground">or</span>
+        <span className="bg-background px-2 text-muted-foreground">
+          {t(($) => {
+            return $.connectors.connectDialog.or;
+          })}
+        </span>
       </div>
     </div>
   );
@@ -1058,10 +1232,13 @@ function ConnectMethodsContent({
   availableAuthMethodCount: number;
   props: ConnectMethodSharedContentProps;
 }) {
+  const { t } = useTranslation();
   if (availableAuthMethodCount === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        No connection method is available.
+        {t(($) => {
+          return $.connectors.connectDialog.noMethod;
+        })}
       </p>
     );
   }
@@ -1285,6 +1462,7 @@ export function ConnectModal({
   selectedConnectorSlug?: ConnectorSlug | null;
   agentId?: string;
 }) {
+  useTranslation();
   const globalSelectedConnectorSlug = useGet(selectedConnectorSlug$);
   const selectedConnectorSlug =
     selectedConnectorSlugOverride === undefined

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -1,5 +1,6 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import {
   IconAdjustmentsHorizontal,
   IconLoader2,
@@ -46,6 +47,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
+import { i18n } from "../../../../i18n/index.ts";
 
 interface ConnectorAccessManagementDialogProps {
   readonly connectorSlug: ConnectorSlug;
@@ -54,7 +56,12 @@ interface ConnectorAccessManagementDialogProps {
 }
 
 function agentName(agent: TeamComposeItem): string {
-  return agent.displayName ?? "Unnamed";
+  return (
+    agent.displayName ??
+    i18n.t(($) => {
+      return $.connectors.access.unnamedAgent;
+    })
+  );
 }
 
 function filterRows(
@@ -77,6 +84,7 @@ function ConnectorAccessSearch({
   readonly value: string;
   readonly onChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="relative">
       <IconSearch
@@ -89,8 +97,12 @@ function ConnectorAccessSearch({
         onChange={(event) => {
           onChange(event.currentTarget.value);
         }}
-        aria-label="Find agents"
-        placeholder="Find agents"
+        aria-label={t(($) => {
+          return $.connectors.access.search;
+        })}
+        placeholder={t(($) => {
+          return $.connectors.access.search;
+        })}
         className="h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input pl-9 pr-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10"
       />
       {value && (
@@ -100,7 +112,9 @@ function ConnectorAccessSearch({
             onChange("");
           }}
           className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-          aria-label="Clear agent search"
+          aria-label={t(($) => {
+            return $.connectors.access.clearSearch;
+          })}
         >
           <IconX size={13} stroke={1.8} />
         </button>
@@ -127,6 +141,7 @@ function AgentAccessRow({
   ) => void;
   readonly onManage: (row: ConnectorAgentAccessRow) => void;
 }) {
+  const { t } = useTranslation();
   const name = agentName(row.agent);
   const canManage = row.authorized && (metadata?.permissionCount ?? 0) > 0;
 
@@ -149,13 +164,22 @@ function AgentAccessRow({
                 onClick={() => {
                   onManage(row);
                 }}
-                aria-label={`Manage ${connectorLabel} permissions for ${name}`}
+                aria-label={t(
+                  ($) => {
+                    return $.connectors.access.managePermissionsFor;
+                  },
+                  { connector: connectorLabel, agent: name },
+                )}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
                 <IconAdjustmentsHorizontal size={16} stroke={1.5} />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Manage permissions</TooltipContent>
+            <TooltipContent>
+              {t(($) => {
+                return $.connectors.access.managePermissions;
+              })}
+            </TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}
@@ -165,7 +189,22 @@ function AgentAccessRow({
         onCheckedChange={(checked) => {
           onToggle(row, checked);
         }}
-        ariaLabel={`${row.authorized ? "Revoke" : "Authorize"} ${connectorLabel} access for ${name}`}
+        ariaLabel={t(
+          ($) => {
+            return $.connectors.access.accessFor;
+          },
+          {
+            action: row.authorized
+              ? t(($) => {
+                  return $.connectors.actions.revoke;
+                })
+              : t(($) => {
+                  return $.connectors.actions.authorize;
+                }),
+            connector: connectorLabel,
+            agent: name,
+          },
+        )}
       />
     </div>
   );
@@ -191,12 +230,20 @@ function AgentAccessList({
   ) => void;
   readonly onManage: (row: ConnectorAgentAccessRow) => void;
 }) {
+  const { t } = useTranslation();
   if (rows.length === 0) {
     return (
       <p className="py-8 text-center text-sm text-muted-foreground">
         {search.trim()
-          ? `No agents matching "${search.trim()}"`
-          : "No agents found"}
+          ? t(
+              ($) => {
+                return $.connectors.access.noMatchingAgents;
+              },
+              { search: search.trim() },
+            )
+          : t(($) => {
+              return $.connectors.access.noAgents;
+            })}
       </p>
     );
   }
@@ -221,10 +268,13 @@ function AgentAccessList({
 }
 
 function LoadingAgents() {
+  const { t } = useTranslation();
   return (
     <div className="flex min-h-[240px] flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
       <IconLoader2 size={16} className="animate-spin" />
-      Loading agents...
+      {t(($) => {
+        return $.connectors.access.loading;
+      })}
     </div>
   );
 }
@@ -255,6 +305,7 @@ function ConnectorAccessDialog({
   ) => void;
   readonly onManage: (row: ConnectorAgentAccessRow) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <Dialog
       open
@@ -270,10 +321,17 @@ function ConnectorAccessDialog({
             </span>
             <div className="min-w-0">
               <DialogTitle className="text-base">
-                Manage {connectorLabel} access
+                {t(
+                  ($) => {
+                    return $.connectors.access.title;
+                  },
+                  { connector: connectorLabel },
+                )}
               </DialogTitle>
               <DialogDescription>
-                Choose which agents can use this connector.
+                {t(($) => {
+                  return $.connectors.access.description;
+                })}
               </DialogDescription>
             </div>
           </div>
@@ -326,6 +384,7 @@ function AgentPermissionDialog({
   readonly applyGrantPolicies: ApplyUserPermissionGrants;
   readonly onClose: () => void;
 }) {
+  const { t } = useTranslation();
   const grants = row?.grants ?? [];
   if (!row || !metadata) {
     return null;
@@ -355,7 +414,11 @@ function AgentPermissionDialog({
           pageSignal,
           applyGrantPolicies,
         });
-        toast.success("Permissions updated");
+        toast.success(
+          t(($) => {
+            return $.connectors.access.permissionsUpdated;
+          }),
+        );
       }}
       onClose={onClose}
     />
@@ -367,6 +430,7 @@ export function ConnectorAccessManagementDialog({
   connectorLabel,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
+  const { t } = useTranslation();
   const rowsLoadable = useLastLoadable(managedConnectorAgentAccessRows$);
   const metadataLoadable = useLastLoadable(
     managedConnectorFirewallPermissionMetadata$,
@@ -407,7 +471,14 @@ export function ConnectorAccessManagementDialog({
             { agentId: row.agent.id, connectorSlug, authorized },
             pageSignal,
           );
-          toast.success(`${connectorLabel} access updated`);
+          toast.success(
+            t(
+              ($) => {
+                return $.connectors.access.accessUpdated;
+              },
+              { connector: connectorLabel },
+            ),
+          );
         })(),
         () => {
           setSavingAgentId(null);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import {
   IconAdjustmentsHorizontal,
   IconCircleCheck,
@@ -106,6 +107,7 @@ function CatalogConnectorCard({
   busy,
   connect,
 }: CatalogConnectorCardProps) {
+  const { t } = useTranslation();
   const handleConnect = () => {
     runConnect(connector, connect, busy);
   };
@@ -114,7 +116,12 @@ function CatalogConnectorCard({
     <div
       role="button"
       tabIndex={busy ? -1 : 0}
-      aria-label={`Connect ${connector.label}`}
+      aria-label={t(
+        ($) => {
+          return $.connectors.card.connectAria;
+        },
+        { connector: connector.label },
+      )}
       aria-disabled={busy}
       className={cn(
         "zero-card overflow-hidden text-left",
@@ -175,12 +182,15 @@ function ConnectorConnectionStatus({
   readonly busy: boolean;
   readonly connect: ConnectorConnectHandlers;
 }) {
+  const { t } = useTranslation();
   const connectionStatus = connectorCurrentConnectionStatus(connector);
   if (busy) {
     return (
       <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
-        Connecting…
+        {t(($) => {
+          return $.connectors.card.connecting;
+        })}
       </span>
     );
   }
@@ -189,7 +199,9 @@ function ConnectorConnectionStatus({
       <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
         <span className="text-amber-600 dark:text-amber-400">
-          Connection expired
+          {t(($) => {
+            return $.connectors.card.connectionExpired;
+          })}
         </span>
       </span>
     );
@@ -199,7 +211,9 @@ function ConnectorConnectionStatus({
       <span className="flex min-w-0 items-center gap-2 text-[11px]">
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />
         <span className="min-w-0 truncate text-amber-600 dark:text-amber-400">
-          Update permissions
+          {t(($) => {
+            return $.connectors.card.updatePermissions;
+          })}
         </span>
       </span>
     );
@@ -210,7 +224,9 @@ function ConnectorConnectionStatus({
       expiryText ??
       (connector.connection?.externalUsername
         ? `@${connector.connection.externalUsername}`
-        : "Connected");
+        : t(($) => {
+            return $.connectors.card.connected;
+          }));
     return (
       <span className="flex items-center gap-2 truncate text-xs text-muted-foreground">
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
@@ -226,7 +242,9 @@ function ConnectorConnectionStatus({
       }}
       className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
     >
-      Connect
+      {t(($) => {
+        return $.connectors.actions.connect;
+      })}
     </button>
   );
 }
@@ -241,6 +259,7 @@ function ConnectionConnectorCard({
   onDisconnect,
   onReviewScopes,
 }: ConnectionConnectorCardProps) {
+  const { t } = useTranslation();
   const connectionStatus = connectorCurrentConnectionStatus(connector);
   return (
     <div className="zero-card flex flex-col">
@@ -273,7 +292,9 @@ function ConnectionConnectorCard({
                   variant="ghost"
                   size="icon"
                   className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                  aria-label="More options"
+                  aria-label={t(($) => {
+                    return $.connectors.custom.moreOptions;
+                  })}
                   disabled={busy}
                 >
                   <IconDotsVertical size={14} stroke={1.5} />
@@ -286,19 +307,25 @@ function ConnectionConnectorCard({
                       runConnect(connector, connect, busy);
                     }}
                   >
-                    Reconnect
+                    {t(($) => {
+                      return $.connectors.actions.reconnect;
+                    })}
                   </DropdownMenuModalItem>
                 ) : null}
                 {connectionStatus === "scope-mismatch" && onReviewScopes ? (
                   <DropdownMenuModalItem onModalSelect={onReviewScopes}>
-                    Review permissions
+                    {t(($) => {
+                      return $.connectors.card.reviewPermissions;
+                    })}
                   </DropdownMenuModalItem>
                 ) : null}
                 <DropdownMenuItem
                   onClick={onDisconnect}
                   disabled={disconnecting || busy}
                 >
-                  Disconnect
+                  {t(($) => {
+                    return $.connectors.actions.disconnect;
+                  })}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -309,8 +336,11 @@ function ConnectionConnectorCard({
   );
 }
 
-function onboardingHelpText(helpText: string | undefined): string {
-  return (helpText ?? "Connect this account to continue")
+function onboardingHelpText(
+  helpText: string | undefined,
+  fallback: string,
+): string {
+  return (helpText ?? fallback)
     .replace(/^Connect your \w+ account to /u, "")
     .replace(/^Connect your Google account to /u, "")
     .replace(/^Connect /u, "");
@@ -326,6 +356,7 @@ function OnboardingConnectorCard({
   required,
   connect,
 }: OnboardingConnectorCardProps) {
+  const { t } = useTranslation();
   const label = connector?.label ?? connectorSlug;
   return (
     <div
@@ -349,16 +380,30 @@ function OnboardingConnectorCard({
         <p className="mt-0.5 truncate text-xs text-muted-foreground">
           {layout === "workflow" ? (
             <span className="text-muted-foreground/70">
-              {required ? "Required" : "Optional"} ·{" "}
+              {required
+                ? t(($) => {
+                    return $.connectors.card.required;
+                  })
+                : t(($) => {
+                    return $.connectors.card.optional;
+                  })}{" "}
+              ·{" "}
             </span>
           ) : null}
-          {onboardingHelpText(connector?.description)}
+          {onboardingHelpText(
+            connector?.description,
+            t(($) => {
+              return $.connectors.card.connectToContinue;
+            }),
+          )}
         </p>
       </div>
       {connected ? (
         <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
           <IconCircleCheck size={16} aria-hidden="true" />
-          Connected
+          {t(($) => {
+            return $.connectors.card.connected;
+          })}
         </span>
       ) : (
         <Button
@@ -376,7 +421,9 @@ function OnboardingConnectorCard({
           {busy ? (
             <IconLoader2 className="animate-spin" aria-hidden="true" />
           ) : null}
-          Connect
+          {t(($) => {
+            return $.connectors.actions.connect;
+          })}
         </Button>
       )}
     </div>
@@ -390,15 +437,24 @@ function ActionConnectorCard({
   busy,
   onActivate,
 }: ActionConnectorCardProps) {
+  const { t } = useTranslation();
   const reconnectRequired =
     connectorCurrentConnectionStatus(connector) === "reconnect-required";
   const actionLabel = complete
-    ? "Authorized"
+    ? t(($) => {
+        return $.connectors.card.authorized;
+      })
     : reconnectRequired
-      ? "Reconnect"
+      ? t(($) => {
+          return $.connectors.actions.reconnect;
+        })
       : connected
-        ? "Authorize"
-        : "Connect";
+        ? t(($) => {
+            return $.connectors.actions.authorize;
+          })
+        : t(($) => {
+            return $.connectors.actions.connect;
+          });
 
   return (
     <div
@@ -453,6 +509,7 @@ function PermissionConnectorCard({
   onManage,
   onToggle,
 }: PermissionConnectorCardProps) {
+  const { t } = useTranslation();
   return (
     <>
       <div className="flex w-full items-center gap-3 px-5 py-4 text-left transition-colors">
@@ -486,13 +543,22 @@ function PermissionConnectorCard({
                     type="button"
                     onClick={onManage}
                     className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                    aria-label={`Manage ${connector.label} permissions`}
+                    aria-label={t(
+                      ($) => {
+                        return $.connectors.card.managePermissionsFor;
+                      },
+                      { connector: connector.label },
+                    )}
                   >
                     <IconAdjustmentsHorizontal size={15} stroke={1.5} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
-                  <p className="text-xs">Manage permissions</p>
+                  <p className="text-xs">
+                    {t(($) => {
+                      return $.connectors.card.managePermissions;
+                    })}
+                  </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -501,7 +567,21 @@ function PermissionConnectorCard({
             checked={enabled}
             onCheckedChange={onToggle}
             loading={loading}
-            ariaLabel={`${enabled ? "Revoke" : "Grant"} ${connector.label} access`}
+            ariaLabel={t(
+              ($) => {
+                return $.connectors.card.accessFor;
+              },
+              {
+                action: enabled
+                  ? t(($) => {
+                      return $.connectors.actions.revoke;
+                    })
+                  : t(($) => {
+                      return $.connectors.actions.grant;
+                    }),
+                connector: connector.label,
+              },
+            )}
           />
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,6 +1,7 @@
 import { IconPlug } from "@tabler/icons-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { cn } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 
 function ConnectorIconFallback({
   size,
@@ -9,11 +10,14 @@ function ConnectorIconFallback({
   size: number;
   hidden?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <span
       hidden={hidden}
       role="img"
-      aria-label="Connector icon unavailable"
+      aria-label={t(($) => {
+        return $.connectors.catalog.iconUnavailable;
+      })}
       className="inline-flex h-full w-full items-center justify-center text-muted-foreground"
     >
       <IconPlug size={size * 0.65} stroke={1.5} aria-hidden="true" />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
@@ -29,6 +30,7 @@ export function CustomConnectorConnectDialog({
   id: string;
   displayName: string;
 }) {
+  const { t } = useTranslation();
   const value = useGet(customConnectorConnectInput$);
   const setValue = useSet(setCustomConnectorConnectInput$);
   const resetValue = useSet(resetCustomConnectorConnectInput$);
@@ -69,13 +71,20 @@ export function CustomConnectorConnectDialog({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <CustomConnectorIcon id={id} displayName={displayName} size={20} />
-            <DialogTitle>Connect {displayName}</DialogTitle>
+            <DialogTitle>
+              {t(
+                ($) => {
+                  return $.connectors.custom.connect.title;
+                },
+                { connector: displayName },
+              )}
+            </DialogTitle>
           </div>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">
-          Your secret is encrypted at rest and injected into outbound requests
-          by the firewall. It&apos;s never exposed to the agent as an
-          environment variable.
+          {t(($) => {
+            return $.connectors.custom.connect.description;
+          })}
         </p>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <div className="flex flex-col gap-2">
@@ -83,7 +92,9 @@ export function CustomConnectorConnectDialog({
               htmlFor="cc-connect-secret"
               className="text-sm font-medium text-foreground"
             >
-              Secret
+              {t(($) => {
+                return $.connectors.custom.connect.secret;
+              })}
             </label>
             <Input
               id="cc-connect-secret"
@@ -102,10 +113,18 @@ export function CustomConnectorConnectDialog({
               onClick={close}
               disabled={submitting}
             >
-              Cancel
+              {t(($) => {
+                return $.connectors.actions.cancel;
+              })}
             </Button>
             <Button type="submit" disabled={!canSubmit}>
-              {submitting ? "Saving…" : "Save"}
+              {submitting
+                ? t(($) => {
+                    return $.connectors.actions.savingEllipsis;
+                  })
+                : t(($) => {
+                    return $.connectors.actions.save;
+                  })}
             </Button>
           </DialogFooter>
         </form>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
@@ -46,6 +47,7 @@ function CreateFormFields({
     value: string,
   ) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
@@ -53,7 +55,9 @@ function CreateFormFields({
           htmlFor="cc-display-name"
           className="text-sm font-medium text-foreground"
         >
-          Display name
+          {t(($) => {
+            return $.connectors.custom.create.displayName;
+          })}
         </label>
         <Input
           id="cc-display-name"
@@ -69,9 +73,13 @@ function CreateFormFields({
           htmlFor="cc-prefixes"
           className="text-sm font-medium text-foreground"
         >
-          Prefixes
+          {t(($) => {
+            return $.connectors.custom.create.prefixes;
+          })}
           <span className="text-muted-foreground font-normal ml-1">
-            (one per line, https only)
+            {t(($) => {
+              return $.connectors.custom.create.prefixesHint;
+            })}
           </span>
         </label>
         <textarea
@@ -90,7 +98,9 @@ function CreateFormFields({
           htmlFor="cc-header-name"
           className="text-sm font-medium text-foreground"
         >
-          Header name
+          {t(($) => {
+            return $.connectors.custom.create.headerName;
+          })}
         </label>
         <Input
           id="cc-header-name"
@@ -106,9 +116,16 @@ function CreateFormFields({
           htmlFor="cc-header-template"
           className="text-sm font-medium text-foreground"
         >
-          Header template
+          {t(($) => {
+            return $.connectors.custom.create.headerTemplate;
+          })}
           <span className="text-muted-foreground font-normal ml-1">
-            (must contain {`{{secret}}`})
+            {t(
+              ($) => {
+                return $.connectors.custom.create.headerTemplateHint;
+              },
+              { placeholder: "{{secret}}" },
+            )}
           </span>
         </label>
         <Input
@@ -125,6 +142,7 @@ function CreateFormFields({
 }
 
 export function CustomConnectorCreateDialog() {
+  const { t } = useTranslation();
   const form = useGet(customConnectorCreateForm$);
   const setField = useSet(setCustomConnectorCreateField$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
@@ -177,7 +195,11 @@ export function CustomConnectorCreateDialog() {
     >
       <DialogContent className="max-w-lg" aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>New custom connector</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.custom.create.title;
+            })}
+          </DialogTitle>
         </DialogHeader>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <CreateFormFields form={form} setField={setField} />
@@ -188,10 +210,18 @@ export function CustomConnectorCreateDialog() {
               onClick={close}
               disabled={submitting}
             >
-              Cancel
+              {t(($) => {
+                return $.connectors.actions.cancel;
+              })}
             </Button>
             <Button type="submit" disabled={!canSubmit}>
-              {submitting ? "Creating…" : "Create"}
+              {submitting
+                ? t(($) => {
+                    return $.connectors.actions.creating;
+                  })
+                : t(($) => {
+                    return $.connectors.actions.create;
+                  })}
             </Button>
           </DialogFooter>
         </form>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-delete-confirm.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-delete-confirm.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
@@ -22,6 +23,7 @@ export function CustomConnectorDeleteConfirm({
   id: string;
   displayName: string;
 }) {
+  const { t } = useTranslation();
   const closeDialog = useSet(closeCustomConnectorDialog$);
   const [loadable, submit] = useLoadableSet(deleteCustomConnector$);
   const signal = useGet(pageSignal$);
@@ -46,23 +48,38 @@ export function CustomConnectorDeleteConfirm({
     >
       <DialogContent className="max-w-md" aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>Delete {displayName}?</DialogTitle>
+          <DialogTitle>
+            {t(
+              ($) => {
+                return $.connectors.custom.delete.title;
+              },
+              { connector: displayName },
+            )}
+          </DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">
-          This removes the connector and every member&apos;s stored secret for
-          it. Agents authorized for this connector will lose access immediately.
-          This can&apos;t be undone.
+          {t(($) => {
+            return $.connectors.custom.delete.description;
+          })}
         </p>
         <DialogFooter>
           <Button variant="outline" onClick={closeDialog} disabled={submitting}>
-            Cancel
+            {t(($) => {
+              return $.connectors.actions.cancel;
+            })}
           </Button>
           <Button
             variant="destructive"
             onClick={onConfirm}
             disabled={submitting}
           >
-            {submitting ? "Deleting…" : "Delete"}
+            {submitting
+              ? t(($) => {
+                  return $.connectors.actions.deleting;
+                })
+              : t(($) => {
+                  return $.connectors.actions.delete;
+                })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-rename-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-rename-dialog.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
@@ -26,6 +27,7 @@ export function CustomConnectorRenameDialog({
   id: string;
   currentDisplayName: string;
 }) {
+  const { t } = useTranslation();
   const displayName = useGet(customConnectorRenameInput$);
   const setDisplayName = useSet(setCustomConnectorRenameInput$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
@@ -60,7 +62,11 @@ export function CustomConnectorRenameDialog({
     >
       <DialogContent className="max-w-md" aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>Rename custom connector</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.custom.rename.title;
+            })}
+          </DialogTitle>
         </DialogHeader>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <div className="flex flex-col gap-2">
@@ -68,7 +74,9 @@ export function CustomConnectorRenameDialog({
               htmlFor="cc-rename-name"
               className="text-sm font-medium text-foreground"
             >
-              Display name
+              {t(($) => {
+                return $.connectors.custom.rename.displayName;
+              })}
             </label>
             <Input
               id="cc-rename-name"
@@ -86,10 +94,18 @@ export function CustomConnectorRenameDialog({
               onClick={closeDialog}
               disabled={submitting}
             >
-              Cancel
+              {t(($) => {
+                return $.connectors.actions.cancel;
+              })}
             </Button>
             <Button type="submit" disabled={!canSubmit}>
-              {submitting ? "Saving…" : "Save"}
+              {submitting
+                ? t(($) => {
+                    return $.connectors.actions.savingEllipsis;
+                  })
+                : t(($) => {
+                    return $.connectors.actions.save;
+                  })}
             </Button>
           </DialogFooter>
         </form>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -1,5 +1,6 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { IconDotsVertical } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
 import {
   Button,
   DropdownMenu,
@@ -43,6 +44,7 @@ function CustomConnectorRow({
   onRename: () => void;
   onDelete: () => void;
 }) {
+  const { t } = useTranslation();
   const hasActions = connector.hasSecret || isAdmin;
 
   return (
@@ -62,7 +64,9 @@ function CustomConnectorRow({
           {connector.hasSecret ? (
             <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-              Connected
+              {t(($) => {
+                return $.connectors.custom.statusConnected;
+              })}
             </span>
           ) : (
             <button
@@ -70,7 +74,9 @@ function CustomConnectorRow({
               onClick={onConnect}
               className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
             >
-              Connect
+              {t(($) => {
+                return $.connectors.actions.connect;
+              })}
             </button>
           )}
           {connector.prefixes[0] && (
@@ -86,7 +92,9 @@ function CustomConnectorRow({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                aria-label="More options"
+                aria-label={t(($) => {
+                  return $.connectors.custom.moreOptions;
+                })}
               >
                 <IconDotsVertical size={14} stroke={1.5} />
               </Button>
@@ -94,24 +102,32 @@ function CustomConnectorRow({
             <DropdownMenuContent align="end" className="w-44">
               {!connector.hasSecret && (
                 <DropdownMenuModalItem onModalSelect={onConnect}>
-                  Connect
+                  {t(($) => {
+                    return $.connectors.actions.connect;
+                  })}
                 </DropdownMenuModalItem>
               )}
               {connector.hasSecret && (
                 <DropdownMenuItem onClick={onDisconnect}>
-                  Disconnect
+                  {t(($) => {
+                    return $.connectors.actions.disconnect;
+                  })}
                 </DropdownMenuItem>
               )}
               {isAdmin && (
                 <>
                   <DropdownMenuModalItem onModalSelect={onRename}>
-                    Rename
+                    {t(($) => {
+                      return $.connectors.actions.rename;
+                    })}
                   </DropdownMenuModalItem>
                   <DropdownMenuModalItem
                     onModalSelect={onDelete}
                     className="text-destructive focus:text-destructive"
                   >
-                    Delete
+                    {t(($) => {
+                      return $.connectors.actions.delete;
+                    })}
                   </DropdownMenuModalItem>
                 </>
               )}
@@ -124,6 +140,7 @@ function CustomConnectorRow({
 }
 
 export function CustomConnectorsPanel() {
+  const { t } = useTranslation();
   const connectors = useLastResolved(customConnectors$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
   const dialog = useGet(customConnectorDialog$);
@@ -149,13 +166,19 @@ export function CustomConnectorsPanel() {
         <div className="zero-card py-12 flex flex-col items-center gap-3">
           <img
             src={noConnectorImg}
-            alt="No connectors"
+            alt={t(($) => {
+              return $.connectors.catalog.noConnectorsAlt;
+            })}
             className="h-20 w-20 object-contain opacity-80"
           />
           <p className="text-sm text-muted-foreground text-center">
             {isAdmin
-              ? "No custom connectors yet. Create one to register an API for every member to use."
-              : "Your org hasn't registered any custom connectors yet."}
+              ? t(($) => {
+                  return $.connectors.custom.emptyAdmin;
+                })
+              : t(($) => {
+                  return $.connectors.custom.emptyMember;
+                })}
           </p>
         </div>
       )}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
@@ -1,4 +1,5 @@
 import { IconBan, IconCheck, IconCircleHalf2 } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
 
 type PermissionPolicyToggleValue = "allow" | "deny";
 type PermissionPolicyToggleState =
@@ -7,10 +8,15 @@ type PermissionPolicyToggleState =
   | "mixed";
 
 export function PermissionPolicyMixedBadge() {
+  const { t } = useTranslation();
   return (
     <span className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md bg-muted/60 px-2 text-[11px] font-medium text-muted-foreground">
       <IconCircleHalf2 size={12} className="shrink-0" />
-      <span>Mixed</span>
+      <span>
+        {t(($) => {
+          return $.connectors.permissions.actions.mixed;
+        })}
+      </span>
     </span>
   );
 }
@@ -46,6 +52,7 @@ export function PermissionPolicyToggle({
   readonly onAllow: () => void;
   readonly onDeny: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <span className="inline-flex shrink-0 overflow-hidden rounded-md text-xs font-medium zero-border">
       <button
@@ -60,7 +67,9 @@ export function PermissionPolicyToggle({
         })}
       >
         <IconCheck size={12} stroke={2.5} />
-        Allow
+        {t(($) => {
+          return $.connectors.permissions.actions.allow;
+        })}
       </button>
       <button
         type="button"
@@ -75,7 +84,9 @@ export function PermissionPolicyToggle({
         })}
       >
         <IconBan size={12} stroke={2.5} />
-        Deny
+        {t(($) => {
+          return $.connectors.permissions.actions.deny;
+        })}
       </button>
     </span>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1,6 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import type { Computed } from "ccstate";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
@@ -95,6 +96,7 @@ import {
 } from "./permission-policy-toggle.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { i18n } from "../../../../i18n/index.ts";
 
 interface ConnectorPermission {
   name: string;
@@ -197,18 +199,33 @@ function PermissionsDrawerHeader({
   readonly icon: PublicConnectorCatalogIcon | undefined;
   readonly surface: PermissionsSurface;
 }) {
+  const { t } = useTranslation();
   const title = (
     <>
-      {connectorLabel} permissions
+      {t(
+        ($) => {
+          return $.connectors.permissions.title;
+        },
+        { connector: connectorLabel },
+      )}
       <span className="text-sm font-normal text-muted-foreground ml-1">
-        for {displayName}
+        {t(
+          ($) => {
+            return $.connectors.permissions.forTarget;
+          },
+          { target: displayName },
+        )}
       </span>
     </>
   );
   const description =
     targetKind === "workflow"
-      ? "Configure which actions this workflow is allowed to perform via this connector."
-      : "Configure which actions this agent is allowed to perform via this connector.";
+      ? t(($) => {
+          return $.connectors.permissions.descriptionWorkflow;
+        })
+      : t(($) => {
+          return $.connectors.permissions.descriptionAgent;
+        });
 
   if (surface === "dialog") {
     return (
@@ -265,10 +282,7 @@ function splitPermName(name: string): [string, string] {
   return [name, ""];
 }
 
-const POLICY_OPTIONS = [
-  { value: "allow" as const, label: "Allow" },
-  { value: "deny" as const, label: "Deny" },
-] as const;
+const POLICY_OPTIONS = ["allow", "deny"] as const;
 
 const PERMISSION_PAGE_SIZE = 100;
 
@@ -293,15 +307,16 @@ function PolicyPill({
   onChange?: (p: PermissionPolicy) => void;
   disabled?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
-      {POLICY_OPTIONS.map((opt, idx) => {
+      {POLICY_OPTIONS.map((option, idx) => {
         return (
           <button
-            key={opt.value}
+            key={option}
             type="button"
             disabled={disabled}
-            aria-pressed={policy === opt.value}
+            aria-pressed={policy === option}
             style={
               idx > 0
                 ? { borderLeft: "0.7px solid hsl(var(--gray-400))" }
@@ -310,11 +325,11 @@ function PolicyPill({
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onChange?.(opt.value);
+              onChange?.(option);
             }}
             className={`flex items-center gap-1 px-2.5 py-1.5 transition-colors ${
-              policy === opt.value
-                ? opt.value === "allow"
+              policy === option
+                ? option === "allow"
                   ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
                   : "bg-rose-500/10 text-rose-700 dark:text-rose-400"
                 : disabled
@@ -322,9 +337,15 @@ function PolicyPill({
                   : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
             } ${disabled ? "cursor-default" : "cursor-pointer"}`}
           >
-            {opt.value === "allow" && <IconCheck size={12} stroke={2.5} />}
-            {opt.value === "deny" && <IconBan size={12} stroke={2.5} />}
-            {opt.label}
+            {option === "allow" && <IconCheck size={12} stroke={2.5} />}
+            {option === "deny" && <IconBan size={12} stroke={2.5} />}
+            {option === "allow"
+              ? t(($) => {
+                  return $.connectors.permissions.actions.allow;
+                })
+              : t(($) => {
+                  return $.connectors.permissions.actions.deny;
+                })}
           </button>
         );
       })}
@@ -423,15 +444,20 @@ function UnknownEndpointsToggle({
 }: {
   policyControl: ReactNode;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="border-t border-border/40 -mx-6 px-3 pt-3 pb-1">
       <div className="flex items-center justify-between px-3">
         <div className="min-w-0 flex-1">
           <span className="text-xs font-medium text-foreground">
-            Other endpoints
+            {t(($) => {
+              return $.connectors.permissions.otherEndpoints;
+            })}
           </span>
           <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-            API endpoints not matched by any permission above
+            {t(($) => {
+              return $.connectors.permissions.otherEndpointsDescription;
+            })}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">{policyControl}</div>
@@ -450,36 +476,80 @@ function permissionDurationLabel({
   return (
     allowDurationStatusLabel(selected) ??
     compactGrantExpirationText(expiresAt) ??
-    "Always"
+    i18n.t(($) => {
+      return $.connectors.permissions.always;
+    })
   );
 }
 
-const ALLOW_DURATION_MENU_OPTIONS: readonly {
-  readonly value: UserPermissionGrantExpiresIn;
-  readonly label: string;
-  readonly statusLabel: string;
-}[] = [
-  { value: "1h", label: "Allow for 1h", statusLabel: "1h" },
-  { value: "24h", label: "Allow for 24h", statusLabel: "24h" },
-  { value: "7d", label: "Allow for 7d", statusLabel: "7d" },
-  { value: "always", label: "Allow always", statusLabel: "Always" },
+const ALLOW_DURATION_MENU_OPTIONS: readonly UserPermissionGrantExpiresIn[] = [
+  "1h",
+  "24h",
+  "7d",
+  "always",
 ];
 
 function compactGrantExpirationText(expiresAt: string | null): string | null {
   const text = permissionGrantExpiryText(expiresAt);
-  if (text === "Expires in less than 1 hour") {
-    return "< 1 hour";
+  if (
+    text ===
+    i18n.t(($) => {
+      return $.authorization.permission.expiration.lessThanHour;
+    })
+  ) {
+    return i18n.t(($) => {
+      return $.authorization.permission.expiration.lessThanHourShort;
+    });
   }
-  return text?.replace(/^Expires in /, "") ?? null;
+  return (
+    text?.replace(
+      i18n.t(($) => {
+        return $.authorization.permission.expiration.prefix;
+      }),
+      "",
+    ) ?? null
+  );
 }
 
 function allowDurationStatusLabel(
   selected: UserPermissionGrantExpiresIn | undefined,
 ): string | null {
   const option = ALLOW_DURATION_MENU_OPTIONS.find((item) => {
-    return item.value === selected;
+    return item === selected;
   });
-  return option?.statusLabel ?? null;
+  if (!option) {
+    return null;
+  }
+  return option === "always"
+    ? i18n.t(($) => {
+        return $.connectors.permissions.always;
+      })
+    : option;
+}
+
+function allowDurationMenuLabel(option: UserPermissionGrantExpiresIn): string {
+  switch (option) {
+    case "1h": {
+      return i18n.t(($) => {
+        return $.connectors.permissions.allowDuration.oneHour;
+      });
+    }
+    case "24h": {
+      return i18n.t(($) => {
+        return $.connectors.permissions.allowDuration.twentyFourHours;
+      });
+    }
+    case "7d": {
+      return i18n.t(($) => {
+        return $.connectors.permissions.allowDuration.sevenDays;
+      });
+    }
+    case "always": {
+      return i18n.t(($) => {
+        return $.connectors.permissions.allowDuration.always;
+      });
+    }
+  }
 }
 
 function MenuItemCheck({ active }: { active: boolean }) {
@@ -530,13 +600,19 @@ function PermissionAllowDurationDropdown({
   saving: boolean;
   onSelect: (expiresIn: UserPermissionGrantExpiresIn) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
           disabled={saving}
-          aria-label={`${permission} allow options`}
+          aria-label={t(
+            ($) => {
+              return $.connectors.permissions.allowOptions;
+            },
+            { permission },
+          )}
           className={`inline-flex h-7 shrink-0 items-center gap-1 rounded-md border px-2 text-[11px] font-medium zero-border transition-colors ${
             saving
               ? "cursor-default text-muted-foreground/50"
@@ -558,18 +634,18 @@ function PermissionAllowDurationDropdown({
         {ALLOW_DURATION_MENU_OPTIONS.map((option) => {
           return (
             <DropdownMenuItem
-              key={option.value}
+              key={option}
               onSelect={() => {
-                onSelect(option.value);
+                onSelect(option);
               }}
               className="flex items-center justify-between gap-4"
             >
-              {option.label}
+              {allowDurationMenuLabel(option)}
               <MenuItemCheck
                 active={isDurationMenuOptionActive({
                   allowAlwaysActive,
                   selected,
-                  value: option.value,
+                  value: option,
                 })}
               />
             </DropdownMenuItem>
@@ -701,10 +777,16 @@ function ShowMorePermissions({
   readonly remaining: number;
   readonly onClick: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="px-3 py-2">
       <Button type="button" variant="outline" className="h-8" onClick={onClick}>
-        Show more ({remaining})
+        {t(
+          ($) => {
+            return $.connectors.permissions.showMore;
+          },
+          { count: remaining },
+        )}
       </Button>
     </div>
   );
@@ -1069,17 +1151,30 @@ function PermissionsDrawerFooter({
   onClose,
   onApply,
 }: PermissionsDrawerFooterProps) {
+  const { t } = useTranslation();
   const showReset = !readOnly && resetEnabled && canReset;
 
   if (!showReset) {
     return (
       <PermissionsFooterShell surface={surface}>
         <Button variant="outline" onClick={onClose}>
-          {readOnly ? "Close" : "Cancel"}
+          {readOnly
+            ? t(($) => {
+                return $.connectors.actions.close;
+              })
+            : t(($) => {
+                return $.connectors.actions.cancel;
+              })}
         </Button>
         {!readOnly && (
           <Button onClick={onApply} disabled={!canApply}>
-            {saving ? "Saving..." : "Apply"}
+            {saving
+              ? t(($) => {
+                  return $.connectors.actions.saving;
+                })
+              : t(($) => {
+                  return $.connectors.actions.apply;
+                })}
           </Button>
         )}
       </PermissionsFooterShell>
@@ -1097,16 +1192,30 @@ function PermissionsDrawerFooter({
           onClick={onReset}
           disabled={saving || !resetAvailable}
         >
-          Restore
+          {t(($) => {
+            return $.connectors.permissions.restore;
+          })}
         </Button>
       </div>
       <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
         <Button variant="outline" onClick={onClose}>
-          {readOnly ? "Close" : "Cancel"}
+          {readOnly
+            ? t(($) => {
+                return $.connectors.actions.close;
+              })
+            : t(($) => {
+                return $.connectors.actions.cancel;
+              })}
         </Button>
         {!readOnly && (
           <Button onClick={onApply} disabled={!canApply}>
-            {saving ? "Saving..." : "Apply"}
+            {saving
+              ? t(($) => {
+                  return $.connectors.actions.saving;
+                })
+              : t(($) => {
+                  return $.connectors.actions.apply;
+                })}
           </Button>
         )}
       </div>
@@ -1127,6 +1236,7 @@ function LoadedPermissionsDrawerContent({
   metadata,
   initialState,
 }: LoadedPermissionsDrawerContentProps) {
+  const { t } = useTranslation();
   const { explicitGrants } = initialState;
   const stateKey = initialContextKey
     ? `${initialState.initialPolicyKey}\u0000${initialContextKey}`
@@ -1399,8 +1509,12 @@ function LoadedPermissionsDrawerContent({
               onChange={(event) => {
                 handleSearchChange(event.currentTarget.value);
               }}
-              aria-label="Find permissions"
-              placeholder="Find permissions..."
+              aria-label={t(($) => {
+                return $.connectors.permissions.find;
+              })}
+              placeholder={t(($) => {
+                return $.connectors.permissions.findPlaceholder;
+              })}
               className="h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input pl-9 pr-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10"
             />
             {search && (
@@ -1410,7 +1524,9 @@ function LoadedPermissionsDrawerContent({
                   handleSearchChange("");
                 }}
                 className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-                aria-label="Clear permission search"
+                aria-label={t(($) => {
+                  return $.connectors.permissions.clearSearch;
+                })}
               >
                 <IconX size={13} stroke={1.8} />
               </button>
@@ -1419,7 +1535,14 @@ function LoadedPermissionsDrawerContent({
           {!groups && !searchActive && (
             <div className="flex items-center justify-between gap-2">
               <span className="text-xs font-medium text-foreground">
-                {readOnly ? "Permissions" : "Select all"} ({permissions.length})
+                {readOnly
+                  ? t(($) => {
+                      return $.connectors.permissions.permissions;
+                    })
+                  : t(($) => {
+                      return $.connectors.permissions.selectAll;
+                    })}{" "}
+                ({permissions.length})
               </span>
               {!readOnly && (
                 <PolicyPill
@@ -1440,7 +1563,12 @@ function LoadedPermissionsDrawerContent({
         >
           {searchActive && displayedPermissions.length === 0 ? (
             <p className="px-3 py-4 text-sm text-muted-foreground">
-              No results for &ldquo;{search.trim()}&rdquo;
+              {t(
+                ($) => {
+                  return $.connectors.permissions.noResults;
+                },
+                { search: search.trim() },
+              )}
             </p>
           ) : (
             <PermissionRows
@@ -1543,6 +1671,7 @@ function PermissionsContent({
   readonly surface: PermissionsSurface;
   readonly onClose: () => void;
 }) {
+  const { t } = useTranslation();
   const metadataLoadable = useLoadable(props.metadata$);
   const loadedMetadata =
     metadataLoadable.state === "hasData" ? metadataLoadable.data : null;
@@ -1558,8 +1687,15 @@ function PermissionsContent({
   const loading = metadataLoadable.state === "loading";
   const message =
     metadataLoadable.state === "hasError"
-      ? "Failed to load permission metadata"
-      : `No permission metadata found for ${props.connectorSlug}`;
+      ? t(($) => {
+          return $.connectors.permissions.loadError;
+        })
+      : t(
+          ($) => {
+            return $.connectors.permissions.metadataMissing;
+          },
+          { connector: props.connectorSlug },
+        );
 
   return (
     <>
@@ -1586,7 +1722,9 @@ function PermissionsContent({
             {loading ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <IconLoader2 size={16} className="animate-spin" />
-                Loading permissions...
+                {t(($) => {
+                  return $.connectors.permissions.loading;
+                })}
               </div>
             ) : (
               <p className="text-sm text-destructive">{message}</p>
@@ -1595,7 +1733,13 @@ function PermissionsContent({
 
           <PermissionsFooterShell surface={surface}>
             <Button variant="outline" onClick={onClose}>
-              {props.readOnly ? "Close" : "Cancel"}
+              {props.readOnly
+                ? t(($) => {
+                    return $.connectors.actions.close;
+                  })
+                : t(($) => {
+                    return $.connectors.actions.cancel;
+                  })}
             </Button>
           </PermissionsFooterShell>
         </>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import { useTranslation } from "react-i18next";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import {
   allConnectorCatalogItems$,
@@ -18,11 +19,110 @@ interface ScopeReviewModalProps {
   onReconnect: (connectorSlug: ConnectorSlug) => void;
 }
 
+function ScopeDiffContent({
+  connectorSlug,
+  addedScopes,
+  removedScopes,
+  onClose,
+  onReconnect,
+}: {
+  connectorSlug: ConnectorSlug;
+  addedScopes: readonly string[];
+  removedScopes: readonly string[];
+  onClose: () => void;
+  onReconnect: (connectorSlug: ConnectorSlug) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        {t(($) => {
+          return $.connectors.permissions.scopeReview.description;
+        })}
+      </p>
+
+      {addedScopes.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            {t(($) => {
+              return $.connectors.permissions.scopeReview.added;
+            })}
+          </span>
+          <ul className="flex flex-col gap-1">
+            {addedScopes.map((scope) => {
+              return (
+                <li
+                  key={scope}
+                  className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400"
+                >
+                  <span>+</span>
+                  <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                    {scope}
+                  </code>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {removedScopes.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            {t(($) => {
+              return $.connectors.permissions.scopeReview.removed;
+            })}
+          </span>
+          <ul className="flex flex-col gap-1">
+            {removedScopes.map((scope) => {
+              return (
+                <li
+                  key={scope}
+                  className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400"
+                >
+                  <span>-</span>
+                  <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                    {scope}
+                  </code>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex gap-2 pt-2">
+        <button
+          type="button"
+          onClick={() => {
+            return onReconnect(connectorSlug);
+          }}
+          className="flex-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          {t(($) => {
+            return $.connectors.actions.reconnect;
+          })}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+        >
+          {t(($) => {
+            return $.connectors.actions.close;
+          })}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function ScopeReviewModal({
   connectorSlug,
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
+  const { t } = useTranslation();
   const scopeDiffLoadable = useLoadable(scopeDiff$);
   const connectorCatalogItems = useLastResolved(allConnectorCatalogItems$);
   const loading = scopeDiffLoadable.state === "loading";
@@ -51,89 +151,36 @@ export function ScopeReviewModal({
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
               <ConnectorIcon icon={connector?.icon} size={20} />
             </div>
-            <DialogTitle>{connectorLabel} permissions update</DialogTitle>
+            <DialogTitle>
+              {t(
+                ($) => {
+                  return $.connectors.permissions.scopeReview.title;
+                },
+                { connector: connectorLabel },
+              )}
+            </DialogTitle>
           </div>
         </DialogHeader>
 
         {loading ? (
           <p className="text-sm text-muted-foreground">
-            Loading scope changes...
+            {t(($) => {
+              return $.connectors.permissions.scopeReview.loading;
+            })}
           </p>
         ) : scopeDiff ? (
-          <div className="flex flex-col gap-4">
-            <p className="text-sm text-muted-foreground">
-              The required permissions for this connector have changed. Please
-              review and reconnect to apply the update.
-            </p>
-
-            {scopeDiff.addedScopes.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  New permissions
-                </span>
-                <ul className="flex flex-col gap-1">
-                  {scopeDiff.addedScopes.map((scope) => {
-                    return (
-                      <li
-                        key={scope}
-                        className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400"
-                      >
-                        <span>+</span>
-                        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                          {scope}
-                        </code>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            )}
-
-            {scopeDiff.removedScopes.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Removed permissions
-                </span>
-                <ul className="flex flex-col gap-1">
-                  {scopeDiff.removedScopes.map((scope) => {
-                    return (
-                      <li
-                        key={scope}
-                        className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400"
-                      >
-                        <span>-</span>
-                        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                          {scope}
-                        </code>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            )}
-
-            <div className="flex gap-2 pt-2">
-              <button
-                type="button"
-                onClick={() => {
-                  return onReconnect(connectorSlug);
-                }}
-                className="flex-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-              >
-                Reconnect
-              </button>
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
-              >
-                Close
-              </button>
-            </div>
-          </div>
+          <ScopeDiffContent
+            connectorSlug={connectorSlug}
+            addedScopes={scopeDiff.addedScopes}
+            removedScopes={scopeDiff.removedScopes}
+            onClose={onClose}
+            onReconnect={onReconnect}
+          />
         ) : (
           <p className="text-sm text-muted-foreground">
-            Failed to load scope changes.
+            {t(($) => {
+              return $.connectors.permissions.scopeReview.failed;
+            })}
           </p>
         )}
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -38,7 +38,9 @@ import {
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { useTranslation } from "react-i18next";
 
+import { i18n } from "../../i18n/index.ts";
 import {
   platformFeishuAppCreatedCredentialsImg,
   platformFeishuAvailabilitySettingsAllMembersImg,
@@ -110,12 +112,20 @@ function agentLabel(
 }
 
 function CopyButton({ value, label }: { value: string; label: string }) {
+  const { t } = useTranslation();
   const copy = () => {
     detach(
       (async () => {
         const copied = await writeToClipboard(value);
         if (copied) {
-          toast.success(`${label} copied`);
+          toast.success(
+            i18n.t(
+              ($) => {
+                return $.connectors.providerSettings.feishu.copied;
+              },
+              { label },
+            ),
+          );
         }
       })(),
       Reason.DomCallback,
@@ -124,7 +134,9 @@ function CopyButton({ value, label }: { value: string; label: string }) {
   return (
     <Button type="button" variant="outline" size="sm" onClick={copy}>
       <IconCopy size={14} />
-      Copy
+      {t(($) => {
+        return $.connectors.providerSettings.feishu.copy;
+      })}
     </Button>
   );
 }
@@ -170,6 +182,7 @@ function FeishuGuideCarousel({
 }: {
   images: readonly [FeishuGuideCarouselImage, ...FeishuGuideCarouselImage[]];
 }) {
+  const { t } = useTranslation();
   const activeIndex = useGet(feishuGuideImageIndex$);
   const moveImage = useSet(moveFeishuGuideImage$);
   const setActiveIndex = useSet(setFeishuGuideImageIndex$);
@@ -190,7 +203,9 @@ function FeishuGuideCarousel({
         <button
           type="button"
           className="absolute left-3 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background/90 text-foreground shadow-sm"
-          aria-label="Show previous Feishu guide image"
+          aria-label={t(($) => {
+            return $.connectors.providerSettings.feishu.guide.previous;
+          })}
           onClick={() => {
             move(-1);
           }}
@@ -200,7 +215,9 @@ function FeishuGuideCarousel({
         <button
           type="button"
           className="absolute right-3 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background/90 text-foreground shadow-sm"
-          aria-label="Show next Feishu guide image"
+          aria-label={t(($) => {
+            return $.connectors.providerSettings.feishu.guide.next;
+          })}
           onClick={() => {
             move(1);
           }}
@@ -219,7 +236,12 @@ function FeishuGuideCarousel({
               <button
                 key={image.src}
                 type="button"
-                aria-label={`Show Feishu guide image ${index + 1}`}
+                aria-label={t(
+                  ($) => {
+                    return $.connectors.providerSettings.feishu.guide.show;
+                  },
+                  { number: index + 1 },
+                )}
                 aria-current={active ? "true" : undefined}
                 className={
                   active
@@ -241,28 +263,24 @@ function FeishuGuideCarousel({
 type FeishuCredentialField = Exclude<keyof FeishuSetupInput, "defaultAgentId">;
 
 const FEISHU_SETUP_STEPS = [
-  { key: "create", label: "Create" },
-  { key: "credentials", label: "Credentials" },
-  { key: "tokens", label: "Tokens" },
-  { key: "events", label: "Events" },
-  { key: "redirect", label: "Redirect" },
-  { key: "publish", label: "Publish" },
-] as const satisfies readonly {
-  key: FeishuSetupStep;
-  label: string;
-}[];
+  "create",
+  "credentials",
+  "tokens",
+  "events",
+  "redirect",
+  "publish",
+] as const satisfies readonly FeishuSetupStep[];
 
 function FeishuSetupProgress({ step }: { step: FeishuSetupStep }) {
-  const currentIndex = FEISHU_SETUP_STEPS.findIndex((item) => {
-    return item.key === step;
-  });
+  const { t } = useTranslation();
+  const currentIndex = FEISHU_SETUP_STEPS.indexOf(step);
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-1.5">
         {FEISHU_SETUP_STEPS.map((item, index) => {
           return (
             <div
-              key={item.key}
+              key={item}
               className={
                 index <= currentIndex
                   ? "h-1 flex-1 rounded-full bg-foreground"
@@ -276,14 +294,16 @@ function FeishuSetupProgress({ step }: { step: FeishuSetupStep }) {
         {FEISHU_SETUP_STEPS.map((item, index) => {
           return (
             <div
-              key={item.key}
+              key={item}
               className={
                 index <= currentIndex
                   ? "truncate font-medium text-foreground"
                   : "truncate text-muted-foreground"
               }
             >
-              {item.label}
+              {t(($) => {
+                return $.connectors.providerSettings.feishu.steps[item];
+              })}
             </div>
           );
         })}
@@ -307,6 +327,7 @@ function FeishuCredentialInput({
   readOnly: boolean;
   placeholder?: string;
 }) {
+  const { t } = useTranslation();
   const updateForm = useSet(updateFeishuSetupForm$);
   const id = `feishu-${field}`;
   return (
@@ -321,7 +342,13 @@ function FeishuCredentialInput({
         disabled={saving || readOnly}
         required
         autoComplete="off"
-        placeholder={readOnly && field !== "appId" ? "Configured" : placeholder}
+        placeholder={
+          readOnly && field !== "appId"
+            ? t(($) => {
+                return $.connectors.providerSettings.feishu.configured;
+              })
+            : placeholder
+        }
         onChange={(event) => {
           updateForm({ [field]: event.target.value });
         }}
@@ -406,11 +433,14 @@ function FeishuAgentSelect({
   readOnly: boolean;
   onAgentChange?: (defaultAgentId: string) => void;
 }) {
+  const { t } = useTranslation();
   const updateForm = useSet(updateFeishuSetupForm$);
   return (
     <div className="flex flex-col gap-2">
       <label htmlFor="feishu-default-agent" className="text-sm font-medium">
-        Default agent
+        {t(($) => {
+          return $.connectors.providerSettings.feishu.defaultAgent;
+        })}
       </label>
       <Select
         value={form.defaultAgentId}
@@ -421,7 +451,11 @@ function FeishuAgentSelect({
         }}
       >
         <SelectTrigger id="feishu-default-agent">
-          <SelectValue placeholder="Select an agent" />
+          <SelectValue
+            placeholder={t(($) => {
+              return $.connectors.providerSettings.feishu.selectAgent;
+            })}
+          />
         </SelectTrigger>
         <SelectContent>
           {agents.map((agent) => {
@@ -453,15 +487,21 @@ function canSubmitFeishuSetup(
 
 function FeishuCreateStep() {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Create an enterprise custom app
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.create.title;
+          })}
         </div>
         <p className="leading-relaxed">
-          In the{" "}
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.create
+              .descriptionBefore;
+          })}
           <a
             href={FEISHU_DEVELOPER_CONSOLE_URL}
             target="_blank"
@@ -470,20 +510,32 @@ function FeishuCreateStep() {
           >
             Feishu developer console
           </a>
-          , create an enterprise custom app named {brandName}, upload the{" "}
-          {brandName} icon, then add the Bot capability.
+          {t(
+            ($) => {
+              return $.connectors.providerSettings.feishu.create
+                .descriptionAfter;
+            },
+            { brandName },
+          )}
         </p>
         <div className="mt-4">
           <FeishuGuideImage
             src={platformFeishuCreateEnterpriseCustomAppImg}
-            alt="Feishu app creation form with the app name, icon, and Create button highlighted"
+            alt={t(($) => {
+              return $.connectors.providerSettings.feishu.create.imageAlt;
+            })}
           />
         </div>
       </div>
       <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-4">
         <div>
           <div className="text-sm font-medium text-foreground">
-            {brandName} app icon
+            {t(
+              ($) => {
+                return $.connectors.providerSettings.feishu.create.iconTitle;
+              },
+              { brandName },
+            )}
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
             <a
@@ -491,14 +543,27 @@ function FeishuCreateStep() {
               download="vm0-feishu-app-icon.png"
               className="font-medium text-foreground underline underline-offset-4"
             >
-              Download the {brandName} icon
+              {t(
+                ($) => {
+                  return $.connectors.providerSettings.feishu.create
+                    .downloadIcon;
+                },
+                { brandName },
+              )}
             </a>
-            , or use any icon you prefer.
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.create.iconHint;
+            })}
           </p>
         </div>
         <img
           src="/icons/icon-512.png"
-          alt={`${brandName} app icon`}
+          alt={t(
+            ($) => {
+              return $.connectors.providerSettings.feishu.create.iconAlt;
+            },
+            { brandName },
+          )}
           className="h-14 w-14 shrink-0 rounded-xl"
         />
       </div>
@@ -515,20 +580,26 @@ function FeishuCredentialsStep({
   saving: boolean;
   readOnly: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Add the app credentials
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.credentials.title;
+          })}
         </div>
         <p className="leading-relaxed">
-          Copy the App ID and App Secret from Credentials &amp; Basic
-          Information.
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.credentials.description;
+          })}
         </p>
         <div className="mt-4">
           <FeishuGuideImage
             src={platformFeishuAppCreatedCredentialsImg}
-            alt="Feishu app creation result showing where to find the App ID and App Secret"
+            alt={t(($) => {
+              return $.connectors.providerSettings.feishu.credentials.imageAlt;
+            })}
           />
         </div>
       </div>
@@ -550,14 +621,20 @@ function FeishuTokensStep({
   saving: boolean;
   readOnly: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Add the event verification tokens
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.tokens.title;
+          })}
         </div>
         <p className="leading-relaxed">
-          Open the{" "}
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.tokens
+              .descriptionBefore;
+          })}
           <a
             href={FEISHU_APP_CONSOLE_URL}
             target="_blank"
@@ -566,14 +643,16 @@ function FeishuTokensStep({
           >
             Feishu developer console
           </a>
-          , select the app you just created, and enter its configuration page.
-          Open Event Configuration → Encryption Strategy, then copy the Encrypt
-          Key and Verification Token.
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.tokens.descriptionAfter;
+          })}
         </p>
         <div className="mt-4">
           <FeishuGuideImage
             src={platformFeishuEncryptionStrategyImg}
-            alt="Feishu Encryption Strategy screen showing the Encrypt Key and Verification Token"
+            alt={t(($) => {
+              return $.connectors.providerSettings.feishu.tokens.imageAlt;
+            })}
           />
         </div>
       </div>
@@ -587,24 +666,33 @@ function FeishuTokensStep({
 }
 
 function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <span className="font-medium text-foreground">
-            Configure event delivery
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.events.title;
+            })}
           </span>
           <SetupStatus complete={data?.callbackVerified ?? false}>
             {data?.callbackVerified
-              ? "Callback verified"
-              : "Waiting for callback"}
+              ? t(($) => {
+                  return $.connectors.providerSettings.feishu
+                    .callbackStatusVerified;
+                })
+              : t(($) => {
+                  return $.connectors.providerSettings.feishu
+                    .callbackStatusWaiting;
+                })}
           </SetupStatus>
         </div>
         <p className="leading-relaxed">
-          Open Event Configuration. Under Subscription mode, select “Send
-          notifications to developer&apos;s server”. Then open Callback
-          Configuration and paste the callback URL. After Feishu verifies it,
-          add the “Receive message v1” event (
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.events.description;
+          })}{" "}
+          (
           <code className="font-mono text-xs text-foreground">
             im.message.receive_v1
           </code>
@@ -615,13 +703,24 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
             images={[
               {
                 src: platformFeishuEventSubscriptionModeImg,
-                alt: "Feishu Event Configuration screen with the subscription mode edit control highlighted",
-                label: "Select the event subscription mode",
+                alt: t(($) => {
+                  return $.connectors.providerSettings.feishu.events
+                    .subscriptionAlt;
+                }),
+                label: t(($) => {
+                  return $.connectors.providerSettings.feishu.events
+                    .subscriptionLabel;
+                }),
               },
               {
                 src: platformFeishuEventRequestUrlImg,
-                alt: "Feishu Event Configuration screen with the Request URL field highlighted",
-                label: "Add the callback request URL",
+                alt: t(($) => {
+                  return $.connectors.providerSettings.feishu.events.requestAlt;
+                }),
+                label: t(($) => {
+                  return $.connectors.providerSettings.feishu.events
+                    .requestLabel;
+                }),
               },
             ]}
           />
@@ -630,13 +729,19 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
       <div className="flex gap-2">
         <Input value={data?.callbackUrl ?? ""} readOnly />
         {data?.callbackUrl ? (
-          <CopyButton value={data.callbackUrl} label="Callback URL" />
+          <CopyButton
+            value={data.callbackUrl}
+            label={t(($) => {
+              return $.connectors.providerSettings.feishu.events.callbackLabel;
+            })}
+          />
         ) : null}
       </div>
       {!data?.callbackVerified ? (
         <p className="text-sm text-muted-foreground">
-          Continue after Feishu verifies the callback URL and the message event
-          is subscribed.
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.events.continue;
+          })}
         </p>
       ) : null}
     </div>
@@ -645,15 +750,21 @@ function FeishuEventsStep({ data }: { data: FeishuDialogData | null }) {
 
 function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Configure the OAuth redirect URL
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.redirect.title;
+          })}
         </div>
         <p className="leading-relaxed">
-          In the{" "}
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.redirect
+              .descriptionBefore;
+          })}
           <a
             href={FEISHU_DEVELOPER_CONSOLE_URL}
             target="_blank"
@@ -662,9 +773,13 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
           >
             Feishu developer console
           </a>
-          , open Development Configuration → Security Settings. Add the URL
-          below under Redirect URLs so workspace members can connect their
-          Feishu account to {brandName}.
+          {t(
+            ($) => {
+              return $.connectors.providerSettings.feishu.redirect
+                .descriptionAfter;
+            },
+            { brandName },
+          )}
         </p>
       </div>
       <div className="flex gap-2">
@@ -672,13 +787,17 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
         {data?.oauthRedirectUrl ? (
           <CopyButton
             value={data.oauthRedirectUrl}
-            label="OAuth redirect URL"
+            label={t(($) => {
+              return $.connectors.providerSettings.feishu.redirect.label;
+            })}
           />
         ) : null}
       </div>
       <FeishuGuideImage
         src={platformFeishuSecuritySettingsRedirectUrlImg}
-        alt="Feishu Security Settings page showing where to add an OAuth redirect URL"
+        alt={t(($) => {
+          return $.connectors.providerSettings.feishu.redirect.imageAlt;
+        })}
       />
     </div>
   );
@@ -699,6 +818,7 @@ function FeishuPublishStep({
   orgDefaultAgentName: string | null;
   readOnly: boolean;
 }) {
+  const { t } = useTranslation();
   const [updateLoadable, updateAgent] = useLoadableSet(
     updateFeishuInstallationAgent$,
   );
@@ -706,29 +826,51 @@ function FeishuPublishStep({
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        <div className="mb-2 font-medium text-foreground">Publish the app</div>
+        <div className="mb-2 font-medium text-foreground">
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.publish.title;
+          })}
+        </div>
         <p className="leading-relaxed">
-          Create and publish an app version, then edit its availability settings
-          and select All members. The app can only be used by other members of
-          your organization after you grant them access.
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.publish.description;
+          })}
         </p>
         <div className="mt-4">
           <FeishuGuideCarousel
             images={[
               {
                 src: platformFeishuVersionManagementCreateVersionImg,
-                alt: "Feishu Version Management page with the Create a version button highlighted",
-                label: "Create an app version",
+                alt: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .createVersionAlt;
+                }),
+                label: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .createVersionLabel;
+                }),
               },
               {
                 src: platformFeishuVersionAvailabilityEditImg,
-                alt: "Feishu version details page with the availability settings edit action highlighted",
-                label: "Edit the availability settings",
+                alt: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .editAvailabilityAlt;
+                }),
+                label: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .editAvailabilityLabel;
+                }),
               },
               {
                 src: platformFeishuAvailabilitySettingsAllMembersImg,
-                alt: "Feishu availability settings with All members selected",
-                label: "Make the app available to all members",
+                alt: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .allMembersAlt;
+                }),
+                label: t(($) => {
+                  return $.connectors.providerSettings.feishu.publish
+                    .allMembersLabel;
+                }),
               },
             ]}
           />
@@ -737,10 +879,14 @@ function FeishuPublishStep({
       <div className="space-y-3 rounded-lg border border-border p-4">
         <div>
           <div className="text-sm font-medium text-foreground">
-            Default agent
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.defaultAgent;
+            })}
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
-            Choose the agent that should handle messages sent to this bot.
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.agentDescription;
+            })}
           </p>
         </div>
         <FeishuAgentSelect
@@ -885,18 +1031,40 @@ function feishuSetupContinueLabel(args: {
   readonly readOnly: boolean;
 }): string {
   if (args.readOnly) {
-    return args.step === "publish" ? "Done" : "Next";
+    return args.step === "publish"
+      ? i18n.t(($) => {
+          return $.connectors.providerSettings.feishu.steps.done;
+        })
+      : i18n.t(($) => {
+          return $.connectors.providerSettings.feishu.steps.next;
+        });
   }
   if (args.step === "tokens") {
-    return args.saving ? "Verifying…" : "Verify and continue";
+    return args.saving
+      ? i18n.t(($) => {
+          return $.connectors.providerSettings.feishu.steps.verifying;
+        })
+      : i18n.t(($) => {
+          return $.connectors.providerSettings.feishu.steps.verify;
+        });
   }
   if (args.step === "credentials" && args.checkingAppId) {
-    return "Checking…";
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.feishu.steps.checking;
+    });
   }
   if (args.step === "events" && !args.callbackVerified) {
-    return "Waiting for callback";
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.feishu.steps.waiting;
+    });
   }
-  return args.step === "publish" ? "Done" : "Next";
+  return args.step === "publish"
+    ? i18n.t(($) => {
+        return $.connectors.providerSettings.feishu.steps.done;
+      })
+    : i18n.t(($) => {
+        return $.connectors.providerSettings.feishu.steps.next;
+      });
 }
 
 function FeishuSetupWizardFooter({
@@ -920,8 +1088,15 @@ function FeishuSetupWizardFooter({
   onBack: () => void;
   onContinue: () => void;
 }) {
+  const { t } = useTranslation();
   const isFirstStep = step === "create";
-  const firstStepLabel = readOnly ? "Close" : "Cancel";
+  const firstStepLabel = readOnly
+    ? t(($) => {
+        return $.connectors.providerSettings.feishu.steps.close;
+      })
+    : t(($) => {
+        return $.connectors.actions.cancel;
+      });
   const continueLabel = feishuSetupContinueLabel({
     step,
     saving,
@@ -942,7 +1117,9 @@ function FeishuSetupWizardFooter({
         ) : (
           <span className="inline-flex items-center gap-2">
             <IconArrowLeft size={16} />
-            Back
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.steps.back;
+            })}
           </span>
         )}
       </Button>
@@ -1074,6 +1251,7 @@ function FeishuSetupWizard({
 }
 
 export function FeishuCard() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname={ROUTES.settingsFeishu}
@@ -1087,12 +1265,16 @@ export function FeishuCard() {
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="text-sm font-medium text-foreground">Feishu</div>
           <div className="truncate text-sm text-muted-foreground">
-            Route Feishu messages to agents
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.routeDescription;
+            })}
           </div>
         </div>
         <span className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
           <IconSettings size={14} stroke={1.5} />
-          Manage
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.manage;
+          })}
         </span>
       </div>
     </Link>
@@ -1100,14 +1282,22 @@ export function FeishuCard() {
 }
 
 function FeishuStatusBadge({ bot }: { bot: FeishuBotInstallation }) {
+  const { t } = useTranslation();
   if (bot.isConnected) {
     return (
       <span className="inline-flex min-w-0 max-w-52 items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-secondary-foreground">
         <IconCircleCheck className="h-3.5 w-3.5 text-green-600" />
         <span className="min-w-0 truncate" title={bot.connectedUserName ?? ""}>
           {bot.connectedUserName
-            ? `Connected (${bot.connectedUserName})`
-            : "Connected"}
+            ? t(
+                ($) => {
+                  return $.connectors.providerSettings.works.connectedDetail;
+                },
+                { detail: bot.connectedUserName },
+              )
+            : t(($) => {
+                return $.connectors.providerSettings.works.connected;
+              })}
         </span>
       </span>
     );
@@ -1115,7 +1305,9 @@ function FeishuStatusBadge({ bot }: { bot: FeishuBotInstallation }) {
   if (!bot.setupCompleted) {
     return (
       <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
-        Setup incomplete
+        {t(($) => {
+          return $.connectors.providerSettings.feishu.setupIncomplete;
+        })}
       </span>
     );
   }
@@ -1131,6 +1323,7 @@ function FeishuBotAgentSelect({
   agents: TeamComposeItem[];
   disabled: boolean;
 }) {
+  const { t } = useTranslation();
   const [updateLoadable, updateAgent] = useLoadableSet(
     updateFeishuInstallationAgent$,
   );
@@ -1146,8 +1339,19 @@ function FeishuBotAgentSelect({
         detach(updateAgent(bot.id, defaultAgentId, signal), Reason.DomCallback);
       }}
     >
-      <SelectTrigger aria-label={`Default agent for ${bot.appId}`}>
-        <SelectValue placeholder="Select an agent" />
+      <SelectTrigger
+        aria-label={t(
+          ($) => {
+            return $.connectors.providerSettings.feishu.defaultAgentAria;
+          },
+          { appId: bot.appId },
+        )}
+      >
+        <SelectValue
+          placeholder={t(($) => {
+            return $.connectors.providerSettings.feishu.selectAgent;
+          })}
+        />
       </SelectTrigger>
       <SelectContent>
         {agents.map((agent) => {
@@ -1171,6 +1375,7 @@ function FeishuBotMenu({
   title: string;
   isAdmin: boolean;
 }) {
+  const { t } = useTranslation();
   const open = useSet(openFeishuDialog$);
   const setUninstallInstallationId = useSet(setFeishuUninstallInstallationId$);
   const [disconnectLoadable, disconnect] = useLoadableSet(disconnectFeishuOrg$);
@@ -1186,7 +1391,12 @@ function FeishuBotMenu({
           type="button"
           disabled={disconnecting}
           className="shrink-0 rounded p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          aria-label={`More options for ${title}`}
+          aria-label={t(
+            ($) => {
+              return $.connectors.providerSettings.feishu.moreOptions;
+            },
+            { bot: title },
+          )}
         >
           <IconDotsVertical size={16} stroke={1.5} />
         </button>
@@ -1206,7 +1416,13 @@ function FeishuBotMenu({
                 });
               }}
             >
-              {bot.setupCompleted ? "Review guide" : "Manage"}
+              {bot.setupCompleted
+                ? t(($) => {
+                    return $.connectors.providerSettings.feishu.reviewGuide;
+                  })
+                : t(($) => {
+                    return $.connectors.providerSettings.feishu.manage;
+                  })}
             </button>
             <button
               type="button"
@@ -1216,7 +1432,9 @@ function FeishuBotMenu({
                 setUninstallInstallationId(bot.id);
               }}
             >
-              Uninstall
+              {t(($) => {
+                return $.connectors.actions.uninstall;
+              })}
             </button>
           </>
         ) : null}
@@ -1229,7 +1447,13 @@ function FeishuBotMenu({
               detach(disconnect(bot.id, signal), Reason.DomCallback);
             }}
           >
-            {disconnecting ? "Disconnecting…" : "Disconnect"}
+            {disconnecting
+              ? t(($) => {
+                  return $.connectors.actions.disconnecting;
+                })
+              : t(($) => {
+                  return $.connectors.actions.disconnect;
+                })}
           </button>
         ) : null}
       </PopoverContent>
@@ -1248,7 +1472,13 @@ function FeishuBotRow({
   agentsLoading: boolean;
   isAdmin: boolean;
 }) {
-  const title = bot.botName ?? bot.tenantName ?? "Feishu bot";
+  const { t } = useTranslation();
+  const title =
+    bot.botName ??
+    bot.tenantName ??
+    t(($) => {
+      return $.connectors.providerSettings.feishu.botFallback;
+    });
   const connectUrl = bot.connectUrl;
   return (
     <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
@@ -1256,7 +1486,12 @@ function FeishuBotRow({
         <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl">
           <img
             src={bot.botAvatarUrl ?? feishuIconImg}
-            alt={`${title} bot icon`}
+            alt={t(
+              ($) => {
+                return $.connectors.providerSettings.feishu.botIconAlt;
+              },
+              { bot: title },
+            )}
             className={
               bot.botAvatarUrl ? "h-10 w-10 rounded-xl object-cover" : "h-7 w-7"
             }
@@ -1297,7 +1532,9 @@ function FeishuBotRow({
               window.open(url.toString(), "_blank");
             }}
           >
-            Connect
+            {t(($) => {
+              return $.connectors.actions.connect;
+            })}
           </Button>
         ) : null}
         <FeishuBotMenu bot={bot} title={title} isAdmin={isAdmin} />
@@ -1317,6 +1554,7 @@ function FeishuBotList({
   agentsLoading: boolean;
   isAdmin: boolean;
 }) {
+  const { t } = useTranslation();
   if (bots.length === 0) {
     return (
       <div className="px-6 py-12 text-center">
@@ -1324,12 +1562,18 @@ function FeishuBotList({
           <img src={feishuIconImg} alt="" className="h-8 w-8" />
         </div>
         <div className="text-sm font-medium text-foreground">
-          No Feishu bots yet
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.emptyTitle;
+          })}
         </div>
         <div className="mt-1 text-sm text-muted-foreground">
           {isAdmin
-            ? "Add a custom app to route Feishu messages to an agent."
-            : "Ask an organization admin to add a Feishu bot."}
+            ? t(($) => {
+                return $.connectors.providerSettings.feishu.emptyAdmin;
+              })
+            : t(($) => {
+                return $.connectors.providerSettings.feishu.emptyMember;
+              })}
         </div>
       </div>
     );
@@ -1368,10 +1612,15 @@ function FeishuBotsCard({
   isAdmin: boolean;
   onAdd: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <section className="zero-card overflow-hidden">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
-        <h2 className="text-sm font-medium text-foreground">Feishu bots</h2>
+        <h2 className="text-sm font-medium text-foreground">
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.bots;
+          })}
+        </h2>
         {isAdmin && bots.length === 0 ? (
           <Button
             type="button"
@@ -1380,7 +1629,9 @@ function FeishuBotsCard({
             onClick={onAdd}
           >
             <IconPlus size={16} />
-            Add bot
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.addBot;
+            })}
           </Button>
         ) : null}
       </div>
@@ -1395,6 +1646,7 @@ function FeishuBotsCard({
 }
 
 function FeishuSetupFaq() {
+  const { t } = useTranslation();
   return (
     <section
       className="zero-card overflow-hidden"
@@ -1405,7 +1657,9 @@ function FeishuSetupFaq() {
           id="feishu-setup-faq-title"
           className="text-sm font-medium text-foreground"
         >
-          Setup FAQ
+          {t(($) => {
+            return $.connectors.providerSettings.feishu.faq.title;
+          })}
         </h2>
       </div>
       <div className="divide-y divide-border/50">
@@ -1417,15 +1671,16 @@ function FeishuSetupFaq() {
               className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
             />
             <span>
-              Why does Feishu show &quot;Challenge code didn&apos;t get a
-              response&quot;?
+              {t(($) => {
+                return $.connectors.providerSettings.feishu.faq
+                  .challengeQuestion;
+              })}
             </span>
           </summary>
           <p className="mt-2 pl-[25px] text-sm leading-relaxed text-muted-foreground">
-            This usually means the Encrypt Key or Verification Token saved
-            during the Tokens step is incorrect. Return to the Tokens step,
-            enter both values from Event Configuration → Encryption Strategy
-            again, save them, and retry the Request URL.
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.faq.challengeAnswer;
+            })}
           </p>
         </details>
         <details className="group px-4 py-4 sm:px-5">
@@ -1435,13 +1690,17 @@ function FeishuSetupFaq() {
               aria-hidden="true"
               className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
             />
-            <span>Why is publishing the app waiting for approval?</span>
+            <span>
+              {t(($) => {
+                return $.connectors.providerSettings.feishu.faq
+                  .approvalQuestion;
+              })}
+            </span>
           </summary>
           <p className="mt-2 pl-[25px] text-sm leading-relaxed text-muted-foreground">
-            If availability is set to All members, a Feishu administrator must
-            approve the release. Feishu sends the approval request to an
-            administrator in a direct message, and the app remains pending until
-            an administrator completes the review.
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.faq.approvalAnswer;
+            })}
           </p>
         </details>
       </div>
@@ -1500,11 +1759,13 @@ function FeishuDialogBody({
   orgDefaultAgentName: string | null;
   onClose: () => void;
 }) {
+  const { t } = useTranslation();
   if (!isAdmin) {
     return (
       <p className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-        An organization admin must configure the app. You can connect your own
-        account from the Feishu bot list after setup is complete.
+        {t(($) => {
+          return $.connectors.providerSettings.feishu.dialogAdminRequired;
+        })}
       </p>
     );
   }
@@ -1534,16 +1795,28 @@ function FeishuSetupDialog({
   orgDefaultAgentId: string | null;
   orgDefaultAgentName: string | null;
 }) {
+  const { t } = useTranslation();
   const open = useGet(feishuDialogOpen$);
   const existing = useGet(feishuDialogExisting$);
   const close = useSet(closeFeishuDialog$);
   const readOnly = data?.setupCompleted ?? false;
-  let title = existing ? "Manage Feishu bot" : "Add a Feishu bot";
-  let description =
-    "Create an enterprise custom app, enable its bot, and complete these steps in the Feishu developer console.";
+  let title = existing
+    ? t(($) => {
+        return $.connectors.providerSettings.feishu.manageDialogTitle;
+      })
+    : t(($) => {
+        return $.connectors.providerSettings.feishu.addDialogTitle;
+      });
+  let description = t(($) => {
+    return $.connectors.providerSettings.feishu.addDialogDescription;
+  });
   if (readOnly) {
-    title = "Feishu review guide";
-    description = "Review the completed setup steps for this Feishu bot.";
+    title = t(($) => {
+      return $.connectors.providerSettings.feishu.reviewGuideTitle;
+    });
+    description = t(($) => {
+      return $.connectors.providerSettings.feishu.reviewGuideDescription;
+    });
   }
   return (
     <Dialog
@@ -1579,13 +1852,19 @@ function FeishuSetupDialog({
 
 function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
   const setUninstallInstallationId = useSet(setFeishuUninstallInstallationId$);
   const [uninstallLoadable, uninstallInstallation] = useLoadableSet(
     uninstallFeishuInstallation$,
   );
   const signal = useGet(pageSignal$);
   const uninstalling = uninstallLoadable.state === "loading";
-  const title = bot?.tenantName ?? bot?.appId ?? "this bot";
+  const title =
+    bot?.tenantName ??
+    bot?.appId ??
+    t(($) => {
+      return $.connectors.providerSettings.feishu.uninstallTargetFallback;
+    });
   return (
     <Dialog
       open={Boolean(bot)}
@@ -1597,10 +1876,19 @@ function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Uninstall Feishu bot?</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.uninstallTitle;
+            })}
+          </DialogTitle>
           <DialogDescription>
-            This uninstalls {title} from the workspace and disconnects every{" "}
-            {brandName} account using it. This action cannot be undone.
+            {t(
+              ($) => {
+                return $.connectors.providerSettings.feishu
+                  .uninstallDescription;
+              },
+              { bot: title, brandName },
+            )}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -1612,7 +1900,9 @@ function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
               setUninstallInstallationId(null);
             }}
           >
-            Cancel
+            {t(($) => {
+              return $.connectors.actions.cancel;
+            })}
           </Button>
           <Button
             type="button"
@@ -1632,7 +1922,13 @@ function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
               );
             }}
           >
-            {uninstalling ? "Uninstalling…" : "Uninstall"}
+            {uninstalling
+              ? t(($) => {
+                  return $.connectors.actions.uninstalling;
+                })
+              : t(($) => {
+                  return $.connectors.actions.uninstall;
+                })}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -1699,6 +1995,7 @@ function feishuSettingsHasError(...states: readonly string[]): boolean {
 }
 
 export function ZeroFeishuSettingsPage() {
+  const { t } = useTranslation();
   const dataLoadable = useLastLoadable(feishuOrgData$);
   const botsLoadable = useLastLoadable(feishuInstallations$);
   const agentsLoadable = useLastLoadable(sortedAgents$);
@@ -1745,9 +2042,17 @@ export function ZeroFeishuSettingsPage() {
               size="sm"
               className="h-8 gap-2 px-2 text-muted-foreground hover:text-foreground"
             >
-              <Link pathname={ROUTES.works} title="Back to integrations">
+              <Link
+                pathname={ROUTES.works}
+                title={t(($) => {
+                  return $.connectors.catalog.title;
+                })}
+              >
                 <IconArrowLeft size={17} stroke={1.8} />
-                Back to integrations
+                {t(($) => {
+                  return $.connectors.providerSettings.feishu
+                    .backToIntegrations;
+                })}
               </Link>
             </Button>
           </div>
@@ -1760,7 +2065,9 @@ export function ZeroFeishuSettingsPage() {
                 Feishu
               </h1>
               <p className="mt-0.5 text-sm text-muted-foreground">
-                Manage bot routing for this workspace
+                {t(($) => {
+                  return $.connectors.providerSettings.feishu.pageDescription;
+                })}
               </p>
             </div>
           </div>
@@ -1770,7 +2077,9 @@ export function ZeroFeishuSettingsPage() {
         <div className="mx-auto flex max-w-[900px] flex-col gap-4">
           {hasError ? (
             <div className="zero-card px-6 py-10 text-center text-sm text-destructive">
-              Couldn&apos;t load Feishu settings.
+              {t(($) => {
+                return $.connectors.providerSettings.feishu.loadError;
+              })}
             </div>
           ) : loading ? (
             <FeishuSettingsSkeleton />

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -8,12 +8,13 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import { connectAgentPhoneAccount$ } from "../../signals/zero-page/agentphone-connect-signals.ts";
 import {
-  AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE,
   isUnreliableAgentPhoneConnectChannel,
   parseAgentPhoneConnectParams,
 } from "../../signals/zero-page/agentphone-connect-params.ts";
@@ -25,6 +26,7 @@ const imessageIconImg = settingsIconAssetUrl("imessage");
 
 function BackLink() {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <Link
@@ -32,7 +34,12 @@ function BackLink() {
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to {brandName}
+      {t(
+        ($) => {
+          return $.connectors.providerConnect.agentphone.back;
+        },
+        { brandName },
+      )}
     </Link>
   );
 }
@@ -100,13 +107,16 @@ function InvalidState({ title, message }: { title: string; message: string }) {
 }
 
 function SmsMmsRiskNotice({ channel }: { channel: string | null }) {
+  const { t } = useTranslation();
   if (!isUnreliableAgentPhoneConnectChannel(channel)) {
     return null;
   }
 
   return (
     <div className="w-full rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
-      {AGENTPHONE_SMS_MMS_CONNECT_RISK_MESSAGE}
+      {t(($) => {
+        return $.connectors.providerConnect.agentphone.risk;
+      })}
     </div>
   );
 }
@@ -114,10 +124,13 @@ function SmsMmsRiskNotice({ channel }: { channel: string | null }) {
 function getAgentPhoneConnectErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
-    : "We couldn't connect this phone number. Try again from your text messages.";
+    : i18n.t(($) => {
+        return $.connectors.providerConnect.agentphone.errorFallback;
+      });
 }
 
 export function ZeroAgentPhoneConnectPage(): JSX.Element {
+  const { t } = useTranslation();
   const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseAgentPhoneConnectParams(params);
@@ -134,9 +147,28 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
       : null;
 
   if (!parsed.ok) {
-    return (
-      <InvalidState title={parsed.error.title} message={parsed.error.message} />
-    );
+    const invalidTitle =
+      parsed.error.code === "incomplete"
+        ? t(($) => {
+            return $.connectors.providerConnect.agentphone.incompleteTitle;
+          })
+        : t(($) => {
+            return $.connectors.providerConnect.agentphone.invalidTitle;
+          });
+    const invalidMessage =
+      parsed.error.code === "incomplete"
+        ? t(($) => {
+            return $.connectors.providerConnect.agentphone
+              .incompleteDescription;
+          })
+        : parsed.error.code === "invalid_timestamp"
+          ? t(($) => {
+              return $.connectors.providerConnect.agentphone.invalidTimestamp;
+            })
+          : t(($) => {
+              return $.connectors.providerConnect.agentphone.invalidSignature;
+            });
+    return <InvalidState title={invalidTitle} message={invalidMessage} />;
   }
 
   if (success) {
@@ -144,13 +176,15 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
       <PageShell>
         <MessageMark state="success" />
         <CenterText
-          title="Phone number connected"
-          body={
-            <>
-              <span className="font-medium">{success.phoneHandle}</span> is
-              connected. Send a text message to start chatting with Zero.
-            </>
-          }
+          title={t(($) => {
+            return $.connectors.providerConnect.agentphone.successTitle;
+          })}
+          body={t(
+            ($) => {
+              return $.connectors.providerConnect.agentphone.successDescription;
+            },
+            { phone: success.phoneHandle },
+          )}
         />
         <SmsMmsRiskNotice channel={parsed.channel} />
         <BackLink />
@@ -162,8 +196,15 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
     <PageShell>
       <MessageMark state={connecting ? "loading" : "idle"} />
       <CenterText
-        title="Connect phone number"
-        body={`Link this phone number to your ${brandName} account so you can interact with Zero from text messages.`}
+        title={t(($) => {
+          return $.connectors.providerConnect.agentphone.connectTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.agentphone.connectDescription;
+          },
+          { brandName },
+        )}
       />
       <SmsMmsRiskNotice channel={parsed.channel} />
       {error ? (
@@ -185,7 +226,13 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
           {connecting ? (
             <IconLoader2 size={16} className="animate-spin" />
           ) : null}
-          {connecting ? "Connecting..." : "Connect"}
+          {connecting
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
         <div className="flex justify-center">
           <BackLink />

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,6 +1,7 @@
 import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
+import { useTranslation } from "react-i18next";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";
 
 type ConnectorCallbackPageStatus = "loading" | "success" | "error";
@@ -18,29 +19,56 @@ export function ZeroConnectorCallbackPage({
   readonly username: string | null;
   readonly errorMessage: string | null;
 }): React.JSX.Element {
+  const { t } = useTranslation();
   const title =
     status === "success"
-      ? `${connectorLabel} connected`
+      ? t(
+          ($) => {
+            return $.connectors.callback.connected;
+          },
+          { connector: connectorLabel },
+        )
       : status === "error"
-        ? `Couldn’t connect ${connectorLabel}`
-        : `Connecting ${connectorLabel}…`;
+        ? t(
+            ($) => {
+              return $.connectors.callback.failedTitle;
+            },
+            { connector: connectorLabel },
+          )
+        : t(
+            ($) => {
+              return $.connectors.callback.connecting;
+            },
+            { connector: connectorLabel },
+          );
   const description =
-    status === "success" ? (
-      username ? (
-        <>
-          Connected as <strong>{username}</strong>. You can close this window.
-        </>
-      ) : (
-        "Your account has been connected. You can close this window."
-      )
-    ) : status === "error" ? (
-      <>
-        {errorMessage || "An error occurred during connection."} Close this
-        window and try again.
-      </>
-    ) : (
-      "Please wait while we finish connecting your account."
-    );
+    status === "success"
+      ? username
+        ? t(
+            ($) => {
+              return $.connectors.callback.connectedAs;
+            },
+            { username },
+          )
+        : t(($) => {
+            return $.connectors.callback.connectedDescription;
+          })
+      : status === "error"
+        ? t(
+            ($) => {
+              return $.connectors.callback.errorDescription;
+            },
+            {
+              error:
+                errorMessage ??
+                t(($) => {
+                  return $.connectors.callback.errorFallback;
+                }),
+            },
+          )
+        : t(($) => {
+            return $.connectors.callback.connectingDescription;
+          });
 
   return (
     <ZeroConnectorFlowCard
@@ -51,7 +79,11 @@ export function ZeroConnectorCallbackPage({
       {status === "loading" ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
-          <span>Finishing the secure connection</span>
+          <span>
+            {t(($) => {
+              return $.connectors.callback.finishing;
+            })}
+          </span>
         </div>
       ) : (
         <div className="flex flex-col items-center gap-4">
@@ -68,7 +100,13 @@ export function ZeroConnectorCallbackPage({
               <IconAlertCircle size={16} aria-hidden="true" />
             )}
             <span>
-              {status === "success" ? "Connected" : "Connection failed"}
+              {status === "success"
+                ? t(($) => {
+                    return $.connectors.callback.success;
+                  })
+                : t(($) => {
+                    return $.connectors.callback.failed;
+                  })}
             </span>
           </div>
           <Button
@@ -77,7 +115,9 @@ export function ZeroConnectorCallbackPage({
               window.close();
             }}
           >
-            Close window
+            {t(($) => {
+              return $.connectors.actions.closeWindow;
+            })}
           </Button>
         </div>
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -6,6 +6,7 @@ import {
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { useGet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
 import {
   connectorRedirectingMobileWarningVisible$,
   type ConnectorRedirectingStatus,
@@ -24,6 +25,7 @@ export function ZeroConnectorRedirectingPage({
   readonly connectorIcon: PublicConnectorCatalogIcon | undefined;
   readonly status: ConnectorRedirectingStatus;
 }) {
+  const { t } = useTranslation();
   const hasError = status === "error";
   const brandName = useGet(brandName$);
   const showMobileWarning = useGet(connectorRedirectingMobileWarningVisible$);
@@ -33,20 +35,44 @@ export function ZeroConnectorRedirectingPage({
       connectorIcon={connectorIcon}
       title={
         hasError
-          ? `Couldn’t open ${connectorLabel}`
-          : `Redirecting to ${connectorLabel}…`
+          ? t(
+              ($) => {
+                return $.connectors.redirect.errorTitle;
+              },
+              { connector: connectorLabel },
+            )
+          : t(
+              ($) => {
+                return $.connectors.redirect.redirectTitle;
+              },
+              { connector: connectorLabel },
+            )
       }
       description={
         hasError
-          ? `Return to ${brandName} and try connecting again.`
-          : `You’ll continue on ${connectorLabel} to authorize ${brandName}.`
+          ? t(
+              ($) => {
+                return $.connectors.redirect.errorDescription;
+              },
+              { brandName },
+            )
+          : t(
+              ($) => {
+                return $.connectors.redirect.redirectDescription;
+              },
+              { connector: connectorLabel, brandName },
+            )
       }
     >
       <div className="flex flex-col items-center gap-4">
         {hasError ? (
           <div className="flex items-center gap-2 text-sm text-destructive">
             <IconAlertCircle size={16} aria-hidden="true" />
-            <span>Unable to start the connection</span>
+            <span>
+              {t(($) => {
+                return $.connectors.redirect.errorStatus;
+              })}
+            </span>
           </div>
         ) : (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -55,19 +81,32 @@ export function ZeroConnectorRedirectingPage({
               className="animate-spin"
               aria-hidden="true"
             />
-            <span>Preparing a secure connection</span>
+            <span>
+              {t(($) => {
+                return $.connectors.redirect.preparing;
+              })}
+            </span>
           </div>
         )}
         {!hasError && showMobileWarning && (
           <p className="w-72 max-w-full text-sm text-amber-600 dark:text-amber-400">
-            The {connectorLabel} app may not support this OAuth link. Please
-            complete this connection in the {brandName} web app on a computer.
+            {t(
+              ($) => {
+                return $.connectors.redirect.mobileWarning;
+              },
+              { connector: connectorLabel, brandName },
+            )}
           </p>
         )}
         <Button variant="outline" asChild>
           <Link pathname={ROUTES.home}>
             <IconArrowLeft size={16} aria-hidden="true" />
-            Back to {brandName}
+            {t(
+              ($) => {
+                return $.connectors.redirect.back;
+              },
+              { brandName },
+            )}
           </Link>
         </Button>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -8,6 +8,7 @@ import {
   useLastResolved,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 import {
   IconSearch,
   IconPlus,
@@ -16,7 +17,10 @@ import {
   IconCheck,
 } from "@tabler/icons-react";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type {
+  PublicConnectorCatalogCategoryMetadata,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -83,9 +87,172 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@vm0/ui";
+import { i18n } from "../../i18n/index.ts";
 
 const CONNECTOR_CARD_AGENT_NAME_LIMIT = 2;
 const CONNECTOR_CARD_AGENT_NAME_MAX_CHARS = 12;
+
+function connectorCategoryTranslation(
+  id: string,
+): { readonly label: string; readonly menuLabel: string } | null {
+  switch (id) {
+    case "ai": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.ai.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.ai.menu;
+        }),
+      };
+    }
+    case "ai-agent-apps": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiAgentApps.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiAgentApps.menu;
+        }),
+      };
+    }
+    case "ai-general-models": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiGeneralModels.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiGeneralModels.menu;
+        }),
+      };
+    }
+    case "ai-image-video": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiImageVideo.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiImageVideo.menu;
+        }),
+      };
+    }
+    case "ai-memory-tracing-eval": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiMemoryTracingEval.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiMemoryTracingEval.menu;
+        }),
+      };
+    }
+    case "ai-voice-audio": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiVoiceAudio.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.aiVoiceAudio.menu;
+        }),
+      };
+    }
+    case "communication-collaboration": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.communicationCollaboration
+            .label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.communicationCollaboration
+            .menu;
+        }),
+      };
+    }
+    case "data-automation-infrastructure": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.dataAutomationInfrastructure
+            .label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.dataAutomationInfrastructure
+            .menu;
+        }),
+      };
+    }
+    case "docs-files-knowledge": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.docsFilesKnowledge.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.docsFilesKnowledge.menu;
+        }),
+      };
+    }
+    case "engineering-team-execution": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.engineeringTeamExecution.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.engineeringTeamExecution.menu;
+        }),
+      };
+    }
+    case "marketing-content-growth": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.marketingContentGrowth.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.marketingContentGrowth.menu;
+        }),
+      };
+    }
+    case "meetings-scheduling": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.meetingsScheduling.label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.meetingsScheduling.menu;
+        }),
+      };
+    }
+    case "sales-crm-business-operations": {
+      return {
+        label: i18n.t(($) => {
+          return $.connectors.catalog.categories.salesCrmBusinessOperations
+            .label;
+        }),
+        menuLabel: i18n.t(($) => {
+          return $.connectors.catalog.categories.salesCrmBusinessOperations
+            .menu;
+        }),
+      };
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function localizeConnectorCategoryMetadata(
+  metadata: PublicConnectorCatalogCategoryMetadata | undefined,
+): PublicConnectorCatalogCategoryMetadata | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  return {
+    categories: metadata.categories.map((category) => {
+      return { ...category, ...connectorCategoryTranslation(category.id) };
+    }),
+    groups: metadata.groups.map((group) => {
+      return { ...group, ...connectorCategoryTranslation(group.id) };
+    }),
+  };
+}
 
 // Callback ref that attaches scroll tracking while enabled. Each call returns
 // a fresh ref callback; React only invokes it when the underlying element
@@ -116,6 +283,7 @@ function ConnectorCategoryMenu({
   activeCategoryId: string | null;
   groups: readonly ConnectorCategoryGroup<PublicConnectorCatalogStatusItem>[];
 }) {
+  const { t } = useTranslation();
   if (groups.length <= 1) {
     return null;
   }
@@ -123,7 +291,9 @@ function ConnectorCategoryMenu({
   return (
     <aside className="pointer-events-none fixed right-6 top-[28vh] z-20 hidden w-44 min-[1332px]:block">
       <nav
-        aria-label="Connector categories"
+        aria-label={t(($) => {
+          return $.connectors.catalog.categoriesAria;
+        })}
         className="group pointer-events-auto ml-auto flex max-h-[68vh] w-6 flex-col gap-3 overflow-x-hidden overflow-y-auto rounded-xl border border-transparent bg-transparent px-1 py-2 transition-all duration-150 hover:w-44 hover:border-border/60 hover:bg-popover hover:shadow-lg focus-within:w-44 focus-within:border-border/60 focus-within:bg-popover focus-within:shadow-lg 2xl:ml-0 2xl:w-full 2xl:overflow-y-auto 2xl:rounded-none 2xl:border-transparent 2xl:px-0 2xl:py-0 2xl:pb-3 2xl:pl-5 2xl:hover:w-full 2xl:hover:border-transparent 2xl:hover:bg-transparent 2xl:hover:shadow-none 2xl:focus-within:w-full 2xl:focus-within:border-transparent 2xl:focus-within:bg-transparent 2xl:focus-within:shadow-none"
       >
         {groups.flatMap((group) => {
@@ -278,22 +448,6 @@ function ConnectorFilterOption({
   );
 }
 
-function connectorFilterTriggerLabel(
-  value: ConnectorsConnectionFilter,
-  activeAgent: TeamComposeItem | undefined,
-): string {
-  if (value.kind === "connected") {
-    return "Connected";
-  }
-  if (value.kind === "not-connected") {
-    return "Not connected";
-  }
-  if (value.kind === "agent" && activeAgent) {
-    return connectorAgentName(activeAgent);
-  }
-  return "All";
-}
-
 function ConnectorFilterDropdown({
   value,
   agents,
@@ -303,12 +457,27 @@ function ConnectorFilterDropdown({
   readonly agents: readonly TeamComposeItem[];
   readonly onChange: (value: ConnectorsConnectionFilter) => void;
 }) {
+  const { t } = useTranslation();
   const activeAgent =
     value.kind === "agent"
       ? agents.find((agent) => {
           return agent.id === value.agentId;
         })
       : undefined;
+  const triggerLabel =
+    value.kind === "connected"
+      ? t(($) => {
+          return $.connectors.catalog.filters.connected;
+        })
+      : value.kind === "not-connected"
+        ? t(($) => {
+            return $.connectors.catalog.filters.notConnected;
+          })
+        : value.kind === "agent" && activeAgent
+          ? connectorAgentName(activeAgent)
+          : t(($) => {
+              return $.connectors.catalog.filters.all;
+            });
 
   return (
     <DropdownMenu>
@@ -316,7 +485,9 @@ function ConnectorFilterDropdown({
         <Button
           variant="outline"
           size="sm"
-          aria-label="Filter connectors"
+          aria-label={t(($) => {
+            return $.connectors.catalog.filters.aria;
+          })}
           className="zero-btn-morandi hidden h-9 shrink-0 gap-1.5 rounded-lg border sm:inline-flex"
         >
           <IconFilter
@@ -332,9 +503,7 @@ function ConnectorFilterDropdown({
               className="h-4 w-4 rounded-full object-cover"
             />
           )}
-          <span className="max-w-[140px] truncate">
-            {connectorFilterTriggerLabel(value, activeAgent)}
-          </span>
+          <span className="max-w-[140px] truncate">{triggerLabel}</span>
           <IconChevronDown
             size={14}
             stroke={1.5}
@@ -352,17 +521,25 @@ function ConnectorFilterDropdown({
             onChange({ kind: "all" });
           }}
         >
-          All
+          {t(($) => {
+            return $.connectors.catalog.filters.all;
+          })}
         </ConnectorFilterOption>
         <DropdownMenuSeparator />
-        <ConnectorFilterSectionLabel>Status</ConnectorFilterSectionLabel>
+        <ConnectorFilterSectionLabel>
+          {t(($) => {
+            return $.connectors.catalog.filters.status;
+          })}
+        </ConnectorFilterSectionLabel>
         <ConnectorFilterOption
           active={value.kind === "connected"}
           onSelect={() => {
             onChange({ kind: "connected" });
           }}
         >
-          Connected
+          {t(($) => {
+            return $.connectors.catalog.filters.connected;
+          })}
         </ConnectorFilterOption>
         <ConnectorFilterOption
           active={value.kind === "not-connected"}
@@ -370,12 +547,18 @@ function ConnectorFilterDropdown({
             onChange({ kind: "not-connected" });
           }}
         >
-          Not connected
+          {t(($) => {
+            return $.connectors.catalog.filters.notConnected;
+          })}
         </ConnectorFilterOption>
         {agents.length > 0 && (
           <>
             <DropdownMenuSeparator />
-            <ConnectorFilterSectionLabel>Agents</ConnectorFilterSectionLabel>
+            <ConnectorFilterSectionLabel>
+              {t(($) => {
+                return $.connectors.catalog.filters.agents;
+              })}
+            </ConnectorFilterSectionLabel>
             {agents.map((agent) => {
               return (
                 <ConnectorFilterOption
@@ -423,6 +606,7 @@ function ConnectorsToolbarActions({
   readonly isAdmin: boolean;
   readonly onCreateCustom: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="flex items-center gap-2">
       {activeTab === "builtin" && (
@@ -434,7 +618,9 @@ function ConnectorsToolbarActions({
           />
           <input
             type="text"
-            placeholder="Find connectors"
+            placeholder={t(($) => {
+              return $.connectors.catalog.search;
+            })}
             value={search}
             onChange={(e) => {
               return setSearch(e.target.value);
@@ -458,7 +644,9 @@ function ConnectorsToolbarActions({
           onClick={onCreateCustom}
         >
           <IconPlus size={14} stroke={2} />
-          New connector
+          {t(($) => {
+            return $.connectors.catalog.newConnector;
+          })}
         </Button>
       )}
     </div>
@@ -525,7 +713,12 @@ function ConnectorCategoryGroupSection({
 }
 
 function connectorAgentName(agent: TeamComposeItem): string {
-  return agent.displayName ?? "Unnamed";
+  return (
+    agent.displayName ??
+    i18n.t(($) => {
+      return $.connectors.catalog.unnamedAgent;
+    })
+  );
 }
 
 function truncateAgentName(name: string): string {
@@ -544,6 +737,7 @@ function ConnectorAccessButton({
   readonly connectorLabel: string;
   readonly onClick: () => void;
 }) {
+  const { t } = useTranslation();
   const agentsBySlugLoadable = useLastLoadable(
     connectorAuthorizedAgentsBySlug$,
   );
@@ -563,7 +757,12 @@ function ConnectorAccessButton({
     <button
       type="button"
       className="inline-flex h-7 min-w-0 shrink items-center gap-0 rounded-lg px-2 text-xs text-muted-foreground transition-colors hover:bg-[hsl(var(--gray-50))] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-      aria-label={`Manage ${connectorLabel} access`}
+      aria-label={t(
+        ($) => {
+          return $.connectors.catalog.access.manage;
+        },
+        { connector: connectorLabel },
+      )}
       onClick={onClick}
     >
       {loading ? (
@@ -573,11 +772,17 @@ function ConnectorAccessButton({
           className="underline decoration-dotted decoration-muted-foreground/40 underline-offset-2"
           data-testid="connector-card-access-empty"
         >
-          Add access
+          {t(($) => {
+            return $.connectors.catalog.access.add;
+          })}
         </span>
       ) : (
         <>
-          <span className="shrink-0">Used by&nbsp;</span>
+          <span className="shrink-0">
+            {t(($) => {
+              return $.connectors.catalog.access.usedBy;
+            })}
+          </span>
           <span
             className="min-w-0 truncate underline decoration-dotted decoration-muted-foreground/40 underline-offset-2"
             data-testid="connector-card-access-names"
@@ -638,18 +843,34 @@ function renderBuiltinList({
     const trimmedSearch = search.trim();
     const base =
       connectionFilter.kind === "connected"
-        ? "No connected connectors"
+        ? i18n.t(($) => {
+            return $.connectors.catalog.empty.connected;
+          })
         : connectionFilter.kind === "not-connected"
-          ? "No connectors left to connect"
+          ? i18n.t(($) => {
+              return $.connectors.catalog.empty.notConnected;
+            })
           : connectionFilter.kind === "agent"
-            ? "No connectors for this agent"
+            ? i18n.t(($) => {
+                return $.connectors.catalog.empty.agent;
+              })
             : null;
     const message = base
       ? trimmedSearch
-        ? `${base} matching "${trimmedSearch}"`
+        ? i18n.t(
+            ($) => {
+              return $.connectors.catalog.empty.matching;
+            },
+            { message: base, search: trimmedSearch },
+          )
         : base
       : trimmedSearch
-        ? `No connectors matching "${trimmedSearch}"`
+        ? i18n.t(
+            ($) => {
+              return $.connectors.catalog.empty.search;
+            },
+            { search: trimmedSearch },
+          )
         : null;
     if (!message) {
       return null;
@@ -658,7 +879,9 @@ function renderBuiltinList({
       <div className="flex flex-col items-center gap-3 py-12">
         <img
           src={noConnectorImg}
-          alt="No connectors"
+          alt={i18n.t(($) => {
+            return $.connectors.catalog.noConnectorsAlt;
+          })}
           className="h-20 w-20 object-contain opacity-80"
         />
         <p className="text-center text-sm text-muted-foreground">{message}</p>
@@ -692,6 +915,7 @@ function connectorLabelForSlug(
 }
 
 export function ZeroConnectorsPage() {
+  const { t } = useTranslation();
   const allCatalogItemsLoadable = useLastLoadable(allConnectorCatalogItems$);
   const filteredCatalogItemsLoadable = useLastLoadable(
     filteredConnectorCatalogItems$,
@@ -738,10 +962,11 @@ export function ZeroConnectorsPage() {
     filteredCatalogItemsLoadable.state === "hasData"
       ? filteredCatalogItemsLoadable.data
       : [];
-  const categoryMetadata =
+  const categoryMetadata = localizeConnectorCategoryMetadata(
     catalogStatusLoadable.state === "hasData"
       ? catalogStatusLoadable.data.categoryMetadata
-      : undefined;
+      : undefined,
+  );
   const allConnectors =
     allCatalogItemsLoadable.state === "hasData"
       ? allCatalogItemsLoadable.data
@@ -848,6 +1073,9 @@ export function ZeroConnectorsPage() {
   const grouped = groupConnectorsByCategory(
     filteredConnectors,
     categoryMetadata,
+    t(($) => {
+      return $.connectors.catalog.otherCategory;
+    }),
   );
 
   const builtinList = renderBuiltinList({
@@ -867,10 +1095,14 @@ export function ZeroConnectorsPage() {
         <div className="mx-auto w-full max-w-[900px]">
           <div className="min-w-0 hidden md:block">
             <h1 className="text-lg font-semibold tracking-tight text-foreground">
-              Connectors
+              {t(($) => {
+                return $.connectors.catalog.title;
+              })}
             </h1>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              Connect third-party services for your agents to use.
+              {t(($) => {
+                return $.connectors.catalog.description;
+              })}
             </p>
           </div>
         </div>
@@ -895,8 +1127,16 @@ export function ZeroConnectorsPage() {
                 }}
               >
                 <TabsList>
-                  <TabsTrigger value="builtin">Built-in</TabsTrigger>
-                  <TabsTrigger value="custom">Custom</TabsTrigger>
+                  <TabsTrigger value="builtin">
+                    {t(($) => {
+                      return $.connectors.catalog.tabs.builtin;
+                    })}
+                  </TabsTrigger>
+                  <TabsTrigger value="custom">
+                    {t(($) => {
+                      return $.connectors.catalog.tabs.custom;
+                    })}
+                  </TabsTrigger>
                 </TabsList>
               </Tabs>
               <ConnectorsToolbarActions
@@ -930,7 +1170,14 @@ export function ZeroConnectorsPage() {
               allConnectors.find((c) => {
                 return c.connectorRef === selectedConnectorSlug;
               })?.label ?? selectedConnectorSlug;
-            toast.success(`${label} connected`);
+            toast.success(
+              t(
+                ($) => {
+                  return $.connectors.callback.connected;
+                },
+                { connector: label },
+              ),
+            );
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-custom-connector-proposal-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-custom-connector-proposal-page.tsx
@@ -5,6 +5,8 @@ import { Button } from "@vm0/ui/components/ui/button";
 import { Input } from "@vm0/ui/components/ui/input";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { IconCheck, IconLoader2, IconPackage } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import {
   customConnectorProposalAgentName$,
   customConnectorProposalCanSave$,
@@ -66,10 +68,13 @@ function ConnectorDefinitionPreview({
   prefixes: readonly string[];
   notes: string | undefined;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-2 rounded-[10px] bg-muted/50 px-3 py-3 text-left">
       <div className="text-xs font-medium uppercase text-muted-foreground">
-        Request scope
+        {t(($) => {
+          return $.connectors.customProposal.requestScope;
+        })}
       </div>
       <div className="flex flex-col gap-1">
         {prefixes.map((prefix) => {
@@ -103,7 +108,59 @@ function ProposalStatusCard({ message }: { message: string }) {
   );
 }
 
+function ProposalSaveControl({
+  saved,
+  saving,
+  canSave,
+  onSave,
+}: {
+  saved: boolean;
+  saving: boolean;
+  canSave: boolean;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div className="flex w-full items-center justify-center">
+        {saved ? (
+          <div className="inline-flex h-9 items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
+            <IconCheck size={16} />
+            {t(($) => {
+              return $.connectors.customProposal.saved;
+            })}
+          </div>
+        ) : (
+          <Button
+            className="min-w-[140px]"
+            onClick={onSave}
+            disabled={!canSave}
+          >
+            {saving && <IconLoader2 size={14} className="animate-spin" />}
+            {saving
+              ? t(($) => {
+                  return $.connectors.actions.saving;
+                })
+              : t(($) => {
+                  return $.connectors.actions.save;
+                })}
+          </Button>
+        )}
+      </div>
+
+      {saved && (
+        <p className="w-72 max-w-full text-xs leading-relaxed text-muted-foreground">
+          {t(($) => {
+            return $.connectors.customProposal.returnToChat;
+          })}
+        </p>
+      )}
+    </>
+  );
+}
+
 function CustomConnectorProposalCard() {
+  const { t } = useTranslation();
   const params = useGet(customConnectorProposalParams$);
   const agentNameLoadable = useLastLoadable(customConnectorProposalAgentName$);
   const valueMap = useGet(customConnectorProposalValueMap$);
@@ -117,7 +174,11 @@ function CustomConnectorProposalCard() {
 
   if (!params) {
     return (
-      <ProposalStatusCard message="This custom connector proposal link is invalid or expired." />
+      <ProposalStatusCard
+        message={t(($) => {
+          return $.connectors.customProposal.invalid;
+        })}
+      />
     );
   }
 
@@ -125,13 +186,25 @@ function CustomConnectorProposalCard() {
   const agentName =
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
       ? agentNameLoadable.data
-      : "this agent";
+      : t(($) => {
+          return $.connectors.customProposal.targetFallback;
+        });
   const saving = saveLoadable.state === "loading";
   const canSave = !saving && hasRequiredFields;
   const title =
     proposal.operation === "create"
-      ? `Configure ${proposal.displayName}`
-      : `Update ${proposal.displayName}`;
+      ? t(
+          ($) => {
+            return $.connectors.customProposal.configure;
+          },
+          { connector: proposal.displayName },
+        )
+      : t(
+          ($) => {
+            return $.connectors.customProposal.update;
+          },
+          { connector: proposal.displayName },
+        );
 
   const onSave = () => {
     if (!canSave) {
@@ -140,7 +213,14 @@ function CustomConnectorProposalCard() {
     detach(
       (async () => {
         const result = await saveProposal(pageSignal);
-        toast.success(`${result.connector.displayName} saved`);
+        toast.success(
+          i18n.t(
+            ($) => {
+              return $.connectors.customProposal.savedToast;
+            },
+            { connector: result.connector.displayName },
+          ),
+        );
       })(),
       Reason.DomCallback,
     );
@@ -158,8 +238,15 @@ function CustomConnectorProposalCard() {
             <h1 className="text-lg font-medium text-foreground">{title}</h1>
             <p className="mx-auto w-72 max-w-full text-sm text-muted-foreground">
               {agentId
-                ? `Saving will connect your values and authorize ${agentName}.`
-                : "Saving will connect this custom connector for your account."}
+                ? t(
+                    ($) => {
+                      return $.connectors.customProposal.descriptionAgent;
+                    },
+                    { agent: agentName },
+                  )
+                : t(($) => {
+                    return $.connectors.customProposal.descriptionUser;
+                  })}
             </p>
           </div>
         </div>
@@ -187,30 +274,12 @@ function CustomConnectorProposalCard() {
           </div>
         </div>
 
-        <div className="flex w-full items-center justify-center">
-          {saved ? (
-            <div className="inline-flex h-9 items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-              <IconCheck size={16} />
-              Saved
-            </div>
-          ) : (
-            <Button
-              className="min-w-[140px]"
-              onClick={onSave}
-              disabled={!canSave}
-            >
-              {saving && <IconLoader2 size={14} className="animate-spin" />}
-              {saving ? "Saving..." : "Save"}
-            </Button>
-          )}
-        </div>
-
-        {saved && (
-          <p className="w-72 max-w-full text-xs leading-relaxed text-muted-foreground">
-            Return to the chat and reply ACK so the agent can verify the
-            connector.
-          </p>
-        )}
+        <ProposalSaveControl
+          saved={saved}
+          saving={saving}
+          canSave={canSave}
+          onSave={onSave}
+        />
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -42,6 +42,7 @@ import { reloadAgentConnectorAuthorizations$ } from "../../signals/zero-page/age
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
 import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
+import { useTranslation } from "react-i18next";
 
 // ---------------------------------------------------------------------------
 // Action button / authorized badge
@@ -60,11 +61,14 @@ function AuthorizeAction({
   agentName: string;
   onAuthorize: () => void;
 }) {
+  const { t } = useTranslation();
   if (isAuthorized) {
     return (
       <div className="inline-flex h-9 w-[140px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
         <IconCheck size={16} />
-        Authorized
+        {t(($) => {
+          return $.connectors.card.authorized;
+        })}
       </div>
     );
   }
@@ -76,7 +80,16 @@ function AuthorizeAction({
       className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
     >
       {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
-      {isConnecting ? "Connecting..." : `Authorize ${agentName}`}
+      {isConnecting
+        ? t(($) => {
+            return $.connectors.actions.connecting;
+          })
+        : t(
+            ($) => {
+              return $.connectors.directed.authorizeAgent;
+            },
+            { agent: agentName },
+          )}
     </button>
   );
 }
@@ -211,6 +224,7 @@ function DirectedAuthorizeCardContent({
   readonly canAuthorize: boolean;
   readonly onAuthorize: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
@@ -226,8 +240,18 @@ function DirectedAuthorizeCardContent({
               <>
                 <h1 className="text-lg font-medium text-foreground">
                   {isAuthorized
-                    ? `${connectorLabel} authorized`
-                    : `${agentName} needs ${connectorLabel} to proceed`}
+                    ? t(
+                        ($) => {
+                          return $.connectors.directed.authorized;
+                        },
+                        { connector: connectorLabel },
+                      )
+                    : t(
+                        ($) => {
+                          return $.connectors.directed.needsConnector;
+                        },
+                        { agent: agentName, connector: connectorLabel },
+                      )}
                 </h1>
                 <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                   <ConnectorIcon icon={icon} size={20} />

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -61,6 +61,7 @@ import { IconCheck, IconLoader2 } from "@tabler/icons-react";
 import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
 import { ConnectorHelpText } from "./components/settings/connector-help-text.tsx";
 import {
   routeChatActionCallback$,
@@ -183,6 +184,7 @@ function ManualGrantForm({
   manualGrantMethod: PublicConnectorCatalogAuthMethodDetail;
   onSuccess: () => void | Promise<void>;
 }) {
+  const { t } = useTranslation();
   const submit = useSet(submitManualGrant$);
   const setFormValue = useSet(setManualGrantFormValue$);
   const clearForm = useSet(clearManualGrantForm$);
@@ -271,7 +273,13 @@ function ManualGrantForm({
         className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
       >
         {submitting && <IconLoader2 size={14} className="animate-spin" />}
-        {submitting ? "Saving..." : "Save"}
+        {submitting
+          ? t(($) => {
+              return $.connectors.actions.saving;
+            })
+          : t(($) => {
+              return $.connectors.actions.save;
+            })}
       </button>
     </form>
   );
@@ -334,12 +342,15 @@ function ConnectActions({
   disabled: boolean;
   onConnect: () => void;
 }) {
+  const { t } = useTranslation();
   if (isConnected) {
     return (
       <>
         <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
           <IconCheck size={16} />
-          Connected
+          {t(($) => {
+            return $.connectors.card.connected;
+          })}
         </div>
         <button
           type="button"
@@ -348,7 +359,13 @@ function ConnectActions({
           className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
         >
           {isConnecting && <IconLoader2 size={12} className="animate-spin" />}
-          {isConnecting ? "Reconnecting..." : "Reconnect"}
+          {isConnecting
+            ? t(($) => {
+                return $.connectors.directed.reconnecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.reconnect;
+              })}
         </button>
       </>
     );
@@ -361,7 +378,13 @@ function ConnectActions({
       className="inline-flex h-9 w-[100px] items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
     >
       {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
-      {isConnecting ? "Connecting..." : "Connect"}
+      {isConnecting
+        ? t(($) => {
+            return $.connectors.actions.connecting;
+          })
+        : t(($) => {
+            return $.connectors.actions.connect;
+          })}
     </button>
   );
 }
@@ -533,6 +556,7 @@ function DirectedConnectCardContent({
   readonly canConnect: boolean;
   readonly onConnect: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
@@ -548,8 +572,18 @@ function DirectedConnectCardContent({
               <>
                 <h1 className="text-lg font-medium text-foreground">
                   {isConnected
-                    ? `${connectorLabel} connected`
-                    : `${agentName} needs ${connectorLabel} to proceed`}
+                    ? t(
+                        ($) => {
+                          return $.connectors.directed.connected;
+                        },
+                        { connector: connectorLabel },
+                      )
+                    : t(
+                        ($) => {
+                          return $.connectors.directed.needsConnector;
+                        },
+                        { agent: agentName, connector: connectorLabel },
+                      )}
                 </h1>
                 <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                   <ConnectorIcon icon={icon} size={20} />

--- a/turbo/apps/platform/src/views/zero-page/zero-feishu-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-feishu-connect-page.tsx
@@ -8,7 +8,9 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 
+import { i18n } from "../../i18n/index.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
@@ -23,13 +25,16 @@ import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets
 const feishuIconImg = settingsIconAssetUrl("lark");
 
 function BackLink() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname="/settings/feishu"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors no-underline hover:text-foreground"
     >
       <IconArrowLeft size={14} />
-      Back to Feishu settings
+      {t(($) => {
+        return $.connectors.providerConnect.feishu.back;
+      })}
     </Link>
   );
 }
@@ -66,10 +71,62 @@ function CenterText({ title, body }: { title: string; body: ReactNode }) {
 function errorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
-    : "We couldn't connect Feishu. Open a fresh connect link and try again.";
+    : i18n.t(($) => {
+        return $.connectors.providerConnect.feishu.errorFallback;
+      });
+}
+
+function SuccessState({
+  botName,
+  openUrl,
+}: {
+  botName: string | null;
+  openUrl: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <PageShell>
+      <IconCircleCheck size={40} className="text-emerald-500" />
+      <CenterText
+        title={t(($) => {
+          return $.connectors.providerConnect.feishu.successTitle;
+        })}
+        body={
+          botName
+            ? t(
+                ($) => {
+                  return $.connectors.providerConnect.feishu
+                    .successDescriptionNamed;
+                },
+                { bot: botName },
+              )
+            : t(($) => {
+                return $.connectors.providerConnect.feishu.successDescription;
+              })
+        }
+      />
+      <div className="flex w-full flex-col gap-3">
+        <Button
+          className="w-full gap-2"
+          onClick={() => {
+            window.location.href = openUrl;
+          }}
+        >
+          <img src={feishuIconImg} alt="" className="h-4 w-4" />
+          {t(($) => {
+            return $.connectors.providerConnect.feishu.open;
+          })}
+        </Button>
+        <div className="flex justify-center">
+          <BackLink />
+        </div>
+      </div>
+    </PageShell>
+  );
 }
 
 export function ZeroFeishuConnectPage() {
+  const { t } = useTranslation();
   const brandName = useGet(brandName$);
   const params = useGet(feishuConnectParams$);
   const statusLoadable = useLoadable(feishuConnectStatus$);
@@ -81,8 +138,12 @@ export function ZeroFeishuConnectPage() {
       <PageShell>
         <IconAlertCircle size={40} className="text-destructive" />
         <CenterText
-          title="Invalid Link"
-          body="Open a fresh connect link from Feishu and try again."
+          title={t(($) => {
+            return $.connectors.providerConnect.common.invalidLink;
+          })}
+          body={t(($) => {
+            return $.connectors.providerConnect.feishu.invalidDescription;
+          })}
         />
         <BackLink />
       </PageShell>
@@ -96,33 +157,7 @@ export function ZeroFeishuConnectPage() {
         ? statusLoadable.data
         : null;
   if (result) {
-    return (
-      <PageShell>
-        <IconCircleCheck size={40} className="text-emerald-500" />
-        <CenterText
-          title="Connected to Feishu!"
-          body={
-            result.botName
-              ? `You're connected to ${result.botName}. Send a message in Feishu to start chatting.`
-              : "You're connected. Send a message in Feishu to start chatting."
-          }
-        />
-        <div className="flex w-full flex-col gap-3">
-          <Button
-            className="w-full gap-2"
-            onClick={() => {
-              window.location.href = result.openUrl;
-            }}
-          >
-            <img src={feishuIconImg} alt="" className="h-4 w-4" />
-            Open Feishu
-          </Button>
-          <div className="flex justify-center">
-            <BackLink />
-          </div>
-        </div>
-      </PageShell>
-    );
+    return <SuccessState botName={result.botName} openUrl={result.openUrl} />;
   }
 
   const connecting = connectLoadable.state === "loading";
@@ -140,11 +175,26 @@ export function ZeroFeishuConnectPage() {
         <FeishuMark />
       )}
       <CenterText
-        title={checking ? "Checking account status…" : "Connect to Feishu"}
+        title={
+          checking
+            ? t(($) => {
+                return $.connectors.providerConnect.feishu.checkingTitle;
+              })
+            : t(($) => {
+                return $.connectors.providerConnect.feishu.connectTitle;
+              })
+        }
         body={
           checking
-            ? "Please wait while we verify your connection."
-            : `Link your ${brandName} account to this Feishu bot so you can work with your agent directly from Feishu.`
+            ? t(($) => {
+                return $.connectors.providerConnect.common.verifying;
+              })
+            : t(
+                ($) => {
+                  return $.connectors.providerConnect.feishu.connectDescription;
+                },
+                { brandName },
+              )
         }
       />
       {error ? (
@@ -166,7 +216,13 @@ export function ZeroFeishuConnectPage() {
           {connecting ? (
             <IconLoader2 size={16} className="animate-spin" />
           ) : null}
-          {connecting ? "Connecting..." : "Connect"}
+          {connecting
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
         <div className="flex justify-center">
           <BackLink />

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -8,6 +8,8 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import { clerk$, resolveAppAuthUrl } from "../../signals/auth.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -31,13 +33,16 @@ function signInHref(): string {
 }
 
 function BackLink() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname="/workflows"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to workflows
+      {t(($) => {
+        return $.connectors.providerConnect.github.back;
+      })}
     </Link>
   );
 }
@@ -101,31 +106,36 @@ function InvalidState({ title, message }: { title: string; message: string }) {
 
 function githubUserLabel(username: string | undefined): string {
   const normalized = username?.trim().replace(/^@+/, "");
-  return normalized ? `@${normalized}` : "this GitHub account";
+  return normalized
+    ? `@${normalized}`
+    : i18n.t(($) => {
+        return $.connectors.providerConnect.github.accountFallback;
+      });
 }
 
 function getGithubConnectErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
-    : "We couldn't connect GitHub. Try again from GitHub.";
+    : i18n.t(($) => {
+        return $.connectors.providerConnect.github.errorFallback;
+      });
 }
 
 function SuccessState({ githubUsername }: { githubUsername?: string }) {
+  const { t } = useTranslation();
   return (
     <PageShell>
       <GithubMark state="success" />
       <CenterText
-        title="Connected to GitHub!"
-        body={
-          <>
-            You&apos;re connected as{" "}
-            <span className="font-medium">
-              {githubUserLabel(githubUsername)}
-            </span>
-            . Mention your agent in GitHub issues or pull requests to start
-            chatting.
-          </>
-        }
+        title={t(($) => {
+          return $.connectors.providerConnect.github.successTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.github.successDescription;
+          },
+          { account: githubUserLabel(githubUsername) },
+        )}
       />
       <BackLink />
     </PageShell>
@@ -137,21 +147,20 @@ function AlreadyConnectedState({
 }: {
   githubUsername?: string;
 }) {
+  const { t } = useTranslation();
   return (
     <PageShell>
       <GithubMark state="success" />
       <CenterText
-        title="Already connected to GitHub"
-        body={
-          <>
-            You&apos;re already connected as{" "}
-            <span className="font-medium">
-              {githubUserLabel(githubUsername)}
-            </span>
-            . Mention your agent in GitHub issues or pull requests to start
-            chatting.
-          </>
-        }
+        title={t(($) => {
+          return $.connectors.providerConnect.github.alreadyTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.github.alreadyDescription;
+          },
+          { account: githubUserLabel(githubUsername) },
+        )}
       />
       <BackLink />
     </PageShell>
@@ -175,19 +184,32 @@ function LoadingState({
 
 function SignInState(): JSX.Element {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <PageShell>
       <GithubMark />
       <CenterText
-        title="Sign in to continue"
-        body={`Use your ${brandName} account before connecting this GitHub user.`}
+        title={t(($) => {
+          return $.connectors.providerConnect.github.signInTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.github.signInDescription;
+          },
+          { brandName },
+        )}
       />
       <a
         href={signInHref()}
         className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
       >
-        Sign in to {brandName}
+        {t(
+          ($) => {
+            return $.connectors.providerConnect.github.signInButton;
+          },
+          { brandName },
+        )}
       </a>
     </PageShell>
   );
@@ -205,22 +227,24 @@ function ConnectState({
   onConnect: () => void;
 }): JSX.Element {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <PageShell>
       <GithubMark />
       <CenterText
-        title="Connect to GitHub"
-        body={
-          <>
-            Link your {brandName} account to{" "}
-            <span className="font-medium">
-              {githubUserLabel(params.githubUsername)}
-            </span>{" "}
-            so GitHub mentions can run your agents from issues and pull
-            requests.
-          </>
-        }
+        title={t(($) => {
+          return $.connectors.providerConnect.github.connectTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.github.connectDescription;
+          },
+          {
+            account: githubUserLabel(params.githubUsername),
+            brandName,
+          },
+        )}
       />
       {error ? (
         <div
@@ -235,7 +259,13 @@ function ConnectState({
           {connecting ? (
             <IconLoader2 size={16} className="animate-spin" />
           ) : null}
-          {connecting ? "Connecting..." : "Connect"}
+          {connecting
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
         <div className="flex justify-center">
           <BackLink />
@@ -245,7 +275,50 @@ function ConnectState({
   );
 }
 
+type GithubConnectParamErrorCode = Extract<
+  ReturnType<typeof parseGithubConnectParams>,
+  { ok: false }
+>["error"]["code"];
+
+function InvalidGithubConnectParams({
+  code,
+}: {
+  code: GithubConnectParamErrorCode;
+}) {
+  const { t } = useTranslation();
+  const title =
+    code === "incomplete"
+      ? t(($) => {
+          return $.connectors.providerConnect.github.linkIncompleteTitle;
+        })
+      : t(($) => {
+          return $.connectors.providerConnect.github.invalidTitle;
+        });
+  const messages: Record<GithubConnectParamErrorCode, string> = {
+    incomplete: t(($) => {
+      return $.connectors.providerConnect.github.linkIncomplete;
+    }),
+    invalid_installation: t(($) => {
+      return $.connectors.providerConnect.github.invalidInstallation;
+    }),
+    invalid_signature: t(($) => {
+      return $.connectors.providerConnect.github.invalidSignature;
+    }),
+    invalid_timestamp: t(($) => {
+      return $.connectors.providerConnect.github.invalidTimestamp;
+    }),
+    invalid_user: t(($) => {
+      return $.connectors.providerConnect.github.invalidUser;
+    }),
+    invalid_username: t(($) => {
+      return $.connectors.providerConnect.github.invalidUsername;
+    }),
+  };
+  return <InvalidState title={title} message={messages[code]} />;
+}
+
 export function ZeroGithubConnectPage(): JSX.Element {
+  const { t } = useTranslation();
   const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseGithubConnectParams(params);
@@ -264,16 +337,21 @@ export function ZeroGithubConnectPage(): JSX.Element {
       : null;
 
   if (!parsed.ok) {
-    return (
-      <InvalidState title={parsed.error.title} message={parsed.error.message} />
-    );
+    return <InvalidGithubConnectParams code={parsed.error.code} />;
   }
 
   if (clerkLoadable.state === "loading") {
     return (
       <LoadingState
-        title="Checking account status..."
-        body={`Please wait while we verify your ${brandName} session.`}
+        title={t(($) => {
+          return $.connectors.providerConnect.common.checkingTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.github.checkingSession;
+          },
+          { brandName },
+        )}
       />
     );
   }
@@ -281,8 +359,12 @@ export function ZeroGithubConnectPage(): JSX.Element {
   if (clerkLoadable.state === "hasError") {
     return (
       <InvalidState
-        title="Couldn't check sign-in"
-        message="Refresh this page and try again."
+        title={t(($) => {
+          return $.connectors.providerConnect.github.signInCheckFailed;
+        })}
+        message={t(($) => {
+          return $.connectors.providerConnect.github.refresh;
+        })}
       />
     );
   }
@@ -298,8 +380,13 @@ export function ZeroGithubConnectPage(): JSX.Element {
   if (linkStatusLoadable.state === "loading") {
     return (
       <LoadingState
-        title="Checking connection..."
-        body="Please wait while we check your GitHub connection."
+        title={t(($) => {
+          return $.connectors.providerConnect.github.checkingConnectionTitle;
+        })}
+        body={t(($) => {
+          return $.connectors.providerConnect.github
+            .checkingConnectionDescription;
+        })}
       />
     );
   }
@@ -318,16 +405,25 @@ export function ZeroGithubConnectPage(): JSX.Element {
   if (linkStatus?.kind === "not_installed") {
     return (
       <InvalidState
-        title="GitHub is not installed"
-        message="Ask an organization admin to install GitHub before connecting your account."
+        title={t(($) => {
+          return $.connectors.providerConnect.github.notInstalledTitle;
+        })}
+        message={t(($) => {
+          return $.connectors.providerConnect.github.notInstalledDescription;
+        })}
       />
     );
   }
   if (linkStatus?.kind === "wrong_organization") {
     return (
       <InvalidState
-        title="Switch organization"
-        message="Your active organization doesn't match this GitHub installation. Switch to the correct organization and open the link again."
+        title={t(($) => {
+          return $.connectors.providerConnect.github.wrongOrganizationTitle;
+        })}
+        message={t(($) => {
+          return $.connectors.providerConnect.github
+            .wrongOrganizationDescription;
+        })}
       />
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -9,6 +9,7 @@ import {
   IconArrowLeft,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { searchParams$ } from "../../signals/route.ts";
@@ -22,13 +23,16 @@ import {
 type PageStatus = SlackConnectStatus | "checking" | "error";
 
 function BackLink() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to settings
+      {t(($) => {
+        return $.connectors.providerConnect.common.backToSettings;
+      })}
     </Link>
   );
 }
@@ -45,7 +49,71 @@ export function ZeroSlackConnectPage() {
   );
 }
 
+function ErrorState({ message }: { message: string }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconAlertCircle size={40} className="text-destructive" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.connectionFailed;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {message}
+        </p>
+      </div>
+      <BackLink />
+    </>
+  );
+}
+
+function CheckingState() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.checkingTitle;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(($) => {
+            return $.connectors.providerConnect.common.verifying;
+          })}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function InvalidState() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.invalidLink;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(($) => {
+            return $.connectors.providerConnect.slack.invalidDescription;
+          })}
+        </p>
+      </div>
+      <BackLink />
+    </>
+  );
+}
+
 function PageContent() {
+  const { t } = useTranslation();
   const params = useGet(searchParams$);
   const workspaceId = params.get("w");
   const slackUserId = params.get("u");
@@ -71,20 +139,7 @@ function PageContent() {
 
   // Error state
   if (status === "error") {
-    return (
-      <>
-        <IconAlertCircle size={40} className="text-destructive" />
-        <div className="text-center space-y-1.5">
-          <h2 className="text-base font-semibold text-foreground">
-            Connection Failed
-          </h2>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            {effectiveError}
-          </p>
-        </div>
-        <BackLink />
-      </>
-    );
+    return <ErrorState message={effectiveError} />;
   }
 
   // Success state
@@ -94,12 +149,22 @@ function PageContent() {
         <IconCircleCheck size={40} className="text-emerald-500" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
-            Connected to Slack!
+            {t(($) => {
+              return $.connectors.providerConnect.slack.successTitle;
+            })}
           </h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            {workspaceName ? `You're connected to ${workspaceName}. ` : ""}
-            Mention <strong>@Zero</strong> in any channel or send a DM to start
-            chatting.
+            {workspaceName
+              ? t(
+                  ($) => {
+                    return $.connectors.providerConnect.slack
+                      .successDescriptionWorkspace;
+                  },
+                  { workspace: workspaceName },
+                )
+              : t(($) => {
+                  return $.connectors.providerConnect.slack.successDescription;
+                })}
           </p>
         </div>
         <div className="flex flex-col gap-3 w-full">
@@ -111,7 +176,9 @@ function PageContent() {
             }}
           >
             <IconBrandSlack size={16} />
-            Open Slack
+            {t(($) => {
+              return $.connectors.providerConnect.slack.open;
+            })}
           </Button>
           <div className="flex justify-center">
             <BackLink />
@@ -123,19 +190,7 @@ function PageContent() {
 
   // Loading — checking login / connection status
   if (status === "checking") {
-    return (
-      <>
-        <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
-        <div className="text-center space-y-1.5">
-          <h2 className="text-base font-semibold text-foreground">
-            Checking account status…
-          </h2>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            Please wait while we verify your connection.
-          </p>
-        </div>
-      </>
-    );
+    return <CheckingState />;
   }
 
   // Connect confirmation (from Slack link with w + u params)
@@ -145,11 +200,14 @@ function PageContent() {
         <IconBrandSlack size={40} className="text-foreground" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
-            Connect to Slack
+            {t(($) => {
+              return $.connectors.providerConnect.slack.connectTitle;
+            })}
           </h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Link your account to this Slack workspace so you can interact with
-            your agent directly from Slack.
+            {t(($) => {
+              return $.connectors.providerConnect.slack.connectDescription;
+            })}
           </p>
         </div>
         <Button
@@ -161,7 +219,13 @@ function PageContent() {
           {connectLoading ? (
             <IconLoader2 size={16} className="animate-spin mr-2" />
           ) : null}
-          {connectLoading ? "Connecting..." : "Connect"}
+          {connectLoading
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
         <BackLink />
       </>
@@ -169,18 +233,5 @@ function PageContent() {
   }
 
   // No params — invalid access
-  return (
-    <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
-      <div className="text-center space-y-1.5">
-        <h2 className="text-base font-semibold text-foreground">
-          Invalid Link
-        </h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          This page is meant to be opened from a Slack connect link.
-        </p>
-      </div>
-      <BackLink />
-    </>
-  );
+  return <InvalidState />;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
@@ -7,6 +7,7 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import {
@@ -24,13 +25,16 @@ type PageStatus = TeamsConnectPageStatus | "checking" | "error";
 const teamsIconImg = settingsIconAssetUrl("teams");
 
 function BackLink() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to settings
+      {t(($) => {
+        return $.connectors.providerConnect.common.backToSettings;
+      })}
     </Link>
   );
 }
@@ -80,7 +84,71 @@ function TeamsLogo({ size }: { readonly size: "sm" | "lg" }) {
   );
 }
 
+function ErrorState({ message }: { message: string }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconAlertCircle size={40} className="text-destructive" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.connectionFailed;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {message}
+        </p>
+      </div>
+      <BackLink />
+    </>
+  );
+}
+
+function CheckingState() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.checkingTitle;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(($) => {
+            return $.connectors.providerConnect.common.verifying;
+          })}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function InvalidState() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          {t(($) => {
+            return $.connectors.providerConnect.common.invalidLink;
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(($) => {
+            return $.connectors.providerConnect.teams.invalidDescription;
+          })}
+        </p>
+      </div>
+      <BackLink />
+    </>
+  );
+}
+
 function PageContent() {
+  const { t } = useTranslation();
   const params = useGet(searchParams$);
   const tenantId = params.get("tenantId");
   const teamsUserId = params.get("teamsUserId");
@@ -106,20 +174,7 @@ function PageContent() {
   };
 
   if (status === "error") {
-    return (
-      <>
-        <IconAlertCircle size={40} className="text-destructive" />
-        <div className="text-center space-y-1.5">
-          <h2 className="text-base font-semibold text-foreground">
-            Connection Failed
-          </h2>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            {effectiveError}
-          </p>
-        </div>
-        <BackLink />
-      </>
-    );
+    return <ErrorState message={effectiveError} />;
   }
 
   if (status === "success") {
@@ -129,11 +184,17 @@ function PageContent() {
         <IconCircleCheck size={40} className="text-emerald-500" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
-            Connected to Microsoft Teams
+            {t(($) => {
+              return $.connectors.providerConnect.teams.successTitle;
+            })}
           </h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            You are connected to {label}. Mention <strong>@Zero</strong> in
-            Teams to start chatting.
+            {t(
+              ($) => {
+                return $.connectors.providerConnect.teams.successDescription;
+              },
+              { team: label },
+            )}
           </p>
         </div>
         <div className="flex flex-col gap-3 w-full">
@@ -145,7 +206,9 @@ function PageContent() {
             }}
           >
             <TeamsLogo size="sm" />
-            Open Teams
+            {t(($) => {
+              return $.connectors.providerConnect.teams.open;
+            })}
           </Button>
           <div className="flex justify-center">
             <BackLink />
@@ -156,19 +219,7 @@ function PageContent() {
   }
 
   if (status === "checking") {
-    return (
-      <>
-        <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
-        <div className="text-center space-y-1.5">
-          <h2 className="text-base font-semibold text-foreground">
-            Checking account status...
-          </h2>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            Please wait while we verify your connection.
-          </p>
-        </div>
-      </>
-    );
+    return <CheckingState />;
   }
 
   if (tenantId && (teamsUserId || teamsAadObjectId)) {
@@ -177,11 +228,22 @@ function PageContent() {
         <TeamsLogo size="lg" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
-            Connect Microsoft Teams
+            {t(($) => {
+              return $.connectors.providerConnect.teams.connectTitle;
+            })}
           </h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            {displayName ? `${displayName}, link` : "Link"} your Teams account
-            so you can interact with your agent directly from Microsoft Teams.
+            {displayName
+              ? t(
+                  ($) => {
+                    return $.connectors.providerConnect.teams
+                      .connectDescriptionNamed;
+                  },
+                  { displayName },
+                )
+              : t(($) => {
+                  return $.connectors.providerConnect.teams.connectDescription;
+                })}
           </p>
         </div>
         <Button
@@ -193,25 +255,18 @@ function PageContent() {
           {connectLoading ? (
             <IconLoader2 size={16} className="animate-spin mr-2" />
           ) : null}
-          {connectLoading ? "Connecting..." : "Connect"}
+          {connectLoading
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
         <BackLink />
       </>
     );
   }
 
-  return (
-    <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
-      <div className="text-center space-y-1.5">
-        <h2 className="text-base font-semibold text-foreground">
-          Invalid Link
-        </h2>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          This page is meant to be opened from a Microsoft Teams connect link.
-        </p>
-      </div>
-      <BackLink />
-    </>
-  );
+  return <InvalidState />;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -8,6 +8,8 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { Button, CopyButton } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 import { clerk$, resolveAppAuthUrl } from "../../signals/auth.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -35,13 +37,16 @@ function signInHref(): string {
 }
 
 function BackLink() {
+  const { t } = useTranslation();
   return (
     <Link
       pathname="/settings/telegram"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
       <IconArrowLeft size={14} />
-      Back to Telegram settings
+      {t(($) => {
+        return $.connectors.providerConnect.telegram.back;
+      })}
     </Link>
   );
 }
@@ -121,23 +126,24 @@ function TelegramAutoOpen({ href }: { href: string }) {
 }
 
 function SuccessState({ botUsername }: { botUsername: string }) {
+  const { t } = useTranslation();
   const telegramHref = `tg://resolve?domain=${botUsername.replace(/^@/, "")}`;
+  const botLabel = `@${botUsername.replace(/^@/, "")}`;
 
   return (
     <PageShell>
       <TelegramAutoOpen href={telegramHref} />
       <TelegramMark state="success" />
       <CenterText
-        title="Connected to Telegram!"
-        body={
-          <>
-            You&apos;re connected to{" "}
-            <span className="font-medium">
-              @{botUsername.replace(/^@/, "")}
-            </span>
-            . Send a message in Telegram to start chatting.
-          </>
-        }
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.successTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.telegram.successDescription;
+          },
+          { bot: botLabel },
+        )}
       />
       <div className="flex w-full flex-col gap-3">
         <Button
@@ -147,7 +153,9 @@ function SuccessState({ botUsername }: { botUsername: string }) {
           }}
         >
           <img src={telegramIconImg} alt="" className="h-4 w-4" />
-          Open Telegram
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.open;
+          })}
         </Button>
         <div className="flex justify-center">
           <BackLink />
@@ -162,6 +170,7 @@ function AlreadyConnectedState({
 }: {
   botUsername: string | undefined;
 }) {
+  const { t } = useTranslation();
   const normalizedBotUsername = botUsername?.replace(/^@/, "");
   const telegramHref = normalizedBotUsername
     ? `tg://resolve?domain=${normalizedBotUsername}`
@@ -171,19 +180,21 @@ function AlreadyConnectedState({
     <PageShell>
       <TelegramMark state="success" />
       <CenterText
-        title="Already connected to Telegram"
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.alreadyTitle;
+        })}
         body={
-          <>
-            {normalizedBotUsername ? (
-              <>
-                You&apos;re already connected to{" "}
-                <span className="font-medium">@{normalizedBotUsername}</span>.
-                Send a message in Telegram to start chatting.
-              </>
-            ) : (
-              "You're already connected. Send a message in Telegram to start chatting."
-            )}
-          </>
+          normalizedBotUsername
+            ? t(
+                ($) => {
+                  return $.connectors.providerConnect.telegram
+                    .alreadyDescriptionNamed;
+                },
+                { bot: `@${normalizedBotUsername}` },
+              )
+            : t(($) => {
+                return $.connectors.providerConnect.telegram.alreadyDescription;
+              })
         }
       />
       <div className="flex w-full flex-col gap-3">
@@ -195,7 +206,9 @@ function AlreadyConnectedState({
             }}
           >
             <img src={telegramIconImg} alt="" className="h-4 w-4" />
-            Open Telegram
+            {t(($) => {
+              return $.connectors.providerConnect.telegram.open;
+            })}
           </Button>
         ) : null}
         <div className="flex justify-center">
@@ -213,10 +226,13 @@ function getTelegramLoginDomain(): string {
 function getTelegramConnectErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
-    : "We couldn't connect Telegram. Try again from Telegram.";
+    : i18n.t(($) => {
+        return $.connectors.providerConnect.telegram.errorFallback;
+      });
 }
 
 function DomainStatusPolling() {
+  const { t } = useTranslation();
   const domainStatusPollerRef = useSet(telegramDomainStatusPollerRef$);
 
   return (
@@ -224,7 +240,9 @@ function DomainStatusPolling() {
       <span ref={domainStatusPollerRef} hidden />
       <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
         <IconLoader2 size={13} className="animate-spin" />
-        Checking domain status...
+        {t(($) => {
+          return $.connectors.providerConnect.telegram.checkingDomain;
+        })}
       </div>
     </>
   );
@@ -235,29 +253,38 @@ function DomainSetupState({
 }: {
   botUsername: string | undefined;
 }) {
+  const { t } = useTranslation();
   const domain = getTelegramLoginDomain();
   const normalizedBotUsername = botUsername?.replace(/^@/, "");
+  const botLabel = normalizedBotUsername
+    ? `@${normalizedBotUsername}`
+    : t(($) => {
+        return $.connectors.providerConnect.telegram.botFallback;
+      });
 
   return (
     <PageShell>
       <TelegramMark state="warning" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
-          Set Telegram login domain
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.domainTitle;
+          })}
         </h2>
         <p className="text-sm text-muted-foreground leading-relaxed">
-          Telegram web login is not enabled for{" "}
-          {normalizedBotUsername ? (
-            <span className="font-medium">@{normalizedBotUsername}</span>
-          ) : (
-            "this bot"
+          {t(
+            ($) => {
+              return $.connectors.providerConnect.telegram.domainDescription;
+            },
+            { bot: botLabel },
           )}
-          .
         </p>
       </div>
       <div className="w-full rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-relaxed text-foreground">
         <p>
-          In{" "}
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.domainIn;
+          })}
           <a
             href="https://t.me/BotFather"
             target="_blank"
@@ -266,11 +293,16 @@ function DomainSetupState({
           >
             @BotFather
           </a>
-          , send{" "}
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.domainSend;
+          })}
           <code className="rounded border border-amber-500/30 bg-background/80 px-1 py-0.5 font-mono text-xs">
             /setdomain
           </code>
-          , choose the bot, then set the domain to:
+          {t(($) => {
+            return $.connectors.providerConnect.telegram
+              .domainInstructionsAfter;
+          })}
         </p>
         <div className="mt-3 flex items-center justify-between gap-2 rounded-md border border-border bg-background px-3 py-2">
           <code className="min-w-0 truncate font-mono text-xs">{domain}</code>
@@ -280,8 +312,9 @@ function DomainSetupState({
           />
         </div>
         <p className="mt-3 text-muted-foreground">
-          Keep this page open after saving the domain. You can also connect from
-          Telegram with <code className="font-mono text-xs">/connect</code>.
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.domainKeepOpen;
+          })}
         </p>
         <DomainStatusPolling />
       </div>
@@ -292,7 +325,9 @@ function DomainSetupState({
           rel="noreferrer"
           className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
-          Open BotFather
+          {t(($) => {
+            return $.connectors.providerConnect.telegram.openBotFather;
+          })}
         </a>
         <div className="flex justify-center">
           <BackLink />
@@ -311,6 +346,7 @@ function ConnectActions({
   connecting: boolean;
   onConnect: () => void;
 }) {
+  const { t } = useTranslation();
   if (parsed.connectSignature) {
     return (
       <div className="flex w-full flex-col gap-3">
@@ -318,7 +354,13 @@ function ConnectActions({
           {connecting ? (
             <IconLoader2 size={16} className="animate-spin" />
           ) : null}
-          {connecting ? "Connecting..." : "Connect"}
+          {connecting
+            ? t(($) => {
+                return $.connectors.actions.connecting;
+              })
+            : t(($) => {
+                return $.connectors.actions.connect;
+              })}
         </Button>
       </div>
     );
@@ -327,12 +369,127 @@ function ConnectActions({
   return (
     <Button className="w-full" disabled={connecting} onClick={onConnect}>
       {connecting ? <IconLoader2 size={16} className="animate-spin" /> : null}
-      {connecting ? "Connecting..." : "Continue with Telegram"}
+      {connecting
+        ? t(($) => {
+            return $.connectors.actions.connecting;
+          })
+        : t(($) => {
+            return $.connectors.providerConnect.telegram.continue;
+          })}
     </Button>
   );
 }
 
+type TelegramConnectParamErrorCode = Extract<
+  ReturnType<typeof parseTelegramConnectParams>,
+  { ok: false }
+>["error"]["code"];
+
+function InvalidTelegramConnectParams({
+  code,
+}: {
+  code: TelegramConnectParamErrorCode;
+}) {
+  const { t } = useTranslation();
+  const title =
+    code === "incomplete"
+      ? t(($) => {
+          return $.connectors.providerConnect.telegram.linkIncompleteTitle;
+        })
+      : t(($) => {
+          return $.connectors.providerConnect.telegram.invalidTitle;
+        });
+  const messages: Record<TelegramConnectParamErrorCode, string> = {
+    incomplete: t(($) => {
+      return $.connectors.providerConnect.telegram.linkIncomplete;
+    }),
+    invalid_signature: t(($) => {
+      return $.connectors.providerConnect.telegram.invalidSignature;
+    }),
+    invalid_timestamp: t(($) => {
+      return $.connectors.providerConnect.telegram.invalidTimestamp;
+    }),
+    invalid_user: t(($) => {
+      return $.connectors.providerConnect.telegram.invalidUser;
+    }),
+    invalid_username: t(($) => {
+      return $.connectors.providerConnect.telegram.invalidUsername;
+    }),
+  };
+  return <InvalidState title={title} message={messages[code]} />;
+}
+
+function TelegramSessionLoadingState({ brandName }: { brandName: string }) {
+  const { t } = useTranslation();
+  return (
+    <PageShell>
+      <TelegramMark state="loading" />
+      <CenterText
+        title={t(($) => {
+          return $.connectors.providerConnect.common.checkingTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.telegram.checkingSession;
+          },
+          { brandName },
+        )}
+      />
+    </PageShell>
+  );
+}
+
+function TelegramSignInState({ brandName }: { brandName: string }) {
+  const { t } = useTranslation();
+  return (
+    <PageShell>
+      <TelegramMark />
+      <CenterText
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.signInTitle;
+        })}
+        body={t(
+          ($) => {
+            return $.connectors.providerConnect.telegram.signInDescription;
+          },
+          { brandName },
+        )}
+      />
+      <a
+        href={signInHref()}
+        className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        {t(
+          ($) => {
+            return $.connectors.providerConnect.telegram.signInButton;
+          },
+          { brandName },
+        )}
+      </a>
+    </PageShell>
+  );
+}
+
+function TelegramConnectionLoadingState() {
+  const { t } = useTranslation();
+  return (
+    <PageShell>
+      <TelegramMark state="loading" />
+      <CenterText
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.checkingConnectionTitle;
+        })}
+        body={t(($) => {
+          return $.connectors.providerConnect.telegram
+            .checkingConnectionDescription;
+        })}
+      />
+    </PageShell>
+  );
+}
+
 export function ZeroTelegramConnectPage(): JSX.Element {
+  const { t } = useTranslation();
   const brandName = useGet(brandName$);
   const params = useGet(searchParams$);
   const parsed = parseTelegramConnectParams(params);
@@ -351,48 +508,28 @@ export function ZeroTelegramConnectPage(): JSX.Element {
       : null;
 
   if (!parsed.ok) {
-    return (
-      <InvalidState title={parsed.error.title} message={parsed.error.message} />
-    );
+    return <InvalidTelegramConnectParams code={parsed.error.code} />;
   }
 
   if (clerkLoadable.state === "loading") {
-    return (
-      <PageShell>
-        <TelegramMark state="loading" />
-        <CenterText
-          title="Checking account status..."
-          body={`Please wait while we verify your ${brandName} session.`}
-        />
-      </PageShell>
-    );
+    return <TelegramSessionLoadingState brandName={brandName} />;
   }
 
   if (clerkLoadable.state === "hasError") {
     return (
       <InvalidState
-        title="Couldn't check sign-in"
-        message="Refresh this page and try again."
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.signInCheckFailed;
+        })}
+        message={t(($) => {
+          return $.connectors.providerConnect.telegram.refresh;
+        })}
       />
     );
   }
 
   if (!clerkLoadable.data.user) {
-    return (
-      <PageShell>
-        <TelegramMark />
-        <CenterText
-          title="Sign in to continue"
-          body={`Use your ${brandName} account before connecting this Telegram user.`}
-        />
-        <a
-          href={signInHref()}
-          className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Sign in to {brandName}
-        </a>
-      </PageShell>
-    );
+    return <TelegramSignInState brandName={brandName} />;
   }
 
   if (success) {
@@ -400,15 +537,7 @@ export function ZeroTelegramConnectPage(): JSX.Element {
   }
 
   if (linkStatusLoadable.state === "loading") {
-    return (
-      <PageShell>
-        <TelegramMark state="loading" />
-        <CenterText
-          title="Checking connection..."
-          body="Please wait while we check your Telegram connection."
-        />
-      </PageShell>
-    );
+    return <TelegramConnectionLoadingState />;
   }
 
   const linkStatus =
@@ -429,8 +558,12 @@ export function ZeroTelegramConnectPage(): JSX.Element {
     <PageShell>
       <TelegramMark />
       <CenterText
-        title="Connect to Telegram"
-        body="Link your account to this Telegram bot so you can interact with your agent directly from Telegram."
+        title={t(($) => {
+          return $.connectors.providerConnect.telegram.connectTitle;
+        })}
+        body={t(($) => {
+          return $.connectors.providerConnect.telegram.connectDescription;
+        })}
       />
       {error ? (
         <div

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -108,6 +108,8 @@ import {
 } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
+import { useTranslation } from "react-i18next";
+import { i18n } from "../../i18n/index.ts";
 
 const telegramIconImg = settingsIconAssetUrl("telegram");
 
@@ -234,11 +236,14 @@ function telegramConnectedUserLabel(bot: TelegramBot): string | null {
 }
 
 function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
+  const { t } = useTranslation();
   if (bot.tokenStatus === "invalid") {
     return (
       <span className="inline-flex items-center gap-1.5 rounded-lg border border-destructive/20 bg-destructive/10 px-2 py-1 text-xs font-medium text-destructive">
         <IconAlertTriangle className="h-3.5 w-3.5" />
-        Token invalid
+        {t(($) => {
+          return $.connectors.providerSettings.telegram.tokenInvalid;
+        })}
       </span>
     );
   }
@@ -247,8 +252,15 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
   if (connected) {
     const connectedUserLabel = telegramConnectedUserLabel(bot);
     const connectedLabel = connectedUserLabel
-      ? `Connected (${connectedUserLabel})`
-      : "Connected";
+      ? t(
+          ($) => {
+            return $.connectors.providerSettings.works.connectedDetail;
+          },
+          { detail: connectedUserLabel },
+        )
+      : t(($) => {
+          return $.connectors.providerSettings.works.connected;
+        });
     return (
       <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-secondary-foreground">
         <IconCircleCheck className="h-3.5 w-3.5 text-green-600" />
@@ -265,7 +277,9 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
   return (
     <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
       <IconAlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-      Not connected
+      {t(($) => {
+        return $.connectors.providerSettings.telegram.notConnected;
+      })}
     </span>
   );
 }
@@ -334,6 +348,7 @@ function getTelegramLoginOrigin(): string {
 }
 
 function CopyableTelegramValue({ value }: { value: string }) {
+  const { t } = useTranslation();
   const copiedValue = useGet(telegramCopiedValue$);
   const copyValueCommand = useSet(copyTelegramValue$);
   const pageSignal = useGet(pageSignal$);
@@ -346,11 +361,22 @@ function CopyableTelegramValue({ value }: { value: string }) {
     <button
       type="button"
       className={TELEGRAM_COMMAND_CLASS}
-      aria-label={`Copy ${value}`}
-      title="Click to copy"
+      aria-label={t(
+        ($) => {
+          return $.connectors.providerSettings.telegram.copyAria;
+        },
+        { value },
+      )}
+      title={t(($) => {
+        return $.connectors.providerSettings.telegram.copyTitle;
+      })}
       onClick={copyValue}
     >
-      {copiedValue === value ? "copied!" : value}
+      {copiedValue === value
+        ? t(($) => {
+            return $.connectors.providerSettings.telegram.copied;
+          })
+        : value}
     </button>
   );
 }
@@ -363,19 +389,18 @@ type AddTelegramStep = TelegramAddSetupStep;
 type SetupCheckTarget = TelegramSetupCheckTarget;
 
 const ADD_TELEGRAM_STEPS = [
-  { key: "token", label: "Token" },
-  { key: "domain", label: "Domain" },
-  { key: "privacy", label: "Privacy" },
-  { key: "create", label: "Create" },
-] as const satisfies readonly { key: AddTelegramStep; label: string }[];
+  "token",
+  "domain",
+  "privacy",
+  "create",
+] as const satisfies readonly AddTelegramStep[];
 
 function telegramStepIndex(step: AddTelegramStep): number {
-  return ADD_TELEGRAM_STEPS.findIndex((item) => {
-    return item.key === step;
-  });
+  return ADD_TELEGRAM_STEPS.indexOf(step);
 }
 
 function AddTelegramBotProgress({ step }: { step: AddTelegramStep }) {
+  const { t } = useTranslation();
   const currentIndex = telegramStepIndex(step);
   return (
     <div className="space-y-3">
@@ -385,7 +410,7 @@ function AddTelegramBotProgress({ step }: { step: AddTelegramStep }) {
           const complete = index < currentIndex;
           return (
             <div
-              key={item.key}
+              key={item}
               className={
                 complete || active
                   ? "h-1 flex-1 rounded-full bg-foreground"
@@ -401,14 +426,16 @@ function AddTelegramBotProgress({ step }: { step: AddTelegramStep }) {
           const complete = index < currentIndex;
           return (
             <div
-              key={item.key}
+              key={item}
               className={
                 active || complete
                   ? "truncate font-medium text-foreground"
                   : "truncate text-muted-foreground"
               }
             >
-              {item.label}
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.steps[item];
+              })}
             </div>
           );
         })}
@@ -422,6 +449,7 @@ function TelegramSetupStatusLine({
 }: {
   setupStatus: TelegramSetupStatus | null;
 }) {
+  const { t } = useTranslation();
   if (!setupStatus) {
     return null;
   }
@@ -430,7 +458,9 @@ function TelegramSetupStatusLine({
     <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
       <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
         <IconCircleCheck className="h-4 w-4 text-green-600" />
-        Token verified
+        {t(($) => {
+          return $.connectors.providerSettings.telegram.token.verified;
+        })}
       </span>
       <span>
         {setupStatus.username ? `@${setupStatus.username}` : setupStatus.id}
@@ -448,13 +478,16 @@ function AddTelegramBotTokenField({
   disabled: boolean;
   onBotTokenChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div>
       <label
         htmlFor="telegram-bot-token"
         className="mb-2 block text-sm font-medium text-foreground"
       >
-        Bot token
+        {t(($) => {
+          return $.connectors.providerSettings.telegram.botToken;
+        })}
       </label>
       <div className="relative">
         <IconKey
@@ -493,13 +526,16 @@ function AddTelegramBotAgentField({
   disabled: boolean;
   onAgentChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="min-w-0">
       <label
         htmlFor="telegram-new-bot-agent"
         className="mb-2 block text-sm font-medium text-foreground"
       >
-        Default agent
+        {t(($) => {
+          return $.connectors.providerSettings.telegram.defaultAgent;
+        })}
       </label>
       <Select
         value={agentId ?? ""}
@@ -549,14 +585,19 @@ function AddTelegramTokenStep({
   setupError: string | null;
   onBotTokenChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Create a bot token in BotFather
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.token.title;
+          })}
         </div>
         <div className="leading-relaxed">
-          Open{" "}
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.token.open;
+          })}
           <a
             href="https://t.me/BotFather"
             target="_blank"
@@ -566,8 +607,14 @@ function AddTelegramTokenStep({
             {BOT_FATHER_HANDLE}
             <IconExternalLink className="h-3.5 w-3.5" />
           </a>
-          , send <TelegramCommand command="/newbot" />, choose a name and
-          username, then paste the token below.
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.token.send;
+          })}
+          <TelegramCommand command="/newbot" />
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.token
+              .instructionAfter;
+          })}
         </div>
       </div>
       <AddTelegramBotTokenField
@@ -590,23 +637,40 @@ function AddTelegramDomainStep({
   confirmed: boolean;
   setupError: string | null;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Set the Telegram login domain
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.domain.title;
+          })}
         </div>
         <div className="leading-relaxed">
-          In {BOT_FATHER_HANDLE}, send <TelegramCommand command="/setdomain" />,
-          choose this bot, and set the domain to{" "}
-          <CopyableTelegramValue value={domain} />. Telegram uses this domain to
-          allow the connect flow for this bot.
+          {t(
+            ($) => {
+              return $.connectors.providerSettings.telegram.domain
+                .instructionStart;
+            },
+            { botFather: BOT_FATHER_HANDLE },
+          )}
+          <TelegramCommand command="/setdomain" />
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.domain
+              .instructionAfter;
+          })}
+          <CopyableTelegramValue value={domain} />
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.domain.instructionEnd;
+          })}
         </div>
       </div>
       {confirmed ? (
         <div className="flex items-center gap-2 rounded-lg border border-green-600/20 bg-green-600/10 px-3 py-2 text-sm text-green-700 dark:text-green-300">
           <IconCircleCheck className="h-4 w-4" />
-          Domain detected
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.domain.detected;
+          })}
         </div>
       ) : null}
       <SetupError message={setupError} />
@@ -621,23 +685,36 @@ function AddTelegramPrivacyStep({
   confirmed: boolean;
   setupError: string | null;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Optional: turn off privacy mode
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.privacy.title;
+          })}
         </div>
         <div className="leading-relaxed">
-          In {BOT_FATHER_HANDLE}, send <TelegramCommand command="/setprivacy" />
-          , choose this bot, then{" "}
-          <strong className="font-medium">disable</strong> privacy mode. This
-          lets the agent read group context around mentions and replies.
+          {t(
+            ($) => {
+              return $.connectors.providerSettings.telegram.privacy
+                .instructionStart;
+            },
+            { botFather: BOT_FATHER_HANDLE },
+          )}
+          <TelegramCommand command="/setprivacy" />
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.privacy
+              .instructionAfter;
+          })}
         </div>
       </div>
       {confirmed ? (
         <div className="flex items-center gap-2 rounded-lg border border-green-600/20 bg-green-600/10 px-3 py-2 text-sm text-green-700 dark:text-green-300">
           <IconCircleCheck className="h-4 w-4" />
-          Privacy mode is off
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.privacy.off;
+          })}
         </div>
       ) : null}
       <SetupError message={setupError} />
@@ -663,19 +740,32 @@ function AddTelegramCreateStep({
   onAgentChange: (value: string) => void;
 }) {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
 
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          Ready to create the integration
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.create.title;
+          })}
         </div>
         <div>
           {setupStatus?.username
-            ? `${brandName} will register @${setupStatus.username} and configure its webhook.`
-            : `${brandName} will register this bot and configure its webhook.`}{" "}
-          After setup, mention the bot in a group or send it a DM to talk with
-          the selected agent.
+            ? t(
+                ($) => {
+                  return $.connectors.providerSettings.telegram.create
+                    .descriptionNamed;
+                },
+                { bot: `@${setupStatus.username}`, brandName },
+              )
+            : t(
+                ($) => {
+                  return $.connectors.providerSettings.telegram.create
+                    .description;
+                },
+                { brandName },
+              )}
         </div>
       </div>
       <AddTelegramBotAgentField
@@ -722,7 +812,10 @@ function getSelectedAddTelegramAgent({
     agentId: selectedAgent?.id,
     selectedAgentLabel: selectedAgent
       ? agentLabel(selectedAgent, defaultAgent)
-      : (defaultAgent.displayName ?? "Select agent"),
+      : (defaultAgent.displayName ??
+        i18n.t(($) => {
+          return $.connectors.providerSettings.telegram.selectAgent;
+        })),
   };
 }
 
@@ -890,24 +983,35 @@ function AddTelegramBotDialogFrame({
   onCancel,
   onAgentChange,
 }: AddTelegramBotDialogFrameProps) {
+  const { t } = useTranslation();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         <Button type="button" size="sm" disabled={disabled}>
           <IconPlus size={16} />
-          Add bot
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.addBot;
+          })}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[640px]">
         <DialogHeader>
-          <DialogTitle>Add Telegram bot</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.providerSettings.telegram.addTitle;
+            })}
+          </DialogTitle>
           <DialogDescription>
-            Complete each BotFather step, then create the workspace bot.
+            {t(($) => {
+              return $.connectors.providerSettings.telegram.addDescription;
+            })}
           </DialogDescription>
         </DialogHeader>
         <form
           className="flex flex-col gap-4"
-          aria-label="Register Telegram bot"
+          aria-label={t(($) => {
+            return $.connectors.providerSettings.telegram.registerAria;
+          })}
           onSubmit={(event) => {
             event.preventDefault();
           }}
@@ -1169,6 +1273,7 @@ function AddTelegramBotDialogFooter({
   onNext: () => void;
   onAddBot: () => void;
 }) {
+  const { t } = useTranslation();
   const isTokenStep = step === "token";
   const isCreateStep = step === "create";
 
@@ -1181,11 +1286,15 @@ function AddTelegramBotDialogFooter({
         onClick={isTokenStep ? onCancel : onBack}
       >
         {isTokenStep ? (
-          "Cancel"
+          t(($) => {
+            return $.connectors.actions.cancel;
+          })
         ) : (
           <span className="inline-flex items-center gap-2">
             <IconArrowLeft size={16} />
-            Back
+            {t(($) => {
+              return $.connectors.providerSettings.telegram.steps.back;
+            })}
           </span>
         )}
       </Button>
@@ -1201,7 +1310,13 @@ function AddTelegramBotDialogFooter({
           ) : (
             <IconPlus size={16} />
           )}
-          {adding ? "Adding..." : "Add bot"}
+          {adding
+            ? t(($) => {
+                return $.connectors.providerSettings.telegram.adding;
+              })
+            : t(($) => {
+                return $.connectors.providerSettings.telegram.addBot;
+              })}
         </Button>
       ) : (
         <Button
@@ -1213,11 +1328,15 @@ function AddTelegramBotDialogFooter({
           {checkingTarget ? (
             <>
               <IconLoader2 size={16} className="animate-spin" />
-              Checking...
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.checking;
+              })}
             </>
           ) : (
             <>
-              Next
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.steps.next;
+              })}
               <IconArrowRight size={16} />
             </>
           )}
@@ -1292,6 +1411,7 @@ function TelegramBotAgentSelect({
   defaultAgent: DefaultAgentLabel;
   disabled: boolean;
 }) {
+  const { t } = useTranslation();
   const setSavingBotId = useSet(setTelegramSavingBotId$);
   const pageSignal = useGet(pageSignal$);
   const [, updateBotAgent] = useLoadableSet(updateTelegramBotAgent$);
@@ -1319,10 +1439,19 @@ function TelegramBotAgentSelect({
       })}
     >
       <SelectTrigger
-        aria-label={`Default agent for ${bot.username ?? bot.id}`}
+        aria-label={t(
+          ($) => {
+            return $.connectors.providerSettings.telegram.agentAria;
+          },
+          { bot: bot.username ?? bot.id },
+        )}
         className="h-9"
       >
-        <SelectValue placeholder="Select agent" />
+        <SelectValue
+          placeholder={t(($) => {
+            return $.connectors.providerSettings.telegram.selectAgent;
+          })}
+        />
       </SelectTrigger>
       <SelectContent>
         {options.map((agent) => {
@@ -1348,6 +1477,7 @@ function TelegramReinstallAction({
   disabled: boolean;
   reinstalling: boolean;
 }) {
+  const { t } = useTranslation();
   const setReinstallDialogBotId = useSet(setTelegramReinstallDialogBotId$);
   const isOfficial = isOfficialTelegramBot(bot);
   const tokenInvalid = !isOfficial && bot.tokenStatus === "invalid";
@@ -1372,7 +1502,13 @@ function TelegramReinstallAction({
       ) : (
         <IconRefresh size={15} />
       )}
-      {reinstalling ? "Reinstalling..." : "Reinstall"}
+      {reinstalling
+        ? t(($) => {
+            return $.connectors.providerSettings.telegram.reinstalling;
+          })
+        : t(($) => {
+            return $.connectors.providerSettings.telegram.reinstall;
+          })}
     </Button>
   );
 }
@@ -1384,6 +1520,7 @@ function TelegramConnectAction({
   bot: TelegramBot;
   disabled: boolean;
 }) {
+  const { t } = useTranslation();
   if (bot.isConnected) {
     return null;
   }
@@ -1397,7 +1534,9 @@ function TelegramConnectAction({
         disabled
         className="h-9 justify-center"
       >
-        Connect
+        {t(($) => {
+          return $.connectors.actions.connect;
+        })}
       </Button>
     );
   }
@@ -1410,7 +1549,9 @@ function TelegramConnectAction({
           searchParams: new URLSearchParams({ bot: bot.id }),
         }}
       >
-        Connect
+        {t(($) => {
+          return $.connectors.actions.connect;
+        })}
       </Link>
     </Button>
   );
@@ -1431,6 +1572,7 @@ function TelegramMoreActions({
   unlinking: boolean;
   uninstalling: boolean;
 }) {
+  const { t } = useTranslation();
   const setUnlinkingBotId = useSet(setTelegramUnlinkingBotId$);
   const setUninstallDialogBotId = useSet(setTelegramUninstallDialogBotId$);
   const pageSignal = useGet(pageSignal$);
@@ -1449,7 +1591,12 @@ function TelegramMoreActions({
           type="button"
           disabled={disabled}
           className="shrink-0 rounded p-2 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-          aria-label={`More options for ${botLabel}`}
+          aria-label={t(
+            ($) => {
+              return $.connectors.providerSettings.telegram.moreOptions;
+            },
+            { bot: botLabel },
+          )}
         >
           <IconDotsVertical size={16} stroke={1.5} />
         </button>
@@ -1458,7 +1605,12 @@ function TelegramMoreActions({
         {bot.isConnected ? (
           <button
             type="button"
-            aria-label={`Disconnect ${botLabel}`}
+            aria-label={t(
+              ($) => {
+                return $.connectors.providerSettings.telegram.disconnectAria;
+              },
+              { bot: botLabel },
+            )}
             disabled={unlinking}
             className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
             onClick={onDomEventFn(async () => {
@@ -1467,20 +1619,37 @@ function TelegramMoreActions({
               setUnlinkingBotId(null);
             })}
           >
-            {unlinking ? "Disconnecting..." : "Disconnect"}
+            {unlinking
+              ? t(($) => {
+                  return $.connectors.actions.disconnecting;
+                })
+              : t(($) => {
+                  return $.connectors.actions.disconnect;
+                })}
           </button>
         ) : null}
         {canUninstall ? (
           <button
             type="button"
-            aria-label={`Uninstall ${botLabel}`}
+            aria-label={t(
+              ($) => {
+                return $.connectors.providerSettings.telegram.uninstallAria;
+              },
+              { bot: botLabel },
+            )}
             disabled={uninstalling}
             className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-destructive transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
             onClick={() => {
               setUninstallDialogBotId(bot.id);
             }}
           >
-            {uninstalling ? "Uninstalling..." : "Uninstall"}
+            {uninstalling
+              ? t(($) => {
+                  return $.connectors.actions.uninstalling;
+                })
+              : t(($) => {
+                  return $.connectors.actions.uninstall;
+                })}
           </button>
         ) : null}
       </PopoverContent>
@@ -1503,7 +1672,12 @@ function TelegramBotActions({
   uninstalling: boolean;
   reinstalling: boolean;
 }) {
-  const botLabel = bot.username ? `@${bot.username}` : "Telegram bot";
+  const { t } = useTranslation();
+  const botLabel = bot.username
+    ? `@${bot.username}`
+    : t(($) => {
+        return $.connectors.providerSettings.telegram.botFallback;
+      });
   const isOfficial = isOfficialTelegramBot(bot);
   const tokenInvalid = !isOfficial && bot.tokenStatus === "invalid";
   const connectDisabled =
@@ -1546,6 +1720,7 @@ function TelegramBotRow({
   disabled: boolean;
 }) {
   const brandName = useGet(brandName$);
+  const { t } = useTranslation();
   const savingBotId = useGet(telegramSavingBotId$);
   const unlinkingBotId = useGet(telegramUnlinkingBotId$);
   const uninstallingBotId = useGet(telegramUninstallingBotId$);
@@ -1563,10 +1738,14 @@ function TelegramBotRow({
   const botTitle = isOfficial
     ? bot.username
       ? `@${bot.username}`
-      : "Zero official bot"
+      : t(($) => {
+          return $.connectors.providerSettings.telegram.officialBot;
+        })
     : bot.username
       ? `@${bot.username}`
-      : "Telegram bot";
+      : t(($) => {
+          return $.connectors.providerSettings.telegram.botFallback;
+        });
 
   return (
     <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
@@ -1581,16 +1760,27 @@ function TelegramBotRow({
           </div>
           {isOfficial ? (
             <div className="mt-1 text-sm text-muted-foreground">
-              Official bot provided by {brandName}.
+              {t(
+                ($) => {
+                  return $.connectors.providerSettings.telegram
+                    .officialDescription;
+                },
+                { brandName },
+              )}
             </div>
           ) : bot.tokenStatus === "invalid" ? (
             <div className="mt-1 text-sm text-muted-foreground">
-              Reinstall the bot with a fresh token from BotFather.
+              {t(($) => {
+                return $.connectors.providerSettings.telegram
+                  .invalidTokenDescription;
+              })}
             </div>
           ) : null}
           {isOfficial && bot.official?.configured === false ? (
             <div className="mt-1 text-sm text-muted-foreground">
-              Official bot configuration is missing.
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.officialMissing;
+              })}
             </div>
           ) : null}
         </div>
@@ -1625,6 +1815,7 @@ function TelegramBotRow({
 }
 
 function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
+  const { t } = useTranslation();
   const token = useGet(telegramReinstallTokenForm$);
   const reinstallingBotId = useGet(telegramReinstallingBotId$);
   const setToken = useSet(setTelegramReinstallTokenForm$);
@@ -1634,7 +1825,11 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
   const [, reinstallBot] = useLoadableSet(reinstallTelegramBot$);
   const reinstalling = !!bot && reinstallingBotId === bot.id;
   const canSubmit = !!bot && token.trim().length > 0 && !reinstalling;
-  const botLabel = bot?.username ? `@${bot.username}` : "this bot";
+  const botLabel = bot?.username
+    ? `@${bot.username}`
+    : t(($) => {
+        return $.connectors.providerSettings.telegram.reinstallTargetFallback;
+      });
 
   return (
     <Dialog
@@ -1647,10 +1842,19 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Reinstall Telegram bot</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.providerSettings.telegram.reinstallTitle;
+            })}
+          </DialogTitle>
           <DialogDescription>
-            Paste the fresh BotFather token for {botLabel}. The token must
-            belong to this same bot.
+            {t(
+              ($) => {
+                return $.connectors.providerSettings.telegram
+                  .reinstallDescription;
+              },
+              { bot: botLabel },
+            )}
           </DialogDescription>
         </DialogHeader>
         <form
@@ -1681,7 +1885,9 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
               htmlFor="telegram-reinstall-token"
               className="mb-2 block text-sm font-medium text-foreground"
             >
-              New bot token
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.newBotToken;
+              })}
             </label>
             <div className="relative">
               <IconKey
@@ -1711,7 +1917,9 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
                 setReinstallDialogBotId(null);
               }}
             >
-              Cancel
+              {t(($) => {
+                return $.connectors.actions.cancel;
+              })}
             </Button>
             <Button type="submit" disabled={!canSubmit} className="gap-2">
               {reinstalling ? (
@@ -1719,7 +1927,13 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
               ) : (
                 <IconRefresh size={16} />
               )}
-              {reinstalling ? "Reinstalling..." : "Reinstall"}
+              {reinstalling
+                ? t(($) => {
+                    return $.connectors.providerSettings.telegram.reinstalling;
+                  })
+                : t(($) => {
+                    return $.connectors.providerSettings.telegram.reinstall;
+                  })}
             </Button>
           </DialogFooter>
         </form>
@@ -1729,6 +1943,7 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
 }
 
 function TelegramUninstallDialog({ bot }: { bot: TelegramBot | null }) {
+  const { t } = useTranslation();
   const setUninstallDialogBotId = useSet(setTelegramUninstallDialogBotId$);
   const setUninstallingBotId = useSet(setTelegramUninstallingBotId$);
   const uninstallingBotId = useGet(telegramUninstallingBotId$);
@@ -1747,11 +1962,26 @@ function TelegramUninstallDialog({ bot }: { bot: TelegramBot | null }) {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Uninstall Telegram bot?</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.providerSettings.telegram.uninstallTitle;
+            })}
+          </DialogTitle>
           <DialogDescription>
-            This removes {bot?.username ? `@${bot.username}` : "this bot"} from
-            the workspace and disconnects Telegram access for users who use it.
-            This action cannot be undone.
+            {t(
+              ($) => {
+                return $.connectors.providerSettings.telegram
+                  .uninstallDescription;
+              },
+              {
+                bot: bot?.username
+                  ? `@${bot.username}`
+                  : t(($) => {
+                      return $.connectors.providerSettings.telegram
+                        .uninstallTargetFallback;
+                    }),
+              },
+            )}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -1762,7 +1992,9 @@ function TelegramUninstallDialog({ bot }: { bot: TelegramBot | null }) {
               setUninstallDialogBotId(null);
             }}
           >
-            Cancel
+            {t(($) => {
+              return $.connectors.actions.cancel;
+            })}
           </Button>
           <Button
             variant="destructive"
@@ -1781,7 +2013,13 @@ function TelegramUninstallDialog({ bot }: { bot: TelegramBot | null }) {
               setUninstallingBotId(null);
             })}
           >
-            {uninstalling ? "Uninstalling..." : "Uninstall"}
+            {uninstalling
+              ? t(($) => {
+                  return $.connectors.actions.uninstalling;
+                })
+              : t(($) => {
+                  return $.connectors.actions.uninstall;
+                })}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -1802,6 +2040,7 @@ function TelegramBotList({
   isAdmin: boolean;
   agentsLoading: boolean;
 }) {
+  const { t } = useTranslation();
   if (bots.length === 0) {
     return (
       <div className="px-6 py-12 text-center">
@@ -1809,10 +2048,14 @@ function TelegramBotList({
           <img src={telegramIconImg} alt="" className="h-8 w-8" />
         </div>
         <div className="text-sm font-medium text-foreground">
-          No Telegram bots yet
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.emptyTitle;
+          })}
         </div>
         <div className="mt-1 text-sm text-muted-foreground">
-          Add a bot token to start routing Telegram messages to an agent.
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.emptyDescription;
+          })}
         </div>
       </div>
     );
@@ -1858,10 +2101,15 @@ function TelegramBotsCard({
   loading: boolean;
   hasError: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <section className="zero-card overflow-hidden">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
-        <h2 className="text-sm font-medium text-foreground">Telegram bots</h2>
+        <h2 className="text-sm font-medium text-foreground">
+          {t(($) => {
+            return $.connectors.providerSettings.telegram.bots;
+          })}
+        </h2>
         {!hasError && loading ? (
           <AddTelegramBotButtonSkeleton />
         ) : !hasError ? (
@@ -1884,6 +2132,7 @@ function TelegramBotsCard({
 }
 
 export function ZeroTelegramSettingsPage() {
+  const { t } = useTranslation();
   const botsLoadable = useLastLoadable(telegramBots$);
   const agentsLoadable = useLastLoadable(sortedAgents$);
   const defaultAgentIdLoadable = useLastLoadable(defaultAgentId$);
@@ -1930,9 +2179,18 @@ export function ZeroTelegramSettingsPage() {
               size="sm"
               className="h-8 gap-2 px-2 text-muted-foreground hover:text-foreground"
             >
-              <Link pathname={ROUTES.works} title="Back to integrations">
+              <Link
+                pathname={ROUTES.works}
+                title={t(($) => {
+                  return $.connectors.providerSettings.telegram
+                    .backToIntegrations;
+                })}
+              >
                 <IconArrowLeft size={17} stroke={1.8} />
-                Back to integrations
+                {t(($) => {
+                  return $.connectors.providerSettings.telegram
+                    .backToIntegrations;
+                })}
               </Link>
             </Button>
           </div>
@@ -1948,7 +2206,10 @@ export function ZeroTelegramSettingsPage() {
                   </h1>
                 </div>
                 <p className="mt-0.5 text-sm text-muted-foreground">
-                  Manage bot routing for this workspace
+                  {t(($) => {
+                    return $.connectors.providerSettings.telegram
+                      .pageDescription;
+                  })}
                 </p>
               </div>
             </div>
@@ -1960,7 +2221,9 @@ export function ZeroTelegramSettingsPage() {
         <div className="mx-auto flex max-w-[900px] flex-col gap-4">
           {hasError ? (
             <div className="zero-card px-6 py-10 text-center text-sm text-destructive">
-              Couldn&apos;t load Telegram settings.
+              {t(($) => {
+                return $.connectors.providerSettings.telegram.loadError;
+              })}
             </div>
           ) : loading ? (
             <TelegramSettingsSkeleton />


### PR DESCRIPTION
## Summary

- localize connector discovery, connection management, custom connector, access, permission, and scope-review surfaces for en-US and pt-BR
- localize directed authorization, OAuth callback and redirect states, browser and computer authorization prompts, and Slack, Teams, Feishu, Telegram, GitHub, and AgentPhone flows
- preserve connector and provider names, permission identifiers, scopes, URLs, commands, and raw provider errors while translating product-owned guidance, statuses, actions, errors, toasts, and accessibility labels
- add Portuguese integration coverage for the connector catalog, reconnect state, access management, OAuth startup failure, and callback failure

## Verification

- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app i18n:check
- pnpm knip
- pnpm vitest --run apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-feishu-connect-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-github-connect-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-slack-connect-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-teams-connect-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-telegram-connect-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx --maxWorkers=1
- pnpm vitest --run apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx --maxWorkers=1

Closes #23461