### PR TITLE
perf(ci): make merge-queue security scans diff-aware

### DIFF
--- a/.github/scripts/run-semgrep.sh
+++ b/.github/scripts/run-semgrep.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -eu
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+
+set -- \
+  scan \
+  --config auto \
+  --json-output semgrep-results.json \
+  --sarif \
+  --output semgrep-results.sarif
+
+case "$EVENT_NAME" in
+  pull_request)
+    baseline_commit="$(git rev-parse --verify HEAD^1)"
+    echo "Running diff-aware Semgrep against pull request base $baseline_commit"
+    set -- "$@" --baseline-commit "$baseline_commit"
+    ;;
+  merge_group)
+    : "${MERGE_GROUP_BASE_SHA:?MERGE_GROUP_BASE_SHA is required for merge_group}"
+    baseline_commit="$(git rev-parse --verify "${MERGE_GROUP_BASE_SHA}^{commit}")"
+    echo "Running diff-aware Semgrep against merge group base $baseline_commit"
+    set -- "$@" --baseline-commit "$baseline_commit"
+    ;;
+  push)
+    echo "Running full Semgrep scan on main"
+    ;;
+  *)
+    echo "Unsupported Semgrep event: $EVENT_NAME" >&2
+    exit 2
+    ;;
+esac
+
+exec semgrep "$@" .

--- a/.github/scripts/semgrep-results.py
+++ b/.github/scripts/semgrep-results.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_json(path):
+    with Path(path).open() as source:
+        return json.load(source)
+
+
+def count_findings(results):
+    counts = {}
+    for result in results.get("results", []):
+        rule_id = result["check_id"]
+        counts[rule_id] = counts.get(rule_id, 0) + 1
+    return counts
+
+
+def check_findings(mode, baseline_path, results_path):
+    baseline = load_json(baseline_path)
+    current = count_findings(load_json(results_path))
+
+    errors = []
+    for rule_id, count in sorted(current.items()):
+        allowed = baseline.get(rule_id, 0) if mode == "full" else 0
+        if count <= allowed:
+            continue
+
+        if mode == "diff" or allowed == 0:
+            errors.append(f"NEW rule {rule_id}: {count} finding(s)")
+        else:
+            errors.append(
+                f"REGRESSION {rule_id}: {count} (baseline: {allowed})"
+            )
+
+    print(f"Semgrep: {len(current)} rules, {sum(current.values())} total findings")
+    for rule_id, count in sorted(current.items()):
+        allowed = baseline.get(rule_id, 0) if mode == "full" else 0
+        status = "OK" if count <= allowed else "FAIL"
+        print(f"  [{status}] {rule_id}: {count} (allowed: {allowed})")
+
+    if errors:
+        print(f"\n{len(errors)} regression(s) found:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    if mode == "diff":
+        print("\nNo new findings in changed code.")
+    else:
+        print("\nNo regressions. All findings within baseline.")
+    return 0
+
+
+def filter_sarif(mode, baseline_path, input_path, output_path):
+    baseline = load_json(baseline_path)
+    sarif = load_json(input_path)
+
+    total_results = 0
+    uploaded_results = 0
+    for run in sarif.get("runs", []):
+        results = run.get("results", [])
+        total_results += len(results)
+
+        if mode == "diff":
+            uploaded_results += len(results)
+            continue
+
+        filtered = []
+        seen = {}
+        for result in results:
+            rule_id = result.get("ruleId")
+            seen[rule_id] = seen.get(rule_id, 0) + 1
+            if seen[rule_id] > baseline.get(rule_id, 0):
+                filtered.append(result)
+
+        uploaded_results += len(filtered)
+        run["results"] = filtered
+
+    with Path(output_path).open("w") as destination:
+        json.dump(sarif, destination)
+
+    if mode == "diff":
+        print(
+            "Semgrep SARIF upload includes "
+            f"{uploaded_results}/{total_results} new result(s)"
+        )
+    else:
+        print(
+            "Semgrep SARIF upload filtered: "
+            f"{uploaded_results}/{total_results} result(s) exceed baseline"
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("mode", choices=("diff", "full"))
+    check_parser.add_argument("baseline")
+    check_parser.add_argument("results")
+
+    filter_parser = subparsers.add_parser("filter")
+    filter_parser.add_argument("mode", choices=("diff", "full"))
+    filter_parser.add_argument("baseline")
+    filter_parser.add_argument("input")
+    filter_parser.add_argument("output")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.command == "check":
+        return check_findings(args.mode, args.baseline, args.results)
+
+    filter_sarif(args.mode, args.baseline, args.input, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/run-semgrep-test.sh
+++ b/.github/scripts/tests/run-semgrep-test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+run_semgrep="$script_dir/run-semgrep.sh"
+test_dir="$(mktemp -d)"
+trap 'rm -rf -- "$test_dir"' EXIT
+
+repo_dir="$test_dir/repo"
+fake_bin="$test_dir/bin"
+args_file="$test_dir/semgrep-args"
+mkdir -p "$repo_dir" "$fake_bin"
+
+cat > "$fake_bin/semgrep" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" > "$SEMGREP_ARGS_FILE"
+EOF
+chmod +x "$fake_bin/semgrep"
+
+git -C "$repo_dir" init --quiet
+git -C "$repo_dir" config user.name "Semgrep Test"
+git -C "$repo_dir" config user.email "semgrep-test@vm0.ai"
+
+printf 'base\n' > "$repo_dir/source.txt"
+git -C "$repo_dir" add source.txt
+git -C "$repo_dir" commit --quiet -m "base"
+base_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+
+git -C "$repo_dir" switch --quiet -c feature
+printf 'feature\n' >> "$repo_dir/source.txt"
+git -C "$repo_dir" commit --quiet -am "feature"
+
+git -C "$repo_dir" switch --quiet -
+git -C "$repo_dir" merge --quiet --no-ff feature -m "merge feature"
+pull_request_base="$(git -C "$repo_dir" rev-parse HEAD^1)"
+
+read_baseline_argument() {
+  awk '
+    previous == "--baseline-commit" {
+      print
+      exit
+    }
+    {
+      previous = $0
+    }
+  ' "$args_file"
+}
+
+(
+  cd "$repo_dir"
+  EVENT_NAME=pull_request \
+    SEMGREP_ARGS_FILE="$args_file" \
+    PATH="$fake_bin:$PATH" \
+    sh "$run_semgrep"
+)
+test "$(read_baseline_argument)" = "$pull_request_base"
+
+(
+  cd "$repo_dir"
+  EVENT_NAME=merge_group \
+    MERGE_GROUP_BASE_SHA="$base_sha" \
+    SEMGREP_ARGS_FILE="$args_file" \
+    PATH="$fake_bin:$PATH" \
+    sh "$run_semgrep"
+)
+test "$(read_baseline_argument)" = "$base_sha"
+
+(
+  cd "$repo_dir"
+  EVENT_NAME=push \
+    SEMGREP_ARGS_FILE="$args_file" \
+    PATH="$fake_bin:$PATH" \
+    sh "$run_semgrep"
+)
+if grep -Fqx -- "--baseline-commit" "$args_file"; then
+  echo "push scans must not use a baseline commit" >&2
+  exit 1
+fi
+
+if (
+  cd "$repo_dir"
+  EVENT_NAME=merge_group \
+    SEMGREP_ARGS_FILE="$args_file" \
+    PATH="$fake_bin:$PATH" \
+    sh "$run_semgrep"
+); then
+  echo "merge_group scans must require a base SHA" >&2
+  exit 1
+fi
+
+if (
+  cd "$repo_dir"
+  EVENT_NAME=workflow_dispatch \
+    SEMGREP_ARGS_FILE="$args_file" \
+    PATH="$fake_bin:$PATH" \
+    sh "$run_semgrep"
+); then
+  echo "unsupported events must fail" >&2
+  exit 1
+fi
+
+echo "run-semgrep tests passed"

--- a/.github/scripts/tests/semgrep-results-test.sh
+++ b/.github/scripts/tests/semgrep-results-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+results_script="$script_dir/semgrep-results.py"
+test_dir="$(mktemp -d)"
+trap 'rm -rf -- "$test_dir"' EXIT
+
+cat > "$test_dir/baseline.json" <<'EOF'
+{
+  "existing.rule": 1
+}
+EOF
+
+cat > "$test_dir/within-baseline.json" <<'EOF'
+{
+  "results": [
+    {"check_id": "existing.rule"}
+  ]
+}
+EOF
+
+cat > "$test_dir/regression.json" <<'EOF'
+{
+  "results": [
+    {"check_id": "existing.rule"},
+    {"check_id": "existing.rule"}
+  ]
+}
+EOF
+
+cat > "$test_dir/empty.json" <<'EOF'
+{
+  "results": []
+}
+EOF
+
+cat > "$test_dir/new-finding.json" <<'EOF'
+{
+  "results": [
+    {"check_id": "new.rule"}
+  ]
+}
+EOF
+
+cat > "$test_dir/results.sarif" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [
+        {"ruleId": "existing.rule", "message": {"text": "baseline"}},
+        {"ruleId": "existing.rule", "message": {"text": "regression"}},
+        {"ruleId": "new.rule", "message": {"text": "new"}}
+      ]
+    }
+  ]
+}
+EOF
+
+python3 "$results_script" \
+  check full "$test_dir/baseline.json" "$test_dir/within-baseline.json"
+
+if python3 "$results_script" \
+  check full "$test_dir/baseline.json" "$test_dir/regression.json"; then
+  echo "full scans must fail when a rule exceeds its baseline" >&2
+  exit 1
+fi
+
+python3 "$results_script" \
+  check diff "$test_dir/baseline.json" "$test_dir/empty.json"
+
+if python3 "$results_script" \
+  check diff "$test_dir/baseline.json" "$test_dir/new-finding.json"; then
+  echo "diff scans must fail on every returned finding" >&2
+  exit 1
+fi
+
+python3 "$results_script" \
+  filter full \
+  "$test_dir/baseline.json" \
+  "$test_dir/results.sarif" \
+  "$test_dir/full-filtered.sarif"
+
+jq -e '
+  [.runs[].results[].message.text] == ["regression", "new"]
+' "$test_dir/full-filtered.sarif" > /dev/null
+
+python3 "$results_script" \
+  filter diff \
+  "$test_dir/baseline.json" \
+  "$test_dir/results.sarif" \
+  "$test_dir/diff-filtered.sarif"
+
+jq -e '
+  [.runs[].results[].message.text] == ["baseline", "regression", "new"]
+' "$test_dir/diff-filtered.sarif" > /dev/null
+
+echo "semgrep-results tests passed"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,86 +93,35 @@ jobs:
       image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Run Semgrep
-        run: semgrep scan --config auto --json-output semgrep-results.json --sarif --output semgrep-results.sarif .
+        run: sh .github/scripts/run-semgrep.sh
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Check against baseline
-        shell: python3 {0}
-        run: |
-          import json, sys
-
-          with open(".github/semgrep-baseline.json") as f:
-              baseline = json.load(f)
-
-          with open("semgrep-results.json") as f:
-              results = json.load(f)
-
-          current = {}
-          for r in results.get("results", []):
-              rid = r["check_id"]
-              current[rid] = current.get(rid, 0) + 1
-
-          errors = []
-          for rule, count in sorted(current.items()):
-              allowed = baseline.get(rule, 0)
-              if count > allowed:
-                  if allowed == 0:
-                      errors.append(f"NEW rule {rule}: {count} finding(s)")
-                  else:
-                      errors.append(f"REGRESSION {rule}: {count} (baseline: {allowed})")
-
-          print(f"Semgrep: {len(current)} rules, {sum(current.values())} total findings")
-          for rule, count in sorted(current.items()):
-              status = "OK" if count <= baseline.get(rule, 0) else "FAIL"
-              print(f"  [{status}] {rule}: {count} (baseline: {baseline.get(rule, 0)})")
-
-          if errors:
-              print(f"\n{len(errors)} regression(s) found:")
-              for e in errors:
-                  print(f"  - {e}")
-              sys.exit(1)
-          else:
-              print("\nNo regressions. All findings within baseline.")
+        run: >-
+          python3 .github/scripts/semgrep-results.py check
+          "$SEMGREP_SCAN_MODE"
+          .github/semgrep-baseline.json
+          semgrep-results.json
+        env:
+          SEMGREP_SCAN_MODE: ${{ github.event_name == 'push' && 'full' || 'diff' }}
 
       - name: Filter Semgrep SARIF for Code Scanning upload
         if: always()
-        shell: python3 {0}
-        run: |
-          import json
-
-          with open(".github/semgrep-baseline.json") as f:
-              baseline = json.load(f)
-
-          with open("semgrep-results.sarif") as f:
-              sarif = json.load(f)
-
-          total_results = 0
-          uploaded_results = 0
-          for run in sarif.get("runs", []):
-              filtered = []
-              seen = {}
-
-              for result in run.get("results", []):
-                  rule = result.get("ruleId")
-                  seen[rule] = seen.get(rule, 0) + 1
-                  total_results += 1
-
-                  if seen[rule] > baseline.get(rule, 0):
-                      filtered.append(result)
-
-              uploaded_results += len(filtered)
-              run["results"] = filtered
-
-          with open("semgrep-results-for-code-scanning.sarif", "w") as f:
-              json.dump(sarif, f)
-
-          print(
-              "Semgrep SARIF upload filtered: "
-              f"{uploaded_results}/{total_results} result(s) exceed baseline"
-          )
+        run: >-
+          python3 .github/scripts/semgrep-results.py filter
+          "$SEMGREP_SCAN_MODE"
+          .github/semgrep-baseline.json
+          semgrep-results.sarif
+          semgrep-results-for-code-scanning.sarif
+        env:
+          SEMGREP_SCAN_MODE: ${{ github.event_name == 'push' && 'full' || 'diff' }}
 
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@v4
@@ -184,8 +133,8 @@ jobs:
   codeql:
     needs: [detect-release]
     name: CodeQL SAST
-    # Skip for release-please PRs, commits, and merge queue entries
-    if: needs.detect-release.outputs.skip != 'true'
+    # PR and main results are uploaded for CASA; merge groups cannot upload SARIF.
+    if: needs.detect-release.outputs.skip != 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -203,7 +152,6 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: codeql
-          upload: ${{ github.event_name != 'merge_group' }}
 
   pnpm-audit:
     needs: [detect-release]
@@ -271,12 +219,15 @@ jobs:
             .github/scripts/check-release-please-component-releases.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/cloudflare-ssh-preconnect.sh \
+            .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/tests/ansible-ssh-control-path-test.sh \
             .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
+            .github/scripts/tests/run-semgrep-test.sh \
+            .github/scripts/tests/semgrep-results-test.sh \
             .github/scripts/tests/runner-behavior-balloon-test.sh
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.
@@ -335,6 +286,7 @@ jobs:
     steps:
       - name: Validate CI results
         env:
+          EVENT_NAME: ${{ github.event_name }}
           IS_RELEASE: ${{ needs.detect-release.outputs.skip }}
         run: |
           # Auto-pass for release-please PRs, commits, and merge queue entries
@@ -357,7 +309,11 @@ jobs:
 
           check_result "pr-title" "${{ needs.pr-title.result }}"
           check_result "semgrep" "${{ needs.semgrep.result }}"
-          check_result "codeql" "${{ needs.codeql.result }}"
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            echo "⏭️ codeql: skipped (merge_group cannot upload SARIF)"
+          else
+            check_result "codeql" "${{ needs.codeql.result }}"
+          fi
           check_result "pnpm-audit" "${{ needs.pnpm-audit.result }}"
           check_result "actionlint" "${{ needs.actionlint.result }}"
           check_result "gitleaks" "${{ needs.gitleaks.result }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,6 +96,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Trust checked out repository
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Run Semgrep
         run: sh .github/scripts/run-semgrep.sh
         env:


### PR DESCRIPTION
## Summary

- run Semgrep with --baseline-commit for pull requests and merge groups, while retaining the full repository scan and existing finding baseline on main
- fail diff scans on every new finding and upload the complete diff SARIF; keep the current baseline filtering for full scans
- skip the custom CodeQL job on merge groups, where SARIF upload was disabled and findings did not gate the job, while retaining PR and main scans for CASA and GitHub Security visibility
- add integration coverage for event-base selection and both Semgrep result modes

## User impact

Merge-queue security validation no longer performs the observed full 6,066-file Semgrep scan or a CodeQL analysis whose output is discarded. The required ci-gate-security check remains explicit on every event.

## Measured result

The corrected PR run passed the complete Security Scanning workflow. Semgrep SAST completed in 1m0s instead of the 5m27s reference job; its scan processed 5 changed files in about 5 seconds and found no new findings. CodeQL remains on this pull request for Security upload and completed in 4m3s; the workflow now skips it only for merge_group events.

- Run: https://github.com/vm0-ai/vm0/actions/runs/30450599755
- Semgrep job: https://github.com/vm0-ai/vm0/actions/runs/30450599755/job/90571496650

## Verification

- .github/scripts/tests/run-semgrep-test.sh
- .github/scripts/tests/semgrep-results-test.sh
- shellcheck on the new shell scripts and tests
- container workflow shell compatibility check for security.yml
- actionlint 1.7.12 on security.yml
- Prettier 3.8.1 check on security.yml
- git diff --check
- complete Security Scanning PR workflow, including ci-gate-security