### PR TITLE
fix(runner): clarify locked workspace cache inspection totals

### DIFF
--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -26,9 +26,10 @@ enum WorkspaceImageCacheCommand {
     /// List entries from a non-blocking, best-effort cache snapshot
     ///
     /// Locked entries skip metadata, image-size, temporary-path, storage, and
-    /// artifact inspection. In JSON, zero and absent fields on locked entries
-    /// mean unavailable rather than measured zero. Entry-derived summary values
-    /// are lower bounds when `lockedEntries` is greater than zero.
+    /// artifact inspection. In JSON, zero measurements and null metadata fields
+    /// on locked entries mean unavailable rather than measured zero.
+    /// Status-category, temporary-path, and size summary values are lower bounds
+    /// when `lockedEntries` is greater than zero.
     List(WorkspaceImageCacheListArgs),
     /// Clean up session workspace image cache entries
     Gc(WorkspaceImageCacheGcArgs),
@@ -185,7 +186,7 @@ fn format_info_text(inspection: &WorkspaceImageCacheInspection) -> String {
     format!(
         "\
 Workspace image cache
-  Snapshot: non-blocking, best effort
+  Snapshot: non-blocking, best-effort
   Cache dir: {cache_dir}
   Lock dir: {lock_dir}
   Filesystem: total {fs_total}, available {fs_available}
@@ -224,7 +225,7 @@ Preview cleanup:
 
 fn format_list_text(output: &WorkspaceImageCacheListOutput) -> String {
     let mut text = format!(
-        "Workspace image cache entries ({shown} shown, {total} total)\n  Snapshot: non-blocking, best effort\n  Cache dir: {cache_dir}\n",
+        "Workspace image cache entries ({shown} shown, {total} total)\n  Snapshot: non-blocking, best-effort\n  Cache dir: {cache_dir}\n",
         shown = output.entries.len(),
         total = output.summary.total_entries,
         cache_dir = output.cache_dir,
@@ -466,7 +467,7 @@ mod tests {
     fn text_info_contains_summary_and_next_actions() {
         let text = format_info_text(&test_inspection());
         assert!(text.contains("Workspace image cache"));
-        assert!(text.contains("Snapshot: non-blocking, best effort"));
+        assert!(text.contains("Snapshot: non-blocking, best-effort"));
         assert!(text.contains("Entries: total 2, reusable 1, invalid 1"));
         assert!(text.contains("Temporary paths: 1"));
         assert!(!text.contains("Lower bounds:"));
@@ -488,7 +489,7 @@ mod tests {
     fn text_list_respects_limit_and_prioritizes_invalid_entries() {
         let text = format_list_text(&list_output(test_inspection(), Some(1)));
         assert!(text.contains("1 shown, 2 total"));
-        assert!(text.contains("Snapshot: non-blocking, best effort"));
+        assert!(text.contains("Snapshot: non-blocking, best-effort"));
         assert!(text.contains("invalid "));
         assert!(text.contains("tempPaths=0"));
         assert!(text.contains("reason=missing metadata"));

--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -17,9 +17,18 @@ pub struct WorkspaceImageCacheArgs {
 
 #[derive(Subcommand)]
 enum WorkspaceImageCacheCommand {
-    /// Show workspace image cache summary information
+    /// Show a non-blocking, best-effort workspace image cache summary
+    ///
+    /// Locked entries skip metadata, image-size, temporary-path, storage, and
+    /// artifact inspection. When any entries are locked, status-category,
+    /// temporary-path, and size values are lower bounds.
     Info(WorkspaceImageCacheInfoArgs),
-    /// List workspace image cache entries
+    /// List entries from a non-blocking, best-effort cache snapshot
+    ///
+    /// Locked entries skip metadata, image-size, temporary-path, storage, and
+    /// artifact inspection. In JSON, zero and absent fields on locked entries
+    /// mean unavailable rather than measured zero. Entry-derived summary values
+    /// are lower bounds when `lockedEntries` is greater than zero.
     List(WorkspaceImageCacheListArgs),
     /// Clean up session workspace image cache entries
     Gc(WorkspaceImageCacheGcArgs),
@@ -168,9 +177,15 @@ fn format_info_text(inspection: &WorkspaceImageCacheInspection) -> String {
     let summary = &inspection.summary;
     let fs = inspection.fs_stats;
     let budget = inspection.budget;
+    let lower_bound_note = if summary.locked_entries > 0 {
+        "  Lower bounds: status-category counts, temporary-path counts/bytes, and allocated/logical size totals exclude locked entry contents.\n"
+    } else {
+        ""
+    };
     format!(
         "\
 Workspace image cache
+  Snapshot: non-blocking, best effort
   Cache dir: {cache_dir}
   Lock dir: {lock_dir}
   Filesystem: total {fs_total}, available {fs_available}
@@ -178,7 +193,7 @@ Workspace image cache
   Entries: total {total}, reusable {reusable}, invalid {invalid}, stale {stale}, temporary-only {temporary}, locked {locked}
   Temporary paths: {temporary_paths} ({temporary_allocated})
   Size: allocated {allocated}, logical {logical}
-
+{lower_bound_note}
 List entries:
   runner workspace-image-cache list --limit 50
 
@@ -203,12 +218,13 @@ Preview cleanup:
         temporary_allocated = human_bytes(summary.temporary_allocated_bytes),
         allocated = human_bytes(summary.total_allocated_bytes),
         logical = human_bytes(summary.total_logical_image_bytes),
+        lower_bound_note = lower_bound_note,
     )
 }
 
 fn format_list_text(output: &WorkspaceImageCacheListOutput) -> String {
     let mut text = format!(
-        "Workspace image cache entries ({shown} shown, {total} total)\n  Cache dir: {cache_dir}\n",
+        "Workspace image cache entries ({shown} shown, {total} total)\n  Snapshot: non-blocking, best effort\n  Cache dir: {cache_dir}\n",
         shown = output.entries.len(),
         total = output.summary.total_entries,
         cache_dir = output.cache_dir,
@@ -224,18 +240,30 @@ fn format_list_text(output: &WorkspaceImageCacheListOutput) -> String {
     for entry in &output.entries {
         text.push('\n');
         text.push_str(&format!(
-            "{status} {key}\n  allocated={allocated} logical={logical} tempPaths={temp_paths} tempAllocated={temp_allocated} storages={storages} artifacts={artifacts}\n",
+            "{status} {key}\n",
             status = entry.status.as_str(),
             key = entry.cache_key,
-            allocated = human_bytes(entry.allocated_bytes),
-            logical = human_bytes(entry.logical_image_size_bytes),
-            temp_paths = entry.temporary_path_count,
-            temp_allocated = human_bytes(entry.temporary_allocated_bytes),
-            storages = entry.storage_count,
-            artifacts = entry.artifact_count,
         ));
+        if entry.status == WorkspaceImageCacheInspectionStatus::Locked {
+            text.push_str(
+                "  Measurements unavailable: metadata, image size, temporary paths, storage, and artifacts were not inspected.\n",
+            );
+        } else {
+            text.push_str(&format!(
+                "  allocated={allocated} logical={logical} tempPaths={temp_paths} tempAllocated={temp_allocated} storages={storages} artifacts={artifacts}\n",
+                allocated = human_bytes(entry.allocated_bytes),
+                logical = human_bytes(entry.logical_image_size_bytes),
+                temp_paths = entry.temporary_path_count,
+                temp_allocated = human_bytes(entry.temporary_allocated_bytes),
+                storages = entry.storage_count,
+                artifacts = entry.artifact_count,
+            ));
+        }
         if let Some(reason) = &entry.reason {
             text.push_str(&format!("  reason={reason}\n"));
+        }
+        if entry.status == WorkspaceImageCacheInspectionStatus::Locked {
+            continue;
         }
         text.push_str(&format!(
             "  scope={} profile={} workingDir={}\n",
@@ -363,6 +391,30 @@ mod tests {
         }
     }
 
+    fn test_inspection_with_locked_entry() -> WorkspaceImageCacheInspection {
+        let mut inspection = test_inspection();
+        inspection.summary.total_entries += 1;
+        inspection.summary.locked_entries = 1;
+        inspection.entries.push(WorkspaceImageCacheInspectionEntry {
+            cache_key: "c".repeat(64),
+            status: WorkspaceImageCacheInspectionStatus::Locked,
+            reason: Some("entry lock is held".into()),
+            cache_scope: None,
+            profile_name: None,
+            working_dir: None,
+            last_completed_at: None,
+            last_used_at: None,
+            last_terminal_status: None,
+            allocated_bytes: 0,
+            logical_image_size_bytes: 0,
+            temporary_path_count: 0,
+            temporary_allocated_bytes: 0,
+            storage_count: 0,
+            artifact_count: 0,
+        });
+        inspection
+    }
+
     #[test]
     fn info_json_omits_entries() {
         let value = serde_json::to_value(info_output(&test_inspection())).unwrap();
@@ -389,23 +441,71 @@ mod tests {
     }
 
     #[test]
+    fn list_json_preserves_locked_entry_placeholders() {
+        let output = list_output(test_inspection_with_locked_entry(), Some(1));
+        let value = serde_json::to_value(&output).unwrap();
+        let entry = &value["entries"][0];
+        assert_eq!(value["summary"]["lockedEntries"], 1);
+        assert_eq!(entry["status"], "locked");
+        assert_eq!(entry["reason"], "entry lock is held");
+        assert_eq!(entry["allocatedBytes"], 0);
+        assert_eq!(entry["logicalImageSizeBytes"], 0);
+        assert_eq!(entry["temporaryPathCount"], 0);
+        assert_eq!(entry["temporaryAllocatedBytes"], 0);
+        assert_eq!(entry["storageCount"], 0);
+        assert_eq!(entry["artifactCount"], 0);
+        assert!(entry.get("cacheScope").unwrap().is_null());
+        assert!(entry.get("profileName").unwrap().is_null());
+        assert!(entry.get("workingDir").unwrap().is_null());
+        assert!(entry.get("lastCompletedAt").unwrap().is_null());
+        assert!(entry.get("lastUsedAt").unwrap().is_null());
+        assert!(entry.get("lastTerminalStatus").unwrap().is_null());
+    }
+
+    #[test]
     fn text_info_contains_summary_and_next_actions() {
         let text = format_info_text(&test_inspection());
         assert!(text.contains("Workspace image cache"));
+        assert!(text.contains("Snapshot: non-blocking, best effort"));
         assert!(text.contains("Entries: total 2, reusable 1, invalid 1"));
         assert!(text.contains("Temporary paths: 1"));
+        assert!(!text.contains("Lower bounds:"));
         assert!(text.contains("runner workspace-image-cache list --limit 50"));
         assert!(text.contains("runner workspace-image-cache gc --dry-run"));
+    }
+
+    #[test]
+    fn text_info_marks_locked_entry_derived_values_as_lower_bounds() {
+        let text = format_info_text(&test_inspection_with_locked_entry());
+        assert!(text.contains("Entries: total 3, reusable 1, invalid 1"));
+        assert!(text.contains("locked 1"));
+        assert!(text.contains(
+            "Lower bounds: status-category counts, temporary-path counts/bytes, and allocated/logical size totals exclude locked entry contents."
+        ));
     }
 
     #[test]
     fn text_list_respects_limit_and_prioritizes_invalid_entries() {
         let text = format_list_text(&list_output(test_inspection(), Some(1)));
         assert!(text.contains("1 shown, 2 total"));
+        assert!(text.contains("Snapshot: non-blocking, best effort"));
         assert!(text.contains("invalid "));
         assert!(text.contains("tempPaths=0"));
         assert!(text.contains("reason=missing metadata"));
         assert!(!text.contains("reusable "));
+    }
+
+    #[test]
+    fn text_list_marks_locked_measurements_unavailable() {
+        let text = format_list_text(&list_output(test_inspection_with_locked_entry(), Some(1)));
+        assert!(text.contains("1 shown, 3 total"));
+        assert!(text.contains("locked "));
+        assert!(text.contains(
+            "Measurements unavailable: metadata, image size, temporary paths, storage, and artifacts were not inspected."
+        ));
+        assert!(text.contains("reason=entry lock is held"));
+        assert!(!text.contains("allocated=0 B"));
+        assert!(!text.contains("scope=-"));
     }
 
     #[test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -459,10 +459,10 @@ mod tests {
             .join(" ");
         assert!(list_help.contains("non-blocking, best-effort"));
         assert!(list_help.contains(
-            "zero and absent fields on locked entries mean unavailable rather than measured zero"
+            "zero measurements and null metadata fields on locked entries mean unavailable rather than measured zero"
         ));
         assert!(list_help.contains(
-            "Entry-derived summary values are lower bounds when `lockedEntries` is greater than zero."
+            "Status-category, temporary-path, and size summary values are lower bounds when `lockedEntries` is greater than zero."
         ));
     }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -430,6 +430,43 @@ mod tests {
     }
 
     #[test]
+    fn workspace_image_cache_help_documents_locked_entry_semantics() {
+        let info_error = Cli::try_parse_from(["runner", "workspace-image-cache", "info", "--help"])
+            .err()
+            .expect("workspace-image-cache info --help should exit through clap");
+        assert_eq!(info_error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let info_help = info_error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(info_help.contains("non-blocking, best-effort"));
+        assert!(info_help.contains(
+            "Locked entries skip metadata, image-size, temporary-path, storage, and artifact inspection."
+        ));
+        assert!(
+            info_help.contains("status-category, temporary-path, and size values are lower bounds")
+        );
+
+        let list_error = Cli::try_parse_from(["runner", "workspace-image-cache", "list", "--help"])
+            .err()
+            .expect("workspace-image-cache list --help should exit through clap");
+        assert_eq!(list_error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let list_help = list_error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(list_help.contains("non-blocking, best-effort"));
+        assert!(list_help.contains(
+            "zero and absent fields on locked entries mean unavailable rather than measured zero"
+        ));
+        assert!(list_help.contains(
+            "Entry-derived summary values are lower bounds when `lockedEntries` is greater than zero."
+        ));
+    }
+
+    #[test]
     fn service_unit_state_command_is_registered() {
         assert!(
             Cli::try_parse_from([

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -188,6 +188,7 @@ impl CacheBudget {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// A non-blocking, best-effort snapshot of the workspace image cache.
 pub(crate) struct WorkspaceImageCacheInspection {
     pub(crate) cache_dir: String,
     pub(crate) lock_dir: String,
@@ -199,6 +200,12 @@ pub(crate) struct WorkspaceImageCacheInspection {
 
 #[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// Aggregates measured from entries whose locks were available.
+///
+/// When `locked_entries` is nonzero, reusable, invalid, stale, and temporary
+/// entry counts and temporary-path and size totals exclude locked entry
+/// contents and are lower bounds. `total_entries` and `locked_entries` remain
+/// observed values.
 pub(crate) struct WorkspaceImageCacheInspectionSummary {
     pub(crate) total_entries: usize,
     pub(crate) reusable_entries: usize,
@@ -214,6 +221,11 @@ pub(crate) struct WorkspaceImageCacheInspectionSummary {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// A best-effort per-entry inspection record.
+///
+/// A locked record skips metadata, image-size, temporary-path, storage, and
+/// artifact inspection. Its absent and zero-valued fields mean unavailable,
+/// not measured zero.
 pub(crate) struct WorkspaceImageCacheInspectionEntry {
     pub(crate) cache_key: String,
     pub(crate) status: WorkspaceImageCacheInspectionStatus,

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -186,9 +186,9 @@ impl CacheBudget {
     }
 }
 
+/// A non-blocking, best-effort snapshot of the workspace image cache.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-/// A non-blocking, best-effort snapshot of the workspace image cache.
 pub(crate) struct WorkspaceImageCacheInspection {
     pub(crate) cache_dir: String,
     pub(crate) lock_dir: String,
@@ -198,14 +198,14 @@ pub(crate) struct WorkspaceImageCacheInspection {
     pub(crate) entries: Vec<WorkspaceImageCacheInspectionEntry>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-/// Aggregates measured from entries whose locks were available.
+/// Aggregates from a non-blocking, best-effort cache scan.
 ///
 /// When `locked_entries` is nonzero, reusable, invalid, stale, and temporary
 /// entry counts and temporary-path and size totals exclude locked entry
 /// contents and are lower bounds. `total_entries` and `locked_entries` remain
 /// observed values.
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct WorkspaceImageCacheInspectionSummary {
     pub(crate) total_entries: usize,
     pub(crate) reusable_entries: usize,
@@ -219,13 +219,13 @@ pub(crate) struct WorkspaceImageCacheInspectionSummary {
     pub(crate) temporary_allocated_bytes: u64,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 /// A best-effort per-entry inspection record.
 ///
 /// A locked record skips metadata, image-size, temporary-path, storage, and
-/// artifact inspection. Its absent and zero-valued fields mean unavailable,
-/// not measured zero.
+/// artifact inspection. Its `None` metadata fields and zero-valued size/count
+/// fields mean unavailable, not measured zero.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct WorkspaceImageCacheInspectionEntry {
     pub(crate) cache_key: String,
     pub(crate) status: WorkspaceImageCacheInspectionStatus,


### PR DESCRIPTION
## Summary

- document workspace image cache inspection as a non-blocking, best-effort snapshot in CLI help and serialized type contracts
- warn in human `info` output when locked entries make status-category, temporary-path, and size aggregates lower bounds
- render locked human `list` measurements as unavailable while preserving their existing JSON zero/null placeholders

## Compatibility

- preserves cache locking, inspection, accounting, and cleanup behavior
- preserves all JSON field names, nesting, types, and values
- does not change APIs, protocols, persisted cache data, database schemas, or migrations

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --all-features workspace_image_cache` (114 passed)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2866 passed, 14 ignored; guest inventory 1 passed)

Closes #23728
