### PR TITLE
refactor(connectors): consume catalog v2 slug identity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -116,7 +116,7 @@ function benchCatalogConnector(args: {
   readonly secretName: string;
 }): ConnectorCatalogArtifactConnector {
   return {
-    connectorRef: args.connectorSlug,
+    slug: args.connectorSlug,
     label: args.label,
     description: `${args.label} connector used by the API benchmark`,
     category: "benchmark",
@@ -836,7 +836,7 @@ const ensureSeeded: () => Promise<BenchChatThreadFixture> = (() => {
       );
       const missingConnectorSlugs = BENCH_CONNECTOR_CATALOG.connectors
         .map((connector) => {
-          return connector.connectorRef;
+          return connector.slug;
         })
         .filter((connectorSlug) => {
           return !listedConnectorSlugs.has(connectorSlug);

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -93,7 +93,7 @@ const miscApi = createMiscRoutesApi(context);
 const CRON_SECRET = "connector-catalog-cron-secret";
 const OFFICIAL_RUNNER_AUTHORIZATION =
   "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
-const ACTIVE_KEY = "connectors/v1/active.json";
+const ACTIVE_KEY = "connectors/v2/active.json";
 const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
 const DIAGNOSTICS_USER_ID = `user_${randomUUID()}`;
 const DIAGNOSTICS_ORG_ID = `org_${randomUUID()}`;
@@ -203,7 +203,7 @@ function catalogTemplate(reference: string): string {
 function releaseKeys(version: string): {
   readonly catalog: string;
 } {
-  const prefix = `connectors/v1/releases/${version}`;
+  const prefix = `connectors/v2/releases/${version}`;
   return {
     catalog: `${prefix}/catalog.json`,
   };
@@ -222,7 +222,7 @@ function buildCatalogConnector(args: {
   });
   presentationMethod.label = "API Token";
   return {
-    connectorRef: args.connectorSlug,
+    slug: args.connectorSlug,
     label: args.label,
     description: "An external connector used only by the sync fixture",
     category: "testing",
@@ -1091,7 +1091,7 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
     "platform/views/zero-page/components/settings/icons/" +
     `${connectorSlug}-${iconDigest.slice("sha256:".length, 19)}.svg`;
   const catalog: JsonRecord = {
-    artifactSchemaVersion: 1,
+    artifactSchemaVersion: 2,
     catalogVersion: options.version,
     categoryMetadata: {
       categories: [
@@ -1937,7 +1937,7 @@ describe("connector catalog valid lifecycle", () => {
     await replaceApiTestConnectorCatalogStoredBytes({
       catalogVersion: schemaRelease.version,
       rawBytes: jsonBytes({
-        artifactSchemaVersion: 2,
+        artifactSchemaVersion: 3,
         catalogVersion: schemaRelease.version,
       }),
       catalogValidationAuthority: apiTestConnectorCatalogValidationAuthority(),
@@ -1959,7 +1959,7 @@ describe("connector catalog valid lifecycle", () => {
     await replaceApiTestConnectorCatalogStoredBytes({
       catalogVersion: shapeRelease.version,
       rawBytes: jsonBytes({
-        artifactSchemaVersion: 1,
+        artifactSchemaVersion: 2,
       }),
       catalogValidationAuthority: apiTestConnectorCatalogValidationAuthority(),
     });
@@ -2864,7 +2864,7 @@ describe("connector catalog valid lifecycle", () => {
         .update(`newer:${connectorSlug}`)
         .digest("hex");
       return {
-        connectorRef: connectorSlug,
+        connectorSlug,
         selectedVersionId,
         newerVersionId,
         skill: buildBundledSkillFixture(connectorSlug, selectedVersionId),
@@ -2887,7 +2887,7 @@ describe("connector catalog valid lifecycle", () => {
     }
     const release = buildRelease({
       version: `2026-07-15.external-batch-skills-${fixtureSuffix}`,
-      connectorSlug: firstSkill.connectorRef,
+      connectorSlug: firstSkill.connectorSlug,
       label: "External Batch Skill 01",
       mutateArtifact: (artifact) => {
         const template = firstRecord(artifact.connectors, "connectors");
@@ -2898,7 +2898,7 @@ describe("connector catalog valid lifecycle", () => {
         artifact.connectors = skills.map((skill, index) => {
           const sequence = String(index + 1).padStart(2, "0");
           const connector = buildCatalogConnector({
-            connectorSlug: skill.connectorRef,
+            connectorSlug: skill.connectorSlug,
             label: `External Batch Skill ${sequence}`,
             iconKey,
           });
@@ -2975,7 +2975,7 @@ describe("connector catalog valid lifecycle", () => {
           storageName: skill.skill.storageName,
           previous: previousSystemStates[index] ?? null,
         });
-        await createConnectorCleanup(actor, skill.connectorRef)();
+        await createConnectorCleanup(actor, skill.connectorSlug)();
       }
       await bdd.deleteAgent(actor, agent.agentId);
     });
@@ -2983,7 +2983,7 @@ describe("connector catalog valid lifecycle", () => {
     for (const [index, skill] of skills.entries()) {
       await connectorsApi.connectManualGrant(
         actor,
-        skill.connectorRef,
+        skill.connectorSlug,
         "api-token",
         { credential: `batch-skill-secret-${index + 1}` },
         agent.agentId,
@@ -3028,7 +3028,7 @@ describe("connector catalog valid lifecycle", () => {
         expect(storageMounts).toContainEqual(
           expect.objectContaining({
             name: skill.skill.storageName,
-            mountPath: `/home/user/.claude/skills/${skill.connectorRef}`,
+            mountPath: `/home/user/.claude/skills/${skill.connectorSlug}`,
             versionId: skill.selectedVersionId,
             archiveSize: 321,
             archiveUrl: expect.any(String),
@@ -4806,7 +4806,7 @@ describe("connector catalog valid lifecycle", () => {
           first.skill = firstSkill.descriptor;
 
           const second = structuredClone(first);
-          second.connectorRef = secondConnectorSlug;
+          second.slug = secondConnectorSlug;
           second.label = "Second Skill Identity";
           const secondMethod = firstRecord(second.authMethods, "authMethods");
           recordValue(secondMethod.storage, "storage").secrets = [
@@ -5630,7 +5630,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         ).placeholder = "your-second-api-key";
 
         const second = structuredClone(first);
-        second.connectorRef = "aa-external-other";
+        second.slug = "aa-external-other";
         second.label = "External Other";
         const secondMethod = firstRecord(second.authMethods, "authMethods");
         recordValue(secondMethod.storage, "storage").secrets = [
@@ -5711,7 +5711,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         );
 
         const second = structuredClone(first);
-        second.connectorRef = "collision-b";
+        second.slug = "collision-b";
         second.label = "Collision B";
         const secondMethod = firstRecord(second.authMethods, "authMethods");
         recordValue(secondMethod.storage, "storage").secrets = [
@@ -5796,7 +5796,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           version: "legacy-pointer-reference",
           mutatePointer: (pointer) => {
             pointer.integrity = {
-              key: "connectors/v1/releases/legacy-pointer-reference/integrity/catalog.json",
+              key: "connectors/v2/releases/legacy-pointer-reference/integrity/catalog.json",
               digest: pointer.catalogDigest,
             };
             delete pointer.catalogDigest;
@@ -5823,7 +5823,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         return buildRelease({
           version: "unsupported-schema",
           mutateArtifact: (artifact) => {
-            artifact.artifactSchemaVersion = 2;
+            artifact.artifactSchemaVersion = 3;
           },
         });
       },
@@ -5975,7 +5975,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const second = structuredClone(
               firstRecord(connectors, "connectors"),
             );
-            second.connectorRef = "zz-external-other";
+            second.slug = "zz-external-other";
             second.label = "External Other";
             connectors.push(second);
           },
@@ -5993,7 +5993,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const second = structuredClone(
               firstRecord(connectors, "connectors"),
             );
-            second.connectorRef = "zz-external-other";
+            second.slug = "zz-external-other";
             second.label = "External Other";
             connectors.push(second);
           },
@@ -6039,7 +6039,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         return buildRelease({
           version: "model-provider-ref",
           mutateCatalog: (artifact) => {
-            firstRecord(artifact.connectors, "connectors").connectorRef =
+            firstRecord(artifact.connectors, "connectors").slug =
               "model-provider:external";
           },
         });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
@@ -60,7 +60,7 @@ function sensitiveStringValues(): SensitiveStringValues {
         }
       }
     }
-    valuesByConnector.set(connector.connectorRef, values);
+    valuesByConnector.set(connector.slug, values);
   }
 
   return {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -77,7 +77,7 @@ function mockOAuthEnv(): void {
 function expectCloudflareAuthorizationScopes(authorizationUrl: URL): void {
   const method = API_TEST_CONNECTOR_CATALOG.connectors
     .find((connector) => {
-      return connector.connectorRef === "cloudflare";
+      return connector.slug === "cloudflare";
     })
     ?.authMethods.find((authMethod) => {
       return authMethod.id === "oauth";

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -28,7 +28,7 @@ import { isConnectorCatalogIconKey } from "./icon";
 
 export { connectorCatalogVersionSchema } from "./common";
 
-export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 1;
+export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 2;
 export const CONNECTOR_CATALOG_ACTIVE_KEY = `connectors/v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/active.json`;
 
 export const CONNECTOR_CATALOG_MAX_RAW_BYTES = 8 * 1024 * 1024;
@@ -197,8 +197,7 @@ const connectorCatalogFirewallSchema = z.discriminatedUnion("kind", [
 
 export const connectorCatalogArtifactConnectorSchema = z
   .object({
-    // TODO(#23619): Rename only with the external catalog producer and version.
-    connectorRef: connectorSlugSchema,
+    slug: connectorSlugSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: z.string().min(1),
@@ -249,7 +248,7 @@ export const connectorCatalogArtifactSchema = z
   .strict()
   .superRefine((artifact, context) => {
     const connectorSlugs = artifact.connectors.map((connector) => {
-      return connector.connectorRef;
+      return connector.slug;
     });
     const duplicates = connectorSlugs.filter((connectorSlug, index) => {
       return connectorSlugs.indexOf(connectorSlug) !== index;
@@ -257,7 +256,7 @@ export const connectorCatalogArtifactSchema = z
     for (const connectorSlug of new Set(duplicates)) {
       context.addIssue({
         code: "custom",
-        message: `Connector catalog refs must be unique: ${connectorSlug}`,
+        message: `Connector catalog slugs must be unique: ${connectorSlug}`,
         path: ["connectors"],
       });
     }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -239,7 +239,7 @@ function publicGrant(
 
 function publicConnector(connector: ConnectorCatalogArtifactConnector) {
   return {
-    connectorRef: connector.connectorRef,
+    connectorRef: connector.slug,
     label: connector.label,
     description: connector.description,
     category: connector.category,
@@ -275,7 +275,7 @@ export function validateConnectorCatalogPublicProjection(
     assertPublicValueHasNoPrivateFields(
       publicConnector(connector),
       connectorCatalogSensitiveValues(connector),
-      `$.connectors[${connector.connectorRef}]`,
+      `$.connectors[${connector.slug}]`,
     );
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -117,7 +117,7 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
   const catalogSource = catalogSourceSchema.parse({
     catalogVersion: artifact.catalogVersion,
     connectorRefs: artifact.connectors.map((connector) => {
-      return connector.connectorRef;
+      return connector.slug;
     }),
     categoryMetadata: artifact.categoryMetadata,
   });
@@ -134,18 +134,16 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
   const skillVersionOwners = new Map<string, string>();
 
   for (const connector of artifact.connectors) {
-    if (connector.connectorRef.startsWith(MODEL_PROVIDER_FIREWALL_PREFIX)) {
+    if (connector.slug.startsWith(MODEL_PROVIDER_FIREWALL_PREFIX)) {
       throw new Error(
-        `Connector catalog uses reserved ownership: ${connector.connectorRef}`,
+        `Connector catalog uses reserved ownership: ${connector.slug}`,
       );
     }
     if (!categoryIds.has(connector.category)) {
-      throw new Error(
-        `Unknown category for connector ${connector.connectorRef}`,
-      );
+      throw new Error(`Unknown category for connector ${connector.slug}`);
     }
     const source = connectorSourceSchema.parse({
-      ref: connector.connectorRef,
+      ref: connector.slug,
       label: connector.label,
       description: connector.description,
       category: connector.category,
@@ -174,41 +172,38 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
       const storageOwner = skillStorageOwners.get(connector.skill.storageName);
       if (storageOwner !== undefined) {
         throw new Error(
-          `Connector skill storage ${connector.skill.storageName} is claimed by ${storageOwner} and ${connector.connectorRef}`,
+          `Connector skill storage ${connector.skill.storageName} is claimed by ${storageOwner} and ${connector.slug}`,
         );
       }
-      skillStorageOwners.set(
-        connector.skill.storageName,
-        connector.connectorRef,
-      );
+      skillStorageOwners.set(connector.skill.storageName, connector.slug);
 
       const versionOwner = skillVersionOwners.get(connector.skill.versionId);
       if (versionOwner !== undefined) {
         throw new Error(
-          `Connector skill version ${connector.skill.versionId} is claimed by ${versionOwner} and ${connector.connectorRef}`,
+          `Connector skill version ${connector.skill.versionId} is claimed by ${versionOwner} and ${connector.slug}`,
         );
       }
-      skillVersionOwners.set(connector.skill.versionId, connector.connectorRef);
+      skillVersionOwners.set(connector.skill.versionId, connector.slug);
     }
 
     for (const method of connector.authMethods) {
       for (const secretName of method.storage.secrets) {
         const owner = secretOwners.get(secretName);
-        if (owner !== undefined && owner !== connector.connectorRef) {
+        if (owner !== undefined && owner !== connector.slug) {
           throw new Error(
-            `Connector storage secret ${secretName} is claimed by ${owner} and ${connector.connectorRef}`,
+            `Connector storage secret ${secretName} is claimed by ${owner} and ${connector.slug}`,
           );
         }
-        secretOwners.set(secretName, connector.connectorRef);
+        secretOwners.set(secretName, connector.slug);
       }
       for (const variableName of method.storage.variables) {
         const owner = variableOwners.get(variableName);
-        if (owner !== undefined && owner !== connector.connectorRef) {
+        if (owner !== undefined && owner !== connector.slug) {
           throw new Error(
-            `Connector storage variable ${variableName} is claimed by ${owner} and ${connector.connectorRef}`,
+            `Connector storage variable ${variableName} is claimed by ${owner} and ${connector.slug}`,
           );
         }
-        variableOwners.set(variableName, connector.connectorRef);
+        variableOwners.set(variableName, connector.slug);
       }
     }
   }
@@ -220,7 +215,7 @@ export function connectorCatalogFirewallConfig(
   return connector.firewall.kind === "none"
     ? null
     : {
-        name: connector.connectorRef,
+        name: connector.slug,
         ...connector.firewall.config,
       };
 }
@@ -352,22 +347,20 @@ function validateFirewallSemantics(artifact: ConnectorCatalogArtifact): void {
       throw new Error("Generated connector firewall is unavailable");
     }
     validateFirewallGeneratorResult({
-      connectorRef: connector.connectorRef,
+      connectorRef: connector.slug,
       firewall,
       categories: connector.firewall.categories,
       defaultAllowed: connector.firewall.defaultAllowed,
       defaultUnknownPolicy: connector.firewall.defaultUnknownPolicy,
     });
     validateFirewallBindings({ connector, firewall });
-    validateBaseUrlTemplates(connector.connectorRef, firewall);
+    validateBaseUrlTemplates(connector.slug, firewall);
 
     const routing = deriveConnectorCatalogFirewallRouting(firewall);
     for (const rawHost of routing.fixedHosts) {
       const host = normalizeFirewallFixedHost(rawHost);
       if (!host) {
-        throw new Error(
-          `Firewall fixed host is invalid: ${connector.connectorRef}`,
-        );
+        throw new Error(`Firewall fixed host is invalid: ${connector.slug}`);
       }
     }
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -259,7 +259,7 @@ function evaluateConnectorCatalogCompatibility(args: {
       const reasons = evaluateMethod({
         method,
         registration: registrations.get(
-          registrationKey(connector.connectorRef, method.id),
+          registrationKey(connector.slug, method.id),
         ),
         configuredNames: args.capability.configuredNames,
       });
@@ -267,7 +267,7 @@ function evaluateConnectorCatalogCompatibility(args: {
         ? []
         : [
             {
-              connectorRef: connector.connectorRef,
+              connectorRef: connector.slug,
               authMethodId: method.id,
               reasons,
             },

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -203,7 +203,7 @@ function privateMethodFacts(
   const facts = new Map<string, PrivateAuthMethodFacts>();
   for (const connector of artifact.connectors) {
     for (const method of connector.authMethods) {
-      facts.set(authMethodKey(connector.connectorRef, method.id), {
+      facts.set(authMethodKey(connector.slug, method.id), {
         requiredScopes: [...requiredScopes(method)],
         supportsRefresh: method.access.kind === "refresh-token",
       });
@@ -415,7 +415,7 @@ async function readCurrentCatalog(args: {
         artifact,
         connectorBySlug: new Map(
           artifact.connectors.map((connector) => {
-            return [connector.connectorRef, connector];
+            return [connector.slug, connector];
           }),
         ),
         privateMethodFacts: privateMethodFacts(artifact),
@@ -553,7 +553,7 @@ function effectiveConnectors(args: {
     const authMethods = connector.authMethods.filter((method) => {
       if (
         args.catalog.filteredMethodKeys.has(
-          authMethodKey(connector.connectorRef, method.id),
+          authMethodKey(connector.slug, method.id),
         )
       ) {
         return false;
@@ -591,10 +591,10 @@ function referenceMetadataForCatalog(
 ): readonly ConnectorCatalogReferenceMetadata[] {
   const requestedSlugs = new Set(connectorSlugs);
   return catalog.artifact.connectors.flatMap((connector) => {
-    return requestedSlugs.has(connector.connectorRef)
+    return requestedSlugs.has(connector.slug)
       ? [
           {
-            connectorSlug: connector.connectorRef,
+            connectorSlug: connector.slug,
             label: connector.label,
             icon: iconForCatalog(connector),
           },
@@ -679,7 +679,7 @@ function connectorCatalogItem(
   effective: EffectiveConnector,
 ): PublicConnectorCatalogItem {
   return {
-    connectorRef: effective.connector.connectorRef,
+    connectorRef: effective.connector.slug,
     label: effective.connector.label,
     description: effective.connector.description,
     icon: iconForCatalog(effective.connector),
@@ -722,7 +722,7 @@ export function listAcceptedConnectorCatalogAvailableSlugs(args: {
     featureStates: args.featureStates,
   })
     .map((entry) => {
-      return entry.connector.connectorRef;
+      return entry.connector.slug;
     })
     .sort();
 }
@@ -814,10 +814,7 @@ function connectorCatalogStatusItem(args: {
   const connector = effectiveMethod ? args.connector : null;
   const facts = effectiveMethod
     ? args.catalog.privateMethodFacts.get(
-        authMethodKey(
-          args.effective.connector.connectorRef,
-          effectiveMethod.id,
-        ),
+        authMethodKey(args.effective.connector.slug, effectiveMethod.id),
       )
     : undefined;
   if (effectiveMethod && !facts) {
@@ -940,7 +937,7 @@ export async function searchExternalConnectorCatalog(
     }
     return [
       {
-        id: connector.connectorRef,
+        id: connector.slug,
         label: connector.label,
         description: connector.description,
         authMethods: entry.authMethods.map((method) => {
@@ -960,7 +957,7 @@ export async function getExternalPublicConnectorCatalogDetail(
     featureStates: args.featureStates,
   });
   const connector = effective.find((entry) => {
-    return entry.connector.connectorRef === args.connectorSlug;
+    return entry.connector.slug === args.connectorSlug;
   });
   return connector ? connectorCatalogDetail(connector) : null;
 }
@@ -982,7 +979,7 @@ export async function listExternalPublicConnectorCatalogStatus(
     return connectorCatalogStatusItem({
       catalog,
       effective: entry,
-      connector: connectorsBySlug.get(entry.connector.connectorRef) ?? null,
+      connector: connectorsBySlug.get(entry.connector.slug) ?? null,
     });
   });
   return {
@@ -1006,7 +1003,7 @@ export async function getExternalPublicConnectorCatalogPermissionDetail(
     featureStates: args.featureStates,
   });
   const entry = effective.find((connector) => {
-    return connector.connector.connectorRef === args.connectorSlug;
+    return connector.connector.slug === args.connectorSlug;
   });
   if (!entry || entry.connector.firewall.kind === "none") {
     return null;
@@ -1016,7 +1013,7 @@ export async function getExternalPublicConnectorCatalogPermissionDetail(
     firewall.config.apis,
   );
   return {
-    connectorRef: entry.connector.connectorRef,
+    connectorRef: entry.connector.slug,
     label: entry.connector.label,
     icon: iconForCatalog(entry.connector),
     permissionCount: permissions.length,

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -451,7 +451,7 @@ function runtimeConnectors(
   const connectors = new Map<ConnectorSlug, ConnectorRuntimeConnector>();
 
   for (const connector of acceptedSnapshot.artifact.connectors) {
-    const connectorSlug = connector.connectorRef;
+    const connectorSlug = connector.slug;
     const catalogConnector = getAcceptedConnectorCatalogResolutionDetail({
       snapshot: acceptedSnapshot,
       connectorSlug,

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -425,18 +425,18 @@ function acceptedEntries(args: {
     if (connector.firewall.kind === "none") {
       continue;
     }
-    if (entries.has(connector.connectorRef)) {
+    if (entries.has(connector.slug)) {
       throw new Error(
-        `Duplicate accepted connector server firewall: ${connector.connectorRef}`,
+        `Duplicate accepted connector server firewall: ${connector.slug}`,
       );
     }
-    const methods = args.runtimeMethodsBySlug.get(connector.connectorRef);
+    const methods = args.runtimeMethodsBySlug.get(connector.slug);
     if (!methods) {
       throw new Error(
-        `Accepted connector server firewall runtime is missing: ${connector.connectorRef}`,
+        `Accepted connector server firewall runtime is missing: ${connector.slug}`,
       );
     }
-    entries.set(connector.connectorRef, {
+    entries.set(connector.slug, {
       connector,
       methods,
       firewall: undefined,
@@ -460,11 +460,11 @@ function acceptedEntryFirewall(
   const firewall = connectorCatalogFirewallConfig(connector);
   if (firewall === null || connector.firewall.kind === "none") {
     throw new Error(
-      `Accepted connector server firewall is missing: ${connector.connectorRef}`,
+      `Accepted connector server firewall is missing: ${connector.slug}`,
     );
   }
   const accepted = {
-    connectorSlug: connector.connectorRef,
+    connectorSlug: connector.slug,
     label: connector.label,
     billable: connector.firewall.billable,
     firewall,

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -506,7 +506,7 @@ interface ConnectorArgs {
 
 function connector(args: ConnectorArgs): ConnectorCatalogArtifactConnector {
   return {
-    connectorRef: args.connectorSlug,
+    slug: args.connectorSlug,
     label: args.label,
     description:
       args.description ?? `${args.label} accepted-catalog test fixture.`,
@@ -1734,8 +1734,8 @@ const connectors = [
 ] satisfies readonly ConnectorCatalogArtifactConnector[];
 
 export const API_TEST_CONNECTOR_CATALOG_ARTIFACT = {
-  artifactSchemaVersion: 1,
-  catalogVersion: "api-test-v1",
+  artifactSchemaVersion: 2,
+  catalogVersion: "api-test-v2",
   categoryMetadata: {
     categories: [
       {

--- a/turbo/apps/api/src/test-fixtures/x-connector.ts
+++ b/turbo/apps/api/src/test-fixtures/x-connector.ts
@@ -18,7 +18,7 @@ import { API_TEST_CONNECTOR_CATALOG } from "./connector-catalog";
 const xOAuthStorageVersion = (() => {
   const version = API_TEST_CONNECTOR_CATALOG.connectors
     .find((connector) => {
-      return connector.connectorRef === "x";
+      return connector.slug === "x";
     })
     ?.authMethods.find((method) => {
       return method.id === "oauth";


### PR DESCRIPTION
## Summary

- switch the external connector catalog consumer from schema v1 to strict schema v2
- use `slug` as the connector identity inside the artifact pipeline
- explicitly project artifact slugs into the existing public API, compatibility, runtime, source, and firewall contracts
- update API fixtures and sync coverage to use `connectors/v2`

## Scope

- no v1 parser, fallback, or dual-read path
- no database migration; catalog rows are already isolated by `schema_version`
- no rename of downstream `connectorRef`, `connectorSlug`, or source `ref` contracts

## Validation

- `pnpm format`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --maxWorkers=4 --silent=passed-only --reporter=dot` (101 passed)
- related connector catalog, OAuth, and image-share integration tests (53 passed)
- parsed and validated the generated `2026-07-29.2` schema-v2 catalog with all 317 connectors
- reset, migrated, and seeded the local database; dev seed accepted catalog `2026-07-29.2`

The full API test run completed 2,440 tests and exposed six order-dependent failures in three unrelated shared-organization test files. Each affected file passed in isolation on a clean database (58 chat tests, 125 run-lifecycle tests, and 4 Strapi tests).

Closes #23757

Parent context: #23619
