### PR TITLE
refactor(api): use chat_events in raw sql

### DIFF
--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -1049,7 +1049,7 @@ async function seedDevBench(args: {
   }
 
   await database.execute(
-    sql`ANALYZE zero_runs, agent_runs, chat_threads, chat_messages`,
+    sql`ANALYZE zero_runs, agent_runs, chat_threads, chat_events`,
   );
 
   writeLine("Seeded prod-shaped chat benchmark threads:");

--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -773,7 +773,7 @@ async function logPlannerDiagnostic(
       zero_runs,
       agent_runs,
       chat_threads,
-      chat_messages,
+      chat_events,
       connectors,
       org_metadata,
       org_members_metadata,

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -169,12 +169,12 @@ function afterSuccessfulRunBoundary(threadId: string, successfulRunId: string) {
     sql`COALESCE(
       (
         SELECT MAX(boundary_message.seq_id)
-        FROM chat_messages boundary_message
+        FROM chat_events boundary_message
         WHERE boundary_message.chat_thread_id = ${threadId}
           AND boundary_message.run_id = ${successfulRunId}
           AND NOT EXISTS (
             SELECT 1
-            FROM chat_messages boundary_revoker
+            FROM chat_events boundary_revoker
             WHERE boundary_revoker.revokes_message_id = boundary_message.id
           )
       ),


### PR DESCRIPTION
## Summary

- Switch the incomplete-round boundary query's remaining raw SQL references from `chat_messages` to the canonical `chat_events` table.
- Update both API development benchmark `ANALYZE` statements to target `chat_events`.
- Re-scan repository SQL usage and confirm no executable application SQL still depends on the `chat_messages` compatibility view; remaining references are historical migrations, migration compatibility fixtures, comments, browser storage names, or lint test source strings.

## Why

This is the prepare step for #23660 PR 2, which will drop the `chat_messages` compatibility view.

Production migrations run before the new API deployment is promoted. Dropping the view while the currently deployed API still contains these raw queries would expose that API to `42P01`. This PR must therefore be released first, followed by another release wave so the previous API and rollback target drain, before the separate contract migration can remove the view.

This PR intentionally does not change the database schema or remove the compatibility view.

## Verification

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `DATABASE_URL=... pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'keeps only the newest 20 incomplete rounds for normal and queued callback sends' --silent=passed-only` — 1 passed, 30 skipped

Refs #23660