### PR TITLE
feat(connectors): route xero oauth through the app callback

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1495,6 +1495,7 @@ describe("connectors page", () => {
     ["strava", "Strava"],
     ["todoist", "Todoist"],
     ["vercel", "Vercel"],
+    ["xero", "Xero"],
   ] as const)(
     "starts %s OAuth with the app callback",
     async (connectorSlug, label) => {

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -2,10 +2,7 @@
 export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
   "vm0.connector.appOauthCallbackMetadata";
 
-const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set([
-  "slack",
-  "xero",
-]);
+const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
 
 export function isConnectorAppOauthCallbackEnabled(
   connectorSlug: string,


### PR DESCRIPTION
## What changed

Removes `xero` from `LEGACY_CALLBACK_CONNECTOR_SLUGS`, so Xero OAuth now uses the App callback origin (`https://app.vm0.ai/connectors/xero/callback`) instead of the legacy API path (`/api/connectors/xero/callback`).

This leaves `slack` as the only remaining connector on the legacy callback.

## Why now

Both Xero OAuth clients have been updated provider-side to accept the App callback URL, and each kept its legacy redirect URI. Because the provider accepts both URLs, this flip is safe in either cross-version pairing during a rolling deploy.

## User-visible impact

Users connecting Xero are redirected to `app.vm0.ai` after authorizing, matching every other App-callback connector. Existing Xero connections are unaffected — this changes only the authorization redirect, not stored credentials or token refresh.

## Implementation

- `turbo/packages/connectors/src/app-oauth-callback.ts` — drop the `xero` entry.
- `turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx` — add `["xero", "Xero"]` to the `starts %s OAuth with the app callback` table, which asserts the start request carries `callbackTarget: "app"` and the auth window opens the returned URL.

Xero is `callbackOrigin: "web"`, so no API-side test change is needed: the web-origin App path is already covered, and the denylist invariant is still exercised on both surfaces by the `slack` fixtures (`keeps denylisted callbacks on the legacy path` in the API tests, `keeps denylisted OAuth connectors on their legacy callback` in the platform tests). `slack` remains in the denylist, so those tests keep their meaning.

## Verification

- Swept the repo for tests depending on `xero` being denylisted: the only test-file reference is `firewall-rule-matcher.test.ts`, which uses `api.xero.com` as a firewall base URL and asserts nothing about callbacks.
- Confirmed no test asserts on the contents of `LEGACY_CALLBACK_CONNECTOR_SLUGS` directly.
- Formatting verified with the repo's Prettier version.
- Per the repository's PR preference, the full local vitest suite was not run; the PR pipeline owns it.
