### PR TITLE
fix(connectors): preserve committed mutations on realtime failure

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -1,5 +1,9 @@
 import Ably from "ably";
-import type { BrowserSessionChangedPayload } from "@vm0/api-contracts/contracts/realtime";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import type {
+  BrowserSessionChangedPayload,
+  ConnectorChangedPayload,
+} from "@vm0/api-contracts/contracts/realtime";
 import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
@@ -69,10 +73,9 @@ export async function createRunnerGroupRealtimeToken(
  * Platform clients subscribe via the existing /api/zero/realtime/token
  * endpoint and receive events published by the API backend.
  *
- * NOT best-effort: rejections from Ably propagate to the caller, matching
- * the original route behaviour. Mutation handlers should use this directly; if
- * a non-blocking publish becomes necessary for a future route, prefer
- * `settle` from ../utils.
+ * NOT best-effort: rejections from Ably propagate to the caller. Use this
+ * directly only when delivery failure should fail the operation. Post-commit
+ * invalidations should expose a topic-specific safe publisher instead.
  */
 export async function publishUserSignal(
   userIds: readonly string[],
@@ -87,6 +90,23 @@ export async function publishUserSignal(
     }),
   );
   L.debug(`Published "${topic}" to ${userIds.length} user(s)`);
+}
+
+export async function publishConnectorChangedForUserSafely(
+  userId: string,
+  connectorSlug: ConnectorSlug,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], "connector:changed", {
+      connectorRef: connectorSlug,
+    } satisfies ConnectorChangedPayload),
+    (error) => {
+      L.warn("Failed to publish connector changed signal", {
+        connectorSlug,
+        error,
+      });
+    },
+  );
 }
 
 export async function publishRunChangedForUserSafely(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -111,14 +111,18 @@ const CONNECTOR_OAUTH_COOKIE_CLEARS = [
 ] as const;
 
 describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant lifecycle", () => {
-  it("authorizes a manual-grant connector for the requested agent in the connect request", async () => {
+  it("keeps a manual-grant connection and authorization when realtime publishing fails", async () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();
     const agent = await authOrgApi.createAgent(actor, {
       displayName: "Manual Connector Agent",
     });
+    const publishError = new Error("Ably channel rate limit exceeded");
+    context.mocks.ably.publish
+      .mockRejectedValueOnce(publishError)
+      .mockRejectedValueOnce(publishError);
 
-    await connectorsApi.connectManualGrant(
+    const connected = await connectorsApi.connectManualGrant(
       actor,
       "openai",
       "api-token",
@@ -126,6 +130,13 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
       agent.agentId,
     );
 
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "openai"),
+    ).resolves.toMatchObject({
+      id: connected.id,
+      type: "openai",
+      connectionStatus: "connected",
+    });
     await expect(
       authOrgApi.readEnabledConnectorSlugs(actor, agent.agentId),
     ).resolves.toContain("openai");

--- a/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
@@ -1,13 +1,12 @@
 import { command } from "ccstate";
 import { and, eq, or } from "drizzle-orm";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
-import type { ConnectorChangedPayload } from "@vm0/api-contracts/contracts/realtime";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { writeDb$, type Db } from "../external/db";
-import { publishUserSignal } from "../external/realtime";
+import { publishConnectorChangedForUserSafely } from "../external/realtime";
 import { recomposeAgentIfStale$ } from "./agent-compose.service";
 import { updateUserConnectors } from "./user-connectors.service";
 
@@ -183,9 +182,7 @@ export const authorizeConnectedConnector$ = command(
         message: agentNotFoundMessage(agent.id),
       };
     }
-    await publishUserSignal([args.userId], "connector:changed", {
-      connectorRef: args.connectorSlug,
-    } satisfies ConnectorChangedPayload);
+    await publishConnectorChangedForUserSafely(args.userId, args.connectorSlug);
     signal.throwIfAborted();
     return { status: "authorized", agentId: agent.id };
   },

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,7 +9,6 @@ import {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
-import type { ConnectorChangedPayload } from "@vm0/api-contracts/contracts/realtime";
 import {
   connectorAuthMethodGrantMetadata,
   connectorAuthMethodOwnedSecretNames,
@@ -36,7 +35,7 @@ import { z } from "zod";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
-import { publishUserSignal } from "../external/realtime";
+import { publishConnectorChangedForUserSafely } from "../external/realtime";
 import { bestEffort } from "../utils";
 import {
   decryptStoredSecretValue,
@@ -288,9 +287,7 @@ async function finalizeConnectorStateChangeAfterCommit(args: {
     }
   }
 
-  await publishUserSignal([args.userId], "connector:changed", {
-    connectorRef: args.connectorSlug,
-  } satisfies ConnectorChangedPayload);
+  await publishConnectorChangedForUserSafely(args.userId, args.connectorSlug);
   if (args.signal.aborted) {
     postCommitAbort ??= args.signal.reason;
   }


### PR DESCRIPTION
## Summary

- add a connector-specific safe realtime publisher that logs non-abort Ably failures while preserving abort propagation
- use the safe publisher after connector state commits and connected-agent authorization changes
- cover both post-commit publishers through a manual-grant route integration test with sequential Ably failures

## Behavior

Connector mutations now return their authoritative committed result when the subsequent `connector:changed` invalidation fails. The realtime topic and payload are unchanged, and the generic realtime publisher retains its propagating error semantics.

This PR does not add Ably retries, an outbox, channel splitting, or runner E2E shard isolation.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/external/realtime.ts apps/api/src/signals/services/zero-connector-data.service.ts apps/api/src/signals/services/connected-connector-authorization.service.ts apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts` — 59 tests passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks — 12 type-check tasks passed

Closes #23765
