### PR TITLE
perf(python): bound websocket json inspection work

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -498,7 +498,17 @@ def feed_model_websocket_usage(
     """
     if not is_model_websocket_usage_enabled(flow):
         return
-    usage_result = usage.extract_openai_responses_usage_from_event(event)
+    usage_result, inspection_error = usage.extract_openai_responses_usage_from_event(event)
+    if inspection_error is not None:
+        log_proxy_entry(
+            flow_metadata.proxy_log_path(flow.metadata),
+            "warn",
+            "Model provider WebSocket usage extraction failed",
+            type="usage_event",
+            usage_protocol="openai_responses_websocket",
+            error=inspection_error,
+        )
+        return
     if not usage_result:
         return
     message_id = usage_result.get("message_id")

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -50,6 +50,9 @@ _UTF8_MAX_CODEPOINT = 0x10FFFF
 _UTF8_SURROGATE_MIN = 0xD800
 _UTF8_SURROGATE_MAX = 0xDFFF
 _DEFAULT_MAX_DEPTH = 256
+_SLOW_SCALAR_BYTES_PER_WORK_UNIT = 32
+_DISCARDED_ASCII_BYTES_PER_WORK_UNIT = 64 * 1024
+JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
 _JSON_STRING_OR_CONTAINER_RE = re.compile(rb'"(?:\\.|[^"\\])*"|[{}\[\]]', re.DOTALL)
 
 
@@ -205,6 +208,7 @@ class JsonSelectiveExtractor:
         max_key_bytes: int = 1024,
         max_number_bytes: int = 128,
         max_wildcard_keys: int = 256,
+        max_work_units: int | None = None,
     ) -> None:
         """Create an extractor for selected JSON observations.
 
@@ -214,6 +218,8 @@ class JsonSelectiveExtractor:
         ``max_number_bytes`` bounds number tokens and fails with
         ``"number limit exceeded"``. ``max_wildcard_keys`` bounds distinct
         wildcard keys and fails with ``"max wildcard keys exceeded"``.
+        ``max_work_units`` optionally bounds total parser work across all
+        chunks and fails with ``"work limit exceeded"``.
         """
         self.scalar_fields = dict(scalar_fields) if scalar_fields is not None else {}
         self.array_count_paths = set(array_count_paths) if array_count_paths is not None else set()
@@ -227,6 +233,7 @@ class JsonSelectiveExtractor:
         self.max_key_bytes = max_key_bytes
         self.max_number_bytes = max_number_bytes
         self.max_wildcard_keys = max_wildcard_keys
+        self.max_work_units = max_work_units
         _validate_extractor_config(
             self.scalar_fields,
             self.array_count_paths,
@@ -236,6 +243,7 @@ class JsonSelectiveExtractor:
             max_key_bytes=self.max_key_bytes,
             max_number_bytes=self.max_number_bytes,
             max_wildcard_keys=self.max_wildcard_keys,
+            max_work_units=self.max_work_units,
         )
         key_collection_paths = _build_key_collection_paths(
             set(self.scalar_fields)
@@ -264,6 +272,9 @@ class JsonSelectiveExtractor:
         self._string: _StringState | None = None
         self._number: _NumberState | None = None
         self._literal: _LiteralState | None = None
+        self._work_units_used = 0
+        self._slow_work_bytes_remaining = 0
+        self._discarded_ascii_work_bytes_remaining = 0
 
     def feed(self, chunk: bytes) -> None:
         """Consume the next bytes for this JSON document.
@@ -327,6 +338,8 @@ class JsonSelectiveExtractor:
         )
 
     def _consume_main(self, chunk: bytes, i: int) -> int:
+        if not self._consume_work_unit():
+            return i
         b = chunk[i]
         if b in b" \t\r\n":
             return i + 1
@@ -602,65 +615,71 @@ class JsonSelectiveExtractor:
             and not state.escape
             and not state.unicode_remaining
             and not state.utf8_remaining
+            and _is_discarded_ascii_string_byte(chunk[i])
         ):
-            if chunk[i] == ord('"'):
-                self._finish_string(state)
-                self._string = None
-                return i + 1
-            match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i)
+            end = self._discarded_ascii_work_span_end(len(chunk), i)
+            if self._error:
+                return i
+            match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i, end)
             if match is None:
-                return len(chunk)
-            i = match.start()
-            if chunk[i] == ord('"'):
-                self._finish_string(state)
-                self._string = None
-                return i + 1
-        while i < len(chunk):
-            b = chunk[i]
-            i += 1
+                self._record_discarded_ascii_work(end - i)
+                return end
+            skipped = match.start() - i
+            self._record_discarded_ascii_work(skipped)
+            return i + skipped
 
-            if state.unicode_remaining:
-                if not _is_hex_byte(b):
-                    self._error = "invalid unicode escape"
-                    return i
-                self._append_string_byte(state, b)
-                if self._error:
-                    return i
-                state.unicode_remaining -= 1
-                continue
+        end = self._slow_work_span_end(len(chunk), i)
+        if self._error:
+            return i
+        start = i
+        try:
+            while i < end:
+                b = chunk[i]
+                i += 1
 
-            if state.escape:
-                if b not in b'"\\/bfnrtu':
-                    self._error = "invalid string escape"
-                    return i
-                self._append_string_byte(state, b)
-                if self._error:
-                    return i
-                state.escape = False
-                if b == ord("u"):
-                    state.unicode_remaining = 4
-                continue
+                if state.unicode_remaining:
+                    if not _is_hex_byte(b):
+                        self._error = "invalid unicode escape"
+                        return i
+                    self._append_string_byte(state, b)
+                    if self._error:
+                        return i
+                    state.unicode_remaining -= 1
+                    continue
 
-            if b == ord("\\"):
+                if state.escape:
+                    if b not in b'"\\/bfnrtu':
+                        self._error = "invalid string escape"
+                        return i
+                    self._append_string_byte(state, b)
+                    if self._error:
+                        return i
+                    state.escape = False
+                    if b == ord("u"):
+                        state.unicode_remaining = 4
+                    continue
+
+                if b == ord("\\"):
+                    self._accept_string_byte(state, b)
+                    if self._error:
+                        return i
+                    state.has_escape = True
+                    state.escape = True
+                    continue
+
+                if b == ord('"'):
+                    self._finish_string(state)
+                    self._string = None
+                    return i
+
+                if b < _JSON_CONTROL_CHAR_MAX:
+                    self._error = "control character in string"
+                    return i
                 self._accept_string_byte(state, b)
                 if self._error:
                     return i
-                state.has_escape = True
-                state.escape = True
-                continue
-
-            if b == ord('"'):
-                self._finish_string(state)
-                self._string = None
-                return i
-
-            if b < _JSON_CONTROL_CHAR_MAX:
-                self._error = "control character in string"
-                return i
-            self._accept_string_byte(state, b)
-            if self._error:
-                return i
-
+        finally:
+            self._record_slow_work(i - start)
         return i
 
     def _accept_string_byte(self, state: _StringState, b: int) -> None:
@@ -750,15 +769,21 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing number parser state"
             return i
-        while i < len(chunk):
+        end = self._slow_work_span_end(len(chunk), i)
+        if self._error:
+            return i
+        start = i
+        while i < end:
             b = chunk[i]
             if b in b" \t\r\n,]}":
                 self._finish_number()
-                return i
+                break
             self._accept_number_byte(state, b)
             if self._error:
-                return i + 1
+                i += 1
+                break
             i += 1
+        self._record_slow_work(i - start)
         return i
 
     def _accept_number_byte(self, state: _NumberState, b: int) -> None:
@@ -868,16 +893,57 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing literal parser state"
             return i
-        while i < len(chunk) and state.offset < len(state.literal):
+        end = self._slow_work_span_end(len(chunk), i)
+        if self._error:
+            return i
+        start = i
+        while i < end and state.offset < len(state.literal):
             if chunk[i] != state.literal[state.offset]:
                 self._error = "invalid literal"
-                return i + 1
+                i += 1
+                break
             i += 1
             state.offset += 1
-        if state.offset == len(state.literal):
+        self._record_slow_work(i - start)
+        if not self._error and state.offset == len(state.literal):
             self._literal = None
             self._value_complete()
         return i
+
+    def _consume_work_unit(self) -> bool:
+        if self.max_work_units is None:
+            return True
+        if self._work_units_used >= self.max_work_units:
+            self._error = JSON_WORK_LIMIT_EXCEEDED
+            return False
+        self._work_units_used += 1
+        return True
+
+    def _slow_work_span_end(self, chunk_len: int, i: int) -> int:
+        if self.max_work_units is None:
+            return chunk_len
+        if self._slow_work_bytes_remaining == 0:
+            if not self._consume_work_unit():
+                return i
+            self._slow_work_bytes_remaining = _SLOW_SCALAR_BYTES_PER_WORK_UNIT
+        return min(chunk_len, i + self._slow_work_bytes_remaining)
+
+    def _discarded_ascii_work_span_end(self, chunk_len: int, i: int) -> int:
+        if self.max_work_units is None:
+            return chunk_len
+        if self._discarded_ascii_work_bytes_remaining == 0:
+            if not self._consume_work_unit():
+                return i
+            self._discarded_ascii_work_bytes_remaining = _DISCARDED_ASCII_BYTES_PER_WORK_UNIT
+        return min(chunk_len, i + self._discarded_ascii_work_bytes_remaining)
+
+    def _record_slow_work(self, byte_count: int) -> None:
+        if self.max_work_units is not None:
+            self._slow_work_bytes_remaining -= byte_count
+
+    def _record_discarded_ascii_work(self, byte_count: int) -> None:
+        if self.max_work_units is not None:
+            self._discarded_ascii_work_bytes_remaining -= byte_count
 
 
 def _is_hex_byte(b: int) -> bool:
@@ -900,6 +966,10 @@ def _is_json_value_start(b: int) -> bool:
     return b in b'{["tfn-' or ord("0") <= b <= ord("9")
 
 
+def _is_discarded_ascii_string_byte(b: int) -> bool:
+    return _JSON_CONTROL_CHAR_MAX <= b < _UTF8_ONE_BYTE_MAX and b not in b'"\\'
+
+
 def _validate_extractor_config(
     scalar_fields: dict[Path, ScalarField],
     array_count_paths: set[Path],
@@ -910,6 +980,7 @@ def _validate_extractor_config(
     max_key_bytes: int,
     max_number_bytes: int,
     max_wildcard_keys: int,
+    max_work_units: int | None,
 ) -> None:
     for name, value in (
         ("max_depth", max_depth),
@@ -918,6 +989,8 @@ def _validate_extractor_config(
         ("max_wildcard_keys", max_wildcard_keys),
     ):
         _validate_positive_int(name, value)
+    if max_work_units is not None:
+        _validate_positive_int("max_work_units", max_work_units)
 
     for scalar_field in scalar_fields.values():
         if not isinstance(scalar_field, ScalarField):

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -286,6 +286,18 @@ class JsonSelectiveExtractor:
         if self._error:
             return
         i = 0
+        if self.max_work_units is None:
+            while i < len(chunk) and not self._error:
+                if self._string is not None:
+                    i = self._consume_string(chunk, i)
+                elif self._number is not None:
+                    i = self._consume_number(chunk, i)
+                elif self._literal is not None:
+                    i = self._consume_literal(chunk, i)
+                else:
+                    i = self._consume_main(chunk, i)
+            return
+
         while i < len(chunk) and not self._error:
             if self._string is not None:
                 i = self._consume_string(chunk, i)
@@ -294,6 +306,8 @@ class JsonSelectiveExtractor:
             elif self._literal is not None:
                 i = self._consume_literal(chunk, i)
             else:
+                if not self._consume_work_unit():
+                    return
                 i = self._consume_main(chunk, i)
 
     def observed_scalar_for_diagnostics(self, path: Path) -> object | None:
@@ -338,8 +352,6 @@ class JsonSelectiveExtractor:
         )
 
     def _consume_main(self, chunk: bytes, i: int) -> int:
-        if not self._consume_work_unit():
-            return i
         b = chunk[i]
         if b in b" \t\r\n":
             return i + 1
@@ -610,6 +622,7 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing string parser state"
             return i
+        work_limited = self.max_work_units is not None
         if (
             state.raw is None
             and not state.escape
@@ -617,18 +630,20 @@ class JsonSelectiveExtractor:
             and not state.utf8_remaining
             and _is_discarded_ascii_string_byte(chunk[i])
         ):
-            end = self._discarded_ascii_work_span_end(len(chunk), i)
+            end = self._discarded_ascii_work_span_end(len(chunk), i) if work_limited else len(chunk)
             if self._error:
                 return i
             match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i, end)
             if match is None:
-                self._record_discarded_ascii_work(end - i)
+                if work_limited:
+                    self._discarded_ascii_work_bytes_remaining -= end - i
                 return end
             skipped = match.start() - i
-            self._record_discarded_ascii_work(skipped)
+            if work_limited:
+                self._discarded_ascii_work_bytes_remaining -= skipped
             return i + skipped
 
-        end = self._slow_work_span_end(len(chunk), i)
+        end = self._slow_work_span_end(len(chunk), i) if work_limited else len(chunk)
         if self._error:
             return i
         start = i
@@ -679,7 +694,8 @@ class JsonSelectiveExtractor:
                 if self._error:
                     return i
         finally:
-            self._record_slow_work(i - start)
+            if work_limited:
+                self._slow_work_bytes_remaining -= i - start
         return i
 
     def _accept_string_byte(self, state: _StringState, b: int) -> None:
@@ -769,7 +785,8 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing number parser state"
             return i
-        end = self._slow_work_span_end(len(chunk), i)
+        work_limited = self.max_work_units is not None
+        end = self._slow_work_span_end(len(chunk), i) if work_limited else len(chunk)
         if self._error:
             return i
         start = i
@@ -783,7 +800,8 @@ class JsonSelectiveExtractor:
                 i += 1
                 break
             i += 1
-        self._record_slow_work(i - start)
+        if work_limited:
+            self._slow_work_bytes_remaining -= i - start
         return i
 
     def _accept_number_byte(self, state: _NumberState, b: int) -> None:
@@ -893,7 +911,8 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing literal parser state"
             return i
-        end = self._slow_work_span_end(len(chunk), i)
+        work_limited = self.max_work_units is not None
+        end = self._slow_work_span_end(len(chunk), i) if work_limited else len(chunk)
         if self._error:
             return i
         start = i
@@ -904,7 +923,8 @@ class JsonSelectiveExtractor:
                 break
             i += 1
             state.offset += 1
-        self._record_slow_work(i - start)
+        if work_limited:
+            self._slow_work_bytes_remaining -= i - start
         if not self._error and state.offset == len(state.literal):
             self._literal = None
             self._value_complete()
@@ -936,14 +956,6 @@ class JsonSelectiveExtractor:
                 return i
             self._discarded_ascii_work_bytes_remaining = _DISCARDED_ASCII_BYTES_PER_WORK_UNIT
         return min(chunk_len, i + self._discarded_ascii_work_bytes_remaining)
-
-    def _record_slow_work(self, byte_count: int) -> None:
-        if self.max_work_units is not None:
-            self._slow_work_bytes_remaining -= byte_count
-
-    def _record_discarded_ascii_work(self, byte_count: int) -> None:
-        if self.max_work_units is not None:
-            self._discarded_ascii_work_bytes_remaining -= byte_count
 
 
 def _is_hex_byte(b: int) -> bool:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -30,7 +30,11 @@ import body_decoding
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
 from .json_probe import TopLevelStringFieldProbeResult, probe_top_level_string_field
-from .json_selective import JsonSelectiveExtractor, ScalarField
+from .json_selective import (
+    JSON_WORK_LIMIT_EXCEEDED,
+    JsonSelectiveExtractor,
+    ScalarField,
+)
 from .model_tokens import (
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
     MODEL_USAGE_CATEGORY_CACHE_READ,
@@ -119,10 +123,12 @@ _RESPONSES_EVENT_UNRESOLVED: _ResponsesEventTypeClassification = "unresolved"
 _RESPONSES_EVENT_PENDING: _ResponsesEventTypeClassification = "pending"
 _JSON_PREFILTER_MAX_DEPTH = 256
 _JSON_PREFILTER_MAX_STRING_BYTES = 1024
-# Eventless SSE frames normally expose ``type`` near the top of the JSON body.
-# After this bounded prefix, fall back to the full streaming extractor so rare
-# terminal frames with late ``type`` fields still report usage.
-_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES = 4096
+# Responses events normally expose ``type`` near the top of the JSON body.
+# After this bounded prefix, fall back to the full selective extractor so rare
+# terminal events with late ``type`` fields still report usage.
+_RESPONSES_EVENT_PREFILTER_MAX_BYTES = 4096
+_RESPONSES_WEBSOCKET_MAX_WORK_UNITS = 65_536
+_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
 
 
 @dataclass(frozen=True)
@@ -173,7 +179,7 @@ def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
 
 def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:
     return probe_top_level_string_field(
-        body,
+        body[:_RESPONSES_EVENT_PREFILTER_MAX_BYTES],
         "type",
         max_depth=_JSON_PREFILTER_MAX_DEPTH,
         max_string_bytes=_JSON_PREFILTER_MAX_STRING_BYTES,
@@ -589,15 +595,12 @@ class _OpenAIResponsesSseUsageHandler:
         if prefix is None:
             return
 
-        remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
+        remaining = max(_RESPONSES_EVENT_PREFILTER_MAX_BYTES - len(prefix), 0)
         captured_len = min(len(chunk), remaining)
         if captured_len:
             prefix.extend(chunk[:captured_len])
 
-        if (
-            captured_len == len(chunk)
-            and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
-        ):
+        if captured_len == len(chunk) and len(prefix) < _RESPONSES_EVENT_PREFILTER_MAX_BYTES:
             return
 
         prefix_bytes = bytes(prefix)
@@ -616,15 +619,12 @@ class _OpenAIResponsesSseUsageHandler:
         if prefix is None:
             return
 
-        remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
+        remaining = max(_RESPONSES_EVENT_PREFILTER_MAX_BYTES - len(prefix), 0)
         captured_len = min(len(chunk), remaining)
         if captured_len:
             prefix.extend(chunk[:captured_len])
 
-        if (
-            captured_len == len(chunk)
-            and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
-        ):
+        if captured_len == len(chunk) and len(prefix) < _RESPONSES_EVENT_PREFILTER_MAX_BYTES:
             return
 
         prefix_bytes = bytes(prefix)
@@ -725,11 +725,11 @@ def extract_openai_responses_usage_with_error_from_json(
 
 def extract_openai_responses_usage_from_event(
     event: OpenAIResponsesEvent,
-) -> dict | None:
-    """Extract usage from a previously inspected Responses WebSocket event."""
+) -> tuple[dict | None, str | None]:
+    """Extract usage and inspection error from one Responses WebSocket event."""
     event_type = event._classification
     if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
-        return None
+        return None, None
 
     data_event_type = _resolved_data_event_type(event_type)
     scalar_fields = (
@@ -737,11 +737,19 @@ def extract_openai_responses_usage_from_event(
         if data_event_type is None
         else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
     )
-    extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
+    extractor = JsonSelectiveExtractor(
+        scalar_fields=scalar_fields,
+        max_work_units=_RESPONSES_WEBSOCKET_MAX_WORK_UNITS,
+    )
     extractor.feed(event._body)
     result = extractor.finish()
     if not result.complete:
-        return None
+        error = (
+            _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR
+            if result.error == JSON_WORK_LIMIT_EXCEEDED
+            else None
+        )
+        return None, error
 
     usage: dict = {}
     _store_sse_result_values(
@@ -751,5 +759,5 @@ def extract_openai_responses_usage_from_event(
         data_event_type=data_event_type,
     )
     if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
-        return None
-    return usage
+        return None, None
+    return usage, None

--- a/crates/runner/mitm-addon/tests/test_json_selective_config.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_config.py
@@ -45,6 +45,7 @@ def test_rejects_invalid_scalar_field_config_value():
         ("max_key_bytes", 0),
         ("max_number_bytes", 0),
         ("max_wildcard_keys", 0),
+        ("max_work_units", 0),
     ],
 )
 def test_rejects_invalid_extractor_bounds(bound, value):
@@ -59,6 +60,7 @@ def test_rejects_invalid_extractor_bounds(bound, value):
         ("max_key_bytes", "1024"),
         ("max_number_bytes", 128.0),
         ("max_wildcard_keys", None),
+        ("max_work_units", True),
     ],
 )
 def test_rejects_non_integer_extractor_bounds(bound, value):

--- a/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
@@ -1,0 +1,59 @@
+"""Total-work contracts for bounded selective JSON extraction."""
+
+import pytest
+
+from usage.json_selective import JsonSelectiveExtractor
+
+
+@pytest.mark.parametrize(
+    ("payload", "exact_work_units"),
+    [
+        (b"[" + b",".join([b"0"] * 10) + b"]", 22),
+        (b"{" + b",".join([b'"x":0'] * 10) + b"}", 43),
+        (b"   null", 5),
+        (b'"' + b"\\n" * 17 + b'"', 3),
+        (b'"' + b"\xe2\x98\x83" * 11 + b'"', 3),
+        (b'"' + b"x" * (64 * 1024 + 1) + b'"', 4),
+    ],
+    ids=[
+        "dense-array",
+        "dense-object",
+        "whitespace",
+        "escaped-string",
+        "non-ascii-string",
+        "bulk-ascii-string",
+    ],
+)
+def test_work_limit_is_exact_and_chunk_independent(
+    payload: bytes,
+    exact_work_units: int,
+):
+    for chunk_size in (1, 7, 4093, len(payload)):
+        extractor = JsonSelectiveExtractor(max_work_units=exact_work_units)
+        for offset in range(0, len(payload), chunk_size):
+            extractor.feed(payload[offset : offset + chunk_size])
+
+        assert extractor.finish().complete is True
+
+        limited = JsonSelectiveExtractor(max_work_units=exact_work_units - 1)
+        for offset in range(0, len(payload), chunk_size):
+            limited.feed(payload[offset : offset + chunk_size])
+        result = limited.finish()
+
+        assert result.complete is False
+        assert result.error == "work limit exceeded"
+        assert result.values == {}
+        assert result.array_counts == {}
+        assert result.wildcard_array_counts == {}
+        assert result.object_present == set()
+
+
+def test_default_extractor_has_no_total_work_limit():
+    element_count = 40_000
+    extractor = JsonSelectiveExtractor(array_count_paths={()})
+
+    extractor.feed(b"[" + b",".join([b"0"] * element_count) + b"]")
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.array_counts == {(): element_count}

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -246,6 +246,56 @@ class TestModelProviderWebSocketUsage:
             ],
         )
 
+    def test_model_websocket_work_limit_warns_and_later_frame_reports(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        over_budget_frame = (
+            b'{"type":"response.completed","response":{"id":"resp_partial",'
+            b'"model":"gpt-5.5","usage":{"input_tokens":100,"output_tokens":40}},'
+            b'"padding":[' + b",".join([b"0"] * 40_000) + b"]}"
+        )
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(flow, over_budget_frame)
+
+            assert flow.websocket is not None
+            assert flow.websocket.messages[-1].content == over_budget_frame
+            assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+            assert model_provider_usage_sources(flow) == {}
+
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp_after_limit",
+                    input_tokens=7,
+                    output_tokens=3,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        warning_entries = [
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log)
+            if entry.get("message") == "Model provider WebSocket usage extraction failed"
+        ]
+        [warning] = warning_entries
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["usage_protocol"] == "openai_responses_websocket"
+        assert warning["error"] == "work_limit_exceeded"
+        assert model_provider_usage_sources(flow) == {}
+        expected_rows = [
+            ("gpt-5.5", "tokens.input", 7),
+            ("gpt-5.5", "tokens.output", 3),
+        ]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
+
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -5,11 +5,19 @@ import json
 import pytest
 
 import usage.openai_responses as openai_responses
+from usage import extract_openai_responses_usage_from_event as _extract_usage_with_error
 from usage import (
-    extract_openai_responses_usage_from_event,
     inspect_openai_responses_event_json,
     merge_openai_responses_usage_result,
 )
+
+
+def extract_openai_responses_usage_from_event(
+    event: openai_responses.OpenAIResponsesEvent,
+) -> dict | None:
+    usage_result, error = _extract_usage_with_error(event)
+    assert error is None
+    return usage_result
 
 
 def test_extracts_usage_from_wrapped_response_completed_event():
@@ -346,12 +354,13 @@ def test_duplicate_top_level_unknown_type_keeps_first_type_boundary():
 def test_late_known_non_usage_event_type_is_ignored():
     body = (
         b'{"padding":"'
-        + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+        + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
         + b'","type":"response.output_text.delta",'
         + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
     )
     event = inspect_openai_responses_event_json(body)
 
+    assert event.event_type is None
     assert extract_openai_responses_usage_from_event(event) is None
 
 
@@ -384,6 +393,23 @@ def test_terminal_event_type_after_skipped_fields_still_extracts_usage():
         "tokens.input": 10,
         "tokens.output": 5,
         "tokens.cache_read": 2,
+    }
+
+
+def test_terminal_event_with_large_bulk_string_still_extracts_usage():
+    body = (
+        b'{"type":"response.completed","padding":"'
+        + b"x" * (256 * 1024)
+        + b'","response":{"id":"resp_bulk","model":"gpt-5.6",'
+        b'"usage":{"input_tokens":9,"output_tokens":4}}}'
+    )
+    event = inspect_openai_responses_event_json(body)
+
+    assert extract_openai_responses_usage_from_event(event) == {
+        "message_id": "resp_bulk",
+        "model": "gpt-5.6",
+        "tokens.input": 9,
+        "tokens.output": 4,
     }
 
 
@@ -442,6 +468,17 @@ def test_returns_none_for_malformed_json():
     event = inspect_openai_responses_event_json(b'{"type":"response.completed"')
 
     assert extract_openai_responses_usage_from_event(event) is None
+
+
+def test_work_limit_rejects_partial_usage_and_returns_stable_error():
+    body = (
+        b'{"type":"response.completed","response":{"id":"resp_partial",'
+        b'"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}},'
+        b'"padding":[' + b",".join([b"0"] * 40_000) + b"]}"
+    )
+    event = inspect_openai_responses_event_json(body)
+
+    assert _extract_usage_with_error(event) == (None, "work_limit_exceeded")
 
 
 def test_returns_none_for_usage_event_without_usage_quantities():

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -156,7 +156,7 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert (
             openai_responses._classify_responses_event_type(
-                large_delta[: openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES]
+                large_delta[: openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES]
             )
             == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
         )
@@ -234,7 +234,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(
             b'data: {"padding":"'
-            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
             + b'","type":"response.output_text.delta",'
             + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
             + b"\n\n"
@@ -247,7 +247,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse(
             b"event: response.completed\n"
             b'data: {"padding":"'
-            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
             + b'","type":"response.output_text.delta",'
             + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
             + b"\n\n"
@@ -303,7 +303,7 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert (
             openai_responses._classify_responses_event_type(
-                delta_payload[: openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES]
+                delta_payload[: openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES]
             )
             == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
         )
@@ -360,7 +360,7 @@ class TestOpenAIResponsesSseUsageExtractor:
             + b',"type":"response.completed","response":{"model":"gpt-5.6",'
             + b'"usage":{"output_tokens":17}}}'
         )
-        assert len(payload) < openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
+        assert len(payload) < openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES
 
         real_classify = openai_responses._classify_responses_event_type
         classified_prefixes: list[bytes] = []
@@ -428,7 +428,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         parse(
             b'data: {"padding":"'
-            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
             + b'","type":"response.completed","response":{"model":"gpt'
         )
         parse.finish()
@@ -451,7 +451,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         parse(
             b'data: {"padding":"'
-            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
             + b'","type":"response.output_text.delta","delta":"hello'
         )
         parse.finish()
@@ -480,7 +480,7 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(
             b'data: {"padding":"'
-            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
             + b'","type":"response.completed","response":{"model":"gpt-5.4",'
             + b'"usage":{"output_tokens":8}}}\n\n'
         )


### PR DESCRIPTION
## Summary

- limit OpenAI Responses WebSocket event classification to the shared 4 KiB prefilter before authoritative fallback extraction
- add an optional, chunk-independent work budget to `JsonSelectiveExtractor`, with bounded structural, slow-scalar, and native discarded-ASCII spans
- apply the 65,536-unit budget only to Responses WebSocket usage extraction, discard partial observations on exhaustion, and emit one structured warning without changing message forwarding
- preserve early documented non-usage handling, conservative late/unknown/missing-type extraction, large bulk-string handling, and later-frame recovery

## Scope

This is runner-local. It does not change APIs, database schemas, queues, persisted state, environment variables, feature switches, message framing, compression, or deployment ordering.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,459 passed)

Closes #23729
