### PR TITLE
test(api): gate concurrent goal run preparation in callback test

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1738,10 +1738,15 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     const runPreparationStarted = createDeferredPromise<void>(context.signal);
     const releaseRunPreparation = deferredGate();
     useSecretKmsProbe((command, callNumber) => {
-      if (callNumber !== 2) {
+      if (callNumber === 1) {
         return undefined;
       }
-      runPreparationStarted.resolve(undefined);
+      // The terminal callback drain and the goal enqueue drain may both prepare
+      // this queued run. Hold every preparation so neither can win the final
+      // claim before the goal is paused.
+      if (!runPreparationStarted.settled()) {
+        runPreparationStarted.resolve(undefined);
+      }
       return releaseRunPreparation.wait().then(() => {
         return generateDataKeyOutput(command);
       });


### PR DESCRIPTION
## Summary

- hold every queued-run preparation KMS call after the initial goal-event encryption
- cover the valid overlap between the terminal-callback drain and goal-enqueue drain
- keep the original assertion that pausing the goal before the final claim rejects the queued event without creating a run

## Root cause

The test assumed a single queued-run preparation and gated only the second `GenerateDataKey` call. When both drains prepared the same queued run, an ungated preparation could win the final claim before the goal was paused. The expected `input.rejected` message was then never emitted and the test timed out.

This changes only the test synchronization; production claim behavior is unchanged.

Original failure: https://github.com/vm0-ai/vm0/actions/runs/30444673756/job/90552174676

## Verification

- affected test passed 5 consecutive diagnostic runs and a final run on the latest `main`
- `chat-callbacks.bdd.test.ts`: 31/31 tests passed
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, app, and API type checks
