### PR TITLE
fix(goals): prevent zombie continuations and render rejections as goals

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -36,6 +36,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import {
+  decryptDataKeyOutput,
   generateDataKeyOutput,
   useSecretKmsProbe,
 } from "./helpers/secret-kms-probe";
@@ -1582,6 +1583,214 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
   }, 90_000);
 
+  it("pauses the goal and rejects an unreadable continuation payload as a goal artifact", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before goal payload decryption fails",
+    });
+    const objectiveBrief = "pause after goal payload decryption failure";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
+    useSecretKmsProbe(undefined, (_command, callNumber) => {
+      return callNumber === 1
+        ? Promise.reject(new Error("internal kms decryption failure"))
+        : undefined;
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before goal payload decryption failure"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    await expect
+      .poll(async () => {
+        const goal = await accept(
+          goalsClient().get({
+            headers: zeroGoalHeaders(actor, first.runId),
+          }),
+          [200],
+        );
+        return goal.body.status;
+      })
+      .toBe("paused");
+    const [goalEventId] = await goalQueueEventIds(first.threadId);
+    expect(goalEventId).toBeDefined();
+    const events = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return items.some((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === goalEventId
+          );
+        });
+      },
+    );
+    const rejected = events.events.find((event) => {
+      return (
+        event.eventType === "input.rejected" &&
+        event.revokesEventId === goalEventId
+      );
+    });
+    if (rejected?.eventType !== "input.rejected") {
+      throw new Error("Expected the unreadable goal event to be rejected");
+    }
+    expect(rejected).toMatchObject({
+      eventType: "input.rejected",
+      content: objectiveBrief,
+      error: "Goal continuation queue payload is unreadable",
+      goalSnapshot: { objectiveBrief },
+      userMessage: {
+        parts: [{ type: "text", text: objectiveBrief }],
+      },
+    });
+    expect(rejected.content).not.toContain("internal kms");
+    expect(JSON.stringify(rejected.userMessage)).not.toContain("internal kms");
+    expect(rejected).not.toHaveProperty("runId");
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+  }, 90_000);
+
+  it("rejects a goal invalidated before launch without creating a run", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before pre-launch goal invalidation",
+    });
+    const objectiveBrief = "invalidate before goal launch";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
+    const decryptStarted = createDeferredPromise<void>(context.signal);
+    const releaseDecrypt = deferredGate();
+    useSecretKmsProbe(undefined, (_command, callNumber) => {
+      if (callNumber !== 1) {
+        return undefined;
+      }
+      decryptStarted.resolve(undefined);
+      return releaseDecrypt.wait().then(() => {
+        return decryptDataKeyOutput();
+      });
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before pre-launch goal invalidation"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await decryptStarted.promise;
+
+    const paused = await accept(
+      goalsClient().pause({
+        headers: zeroGoalHeaders(actor, first.runId),
+      }),
+      [200],
+    );
+    expect(paused.body.status).toBe("paused");
+    const [goalEventId] = await goalQueueEventIds(first.threadId);
+    expect(goalEventId).toBeDefined();
+    releaseDecrypt.release();
+
+    const events = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return items.some((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === goalEventId
+          );
+        });
+      },
+    );
+    expect(events.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.rejected",
+        revokesEventId: goalEventId,
+        content: objectiveBrief,
+        error: "Goal continuation no longer matches the active goal",
+        goalSnapshot: { objectiveBrief },
+      }),
+    );
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+  }, 90_000);
+
+  it("rejects a goal invalidated after a lost final claim without creating a run", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before post-claim goal invalidation",
+    });
+    const objectiveBrief = "invalidate after goal preparation";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
+    const runPreparationStarted = createDeferredPromise<void>(context.signal);
+    const releaseRunPreparation = deferredGate();
+    useSecretKmsProbe((command, callNumber) => {
+      if (callNumber !== 2) {
+        return undefined;
+      }
+      runPreparationStarted.resolve(undefined);
+      return releaseRunPreparation.wait().then(() => {
+        return generateDataKeyOutput(command);
+      });
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before post-claim goal invalidation"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await runPreparationStarted.promise;
+
+    const paused = await accept(
+      goalsClient().pause({
+        headers: zeroGoalHeaders(actor, first.runId),
+      }),
+      [200],
+    );
+    expect(paused.body.status).toBe("paused");
+    const [goalEventId] = await goalQueueEventIds(first.threadId);
+    expect(goalEventId).toBeDefined();
+    releaseRunPreparation.release();
+
+    const events = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return items.some((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === goalEventId
+          );
+        });
+      },
+    );
+    expect(events.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.rejected",
+        revokesEventId: goalEventId,
+        content: objectiveBrief,
+        error: "Goal continuation no longer matches the active goal",
+        goalSnapshot: { objectiveBrief },
+      }),
+    );
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+  }, 90_000);
+
   it("pauses the goal and rejects its event when claim-time run creation fails", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
@@ -1633,9 +1842,18 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         event.revokesEventId === goalEventId
       );
     });
+    if (rejectedGoalEvent?.eventType !== "input.rejected") {
+      throw new Error("Expected the failed goal event to be rejected");
+    }
     expect(rejectedGoalEvent).toMatchObject({
       eventType: "input.rejected",
+      content: "pause after claim failure",
+      goalSnapshot: { objectiveBrief: "pause after claim failure" },
     });
+    expect(rejectedGoalEvent?.content).not.toBe(rejectedGoalEvent?.error);
+    expect(JSON.stringify(rejectedGoalEvent?.userMessage)).not.toContain(
+      rejectedGoalEvent.error,
+    );
     expect(rejectedGoalEvent).not.toHaveProperty("runId");
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
   }, 90_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
@@ -14,6 +14,7 @@ const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
 interface SecretKmsProbe {
   readonly generateDataKeyCalls: number;
+  readonly decryptCalls: number;
 }
 
 export function generateDataKeyOutput(
@@ -30,13 +31,22 @@ export function generateDataKeyOutput(
   };
 }
 
+export function decryptDataKeyOutput(): DecryptCommandOutput {
+  return { $metadata: {}, Plaintext: TEST_DATA_KEY };
+}
+
 export function useSecretKmsProbe(
   overrideGenerateDataKey?: (
     command: GenerateDataKeyCommand,
     callNumber: number,
   ) => Promise<GenerateDataKeyCommandOutput> | undefined,
+  overrideDecrypt?: (
+    command: DecryptCommand,
+    callNumber: number,
+  ) => Promise<DecryptCommandOutput> | undefined,
 ): SecretKmsProbe {
   let generateDataKeyCalls = 0;
+  let decryptCalls = 0;
 
   function send(
     command: GenerateDataKeyCommand,
@@ -54,7 +64,9 @@ export function useSecretKmsProbe(
       return overridden ?? Promise.resolve(generateDataKeyOutput(command));
     }
 
-    return Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY });
+    decryptCalls += 1;
+    const overridden = overrideDecrypt?.(command, decryptCalls);
+    return overridden ?? Promise.resolve(decryptDataKeyOutput());
   }
 
   const client: SecretKmsClient = { send };
@@ -62,6 +74,9 @@ export function useSecretKmsProbe(
   return {
     get generateDataKeyCalls() {
       return generateDataKeyCalls;
+    },
+    get decryptCalls() {
+      return decryptCalls;
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../test-fixtures/goal-queue";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../external/time";
-import { createBddApi } from "./helpers/api-bdd";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
@@ -26,12 +26,16 @@ const ALL_GOAL_CAPABILITIES = [
   "goal:user-control:write",
 ] as const satisfies readonly ZeroCapability[];
 
-interface GoalApiFixture {
+interface GoalApiAuthFixture {
   readonly orgId: string;
   readonly userId: string;
   readonly runId: string;
   readonly threadId: string;
   readonly agentId: string;
+}
+
+interface GoalApiFixture extends GoalApiAuthFixture {
+  readonly actor: ApiTestUser;
 }
 
 function currentSecond(): number {
@@ -43,7 +47,7 @@ function goalsClient() {
 }
 
 function zeroToken(
-  fixture: GoalApiFixture,
+  fixture: GoalApiAuthFixture,
   capabilities: readonly ZeroCapability[],
 ): string {
   const seconds = currentSecond();
@@ -59,7 +63,7 @@ function zeroToken(
 }
 
 function headers(
-  fixture: GoalApiFixture,
+  fixture: GoalApiAuthFixture,
   capabilities: readonly ZeroCapability[] = ALL_GOAL_CAPABILITIES,
 ) {
   return { authorization: `Bearer ${zeroToken(fixture, capabilities)}` };
@@ -96,6 +100,7 @@ async function seedGoalApiFixture(): Promise<GoalApiFixture> {
     throw new Error("Expected the chat send to create a thread-linked run");
   }
   return {
+    actor,
     orgId: actor.orgId,
     userId: actor.userId,
     runId: sent.body.runId,
@@ -294,6 +299,7 @@ describe("zero goals", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       goalId: goal.goalId,
+      objectiveBrief: "coalesce goal triggers",
       callbackSecret: "first-callback-secret",
     });
     const second = await admitGoalQueueEventFixture({
@@ -301,6 +307,7 @@ describe("zero goals", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       goalId: goal.goalId,
+      objectiveBrief: "coalesce goal triggers",
       callbackSecret: "second-callback-secret",
     });
 
@@ -309,6 +316,47 @@ describe("zero goals", () => {
     expect(kms.generateDataKeyCalls).toBe(1);
     const state = await readGoalQueueStateFixture(fixture.threadId);
     expect(state.eventIds).toHaveLength(1);
+  });
+
+  it("keeps an unclaimed input.goal event out of materialized thread messages", async () => {
+    const fixture = await seedGoalApiFixture();
+    const objectiveBrief = "keep pending goal triggers internal";
+    await createGoal(fixture, objectiveBrief);
+    const goal = await readGoalThreadFixture({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      threadId: fixture.threadId,
+    });
+    if (!goal) {
+      throw new Error("Expected the active goal");
+    }
+    useSecretKmsProbe();
+
+    const admission = await admitGoalQueueEventFixture({
+      threadId: fixture.threadId,
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      goalId: goal.goalId,
+      objectiveBrief,
+      callbackSecret: "pending-goal-callback-secret",
+    });
+    if (admission.kind !== "inserted") {
+      throw new Error("Expected an unclaimed goal queue event");
+    }
+
+    const chat = createChatFilesBddApi(context);
+    const page = await chat.listThreadEvents(fixture.actor, fixture.threadId);
+    expect(
+      page.events.map((event) => {
+        return event.id;
+      }),
+    ).not.toContain(admission.eventId);
+    expect(page.events).not.toContainEqual(
+      expect.objectContaining({
+        eventType: "input.goal",
+        goalSnapshot: { objectiveBrief },
+      }),
+    );
   });
 
   it("edits a blocked goal back to active and replaces a completed goal", async () => {

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -1,4 +1,7 @@
-import { chatMessages } from "@vm0/db/schema/chat-message";
+import {
+  chatMessages,
+  type ChatMessageGoalSnapshot,
+} from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -119,6 +122,7 @@ async function attemptGoalQueueAdmission(
   args: {
     readonly chatThreadId: string;
     readonly encryptedParams: string | undefined;
+    readonly goalSnapshot: ChatMessageGoalSnapshot;
   },
 ): Promise<GoalQueueAdmissionAttempt> {
   return await db.transaction(async (tx) => {
@@ -137,6 +141,7 @@ async function attemptGoalQueueAdmission(
       content: null,
       runId: null,
       encryptedParams: args.encryptedParams,
+      goalSnapshot: args.goalSnapshot,
     });
     if (!inserted) {
       throw new Error("Goal queue event insert returned no row");
@@ -152,12 +157,17 @@ export async function admitGoalQueueEvent(
     readonly chatThreadId: string;
     readonly orgId: string;
     readonly userId: string;
+    readonly objectiveBrief: string;
     readonly params: GoalQueueEventParams;
   },
 ): Promise<GoalQueueAdmission> {
+  const goalSnapshot: ChatMessageGoalSnapshot = {
+    objectiveBrief: args.objectiveBrief,
+  };
   const initial = await attemptGoalQueueAdmission(db, {
     chatThreadId: args.chatThreadId,
     encryptedParams: undefined,
+    goalSnapshot,
   });
   if (initial.kind !== "payload-required") {
     return initial;
@@ -173,6 +183,7 @@ export async function admitGoalQueueEvent(
     const retryWithoutPayload = await attemptGoalQueueAdmission(db, {
       chatThreadId: args.chatThreadId,
       encryptedParams: undefined,
+      goalSnapshot,
     });
     if (retryWithoutPayload.kind !== "payload-required") {
       return retryWithoutPayload;
@@ -183,6 +194,7 @@ export async function admitGoalQueueEvent(
   const final = await attemptGoalQueueAdmission(db, {
     chatThreadId: args.chatThreadId,
     encryptedParams: encrypted.value,
+    goalSnapshot,
   });
   if (final.kind === "payload-required") {
     throw new Error("Goal queue admission still required encrypted params");
@@ -322,6 +334,8 @@ export async function goalQueueEventMatchesActiveGoal(
     readonly chatThreadId: string;
     readonly goalId: string;
     readonly eventId: string;
+    readonly orgId: string;
+    readonly userId: string;
   },
 ): Promise<boolean> {
   const [goal] = await db
@@ -340,6 +354,8 @@ export async function goalQueueEventMatchesActiveGoal(
       and(
         eq(threadGoals.id, args.goalId),
         eq(threadGoals.chatThreadId, args.chatThreadId),
+        eq(threadGoals.orgId, args.orgId),
+        eq(threadGoals.ownerUserId, args.userId),
         noGoalChangeAfterQueueEvent(db),
       ),
     )
@@ -361,6 +377,8 @@ export async function rejectGoalQueueEvent(
   args: {
     readonly chatThreadId: string;
     readonly eventId: string;
+    readonly orgId: string;
+    readonly userId: string;
     readonly reason: string;
   },
 ): Promise<boolean> {
@@ -371,13 +389,42 @@ export async function rejectGoalQueueEvent(
     if (!(await pendingGoalEventStillExists(tx, args))) {
       return false;
     }
+    const [payload] = await tx
+      .select({
+        goalSnapshot: chatMessages.goalSnapshot,
+        currentGoalObjectiveBrief: threadGoals.objectiveBrief,
+      })
+      .from(chatMessages)
+      .leftJoin(
+        threadGoals,
+        and(
+          eq(threadGoals.chatThreadId, chatMessages.chatThreadId),
+          eq(threadGoals.orgId, args.orgId),
+          eq(threadGoals.ownerUserId, args.userId),
+        ),
+      )
+      .where(
+        and(
+          eq(chatMessages.id, args.eventId),
+          eq(chatMessages.chatThreadId, args.chatThreadId),
+        ),
+      )
+      .limit(1);
+    if (!payload) {
+      return false;
+    }
+    const objectiveBrief =
+      payload.goalSnapshot?.objectiveBrief ??
+      payload.currentGoalObjectiveBrief ??
+      "Goal";
     const rejected = await replaceChatEvent(tx, args.eventId, {
       chatThreadId: args.chatThreadId,
       eventType: "input.rejected",
-      content: args.reason,
-      userMessage: createUserMessageDocument({ text: args.reason }),
+      content: objectiveBrief,
+      userMessage: createUserMessageDocument({ text: objectiveBrief }),
       runId: null,
       error: args.reason,
+      goalSnapshot: { objectiveBrief },
     });
     return rejected !== null;
   });

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -62,6 +62,7 @@ type InputGoalEvent = ChatEventIdentity & {
   readonly eventType: "input.goal";
   readonly content?: null;
   readonly encryptedParams: string;
+  readonly goalSnapshot: NonNullable<ChatEventInsert["goalSnapshot"]>;
 };
 
 type InputRejectedEvent = ChatEventIdentity &

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -131,6 +131,8 @@ export type QueueFirstRunAssociation =
       readonly eventId: string;
       readonly prompt: string;
       readonly goalId: string;
+      readonly orgId: string;
+      readonly userId: string;
       readonly objectiveBrief: string;
     };
 
@@ -372,6 +374,8 @@ async function claimGoalQueueFirstRunAssociation(
     chatThreadId: args.threadId,
     goalId: args.goalId,
     eventId: args.eventId,
+    orgId: args.orgId,
+    userId: args.userId,
   });
   const head =
     automationPause === null

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -99,6 +99,7 @@ const enqueueGoalContinuation$ = command(
         chatThreadId: args.goal.threadId,
         orgId: args.goal.orgId,
         userId: args.goal.userId,
+        objectiveBrief: args.goal.objectiveBrief,
         params: {
           goalId: args.goal.goalId,
           callbackSecret: generateCallbackSecret(),
@@ -199,6 +200,7 @@ export const continueGoalIfIdle$ = command(
           orgId: goal.orgId,
           userId: goal.ownerUserId,
           threadId: goal.chatThreadId,
+          objectiveBrief: goal.objectiveBrief,
         },
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -181,6 +181,8 @@ async function rejectGoalEvent(
   const rejected = await rejectGoalQueueEvent(db, {
     chatThreadId: event.chatThreadId,
     eventId: event.id,
+    orgId: event.orgId,
+    userId: event.userId,
     reason,
   });
   signal.throwIfAborted();
@@ -268,6 +270,8 @@ const launchQueuedGoal$ = command(
           eventId: args.event.id,
           prompt,
           goalId: normalizedGoal.goalId,
+          orgId: normalizedGoal.orgId,
+          userId: normalizedGoal.userId,
           objectiveBrief: goalSnapshot.objectiveBrief,
         },
         zeroRunModelPin: {
@@ -323,11 +327,24 @@ export const drainGoalQueueForThread$ = command(
       );
       signal.throwIfAborted();
       if (!decrypted.ok || !decrypted.value) {
+        const paused = await pauseActiveGoalForThread(db, {
+          orgId: event.orgId,
+          userId: event.userId,
+          threadId: event.chatThreadId,
+        });
+        signal.throwIfAborted();
         await rejectGoalEvent(
           db,
           event,
           GOAL_PAYLOAD_UNREADABLE_REASON,
           signal,
+        );
+        log.warn(
+          "Goal queue event payload could not be decrypted; goal paused",
+          {
+            eventId: event.id,
+            pauseResult: paused.kind,
+          },
         );
         continue;
       }

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -35,6 +35,7 @@ export interface GoalBootstrap {
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
+  readonly objectiveBrief: string;
 }
 
 export type GoalResult =
@@ -371,6 +372,7 @@ export async function createGoalForCurrentThread(
             orgId: args.orgId,
             userId: args.userId,
             threadId: created.threadId,
+            objectiveBrief: created.goal.objectiveBrief,
           },
         }
       : {}),

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -15,6 +15,7 @@ interface GoalQueueAdmissionFixtureArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly goalId: string;
+  readonly objectiveBrief: string;
   readonly callbackSecret: string;
 }
 
@@ -30,6 +31,7 @@ export async function admitGoalQueueEventFixture(
     chatThreadId: args.threadId,
     orgId: args.orgId,
     userId: args.userId,
+    objectiveBrief: args.objectiveBrief,
     params: {
       goalId: args.goalId,
       callbackSecret: args.callbackSecret,
@@ -134,6 +136,7 @@ export async function createActiveGoalQueueEventFixture(args: {
     orgId: args.orgId,
     userId: args.userId,
     goalId: goal.id,
+    objectiveBrief: args.objectiveBrief,
     callbackSecret: args.callbackSecret,
   });
   if (admission.kind !== "inserted") {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -44,6 +44,46 @@ import {
 } from "./chat-lifecycle-test-helpers.ts";
 
 describe("chat lifecycle", () => {
+  it("renders a rejected goal continuation as a goal artifact without exposing its machine reason", async () => {
+    const threadId = "thread-rejected-goal-artifact";
+    const objectiveBrief = "Keep the launch moving";
+    const machineReason = "internal provider credential id abc123 is invalid";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Rejected goal artifact",
+      chatEvents: [
+        {
+          id: "msg-rejected-goal",
+          role: "user",
+          eventType: "input.rejected",
+          content: objectiveBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: objectiveBrief }],
+          },
+          error: machineReason,
+          goalSnapshot: { objectiveBrief },
+          createdAt: "2026-07-29T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Goal")).toBeInTheDocument();
+      expect(screen.getByText(objectiveBrief)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(machineReason)).not.toBeInTheDocument();
+    const goalArtifact = screen
+      .getByText(objectiveBrief)
+      .closest('[data-role="user"]');
+    if (!(goalArtifact instanceof HTMLElement)) {
+      throw new Error("Expected the rejected goal artifact");
+    }
+    expect(within(goalArtifact).getByLabelText("Goal")).toBeInTheDocument();
+  });
+
   it("opens run logs from assistant message actions", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "message-run-logs-thread";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2617,7 +2617,9 @@ function isGoalUserMessage(
 ): event is EnrichedChatEvent & ChatInputEvent {
   return (
     isInputChatEvent(event) &&
-    event.isGoalRun === true &&
+    (event.isGoalRun === true ||
+      (event.eventType === "input.rejected" &&
+        event.goalSnapshot !== undefined)) &&
     !hasWorkflowMessageMetadata(event) &&
     goalUserMessageBrief(event) !== null
   );


### PR DESCRIPTION
## Summary

- pause an active goal when its queued continuation payload cannot be decrypted, then reject the queue event so the goal cannot remain silently active and stalled
- persist the human-facing objective brief on `input.goal` events and use it for rejected event content, structured user message, and `goalSnapshot`; machine rejection details remain only in `error`
- render rejected goal events through `GoalUserMessage` instead of as user-authored speech
- align final-claim validation with load-time `orgId` and `ownerUserId` scoping
- add deterministic integration coverage for pre-launch invalidation, post-lost revalidation, decrypt failure and pause, run-creation failure rendering, and pending goal-event invisibility

## Validation

- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace api --workspace @vm0/app`
- focused API Vitest: claim-time/decrypt/rejection paths (4 tests)
- focused API Vitest: bootstrap/coalescing/materialization paths (3 tests)
- focused Platform Vitest: rejected goal artifact rendering (1 test)

## Optional findings

- D3 SQLSTATE `23514` retry hardening: skipped; this PR does not change deployment ordering behavior
- D6 queue lock unification: skipped as non-trivial and outside the focused failure-path fix
- D7 drain return type cleanup: skipped because no current caller consumes it

Closes #23724

Parent: #23182. These findings originated from the #23683 acceptance review of PR #23714.