### PR TITLE
refactor(python): retire auto model routing exception

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -18,12 +18,8 @@ TLS_ADMISSION_VALID_REGISTRY_VM: Final = "valid_registry_vm"
 TLS_ADMISSION_INVALID_REGISTRY_VM: Final = "invalid_registry_vm"
 TLS_ADMISSION_REGISTRY_UNAVAILABLE: Final = "registry_unavailable"
 
+_TEST_ENDPOINT_PATH_PREFIX: Final = "/api/test/"
 _TEST_ENDPOINT_BYPASS_HEADER: Final = "x-vm0-test-endpoint-bypass"
-_PLATFORM_FIREWALL_PATH_PREFIXES: Final = (
-    "/api/test/",
-    "/api/internal/vm0-model/v1/",
-)
-_VM0_MODEL_PROXY_PATH_PREFIX: Final = "/api/internal/vm0-model/v1/"
 _UPSTREAM_BINDING_DIAGNOSTICS = "_upstream_binding_diagnostics"
 
 TlsAdmissionKind = Literal[
@@ -109,7 +105,7 @@ def _connected_verified_tls_destination_endpoint(
 
 
 def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
-    if not flow.request.path.startswith("/api/test/"):
+    if not flow.request.path.startswith(_TEST_ENDPOINT_PATH_PREFIX):
         return False
     expected_bypass = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
     if not expected_bypass:
@@ -118,17 +114,7 @@ def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
 
 
 def request_path_uses_platform_firewall(path: str) -> bool:
-    return path.startswith(_PLATFORM_FIREWALL_PATH_PREFIXES)
-
-
-def _request_allows_platform_connector_auth(flow: http.HTTPFlow) -> bool:
-    if flow.request.path.startswith(_VM0_MODEL_PROXY_PATH_PREFIX):
-        return True
-    # Synthetic test providers live on the platform API preview host but
-    # intentionally exercise connector auth injection instead of API auto-allow.
-    # Keep this path limited to test endpoints gated by the same internal
-    # bypass secret that the API route validates.
-    return _request_has_platform_test_endpoint_bypass(flow)
+    return path.startswith(_TEST_ENDPOINT_PATH_PREFIX)
 
 
 def api_destination_matches(api_url: str, hostname: str, port: int) -> bool:
@@ -504,6 +490,10 @@ def ensure_bound_destination(
         return False
 
     api_destination = _api_destination(api_url) if kind == "connector_auth" else None
+    # Synthetic test providers live on the platform API preview host but
+    # intentionally exercise connector auth injection instead of API auto-allow.
+    # Keep this path limited to test endpoints gated by the same internal
+    # bypass secret that the API route validates.
     if (
         api_destination is not None
         and _hostname_port_matches_api_destination(
@@ -511,7 +501,7 @@ def ensure_bound_destination(
             port=destination.port,
             api_destination=api_destination,
         )
-        and not _request_allows_platform_connector_auth(flow)
+        and not _request_has_platform_test_endpoint_bypass(flow)
     ):
         return False
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -14,7 +14,6 @@ from tests.auth_state_helpers import auth_cache_key, has_auth_state
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
-from tests.upstream_connection_helpers import seed_server_binding
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -331,74 +330,6 @@ async def test_vm0_api_test_paths_skip_auto_allow(
     )
     binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
     assert binding.kinds == frozenset(("connector_auth",))
-
-
-async def test_vm0_model_proxy_path_on_vm0_api_host_uses_firewall_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
-):
-    reg_path = _write_registry(
-        tmp_path,
-        client_ip="10.200.0.1",
-        vm_info=_single_firewall_vm(
-            tmp_path,
-            run_id="run-vm0-model",
-            sandbox_marker="tok-vm0-model",
-            firewall_name="model-provider:vm0-model",
-            api_entry={
-                "base": "https://api.vm0.ai/api/internal/vm0-model/v1/responses",
-                "auth": {
-                    "headers": {
-                        "Authorization": "Bearer ${{ secrets.OPENAI_API_KEY }}",
-                        "X-VM0-Upstream-Authorization": (
-                            "Bearer ${{ secrets.VM0_MODEL_UPSTREAM_API_KEY }}"
-                        ),
-                    }
-                },
-                "permissions": [],
-            },
-            network_policy=None,
-        ),
-    )
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.1",
-        host="api.vm0.ai",
-        method="POST",
-        path="/api/internal/vm0-model/v1/responses",
-    )
-    seed_server_binding(
-        flow.server_conn,
-        client=flow.client_conn,
-        host="api.vm0.ai",
-        port=443,
-        kinds=frozenset(("api_allow",)),
-        original_address=("api.vm0.ai", 443),
-    )
-
-    with (
-        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        fake_firewall_headers(
-            headers={
-                "Authorization": "Bearer resolved-proxy-token",
-                "X-VM0-Upstream-Authorization": "Bearer resolved-upstream-token",
-            }
-        ) as auth_fetch,
-    ):
-        mitm_addon.requestheaders(flow)
-        await mitm_addon.request(flow)
-
-    auth_fetch.assert_awaited_once()
-    assert flow.response is None
-    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "model-provider:vm0-model"
-    assert (
-        flow.metadata[metadata_keys.FIREWALL_BASE]
-        == "https://api.vm0.ai/api/internal/vm0-model/v1/responses"
-    )
-    assert flow.request.headers["Authorization"] == "Bearer resolved-proxy-token"
-    assert flow.request.headers["X-VM0-Upstream-Authorization"] == "Bearer resolved-upstream-token"
-    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
-    assert binding.kinds == frozenset(("api_allow", "connector_auth"))
 
 
 async def test_vm0_api_non_test_paths_auto_allow_before_firewall_auth(

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -375,49 +375,25 @@ def test_server_connect_does_not_bind_connected_connector_from_sni_only(tmp_path
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_server_connect_does_not_bind_api_authority_from_shared_cdn_ip(
+async def test_server_connect_waits_for_tls_before_binding_connector_on_shared_ip(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
     shared_address = ("198.18.20.34", 443)
-    model_base = "https://www.vm0.ai/api/internal/vm0-model/v1/responses"
-    reg_path = _write_registry(
-        tmp_path,
-        vm_info=_single_firewall_vm(
-            tmp_path,
-            firewall_name="model-provider:vm0-model",
-            api_entry={
-                "base": model_base,
-                "auth": {
-                    "headers": {
-                        "Authorization": "Bearer ${{ secrets.OPENAI_API_KEY }}",
-                        "X-VM0-Upstream-Authorization": (
-                            "Bearer ${{ secrets.VM0_MODEL_UPSTREAM_API_KEY }}"
-                        ),
-                    }
-                },
-                "permissions": [],
-            },
-            network_policy=None,
-        ),
-    )
+    reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host=shared_address[0],
         sni="",
-        method="POST",
-        path="/api/internal/vm0-model/v1/responses",
-        request_headers=headers(("Host", "www.vm0.ai")),
+        path="/repos/vm0-ai/vm0",
+        request_headers=headers(("Host", "api.github.com")),
     )
     data = _ServerConnectData(client=flow.client_conn, server=flow.server_conn)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(
-            headers={
-                "Authorization": "Bearer resolved-proxy-token",
-                "X-VM0-Upstream-Authorization": "Bearer resolved-upstream-token",
-            }
+            headers={"Authorization": "Bearer resolved-github-token"}
         ) as auth_fetch,
     ):
         mitm_addon.server_connect(data)
@@ -425,10 +401,10 @@ async def test_server_connect_does_not_bind_api_authority_from_shared_cdn_ip(
         assert flow.server_conn.address == shared_address
         assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
-        flow.client_conn.sni = "www.vm0.ai"
+        flow.client_conn.sni = "api.github.com"
         mark_connected_tls_upstream(
             flow,
-            sni="www.vm0.ai",
+            sni="api.github.com",
             server_address=shared_address,
             peername=shared_address,
         )
@@ -439,12 +415,11 @@ async def test_server_connect_does_not_bind_api_authority_from_shared_cdn_ip(
     assert flow.response is None
     assert flow.server_conn.address == shared_address
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "model-provider:vm0-model"
-    assert flow.metadata[metadata_keys.FIREWALL_BASE] == model_base
-    assert flow.request.headers["Authorization"] == "Bearer resolved-proxy-token"
-    assert flow.request.headers["X-VM0-Upstream-Authorization"] == "Bearer resolved-upstream-token"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.request.headers["Authorization"] == "Bearer resolved-github-token"
     binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
-    assert binding.host == "www.vm0.ai"
+    assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == shared_address
 

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -6,16 +6,9 @@
 	}
 }
 
-# Public dev tunnel ingress. Retain the legacy Auto route temporarily for runs
-# claimed by pre-retirement API deployments.
+# Public dev tunnel ingress.
 :3043 {
-	handle /api/internal/vm0-model/v1/* {
-		reverse_proxy localhost:3042
-	}
-
-	handle {
-		reverse_proxy localhost:3001
-	}
+	reverse_proxy localhost:3001
 }
 
 # Main domain redirect to www

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -27,8 +27,8 @@ Marketing      App            API
 Cloudflare www tunnel
   ↓
 Caddy tunnel ingress (HTTP: 3043)
-  ├─ legacy Auto route → Marketing (port 3042)
-  └─ all other paths                       → API (port 3001)
+  ↓
+API (port 3001)
 ```
 
 ## Quick Start
@@ -91,8 +91,7 @@ The `Caddyfile` defines:
 | api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)   |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443 |
 
-The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043. Caddy temporarily preserves the retired Auto proxy path for old API
-claims and uses the API as the fallback for every other path.
+The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043, which proxies every request to the API.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary

- remove the retired Auto route from platform-firewall classification and connector-auth admission
- send all local tunnel ingress traffic to the API and update the proxy documentation
- delete the retired request regression while preserving the shared-IP/TLS binding regression with a supported GitHub connector fixture

## Compatibility

- no API, queue, runner protocol, schema, migration, or persisted-data changes
- retains the secret-gated `/api/test/` firewall path and every supported provider path
- leaves the separately tracked signed-pricing cleanup in #23737 unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_passthrough.py tests/test_server_connect_hook.py` — 63 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 4446 passed
- `caddy fmt --diff turbo/packages/proxy/Caddyfile`
- `caddy validate --config turbo/packages/proxy/Caddyfile --adapter caddyfile --envfile scripts/.env.local`
- `cd turbo && pnpm exec prettier --check packages/proxy/README.md`
- `lefthook run pre-commit`

Closes #23738
