### PR TITLE
fix(runner): bound aws sigv4 request body buffering

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -31,7 +31,13 @@ from auth_base_forwarder import (
     resolved_auth_header_pairs,
     take_forward_request_admission_from_flow,
 )
-from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
+from aws_sigv4 import (
+    AwsSigV4Credentials,
+    AwsSigV4SigningError,
+    request_requires_body_for_signing,
+    sign_request,
+)
+from aws_sigv4_body_admission import MAX_AWS_SIGV4_REQUEST_BODY_BYTES
 from firewall_auth_cache import (
     FirewallAuthCacheKey,
     InvalidBillableAuthExpiryError,
@@ -73,6 +79,9 @@ type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
+AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR = "aws_sigv4_request_body_admission_saturated"
+AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR = "aws_sigv4_request_body_length_required"
+AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR = "aws_sigv4_request_body_too_large"
 _FIREWALL_AUTH_IDENTITY_VERSION = 1
 _FIREWALL_AUTH_IDENTITY_CACHE_KEY = "_firewallAuthIdentityCache"
 
@@ -338,14 +347,21 @@ def _empty_firewall_auth_metadata() -> dict:
     }
 
 
-def _auth_config_uses_body_dependent_auth(auth_config: object) -> bool:
+def _auth_config_uses_body_dependent_auth(
+    flow: http.HTTPFlow,
+    auth_config: object,
+) -> bool:
     if not isinstance(auth_config, dict):
         return False
     auth_base = auth_config.get("base")
     if isinstance(auth_base, str) and auth_base:
         return True
     auth_aws_sigv4 = auth_config.get("awsSigv4")
-    return isinstance(auth_aws_sigv4, dict) and bool(auth_aws_sigv4)
+    return (
+        isinstance(auth_aws_sigv4, dict)
+        and bool(auth_aws_sigv4)
+        and aws_sigv4_request_requires_body_for_signing(flow)
+    )
 
 
 def _restore_header_phase_probe_state(
@@ -353,12 +369,12 @@ def _restore_header_phase_probe_state(
     *,
     metadata_snapshot: dict,
     request_headers_snapshot: http.Headers,
-    request_path_snapshot: str,
+    request_url_snapshot: str,
 ) -> None:
     flow.metadata.clear()
     flow.metadata.update(metadata_snapshot)
+    flow.request.url = request_url_snapshot
     flow.request.headers = http.Headers(request_headers_snapshot.fields)
-    flow.request.path = request_path_snapshot
 
 
 def _apply_header_query_injection(
@@ -397,6 +413,19 @@ def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
     return urllib.parse.urlunsplit(
         (original.scheme, original.netloc, original.path, current_query, original.fragment)
     )
+
+
+def aws_sigv4_request_requires_body_for_signing(flow: http.HTTPFlow) -> bool:
+    """Conservatively classify whether a configured SigV4 request needs its body."""
+    try:
+        return request_requires_body_for_signing(
+            url=_trusted_aws_sigv4_url(flow),
+            headers=header_pairs(flow.request.headers),
+        )
+    except AwsSigV4SigningError:
+        # Preserve the request-hook signing failure response for malformed or
+        # unsupported placeholders without allowing unbounded body streaming.
+        return True
 
 
 def _request_path_query(flow: http.HTTPFlow) -> str:
@@ -602,6 +631,118 @@ def mark_auth_base_request_length_required(
     )
 
 
+def _log_aws_sigv4_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+    observed_size: int | None = None,
+) -> None:
+    if observed_size is None:
+        body = flow.request.raw_content
+        observed_size = len(body) if body is not None else 0
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "AWS SigV4 request body too large",
+        type="firewall",
+        firewall_base=firewall_base,
+        request_body_size_bytes=observed_size,
+        request_body_limit_bytes=MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+    )
+
+
+def _set_aws_sigv4_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    _log_aws_sigv4_request_too_large(
+        flow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=413,
+        action="ALLOW",
+        error_code=AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR,
+        message="AWS SigV4 request body too large",
+        permission=allow.name,
+    )
+
+
+def mark_aws_sigv4_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+    observed_size: int,
+) -> None:
+    """Record an oversized body-dependent SigV4 request before killing it."""
+    _log_aws_sigv4_request_too_large(
+        flow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+        observed_size=observed_size,
+    )
+    _mark_matched_firewall_failure(
+        flow,
+        action="ALLOW",
+        error_code=AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR,
+    )
+
+
+def mark_aws_sigv4_request_length_required(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+    reason: str,
+) -> None:
+    """Record unbounded SigV4 body framing before killing the flow."""
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "AWS SigV4 request body requires a valid Content-Length",
+        type="firewall",
+        firewall_base=firewall_base,
+        framing_error=reason,
+        request_body_limit_bytes=MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+    )
+    _mark_matched_firewall_failure(
+        flow,
+        action="ALLOW",
+        error_code=AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+    )
+
+
+def mark_aws_sigv4_request_admission_saturated(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    """Record aggregate SigV4 body admission saturation before killing the flow."""
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "AWS SigV4 request-body admission saturated",
+        type="firewall",
+        firewall_base=firewall_base,
+    )
+    _mark_matched_firewall_failure(
+        flow,
+        action="ALLOW",
+        error_code=AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR,
+    )
+
+
 def _preflight_firewall_auth(
     flow: http.HTTPFlow,
     context: _FirewallAuthContext,
@@ -609,6 +750,21 @@ def _preflight_firewall_auth(
     """Handle local firewall auth failures that must happen before auth resolution."""
     if context.auth_request.auth_base and _request_body_exceeds_auth_base_limit(flow):
         _set_auth_base_request_too_large(
+            flow,
+            allow=context.allow,
+            proxy_log_path=context.proxy_log_path,
+            firewall_base=context.firewall_base,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
+    body = flow.request.raw_content
+    if (
+        context.auth_request.auth_aws_sigv4 is not None
+        and aws_sigv4_request_requires_body_for_signing(flow)
+        and body is not None
+        and len(body) > MAX_AWS_SIGV4_REQUEST_BODY_BYTES
+    ):
+        _set_aws_sigv4_request_too_large(
             flow,
             allow=context.allow,
             proxy_log_path=context.proxy_log_path,
@@ -1122,9 +1278,14 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     back before mutation.
     """
     auth_config = allow.api_entry.get("auth", {})
-    if _auth_config_uses_body_dependent_auth(auth_config):
+    if _auth_config_uses_body_dependent_auth(flow, auth_config):
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
+    configured_aws_sigv4 = (
+        isinstance(auth_config, dict)
+        and isinstance(auth_config.get("awsSigv4"), dict)
+        and bool(auth_config["awsSigv4"])
+    )
     injects_credentials = auth_config_injects_credentials(auth_config)
     if injects_credentials and _request_method_forbids_managed_credentials(flow.request.method):
         return FirewallHeaderPhaseAuthResult.FALLBACK
@@ -1139,7 +1300,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
 
     metadata_snapshot = dict(flow.metadata)
     request_headers_snapshot = http.Headers(flow.request.headers.fields)
-    request_path_snapshot = flow.request.path
+    request_url_snapshot = flow.request.url
 
     _prepare_firewall_metadata(flow, allow, vm_info)
     context = _build_firewall_auth_context(flow, allow, vm_info)
@@ -1155,7 +1316,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
                 flow,
                 metadata_snapshot=metadata_snapshot,
                 request_headers_snapshot=request_headers_snapshot,
-                request_path_snapshot=request_path_snapshot,
+                request_url_snapshot=request_url_snapshot,
             )
             raise
         except Exception as exc:
@@ -1163,7 +1324,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
                 flow,
                 metadata_snapshot=metadata_snapshot,
                 request_headers_snapshot=request_headers_snapshot,
-                request_path_snapshot=request_path_snapshot,
+                request_url_snapshot=request_url_snapshot,
             )
             flow.metadata[metadata_keys.FIREWALL_AUTH_PROBE_FAILURE] = exc
             return FirewallHeaderPhaseAuthResult.FALLBACK
@@ -1175,16 +1336,26 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
             flow,
             metadata_snapshot=metadata_snapshot,
             request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
+            request_url_snapshot=request_url_snapshot,
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    if token_meta.get("base") or token_meta.get("aws_sigv4") is not None:
+    resolved_aws_sigv4_value = token_meta.get("aws_sigv4")
+    resolved_aws_sigv4 = (
+        resolved_aws_sigv4_value
+        if isinstance(resolved_aws_sigv4_value, AwsSigV4Credentials)
+        else None
+    )
+    if (
+        token_meta.get("base")
+        or (resolved_aws_sigv4_value is not None and not configured_aws_sigv4)
+        or (configured_aws_sigv4 and resolved_aws_sigv4 is None)
+    ):
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,
             request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
+            request_url_snapshot=request_url_snapshot,
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
@@ -1193,7 +1364,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
             flow,
             metadata_snapshot=metadata_snapshot,
             request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
+            request_url_snapshot=request_url_snapshot,
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
@@ -1205,12 +1376,14 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
             headers=headers,
             resolved_query=resolved_query,
         )
+        if resolved_aws_sigv4 is not None:
+            _sign_flow_request_with_aws_sigv4(flow, resolved_aws_sigv4)
     except Exception:
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,
             request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
+            request_url_snapshot=request_url_snapshot,
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -139,16 +139,9 @@ def sign_request(
     _validate_credentials(credentials)
     _validate_headers(headers)
     context, signing_url = _classify_request(url, headers)
-    if context.algorithm == _ASYMMETRIC_ALGORITHM:
-        raise AwsSigV4SigningError("SigV4A is not supported by this runner")
-    if context.algorithm != _HMAC_ALGORITHM:
-        raise AwsSigV4SigningError("Unsupported AWS signing algorithm")
+    _validate_signing_context(context)
     if context.source_access_key_id == credentials.access_key_id:
         raise AwsSigV4SigningError("AWS request must use a placeholder access key ID")
-    if context.scope.region == "*":
-        raise AwsSigV4SigningError("Wildcard AWS signing region requires SigV4A")
-    if context.scope.service == _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME:
-        raise AwsSigV4SigningError("S3 Express signing is not supported by this runner")
 
     is_s3 = context.scope.service in _S3_SIGNING_NAMES
     if context.location is _AuthLocation.QUERY:
@@ -170,6 +163,33 @@ def sign_request(
         context=context,
         is_s3=is_s3,
     )
+
+
+def request_requires_body_for_signing(
+    *,
+    url: str,
+    headers: list[tuple[str, str]],
+) -> bool:
+    """Return whether re-signing must hash the request body bytes."""
+    _validate_headers(headers)
+    context, _signing_url = _classify_request(url, headers)
+    _validate_signing_context(context)
+    if _content_hash_header_value(headers) is not None:
+        return False
+    return not (
+        context.location is _AuthLocation.QUERY and context.scope.service in _S3_SIGNING_NAMES
+    )
+
+
+def _validate_signing_context(context: _SigningContext) -> None:
+    if context.algorithm == _ASYMMETRIC_ALGORITHM:
+        raise AwsSigV4SigningError("SigV4A is not supported by this runner")
+    if context.algorithm != _HMAC_ALGORITHM:
+        raise AwsSigV4SigningError("Unsupported AWS signing algorithm")
+    if context.scope.region == "*":
+        raise AwsSigV4SigningError("Wildcard AWS signing region requires SigV4A")
+    if context.scope.service == _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME:
+        raise AwsSigV4SigningError("S3 Express signing is not supported by this runner")
 
 
 def _classify_request(

--- a/crates/runner/mitm-addon/src/aws_sigv4_body_admission.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4_body_admission.py
@@ -1,0 +1,98 @@
+"""Aggregate admission for request bodies retained by AWS SigV4 signing."""
+
+import threading
+
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+
+# Match the established auth.base buffered-request envelope while keeping the
+# two admission owners independent: auth.base also reserves forwarder capacity.
+MAX_AWS_SIGV4_REQUEST_BODY_BYTES = 32 * 1024 * 1024
+MAX_ADMITTED_AWS_SIGV4_REQUESTS = 16
+MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES = 128 * 1024 * 1024
+
+_budget_lock = threading.Lock()
+_admitted_count = 0
+_admitted_body_bytes = 0
+
+
+class AwsSigV4BodyAdmissionSaturatedError(Exception):
+    """Raised when the retained SigV4 request-body budget is full."""
+
+
+class AwsSigV4BodyAdmission:
+    """Opaque reservation for one retained SigV4 request body."""
+
+    __slots__ = ("_body_bytes", "_released")
+
+    def __init__(self, body_bytes: int) -> None:
+        self._body_bytes = body_bytes
+        self._released = False
+
+
+def reserve(body_bytes: int) -> AwsSigV4BodyAdmission:
+    """Reserve aggregate capacity before mitmproxy buffers a SigV4 body."""
+    global _admitted_body_bytes
+    global _admitted_count
+
+    if body_bytes < 0:
+        raise ValueError("AWS SigV4 request body size cannot be negative")
+
+    with _budget_lock:
+        if _admitted_count + 1 > MAX_ADMITTED_AWS_SIGV4_REQUESTS:
+            raise AwsSigV4BodyAdmissionSaturatedError("AWS SigV4 request-body admission is full")
+        if _admitted_body_bytes + body_bytes > MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES:
+            raise AwsSigV4BodyAdmissionSaturatedError("AWS SigV4 request-body byte budget is full")
+        _admitted_count += 1
+        _admitted_body_bytes += body_bytes
+        return AwsSigV4BodyAdmission(body_bytes)
+
+
+def release(admission: AwsSigV4BodyAdmission) -> None:
+    """Release aggregate capacity exactly once."""
+    global _admitted_body_bytes
+    global _admitted_count
+
+    with _budget_lock:
+        if admission._released:
+            return
+        admission._released = True
+        _admitted_count -= 1
+        _admitted_body_bytes -= admission._body_bytes
+
+
+def attach_to_flow(flow: http.HTTPFlow, admission: AwsSigV4BodyAdmission) -> None:
+    """Attach a reservation to its retaining flow."""
+    if metadata_keys.AWS_SIGV4_BODY_ADMISSION in flow.metadata:
+        raise RuntimeError("AWS SigV4 request-body admission is already attached")
+    flow.metadata[metadata_keys.AWS_SIGV4_BODY_ADMISSION] = admission
+
+
+def take_from_flow(flow: http.HTTPFlow) -> AwsSigV4BodyAdmission | None:
+    """Remove and return the flow reservation, if present."""
+    admission = flow.metadata.pop(metadata_keys.AWS_SIGV4_BODY_ADMISSION, None)
+    return admission if isinstance(admission, AwsSigV4BodyAdmission) else None
+
+
+def release_from_flow(flow: http.HTTPFlow) -> None:
+    """Release any reservation attached to a flow."""
+    admission = take_from_flow(flow)
+    if admission is not None:
+        release(admission)
+
+
+def state_for_tests() -> tuple[int, int]:
+    """Return admitted flow count and declared bytes for tests."""
+    with _budget_lock:
+        return _admitted_count, _admitted_body_bytes
+
+
+def reset_for_tests() -> None:
+    """Reset aggregate admission between tests."""
+    global _admitted_body_bytes
+    global _admitted_count
+
+    with _budget_lock:
+        _admitted_count = 0
+        _admitted_body_bytes = 0

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -112,6 +112,9 @@ Firewall and auth context
   reservation written by header-phase auth.base admission and consumed by the
   request auth.base forwarder path. Released by request/terminal cleanup if it
   is not transferred to the forwarder.
+- ``AWS_SIGV4_BODY_ADMISSION``: opaque aggregate reservation for a buffered
+  body-dependent SigV4 request. Written before body buffering and released by
+  terminal flow cleanup.
 - ``TRUSTED_AUTHORITY_HOST``: ``str`` host from authority validation. Read by
   auth-base URL rewrite logic when reconstructing trusted request authority.
 
@@ -135,9 +138,10 @@ Request streaming
   capture paths. Read by request body capture and connector billing refinement.
   Removed by stream cleanup after terminal hooks.
 - ``REQUEST_STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
-  ``total_bytes``. Written with ``REQUEST_STREAM_BUFFER`` and read for request
-  size, capture truncation, and connector billing refinement. Removed by stream
-  cleanup.
+  ``total_bytes``. Always written by request streaming setup and read for
+  request size. Capture-enabled paths also write ``REQUEST_STREAM_BUFFER`` and
+  use this state for capture truncation and connector billing refinement.
+  Removed by stream cleanup.
 - ``REQUEST_STREAM_COMPLETE``: ``bool`` written by ``request()`` after
   mitmproxy has delivered the full streamed request body to the addon. Read by
   connector billing before treating a non-truncated request stream buffer as a
@@ -215,6 +219,7 @@ AUTH_REFRESHED_SECRETS: Final = "auth_refreshed_secrets"
 AUTH_CACHE_HIT: Final = "auth_cache_hit"
 AUTH_URL_REWRITE: Final = "auth_url_rewrite"
 AUTH_BASE_FORWARD_ADMISSION: Final = "auth_base_forward_admission"
+AWS_SIGV4_BODY_ADMISSION: Final = "aws_sigv4_body_admission"
 TRUSTED_AUTHORITY_HOST: Final = "trusted_authority_host"
 
 # Usage and streaming metadata

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1498,6 +1498,7 @@ def _release_terminal_flow_state(
     flow: http.HTTPFlow,
     *,
     release_tracking: bool,
+    release_aws_sigv4_body_admission: bool = True,
 ) -> None:
     if release_tracking:
         websocket_retention.release_terminal_messages(flow)
@@ -1511,7 +1512,8 @@ def _release_terminal_flow_state(
     codex_model_catalog_cache.release_flow_state(flow)
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
-    aws_sigv4_body_admission.release_from_flow(flow)
+    if release_aws_sigv4_body_admission:
+        aws_sigv4_body_admission.release_from_flow(flow)
     if flow.error is not None:
         upstream_admission.forget_server_binding(flow.server_conn)
     if release_tracking:
@@ -1534,7 +1536,11 @@ def response(flow: http.HTTPFlow) -> None:
         _handle_response(flow)
         release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
     finally:
-        _release_terminal_flow_state(flow, release_tracking=release_tracking)
+        _release_terminal_flow_state(
+            flow,
+            release_tracking=release_tracking,
+            release_aws_sigv4_body_admission=flow.websocket is None,
+        )
 
 
 def _handle_response(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -40,6 +40,7 @@ from mitmproxy.addonmanager import Loader
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
+import aws_sigv4_body_admission
 import body_capture
 import builtin_host_policy
 import codex_model_catalog_cache
@@ -70,11 +71,15 @@ import websocket_retention
 from auth import (
     FirewallAuthHandlingResult,
     FirewallHeaderPhaseAuthResult,
+    aws_sigv4_request_requires_body_for_signing,
     handle_firewall_request,
     is_billable_firewall,
     mark_auth_base_forwarding_saturated,
     mark_auth_base_request_length_required,
     mark_auth_base_request_too_large,
+    mark_aws_sigv4_request_admission_saturated,
+    mark_aws_sigv4_request_length_required,
+    mark_aws_sigv4_request_too_large,
     prepare_firewall_metadata,
     try_apply_stream_safe_firewall_auth_for_requestheaders,
 )
@@ -113,12 +118,12 @@ _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requesthea
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
-_AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
+_BufferedRequestBodyCheckKind = Literal["ok", "too_large", "length_required"]
 
 
 @dataclass(frozen=True)
-class _AuthBaseBodyCheck:
-    kind: _AuthBaseBodyCheckKind
+class _BufferedRequestBodyCheck:
+    kind: _BufferedRequestBodyCheckKind
     observed_size: int = 0
     reason: str = ""
 
@@ -297,9 +302,11 @@ def _prebind_requestheaders_upstream_destination(
     )
 
 
-def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) -> None:
+def _prebind_bounded_requestheaders_upstream_destination(
+    flow: http.HTTPFlow,
+) -> request_classification.RequestClassification | None:
     if getattr(ctx, "options", None) is None:
-        return
+        return None
     api_url = get_api_url()
     metadata_snapshot = {
         key: flow.metadata[key]
@@ -310,7 +317,7 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
         try:
             trusted_authority = get_trusted_authority(flow)
         except AuthorityValidationError:
-            return
+            return None
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
         if upstream_admission.api_destination_matches(
             api_url,
@@ -328,20 +335,19 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
                     kind="api_allow",
                     api_url=api_url,
                 )
-            return
+            return classification
         if upstream_admission.has_bound_destination(
             flow,
             allowed_kinds=frozenset(("connector_auth",)),
-        ):
-            return
-        _prebind_requestheaders_upstream_destination(
+        ) and not _request_may_use_aws_sigv4(flow):
+            return None
+        classification = _classify_request_for_flow_with_trusted_authority(
             flow,
-            _classify_request_for_flow_with_trusted_authority(
-                flow,
-                trusted_authority=trusted_authority,
-                defer_unresolved_public_destination=True,
-            ),
+            trusted_authority=trusted_authority,
+            defer_unresolved_public_destination=True,
         )
+        _prebind_requestheaders_upstream_destination(flow, classification)
+        return classification
     finally:
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
 
@@ -354,6 +360,23 @@ def _firewall_allow_auth_base(allow: matching.FirewallAllow) -> str | None:
     auth_config = allow.api_entry.get("auth", {})
     auth_base = auth_config.get("base") if isinstance(auth_config, dict) else None
     return auth_base if isinstance(auth_base, str) and auth_base else None
+
+
+def _firewall_allow_uses_aws_sigv4(allow: matching.FirewallAllow) -> bool:
+    auth_config = allow.api_entry.get("auth", {})
+    if not isinstance(auth_config, dict):
+        return False
+    aws_sigv4 = auth_config.get("awsSigv4")
+    return isinstance(aws_sigv4, dict) and bool(aws_sigv4)
+
+
+def _request_may_use_aws_sigv4(flow: http.HTTPFlow) -> bool:
+    if any(
+        value.lstrip().startswith("AWS4-")
+        for value in flow.request.headers.get_all("Authorization")
+    ):
+        return True
+    return "X-Amz-Algorithm" in flow.request.path
 
 
 def _firewall_allow_injects_ordinary_upstream_credentials(
@@ -423,41 +446,98 @@ def _auth_base_body_header_check(
     flow: http.HTTPFlow,
     *,
     request_end_stream: bool | None,
-) -> _AuthBaseBodyCheck:
+) -> _BufferedRequestBodyCheck:
     if flow.request.headers.get_all("Transfer-Encoding"):
-        return _AuthBaseBodyCheck(kind="length_required", reason="transfer_encoding")
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="transfer_encoding",
+        )
 
     raw_content_lengths = flow.request.headers.get_all("Content-Length")
     if not raw_content_lengths:
         if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
-            return _AuthBaseBodyCheck(kind="length_required", reason="missing_content_length")
+            return _BufferedRequestBodyCheck(
+                kind="length_required",
+                reason="missing_content_length",
+            )
         if request_end_stream is not True:
             reason = (
                 "request_stream_open"
                 if request_end_stream is False
                 else "request_end_stream_unavailable"
             )
-            return _AuthBaseBodyCheck(kind="length_required", reason=reason)
-        return _AuthBaseBodyCheck(kind="ok")
+            return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
+        return _BufferedRequestBodyCheck(kind="ok")
 
     parsed_length: int | None = None
     for raw_content_length in raw_content_lengths:
         for part in raw_content_length.split(","):
             candidate = _parse_auth_base_content_length_part(part)
             if candidate is None:
-                return _AuthBaseBodyCheck(kind="length_required", reason="invalid_content_length")
+                return _BufferedRequestBodyCheck(
+                    kind="length_required",
+                    reason="invalid_content_length",
+                )
             if parsed_length is None:
                 parsed_length = candidate
             elif parsed_length != candidate:
-                return _AuthBaseBodyCheck(
+                return _BufferedRequestBodyCheck(
                     kind="length_required",
                     reason="conflicting_content_length",
                 )
 
     observed_size = parsed_length if parsed_length is not None else 0
     if observed_size > auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES:
-        return _AuthBaseBodyCheck(kind="too_large", observed_size=observed_size)
-    return _AuthBaseBodyCheck(kind="ok", observed_size=observed_size)
+        return _BufferedRequestBodyCheck(kind="too_large", observed_size=observed_size)
+    return _BufferedRequestBodyCheck(kind="ok", observed_size=observed_size)
+
+
+def _aws_sigv4_body_header_check(
+    flow: http.HTTPFlow,
+    *,
+    request_end_stream: bool | None,
+) -> _BufferedRequestBodyCheck:
+    if flow.request.headers.get_all("Transfer-Encoding"):
+        return _BufferedRequestBodyCheck(
+            kind="length_required",
+            reason="transfer_encoding",
+        )
+
+    raw_content_lengths = flow.request.headers.get_all("Content-Length")
+    if not raw_content_lengths:
+        if request_end_stream is True:
+            return _BufferedRequestBodyCheck(kind="ok")
+        reason = (
+            "request_stream_open"
+            if request_end_stream is False
+            else "request_end_stream_unavailable"
+        )
+        return _BufferedRequestBodyCheck(kind="length_required", reason=reason)
+
+    parsed_length: int | None = None
+    for raw_content_length in raw_content_lengths:
+        for part in raw_content_length.split(","):
+            candidate = _parse_limited_content_length_part(
+                part,
+                max_value=aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES,
+            )
+            if candidate is None:
+                return _BufferedRequestBodyCheck(
+                    kind="length_required",
+                    reason="invalid_content_length",
+                )
+            if parsed_length is None:
+                parsed_length = candidate
+            elif parsed_length != candidate:
+                return _BufferedRequestBodyCheck(
+                    kind="length_required",
+                    reason="conflicting_content_length",
+                )
+
+    observed_size = parsed_length if parsed_length is not None else 0
+    if observed_size > aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES:
+        return _BufferedRequestBodyCheck(kind="too_large", observed_size=observed_size)
+    return _BufferedRequestBodyCheck(kind="ok", observed_size=observed_size)
 
 
 def _parse_auth_base_content_length_part(value: str) -> int | None:
@@ -661,14 +741,26 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     codex_model_catalog_cache.capture_and_strip_prefetch_marker(flow)
     connector_intent.capture_and_strip(flow)
 
-    body_check = _auth_base_body_header_check(
+    auth_base_body_check = _auth_base_body_header_check(
         flow,
         request_end_stream=request_end_stream,
     )
-    body_fits_stream_buffer = body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
+    aws_sigv4_body_check = _aws_sigv4_body_header_check(
+        flow,
+        request_end_stream=request_end_stream,
+    )
+    body_fits_stream_buffer = (
+        auth_base_body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
+    )
     if body_fits_stream_buffer:
-        _prebind_bounded_requestheaders_upstream_destination(flow)
-        return None
+        bounded_classification = _prebind_bounded_requestheaders_upstream_destination(flow)
+        if (
+            bounded_classification is None
+            or bounded_classification.kind != "firewall_allow"
+            or _firewall_allow_auth_base(bounded_classification.firewall_allow)
+            or not _firewall_allow_uses_aws_sigv4(bounded_classification.firewall_allow)
+        ):
+            return None
 
     metadata_snapshot = {
         key: flow.metadata[key]
@@ -708,24 +800,24 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         allow = classification.firewall_allow
         vm_info = classification.vm_info
         auth_base = _firewall_allow_auth_base(allow)
-        if body_check.kind != "ok" and auth_base:
+        if auth_base_body_check.kind != "ok" and auth_base:
             _start_request_timing(flow)
             prepare_firewall_metadata(flow, allow, vm_info)
             proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
             firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
-            if body_check.kind == "too_large":
+            if auth_base_body_check.kind == "too_large":
                 mark_auth_base_request_too_large(
                     flow,
                     proxy_log_path=proxy_log_path,
                     firewall_base=firewall_base,
-                    observed_size=body_check.observed_size,
+                    observed_size=auth_base_body_check.observed_size,
                 )
             else:
                 mark_auth_base_request_length_required(
                     flow,
                     proxy_log_path=proxy_log_path,
                     firewall_base=firewall_base,
-                    reason=body_check.reason,
+                    reason=auth_base_body_check.reason,
                 )
             request_classification.pop_cached_classification(flow)
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
@@ -733,10 +825,10 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.kill()
             return None
 
-        if auth_base and body_check.kind == "ok":
+        if auth_base and auth_base_body_check.kind == "ok":
             try:
                 admission = auth_base_forwarder.reserve_forward_request_admission(
-                    body_check.observed_size
+                    auth_base_body_check.observed_size
                 )
             except (
                 auth_base_forwarder.AuthBaseForwardingSaturatedError,
@@ -764,6 +856,27 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             request_classification.cache_classification(flow, classification)
             return None
 
+        if _firewall_allow_uses_aws_sigv4(allow):
+            can_apply_from_headers = (
+                not request_classification.firewall_allow_uses_public_destination(allow)
+                and not aws_sigv4_request_requires_body_for_signing(flow)
+            )
+            if can_apply_from_headers:
+                return _try_firewall_request_stream_from_headers(
+                    flow,
+                    classification=classification,
+                    metadata_snapshot=metadata_snapshot,
+                    request_end_stream=request_end_stream,
+                    capture_body=bool(vm_info.get("captureNetworkBodies", False)),
+                    aws_sigv4_buffered_fallback=aws_sigv4_body_check,
+                )
+            _admit_buffered_aws_sigv4_request(
+                flow,
+                classification=classification,
+                body_check=aws_sigv4_body_check,
+            )
+            return None
+
     if isinstance(
         classification,
         request_classification.ApiAllow
@@ -789,26 +902,101 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         classification.kind == "firewall_allow"
         and request_classification.should_try_firewall_stream_capture_request(classification)
     ):
-        return _try_firewall_request_stream_capture_from_headers(
+        return _try_firewall_request_stream_from_headers(
             flow,
             classification=classification,
             metadata_snapshot=metadata_snapshot,
             request_end_stream=request_end_stream,
+            capture_body=True,
+            aws_sigv4_buffered_fallback=None,
         )
 
     _restore_request_headers_probe_metadata(flow, metadata_snapshot)
     return None
 
 
-async def _try_firewall_request_stream_capture_from_headers(
+def _admit_buffered_aws_sigv4_request(
+    flow: http.HTTPFlow,
+    *,
+    classification: request_classification.FirewallAllow,
+    body_check: _BufferedRequestBodyCheck,
+) -> None:
+    allow = classification.firewall_allow
+    vm_info = classification.vm_info
+
+    if body_check.kind != "ok":
+        _start_request_timing(flow)
+        prepare_firewall_metadata(flow, allow, vm_info)
+        proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+        firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+        if body_check.kind == "too_large":
+            mark_aws_sigv4_request_too_large(
+                flow,
+                proxy_log_path=proxy_log_path,
+                firewall_base=firewall_base,
+                observed_size=body_check.observed_size,
+            )
+        else:
+            mark_aws_sigv4_request_length_required(
+                flow,
+                proxy_log_path=proxy_log_path,
+                firewall_base=firewall_base,
+                reason=body_check.reason,
+            )
+        request_classification.pop_cached_classification(flow)
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        upstream_admission.forget_server_binding(flow.server_conn)
+        flow.kill()
+        return
+
+    try:
+        admission = aws_sigv4_body_admission.reserve(body_check.observed_size)
+    except aws_sigv4_body_admission.AwsSigV4BodyAdmissionSaturatedError:
+        _start_request_timing(flow)
+        prepare_firewall_metadata(flow, allow, vm_info)
+        proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+        firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+        mark_aws_sigv4_request_admission_saturated(
+            flow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+        )
+        request_classification.pop_cached_classification(flow)
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        upstream_admission.forget_server_binding(flow.server_conn)
+        flow.kill()
+        return
+
+    try:
+        aws_sigv4_body_admission.attach_to_flow(flow, admission)
+    except BaseException:
+        aws_sigv4_body_admission.release(admission)
+        raise
+    request_classification.cache_classification(flow, classification)
+
+
+async def _try_firewall_request_stream_from_headers(
     flow: http.HTTPFlow,
     *,
     classification: request_classification.FirewallAllow,
     metadata_snapshot: dict[str, object],
     request_end_stream: bool | None,
+    capture_body: bool,
+    aws_sigv4_buffered_fallback: _BufferedRequestBodyCheck | None,
 ) -> None:
     allow = classification.firewall_allow
     vm_info = classification.vm_info
+
+    def fall_back() -> None:
+        if aws_sigv4_buffered_fallback is None:
+            _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+            return
+        _admit_buffered_aws_sigv4_request(
+            flow,
+            classification=classification,
+            body_check=aws_sigv4_buffered_fallback,
+        )
+
     if _firewall_allow_injects_ordinary_upstream_credentials(
         allow
     ) and not upstream_admission.ensure_bound_destination(
@@ -816,10 +1004,10 @@ async def _try_firewall_request_stream_capture_from_headers(
         kind="connector_auth",
         api_url=get_api_url(),
     ):
-        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        fall_back()
         return
     if _builtin_host_policy_error_for_firewall_allow(flow, allow) is not None:
-        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        fall_back()
         return
 
     _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
@@ -845,7 +1033,7 @@ async def _try_firewall_request_stream_capture_from_headers(
         upstream_admission.forget_server_binding(flow.server_conn)
         raise
     if result is not FirewallHeaderPhaseAuthResult.APPLIED:
-        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        fall_back()
         return
 
     terminal_usage.track_flow_if_needed(
@@ -860,7 +1048,7 @@ async def _try_firewall_request_stream_capture_from_headers(
         request_end_stream=request_end_stream is True,
     )
     if flow.response is None:
-        request_streaming.configure_request_stream(flow)
+        request_streaming.configure_request_stream(flow, capture_body=capture_body)
     else:
         upstream_admission.forget_server_binding(flow.server_conn)
 
@@ -946,12 +1134,14 @@ async def request(flow: http.HTTPFlow) -> None:
 
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+        aws_sigv4_body_admission.release_from_flow(flow)
         upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
 
     if flow.response is not None or flow.error is not None:
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+        aws_sigv4_body_admission.release_from_flow(flow)
         upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
@@ -961,6 +1151,10 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
 
         classification = _request_classification_for_flow(flow)
+        if classification.kind != "firewall_allow" or not _firewall_allow_uses_aws_sigv4(
+            classification.firewall_allow
+        ):
+            aws_sigv4_body_admission.release_from_flow(flow)
 
         if request_classification.classification_needs_request_timing(classification):
             _start_request_timing(flow)
@@ -1106,6 +1300,7 @@ async def request(flow: http.HTTPFlow) -> None:
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+        aws_sigv4_body_admission.release_from_flow(flow)
         upstream_admission.forget_server_binding(flow.server_conn)
         terminal_usage.release_tracked_flow(flow)
         raise
@@ -1316,6 +1511,7 @@ def _release_terminal_flow_state(
     codex_model_catalog_cache.release_flow_state(flow)
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+    aws_sigv4_body_admission.release_from_flow(flow)
     if flow.error is not None:
         upstream_admission.forget_server_binding(flow.server_conn)
     if release_tracking:

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -1,8 +1,9 @@
-"""Shared capped request streaming state for capture logging and X billing.
+"""Shared request streaming state for size, capture logging, and X billing.
 
-The pass-through buffer is consumed by network capture and X connector billing
-refinement. Terminal response and error handling retain its metadata through
-applicable connector usage reporting, then release it.
+The callback always counts pass-through bytes. Capture-enabled callers also
+retain a capped prefix consumed by network capture and X connector billing
+refinement. Terminal response and error handling retain the applicable metadata
+through connector usage reporting, then release it.
 """
 
 from typing import NamedTuple
@@ -20,8 +21,12 @@ class CapturedRequestStreamBody(NamedTuple):
     truncated: bool
 
 
-def configure_request_stream(flow: http.HTTPFlow) -> None:
-    """Enable capped shared body observation without modifying forwarded chunks."""
+def configure_request_stream(
+    flow: http.HTTPFlow,
+    *,
+    capture_body: bool = True,
+) -> None:
+    """Enable request-size observation and optional capped body capture."""
     if callable(flow.request.stream):
         return
 
@@ -31,7 +36,7 @@ def configure_request_stream(flow: http.HTTPFlow) -> None:
 
     def stream_and_buffer(chunk: bytes) -> bytes:
         state["total_bytes"] += len(chunk)
-        if not state["truncated"]:
+        if capture_body and not state["truncated"]:
             remaining = buf_limit - len(buf)
             if len(chunk) <= remaining:
                 buf.extend(chunk)
@@ -41,7 +46,8 @@ def configure_request_stream(flow: http.HTTPFlow) -> None:
         return chunk
 
     flow.request.stream = stream_and_buffer
-    flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = buf
+    if capture_body:
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = buf
     flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = state
     flow.metadata[_REQUEST_STREAM_CALLBACK] = stream_and_buffer
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -27,6 +27,7 @@ from mitmproxy.test import tflow, tutils
 
 import auth
 import auth_base_forwarder
+import aws_sigv4_body_admission
 import builtin_connector_diagnostics
 import claude_output_timing
 import codex_model_catalog_cache
@@ -57,6 +58,7 @@ def _reset_module_state() -> Iterator[None]:
     reset them around each case to avoid cross-test callbacks.
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     registry.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
@@ -80,6 +82,7 @@ def _reset_module_state() -> Iterator[None]:
     codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
     upstream_admission.reset_tls_admission_state_for_tests()

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
-from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
+from aws_sigv4 import (
+    AwsSigV4Credentials,
+    AwsSigV4SigningError,
+    request_requires_body_for_signing,
+    sign_request,
+)
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
     STS_HOST,
@@ -104,6 +109,101 @@ def _presigned_url(
     timestamp: str = DEFAULT_SIGV4_TIMESTAMP,
 ) -> str:
     return aws_sigv4_presigned_url(host, date=timestamp[:8], timestamp=timestamp)
+
+
+@pytest.mark.parametrize(
+    ("url", "headers", "requires_body"),
+    [
+        pytest.param(
+            f"https://{STS_HOST}/",
+            _header_auth_headers(),
+            True,
+            id="header-body-hash",
+        ),
+        pytest.param(
+            f"https://{STS_HOST}/",
+            _header_auth_headers_with_content_hash(_AWS_S3_EMPTY_PAYLOAD_HASH),
+            False,
+            id="header-explicit-digest",
+        ),
+        pytest.param(
+            f"https://{STS_HOST}/",
+            _header_auth_headers_with_content_hash("UNSIGNED-PAYLOAD"),
+            False,
+            id="header-unsigned",
+        ),
+        pytest.param(
+            _presigned_url(STS_HOST),
+            [("Host", STS_HOST)],
+            True,
+            id="presigned-non-s3",
+        ),
+        pytest.param(
+            aws_sigv4_presigned_url(
+                _AWS_S3_EXAMPLE_HOST,
+                service="s3",
+                date="20130524",
+                timestamp=_AWS_S3_EXAMPLE_TIMESTAMP,
+            ),
+            [("Host", _AWS_S3_EXAMPLE_HOST)],
+            False,
+            id="presigned-s3",
+        ),
+    ],
+)
+def test_request_requires_body_for_signing_matches_payload_semantics(
+    url: str,
+    headers: list[tuple[str, str]],
+    requires_body: bool,
+) -> None:
+    assert request_requires_body_for_signing(url=url, headers=headers) is requires_body
+
+
+@pytest.mark.parametrize(
+    ("headers", "error"),
+    [
+        pytest.param(
+            _header_auth_headers_with_content_hash(
+                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+            ),
+            "AWS streaming payload signing is not supported",
+            id="streaming-payload",
+        ),
+        pytest.param(
+            [
+                (
+                    "Authorization",
+                    aws_sigv4_authorization(
+                        algorithm="AWS4-ECDSA-P256-SHA256",
+                        region="*",
+                    ),
+                ),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+                ("Host", STS_HOST),
+            ],
+            "SigV4A is not supported",
+            id="sigv4a",
+        ),
+        pytest.param(
+            [
+                ("Authorization", "malformed"),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+                ("Host", STS_HOST),
+            ],
+            "Malformed AWS authorization header",
+            id="malformed",
+        ),
+    ],
+)
+def test_request_requires_body_for_signing_preserves_signer_errors(
+    headers: list[tuple[str, str]],
+    error: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match=error):
+        request_requires_body_for_signing(
+            url=f"https://{STS_HOST}/",
+            headers=headers,
+        )
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -37,11 +37,20 @@ from mitmproxy.test import taddons, tutils
 
 import auth
 import auth_base_forwarder
+import aws_sigv4_body_admission
 import codex_model_catalog_cache
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.aws_sigv4_helpers import (
+    DEFAULT_SIGV4_TIMESTAMP,
+    RESOLVED_AWS_ACCESS_KEY_ID,
+    STS_HOST,
+    aws_sigv4_authorization,
+    resolved_aws_sigv4_credentials,
+)
+from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
@@ -68,6 +77,31 @@ def _write_auth_base_firewall_registry(tmp_path: Path) -> Path:
             },
             network_policy={
                 "allow": ["send"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+
+
+def _write_aws_sigv4_firewall_registry(tmp_path: Path) -> Path:
+    api_entry: dict[str, object] = dict(aws_api_entry())
+    api_entry["permissions"] = [
+        {
+            "name": "identity",
+            "rules": ["POST /"],
+        }
+    ]
+    return _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="aws",
+            api_entry=api_entry,
+            network_policy={
+                "allow": ["identity"],
                 "deny": [],
                 "ask": [],
                 "unknownPolicy": "deny",
@@ -709,6 +743,100 @@ async def test_http2_unbounded_brotli_catalog_is_passed_through_but_not_retained
         == oversized_body
     )
     assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
+
+
+async def test_http2_open_sigv4_request_without_length_is_rejected_before_body(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_aws_sigv4_firewall_registry(tmp_path)
+    get_headers = AsyncMock()
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_http2_request(
+            addon_context,
+            method="POST",
+            end_stream=False,
+            host=STS_HOST,
+            regular_headers=(
+                (b"x-amz-date", DEFAULT_SIGV4_TIMESTAMP.encode()),
+                (b"authorization", aws_sigv4_authorization().encode()),
+            ),
+        )
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        flow = request_headers_hook.flow
+        commands = list(http_layer.handle_event(events.HookCompleted(request_headers_hook, None)))
+        error_hook = next(command for command in commands if isinstance(command, HttpErrorHook))
+        await addon_context.master.addons.invoke_addon(mitm_addon, error_hook)
+
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.request.raw_content is None
+    assert (
+        flow.metadata[metadata_keys.FIREWALL_ERROR]
+        == auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR
+    )
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert not any(isinstance(command, HttpRequestHook) for command in commands)
+    get_headers.assert_not_awaited()
+
+
+async def test_http2_headers_only_sigv4_request_uses_zero_byte_admission(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_aws_sigv4_firewall_registry(tmp_path)
+    token_meta = {
+        "headers": {},
+        "aws_sigv4": resolved_aws_sigv4_credentials(),
+        "resolved_secrets": [],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+    get_headers = AsyncMock(return_value=token_meta)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_http2_request(
+            addon_context,
+            method="POST",
+            end_stream=True,
+            host=STS_HOST,
+            regular_headers=(
+                (b"x-amz-date", DEFAULT_SIGV4_TIMESTAMP.encode()),
+                (b"authorization", aws_sigv4_authorization().encode()),
+            ),
+        )
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        assert aws_sigv4_body_admission.state_for_tests() == (1, 0)
+        commands = list(http_layer.handle_event(events.HookCompleted(request_headers_hook, None)))
+        request_hook = next(command for command in commands if isinstance(command, HttpRequestHook))
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+        flow = request_hook.flow
+
+        assert f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+        assert aws_sigv4_body_admission.state_for_tests() == (1, 0)
+        flow.response = http.Response.make(200, b"ok")
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
 @pytest.mark.parametrize("method", ["GET", "HEAD"])

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -4,10 +4,12 @@ import asyncio
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mitmproxy import http
+from mitmproxy import connection, http
+from mitmproxy.websocket import WebSocketData
 
 import auth
 import aws_sigv4_body_admission
@@ -24,8 +26,13 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
+from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
-from tests.requestheaders_helpers import await_requestheaders_result
+from tests.requestheaders_helpers import (
+    _assert_no_request_stream,
+    await_requestheaders_result,
+)
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 _CLIENT_IP = "10.200.0.5"
 _AWS_PERMISSION = "aws-request"
@@ -185,6 +192,80 @@ async def test_payload_independent_large_fixed_length_bypasses_buffer_limit(
     assert flow.error is None
 
 
+async def test_payload_independent_sigv4_disconnect_during_auth_falls_back_without_credentials(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="93.184.216.34",
+        sni=STS_HOST,
+        method="POST",
+        path="/",
+        request_headers=headers(
+            *aws_sigv4_header_auth_headers(
+                authorization=aws_sigv4_authorization(
+                    signed_headers="host;x-amz-content-sha256;x-amz-date",
+                ),
+                extra_headers=[
+                    ("Content-Length", "4"),
+                    ("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD"),
+                ],
+            )
+        ),
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni=STS_HOST,
+        server_address=("93.184.216.34", 443),
+        peername=("93.184.216.34", 443),
+    )
+    original_headers = flow.request.headers.fields
+    original_url = flow.request.url
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_token_meta()
+
+    get_headers = AsyncMock(side_effect=resolve_auth)
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        requestheaders_task = asyncio.create_task(
+            await_requestheaders_result(mitm_addon.requestheaders(flow))
+        )
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            flow.server_conn.state = connection.ConnectionState.CLOSED
+            mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            release_auth_resolution.set()
+            await requestheaders_task
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(requestheaders_task)
+
+        assert flow.request.stream is False
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.headers.fields == original_headers
+        assert flow.request.url == original_url
+        assert RESOLVED_AWS_ACCESS_KEY_ID not in flow.request.url
+        assert aws_sigv4_body_admission.state_for_tests() == (1, 4)
+        mitm_addon.error(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
 async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
     tmp_path,
     real_flow,
@@ -215,6 +296,54 @@ async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
 
         flow.response = http.Response.make(200, b"ok")
         mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+async def test_payload_dependent_sigv4_holds_admission_until_websocket_end(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    flow.request.headers["Connection"] = "Upgrade"
+    flow.request.headers["Upgrade"] = "websocket"
+    flow.request.headers["Sec-WebSocket-Key"] = "MDEyMzQ1Njc4OWFiY2RlZg=="
+    flow.request.headers["Sec-WebSocket-Version"] = "13"
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        await mitm_addon.request(flow)
+
+        flow.response = http.Response.make(
+            101,
+            b"",
+            {
+                "Connection": "Upgrade",
+                "Upgrade": "websocket",
+            },
+        )
+        flow.websocket = WebSocketData()
+        mitm_addon.response(flow)
+
+        assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+        assert metadata_keys.AWS_SIGV4_BODY_ADMISSION in flow.metadata
+
+        mitm_addon.websocket_end(flow)
 
     get_headers.assert_awaited_once()
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
@@ -311,11 +440,21 @@ def test_malformed_sigv4_placeholder_uses_bounded_fallback(
     )
 
 
+@pytest.mark.parametrize(
+    ("limit_name", "limit_value"),
+    [
+        ("MAX_ADMITTED_AWS_SIGV4_REQUESTS", 0),
+        ("MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES", 3),
+    ],
+    ids=["request-count", "body-bytes"],
+)
 def test_payload_dependent_sigv4_rejects_saturated_admission_before_auth(
     tmp_path,
     real_flow,
     headers,
     mitm_ctx,
+    limit_name: str,
+    limit_value: int,
 ) -> None:
     registry_path = _write_aws_registry(tmp_path)
     flow = _header_auth_flow(
@@ -324,20 +463,13 @@ def test_payload_dependent_sigv4_rejects_saturated_admission_before_auth(
         content_length="4",
     )
     get_headers = AsyncMock()
-    admissions = [
-        aws_sigv4_body_admission.reserve(0)
-        for _index in range(aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUESTS)
-    ]
 
-    try:
-        with (
-            mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
-            patch.object(auth, "get_firewall_headers", get_headers),
-        ):
-            assert mitm_addon.requestheaders(flow) is None
-    finally:
-        for admission in admissions:
-            aws_sigv4_body_admission.release(admission)
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(aws_sigv4_body_admission, limit_name, limit_value),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
 
     get_headers.assert_not_called()
     assert flow.error is not None
@@ -469,29 +601,44 @@ async def test_presigned_s3_request_signs_before_streaming(
     assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
 
 
-def test_sigv4_admission_enforces_count_and_aggregate_byte_limits() -> None:
-    with pytest.raises(ValueError, match="cannot be negative"):
-        aws_sigv4_body_admission.reserve(-1)
+def test_public_destination_presigned_s3_uses_bounded_fallback(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    host = "bucket.s3.amazonaws.com"
+    registry_path = _write_aws_registry(
+        tmp_path,
+        base=f"https://{host}",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=host,
+        method="GET",
+        path=aws_sigv4_presigned_query_path(
+            service="s3",
+            leading_query="",
+        ),
+        request_headers=headers(
+            ("Host", host),
+            ("Transfer-Encoding", "chunked"),
+        ),
+    )
+    get_headers = AsyncMock()
 
-    count_admissions = [
-        aws_sigv4_body_admission.reserve(0)
-        for _index in range(aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUESTS)
-    ]
-    with pytest.raises(aws_sigv4_body_admission.AwsSigV4BodyAdmissionSaturatedError):
-        aws_sigv4_body_admission.reserve(0)
-    for admission in count_admissions:
-        aws_sigv4_body_admission.release(admission)
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
 
-    byte_admissions = [
-        aws_sigv4_body_admission.reserve(aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES)
-        for _index in range(
-            aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES
-            // aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES
-        )
-    ]
-    with pytest.raises(aws_sigv4_body_admission.AwsSigV4BodyAdmissionSaturatedError):
-        aws_sigv4_body_admission.reserve(1)
-    for admission in byte_admissions:
-        aws_sigv4_body_admission.release(admission)
-
-    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    get_headers.assert_not_called()
+    _assert_no_request_stream(flow)
+    assert flow.error is not None
+    assert (
+        flow.metadata[metadata_keys.FIREWALL_ERROR]
+        == auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR
+    )

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -1,0 +1,497 @@
+"""Bounded-body and streaming integration tests for AWS SigV4 firewalls."""
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mitmproxy import http
+
+import auth
+import aws_sigv4_body_admission
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import request_streaming
+from body_limits import STREAM_BUFFER_LIMIT
+from tests.aws_sigv4_helpers import (
+    RESOLVED_AWS_ACCESS_KEY_ID,
+    STS_HOST,
+    aws_sigv4_authorization,
+    aws_sigv4_header_auth_headers,
+    aws_sigv4_presigned_query_path,
+    resolved_aws_sigv4_credentials,
+)
+from tests.firewall_aws_sigv4_helpers import aws_api_entry
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.requestheaders_helpers import await_requestheaders_result
+
+_CLIENT_IP = "10.200.0.5"
+_AWS_PERMISSION = "aws-request"
+
+
+def _resolved_token_meta() -> dict[str, object]:
+    return {
+        "headers": {},
+        "aws_sigv4": resolved_aws_sigv4_credentials(),
+        "resolved_secrets": [],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+
+def _write_aws_registry(
+    tmp_path: Path,
+    *,
+    base: str = f"https://{STS_HOST}",
+    capture_body: bool = False,
+    host_policy: dict[str, object] | None = None,
+) -> Path:
+    api_entry: dict[str, object] = dict(aws_api_entry(base=base))
+    api_entry["permissions"] = [
+        {
+            "name": _AWS_PERMISSION,
+            "rules": ["GET /{path*}", "POST /{path*}"],
+        }
+    ]
+    if host_policy is not None:
+        api_entry["hostPolicy"] = host_policy
+    return _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="aws",
+            api_entry=api_entry,
+            network_policy={
+                "allow": [_AWS_PERMISSION],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": capture_body},
+        ),
+    )
+
+
+def _header_auth_flow(
+    real_flow,
+    headers,
+    *,
+    body: bytes | None = None,
+    content_length: str | None = None,
+    content_hash: str | None = None,
+    transfer_encoding: str | None = None,
+):
+    extra_headers: list[tuple[str, str]] = []
+    signed_headers = "host;x-amz-date"
+    if content_length is not None:
+        extra_headers.append(("Content-Length", content_length))
+    if content_hash is not None:
+        extra_headers.append(("X-Amz-Content-Sha256", content_hash))
+        signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    if transfer_encoding is not None:
+        extra_headers.append(("Transfer-Encoding", transfer_encoding))
+    return real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=STS_HOST,
+        method="POST",
+        path="/",
+        request_body=body,
+        request_headers=headers(
+            *aws_sigv4_header_auth_headers(
+                authorization=aws_sigv4_authorization(
+                    signed_headers=signed_headers,
+                ),
+                extra_headers=extra_headers,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("capture_body", [False, True])
+async def test_payload_independent_sigv4_signs_before_streaming(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    capture_body: bool,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path, capture_body=capture_body)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        content_hash="UNSIGNED-PAYLOAD",
+        transfer_encoding="chunked",
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        await await_requestheaders_result(mitm_addon.requestheaders(flow))
+
+        assert callable(flow.request.stream)
+        callback = flow.request.stream
+        streamed_body = b"x" * (STREAM_BUFFER_LIMIT + 17)
+        assert callback(streamed_body) == streamed_body
+        assert request_streaming.streamed_request_size(flow) == len(streamed_body)
+        if capture_body:
+            assert len(flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        else:
+            assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+            assert request_streaming.captured_request_stream_body(flow) is None
+
+        assert f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+        await mitm_addon.request(flow)
+
+        flow.response = http.Response.make(200, b"ok")
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
+
+async def test_payload_independent_large_fixed_length_bypasses_buffer_limit(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body_size = aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES + 1
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        content_length=str(body_size),
+        content_hash=hashlib.sha256(b"expected body").hexdigest(),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        await await_requestheaders_result(mitm_addon.requestheaders(flow))
+
+    get_headers.assert_awaited_once()
+    assert callable(flow.request.stream)
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+    assert flow.error is None
+
+
+async def test_payload_dependent_sigv4_holds_admission_until_terminal_cleanup(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"body"
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=body,
+        content_length=str(len(body)),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+        get_headers.assert_not_awaited()
+
+        await mitm_addon.request(flow)
+        assert aws_sigv4_body_admission.state_for_tests() == (1, len(body))
+        assert f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/" in flow.request.headers["authorization"]
+
+        flow.response = http.Response.make(200, b"ok")
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    ("extra_headers", "expected_error"),
+    [
+        (
+            [
+                (
+                    "Content-Length",
+                    str(aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES + 1),
+                )
+            ],
+            auth.AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR,
+        ),
+        (
+            [("Transfer-Encoding", "chunked")],
+            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+        ),
+        (
+            [],
+            auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR,
+        ),
+    ],
+    ids=["oversized", "chunked", "indeterminate"],
+)
+def test_payload_dependent_sigv4_rejects_unbounded_framing_before_auth(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    extra_headers: list[tuple[str, str]],
+    expected_error: str,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=STS_HOST,
+        method="POST",
+        path="/",
+        request_headers=headers(*aws_sigv4_header_auth_headers(extra_headers=extra_headers)),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+
+    get_headers.assert_not_called()
+    assert flow.error is not None
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_error
+    assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+def test_malformed_sigv4_placeholder_uses_bounded_fallback(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=STS_HOST,
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", STS_HOST),
+            ("Authorization", "AWS4-HMAC-SHA256 malformed"),
+            ("Transfer-Encoding", "chunked"),
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+
+    get_headers.assert_not_called()
+    assert flow.error is not None
+    assert (
+        flow.metadata[metadata_keys.FIREWALL_ERROR]
+        == auth.AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR
+    )
+
+
+def test_payload_dependent_sigv4_rejects_saturated_admission_before_auth(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        content_length="4",
+    )
+    get_headers = AsyncMock()
+    admissions = [
+        aws_sigv4_body_admission.reserve(0)
+        for _index in range(aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUESTS)
+    ]
+
+    try:
+        with (
+            mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+            patch.object(auth, "get_firewall_headers", get_headers),
+        ):
+            assert mitm_addon.requestheaders(flow) is None
+    finally:
+        for admission in admissions:
+            aws_sigv4_body_admission.release(admission)
+
+    get_headers.assert_not_called()
+    assert flow.error is not None
+    assert (
+        flow.metadata[metadata_keys.FIREWALL_ERROR]
+        == auth.AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR
+    )
+    assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+async def test_payload_dependent_sigv4_cancellation_releases_admission(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=b"body",
+        content_length="4",
+    )
+    get_headers = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        with pytest.raises(asyncio.CancelledError):
+            await mitm_addon.request(flow)
+
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+async def test_payload_dependent_sigv4_auth_failure_releases_at_local_response_terminal(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    flow = _header_auth_flow(
+        real_flow,
+        headers,
+        body=b"body",
+        content_length="4",
+    )
+    get_headers = AsyncMock(side_effect=RuntimeError("auth unavailable"))
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        await mitm_addon.request(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert aws_sigv4_body_admission.state_for_tests() == (1, 4)
+        mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+async def test_direct_oversized_sigv4_request_returns_413_without_auth(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    registry_path = _write_aws_registry(tmp_path)
+    body = b"x" * (aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES + 1)
+    flow = _header_auth_flow(real_flow, headers, body=body)
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 413
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content)["error"] == (
+        auth.AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR
+    )
+
+
+async def test_presigned_s3_request_signs_before_streaming(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+) -> None:
+    host = "bucket.s3.amazonaws.com"
+    registry_path = _write_aws_registry(tmp_path, base=f"https://{host}")
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=host,
+        method="GET",
+        path=aws_sigv4_presigned_query_path(
+            service="s3",
+            leading_query="",
+        ),
+        request_headers=headers(
+            ("Host", host),
+            ("Transfer-Encoding", "chunked"),
+        ),
+    )
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        await await_requestheaders_result(mitm_addon.requestheaders(flow))
+
+    get_headers.assert_awaited_once()
+    assert callable(flow.request.stream)
+    assert f"X-Amz-Credential={RESOLVED_AWS_ACCESS_KEY_ID}%2F" in flow.request.url
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+
+
+def test_sigv4_admission_enforces_count_and_aggregate_byte_limits() -> None:
+    with pytest.raises(ValueError, match="cannot be negative"):
+        aws_sigv4_body_admission.reserve(-1)
+
+    count_admissions = [
+        aws_sigv4_body_admission.reserve(0)
+        for _index in range(aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUESTS)
+    ]
+    with pytest.raises(aws_sigv4_body_admission.AwsSigV4BodyAdmissionSaturatedError):
+        aws_sigv4_body_admission.reserve(0)
+    for admission in count_admissions:
+        aws_sigv4_body_admission.release(admission)
+
+    byte_admissions = [
+        aws_sigv4_body_admission.reserve(aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES)
+        for _index in range(
+            aws_sigv4_body_admission.MAX_ADMITTED_AWS_SIGV4_REQUEST_BODY_BYTES
+            // aws_sigv4_body_admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES
+        )
+    ]
+    with pytest.raises(aws_sigv4_body_admission.AwsSigV4BodyAdmissionSaturatedError):
+        aws_sigv4_body_admission.reserve(1)
+    for admission in byte_admissions:
+        aws_sigv4_body_admission.release(admission)
+
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)

--- a/crates/runner/mitm-addon/tests/test_request_headers_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_firewall_auth.py
@@ -430,30 +430,27 @@ async def test_capture_enabled_body_dependent_firewall_auth_does_not_install_req
         ),
     )
     get_headers = AsyncMock()
-    used_auth_base_header_admission = False
+    admission_key = (
+        metadata_keys.AUTH_BASE_FORWARD_ADMISSION
+        if "base" in auth_config
+        else metadata_keys.AWS_SIGV4_BODY_ADMISSION
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        if "base" in auth_config:
-            used_auth_base_header_admission = True
-            assert requestheaders_result is None
-            assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION in flow.metadata
-            mitm_addon.error(flow)
-        else:
-            await await_requestheaders_result(requestheaders_result)
+        assert requestheaders_result is None
+        assert admission_key in flow.metadata
+        mitm_addon.error(flow)
 
     get_headers.assert_not_called()
     _assert_no_request_stream(flow)
     assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
-    if used_auth_base_header_admission:
-        assert metadata_keys.VM_RUN_ID in flow.metadata
-        assert metadata_keys.ORIGINAL_URL in flow.metadata
-    else:
-        assert metadata_keys.VM_RUN_ID not in flow.metadata
-        assert metadata_keys.ORIGINAL_URL not in flow.metadata
+    assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
+    assert metadata_keys.VM_RUN_ID in flow.metadata
+    assert metadata_keys.ORIGINAL_URL in flow.metadata
 
 
 def test_capture_enabled_firewall_block_does_not_install_request_stream(


### PR DESCRIPTION
## Summary

- sign payload-independent AWS SigV4 requests during `requestheaders()` and stream their bodies without retaining the complete payload
- require fixed-length framing for payload-dependent SigV4 requests, with a 32 MiB per-request limit and independent 16-flow / 128 MiB aggregate admission
- release buffered-body reservations across response, error, cancellation, reclassification, and WebSocket terminal paths
- cover HTTP/1.1 and HTTP/2 framing, signing modes, admission pressure, auth failures, destination races, and cleanup behavior

## Scope

This changes only the runner mitmproxy addon. It does not change API contracts, persisted state, database schemas, connector definitions, feature switches, or Rust runner protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4473 passed)

Closes #23669
