### PR TITLE
fix(platform): remove workspace slug setting

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -452,12 +452,7 @@
           "placeholder": "Workspace name",
           "title": "Name"
         },
-        "sectionTitle": "Profile",
-        "slug": {
-          "description": "URL-friendly identifier for the organization",
-          "placeholder": "organization-slug",
-          "title": "Slug"
-        }
+        "sectionTitle": "Profile"
       },
       "toasts": {
         "deleted": "Workspace deleted",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -454,12 +454,7 @@
           "placeholder": "Nome do espaço de trabalho",
           "title": "Nome"
         },
-        "sectionTitle": "Perfil",
-        "slug": {
-          "description": "Identificador da organização usado em URLs",
-          "placeholder": "organization-slug",
-          "title": "Slug"
-        }
+        "sectionTitle": "Perfil"
       },
       "toasts": {
         "deleted": "Espaço de trabalho excluído",

--- a/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
@@ -69,16 +69,6 @@ export const setProfileName$ = command(({ set }, value: string) => {
   set(internalProfileName$, value);
 });
 
-const internalProfileSlug$ = state("");
-
-export const profileSlug$ = computed((get) => {
-  return get(internalProfileSlug$);
-});
-
-export const setProfileSlug$ = command(({ set }, value: string) => {
-  set(internalProfileSlug$, value);
-});
-
 const internalProfileLogoUrl$ = state<string | null>(null);
 
 export const profileLogoUrl$ = computed((get) => {
@@ -148,7 +138,6 @@ export const initProfileName$ = command(
     const org = await get(org$);
     signal.throwIfAborted();
     set(internalProfileName$, org?.name ?? "");
-    set(internalProfileSlug$, org?.slug ?? "");
     set(internalProfileLogoUrl$, null);
     set(clearPendingLogo$);
     set(internalLogoLoaded$, false);
@@ -327,7 +316,6 @@ export const setLockedTarget$ = command(
 
 interface SaveOrgProfileInput {
   readonly name: string;
-  readonly slug: string;
   readonly logoFile: File | null;
 }
 
@@ -379,7 +367,6 @@ export const saveOrgProfile$ = command(
     }
 
     const hasNameChange = input.name !== (org.name ?? "");
-    const hasSlugChange = input.slug !== (org.slug ?? "");
 
     if (input.logoFile) {
       const result = await set(uploadOrgLogo$, input.logoFile, signal);
@@ -387,19 +374,11 @@ export const saveOrgProfile$ = command(
       set(internalProfileLogoUrl$, result.logoUrl);
     }
 
-    if (hasNameChange || hasSlugChange) {
-      const body: { name?: string; slug?: string; force?: boolean } = {};
-      if (hasNameChange) {
-        body.name = input.name;
-      }
-      if (hasSlugChange) {
-        body.slug = input.slug;
-        body.force = true;
-      }
+    if (hasNameChange) {
       const client = get(zeroClient$)(zeroOrgContract);
       await accept(
         client.update({
-          body,
+          body: { name: input.name },
           fetchOptions: { signal },
         }),
         [200],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -47,7 +47,7 @@ describe("organization general settings", () => {
       return respond(200, {
         id: "org_1",
         name: "New Name",
-        slug: "new-slug",
+        slug: "old-slug",
         role: "admin",
       });
     });
@@ -62,23 +62,20 @@ describe("organization general settings", () => {
     });
 
     await fill(await screen.findByDisplayValue("Old Name"), "New Name");
-    await fill(screen.getByDisplayValue("old-slug"), "new-slug");
+    expect(screen.queryByText("Slug")).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue("old-slug")).not.toBeInTheDocument();
     expect(screen.getByText("Save changes")).toBeInTheDocument();
     expect(screen.getByText("Discard")).toBeInTheDocument();
 
     click(screen.getByText("Discard"));
     expect(screen.getByDisplayValue("Old Name")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("old-slug")).toBeInTheDocument();
 
     await fill(screen.getByDisplayValue("Old Name"), "New Name");
-    await fill(screen.getByDisplayValue("old-slug"), "new-slug");
     click(screen.getByText("Save changes"));
 
     await waitFor(() => {
       expect(capturedBody).toStrictEqual({
         name: "New Name",
-        slug: "new-slug",
-        force: true,
       });
     });
   });
@@ -91,22 +88,22 @@ describe("organization general settings", () => {
       role: "admin",
     });
     context.mocks.api(zeroOrgContract.update, ({ respond }) => {
-      return respond(409, {
+      return respond(500, {
         error: {
-          code: "ORG_SLUG_TAKEN",
-          message: "Workspace slug is already taken",
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Could not update workspace",
         },
       });
     });
 
     await openGeneralTab();
 
-    await fill(screen.getByDisplayValue("old-slug"), "taken-slug");
+    await fill(screen.getByDisplayValue("Old Name"), "New Name");
     click(screen.getByText("Save changes"));
 
     await waitFor(() => {
       expect(
-        screen.getByText("Workspace slug is already taken"),
+        screen.getByText("Could not update workspace"),
       ).toBeInTheDocument();
       expect(screen.getByText("Save changes")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -25,8 +25,6 @@ import {
   clearPendingLogo$,
   profileName$,
   setProfileName$,
-  profileSlug$,
-  setProfileSlug$,
   profileLogoUrl$,
   pendingLogoFile$,
   pendingLogoPreview$,
@@ -62,9 +60,6 @@ function ProfileSection({
   const name = useGet(profileName$);
   const setName = useSet(setProfileName$);
 
-  const slug = useGet(profileSlug$);
-  const setSlug = useSet(setProfileSlug$);
-
   const [saveLoadable, saveProfile] = useLoadableSet(saveOrgProfile$);
   const saving = saveLoadable.state === "loading";
 
@@ -84,8 +79,7 @@ function ProfileSection({
   const setLogoLoaded = useSet(setLogoLoaded$);
   const loadOrgLogo = useSet(loadOrgLogo$);
   const hasNameChange = name !== (org.name ?? "");
-  const hasSlugChange = slug !== (org.slug ?? "");
-  const hasChanges = hasNameChange || hasSlugChange || !!pendingLogoFile;
+  const hasChanges = hasNameChange || !!pendingLogoFile;
 
   const handleFileSelect = async (file: File) => {
     if (!modalSignal) {
@@ -137,7 +131,6 @@ function ProfileSection({
 
   const handleDiscard = () => {
     setName(org.name ?? "");
-    setSlug(org.slug ?? "");
     clearPendingLogo();
   };
 
@@ -148,7 +141,6 @@ function ProfileSection({
     await saveProfile(
       {
         name,
-        slug,
         logoFile: pendingLogoFile,
       },
       modalSignal,
@@ -274,39 +266,6 @@ function ProfileSection({
           ) : (
             <span className="text-sm text-foreground shrink-0">
               {org.name ?? ""}
-            </span>
-          )}
-        </div>
-        <div className="h-0 zero-border-t mx-5" />
-        {/* Slug row */}
-        <div className="flex items-center justify-between gap-4 px-5 py-4">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground">
-              {t(($) => {
-                return $.settings.workspace.profile.slug.title;
-              })}
-            </p>
-            <p className="text-[13px] text-muted-foreground mt-0.5">
-              {t(($) => {
-                return $.settings.workspace.profile.slug.description;
-              })}
-            </p>
-          </div>
-          {isAdmin ? (
-            <Input
-              id="org-slug"
-              value={slug}
-              onChange={(e) => {
-                return setSlug(e.target.value);
-              }}
-              placeholder={t(($) => {
-                return $.settings.workspace.profile.slug.placeholder;
-              })}
-              className="w-[220px] shrink-0"
-            />
-          ) : (
-            <span className="text-sm text-foreground shrink-0">
-              {org.slug ?? ""}
             </span>
           )}
         </div>
@@ -605,15 +564,6 @@ function GeneralTabSkeleton() {
             <div className="min-w-0">
               <div className="h-4 w-10 rounded bg-muted/50 animate-pulse" />
               <div className="h-3 w-40 rounded bg-muted/30 animate-pulse mt-1.5" />
-            </div>
-            <div className="h-9 w-[220px] shrink-0 rounded-lg bg-muted/30 animate-pulse" />
-          </div>
-          <div className="h-0 zero-border-t mx-5" />
-          {/* Slug row */}
-          <div className="flex items-center justify-between gap-4 px-5 py-4">
-            <div className="min-w-0">
-              <div className="h-4 w-8 rounded bg-muted/50 animate-pulse" />
-              <div className="h-3 w-52 rounded bg-muted/30 animate-pulse mt-1.5" />
             </div>
             <div className="h-9 w-[220px] shrink-0 rounded-lg bg-muted/30 animate-pulse" />
           </div>


### PR DESCRIPTION
## Summary

- remove the editable Slug row from workspace General settings, including its loading skeleton and localized copy
- stop tracking or submitting slug changes from the workspace profile form while preserving the organization slug for identity and destructive-action flows
- update General settings integration coverage for name-only profile updates and the absence of the Slug field

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-general-tab.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`

PR preview browser verification will be completed with `pr-verify`.
