### PR TITLE
fix(runner): checkpoint sessions before job timeout

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -25,11 +25,14 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
-    LOG_TAG, ParsedEventAction, command,
+    AgentExecutionDeadline, CliEventIngestor, CliExecutionResult, CliRuntimeConfig,
+    HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction, command,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
+use guest_contracts::diagnostics::{
+    AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationDiagnostic, CliTerminationReason,
+};
 
 const TURN_NOTIFICATION_LABEL: &str = "turn notification";
 const API_TO_CODEX_OUTPUT_ITEM_STARTED: &str = "api_to_codex_output_item_started";
@@ -95,6 +98,34 @@ enum CodexRunEvent {
     ActiveInput(Option<ActiveInputFrame>),
 }
 
+enum AppServerRunOutcome {
+    Completed(Box<Result<CliExecutionResult, AgentError>>),
+    ExecutionTimedOut { timeout_secs: u64 },
+}
+
+async fn run_with_execution_deadline(
+    run: impl Future<Output = Result<CliExecutionResult, AgentError>>,
+    deadline: Option<AgentExecutionDeadline>,
+) -> AppServerRunOutcome {
+    tokio::pin!(run);
+
+    match deadline {
+        Some(deadline) => {
+            let deadline_sleep =
+                tokio::time::sleep_until(tokio::time::Instant::from_std(deadline.at));
+            tokio::pin!(deadline_sleep);
+            tokio::select! {
+                biased;
+                result = &mut run => AppServerRunOutcome::Completed(Box::new(result)),
+                () = &mut deadline_sleep => AppServerRunOutcome::ExecutionTimedOut {
+                    timeout_secs: deadline.timeout_secs,
+                },
+            }
+        }
+        None => AppServerRunOutcome::Completed(Box::new(run.await)),
+    }
+}
+
 pub(super) async fn execute_codex_app_server_for_runtime(
     masker: &SecretMasker,
     mut heartbeat_monitor: HeartbeatMonitor,
@@ -122,6 +153,10 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     .await;
 
     match run_result {
+        Ok(result) if result.control_error.is_some() => {
+            event_delivery.abort().await;
+            Ok(result)
+        }
         Ok(mut result) => {
             result.last_event_sequence = event_delivery.finish().await?;
             Ok(result)
@@ -150,7 +185,7 @@ async fn run_codex_app_server(
         .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;
 
-    let run_result = async {
+    let run = async {
         race_with_heartbeat(
             client.initialize(),
             heartbeat_monitor,
@@ -322,34 +357,61 @@ async fn run_codex_app_server(
             control_error: None,
             cli_termination: None,
         })
-    }
-    .await;
+    };
+    let run_outcome = run_with_execution_deadline(run, runtime.agent_execution_deadline).await;
     active_input.close_terminal();
 
-    let shutdown_result = if run_result.is_ok() {
-        client.shutdown().await
-    } else {
-        client.terminate().await
+    let shutdown_result = match &run_outcome {
+        AppServerRunOutcome::Completed(result) if result.is_ok() => client.shutdown().await,
+        AppServerRunOutcome::Completed(_) | AppServerRunOutcome::ExecutionTimedOut { .. } => {
+            client.terminate().await
+        }
     };
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
 
-    match (run_result, shutdown_result) {
-        (Ok(mut result), Ok(())) => {
-            result.stderr_lines = stderr_lines;
-            Ok(result)
-        }
-        (Ok(_result), Err(error)) => Err(AgentError::Execution(format!(
-            "codex app-server shutdown failed: {}",
-            masker.mask_string(&error.to_string())
-        ))),
-        (Err(error), Ok(())) => Err(error),
-        (Err(error), Err(shutdown_error)) => {
-            let shutdown_error = masker.mask_string(&shutdown_error.to_string());
-            log_warn!(
-                LOG_TAG,
-                "codex app-server shutdown failed after run error: {shutdown_error}"
-            );
-            Err(error)
+    match run_outcome {
+        AppServerRunOutcome::Completed(run_result) => match (*run_result, shutdown_result) {
+            (Ok(mut result), Ok(())) => {
+                result.stderr_lines = stderr_lines;
+                Ok(result)
+            }
+            (Ok(_result), Err(error)) => Err(AgentError::Execution(format!(
+                "codex app-server shutdown failed: {}",
+                masker.mask_string(&error.to_string())
+            ))),
+            (Err(error), Ok(())) => Err(error),
+            (Err(error), Err(shutdown_error)) => {
+                let shutdown_error = masker.mask_string(&shutdown_error.to_string());
+                log_warn!(
+                    LOG_TAG,
+                    "codex app-server shutdown failed after run error: {shutdown_error}"
+                );
+                Err(error)
+            }
+        },
+        AppServerRunOutcome::ExecutionTimedOut { timeout_secs } => {
+            if let Err(shutdown_error) = shutdown_result {
+                let shutdown_error = masker.mask_string(&shutdown_error.to_string());
+                log_warn!(
+                    LOG_TAG,
+                    "codex app-server termination failed after execution timeout: {shutdown_error}"
+                );
+            }
+            Ok(CliExecutionResult {
+                exit_code: AGENT_EXECUTION_TIMEOUT_EXIT_CODE,
+                cli_observed_exit: None,
+                stderr_lines,
+                last_event_sequence: None,
+                claude_result: None,
+                post_result_cleanup_result: None,
+                failure_diagnostic: ingestor.failure_diagnostic(),
+                control_error: Some(AgentError::Execution(format!(
+                    "Agent execution timed out after {timeout_secs} seconds"
+                ))),
+                cli_termination: Some(CliTerminationDiagnostic::new(
+                    CliTerminationReason::ExecutionTimeout,
+                )),
+            })
         }
     }
 }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::path::PathBuf;
 
 use serde_json::{Map, Value, json};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 
 use crate::env::Framework;
@@ -368,6 +369,9 @@ async fn run_codex_app_server(
         }
     };
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
+    // Complete the final event-log write after the child is stopped and
+    // before callers observe the finished app-server execution.
+    let _ = log_file.flush().await;
 
     match run_outcome {
         AppServerRunOutcome::Completed(run_result) => match (*run_result, shutdown_result) {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -307,6 +307,12 @@ pub enum HeartbeatStatus {
 /// callers that do not own a heartbeat task.
 pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
 
+#[derive(Clone, Copy)]
+struct AgentExecutionDeadline {
+    at: Instant,
+    timeout_secs: u64,
+}
+
 pub(super) struct CliRuntimeConfig<'a> {
     framework: env::Framework,
     run_id: Cow<'a, str>,
@@ -331,6 +337,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     codex_oauth_mode: bool,
     codex_fast_mode: bool,
     disable_builtin_web_search: bool,
+    agent_execution_deadline: Option<AgentExecutionDeadline>,
     stuck_tool_timeout_secs: u64,
     post_result_cleanup_policy: PostResultCleanupPolicy,
     agent_log_file: Cow<'a, str>,
@@ -344,6 +351,7 @@ impl<'a> CliRuntimeConfig<'a> {
     fn from_config(
         config: &'a env::GuestConfig,
         paths: &'a paths::GuestPaths,
+        execution_started_at: Instant,
     ) -> Result<Self, AgentError> {
         let codex_runtime_config = if matches!(config.framework, env::Framework::Codex) {
             codex_runtime_config::parse_raw(&config.codex_runtime_config)?
@@ -355,6 +363,23 @@ impl<'a> CliRuntimeConfig<'a> {
             &config.disallowed_tools,
             disable_builtin_web_search,
         );
+        let agent_execution_deadline = config
+            .agent_execution_timeout
+            .map(|timeout| {
+                execution_started_at
+                    .checked_add(timeout)
+                    .map(|at| AgentExecutionDeadline {
+                        at,
+                        timeout_secs: timeout.as_secs(),
+                    })
+                    .ok_or_else(|| {
+                        AgentError::Execution(format!(
+                            "{} is too large",
+                            guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV
+                        ))
+                    })
+            })
+            .transpose()?;
         Ok(Self {
             framework: config.framework,
             run_id: Cow::Borrowed(&config.run_id),
@@ -383,6 +408,7 @@ impl<'a> CliRuntimeConfig<'a> {
             codex_fast_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty()
                 && user_env_value(&config.user_env, "VM0_CODEX_SERVICE_TIER") == "fast",
             disable_builtin_web_search,
+            agent_execution_deadline,
             stuck_tool_timeout_secs: config.stuck_tool_timeout_secs,
             post_result_cleanup_policy: PostResultCleanupPolicy::new(
                 config.post_result_sigterm_grace,
@@ -586,9 +612,6 @@ impl CliEventIngestor {
 
 /// Execute the CLI process using values captured in a [`env::GuestConfig`] and
 /// [`paths::GuestPaths`].
-///
-/// Production guest-agent bootstrap should prefer this entry point so CLI
-/// setup observes the same immutable runtime snapshot as the rest of the run.
 pub async fn execute_cli_with_active_input_for_config(
     masker: &SecretMasker,
     heartbeat_monitor: HeartbeatMonitor,
@@ -597,7 +620,33 @@ pub async fn execute_cli_with_active_input_for_config(
     config: &env::GuestConfig,
     paths: &paths::GuestPaths,
 ) -> Result<CliExecutionResult, AgentError> {
-    let runtime = CliRuntimeConfig::from_config(config, paths)?;
+    execute_cli_with_active_input_for_config_started_at(
+        masker,
+        heartbeat_monitor,
+        http,
+        active_input,
+        config,
+        paths,
+        Instant::now(),
+    )
+    .await
+}
+
+/// Execute the CLI against an execution budget that started before guest
+/// initialization.
+///
+/// Production guest-agent bootstrap uses this entry point so setup time counts
+/// against the runner-owned execution budget.
+pub async fn execute_cli_with_active_input_for_config_started_at(
+    masker: &SecretMasker,
+    heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+    active_input: ActiveInputWriter,
+    config: &env::GuestConfig,
+    paths: &paths::GuestPaths,
+    execution_started_at: Instant,
+) -> Result<CliExecutionResult, AgentError> {
+    let runtime = CliRuntimeConfig::from_config(config, paths, execution_started_at)?;
     execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
 }
 
@@ -780,6 +829,18 @@ async fn execute_cli_inner(
     let mut termination_runtime =
         CliTerminationRuntime::new(process_group, runtime.post_result_cleanup_policy);
 
+    let agent_execution_deadline = tokio::time::sleep(Duration::MAX);
+    tokio::pin!(agent_execution_deadline);
+    let mut agent_execution_deadline_armed = false;
+    let mut agent_execution_timeout_secs = 0;
+    if let Some(deadline) = runtime.agent_execution_deadline {
+        agent_execution_deadline
+            .as_mut()
+            .reset(tokio::time::Instant::from_std(deadline.at));
+        agent_execution_deadline_armed = true;
+        agent_execution_timeout_secs = deadline.timeout_secs;
+    }
+
     // A resumed Codex process prints `thread.started` from the resume response
     // before its real turn notifications begin. Bound only that transition;
     // once any real lifecycle event arrives, long turns remain unrestricted.
@@ -828,6 +889,37 @@ async fn execute_cli_inner(
     let mut event_ingestor = CliEventIngestor::new(runtime);
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
+            () = &mut agent_execution_deadline, if agent_execution_deadline_armed && cli_status.is_none() => {
+                match try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_closed,
+                    drain_deadline.as_mut(),
+                )? {
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => {
+                        agent_execution_deadline_armed = false;
+                        continue;
+                    }
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
+                }
+                agent_execution_deadline_armed = false;
+                active_input_controller.close_terminal();
+                let timeout_error = AgentError::Execution(format!(
+                    "Agent execution timed out after {agent_execution_timeout_secs} seconds"
+                ));
+                termination_runtime.begin_control_failure(
+                    TerminationReason::ExecutionTimeout,
+                    timeout_error,
+                    ControlTerminationLog::ExecutionTimeout {
+                        timeout_secs: agent_execution_timeout_secs,
+                    },
+                    termination_deadline.as_mut(),
+                );
+            }
             stdin_write_result = async {
                 match claude_stdin_write_handle.as_mut() {
                     Some(handle) => Some(handle.await),
@@ -1598,6 +1690,7 @@ mod tests {
             codex_oauth_mode: false,
             codex_fast_mode: false,
             disable_builtin_web_search: false,
+            agent_execution_deadline: None,
             stuck_tool_timeout_secs: constants::STUCK_TOOL_TIMEOUT_SECS,
             post_result_cleanup_policy: PostResultCleanupPolicy::new(
                 Duration::from_secs(constants::POST_RESULT_SIGTERM_GRACE_SECS),

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1391,6 +1391,11 @@ async fn execute_cli_inner(
         }
     };
 
+    // `tokio::fs::File` may still own an in-flight blocking write after
+    // `write_all` returns. Wait for it before callers observe the completed
+    // execution and read the run log.
+    let _ = log_file.flush().await;
+
     active_input_controller.close_terminal();
     if let Some(handle) = claude_stdin_write_handle.take() {
         if handle.is_finished() {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -907,10 +907,14 @@ async fn execute_cli_inner(
                     CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 agent_execution_deadline_armed = false;
-                if termination_runtime.has_post_result_cleanup() {
+                if termination_runtime
+                    .expedite_post_result_cleanup_for_execution_deadline(
+                        termination_deadline.as_mut(),
+                    )
+                {
                     // A terminal result already ended semantic execution.
-                    // Its bounded reaper now belongs to finalization and must
-                    // retain the result's success or failure classification.
+                    // Advance its bounded reaper without changing the result's
+                    // success or failure classification.
                     continue;
                 }
                 active_input_controller.close_terminal();

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -908,13 +908,13 @@ async fn execute_cli_inner(
                 }
                 agent_execution_deadline_armed = false;
                 if termination_runtime
-                    .expedite_post_result_cleanup_for_execution_deadline(
+                    .preserve_post_result_cleanup_at_execution_deadline(
                         termination_deadline.as_mut(),
                     )
                 {
                     // A terminal result already ended semantic execution.
-                    // Advance its bounded reaper without changing the result's
-                    // success or failure classification.
+                    // Preserve its classification and, when SIGTERM has not
+                    // already been sent, advance its bounded reaper.
                     continue;
                 }
                 active_input_controller.close_terminal();

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -907,6 +907,12 @@ async fn execute_cli_inner(
                     CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 agent_execution_deadline_armed = false;
+                if termination_runtime.has_post_result_cleanup() {
+                    // A terminal result already ended semantic execution.
+                    // Its bounded reaper now belongs to finalization and must
+                    // retain the result's success or failure classification.
+                    continue;
+                }
                 active_input_controller.close_terminal();
                 let timeout_error = AgentError::Execution(format!(
                     "Agent execution timed out after {agent_execution_timeout_secs} seconds"

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -387,10 +387,23 @@ impl CliTerminationRuntime {
         }
     }
 
-    pub(super) fn expedite_post_result_cleanup_for_execution_deadline(
+    /// Returns true when a terminal result already owns process cleanup.
+    ///
+    /// Before SIGTERM, the execution deadline advances that cleanup. During
+    /// the SIGKILL grace, the existing state machine already has the shortest
+    /// remaining bound, so only the result classification needs preserving.
+    pub(super) fn preserve_post_result_cleanup_at_execution_deadline(
         &mut self,
         termination_deadline: Pin<&mut Sleep>,
     ) -> bool {
+        if matches!(
+            self.state,
+            TerminationState::SigkillPending {
+                reason: TerminationReason::PostResult
+            }
+        ) {
+            return true;
+        }
         if !matches!(
             self.state,
             TerminationState::SigtermPending {

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -387,6 +387,50 @@ impl CliTerminationRuntime {
         }
     }
 
+    pub(super) fn expedite_post_result_cleanup_for_execution_deadline(
+        &mut self,
+        termination_deadline: Pin<&mut Sleep>,
+    ) -> bool {
+        if !matches!(
+            self.state,
+            TerminationState::SigtermPending {
+                reason: TerminationReason::PostResult
+            }
+        ) {
+            return false;
+        }
+        let now = Instant::now();
+        let Some(cleanup) = self.post_result_cleanup.as_mut() else {
+            return false;
+        };
+        let elapsed = cleanup.elapsed(now);
+        let quiet_for = cleanup.quiet_for(now);
+        let meaningful_events = cleanup.meaningful_event_count();
+        let _ = cleanup.mark_signal_sent(now);
+        let elapsed_ms = elapsed.as_millis();
+        let quiet_ms = quiet_for.as_millis();
+        let detail = format!(
+            "trigger=execution_deadline signal=sigterm elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
+        );
+        log_warn!(
+            LOG_TAG,
+            "Agent execution deadline reached during post-result cleanup after {elapsed_ms}ms (quiet {quiet_ms}ms, meaningful events {meaningful_events}), SIGTERM pgid={}",
+            self.pgid_label()
+        );
+        record_sandbox_op(
+            "post_result_cleanup_terminated",
+            elapsed,
+            true,
+            Some(&detail),
+        );
+        self.begin_sigkill_pending_after_sigterm(
+            TerminationReason::PostResult,
+            elapsed,
+            termination_deadline,
+        );
+        true
+    }
+
     pub(super) fn mark_child_exited(&mut self) {
         self.state = TerminationState::Done;
         self.post_result_cleanup = None;
@@ -439,7 +483,31 @@ impl CliTerminationRuntime {
             .reset(deadline_after(Instant::now(), grace));
     }
 
-    pub(super) fn handle_deadline(&mut self, mut termination_deadline: Pin<&mut Sleep>) {
+    fn begin_sigkill_pending_after_sigterm(
+        &mut self,
+        reason: TerminationReason,
+        diagnostic_grace: Duration,
+        mut termination_deadline: Pin<&mut Sleep>,
+    ) {
+        if self.pgid.is_some() {
+            record_cli_termination_signal(
+                &mut self.diagnostic,
+                reason,
+                CliTerminationSignal::Sigterm,
+                self.pgid,
+                diagnostic_grace,
+            );
+            if let Some(process_group) = self.process_group {
+                process_group.sigterm();
+            }
+        }
+        self.state = TerminationState::SigkillPending { reason };
+        termination_deadline
+            .as_mut()
+            .reset(deadline_after(Instant::now(), self.policy.sigkill_grace));
+    }
+
+    pub(super) fn handle_deadline(&mut self, termination_deadline: Pin<&mut Sleep>) {
         match self.state {
             TerminationState::SigtermPending { reason } => {
                 let now = Instant::now();
@@ -488,22 +556,9 @@ impl CliTerminationRuntime {
                             grace.as_millis()
                         );
                     }
-                    record_cli_termination_signal(
-                        &mut self.diagnostic,
-                        reason,
-                        CliTerminationSignal::Sigterm,
-                        self.pgid,
-                        grace,
-                    );
-                    if let Some(process_group) = self.process_group {
-                        process_group.sigterm();
-                    }
                 }
 
-                self.state = TerminationState::SigkillPending { reason };
-                termination_deadline
-                    .as_mut()
-                    .reset(deadline_after(Instant::now(), self.policy.sigkill_grace));
+                self.begin_sigkill_pending_after_sigterm(reason, grace, termination_deadline);
             }
             TerminationState::SigkillPending { reason } => {
                 let grace = self.policy.sigkill_grace;

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -64,6 +64,7 @@ enum TerminationState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TerminationReason {
+    ExecutionTimeout,
     PostResult,
     InitialPromptStdin,
     StuckTool,
@@ -77,6 +78,7 @@ pub(super) enum TerminationReason {
 impl TerminationReason {
     fn label(self) -> &'static str {
         match self {
+            TerminationReason::ExecutionTimeout => "agent execution timeout",
             TerminationReason::PostResult => "post-result reap",
             TerminationReason::InitialPromptStdin => "initial-prompt stdin",
             TerminationReason::StuckTool => "stuck-tool watchdog",
@@ -222,6 +224,7 @@ impl PostResultCleanupState {
 }
 
 pub(super) enum ControlTerminationLog {
+    ExecutionTimeout { timeout_secs: u64 },
     ClaudeStdinWriterFailed { error: String },
     ClaudeStdinWriterTaskFailed { error: String },
     StuckTool { name: String, elapsed: u64 },
@@ -236,6 +239,12 @@ pub(super) enum ControlTerminationLog {
 impl ControlTerminationLog {
     fn write(self, pgid: &str) {
         match self {
+            Self::ExecutionTimeout { timeout_secs } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Agent execution timed out after {timeout_secs}s, SIGTERM pgid={pgid}"
+                );
+            }
             Self::ClaudeStdinWriterFailed { error } => {
                 log_warn!(
                     LOG_TAG,
@@ -582,6 +591,7 @@ fn record_cli_termination_signal(
 
 fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
     match reason {
+        TerminationReason::ExecutionTimeout => DiagnosticTerminationReason::ExecutionTimeout,
         TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
         TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
         TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -95,6 +95,26 @@ fn bounded_duration_secs_value_or(
     }
 }
 
+fn optional_positive_duration_secs(
+    name: &str,
+    value: Option<&str>,
+) -> Result<Option<Duration>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|_| format!("{name} must be a positive integer number of seconds"))?;
+    if seconds == 0 {
+        return Err(format!("{name} must be greater than zero"));
+    }
+    let duration = Duration::from_secs(seconds);
+    if std::time::Instant::now().checked_add(duration).is_none() {
+        return Err(format!("{name} is too large"));
+    }
+    Ok(Some(duration))
+}
+
 // ---------------------------------------------------------------------------
 // Artifacts (multi-mount)
 //
@@ -142,6 +162,7 @@ pub struct GuestConfigRaw {
     pub vercel_bypass: String,
     pub resume_session_id: String,
     pub api_start_time: String,
+    pub agent_execution_timeout_secs: String,
     pub use_mock_claude: String,
     pub mock_claude_path: Option<String>,
     pub cli_agent_type: String,
@@ -176,6 +197,9 @@ impl GuestConfigRaw {
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
             resume_session_id: env_or_empty(guest_contracts::env::RESUME_SESSION_ID_ENV),
             api_start_time: env_or_empty(guest_contracts::env::API_START_TIME_ENV),
+            agent_execution_timeout_secs: env_or_empty(
+                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            ),
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
@@ -225,6 +249,7 @@ pub struct GuestConfig {
     pub vercel_bypass: String,
     pub resume_session_id: String,
     pub api_start_time: String,
+    pub agent_execution_timeout: Option<Duration>,
     pub secret_values: String,
     pub disallowed_tools: String,
     pub tools: String,
@@ -298,6 +323,10 @@ impl GuestConfig {
             vercel_bypass: raw.vercel_bypass,
             resume_session_id: raw.resume_session_id,
             api_start_time: raw.api_start_time,
+            agent_execution_timeout: optional_positive_duration_secs(
+                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                non_empty(&raw.agent_execution_timeout_secs),
+            )?,
             secret_values: payload.secret_values,
             disallowed_tools: payload.disallowed_tools,
             tools: payload.tools,
@@ -709,6 +738,38 @@ mod tests {
     }
 
     #[test]
+    fn agent_execution_timeout_is_optional_and_strict() {
+        assert_eq!(
+            optional_positive_duration_secs(
+                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                None,
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            optional_positive_duration_secs(
+                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                Some("7200"),
+            )
+            .unwrap(),
+            Some(Duration::from_secs(7200))
+        );
+
+        for invalid in ["0", "-1", "not-a-number", "18446744073709551615"] {
+            let error = optional_positive_duration_secs(
+                guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+                Some(invalid),
+            )
+            .unwrap_err();
+            assert!(
+                error.contains(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
     fn framework_from_cli_agent_type_accepts_known_values_and_defaults_unknown() {
         assert_eq!(framework_from_cli_agent_type(""), Framework::ClaudeCode);
         assert_eq!(
@@ -745,6 +806,7 @@ mod tests {
             vercel_bypass: "bypass".to_string(),
             resume_session_id: "session-1".to_string(),
             api_start_time: "123".to_string(),
+            agent_execution_timeout_secs: "11".to_string(),
             use_mock_claude: "true".to_string(),
             cli_agent_type: "codex".to_string(),
             use_mock_codex: "1".to_string(),
@@ -768,6 +830,10 @@ mod tests {
         assert_eq!(config.vercel_bypass, "bypass");
         assert_eq!(config.resume_session_id, "session-1");
         assert_eq!(config.api_start_time, "123");
+        assert_eq!(
+            config.agent_execution_timeout,
+            Some(Duration::from_secs(11))
+        );
         assert_eq!(config.secret_values, "encoded-secret");
         assert_eq!(config.disallowed_tools, "WebFetch");
         assert_eq!(config.tools, "Bash");

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -21,7 +21,8 @@ use guest_agent::telemetry::{Telemetry, UploadMode};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use guest_contracts::diagnostics::{
-    CliTerminationReason, FailureClass, FailureDiagnostic, FailureReason,
+    AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason, FailureClass, FailureDiagnostic,
+    FailureReason,
 };
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
@@ -199,6 +200,8 @@ fn parse_session_history_identity_expectation(
 /// Final telemetry upload is attempted on all paths where the HTTP client can
 /// be initialized; when no API token is configured, that upload is a no-op.
 async fn run(runtime: GuestRuntime) -> i32 {
+    let start = Instant::now();
+
     // Record API-to-agent E2E time (as early as possible)
     guest_agent::timing::record_e2e_from_api_start(
         "api_to_agent_start",
@@ -228,8 +231,6 @@ async fn run(runtime: GuestRuntime) -> i32 {
         &runtime.config.prompt,
     );
     let control_handle = control::ControlHandle::spawn(shutdown.clone(), active_input.controller());
-    let start = Instant::now();
-
     log_info!(
         LOG_TAG,
         "Working directory: {}",
@@ -393,13 +394,14 @@ async fn execute(
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
         cli_execution_succeeded,
-    ) = match cli::execute_cli_with_active_input_for_config(
+    ) = match cli::execute_cli_with_active_input_for_config_started_at(
         masker,
         heartbeat_monitor,
         http.clone(),
         active_input,
         config,
         runtime_paths,
+        start,
     )
     .await
     {
@@ -413,7 +415,24 @@ async fn execute(
                     runtime_paths,
                     &cli_result,
                 );
-                (cli_exit_code, 1, msg, false, Some(diagnostic), false)
+                let exit_code = if cli_result
+                    .cli_termination
+                    .as_ref()
+                    .is_some_and(|termination| {
+                        termination.reason == CliTerminationReason::ExecutionTimeout
+                    }) {
+                    AGENT_EXECUTION_TIMEOUT_EXIT_CODE
+                } else {
+                    1
+                };
+                (
+                    cli_exit_code,
+                    exit_code,
+                    msg,
+                    false,
+                    Some(diagnostic),
+                    false,
+                )
             } else if preserves_successful_post_result_cleanup(config.framework, &cli_result) {
                 (cli_exit_code, 0, String::new(), false, None, true)
             } else if cli_exit_code != 0 {

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -36,6 +36,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_APPEND_SYSTEM_PROMPT", "runner append prompt");
         std::env::set_var("VM0_FEATURE_FLAGS", r#"{"flag":true}"#);
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "60");
     }
 
     let run_id = std::env::var("VM0_RUN_ID")?;
@@ -139,6 +140,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key("VM0_SANDBOX_ID"));
     assert!(!cli_env.contains_key("VM0_SANDBOX_REUSE_RESULT"));
     assert!(!cli_env.contains_key("VM0_FEATURE_FLAGS"));
+    assert!(!cli_env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
     assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
     assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
 

--- a/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
@@ -1,0 +1,59 @@
+//! The runner-owned execution deadline must interrupt and explicitly terminate
+//! a hung Codex app-server request.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_execution_timeout_interrupts_hung_turn_start()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-execution-timeout-test",
+                prompt: "drive the app-server execution timeout path",
+                scenario: Some("hang-on-turn-start"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = SecretMasker::from_raw("");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("execution deadline did not interrupt the app-server request")?;
+
+    assert_eq!(result.exit_code, AGENT_EXECUTION_TIMEOUT_EXIT_CODE);
+    let error = result
+        .control_error
+        .as_ref()
+        .expect("execution timeout should preserve a controlled error");
+    assert!(
+        error
+            .to_string()
+            .contains("Agent execution timed out after 1 seconds"),
+        "unexpected timeout error: {error}"
+    );
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("execution timeout should attach termination diagnostics")
+            .reason,
+        CliTerminationReason::ExecutionTimeout
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_execution_timeout.rs
@@ -30,7 +30,7 @@ async fn codex_app_server_execution_timeout_interrupts_hung_turn_start()
     let masker = SecretMasker::from_raw("");
 
     let result = tokio::time::timeout(
-        Duration::from_secs(5),
+        Duration::from_secs(10),
         common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -657,6 +657,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
         guest_contracts::env::RESUME_SESSION_ID_ENV,
         guest_contracts::env::API_START_TIME_ENV,
+        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV,
         guest_contracts::env::SECRET_VALUES_ENV,
         guest_contracts::env::DISALLOWED_TOOLS_ENV,
         guest_contracts::env::TOOLS_ENV,

--- a/crates/guest-agent/tests/execution_timeout.rs
+++ b/crates/guest-agent/tests/execution_timeout.rs
@@ -1,0 +1,47 @@
+//! A runner-owned execution deadline must reap the ordinary CLI process group
+//! through the existing bounded termination state machine.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn execution_timeout_reaps_a_sigterm_deaf_cli() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let masker = SecretMasker::from_raw("");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("execution deadline did not reap the CLI process group")?;
+
+    let error = result
+        .control_error
+        .as_ref()
+        .expect("execution timeout should preserve a controlled error");
+    assert!(
+        error
+            .to_string()
+            .contains("Agent execution timed out after 1 seconds"),
+        "unexpected timeout error: {error}"
+    );
+    let termination = result
+        .cli_termination
+        .expect("execution timeout should attach termination diagnostics");
+    assert_eq!(termination.reason, CliTerminationReason::ExecutionTimeout);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/execution_timeout_recovery.rs
+++ b/crates/guest-agent/tests/execution_timeout_recovery.rs
@@ -1,0 +1,185 @@
+//! The guest-agent entry point must turn the runner-owned execution deadline
+//! into a recovery checkpoint before exiting with the shared timeout code.
+
+mod common;
+
+use guest_contracts::diagnostics::{
+    AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason, FailureDiagnostic,
+};
+use httpmock::prelude::*;
+use serde_json::json;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+
+const RUN_ID: &str = "execution-timeout-recovery";
+const THREAD_ID: &str = "019fac13-2355-74d3-8414-b467fbb80c60";
+
+#[tokio::test]
+async fn execution_timeout_checkpoints_the_resumable_session_before_exit()
+-> Result<(), Box<dyn std::error::Error>> {
+    common::ensure_canonical_workspace_for_test()?;
+    let server = MockServer::start();
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path().join("home");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let history = format!(
+        "{{\"type\":\"thread.started\",\"thread_id\":\"{THREAD_ID}\"}}\n\
+         {{\"type\":\"turn.started\"}}\n"
+    );
+    let mock_codex = write_stalled_codex(tmp.path(), &history)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "keep working until the execution deadline".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+
+    let _heartbeat = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/heartbeat")
+            .json_body_includes(format!(r#"{{"runId":"{RUN_ID}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _telemetry = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"runId":"{RUN_ID}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/execution-timeout-history"),
+                "existing": false
+            }));
+    });
+    let upload = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/execution-timeout-history")
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{THREAD_ID}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "execution-timeout-recovery-checkpoint"}));
+    });
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(20),
+        Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+            .env_clear()
+            .env(
+                "PATH",
+                std::env::var("PATH")
+                    .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string()),
+            )
+            .env("SHELL", "/bin/sh")
+            .env("HOME", &home)
+            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
+            .env(
+                guest_contracts::env::SANDBOX_ID_ENV,
+                "00000000-0000-4000-8000-000000000abc",
+            )
+            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
+            .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
+            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1")
+            .env(
+                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                "1",
+            )
+            .env(
+                guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+                &run_payload_file,
+            )
+            .env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            )
+            .output(),
+    )
+    .await
+    .expect("guest-agent did not finish within its finalization budget")?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(AGENT_EXECUTION_TIMEOUT_EXIT_CODE),
+        "guest-agent output:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    prepare.assert_calls_async(1).await;
+    upload.assert_calls_async(1).await;
+    checkpoint.assert_calls_async(1).await;
+
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
+    let diagnostic: FailureDiagnostic =
+        serde_json::from_slice(&std::fs::read(paths.failure_diagnostic_file())?)?;
+    assert_eq!(
+        diagnostic
+            .cli_termination
+            .expect("timeout diagnostic should record CLI termination")
+            .reason,
+        CliTerminationReason::ExecutionTimeout
+    );
+    assert_eq!(
+        std::fs::read_to_string(paths.session_id_file())?.trim(),
+        THREAD_ID
+    );
+    let child_pid = std::fs::read_to_string(tmp.path().join("codex.pid"))?;
+    assert!(
+        !Path::new(&format!("/proc/{}", child_pid.trim())).exists(),
+        "timed-out Codex process should be gone before guest-agent exits"
+    );
+
+    Ok(())
+}
+
+fn write_stalled_codex(
+    root: &Path,
+    history: &str,
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let path = root.join("stalled-codex");
+    let script = format!(
+        "#!/bin/sh\n\
+         set -eu\n\
+         printf '%s\\n' \"$$\" > '{}'\n\
+         history_dir=\"$HOME/.codex/sessions/2026/07/29\"\n\
+         mkdir -p \"$history_dir\"\n\
+         printf '%s' '{}' > \"$history_dir/{THREAD_ID}.jsonl\"\n\
+         printf '%s\\n' '{{\"type\":\"thread.started\",\"thread_id\":\"{THREAD_ID}\"}}'\n\
+         printf '%s\\n' '{{\"type\":\"turn.started\"}}'\n\
+         while :; do sleep 1; done\n",
+        root.join("codex.pid").display(),
+        history.replace('\'', "'\\''"),
+    );
+    std::fs::write(&path, script)?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}

--- a/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
+++ b/crates/guest-agent/tests/post_result_reap_execution_deadline.rs
@@ -1,0 +1,47 @@
+//! End-to-end: when the execution deadline lands after post-result SIGTERM but
+//! before SIGKILL escalation, it must preserve the accepted terminal result
+//! instead of reclassifying the run as an execution timeout.
+
+mod common;
+
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn execution_deadline_preserves_post_result_sigkill_pending()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        // The mock emits its result immediately and ignores SIGTERM. The
+        // post-result reaper sends SIGTERM after 1s, the execution deadline
+        // lands at 5s, and the 8s SIGKILL grace then completes the reaper.
+        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 1, 8)?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "5");
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("post-result reaper did not finish within its bounded grace")?;
+
+    assert_eq!(result.exit_code, common::SIGKILL_EXIT);
+    assert!(
+        result.control_error.is_none(),
+        "an accepted terminal result must not become an execution timeout"
+    );
+    let termination = result
+        .cli_termination
+        .expect("post-result reaper should attach termination diagnostics");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -24,6 +24,7 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
         // happy path returns successfully, it returned before the reap
         // deadline could fire. sigkill grace is unused on this path.
         common::setup_env(&mock, tmp.path(), "@exit-after-result", 60, 1)?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "2");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;
@@ -58,6 +59,10 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
         exit_code,
         common::CLEAN_EXIT,
         "expected clean exit, got {exit_code} — reap may have killed a healthy CLI"
+    );
+    assert!(
+        result.cli_termination.is_none(),
+        "a CLI that exits before the execution deadline must keep its natural result"
     );
     Ok(())
 }

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -3,8 +3,9 @@
 //! → SigkillPending → Done, which the main `post_result_reap` test
 //! never reaches (default SIGTERM handler terminates its mock).
 //!
-//! This is the only coverage for the SigkillPending match arm and the
-//! process-group SIGKILL escalation path in `cli`.
+//! This specifically covers execution-deadline acceleration before SIGTERM;
+//! the adjacent execution-deadline boundary test covers the later
+//! SigkillPending window.
 //!
 //! See: https://github.com/vm0-ai/vm0/issues/10879
 

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -20,10 +20,11 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     let tmp = tempfile::tempdir()?;
     unsafe {
         // The 1s execution deadline expires after the terminal result but
-        // before the 2s post-result SIGTERM. It must not reclassify semantic
-        // completion as an execution timeout. SIGTERM is ignored, then the
-        // 1s SIGKILL grace makes the total runtime ~3s.
-        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 2, 1)?;
+        // before the 60s post-result SIGTERM. It must advance the existing
+        // reaper without reclassifying semantic completion as an execution
+        // timeout. SIGTERM is ignored, then the 1s SIGKILL grace completes
+        // within the outer test bound.
+        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 60, 1)?;
         std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
     }
 
@@ -32,14 +33,14 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
-    // Budget: sigterm (2s, ignored) + sigkill (1s, unignorable) +
-    // stdout drain (5s) + slack = 15s.
+    // Without execution-deadline acceleration, the configured 60s
+    // post-result grace would exceed this bound.
     let result = tokio::time::timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(10),
         common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
-    .expect("execute_cli did not return within 15s — sigkill escalation likely broken");
+    .expect("execute_cli did not return within 10s — deadline acceleration likely broken");
 
     let result = result.expect("execute_cli returned Err");
     let exit_code = result.exit_code;

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -19,8 +19,12 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     unsafe {
-        // 1s sigterm (ignored by mock) + 1s sigkill (unignorable) → ~2s total.
-        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 1, 1)?;
+        // The 1s execution deadline expires after the terminal result but
+        // before the 2s post-result SIGTERM. It must not reclassify semantic
+        // completion as an execution timeout. SIGTERM is ignored, then the
+        // 1s SIGKILL grace makes the total runtime ~3s.
+        common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 2, 1)?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;
@@ -28,7 +32,7 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
-    // Budget: sigterm (1s, ignored) + sigkill (1s, unignorable) +
+    // Budget: sigterm (2s, ignored) + sigkill (1s, unignorable) +
     // stdout drain (5s) + slack = 15s.
     let result = tokio::time::timeout(
         Duration::from_secs(15),

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 /// Current JSON schema version for failure diagnostics.
 pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
 
+/// Process exit code used for the runner-owned agent execution timeout.
+pub const AGENT_EXECUTION_TIMEOUT_EXIT_CODE: i32 = 124;
+
 // These are stable Unix signal numbers in the serialized diagnostic contract.
 const UNIX_SIGHUP_SIGNAL_NUMBER: i32 = 1;
 const UNIX_SIGINT_SIGNAL_NUMBER: i32 = 2;
@@ -323,6 +326,8 @@ impl CliTerminationInitiator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CliTerminationReason {
+    /// The runner-owned agent execution budget elapsed.
+    ExecutionTimeout,
     /// The guest agent reaped the process after receiving a final result.
     PostResultReap,
     /// The stuck-tool watchdog terminated the process.
@@ -346,6 +351,7 @@ impl CliTerminationReason {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::ExecutionTimeout => "execution_timeout",
             Self::PostResultReap => "post_result_reap",
             Self::StuckToolWatchdog => "stuck_tool_watchdog",
             Self::CodexResumeStartupTimeout => "codex_resume_startup_timeout",
@@ -709,6 +715,22 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_value::<CliTerminationReason>(serde_json::json!("stdout_ingestion"))
+                .unwrap(),
+            reason
+        );
+    }
+
+    #[test]
+    fn execution_timeout_reason_has_stable_serialization_and_exit_code() {
+        let reason = CliTerminationReason::ExecutionTimeout;
+        assert_eq!(AGENT_EXECUTION_TIMEOUT_EXIT_CODE, 124);
+        assert_eq!(reason.as_str(), "execution_timeout");
+        assert_eq!(
+            serde_json::to_value(reason).unwrap(),
+            serde_json::json!("execution_timeout")
+        );
+        assert_eq!(
+            serde_json::from_value::<CliTerminationReason>(serde_json::json!("execution_timeout"))
                 .unwrap(),
             reason
         );

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -70,6 +70,14 @@ pub const RESUME_SESSION_ID_ENV: &str = "VM0_RESUME_SESSION_ID";
 /// The runner emits an empty string when the timestamp is unavailable.
 pub const API_START_TIME_ENV: &str = "VM0_API_START_TIME";
 
+/// Maximum agent execution duration in seconds.
+///
+/// The runner owns this fixed lifecycle budget. Guest-agent uses it to stop
+/// the CLI before the later sandbox supervisor deadline, leaving time for
+/// recovery checkpointing and final telemetry. It is intentionally not a
+/// local user-tuning key.
+pub const AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "VM0_AGENT_EXECUTION_TIMEOUT_SECS";
+
 /// Logical run-payload field name for sensitive values used by the guest-agent
 /// masker.
 ///
@@ -410,6 +418,10 @@ mod tests {
         assert_eq!(API_URL_ENV, "VM0_API_BACKEND_URL");
         assert_eq!(RUN_ID_ENV, "VM0_RUN_ID");
         assert_eq!(CLI_AGENT_TYPE_ENV, "CLI_AGENT_TYPE");
+        assert_eq!(
+            AGENT_EXECUTION_TIMEOUT_SECS_ENV,
+            "VM0_AGENT_EXECUTION_TIMEOUT_SECS"
+        );
         assert_eq!(USER_ENV_FILE_ENV, "VM0_USER_ENV_FILE");
         assert_eq!(USER_ENV_PRIVATE_DIR_NAME, "user-env");
         assert_eq!(USER_ENV_FILENAME, "env.json");

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::time::{Duration, Instant};
 
-use guest_contracts::diagnostics::FailureDiagnostic;
+use guest_contracts::diagnostics::{CliTerminationReason, FailureDiagnostic};
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
@@ -57,8 +57,8 @@ use super::{
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, ResourceFailureDiagnostics,
     ResourceFailureKind, RunnerError, RunnerResult, SandboxReuseResult,
     SessionHistoryRestoreFallback, SessionHistoryRestorePlan, USER_ENV_FILE_ENV_KEY,
-    agent_exit_failure_message, guest_runtime_dir, guest_runtime_path, job_terminal_wait_timeout,
-    normalize_failure_exit_code,
+    agent_exit_failure_message, guest_runtime_dir, guest_runtime_path, job_supervisor_timeout,
+    job_terminal_wait_timeout, normalize_failure_exit_code,
 };
 use crate::active_input::ActiveInputSource;
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
@@ -808,6 +808,12 @@ fn process_exit_code(exit: &sandbox::ProcessExit) -> Option<i32> {
 
 fn process_failed(exit: &sandbox::ProcessExit) -> bool {
     !matches!(exit.termination, ExecTermination::Exited { exit_code: 0 })
+}
+
+fn diagnostic_is_agent_execution_timeout(diagnostic: Option<&FailureDiagnostic>) -> bool {
+    diagnostic
+        .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
+        .is_some_and(|termination| termination.reason == CliTerminationReason::ExecutionTimeout)
 }
 
 fn process_exit_oom_candidate(exit: &sandbox::ProcessExit) -> bool {
@@ -1718,14 +1724,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     validate_agent_bootstrap_exec_boundary(&agent_cmd, &env_pairs)?;
     info!(run_id = %context.run_id, "spawning agent");
 
-    // JOB_TIMEOUT remains the guest-side runtime budget. The host waits a
-    // little longer for terminal proof so the guest timeout path can kill,
-    // drain stdout/stderr, and report ExecTermination::TimedOut.
+    // Guest-agent receives JOB_TIMEOUT as the user execution budget. The
+    // sandbox supervisor remains a later hard fallback so guest-agent can
+    // terminate the CLI and create a recovery checkpoint first.
     let t = Instant::now();
     let handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: &agent_cmd,
-            timeout: JOB_TIMEOUT,
+            timeout: job_supervisor_timeout(),
             env: &env_refs,
             sudo: false,
             output: ProcessOutputMode::stream_with_stderr_capture(
@@ -2141,7 +2147,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             // handoff.
             guest_error.unwrap_or_else(|| agent_exit_failure_message(failure_exit_code))
         };
-        Some(if matches!(exit.termination, ExecTermination::TimedOut) {
+        let is_runner_job_timeout = matches!(exit.termination, ExecTermination::TimedOut)
+            || diagnostic_is_agent_execution_timeout(failure_diagnostic.as_ref());
+        Some(if is_runner_job_timeout {
             ExecutionFailure::runner_job_timeout(
                 failure_exit_code,
                 error,

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -7,7 +7,7 @@ use super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
-use super::{RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path};
+use super::{JOB_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path};
 use crate::ids::RunId;
 use crate::types::{CodexRuntimeConfig, ExecutionContext, SandboxReuseResult};
 
@@ -418,6 +418,10 @@ pub(super) fn build_env_json_with_host_env_for_run(
     env.insert(
         guest_contracts::env::SANDBOX_REUSE_RESULT_ENV.into(),
         reuse_result.as_wire().into(),
+    );
+    env.insert(
+        guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV.into(),
+        JOB_TIMEOUT.as_secs().to_string(),
     );
     insert_guest_agent_tuning_env(&mut env, context);
     env.insert(

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -67,13 +67,18 @@ use api_contracts::generated::constants::runners::paths::{
 /// Maximum guest-side runtime budget for a single agent process (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
 /// Exit code used when the runner's job timeout stops an agent process.
-const JOB_TIMEOUT_EXIT_CODE: i32 = 124;
+const JOB_TIMEOUT_EXIT_CODE: i32 = guest_contracts::diagnostics::AGENT_EXECUTION_TIMEOUT_EXIT_CODE;
+/// Bounded best-effort window after the execution budget for recovery
+/// checkpointing and final telemetry. This covers normal checkpoint latency
+/// plus a full presigned-upload timeout without letting an unavailable backend
+/// hold runner capacity indefinitely.
+const JOB_FINALIZATION_GRACE_TIMEOUT: Duration = Duration::from_secs(90);
 /// Extra time for the host to receive guest timeout terminal proof.
 ///
-/// The guest process still receives `JOB_TIMEOUT` as its runtime budget. This
-/// grace covers vsock-guest's bounded supervised-process cleanup, its 5s
-/// stdout/stderr drain deadline, and normal scheduling overhead before it sends
-/// the terminal `TimedOut` result.
+/// The sandbox supervisor receives the execution budget plus finalization
+/// grace. This additional host grace covers vsock-guest's bounded
+/// supervised-process cleanup, its 5s stdout/stderr drain deadline, and normal
+/// scheduling overhead before it sends terminal proof.
 const JOB_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Maximum time to spend writing the guest cancel frame after a user cancel.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -101,8 +106,12 @@ const STDOUT_STREAM_LIMIT_MARKER: &[u8] =
     b"[vm0] stdout stream reached the guest stream limit; later output was omitted\n";
 const STDOUT_STREAM_OVERFLOW_MARKER: &[u8] =
     b"[vm0] stdout stream overflowed the host queue; some output was dropped\n";
+fn job_supervisor_timeout() -> Duration {
+    JOB_TIMEOUT + JOB_FINALIZATION_GRACE_TIMEOUT
+}
+
 fn job_terminal_wait_timeout() -> Duration {
-    JOB_TIMEOUT + JOB_TERMINAL_GRACE_TIMEOUT
+    job_supervisor_timeout() + JOB_TERMINAL_GRACE_TIMEOUT
 }
 const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -377,6 +377,11 @@ fn build_env_json_required_keys() {
     assert_eq!(env.get("VM0_RUN_ID").unwrap(), &RunId::nil().to_string());
     assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(
+        env.get(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV)
+            .unwrap(),
+        "7200"
+    );
+    assert_eq!(
         env.get(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -554,7 +554,7 @@ async fn execute_inner_guest_process_timeout_waits_for_terminal_grace_and_copies
 
     let start_calls = overrides.start_process_calls();
     assert_eq!(start_calls.len(), 1);
-    assert_eq!(start_calls[0].timeout, JOB_TIMEOUT);
+    assert_eq!(start_calls[0].timeout, job_supervisor_timeout());
 
     let wait_calls = overrides.wait_process_calls();
     assert_eq!(wait_calls.len(), 1);
@@ -643,6 +643,45 @@ async fn execute_inner_ordinary_124_timeout_text_is_generic_failure() {
     assert_eq!(failure.exit_code, 124);
     assert_eq!(failure.error, "Timeout");
     assert_eq!(failure.kind, ExecutionFailureKind::Generic);
+}
+
+#[tokio::test]
+async fn execute_inner_structured_guest_execution_timeout_marks_failure_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 124, Vec::new(), Vec::new()));
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliExecutionError,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(143)
+    .with_cli_termination(guest_contracts::diagnostics::CliTerminationDiagnostic::new(
+        guest_contracts::diagnostics::CliTerminationReason::ExecutionTimeout,
+    ));
+    overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+    overrides.push_read_file_result(Ok(Some(b"Agent execution timed out".to_vec())));
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 124);
+    assert_eq!(failure.error, "Agent execution timed out");
+    match failure.kind {
+        ExecutionFailureKind::RunnerJobTimeout {
+            timeout_ms,
+            elapsed_ms: _,
+            guest_duration_ms,
+        } => {
+            assert_eq!(timeout_ms, JOB_TIMEOUT.as_millis());
+            assert_eq!(guest_duration_ms, None);
+        }
+        ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -28,7 +28,7 @@ use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JOB_TIMEOUT,
     JobParams, NewSandboxDispatch, ResourceFailureKind, STDOUT_STREAM_LIMIT_MARKER,
     STDOUT_STREAM_OVERFLOW_MARKER, SandboxPreparedNotifier, USER_ENV_FILE_ENV_KEY, execute_job,
-    execute_job_reuse, job_terminal_wait_timeout,
+    execute_job_reuse, job_supervisor_timeout, job_terminal_wait_timeout,
 };
 use super::support::{
     CapturedEvent, CapturedEvents, DestroyPanicFactory, QueuedCopyFileSandbox, api_artifact,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11392,7 +11392,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     expect(expiredTelemetry.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("continues from a recovery checkpoint after timeout completion", async () => {
+  it("continues from a recovery checkpoint posted after timeout completion", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -11411,16 +11411,6 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       authorization: `Bearer ${sourceClaim.sandboxToken}`,
     };
 
-    await webhooks.requestAgentCheckpoint(
-      {
-        runId: source.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: cliSessionId,
-        cliAgentSessionHistoryHash: historyHash,
-      },
-      sandboxHeaders,
-      [200],
-    );
     const completion = await webhooks.requestAgentComplete(
       {
         runId: source.runId,
@@ -11435,6 +11425,17 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const failed = await api.readRun(actor, source.runId);
     expect(failed.status).toBe("failed");
     expect(failed.error).toBe("Agent execution timed out after 7200 seconds");
+
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: source.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: cliSessionId,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      sandboxHeaders,
+      [200],
+    );
 
     const continued = await api.createRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11392,6 +11392,69 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     expect(expiredTelemetry.body.error.code).toBe("UNAUTHORIZED");
   });
 
+  it("continues from a recovery checkpoint after timeout completion", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const source = await api.createRun(actor, {
+      agentId,
+      prompt: "run until the execution deadline",
+      modelProvider: "anthropic-api-key",
+    });
+    const sourceClaim = await api.claimRunnerJob(source.runId);
+    const history = `bdd timeout recovery history ${source.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const cliSessionId = `bdd-timeout-cli-${source.runId}`;
+    mockSessionHistoryBlob(historyHash, history);
+    const sandboxHeaders = {
+      authorization: `Bearer ${sourceClaim.sandboxToken}`,
+    };
+
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: source.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: cliSessionId,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      sandboxHeaders,
+      [200],
+    );
+    const completion = await webhooks.requestAgentComplete(
+      {
+        runId: source.runId,
+        exitCode: 124,
+        error: "Agent execution timed out after 7200 seconds",
+        lastEventSequence: 0,
+      },
+      sandboxHeaders,
+      [200],
+    );
+    expect(completion.body).toStrictEqual({ success: true, status: "failed" });
+    const failed = await api.readRun(actor, source.runId);
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("Agent execution timed out after 7200 seconds");
+
+    const continued = await api.createRun(actor, {
+      agentId,
+      sessionId: source.sessionId,
+      prompt: "continue after the execution deadline",
+      modelProvider: "anthropic-api-key",
+    });
+    const continuedClaim = await api.claimRunnerJob(continued.runId);
+    expect(continuedClaim.resumeSession).toMatchObject({
+      sessionId: cliSessionId,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: expect.any(String),
+      },
+    });
+
+    await api.requestCancelRun(actor, continued.runId, [200]);
+  });
+
   it("acknowledges a clean exit whose missing checkpoint fails the run", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);


### PR DESCRIPTION
## Summary

- pass the runner-owned two-hour execution budget to guest-agent and terminate the CLI through its existing bounded process-group state machine
- preserve an already accepted terminal result by advancing or continuing its existing post-result reaper at the deadline instead of reclassifying it as a timeout
- reserve a bounded 90-second supervisor window so failed resumable sessions can create a recovery checkpoint and flush final telemetry
- classify only the new structured `execution_timeout` diagnostic as `RunnerJobTimeout`, preserving generic handling for unrelated exit code 124
- apply the same absolute deadline to the Codex app-server backend

## Behavior

The two-hour limit remains the user-visible execution budget. If it expires before a terminal result is accepted, guest-agent stops the CLI, records a typed timeout diagnostic, creates the existing best-effort recovery checkpoint, and exits with the shared timeout code. The runner's later hard timeout remains a fallback and does not replace the guest-owned finalization path.

If a terminal result has already ended semantic execution but the CLI is still alive, the deadline preserves the existing post-result reaper without changing the result's success or failure classification. It sends SIGTERM immediately when cleanup has not started yet, or lets an already active SIGKILL grace continue.

A timed-out source run remains failed. A later run in the same session can resume from the checkpoint created during timeout finalization.

## Exclusions

- no database or API schema changes
- no persisted checkpoint format changes
- no changes to ordinary nonzero CLI exit semantics
- no change to the two-hour execution budget

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-contracts -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent -p guest-contracts -p runner --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only --reporter=dot`
- pre-commit hooks: repository Rust docs/Clippy, Turbo type checks, Prettier, and full Knip

Closes #23693
