### PR TITLE
fix: prevent zombie goals and render queue rejections as goal artifacts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -125,6 +125,10 @@ type UserMessage = Extract<
 >;
 type AssistantMessage = Exclude<ChatEventResponse, UserMessage>;
 type PromptMessage = Extract<ChatEventResponse, { eventType: "input.prompt" }>;
+type RejectedMessage = Extract<
+  ChatEventResponse,
+  { eventType: "input.rejected" }
+>;
 type OutputMessage = Extract<
   ChatEventResponse,
   { eventType: "output.message" }
@@ -468,6 +472,18 @@ async function goalRunIds(threadId: string): Promise<readonly string[]> {
   return (await readGoalQueueStateFixture(threadId)).runIds;
 }
 
+function rejectedGoalEventForSource(
+  events: readonly ChatEventResponse[],
+  sourceEventId: string | undefined,
+): RejectedMessage | undefined {
+  return events.find((event): event is RejectedMessage => {
+    return (
+      event.eventType === "input.rejected" &&
+      event.revokesEventId === sourceEventId
+    );
+  });
+}
+
 /**
  * Checkpoint + exitCode-0 complete. Completing without a checkpoint routes to
  * the missing-checkpoint handler and FAILS the run, so every successful chat
@@ -478,6 +494,24 @@ async function completeChatRunOk(
   sandboxHeaders: { readonly authorization: string },
   options: { readonly lastEventSequence?: number } = {},
 ): Promise<void> {
+  await checkpointChatRun(runId, sandboxHeaders);
+  await webhooks.requestAgentComplete(
+    {
+      runId,
+      exitCode: 0,
+      ...(options.lastEventSequence === undefined
+        ? {}
+        : { lastEventSequence: options.lastEventSequence }),
+    },
+    sandboxHeaders,
+    [200],
+  );
+}
+
+async function checkpointChatRun(
+  runId: string,
+  sandboxHeaders: { readonly authorization: string },
+): Promise<void> {
   const historyHash = createHash("sha256")
     .update(`bdd chat session history ${runId}`)
     .digest("hex");
@@ -487,17 +521,6 @@ async function completeChatRunOk(
       cliAgentType: "claude-code",
       cliAgentSessionId: cliAgentSessionIdForChatRun(runId),
       cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders,
-    [200],
-  );
-  await webhooks.requestAgentComplete(
-    {
-      runId,
-      exitCode: 0,
-      ...(options.lastEventSequence === undefined
-        ? {}
-        : { lastEventSequence: options.lastEventSequence }),
     },
     sandboxHeaders,
     [200],
@@ -1582,6 +1605,78 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
   }, 90_000);
 
+  it("pauses the goal and renders its rejection as a goal when claim-time payload decryption fails", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before goal payload decryption fails",
+    });
+    const objectiveBrief = "Pause after payload decryption failure";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
+    const kms = useSecretKmsProbe(undefined, (_command, callNumber) => {
+      return callNumber === 1
+        ? Promise.reject(new Error("internal goal payload decrypt failure"))
+        : undefined;
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before goal payload decryption failure"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    await expect
+      .poll(async () => {
+        const goal = await accept(
+          goalsClient().get({
+            headers: zeroGoalHeaders(actor, first.runId),
+          }),
+          [200],
+        );
+        return goal.body.status;
+      })
+      .toBe("paused");
+    const [goalEventId] = await goalQueueEventIds(first.threadId);
+    expect(goalEventId).toBeDefined();
+    const events = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return items.some((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === goalEventId
+          );
+        });
+      },
+    );
+    const rejectedGoalEvent = rejectedGoalEventForSource(
+      events.events,
+      goalEventId,
+    );
+    expect(rejectedGoalEvent).toMatchObject({
+      eventType: "input.rejected",
+      content: objectiveBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text: objectiveBrief }],
+      },
+      error: "Goal continuation queue payload is unreadable",
+      goalSnapshot: { objectiveBrief },
+    });
+    expect(JSON.stringify(rejectedGoalEvent?.userMessage)).not.toContain(
+      "internal goal payload decrypt failure",
+    );
+    expect(rejectedGoalEvent).not.toHaveProperty("runId");
+    expect(kms.decryptCalls).toBeGreaterThanOrEqual(1);
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+  }, 90_000);
+
   it("pauses the goal and rejects its event when claim-time run creation fails", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
@@ -1591,7 +1686,8 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       agentId,
       prompt: "finish before goal claim fails",
     });
-    await createGoalForRun(actor, first.runId, "pause after claim failure");
+    const objectiveBrief = "Pause after claim failure";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
     await misc.deleteOrgModelProvider(actor, "anthropic-api-key", [204]);
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "completed before goal claim failure"),
@@ -1627,15 +1723,24 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         });
       },
     );
-    const rejectedGoalEvent = events.events.find((event) => {
-      return (
-        event.eventType === "input.rejected" &&
-        event.revokesEventId === goalEventId
-      );
-    });
+    const rejectedGoalEvent = rejectedGoalEventForSource(
+      events.events,
+      goalEventId,
+    );
     expect(rejectedGoalEvent).toMatchObject({
       eventType: "input.rejected",
+      content: objectiveBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text: objectiveBrief }],
+      },
+      error: expect.any(String),
+      goalSnapshot: { objectiveBrief },
     });
+    expect(rejectedGoalEvent?.content).not.toBe(rejectedGoalEvent?.error);
+    expect(JSON.stringify(rejectedGoalEvent?.userMessage)).not.toContain(
+      rejectedGoalEvent?.error,
+    );
     expect(rejectedGoalEvent).not.toHaveProperty("runId");
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
   }, 90_000);
@@ -1703,7 +1808,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
-  it("admits a user message enqueued while the goal trigger is in flight before the pending goal event", async () => {
+  it("keeps an unclaimed goal event invisible, then rejects it without a run when pre-launch validation fails", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -1798,14 +1903,100 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         });
       },
     );
-    const rejectedGoalEvent = rejected.events.find((event) => {
-      return (
-        event.eventType === "input.rejected" &&
-        event.revokesEventId === goalEventId
-      );
-    });
+    const rejectedGoalEvent = rejectedGoalEventForSource(
+      rejected.events,
+      goalEventId,
+    );
     expect(rejectedGoalEvent).toMatchObject({
       eventType: "input.rejected",
+      content: goalBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text: goalBrief }],
+      },
+      error: "Goal continuation no longer matches the active goal",
+      goalSnapshot: { objectiveBrief: goalBrief },
+    });
+    expect(rejectedGoalEvent?.content).not.toBe(rejectedGoalEvent?.error);
+    expect(rejectedGoalEvent).not.toHaveProperty("runId");
+    await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);
+    await flushWaitUntilForTest();
+  }, 90_000);
+
+  it("rejects a goal event without a run when post-lost re-validation finds the goal paused", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before the goal final claim is lost",
+    });
+    const objectiveBrief = "Reject after final claim loss";
+    await createGoalForRun(actor, first.runId, objectiveBrief);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before the goal final claim was lost"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await checkpointChatRun(first.runId, sandboxHeaders);
+    const goalLaunchPreparationStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseGoalLaunchPreparation = deferredGate();
+    context.mocks.s3.getSignedUrl.mockImplementationOnce(async () => {
+      goalLaunchPreparationStarted.resolve(undefined);
+      await releaseGoalLaunchPreparation.wait();
+      return "https://r2.example.com/storage/archive.tar.gz?sig=goal-lost";
+    });
+
+    await webhooks.requestAgentComplete(
+      {
+        runId: first.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+      },
+      sandboxHeaders,
+      [200],
+    );
+    await goalLaunchPreparationStarted.promise;
+
+    const paused = await accept(
+      goalsClient().pause({
+        headers: zeroGoalHeaders(actor, first.runId),
+      }),
+      [200],
+    );
+    expect(paused.body.status).toBe("paused");
+    releaseGoalLaunchPreparation.release();
+
+    const [goalEventId] = await goalQueueEventIds(first.threadId);
+    expect(goalEventId).toBeDefined();
+    const events = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return items.some((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === goalEventId
+          );
+        });
+      },
+    );
+    const rejectedGoalEvent = rejectedGoalEventForSource(
+      events.events,
+      goalEventId,
+    );
+    expect(rejectedGoalEvent).toMatchObject({
+      eventType: "input.rejected",
+      content: objectiveBrief,
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text: objectiveBrief }],
+      },
+      error: "Goal continuation no longer matches the active goal",
+      goalSnapshot: { objectiveBrief },
     });
     expect(rejectedGoalEvent).not.toHaveProperty("runId");
     await expect(goalRunIds(first.threadId)).resolves.toHaveLength(0);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
@@ -14,6 +14,7 @@ const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
 interface SecretKmsProbe {
   readonly generateDataKeyCalls: number;
+  readonly decryptCalls: number;
 }
 
 export function generateDataKeyOutput(
@@ -35,8 +36,13 @@ export function useSecretKmsProbe(
     command: GenerateDataKeyCommand,
     callNumber: number,
   ) => Promise<GenerateDataKeyCommandOutput> | undefined,
+  overrideDecrypt?: (
+    command: DecryptCommand,
+    callNumber: number,
+  ) => Promise<DecryptCommandOutput> | undefined,
 ): SecretKmsProbe {
   let generateDataKeyCalls = 0;
+  let decryptCalls = 0;
 
   function send(
     command: GenerateDataKeyCommand,
@@ -54,7 +60,11 @@ export function useSecretKmsProbe(
       return overridden ?? Promise.resolve(generateDataKeyOutput(command));
     }
 
-    return Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY });
+    decryptCalls += 1;
+    const overridden = overrideDecrypt?.(command, decryptCalls);
+    return (
+      overridden ?? Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY })
+    );
   }
 
   const client: SecretKmsClient = { send };
@@ -62,6 +72,9 @@ export function useSecretKmsProbe(
   return {
     get generateDataKeyCalls() {
       return generateDataKeyCalls;
+    },
+    get decryptCalls() {
+      return decryptCalls;
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -294,6 +294,7 @@ describe("zero goals", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       goalId: goal.goalId,
+      objectiveBrief: "coalesce goal triggers",
       callbackSecret: "first-callback-secret",
     });
     const second = await admitGoalQueueEventFixture({
@@ -301,6 +302,7 @@ describe("zero goals", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       goalId: goal.goalId,
+      objectiveBrief: "coalesce goal triggers",
       callbackSecret: "second-callback-secret",
     });
 

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -119,6 +119,7 @@ async function attemptGoalQueueAdmission(
   args: {
     readonly chatThreadId: string;
     readonly encryptedParams: string | undefined;
+    readonly objectiveBrief: string;
   },
 ): Promise<GoalQueueAdmissionAttempt> {
   return await db.transaction(async (tx) => {
@@ -137,6 +138,7 @@ async function attemptGoalQueueAdmission(
       content: null,
       runId: null,
       encryptedParams: args.encryptedParams,
+      goalSnapshot: { objectiveBrief: args.objectiveBrief },
     });
     if (!inserted) {
       throw new Error("Goal queue event insert returned no row");
@@ -152,12 +154,14 @@ export async function admitGoalQueueEvent(
     readonly chatThreadId: string;
     readonly orgId: string;
     readonly userId: string;
+    readonly objectiveBrief: string;
     readonly params: GoalQueueEventParams;
   },
 ): Promise<GoalQueueAdmission> {
   const initial = await attemptGoalQueueAdmission(db, {
     chatThreadId: args.chatThreadId,
     encryptedParams: undefined,
+    objectiveBrief: args.objectiveBrief,
   });
   if (initial.kind !== "payload-required") {
     return initial;
@@ -173,6 +177,7 @@ export async function admitGoalQueueEvent(
     const retryWithoutPayload = await attemptGoalQueueAdmission(db, {
       chatThreadId: args.chatThreadId,
       encryptedParams: undefined,
+      objectiveBrief: args.objectiveBrief,
     });
     if (retryWithoutPayload.kind !== "payload-required") {
       return retryWithoutPayload;
@@ -183,6 +188,7 @@ export async function admitGoalQueueEvent(
   const final = await attemptGoalQueueAdmission(db, {
     chatThreadId: args.chatThreadId,
     encryptedParams: encrypted.value,
+    objectiveBrief: args.objectiveBrief,
   });
   if (final.kind === "payload-required") {
     throw new Error("Goal queue admission still required encrypted params");
@@ -322,6 +328,8 @@ export async function goalQueueEventMatchesActiveGoal(
     readonly chatThreadId: string;
     readonly goalId: string;
     readonly eventId: string;
+    readonly orgId: string;
+    readonly userId: string;
   },
 ): Promise<boolean> {
   const [goal] = await db
@@ -340,6 +348,8 @@ export async function goalQueueEventMatchesActiveGoal(
       and(
         eq(threadGoals.id, args.goalId),
         eq(threadGoals.chatThreadId, args.chatThreadId),
+        eq(threadGoals.orgId, args.orgId),
+        eq(threadGoals.ownerUserId, args.userId),
         noGoalChangeAfterQueueEvent(db),
       ),
     )
@@ -371,13 +381,28 @@ export async function rejectGoalQueueEvent(
     if (!(await pendingGoalEventStillExists(tx, args))) {
       return false;
     }
+    const [pending] = await tx
+      .select({ goalSnapshot: chatMessages.goalSnapshot })
+      .from(chatMessages)
+      .where(eq(chatMessages.id, args.eventId))
+      .limit(1);
+    let objectiveBrief = pending?.goalSnapshot?.objectiveBrief;
+    if (!objectiveBrief) {
+      const [goal] = await tx
+        .select({ objectiveBrief: threadGoals.objectiveBrief })
+        .from(threadGoals)
+        .where(eq(threadGoals.chatThreadId, args.chatThreadId))
+        .limit(1);
+      objectiveBrief = goal?.objectiveBrief ?? "Goal continuation";
+    }
     const rejected = await replaceChatEvent(tx, args.eventId, {
       chatThreadId: args.chatThreadId,
       eventType: "input.rejected",
-      content: args.reason,
-      userMessage: createUserMessageDocument({ text: args.reason }),
+      content: objectiveBrief,
+      userMessage: createUserMessageDocument({ text: objectiveBrief }),
       runId: null,
       error: args.reason,
+      goalSnapshot: { objectiveBrief },
     });
     return rejected !== null;
   });

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -62,6 +62,7 @@ type InputGoalEvent = ChatEventIdentity & {
   readonly eventType: "input.goal";
   readonly content?: null;
   readonly encryptedParams: string;
+  readonly goalSnapshot: NonNullable<ChatEventInsert["goalSnapshot"]>;
 };
 
 type InputRejectedEvent = ChatEventIdentity &

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -132,6 +132,8 @@ export type QueueFirstRunAssociation =
       readonly prompt: string;
       readonly goalId: string;
       readonly objectiveBrief: string;
+      readonly orgId: string;
+      readonly userId: string;
     };
 
 export type QueueFirstRunClaimResult =
@@ -372,6 +374,8 @@ async function claimGoalQueueFirstRunAssociation(
     chatThreadId: args.threadId,
     goalId: args.goalId,
     eventId: args.eventId,
+    orgId: args.orgId,
+    userId: args.userId,
   });
   const head =
     automationPause === null

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -99,6 +99,7 @@ const enqueueGoalContinuation$ = command(
         chatThreadId: args.goal.threadId,
         orgId: args.goal.orgId,
         userId: args.goal.userId,
+        objectiveBrief: args.goal.objectiveBrief,
         params: {
           goalId: args.goal.goalId,
           callbackSecret: generateCallbackSecret(),
@@ -199,6 +200,7 @@ export const continueGoalIfIdle$ = command(
           orgId: goal.orgId,
           userId: goal.ownerUserId,
           threadId: goal.chatThreadId,
+          objectiveBrief: goal.objectiveBrief,
         },
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -269,6 +269,8 @@ const launchQueuedGoal$ = command(
           prompt,
           goalId: normalizedGoal.goalId,
           objectiveBrief: goalSnapshot.objectiveBrief,
+          orgId: normalizedGoal.orgId,
+          userId: normalizedGoal.userId,
         },
         zeroRunModelPin: {
           modelProvider: effectiveModelProvider ?? null,
@@ -323,12 +325,22 @@ export const drainGoalQueueForThread$ = command(
       );
       signal.throwIfAborted();
       if (!decrypted.ok || !decrypted.value) {
+        const paused = await pauseActiveGoalForThread(db, {
+          orgId: event.orgId,
+          userId: event.userId,
+          threadId: event.chatThreadId,
+        });
+        signal.throwIfAborted();
         await rejectGoalEvent(
           db,
           event,
           GOAL_PAYLOAD_UNREADABLE_REASON,
           signal,
         );
+        log.warn("Goal queue event payload unreadable; goal paused", {
+          eventId: event.id,
+          pauseResult: paused.kind,
+        });
         continue;
       }
 

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -35,6 +35,7 @@ export interface GoalBootstrap {
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
+  readonly objectiveBrief: string;
 }
 
 export type GoalResult =
@@ -371,6 +372,7 @@ export async function createGoalForCurrentThread(
             orgId: args.orgId,
             userId: args.userId,
             threadId: created.threadId,
+            objectiveBrief: created.goal.objectiveBrief,
           },
         }
       : {}),

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -15,6 +15,7 @@ interface GoalQueueAdmissionFixtureArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly goalId: string;
+  readonly objectiveBrief: string;
   readonly callbackSecret: string;
 }
 
@@ -30,6 +31,7 @@ export async function admitGoalQueueEventFixture(
     chatThreadId: args.threadId,
     orgId: args.orgId,
     userId: args.userId,
+    objectiveBrief: args.objectiveBrief,
     params: {
       goalId: args.goalId,
       callbackSecret: args.callbackSecret,
@@ -134,6 +136,7 @@ export async function createActiveGoalQueueEventFixture(args: {
     orgId: args.orgId,
     userId: args.userId,
     goalId: goal.id,
+    objectiveBrief: args.objectiveBrief,
     callbackSecret: args.callbackSecret,
   });
   if (admission.kind !== "inserted") {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -733,6 +733,44 @@ describe("chat lifecycle", () => {
     expect(screen.queryByLabelText("Active goal")).not.toBeInTheDocument();
   });
 
+  it("renders a rejected goal event as a goal artifact without its machine error", async () => {
+    const threadId = "thread-rejected-goal-artifact";
+    const objectiveBrief = "Keep the release moving";
+    const machineError = "Goal continuation no longer matches the active goal";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Rejected goal artifact",
+      chatEvents: [
+        {
+          id: "msg-rejected-goal",
+          eventType: "input.rejected",
+          role: "user",
+          content: objectiveBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: objectiveBrief }],
+          },
+          error: machineError,
+          goalSnapshot: { objectiveBrief },
+          revokesEventId: "msg-pending-goal",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Goal")).toBeInTheDocument();
+      expect(screen.getByText(objectiveBrief)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(machineError)).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Goal").closest('[data-role="user"]'),
+    ).not.toBeNull();
+  });
+
   it("surfaces archived goal history in the latest assistant row", async () => {
     const threadId = "thread-goal-run-group-folding";
     const runGroupId = "f0000001-0000-4000-a000-00000000072b";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2617,7 +2617,9 @@ function isGoalUserMessage(
 ): event is EnrichedChatEvent & ChatInputEvent {
   return (
     isInputChatEvent(event) &&
-    event.isGoalRun === true &&
+    (event.isGoalRun === true ||
+      (event.eventType === "input.rejected" &&
+        event.goalSnapshot !== undefined)) &&
     !hasWorkflowMessageMetadata(event) &&
     goalUserMessageBrief(event) !== null
   );


### PR DESCRIPTION
## Summary

- pause the active goal when a claimed `input.goal` payload cannot be decrypted, then reject the event so the goal cannot remain active but permanently stalled
- snapshot the goal objective brief on queue admission and use it for rejected-row content, `userMessage`, and `goalSnapshot`; keep machine failure reasons only in `error`
- render rejected goal inputs as Goal artifacts in the platform instead of ordinary user-authored speech
- apply `orgId` and `ownerUserId` scoping in the final active-goal claim check, matching the load-time decision

This preserves queue priority (`input.prompt` > `input.automation` > `input.goal`), automation-pause semantics, coalescing, append-only history, and canonical session binding.

## Acceptance coverage

- decrypt failure pauses the goal, rejects the source event, exposes no internal decrypt error in visible message content, and creates no run
- pre-launch invalidation rejects the event with no run; the same test directly proves the unclaimed `input.goal` source row is absent from materialized thread messages
- post-lost re-validation rejects the event with no run after the goal changes during launch preparation
- claim-time run creation failure renders the objective brief with a goal snapshot instead of the machine error
- platform coverage asserts a rejected goal event renders with the Goal artifact treatment and does not display its machine error

## Optional findings

- D3 SQLSTATE `23514` hardening: skipped; deploy ordering remains the release requirement
- D6 lock unification: skipped
- D7 drain return type: skipped

## Validation

- `pnpm turbo run check-types --filter=api --filter=@vm0/app --concurrency=1`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace api --workspace @vm0/app`
- focused API goal queue tests: 4 passed
- focused goal admission coalescing test: 1 passed
- focused platform rejected-goal rendering test: 1 passed

Follow-up to #23683 and PR #23714 (`5913886`); parent #23182.

Closes #23724