### PR TITLE
fix(api): harden morning brief failure paths

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -14,6 +14,7 @@ import {
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroMorningBriefContract } from "@vm0/api-contracts/contracts/zero-morning-brief";
+import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
 import { Cron } from "croner";
@@ -44,8 +45,10 @@ import {
   insertQueuedWebUserMessageFixture,
   pauseMorningBriefAutomationIntakeFixture,
   readMorningBriefDeliveryFixture,
+  readMorningBriefQueuedParamsForDeliveryFixture,
   readMorningBriefQueuedParamsFixture,
 } from "../../../test-fixtures/morning-brief";
+import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -110,6 +113,10 @@ function preferencesClient() {
 
 function morningBriefTriggerClient() {
   return setupApp({ context })(zeroMorningBriefContract);
+}
+
+function modelProvidersByTypeClient() {
+  return setupApp({ context })(zeroModelProvidersByTypeContract);
 }
 
 // Counts cover every due member in the shared test database, so assertions
@@ -276,6 +283,7 @@ function mockMorningBriefDataSources(gmailAfterSeconds: number[]): void {
 
 interface Scenario {
   readonly actor: ApiTestUser & { readonly orgId: string };
+  readonly agentId: string;
   readonly runnerGroup: string;
   readonly gmailAfterSeconds: number[];
 }
@@ -298,6 +306,10 @@ async function setupMorningBriefActor(
   const runnerGroup = api.configureRunnerGroup();
   await api.grantProEntitlement(actor);
   await api.ensureOrgModelProvider(actor);
+  const onboarding = await bdd.readOnboardingStatus(actor);
+  if (!onboarding.defaultAgentId) {
+    throw new Error("Expected the Morning Brief default agent");
+  }
   if (!actor.orgId) {
     throw new Error("Expected an org-scoped actor");
   }
@@ -341,7 +353,12 @@ async function setupMorningBriefActor(
     new Date(SEVEN_LOCAL).toISOString(),
   );
 
-  return { actor: orgActor, runnerGroup, gmailAfterSeconds };
+  return {
+    actor: orgActor,
+    agentId: onboarding.defaultAgentId,
+    runnerGroup,
+    gmailAfterSeconds,
+  };
 }
 
 async function findMorningBriefThreadIdOrNull(
@@ -623,8 +640,9 @@ describe("cron execute morning briefs", () => {
     if (!delivery) {
       throw new Error("Expected the admitted Morning Brief delivery");
     }
-    const queuedParams = await readMorningBriefQueuedParamsFixture({
-      messageId: delivery.id,
+    const queuedParams = await readMorningBriefQueuedParamsForDeliveryFixture({
+      deliveryId: delivery.id,
+      threadId,
       orgId: scenario.actor.orgId,
       userId: scenario.actor.userId,
     });
@@ -643,6 +661,7 @@ describe("cron execute morning briefs", () => {
         },
       }),
     );
+    expect(queuedParams).not.toHaveProperty("apiStartTime");
     const threadMessages = await readMorningBriefThreadEvents(
       scenario,
       threadId,
@@ -921,7 +940,11 @@ describe("cron execute morning briefs", () => {
       [200],
     );
     await flushWaitUntilForTest();
-    expect(triggered.body.runId).toBeTruthy();
+    expect(triggered.body.queued).toBeFalsy();
+    if (!triggered.body.runId) {
+      throw new Error("Expected the manually triggered Morning Brief run");
+    }
+    const triggeredRunId = triggered.body.runId;
 
     const githubConnector = await connectors.readConnectorBySlug(
       scenario.actor,
@@ -940,7 +963,7 @@ describe("cron execute morning briefs", () => {
     }
 
     mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(scenario, triggered.body.runId, 0, null);
+    await completeMorningBriefRun(scenario, triggeredRunId, 0, null);
     await drainOutbox();
     expect(sentMorningBriefEmails()).toHaveLength(1);
 
@@ -956,7 +979,11 @@ describe("cron execute morning briefs", () => {
     );
     await flushWaitUntilForTest();
     await drainOutbox();
-    expect(second.body.runId).toBe(triggered.body.runId);
+    expect(second.body).toStrictEqual({
+      runId: triggeredRunId,
+      briefDate: BRIEF_DATE,
+      queued: false,
+    });
     expect(sentMorningBriefEmails()).toHaveLength(1);
     const thread = await findMorningBriefThread(scenario);
     const events = await readMorningBriefThreadEvents(
@@ -974,6 +1001,270 @@ describe("cron execute morning briefs", () => {
     ).toHaveLength(1);
     clearMockNow();
   });
+
+  it("marks a failed queued launch failed and dispatches its failure callback", async () => {
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    useSecretKmsProbe(undefined, (_command, callNumber) => {
+      return callNumber === 2
+        ? Promise.reject(new Error("Morning Brief launch decryption failed"))
+        : undefined;
+    });
+
+    mockNow(AFTER_SEVEN_LOCAL);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [400],
+    );
+    await flushWaitUntilForTest();
+
+    const delivery = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(delivery).toStrictEqual(
+      expect.objectContaining({
+        status: "failed",
+        runId: expect.any(String),
+        error: expect.stringContaining("launch decryption failed"),
+      }),
+    );
+    if (!delivery?.runId) {
+      throw new Error("Expected the failed Morning Brief run");
+    }
+    const run = await api.readRun(scenario.actor, delivery.runId);
+    expect(run.status).toBe("failed");
+    expect(sentMorningBriefEmails()).toHaveLength(0);
+    clearMockNow();
+  });
+
+  it("rejects a Morning Brief admission failure and keeps the thread drainable", async () => {
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    await accept(
+      modelProvidersByTypeClient().delete({
+        headers: actorHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+
+    mockNow(AFTER_SEVEN_LOCAL);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [400],
+    );
+
+    const threadId = await findMorningBriefThreadIdOrNull(scenario);
+    if (!threadId) {
+      throw new Error("Expected the Morning Brief thread");
+    }
+    const delivery = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(delivery).toStrictEqual(
+      expect.objectContaining({
+        status: "failed",
+        runId: null,
+        error: expect.any(String),
+      }),
+    );
+    const events = await readMorningBriefThreadEvents(scenario, threadId);
+    expect(
+      events.some((event) => {
+        return (
+          event.eventType === "input.prompt" &&
+          event.content === `Generate my Morning Brief for ${BRIEF_DATE}.`
+        );
+      }),
+    ).toBeFalsy();
+
+    await api.ensureOrgModelProvider(scenario.actor);
+    const userMessage = await chat.requestSendEvent(
+      scenario.actor,
+      {
+        agentId: scenario.agentId,
+        threadId,
+        prompt: "Continue after the failed Morning Brief admission.",
+      },
+      [201],
+    );
+    if ("error" in userMessage.body) {
+      throw new Error(userMessage.body.error.message);
+    }
+    expect(userMessage.body.runId).toStrictEqual(expect.any(String));
+    clearMockNow();
+  });
+
+  it("retries the same-day delivery after an admission failure", async () => {
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    await accept(
+      modelProvidersByTypeClient().delete({
+        headers: actorHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+
+    mockNow(AFTER_SEVEN_LOCAL);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [400],
+    );
+    const failed = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(failed?.status).toBe("failed");
+
+    await api.ensureOrgModelProvider(scenario.actor);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const retried = await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [200],
+    );
+    expect(retried.body.queued).toBeFalsy();
+    if (!retried.body.runId) {
+      throw new Error("Expected the retried Morning Brief run");
+    }
+    const running = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(running).toStrictEqual(
+      expect.objectContaining({
+        id: failed?.id,
+        status: "running",
+        runId: retried.body.runId,
+        error: null,
+      }),
+    );
+    clearMockNow();
+  });
+
+  it("returns a successful queued response behind an active run", async () => {
+    context.mocks.resend.send.mockResolvedValue({
+      data: { id: "resend-queued-retry" },
+      error: null,
+    });
+    const scenario = await setupMorningBriefActor();
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.ManualMorningBrief]: true,
+    });
+
+    const previousTriggerTime = AFTER_SEVEN_LOCAL - DAY_MS;
+    const previousBriefDate = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      timeZone: TIMEZONE,
+    }).format(previousTriggerTime);
+    mockNow(previousTriggerTime);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const previous = await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [200],
+    );
+    if (!previous.body.runId) {
+      throw new Error("Expected the active predecessor run");
+    }
+
+    mockNow(AFTER_SEVEN_LOCAL);
+    routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+    const queued = await accept(
+      morningBriefTriggerClient().trigger({
+        headers: actorHeaders(),
+        body: {},
+      }),
+      [200],
+    );
+    expect(queued.body).toStrictEqual({
+      runId: null,
+      briefDate: BRIEF_DATE,
+      queued: true,
+    });
+
+    const threadId = await findMorningBriefThreadIdOrNull(scenario);
+    if (!threadId) {
+      throw new Error("Expected the queued Morning Brief thread");
+    }
+    const delivery = await readMorningBriefDeliveryFixture({
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+      briefDate: BRIEF_DATE,
+    });
+    expect(delivery).toStrictEqual(
+      expect.objectContaining({ status: "queued", runId: null }),
+    );
+    if (!delivery) {
+      throw new Error("Expected the queued Morning Brief delivery");
+    }
+    const queuedParams = await readMorningBriefQueuedParamsForDeliveryFixture({
+      deliveryId: delivery.id,
+      threadId,
+      orgId: scenario.actor.orgId,
+      userId: scenario.actor.userId,
+    });
+    expect(queuedParams).not.toHaveProperty("apiStartTime");
+    expect(queuedParams?.prompt).toContain(
+      "expire 1440 minutes after the trigger above",
+    );
+
+    mockNow(AFTER_SEVEN_LOCAL + 31 * 60 * 1000);
+    mockUploadedBriefOutput(VALID_OUTPUT);
+    await completeMorningBriefRun(scenario, previous.body.runId, 0);
+
+    let queuedRunId: string | null = null;
+    await expect
+      .poll(async () => {
+        const claimed = await readMorningBriefDeliveryFixture({
+          orgId: scenario.actor.orgId,
+          userId: scenario.actor.userId,
+          briefDate: BRIEF_DATE,
+        });
+        queuedRunId = claimed?.runId ?? null;
+        return claimed?.status;
+      })
+      .toBe("running");
+    if (!queuedRunId) {
+      throw new Error("Expected the queued Morning Brief to drain");
+    }
+    expect(previousBriefDate).not.toBe(BRIEF_DATE);
+    await completeMorningBriefRun(scenario, queuedRunId, 0);
+    clearMockNow();
+  }, 90_000);
 
   it("keeps a queued brief and a concurrent user message in FIFO order", async () => {
     context.mocks.resend.send.mockResolvedValue({
@@ -1050,9 +1341,13 @@ describe("cron execute morning briefs", () => {
     admissionLock.release();
     const brief = await accept(briefRequest, [200]);
     await admissionLock.done;
+    if (!brief.body.runId) {
+      throw new Error("Expected the admitted Morning Brief run");
+    }
+    const briefRunId = brief.body.runId;
 
     mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(scenario, brief.body.runId, 0);
+    await completeMorningBriefRun(scenario, briefRunId, 0);
     await drainOutbox();
 
     let userRunId: string | null = null;
@@ -1085,7 +1380,7 @@ describe("cron execute morning briefs", () => {
     if (!userRunId) {
       throw new Error("Expected the concurrent user message run");
     }
-    expect(userRunId).not.toBe(brief.body.runId);
+    expect(userRunId).not.toBe(briefRunId);
     await completeMorningBriefRun(scenario, userRunId, 0);
     clearMockNow();
   }, 90_000);
@@ -1153,10 +1448,14 @@ describe("cron execute morning briefs", () => {
     admissionLock.release();
     const triggered = await accept(briefRequest, [200]);
     await admissionLock.done;
+    if (!triggered.body.runId) {
+      throw new Error("Expected the paused-intake Morning Brief run");
+    }
+    const triggeredRunId = triggered.body.runId;
     const thread = await findMorningBriefThread(scenario);
-    expect(thread.runId).toBe(triggered.body.runId);
+    expect(thread.runId).toBe(triggeredRunId);
     mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(scenario, triggered.body.runId, 0);
+    await completeMorningBriefRun(scenario, triggeredRunId, 0);
     await drainOutbox();
     clearMockNow();
   }, 90_000);
@@ -1179,6 +1478,10 @@ describe("cron execute morning briefs", () => {
       }),
       [200],
     );
+    if (!triggered.body.runId) {
+      throw new Error("Expected the initial Morning Brief run");
+    }
+    const triggeredRunId = triggered.body.runId;
     const thread = await findMorningBriefThread(scenario);
 
     const displayContent = "Legacy queued Morning Brief display text.";
@@ -1204,7 +1507,7 @@ describe("cron execute morning briefs", () => {
     });
 
     mockUploadedBriefOutput(VALID_OUTPUT);
-    await completeMorningBriefRun(scenario, triggered.body.runId, 0);
+    await completeMorningBriefRun(scenario, triggeredRunId, 0);
     await drainOutbox();
     const events = await readMorningBriefThreadEvents(
       scenario,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -49,6 +49,7 @@ import {
   readMorningBriefQueuedParamsFixture,
 } from "../../../test-fixtures/morning-brief";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
+import { readRunApiStart } from "./helpers/runtime-state";
 
 /**
  * MORNING-BRIEF: the daily 7:00 local-time brief end to end.
@@ -1494,6 +1495,7 @@ describe("cron execute morning briefs", () => {
       content: displayContent,
       prompt: realPrompt,
       appendSystemPrompt,
+      apiStartTime: BEFORE_SEVEN_LOCAL,
     });
     const oldParams = await readMorningBriefQueuedParamsFixture({
       messageId,
@@ -1504,6 +1506,7 @@ describe("cron execute morning briefs", () => {
       version: 1,
       prompt: realPrompt,
       appendSystemPrompt,
+      apiStartTime: BEFORE_SEVEN_LOCAL,
     });
 
     mockUploadedBriefOutput(VALID_OUTPUT);
@@ -1523,6 +1526,9 @@ describe("cron execute morning briefs", () => {
     if (!claimed?.runId) {
       throw new Error("Expected the old-format queue item to drain");
     }
+    await expect(readRunApiStart(context, claimed.runId)).resolves.toBe(
+      new Date(AFTER_SEVEN_LOCAL).toISOString(),
+    );
     const runInput = await completeMorningBriefRun(scenario, claimed.runId, 0);
     expect(runInput.prompt).toBe(realPrompt);
     expect(runInput.appendSystemPrompt).toContain(appendSystemPrompt);

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -1104,14 +1104,22 @@ describe("cron execute morning briefs", () => {
       }),
     );
     const events = await readMorningBriefThreadEvents(scenario, threadId);
-    expect(
-      events.some((event) => {
-        return (
-          event.eventType === "input.prompt" &&
-          event.content === `Generate my Morning Brief for ${BRIEF_DATE}.`
-        );
+    const rejectedBrief = events.find((event) => {
+      return (
+        event.eventType === "input.prompt" &&
+        event.content === `Generate my Morning Brief for ${BRIEF_DATE}.` &&
+        event.runId === undefined
+      );
+    });
+    if (!rejectedBrief) {
+      throw new Error("Expected the rejected Morning Brief input event");
+    }
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        eventType: "control.revoke",
+        revokesEventId: rejectedBrief.id,
       }),
-    ).toBeFalsy();
+    );
 
     await api.ensureOrgModelProvider(scenario.actor);
     const userMessage = await chat.requestSendEvent(

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -529,6 +529,22 @@ async function completeMorningBriefRun(
   };
 }
 
+async function primeMorningBriefThread(scenario: Scenario): Promise<void> {
+  mockNow(AFTER_SEVEN_LOCAL - DAY_MS);
+  routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+  const previous = await accept(
+    morningBriefTriggerClient().trigger({
+      headers: actorHeaders(),
+      body: {},
+    }),
+    [200],
+  );
+  if (!previous.body.runId) {
+    throw new Error("Expected the previous-day Morning Brief run");
+  }
+  await completeMorningBriefRun(scenario, previous.body.runId, 1);
+}
+
 async function drainOutbox(): Promise<void> {
   await accept(drainOutboxClient().drain({ headers: cronHeaders() }), [200]);
 }
@@ -1008,9 +1024,9 @@ describe("cron execute morning briefs", () => {
     await updateFeatureSwitchesForUser(context, scenario.actor, {
       [FeatureSwitchKey.ManualMorningBrief]: true,
     });
-    useSecretKmsProbe(undefined, (_command, callNumber) => {
+    useSecretKmsProbe((_command, callNumber) => {
       return callNumber === 2
-        ? Promise.reject(new Error("Morning Brief launch decryption failed"))
+        ? Promise.reject(new Error("Morning Brief launch encryption failed"))
         : undefined;
     });
 
@@ -1034,7 +1050,7 @@ describe("cron execute morning briefs", () => {
       expect.objectContaining({
         status: "failed",
         runId: expect.any(String),
-        error: expect.stringContaining("launch decryption failed"),
+        error: expect.stringContaining("launch encryption failed"),
       }),
     );
     if (!delivery?.runId) {
@@ -1051,6 +1067,7 @@ describe("cron execute morning briefs", () => {
     await updateFeatureSwitchesForUser(context, scenario.actor, {
       [FeatureSwitchKey.ManualMorningBrief]: true,
     });
+    await primeMorningBriefThread(scenario);
     routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
     await accept(
       modelProvidersByTypeClient().delete({
@@ -1118,6 +1135,7 @@ describe("cron execute morning briefs", () => {
     await updateFeatureSwitchesForUser(context, scenario.actor, {
       [FeatureSwitchKey.ManualMorningBrief]: true,
     });
+    await primeMorningBriefThread(scenario);
     routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
     await accept(
       modelProvidersByTypeClient().delete({

--- a/turbo/apps/api/src/signals/routes/cron-execute-morning-briefs.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-morning-briefs.ts
@@ -2,7 +2,7 @@ import { cronExecuteMorningBriefsContract } from "@vm0/api-contracts/contracts/c
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { now, nowDate } from "../external/time";
+import { nowDate } from "../external/time";
 import { executeDueMorningBriefs$ } from "../services/morning-brief-run.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
@@ -16,7 +16,7 @@ const executeMorningBriefsRoute$: RouteEntry["handler"] = command(
 
     const result = await set(
       executeDueMorningBriefs$,
-      { currentTime: nowDate(), apiStartTime: now() },
+      { currentTime: nowDate() },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-morning-brief.ts
+++ b/turbo/apps/api/src/signals/routes/zero-morning-brief.ts
@@ -2,7 +2,6 @@ import { command } from "ccstate";
 import { zeroMorningBriefContract } from "@vm0/api-contracts/contracts/zero-morning-brief";
 
 import { badRequestMessage } from "../../lib/error";
-import { now } from "../external/time";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route-entry";
@@ -13,7 +12,7 @@ const triggerMorningBriefInner$ = command(
     const auth = get(organizationAuthContext$);
     const result = await set(
       triggerMorningBriefNow$,
-      { orgId: auth.orgId, userId: auth.userId, apiStartTime: now() },
+      { orgId: auth.orgId, userId: auth.userId },
       signal,
     );
 
@@ -34,7 +33,11 @@ const triggerMorningBriefInner$ = command(
 
     return {
       status: 200 as const,
-      body: { runId: result.runId, briefDate: result.briefDate },
+      body: {
+        runId: result.runId,
+        briefDate: result.briefDate,
+        queued: result.queued,
+      },
     };
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -195,6 +195,7 @@ import type {
 import {
   claimQueueFirstRunAssociation,
   recordQueueFirstClaimedRun,
+  recordQueueFirstFailedRun,
   type QueueFirstRunAssociation,
   type QueueFirstRunClaimResult,
 } from "./zero-chat-queued-message.service";
@@ -5513,7 +5514,7 @@ async function commitFailedLaunch(args: {
         error: message,
       });
       if (queueFirstClaim) {
-        await recordQueueFirstClaimedRun(tx, {
+        await recordQueueFirstFailedRun(tx, {
           claim: queueFirstClaim,
           runId: args.identity.runId,
         });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2444,6 +2444,16 @@ function queuedMessageAdmissionFailure(
   );
 }
 
+function queuedMessageApiStartTime(
+  triggerSource: QueuedUserMessage["triggerSource"],
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+): number | undefined {
+  if (triggerSource === "workflow-schedule") {
+    return undefined;
+  }
+  return sourceParams?.apiStartTime;
+}
+
 function resolveQueuedMessageGenerationTemplatePrompt(args: {
   readonly input: CreateQueuedChatRunInputArgs;
   readonly userMessageProjection:
@@ -2582,7 +2592,10 @@ async function buildCreateQueuedChatRunInput(
     feishuDelivery: sourceParams?.feishuDelivery,
     teamsDelivery: sourceParams?.teamsDelivery,
     morningBriefDelivery: sourceParams?.morningBriefDelivery,
-    apiStartTime: sourceParams?.apiStartTime,
+    apiStartTime: queuedMessageApiStartTime(
+      args.queuedMessage.triggerSource,
+      sourceParams,
+    ),
     userInfoExtras: sourceParams?.userInfoExtras,
   };
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -20,6 +20,7 @@ import {
   type ChatMessageUserMessage,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { morningBriefDeliveries } from "@vm0/db/schema/morning-brief";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
@@ -109,10 +110,12 @@ import {
 import { attachCanonicalPublishedAssetsToCompletionEvent } from "./canonical-published-asset-message.service";
 import {
   decryptQueuedUserMessageRunParams,
+  discardUnclaimedUserMessage,
   failQueuedUserMessage,
   loadNextUnclaimedQueuedUserMessage,
   type QueuedUserMessage,
 } from "./zero-chat-queued-message.service";
+import { handleMorningBriefEmailInternalCallback } from "./internal-morning-brief-run-callback.service";
 import { sendUserPushNotifications } from "./zero-push-notifications.service";
 import {
   type ChatCompletionContextMessage,
@@ -576,9 +579,20 @@ interface TeamsQueuedMessageAdmissionFailure {
   readonly error: QueuedMessageModelRouteError;
 }
 
+interface MorningBriefQueuedMessageAdmissionFailure {
+  readonly kind: "morning_brief_admission_failure";
+  readonly threadId: string;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly morningBriefDelivery?: NonNullable<
+    CreateQueuedChatRunInput["morningBriefDelivery"]
+  >;
+  readonly error: QueuedMessageModelRouteError;
+}
+
 type QueuedMessageAdmissionFailure =
   | SlackQueuedMessageAdmissionFailure
-  | TeamsQueuedMessageAdmissionFailure;
+  | TeamsQueuedMessageAdmissionFailure
+  | MorningBriefQueuedMessageAdmissionFailure;
 
 type CompletedChatCallbackResult =
   | {
@@ -2401,6 +2415,23 @@ function teamsQueuedMessageAdmissionFailure(
   };
 }
 
+function morningBriefQueuedMessageAdmissionFailure(
+  args: CreateQueuedChatRunInputArgs,
+  sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
+  error: QueuedMessageModelRouteError,
+): MorningBriefQueuedMessageAdmissionFailure | null {
+  if (args.queuedMessage.triggerSource !== "workflow-schedule") {
+    return null;
+  }
+  return {
+    kind: "morning_brief_admission_failure",
+    threadId: args.threadId,
+    queuedMessage: args.queuedMessage,
+    morningBriefDelivery: sourceParams?.morningBriefDelivery,
+    error,
+  };
+}
+
 function queuedMessageAdmissionFailure(
   args: CreateQueuedChatRunInputArgs,
   sourceParams: Awaited<ReturnType<typeof decryptQueuedUserMessageRunParams>>,
@@ -2408,7 +2439,8 @@ function queuedMessageAdmissionFailure(
 ): QueuedMessageAdmissionFailure | null {
   return (
     slackQueuedMessageAdmissionFailure(args, sourceParams, error) ??
-    teamsQueuedMessageAdmissionFailure(args, sourceParams, error)
+    teamsQueuedMessageAdmissionFailure(args, sourceParams, error) ??
+    morningBriefQueuedMessageAdmissionFailure(args, sourceParams, error)
   );
 }
 
@@ -2771,6 +2803,7 @@ async function handleQueuedMessageAdmissionFailure(args: {
   readonly formatError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlack: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
   readonly deliverTeams: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
+  readonly continueDrain: () => Promise<void>;
 }): Promise<void> {
   if (args.failure.kind === "slack_admission_failure") {
     await handleSlackQueuedMessageAdmissionFailure({
@@ -2782,22 +2815,44 @@ async function handleQueuedMessageAdmissionFailure(args: {
     });
     return;
   }
-  await handleTeamsQueuedMessageAdmissionFailure({
-    db: args.db,
-    failure: args.failure,
-    signal: args.signal,
-    formatError: args.formatError,
-    deliver: args.deliverTeams,
+  if (args.failure.kind === "teams_admission_failure") {
+    await handleTeamsQueuedMessageAdmissionFailure({
+      db: args.db,
+      failure: args.failure,
+      signal: args.signal,
+      formatError: args.formatError,
+      deliver: args.deliverTeams,
+    });
+    return;
+  }
+  await discardUnclaimedUserMessage(args.db, {
+    threadId: args.failure.threadId,
+    messageId: args.failure.queuedMessage.id,
   });
+  args.signal.throwIfAborted();
+  if (args.failure.morningBriefDelivery) {
+    const [delivery] = await args.db
+      .update(morningBriefDeliveries)
+      .set({
+        status: "failed",
+        error: args.failure.error.message,
+        updatedAt: nowDate(),
+      })
+      .where(
+        eq(
+          morningBriefDeliveries.id,
+          args.failure.morningBriefDelivery.deliveryId,
+        ),
+      )
+      .returning({ id: morningBriefDeliveries.id });
+    if (!delivery) {
+      throw new Error("Failed to record Morning Brief admission failure");
+    }
+  }
+  await args.continueDrain();
 }
 
-/**
- * User-message half of the per-thread scheduler: when the thread has no
- * in-flight run, dispatch the oldest queued user message — whoever sent it.
- * The shared thread scheduler calls this before attempting the workflow-event
- * half, preserving user-message priority.
- */
-async function autoSendQueuedMessageForThread(args: {
+interface AutoSendQueuedMessageArgs {
   readonly createRun: (
     input: CreateQueuedChatRunInput,
   ) => Promise<CreatedQueuedRun | null>;
@@ -2811,7 +2866,17 @@ async function autoSendQueuedMessageForThread(args: {
   readonly formatIntegrationRunError: ChatCallbackDependencies["formatIntegrationRunError"];
   readonly deliverSlackAdmissionFailure: ChatCallbackDependencies["deliverSlackAdmissionFailure"];
   readonly deliverTeamsAdmissionFailure: ChatCallbackDependencies["deliverTeamsAdmissionFailure"];
-}): Promise<void> {
+}
+
+/**
+ * User-message half of the per-thread scheduler: when the thread has no
+ * in-flight run, dispatch the oldest queued user message — whoever sent it.
+ * The shared thread scheduler calls this before attempting the workflow-event
+ * half, preserving user-message priority.
+ */
+async function autoSendQueuedMessageForThread(
+  args: AutoSendQueuedMessageArgs,
+): Promise<void> {
   const { chatThreadId: threadId, userId } = args;
 
   const queuedMessage = await measureChatCallbackPreCreateTiming(
@@ -2883,6 +2948,9 @@ async function autoSendQueuedMessageForThread(args: {
       formatError: args.formatIntegrationRunError,
       deliverSlack: args.deliverSlackAdmissionFailure,
       deliverTeams: args.deliverTeamsAdmissionFailure,
+      continueDrain: async () => {
+        await autoSendQueuedMessageForThread(args);
+      },
     });
     return;
   }
@@ -3521,7 +3589,19 @@ function buildQueuedChatDispatchFailedCallbacks(args: {
       slackDelivery: args.runInput.slackDelivery,
       feishuDelivery: args.runInput.feishuDelivery,
       teamsDelivery: args.runInput.teamsDelivery,
+      morningBriefDelivery: args.runInput.morningBriefDelivery,
     };
+    if (payload.morningBriefDelivery) {
+      const deliveryResult = await handleMorningBriefEmailInternalCallback(db, {
+        runId,
+        status: "failed",
+        error,
+        payload: payload.morningBriefDelivery.payload,
+      });
+      if (!deliveryResult.success) {
+        throw new Error(deliveryResult.error);
+      }
+    }
     const suppressWebPushForActiveGoal = await runHasActiveGoal(db, runId);
     args.signal.throwIfAborted();
     await processTerminalChatCallback({

--- a/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
@@ -247,6 +247,19 @@ export async function handleMorningBriefEmailInternalCallback(
   if (!delivery) {
     return { success: false, error: "Morning brief delivery not found" };
   }
+  if (
+    envelope.status === "failed" &&
+    delivery.status === "failed" &&
+    delivery.error === null
+  ) {
+    await markDelivery(
+      db,
+      deliveryId,
+      "failed",
+      envelope.error ?? "Run failed",
+    );
+    return { success: true };
+  }
   // Idempotency guard: retried callbacks after a terminal state are no-ops.
   if (delivery.status !== "running" && delivery.status !== "collecting") {
     return { success: true, skipped: true };

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -8,7 +8,7 @@ import {
 } from "@vm0/db/schema/morning-brief";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { command } from "ccstate";
-import { and, asc, eq, isNotNull, lte } from "drizzle-orm";
+import { and, asc, eq, isNotNull, isNull, lte, ne, or } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -38,7 +38,10 @@ import {
 } from "./morning-brief-schedule.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-message-shared.service";
-import { encryptQueuedUserMessageRunParams } from "./zero-chat-queued-message.service";
+import {
+  discardUnclaimedUserMessage,
+  encryptQueuedUserMessageRunParams,
+} from "./zero-chat-queued-message.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { resolveDefaultAgent } from "./zero-email-common.service";
 import { createAutomationChatThread } from "./zero-workflow-user-automation-thread.service";
@@ -49,7 +52,7 @@ const CLAIM_LIMIT = 50;
 const PROCESS_CONCURRENCY = 5;
 const MAX_LOOKBACK_MS = 72 * 60 * 60 * 1000;
 const MIN_LOOKBACK_MS = 24 * 60 * 60 * 1000;
-const SIGNED_URL_TTL_SECONDS = 30 * 60;
+const SIGNED_URL_TTL_SECONDS = 24 * 60 * 60;
 const MORNING_BRIEF_THREAD_TITLE = "Morning Brief";
 
 interface ExecuteMorningBriefsResult {
@@ -406,7 +409,7 @@ async function persistMorningBriefQueueEvent(
   const { claimed, staged } = args;
   await db.transaction(async (tx) => {
     const inserted = await insertChatEvent(tx, {
-      id: claimed.deliveryId,
+      id: randomUUID(),
       chatThreadId: args.chatThreadId,
       eventType: "input.prompt",
       content: args.chatMessage,
@@ -428,6 +431,7 @@ async function persistMorningBriefQueueEvent(
     const [delivery] = await tx
       .update(morningBriefDeliveries)
       .set({
+        status: "queued",
         inputKey: staged.inputKey,
         outputKey: staged.outputKey,
         updatedAt: claimed.currentTime,
@@ -446,7 +450,6 @@ const startMorningBriefRun$ = command(
     args: {
       readonly claimed: ClaimedMorningBrief;
       readonly staged: StagedMorningBriefInput;
-      readonly apiStartTime: number;
     },
     signal: AbortSignal,
   ): Promise<{ readonly runId: string | null } | "skipped"> => {
@@ -499,7 +502,6 @@ const startMorningBriefRun$ = command(
           secret: generateCallbackSecret(),
           payload: { deliveryId },
         },
-        apiStartTime: args.apiStartTime,
       },
       { orgId: row.orgId, userId: row.userId },
     );
@@ -529,11 +531,17 @@ const startMorningBriefRun$ = command(
     signal.throwIfAborted();
 
     const [delivery] = await db
-      .select({ runId: morningBriefDeliveries.runId })
+      .select({
+        status: morningBriefDeliveries.status,
+        runId: morningBriefDeliveries.runId,
+      })
       .from(morningBriefDeliveries)
       .where(eq(morningBriefDeliveries.id, deliveryId))
       .limit(1);
     signal.throwIfAborted();
+    if (!delivery || delivery.status === "failed") {
+      return "skipped";
+    }
     return { runId: delivery?.runId ?? null };
   },
 );
@@ -544,7 +552,6 @@ const processDueMorningBrief$ = command(
     args: {
       readonly row: DueMorningBriefRow;
       readonly currentTime: Date;
-      readonly apiStartTime: number;
     },
     signal: AbortSignal,
   ): Promise<"executed" | "skipped"> => {
@@ -566,7 +573,7 @@ const processDueMorningBrief$ = command(
 
     const started = await set(
       startMorningBriefRun$,
-      { claimed, staged, apiStartTime: args.apiStartTime },
+      { claimed, staged },
       signal,
     );
     return started === "skipped" ? "skipped" : "executed";
@@ -579,9 +586,126 @@ type ManualMorningBriefAdmission =
       readonly kind: "duplicate";
       readonly runId: string | null;
       readonly briefDate: string;
+      readonly queued: boolean;
     }
   | { readonly kind: "forbidden" }
   | { readonly kind: "bad_request"; readonly message: string };
+
+type ManualMorningBriefDeliveryAdmission =
+  | { readonly kind: "ok"; readonly deliveryId: string }
+  | Extract<ManualMorningBriefAdmission, { readonly kind: "duplicate" }>;
+
+async function admitManualMorningBriefDelivery(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly briefDate: string;
+    readonly chatThreadId: string | null;
+    readonly currentTime: Date;
+  },
+  signal: AbortSignal,
+): Promise<ManualMorningBriefDeliveryAdmission> {
+  let [delivery] = await db
+    .insert(morningBriefDeliveries)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      briefDate: args.briefDate,
+      status: "collecting",
+      createdAt: args.currentTime,
+      updatedAt: args.currentTime,
+    })
+    .onConflictDoNothing()
+    .returning({ id: morningBriefDeliveries.id });
+  signal.throwIfAborted();
+  if (delivery) {
+    return { kind: "ok", deliveryId: delivery.id };
+  }
+
+  const [existing] = await db
+    .select({
+      id: morningBriefDeliveries.id,
+      status: morningBriefDeliveries.status,
+      runId: morningBriefDeliveries.runId,
+      updatedAt: morningBriefDeliveries.updatedAt,
+    })
+    .from(morningBriefDeliveries)
+    .where(
+      and(
+        eq(morningBriefDeliveries.orgId, args.orgId),
+        eq(morningBriefDeliveries.userId, args.userId),
+        eq(morningBriefDeliveries.briefDate, args.briefDate),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error("Expected the existing morning brief delivery");
+  }
+  if (existing.status === "queued") {
+    return {
+      kind: "duplicate",
+      runId: null,
+      briefDate: args.briefDate,
+      queued: true,
+    };
+  }
+  if (existing.runId && existing.status !== "failed") {
+    return {
+      kind: "duplicate",
+      runId: existing.runId,
+      briefDate: args.briefDate,
+      queued: false,
+    };
+  }
+  if (args.chatThreadId) {
+    await discardUnclaimedUserMessage(db, {
+      threadId: args.chatThreadId,
+      messageId: existing.id,
+    });
+    signal.throwIfAborted();
+  }
+  [delivery] = await db
+    .update(morningBriefDeliveries)
+    .set({
+      status: "collecting",
+      runId: null,
+      inputKey: null,
+      outputKey: null,
+      error: null,
+      updatedAt: args.currentTime,
+    })
+    .where(
+      and(
+        eq(morningBriefDeliveries.id, existing.id),
+        eq(morningBriefDeliveries.updatedAt, existing.updatedAt),
+        or(
+          eq(morningBriefDeliveries.status, "failed"),
+          and(
+            isNull(morningBriefDeliveries.runId),
+            ne(morningBriefDeliveries.status, "queued"),
+          ),
+        ),
+      ),
+    )
+    .returning({ id: morningBriefDeliveries.id });
+  signal.throwIfAborted();
+  if (delivery) {
+    return { kind: "ok", deliveryId: delivery.id };
+  }
+
+  const [current] = await db
+    .select({ runId: morningBriefDeliveries.runId })
+    .from(morningBriefDeliveries)
+    .where(eq(morningBriefDeliveries.id, existing.id))
+    .limit(1);
+  return {
+    kind: "duplicate",
+    runId: current?.runId ?? null,
+    briefDate: args.briefDate,
+    queued: current?.runId === null,
+  };
+}
 
 async function admitManualMorningBrief(
   db: Db,
@@ -649,36 +773,19 @@ async function admitManualMorningBrief(
   signal.throwIfAborted();
 
   const briefDate = morningBriefLocalDate(timezone, currentTime);
-  const [delivery] = await db
-    .insert(morningBriefDeliveries)
-    .values({
+  const delivery = await admitManualMorningBriefDelivery(
+    db,
+    {
       orgId: args.orgId,
       userId: args.userId,
       briefDate,
-      status: "collecting",
-      createdAt: currentTime,
-      updatedAt: currentTime,
-    })
-    .onConflictDoNothing()
-    .returning({ id: morningBriefDeliveries.id });
-  signal.throwIfAborted();
-  if (!delivery) {
-    const [existing] = await db
-      .select({ runId: morningBriefDeliveries.runId })
-      .from(morningBriefDeliveries)
-      .where(
-        and(
-          eq(morningBriefDeliveries.orgId, args.orgId),
-          eq(morningBriefDeliveries.userId, args.userId),
-          eq(morningBriefDeliveries.briefDate, briefDate),
-        ),
-      )
-      .limit(1);
-    return {
-      kind: "duplicate",
-      runId: existing?.runId ?? null,
-      briefDate,
-    };
+      chatThreadId: schedule?.chatThreadId ?? null,
+      currentTime,
+    },
+    signal,
+  );
+  if (delivery.kind === "duplicate") {
+    return delivery;
   }
 
   return {
@@ -695,21 +802,27 @@ async function admitManualMorningBrief(
       },
       timezone,
       briefDate,
-      deliveryId: delivery.id,
+      deliveryId: delivery.deliveryId,
       currentTime,
     },
   };
 }
 
 type TriggerMorningBriefResult =
-  | { readonly kind: "ok"; readonly runId: string; readonly briefDate: string }
+  | {
+      readonly kind: "ok";
+      readonly runId: string | null;
+      readonly briefDate: string;
+      readonly queued: boolean;
+    }
   | { readonly kind: "forbidden" }
   | { readonly kind: "bad_request"; readonly message: string };
 
 /**
  * Testing entry point behind the manualMorningBrief feature switch: runs the
- * full collect → queue pipeline for the caller immediately. The same
- * once-per-local-date delivery guard used by cron deduplicates repeats.
+ * full collect → queue pipeline for the caller immediately. Active and
+ * completed deliveries deduplicate; failed or interrupted collection attempts
+ * reset today's delivery so the member can retry.
  */
 export const triggerMorningBriefNow$ = command(
   async (
@@ -717,7 +830,6 @@ export const triggerMorningBriefNow$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly apiStartTime: number;
     },
     signal: AbortSignal,
   ): Promise<TriggerMorningBriefResult> => {
@@ -731,16 +843,12 @@ export const triggerMorningBriefNow$ = command(
       signal,
     );
     if (admission.kind === "duplicate") {
-      return admission.runId
-        ? {
-            kind: "ok",
-            runId: admission.runId,
-            briefDate: admission.briefDate,
-          }
-        : {
-            kind: "bad_request",
-            message: "Morning brief is already queued for today",
-          };
+      return {
+        kind: "ok",
+        runId: admission.runId,
+        briefDate: admission.briefDate,
+        queued: admission.queued,
+      };
     }
     if (admission.kind !== "ok") {
       return admission;
@@ -757,27 +865,29 @@ export const triggerMorningBriefNow$ = command(
 
     const started = await set(
       startMorningBriefRun$,
-      { claimed, staged, apiStartTime: args.apiStartTime },
+      { claimed, staged },
       signal,
     );
-    if (started === "skipped" || !started.runId) {
+    if (started === "skipped") {
       return {
         kind: "bad_request",
-        message:
-          started === "skipped"
-            ? "Morning brief run could not be started"
-            : "Morning brief is queued behind another message",
+        message: "Morning brief run could not be started",
       };
     }
 
-    return { kind: "ok", runId: started.runId, briefDate: claimed.briefDate };
+    return {
+      kind: "ok",
+      runId: started.runId,
+      briefDate: claimed.briefDate,
+      queued: started.runId === null,
+    };
   },
 );
 
 export const executeDueMorningBriefs$ = command(
   async (
     { set },
-    args: { readonly currentTime: Date; readonly apiStartTime: number },
+    args: { readonly currentTime: Date },
     signal: AbortSignal,
   ): Promise<ExecuteMorningBriefsResult> => {
     const db = set(writeDb$);
@@ -829,11 +939,7 @@ export const executeDueMorningBriefs$ = command(
             continue;
           }
           const outcome = await settle(
-            set(
-              processDueMorningBrief$,
-              { row, currentTime, apiStartTime: args.apiStartTime },
-              signal,
-            ),
+            set(processDueMorningBrief$, { row, currentTime }, signal),
             signal,
           );
           if (outcome.ok && outcome.value === "executed") {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -608,6 +608,37 @@ export async function recordQueueFirstClaimedRun(
 }
 
 /**
+ * A failed queue-first launch still owns the queue claim and run foreign key,
+ * but must never make the Morning Brief delivery look active.
+ */
+export async function recordQueueFirstFailedRun(
+  db: DbTransaction,
+  args: {
+    readonly claim: Extract<
+      QueueFirstRunClaimResult,
+      { readonly kind: "claimed" }
+    >;
+    readonly runId: string;
+  },
+): Promise<void> {
+  if (!args.claim.morningBriefDeliveryId) {
+    return;
+  }
+  const [delivery] = await db
+    .update(morningBriefDeliveries)
+    .set({
+      status: "failed",
+      runId: args.runId,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(morningBriefDeliveries.id, args.claim.morningBriefDeliveryId))
+    .returning({ id: morningBriefDeliveries.id });
+  if (!delivery) {
+    throw new Error("Failed to record the failed morning brief run");
+  }
+}
+
+/**
  * Discard a queue-first user message that never dispatched by appending a
  * tombstone. The revoke edge removes it from both queue and visible history.
  */

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -140,6 +140,7 @@ export async function insertOldFormatQueuedUserMessageFixture(args: {
   readonly content: string;
   readonly prompt: string;
   readonly appendSystemPrompt: string;
+  readonly apiStartTime?: number;
 }): Promise<string> {
   const messageId = randomUUID();
   const encryptedParams = await encryptQueuedUserMessageRunParams(
@@ -147,6 +148,7 @@ export async function insertOldFormatQueuedUserMessageFixture(args: {
       version: 1,
       prompt: args.prompt,
       appendSystemPrompt: args.appendSystemPrompt,
+      apiStartTime: args.apiStartTime,
     },
     { orgId: args.orgId, userId: args.userId },
   );

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -25,6 +25,7 @@ export async function readMorningBriefDeliveryFixture(args: {
       runId: morningBriefDeliveries.runId,
       inputKey: morningBriefDeliveries.inputKey,
       outputKey: morningBriefDeliveries.outputKey,
+      error: morningBriefDeliveries.error,
     })
     .from(morningBriefDeliveries)
     .where(
@@ -36,6 +37,28 @@ export async function readMorningBriefDeliveryFixture(args: {
     )
     .limit(1);
   return delivery ?? null;
+}
+
+export async function readMorningBriefQueuedParamsForDeliveryFixture(args: {
+  readonly deliveryId: string;
+  readonly threadId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}) {
+  const messages = await db()
+    .select({ encryptedParams: chatMessages.encryptedParams })
+    .from(chatMessages)
+    .where(eq(chatMessages.chatThreadId, args.threadId));
+  for (const message of messages) {
+    const params = await decryptQueuedUserMessageRunParams(
+      message.encryptedParams,
+      { orgId: args.orgId, userId: args.userId },
+    );
+    if (params?.morningBriefDelivery?.deliveryId === args.deliveryId) {
+      return params;
+    }
+  }
+  return null;
 }
 
 export async function readMorningBriefQueuedParamsFixture(args: {

--- a/turbo/apps/platform/src/signals/zero-page/settings/user-preferences.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/user-preferences.ts
@@ -61,13 +61,16 @@ export const updateUserPreference$ = command(
 );
 
 export const triggerMorningBrief$ = command(
-  async ({ get }, _signal: AbortSignal): Promise<{ runId: string }> => {
+  async (
+    { get },
+    _signal: AbortSignal,
+  ): Promise<{ runId: string | null; queued: boolean }> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroMorningBriefContract);
     const result = await accept(
       client.trigger({ body: {}, fetchOptions: { signal: _signal } }),
       [200],
     );
-    return { runId: result.body.runId };
+    return { runId: result.body.runId, queued: result.body.queued };
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/zero-morning-brief.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-morning-brief.ts
@@ -6,8 +6,9 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 const triggerMorningBriefResponseSchema = z.object({
-  runId: z.string(),
+  runId: z.string().nullable(),
   briefDate: z.string(),
+  queued: z.boolean(),
 });
 
 /**

--- a/turbo/packages/db/src/schema/morning-brief.ts
+++ b/turbo/packages/db/src/schema/morning-brief.ts
@@ -54,7 +54,7 @@ export const morningBriefSchedules = pgTable(
  * The unique index is the idempotency guard: a delivery for a local date is
  * created exactly once regardless of concurrent cron ticks.
  *
- * Status flow: collecting → running → emailed | failed | skipped.
+ * Status flow: collecting → queued → running → emailed | failed | skipped.
  */
 export const morningBriefDeliveries = pgTable(
   "morning_brief_deliveries",


### PR DESCRIPTION
## Summary

- converge queued Morning Brief launch and model/provider admission failures on a failed delivery state, including the Morning Brief failure callback
- revoke rejected brief queue events and continue draining the dedicated thread so later briefs and user messages are not blocked
- restore same-day manual retries for failed or interrupted deliveries and return a successful queued response behind an active run
- exclude queue wait from API dispatch timing by omitting the enqueue-time `apiStartTime`

## Behavior changes

- failed queue-first launches now persist the failed run ID without leaving the delivery `running`
- failed or stuck same-day deliveries reuse and reset the existing delivery row, while active/completed deliveries remain idempotent
- queue event IDs are independent from delivery IDs so retry enqueue remains append-only
- successful manual admission returns `{ runId: null, queued: true }` when the brief is waiting behind another run

## Presigned URL choice

Presigned input/output URL TTL is extended from 30 minutes to 24 hours. This keeps URL creation at enqueue time while covering realistic waits behind a long-running predecessor, including the 31-minute regression case.

## Validation

- `pnpm exec prettier --check <changed files>`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/db check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- focused integration test command attempted locally; the workspace has no `vm0_test` PostgreSQL database, so the PR pipeline will execute it in the configured test environment

Discovered during the acceptance review of #23700 and PR #23713. Parent context: #23182. Related queue hardening: #23724.

Closes #23746
