### PR TITLE
fix(api): use custom plan periods for team usage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2328,7 +2328,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     ]);
   });
 
-  it("cancels replaced Stripe subscriptions after Atom Team and Custom grants", async () => {
+  it("cancels replaced subscriptions and reads the Custom grant billing period", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);
     const runs = createRunsApi(context);
@@ -2336,7 +2336,8 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     const orgId = orgOf(actor);
     const granted = await runs.grantProEntitlement(actor);
     const suffix = randomUUID().slice(0, 8);
-    const grantExpiresAtUnix = epochSeconds(30);
+    const grantStartsAtUnix = epochSeconds(0);
+    const grantExpiresAtUnix = epochSeconds(7);
 
     context.mocks.stripe.subscriptions.list.mockResolvedValue({
       data: [
@@ -2364,7 +2365,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
             source: "atom_entitlement",
             orgId,
             tier: "team",
-            duration: "30d",
+            duration: "7d",
             atomGrantExpiresAt: isoOf(grantExpiresAtUnix),
           },
           parent: null,
@@ -2375,7 +2376,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
                 quantity: 1,
                 price: { id: "price_bdd_atom_grant" },
                 period: {
-                  start: epochSeconds(0),
+                  start: grantStartsAtUnix,
                   end: grantExpiresAtUnix,
                 },
                 parent: { type: "invoice_item_details" },
@@ -2420,7 +2421,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
             source: "atom_entitlement",
             orgId,
             tier: "custom",
-            duration: "30d",
+            duration: "7d",
             atomGrantExpiresAt: isoOf(grantExpiresAtUnix),
           },
           parent: null,
@@ -2431,7 +2432,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
                 quantity: 1,
                 price: { id: "price_bdd_atom_grant" },
                 period: {
-                  start: epochSeconds(0),
+                  start: grantStartsAtUnix,
                   end: grantExpiresAtUnix,
                 },
                 parent: { type: "invoice_item_details" },
@@ -2448,6 +2449,10 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       { invoice_now: false, prorate: false },
     );
     expect((await billing.readBillingStatus(actor)).tier).toBe("custom");
+    expect((await billing.readUsageMembers(actor)).body.period).toStrictEqual({
+      start: isoOf(grantStartsAtUnix),
+      end: isoOf(grantExpiresAtUnix),
+    });
   });
 
   it("rejects lower Atom grants after a Custom grant without canceling subscriptions", async () => {

--- a/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-billing-period.service.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
 import { eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
@@ -14,13 +15,38 @@ interface OrgBillingPeriod {
   readonly end: Date;
 }
 
+interface StoredBillingPeriod {
+  readonly start: Date | null;
+  readonly end: Date | null;
+}
+
+function resolveStoredBillingPeriod(args: {
+  readonly planStart: Date | null;
+  readonly planEnd: Date | null;
+  readonly metadataEnd: Date | null;
+}): StoredBillingPeriod {
+  // Older API versions can update orgMetadata first during a rolling
+  // deployment. Prefer its later end, but let equal entitlement periods
+  // supply the exact start.
+  if (
+    args.planEnd !== null &&
+    (args.metadataEnd === null ||
+      args.planEnd.getTime() >= args.metadataEnd.getTime())
+  ) {
+    return { start: args.planStart, end: args.planEnd };
+  }
+  return { start: null, end: args.metadataEnd };
+}
+
 /**
  * Resolve an org's current billing period `{ start, end }`.
  *
- * Reads `orgMetadata.currentPeriodEnd` first; if missing or expired AND a
- * `stripeSubscriptionId` exists, falls back to `stripe.subscriptions.retrieve`
- * and writes the refreshed value back to orgMetadata. This API service owns the
- * runtime behavior and preserves the Stripe-API rationale and past-dated guard.
+ * Reads the exact period stored in `orgPlanEntitlements` first, including
+ * non-monthly Custom plan grants. Falls back to
+ * `orgMetadata.currentPeriodEnd`; if missing or expired AND a
+ * `stripeSubscriptionId` exists, retrieves the Stripe subscription and writes
+ * the refreshed value back to orgMetadata. This API service owns the runtime
+ * behavior and preserves the Stripe-API rationale and past-dated guard.
  *
  * Returns `null` for free-tier orgs (no subscription, no period). Callers
  * MUST short-circuit on null — there is no synthetic period for the free
@@ -45,15 +71,27 @@ export const getOrgBillingPeriod$ = command(
 
     const [orgRow] = await writeDb
       .select({
+        planPeriodStart: orgPlanEntitlements.currentPeriodStart,
+        planPeriodEnd: orgPlanEntitlements.currentPeriodEnd,
         currentPeriodEnd: orgMetadata.currentPeriodEnd,
         stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
       })
       .from(orgMetadata)
+      .leftJoin(
+        orgPlanEntitlements,
+        eq(orgPlanEntitlements.orgId, orgMetadata.orgId),
+      )
       .where(eq(orgMetadata.orgId, orgId))
       .limit(1);
     signal.throwIfAborted();
 
-    let periodEnd = orgRow?.currentPeriodEnd ?? null;
+    const storedPeriod = resolveStoredBillingPeriod({
+      planStart: orgRow?.planPeriodStart ?? null,
+      planEnd: orgRow?.planPeriodEnd ?? null,
+      metadataEnd: orgRow?.currentPeriodEnd ?? null,
+    });
+    let periodStart = storedPeriod.start;
+    let periodEnd = storedPeriod.end;
     const now = nowDate();
 
     if ((!periodEnd || periodEnd < now) && orgRow?.stripeSubscriptionId) {
@@ -85,6 +123,7 @@ export const getOrgBillingPeriod$ = command(
           });
           return null;
         }
+        periodStart = null;
         periodEnd = refreshed;
         await writeDb
           .update(orgMetadata)
@@ -95,8 +134,10 @@ export const getOrgBillingPeriod$ = command(
     }
 
     if (periodEnd) {
-      const periodStart = new Date(periodEnd);
-      periodStart.setMonth(periodStart.getMonth() - 1);
+      if (!periodStart) {
+        periodStart = new Date(periodEnd);
+        periodStart.setMonth(periodStart.getMonth() - 1);
+      }
       L.debug("billing period resolved", { orgId, periodStart, periodEnd });
       return { start: periodStart, end: periodEnd };
     }


### PR DESCRIPTION
## Summary

- resolve Team usage billing periods from the canonical org plan entitlement start and end
- preserve the newer legacy period end during mixed-version deployments and retain the Stripe refresh fallback
- cover a seven-day Custom grant through the Stripe webhook and public Team usage API

## Testing

- `pnpm exec prettier --write apps/api/src/signals/services/zero-org-billing-period.service.ts apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- API CI-equivalent shards 1-8 on isolated migrated databases (`2448` tests passed)
- pre-commit hook (repository Knip and TypeScript checks)