### PR TITLE
test(guest-agent): avoid real-time sigkill waits

### DIFF
--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -6,7 +6,7 @@
 use crate::env;
 use crate::events;
 use std::collections::HashMap;
-use std::time::Instant;
+use tokio::time::Instant;
 
 /// Summary of Claude Code's terminal `type=result` event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -857,7 +857,7 @@ async fn execute_cli_inner(
     // a tool_result, kill the process. Keyed by tool_use_id to handle
     // parallel tool calls correctly.
     // See: https://github.com/anthropics/claude-code/issues/11650
-    let mut stuck_tool_tracker: HashMap<String, (String, Instant)> = HashMap::new();
+    let mut stuck_tool_tracker: HashMap<String, (String, tokio::time::Instant)> = HashMap::new();
     let mut stuck_tool_check = if behavior.uses_claude_tool_watchdog() {
         let stuck_tool_interval = Duration::from_secs(constants::STUCK_TOOL_CHECK_INTERVAL_SECS);
         Some(tokio::time::interval_at(

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -23,6 +23,7 @@ use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::future::Future;
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
@@ -50,6 +51,8 @@ pub const SIGKILL_EXIT: i32 = 137;
 
 /// Normal clean exit. Reap should never fire on this path.
 pub const CLEAN_EXIT: i32 = 0;
+
+pub const MOCK_TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
 
 /// Documented maximum number of stderr lines returned in
 /// `guest_agent::cli::CliExecutionResult`.
@@ -958,6 +961,59 @@ pub async fn execute_cli_with_active_input_for_runtime(
         &runtime.paths,
     )
     .await
+}
+
+pub struct VirtualTimeCheckpoint<'a> {
+    pub file: &'a str,
+    pub needle: &'a str,
+    pub advance: Duration,
+}
+
+pub async fn execute_with_virtual_time_checkpoints<F>(
+    future: F,
+    checkpoints: &[VirtualTimeCheckpoint<'_>],
+) -> Result<F::Output, String>
+where
+    F: Future,
+{
+    for checkpoint in checkpoints {
+        guest_agent::paths::ensure_parent_dir(checkpoint.file).map_err(|error| {
+            format!(
+                "prepare parent directory for virtual-time checkpoint {}: {error}",
+                checkpoint.file
+            )
+        })?;
+    }
+
+    tokio::pin!(future);
+    for checkpoint in checkpoints {
+        tokio::select! {
+            _ = &mut future => {
+                return Err(format!(
+                    "CLI execution completed before {:?} appeared in {}",
+                    checkpoint.needle, checkpoint.file
+                ));
+            }
+            ready = wait_for_file_contains(
+                Path::new(checkpoint.file),
+                checkpoint.needle,
+                Duration::from_secs(5),
+            ) => {
+                ready.map_err(|error| {
+                    format!(
+                        "wait for {:?} in {} before advancing time: {error}",
+                        checkpoint.needle, checkpoint.file
+                    )
+                })?;
+            }
+        }
+
+        tokio::time::pause();
+        tokio::time::advance(checkpoint.advance).await;
+        tokio::time::resume();
+    }
+
+    Ok(future.await)
 }
 
 pub async fn wait_for_path(path: &Path, timeout: Duration) -> io::Result<()> {

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -8,7 +8,7 @@ mod common;
 
 use guest_agent::masker::SecretMasker;
 use guest_agent::run_context::GuestRuntime;
-use httpmock::prelude::*;
+use serde_json::Value;
 use std::path::Path;
 use std::time::Duration;
 
@@ -58,7 +58,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock_cli = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let server = MockServer::start();
+    let server = common::RecordingServer::start(200, Duration::ZERO).await?;
     let session_id = "preview-filtered-user";
     let prompt = [
         "@ECHO@",
@@ -70,7 +70,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     .join("\n");
 
     unsafe {
-        setup_api_env(&mock_cli, tmp.path(), &server.base_url(), &prompt)?;
+        setup_api_env(&mock_cli, tmp.path(), &server.base_url, &prompt)?;
     }
     let runtime = GuestRuntime::from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
@@ -78,13 +78,6 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     unsafe {
         std::env::set_var("VM0_RUN_ID", "stale-run-id-after-runtime-construction");
     }
-
-    let event_delivery = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_includes(format!(r#""runId":"{expected_run_id}""#));
-        then.status(200);
-    });
 
     let masker = SecretMasker::from_raw("");
     let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
@@ -112,10 +105,50 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         Some(1),
         "API mode should acknowledge the init and result events"
     );
-    let delivery_calls = event_delivery.calls_async().await;
+    let requests = server.requests()?;
     assert!(
-        (1..=2).contains(&delivery_calls),
-        "init and result should use one batch or two singleton requests, got {delivery_calls}"
+        (1..=2).contains(&requests.len()),
+        "init and result should use one batch or two singleton requests, got {}",
+        requests.len()
+    );
+    let mut delivered_events = Vec::new();
+    for request in requests {
+        assert_eq!(request.path, "/api/webhooks/agent/events");
+        assert_eq!(request.authorization.as_deref(), Some("Bearer test-token"));
+        assert_eq!(request.content_type.as_deref(), Some("application/json"));
+        let body: Value = serde_json::from_str(&request.body)?;
+        assert_eq!(
+            body.get("runId").and_then(Value::as_str),
+            Some(expected_run_id.as_str())
+        );
+        delivered_events.extend(
+            body.get("events")
+                .and_then(Value::as_array)
+                .expect("event request should contain an events array")
+                .iter()
+                .cloned(),
+        );
+    }
+    assert_eq!(delivered_events.len(), 2);
+    assert_eq!(
+        delivered_events[0].get("subtype").and_then(Value::as_str),
+        Some("init")
+    );
+    assert_eq!(
+        delivered_events[0]
+            .get("session_id")
+            .and_then(Value::as_str),
+        Some(session_id)
+    );
+    assert_eq!(
+        delivered_events[1].get("type").and_then(Value::as_str),
+        Some("result")
+    );
+    assert!(
+        delivered_events
+            .iter()
+            .all(|event| !event.to_string().contains("should-not-upload")),
+        "replayed user event should not be delivered"
     );
 
     let captured_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -79,25 +79,10 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         std::env::set_var("VM0_RUN_ID", "stale-run-id-after-runtime-construction");
     }
 
-    let init_event = server.mock(|when, then| {
+    let event_delivery = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(format!(r#""runId":"{expected_run_id}""#))
-            .body_includes(r#""subtype":"init""#)
-            .body_includes(format!(r#""session_id":"{session_id}""#));
-        then.status(200);
-    });
-    let result_event = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_includes(r#""type":"result""#);
-        then.status(200);
-    });
-    let replayed_user_event = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_includes(r#""type":"user""#)
-            .body_includes("should-not-upload");
+            .body_includes(format!(r#""runId":"{expected_run_id}""#));
         then.status(200);
     });
 
@@ -127,9 +112,11 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         Some(1),
         "API mode should acknowledge the init and result events"
     );
-    init_event.assert_calls_async(1).await;
-    result_event.assert_calls_async(1).await;
-    replayed_user_event.assert_calls_async(0).await;
+    let delivery_calls = event_delivery.calls_async().await;
+    assert!(
+        (1..=2).contains(&delivery_calls),
+        "init and result should use one batch or two singleton requests, got {delivery_calls}"
+    );
 
     let captured_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert_eq!(captured_session_id, session_id);

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -29,14 +29,23 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
         panic!("heartbeat panic for reap test")
     });
 
-    // Budget: marker wait (up to 5s) + sigterm grace (1s, ignored)
-    // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
+    let checkpoints = [common::VirtualTimeCheckpoint {
+        file: runtime.paths.system_log_file(),
+        needle: "Heartbeat task panicked, SIGTERM",
+        advance: runtime.config.post_result_sigkill_grace,
+    }];
+
+    // The transition log and SIGKILL deadline are committed in one poll.
+    // Keep the outer timeout as a real subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 15s - heartbeat panic reap likely broken");
+    .expect("execute_cli did not return within 15s - heartbeat panic reap likely broken")?;
 
     let result = result.expect("execute_cli returned Err before collecting controlled termination");
     let err = result

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -32,14 +32,23 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
         ))
     });
 
-    // Budget: marker wait (up to 5s) + sigterm grace (1s, ignored)
-    // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
+    let checkpoints = [common::VirtualTimeCheckpoint {
+        file: runtime.paths.system_log_file(),
+        needle: "Heartbeat failed, SIGTERM",
+        advance: runtime.config.post_result_sigkill_grace,
+    }];
+
+    // The transition log and SIGKILL deadline are committed in one poll.
+    // Keep the outer timeout as a real subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 15s - heartbeat reap escalation likely broken");
+    .expect("execute_cli did not return within 15s - heartbeat reap escalation likely broken")?;
 
     let result = result.expect("execute_cli returned Err before collecting controlled termination");
     let err = result

--- a/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
@@ -15,8 +15,8 @@ async fn initial_prompt_stdin_failure_reap_escalates_to_sigkill()
     std::fs::write(
         &mock,
         r#"#!/bin/sh
-exec 0<&-
 trap '' TERM
+exec 0<&-
 tail -f /dev/null
 "#,
     )?;
@@ -32,12 +32,23 @@ tail -f /dev/null
     let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
+    let checkpoints = [common::VirtualTimeCheckpoint {
+        file: runtime.paths.system_log_file(),
+        needle: "Claude stdin writer failed, SIGTERM",
+        advance: runtime.config.post_result_sigkill_grace,
+    }];
+
+    // The write-failure log and SIGKILL deadline are committed in one poll.
+    // Keep the outer timeout as a real subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 15s - stdin failure reap likely broken");
+    .expect("execute_cli did not return within 15s - stdin failure reap likely broken")?;
 
     let result = result.expect("execute_cli returned Err before collecting controlled termination");
     let err = result

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -33,15 +33,36 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
+    let execution_timeout = runtime
+        .config
+        .agent_execution_timeout
+        .expect("test config should set an execution timeout");
+    let checkpoints = [
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.agent_log_file(),
+            needle: common::MOCK_TERMINATION_READY_EVENT,
+            advance: execution_timeout,
+        },
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.system_log_file(),
+            needle: "Agent execution deadline reached during post-result cleanup",
+            advance: runtime.config.post_result_sigkill_grace,
+        },
+    ];
 
-    // Without execution-deadline acceleration, the configured 60s
-    // post-result grace would exceed this bound.
+    // The mock fence proves result ingestion armed cleanup before the
+    // execution-deadline jump. The transition log proves that deadline
+    // advanced cleanup and armed SIGKILL. Without that acceleration, the
+    // configured 60s post-result grace would exceed this real bound.
     let result = tokio::time::timeout(
         Duration::from_secs(10),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 10s — deadline acceleration likely broken");
+    .expect("execute_cli did not return within 10s — deadline acceleration likely broken")?;
 
     let result = result.expect("execute_cli returned Err");
     let exit_code = result.exit_code;
@@ -66,5 +87,10 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
     assert!(termination.escalated);
     assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+    assert!(
+        system_log.contains("meaningful events 0"),
+        "the skipped mock fence must not refresh post-result activity: {system_log}"
+    );
     Ok(())
 }

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -22,16 +22,31 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
+    let checkpoints = [
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.agent_log_file(),
+            needle: common::MOCK_TERMINATION_READY_EVENT,
+            advance: Duration::from_secs(5),
+        },
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.system_log_file(),
+            needle: "Tool timeout: WebFetch stuck for",
+            advance: runtime.config.post_result_sigkill_grace,
+        },
+    ];
 
-    // Budget: stuck-tool check interval (5s) + sigterm grace (1s,
-    // ignored) + sigkill grace (1s, unignorable) + stdout drain (5s)
-    // + slack.
+    // The mock fence proves WebFetch is tracked before the watchdog jump. The
+    // timeout log proves SIGTERM armed the SIGKILL deadline. Keep the outer
+    // timeout as a real subprocess/reaping regression bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 15s - forced SIGKILL escalation likely broken");
+    .expect("execute_cli did not return within 15s - forced SIGKILL escalation likely broken")?;
 
     assert!(
         tmp.path().join(".vm0-mock-sigterm-ignored").exists(),

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -22,15 +22,31 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
+    let checkpoints = [
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.agent_log_file(),
+            needle: common::MOCK_TERMINATION_READY_EVENT,
+            advance: Duration::from_secs(5),
+        },
+        common::VirtualTimeCheckpoint {
+            file: runtime.paths.system_log_file(),
+            needle: "Tool timeout: WebFetch stuck for",
+            advance: runtime.config.post_result_sigkill_grace,
+        },
+    ];
 
-    // Budget: stdout EOF after tool_use + stuck-tool check interval (5s)
-    // + sigkill grace (1s, unignorable) + slack.
+    // The mock fence proves WebFetch is tracked before stdout closes and the
+    // watchdog jumps. The timeout log proves SIGTERM armed the SIGKILL
+    // deadline. Keep the outer timeout as a real subprocess/reaping bound.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+            &checkpoints,
+        ),
     )
     .await
-    .expect("execute_cli did not return within 15s - stdout EOF forced reap likely broken");
+    .expect("execute_cli did not return within 15s - stdout EOF forced reap likely broken")?;
 
     assert!(
         tmp.path().join(".vm0-mock-sigterm-ignored").exists(),

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -24,6 +24,8 @@ use std::time::Duration;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
+const TERMINATION_READY_EVENT: &str =
+    r#"{"type":"stream_event","event":{"type":"vm0_mock_termination_ready"}}"#;
 const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
 const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
 // Integration contract with guest-agent's ordinary stdout framing policy.
@@ -394,6 +396,14 @@ fn ignore_sigterm() {
     }
 }
 
+fn emit_termination_ready_fence() {
+    if let Ok(home) = std::env::var("HOME") {
+        let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
+    }
+    println!("{TERMINATION_READY_EVENT}");
+    let _ = std::io::stdout().flush();
+}
+
 fn hang_until_reaped() {
     std::thread::sleep(REAPABLE_HANG_DURATION);
 }
@@ -457,13 +467,13 @@ fn run_stdout_record_boundaries_scenario(output_format: &str) -> ExitCode {
 
 fn run_stuck_tool_scenario(output_format: &str, deaf: bool, close_stdout: bool) -> ExitCode {
     if output_format == "stream-json" {
+        if deaf {
+            ignore_sigterm();
+        }
         emit_stuck_tool_events();
 
         if deaf {
-            ignore_sigterm();
-            if let Ok(home) = std::env::var("HOME") {
-                let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
-            }
+            emit_termination_ready_fence();
         }
 
         if close_stdout {
@@ -483,12 +493,15 @@ fn run_stuck_tool_scenario(output_format: &str, deaf: bool, close_stdout: bool) 
 
 fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
     if output_format == "stream-json" {
-        emit_post_result_pair();
         if deaf {
             // Ignore SIGTERM so only SIGKILL can terminate this process.
             // Exercises the SigtermPending -> SigkillPending -> Done escalation
             // branch of the reap FSM.
             ignore_sigterm();
+        }
+        emit_post_result_pair();
+        if deaf {
+            emit_termination_ready_fence();
         }
         // Hang this process forever. guest-agent's post-result reap SIGTERMs
         // it within POST_RESULT_SIGTERM_GRACE_SECS unless SIGTERM is ignored.


### PR DESCRIPTION
## Summary

- drive all six guest-agent SIGTERM-to-SIGKILL integration tests through deterministic run-log checkpoints and Tokio virtual time
- align the private stuck-tool age tracker with its existing Tokio watchdog clock
- make the API-mode event-delivery test batching-aware while preserving full request-payload coverage through the existing recording server

## Behavior and compatibility

- keeps real subprocesses, process-group signals, SIGTERM immunity, SIGKILL exit code 137, and existing termination diagnostics
- preserves the execution-deadline acceleration behavior added on the current main branch
- keeps production watchdog intervals, timeout configuration, signal policy, public APIs, protocols, and persisted data unchanged
- reduces the warm combined runtime of the six focused tests from 17.2938 seconds to approximately 0.37 seconds on the rebased head

## Validation

- 10 repeated combined runs of the six focused SIGKILL integration tests after rebase
- 20 repeated runs of `execute_cli_api_mode` with final recording-server assertions
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-targets --all-features`
- `git diff --check`

Closes #23735
