### PR TITLE
refactor(guest-download): reject trailing path arguments

### DIFF
--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -63,10 +63,10 @@ fn install_runtime_log_paths() -> Result<(), String> {
 fn manifest_input_from_args() -> Option<ManifestInput> {
     let mut args = std::env::args().skip(1);
     let arg = args.next()?;
+    if args.next().is_some() {
+        return None;
+    }
     if arg == MANIFEST_STDIN_ARG {
-        if args.next().is_some() {
-            return None;
-        }
         Some(ManifestInput::Stdin)
     } else {
         Some(ManifestInput::Path(arg))

--- a/crates/guest-download/tests/integration/binary_logging/manifest_input.rs
+++ b/crates/guest-download/tests/integration/binary_logging/manifest_input.rs
@@ -28,16 +28,11 @@ fn binary_reads_manifest_from_stdin() {
 }
 
 #[test]
-fn binary_path_mode_ignores_extra_args_for_compatibility() {
-    let fixture = BinaryLoggingFixture::new("path-extra-arg").unwrap();
+fn binary_reads_manifest_from_path() {
+    let fixture = BinaryLoggingFixture::new("path-success").unwrap();
     let manifest_path = write_manifest(&fixture.dir, &[], None).unwrap();
 
-    let output = fixture
-        .command()
-        .arg(&manifest_path)
-        .arg("--ignored")
-        .output()
-        .unwrap();
+    let output = fixture.run_manifest_path(&manifest_path).unwrap();
 
     assert!(
         output.status.success(),
@@ -49,6 +44,31 @@ fn binary_path_mode_ignores_extra_args_for_compatibility() {
         content.contains("[INFO] [sandbox:download] Download completed"),
         "unexpected system log: {content:?}"
     );
+    let actions = fixture.action_types().unwrap();
+    assert_default_zero_task_attribution(&actions);
+    let ops = fixture.ops_entries().unwrap();
+    assert_single_download_total_success(&ops, true);
+}
+
+#[test]
+fn binary_path_mode_rejects_extra_args_before_telemetry() {
+    let fixture = BinaryLoggingFixture::new("path-extra-arg").unwrap();
+    let manifest_path = write_manifest(&fixture.dir, &[], None).unwrap();
+
+    let output = fixture
+        .command()
+        .arg(&manifest_path)
+        .arg("--ignored")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let content = fixture.read_system_log().unwrap();
+    assert!(
+        content.contains("[ERROR] [sandbox:download] Usage: guest-download"),
+        "unexpected system log: {content:?}"
+    );
+    assert!(!fixture.logs.ops_log.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- enforce exact-one-argument arity for both `guest-download` manifest input modes
- keep successful compiled-binary coverage for the single-path form
- reject path-mode trailing arguments through the existing usage path before download telemetry starts

## Compatibility

- keeps `--manifest-stdin` and the oversized-manifest path fallback unchanged
- does not change manifest parsing, staged-file cleanup, telemetry formats, runner commands, APIs, protocols, or persisted data
- intentionally removes only the legacy tolerance for unsupported trailing path-mode arguments

## Validation

- `cargo test -p guest-download --test integration binary_logging::manifest_input`
- `cargo fmt --all -- --check`
- `cargo test -p guest-download --all-targets --all-features`
- `cargo test -p runner storage_tests --all-features`
- `cargo clippy -p guest-download --all-targets --all-features`
- `cargo doc -p guest-download --all-features --no-deps`
- pre-commit workspace Rust formatting, Clippy, documentation, and file-size checks

Closes #23730
