### PR TITLE
docs(rust): document codex compact-generation invariants

### DIFF
--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -252,8 +252,8 @@ impl CandidateState {
 /// [`CodexHistorySelection::Ineligible`].
 ///
 /// `Ineligible` is an expected eligibility or compatibility outcome that lets
-/// the caller use its ordinary checkpoint path. The selector only returns the
-/// candidate bytes: staging, checkpoint commit, and live-file reconciliation
+/// the caller use its ordinary checkpoint path. The selector only chooses an
+/// in-memory candidate: staging, checkpoint commit, and live-file reconciliation
 /// remain the caller's responsibility.
 ///
 /// # Errors

--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -234,6 +234,32 @@ impl CandidateState {
 /// source is never modified. Files at or below 64 MiB are left unchanged. For
 /// larger files, selection reads only the canonical first record and the final
 /// bounded window that can still produce an accepted candidate.
+///
+/// # Selection contract
+///
+/// An eligible candidate contains the exact canonical first metadata record,
+/// followed by the exact raw records from the native turn containing the newest
+/// `compacted` record through the EOF observed during selection. The compacting
+/// turn and every retained later turn must preserve a real user-message
+/// boundary, compatible turn context, and a native delimiter. Either a matching
+/// turn completion or the next turn start can delimit a turn.
+///
+/// Every newer `compacted` record supersedes the preceding candidate. If the
+/// newest boundary is invalid, selection fails closed instead of falling back
+/// to an older generation. Retained rollbacks, unsupported rollout or
+/// response-item shapes, inconsistent turn relationships, and changes to the
+/// observed EOF or source length likewise make the source
+/// [`CodexHistorySelection::Ineligible`].
+///
+/// `Ineligible` is an expected eligibility or compatibility outcome that lets
+/// the caller use its ordinary checkpoint path. The selector only returns the
+/// candidate bytes: staging, checkpoint commit, and live-file reconciliation
+/// remain the caller's responsibility.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] when an underlying file metadata, seek, or read
+/// operation fails.
 pub fn select_codex_compact_generation(
     source: &mut File,
     expected_thread_id: &str,


### PR DESCRIPTION
## Summary

- document the exact canonical-metadata and native-turn suffix retained by Codex compact-generation selection
- clarify native turn delimiting, invalid-newest precedence, and fail-closed compatibility outcomes
- distinguish expected `Ineligible` fallback from underlying I/O errors and record caller ownership of checkpoint commit and live-file reconciliation

## Scope

- documentation-only change in `guest-session-prune`
- no selection behavior, limits, accepted format, checkpoint lifecycle, feature switch, API, data, or deployment change
- no new tests because the existing focused selector suite already covers every documented invariant

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-session-prune --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-session-prune --all-features --no-deps`
- `cargo test -p guest-session-prune --all-features`
- `git diff --check`
- repository pre-commit hooks, including workspace Rust format, Clippy, and documentation checks

Closes #23727
