### PR TITLE
refactor(api): replace raw scalar subquery

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -200,6 +200,7 @@ async function startChatRun(
     readonly attachFiles?: readonly AttachFile[];
     readonly generationTemplate?: GenerationTemplateRequest;
     readonly userMessage?: UserMessageDocument;
+    readonly revokesEventId?: string;
   },
 ): Promise<{
   readonly runId: string;
@@ -221,6 +222,9 @@ async function startChatRun(
     ...(body.userMessage === undefined
       ? {}
       : { userMessage: body.userMessage }),
+    ...(body.revokesEventId === undefined
+      ? {}
+      : { revokesEventId: body.revokesEventId }),
     ...(body.selectedModel === undefined
       ? body.threadId === undefined
         ? { model: "claude-sonnet-4-6" }
@@ -2985,6 +2989,117 @@ describe("CHAT-02: auto-send after failures", () => {
 
     await api.requestCancelRun(actor, promoted.runId, [200]);
     await waitForRunStatus(actor, promoted.runId, "cancelled");
+  }, 90_000);
+
+  it("uses the latest unrevoked successful event as the incomplete-round boundary", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const followupGate = deferredGate();
+    let followupRequests = 0;
+
+    const anchor = await startChatRun(actor, {
+      agentId,
+      prompt: "successful boundary anchor",
+    });
+    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions(async (body) => {
+      const systemContent = body.messages[0]?.content ?? "";
+      if (systemContent.includes("concise follow-up prompts")) {
+        followupRequests += 1;
+        await followupGate.wait();
+        return JSON.stringify([
+          { prompt: "Inspect the failed round", kind: "talk" },
+        ]);
+      }
+      if (systemContent.includes("Generate a short, descriptive title")) {
+        return "Revoked Boundary";
+      }
+      return "Boundary summary";
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "successful boundary answer"),
+    ]);
+    await completeChatRunOk(anchor.runId, anchorHeaders, {
+      lastEventSequence: 0,
+    });
+    await waitForThreadMessages(actor, anchor.threadId, (messages) => {
+      return lifecycleMarkers(messages, anchor.runId, "completed").length > 0;
+    });
+    await expect
+      .poll(() => {
+        return followupRequests;
+      })
+      .toBe(1);
+
+    const firstFailedPrompt = "failed before the late successful follow-up";
+    const firstFailed = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: firstFailedPrompt,
+    });
+    const firstFailedHeaders = await claimChatRun(
+      runnerGroup,
+      firstFailed.runId,
+    );
+    await failChatRun(
+      firstFailed.runId,
+      firstFailedHeaders,
+      "first boundary failure",
+    );
+    await waitForThreadMessages(actor, anchor.threadId, (messages) => {
+      return lifecycleMarkers(messages, firstFailed.runId, "failed").length > 0;
+    });
+
+    followupGate.release();
+    const afterFollowup = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (messages) => {
+        return recommendedFollowupMessages(messages, anchor.runId).length > 0;
+      },
+    );
+    const lateFollowup = recommendedFollowupMessages(
+      afterFollowup.events,
+      anchor.runId,
+    )[0];
+    if (!lateFollowup) {
+      throw new Error("Expected the delayed recommended follow-up event");
+    }
+    await flushWaitUntilForTest();
+
+    const revokingFailure = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "revoke the late successful follow-up",
+      revokesEventId: lateFollowup.id,
+    });
+    const revokingFailureHeaders = await claimChatRun(
+      runnerGroup,
+      revokingFailure.runId,
+    );
+    await failChatRun(
+      revokingFailure.runId,
+      revokingFailureHeaders,
+      "revoking boundary failure",
+    );
+    await waitForThreadMessages(actor, anchor.threadId, (messages) => {
+      return (
+        lifecycleMarkers(messages, revokingFailure.runId, "failed").length > 0
+      );
+    });
+
+    const probe = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "probe the revoked boundary",
+    });
+    const probeContext = await waitForRunContext(actor, probe.runId);
+    expect(probeContext.body.appendSystemPrompt).toContain(firstFailedPrompt);
+
+    await api.requestCancelRun(actor, probe.runId, [200]);
+    await waitForRunStatus(actor, probe.runId, "cancelled");
   }, 90_000);
 
   it("auto-sends the queued message after a failure, carrying attachments, incomplete-round context, and the continued session", async () => {

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -14,10 +14,13 @@ import {
   gt,
   inArray,
   isNotNull,
+  max,
   not,
+  notExists,
   or,
   sql,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -31,6 +34,14 @@ import {
 
 const INCOMPLETE_ROUND_LIMIT = 20;
 const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+const successfulRunBoundaryEvent = alias(
+  chatMessages,
+  "successful_run_boundary_event",
+);
+const successfulRunBoundaryRevoker = alias(
+  chatMessages,
+  "successful_run_boundary_revoker",
+);
 
 type IncompleteRunStatus = "cancelled" | "failed" | "timeout";
 
@@ -163,24 +174,32 @@ async function selectIncompleteRoundFrontier(
   return { rounds: rounds.reverse(), successfulRunId };
 }
 
-function afterSuccessfulRunBoundary(threadId: string, successfulRunId: string) {
-  return gt(
-    chatMessages.seqId,
-    sql`COALESCE(
-      (
-        SELECT MAX(boundary_message.seq_id)
-        FROM chat_events boundary_message
-        WHERE boundary_message.chat_thread_id = ${threadId}
-          AND boundary_message.run_id = ${successfulRunId}
-          AND NOT EXISTS (
-            SELECT 1
-            FROM chat_events boundary_revoker
-            WHERE boundary_revoker.revokes_message_id = boundary_message.id
-          )
+function afterSuccessfulRunBoundary(
+  db: Pick<Db, "select">,
+  threadId: string,
+  successfulRunId: string,
+) {
+  const boundary = db
+    .select({ seqId: max(successfulRunBoundaryEvent.seqId) })
+    .from(successfulRunBoundaryEvent)
+    .where(
+      and(
+        eq(successfulRunBoundaryEvent.chatThreadId, threadId),
+        eq(successfulRunBoundaryEvent.runId, successfulRunId),
+        notExists(
+          db
+            .select({ id: successfulRunBoundaryRevoker.id })
+            .from(successfulRunBoundaryRevoker)
+            .where(
+              eq(
+                successfulRunBoundaryRevoker.revokesEventId,
+                successfulRunBoundaryEvent.id,
+              ),
+            ),
+        ),
       ),
-      0::bigint
-    )`,
-  );
+    );
+  return gt(chatMessages.seqId, sql`COALESCE(${boundary}, 0::bigint)`);
 }
 
 async function loadSelectedIncompleteRounds(
@@ -215,7 +234,13 @@ async function loadSelectedIncompleteRounds(
         visibleChatEventCondition(db),
         ...(selection.successfulRunId === null
           ? []
-          : [afterSuccessfulRunBoundary(threadId, selection.successfulRunId)]),
+          : [
+              afterSuccessfulRunBoundary(
+                db,
+                threadId,
+                selection.successfulRunId,
+              ),
+            ]),
       ),
     )
     .orderBy(asc(chatMessages.seqId));

--- a/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/drizzle-query-builder-cases.ts
@@ -2259,6 +2259,21 @@ const queryBuilderCases = {
         await db.execute(query);
       `,
     },
+    {
+      code: `${structuredSelectionPreamble}
+        import { eq, max, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryMessage = alias(messages, "boundary_message");
+        const boundary = db
+          .select({ id: max(boundaryMessage.id) })
+          .from(boundaryMessage)
+          .where(eq(boundaryMessage.userId, users.id));
+        db
+          .select()
+          .from(users)
+          .where(sql\`\${users.id} > COALESCE(\${boundary}, 0)\`);
+      `,
+    },
   ],
   readInvalid: [
     {
@@ -3513,6 +3528,23 @@ const queryBuilderCases = {
         { messageId: "structuredScalarQuery" },
         { messageId: "structuredScalarQuery" },
       ],
+    },
+    {
+      code: `${structuredSelectionPreamble}
+        import { eq, max, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryMessage = alias(messages, "boundary_message");
+        const boundary = sql\`COALESCE((
+          SELECT \${max(boundaryMessage.id)}
+          FROM \${boundaryMessage}
+          WHERE \${eq(boundaryMessage.userId, users.id)}
+        ), 0)\`;
+        db
+          .select()
+          .from(users)
+          .where(sql\`boundary_matches(\${boundary})\`);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
     },
   ],
 } satisfies {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -663,6 +663,112 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select({ name: sql\`\${lookalike}\` }).from(users);
       `,
     },
+    {
+      name: "scalar select builders inside retained predicates remain valid",
+      code: `${drizzlePreamble}
+        import { and, eq, max, notExists, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        const boundaryRevoker = alias(users, "boundary_revoker");
+        const boundary = db
+          .select({ id: max(boundaryEvent.id) })
+          .from(boundaryEvent)
+          .where(
+            and(
+              eq(boundaryEvent.name, users.name),
+              notExists(
+                db
+                  .select({ id: boundaryRevoker.id })
+                  .from(boundaryRevoker)
+                  .where(eq(boundaryRevoker.id, boundaryEvent.id)),
+              ),
+            ),
+          );
+        db
+          .select()
+          .from(users)
+          .where(sql\`\${users.id} > COALESCE(\${boundary}, 0)\`);
+      `,
+    },
+    {
+      name: "unproven scalar relations and unsupported clauses remain valid",
+      code: `${drizzlePreamble}
+        import { asc, eq, max, sql, type SQL } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        declare const unresolvedRelation: SQL;
+        const literalRelation = sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM users AS boundary_event
+          WHERE \${eq(boundaryEvent.name, users.name)}
+        ), 0)\`;
+        const unresolved = sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM \${unresolvedRelation}
+          WHERE \${eq(boundaryEvent.name, users.name)}
+        ), 0)\`;
+        const ordered = sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM \${boundaryEvent}
+          WHERE \${eq(boundaryEvent.name, users.name)}
+          ORDER BY \${asc(boundaryEvent.id)}
+        ), 0)\`;
+        db
+          .select()
+          .from(users)
+          .where(
+            sql\`boundary_matches(
+              \${literalRelation},
+              \${unresolved},
+              \${ordered}
+            )\`,
+          );
+      `,
+    },
+    {
+      name: "predicate scalar capability stays out of other SQL contexts",
+      code: `${drizzlePreamble}
+        import { eq, max, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        const scalar = sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM \${boundaryEvent}
+          WHERE \${eq(boundaryEvent.name, users.name)}
+        ), 0)\`;
+        db.select({ value: scalar }).from(users);
+        db.select().from(users).orderBy(scalar);
+        db.update(users).set({ id: scalar });
+      `,
+    },
+    {
+      name: "scalar branch disagreement and opaque flow stay conservative",
+      code: `${drizzlePreamble}
+        import { eq, max, sql, type SQL } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        declare const chooseScalar: boolean;
+        function opaque(value: SQL): SQL {
+          return value;
+        }
+        const conditional = chooseScalar
+          ? sql\`COALESCE((
+              SELECT \${max(boundaryEvent.id)}
+              FROM \${boundaryEvent}
+              WHERE \${eq(boundaryEvent.name, users.name)}
+            ), 0)\`
+          : sql\`COALESCE(\${users.id}, 0)\`;
+        const hidden = opaque(sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM \${boundaryEvent}
+          WHERE \${eq(boundaryEvent.name, users.name)}
+        ), 0)\`);
+        db
+          .select()
+          .from(users)
+          .where(sql\`boundary_matches(\${conditional}, \${hidden})\`);
+      `,
+    },
   ],
   invalid: [
     {
@@ -2712,6 +2818,82 @@ ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
         )\`;
       `,
       errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      name: "schema-backed scalar subquery is the maximal predicate finding",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        const boundaryRevoker = alias(users, "boundary_revoker");
+        db
+          .select()
+          .from(users)
+          .where(sql\`boundary_matches(COALESCE(
+            (
+              SELECT MAX(\${boundaryEvent.id})
+              FROM \${boundaryEvent}
+              WHERE \${boundaryEvent.name} = \${users.name}
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM \${boundaryRevoker}
+                  WHERE \${boundaryRevoker.id} = \${boundaryEvent.id}
+                )
+            ),
+            0
+          ))\`);
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
+      name: "independent scalar subqueries retain independent findings",
+      code: `${drizzlePreamble}
+        import { eq, max, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const firstBoundary = alias(users, "first_boundary");
+        const secondBoundary = alias(users, "second_boundary");
+        db
+          .select()
+          .from(users)
+          .where(sql\`
+            COALESCE((
+              SELECT \${max(firstBoundary.id)}
+              FROM \${firstBoundary}
+              WHERE \${eq(firstBoundary.name, users.name)}
+            ), 0)
+            >
+            COALESCE((
+              SELECT \${max(secondBoundary.id)}
+              FROM \${secondBoundary}
+              WHERE \${eq(secondBoundary.name, users.name)}
+            ), 0)
+          \`);
+      `,
+      errors: [
+        { messageId: "structuredScalarQuery" },
+        { messageId: "structuredScalarQuery" },
+      ],
+    },
+    {
+      name: "unsupported scalar shape still exposes supported descendants",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        db
+          .select()
+          .from(users)
+          .where(sql\`boundary_matches(COALESCE((
+            SELECT MAX(\${boundaryEvent.id})
+            FROM \${boundaryEvent}
+            WHERE \${boundaryEvent.name} = \${users.name}
+            GROUP BY \${boundaryEvent.name}
+          ), 0))\`);
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "max" } },
+        { messageId: "typedApi", data: { helper: "eq" } },
+      ],
     },
     {
       name: "nested hand-built existence leaves remain source-local",

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -2875,6 +2875,27 @@ ruleTester.run("prefer-drizzle-apis source-local analysis", preferDrizzleApis, {
       ],
     },
     {
+      name: "scalar query remains maximal in an optional predicate argument",
+      code: `${drizzlePreamble}
+        import { and, eq, max, sql } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const boundaryEvent = alias(users, "boundary_event");
+        const boundary = sql\`COALESCE((
+          SELECT \${max(boundaryEvent.id)}
+          FROM \${boundaryEvent}
+          WHERE \${and(
+            eq(boundaryEvent.name, users.name),
+            eq(boundaryEvent.id, users.id),
+          )}
+        ), 0)\`;
+        db
+          .select()
+          .from(users)
+          .where(and(sql\`boundary_matches(\${boundary})\`, eq(users.id, 1)));
+      `,
+      errors: [{ messageId: "structuredScalarQuery" }],
+    },
+    {
       name: "unsupported scalar shape still exposes supported descendants",
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -152,7 +152,7 @@ export const preferDrizzleApis = createRule({
       scalarCteQueryBuilder:
         "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
       structuredScalarQuery:
-        "Use a Drizzle query builder or joined relation instead of a complete raw scalar query in a structured result field.",
+        "Use a Drizzle select builder for this complete raw scalar query.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
       unnestUpdateQueryBuilder:
         "Use Drizzle update(...).set(...).from(...).where(...) for this complete unnest-backed update query.",
@@ -171,6 +171,8 @@ export const preferDrizzleApis = createRule({
       services,
     );
     const sourceLocalCandidates: TSESTree.TaggedTemplateExpression[] = [];
+    const deferredSourceLocalCandidates: TSESTree.TaggedTemplateExpression[] =
+      [];
     const structuralCallInspections: Array<() => void> = [];
     const structuredScalarCandidates =
       new Set<TSESTree.TaggedTemplateExpression>();
@@ -181,6 +183,7 @@ export const preferDrizzleApis = createRule({
       TSESTree.Node,
       Set<string>
     >();
+    const coveredSourceFindings = new Set<string>();
     const reportedSourceLocalFindings = new Set<string>();
     const resolvedCallSignatureCache = new WeakMap<
       TSESTree.CallExpression,
@@ -309,11 +312,22 @@ export const preferDrizzleApis = createRule({
       sourceLocal = false,
     ): void {
       for (const finding of findings) {
+        if (finding.kind === "query-builder") {
+          for (const sourceKey of finding.coveredSourceKeys ?? []) {
+            coveredSourceFindings.add(sourceKey);
+          }
+        }
         const sourceKey =
           finding.kind === "helper" || finding.kind === "existence-predicate"
             ? `${finding.kind}:${finding.helper}:${finding.sourceKey}`
-            : undefined;
+            : finding.kind === "query-builder" &&
+                finding.sourceKey !== undefined
+              ? `${finding.kind}:${finding.capability}:${finding.sourceKey}`
+              : undefined;
         if (sourceKey !== undefined) {
+          if (sourceLocal && coveredSourceFindings.has(sourceKey)) {
+            continue;
+          }
           if (sourceLocal) {
             reportedSourceLocalFindings.add(sourceKey);
           } else if (reportedSourceLocalFindings.has(sourceKey)) {
@@ -322,7 +336,7 @@ export const preferDrizzleApis = createRule({
         }
         const key =
           finding.kind === "query-builder"
-            ? finding.kind
+            ? `${finding.kind}:${finding.capability}:${finding.sourceKey ?? ""}`
             : finding.kind === "empty-fragment"
               ? finding.kind
               : `${finding.kind}:${finding.helper}`;
@@ -1834,7 +1848,22 @@ export const preferDrizzleApis = createRule({
           (firstQuasi.value.cooked ?? firstQuasi.value.raw) === "";
         if (!isExactEmpty) {
           if (sqlTagMightContainHelper(node)) {
-            sourceLocalCandidates.push(node);
+            const hasSelect = /\bSELECT\b/iu.test(literalSource);
+            const leadingLiteral =
+              node.quasi.quasis[0]?.value.cooked ??
+              node.quasi.quasis[0]?.value.raw ??
+              "";
+            const isStatement =
+              /^\s*(?:DELETE|INSERT|SELECT|UPDATE|WITH)\b/iu.test(
+                leadingLiteral,
+              );
+            // Conventional scalar fragments are also analyzed at their typed
+            // predicate use site. Defer their local leaves so the complete
+            // query diagnostic can suppress only the descendants it owns.
+            (hasSelect && !isStatement
+              ? deferredSourceLocalCandidates
+              : sourceLocalCandidates
+            ).push(node);
           }
           return;
         }
@@ -1846,25 +1875,32 @@ export const preferDrizzleApis = createRule({
         });
       },
       "Program:exit"(): void {
-        for (const node of sourceLocalCandidates) {
-          if (!isDrizzleSqlTag(checker, services, node.tag)) {
-            continue;
+        function reportSourceLocal(
+          nodes: readonly TSESTree.TaggedTemplateExpression[],
+        ): void {
+          for (const node of nodes) {
+            if (!isDrizzleSqlTag(checker, services, node.tag)) {
+              continue;
+            }
+            reportStructuralFindings(
+              analyzeSqlSource(
+                node,
+                checker,
+                services,
+                sqlSourceComposer,
+                sqlCapabilityChecks,
+              ),
+              true,
+            );
           }
-          reportStructuralFindings(
-            analyzeSqlSource(
-              node,
-              checker,
-              services,
-              sqlSourceComposer,
-              sqlCapabilityChecks,
-            ),
-            true,
-          );
         }
+
+        reportSourceLocal(sourceLocalCandidates);
         for (const inspect of structuralCallInspections) {
           inspect();
         }
         inspectStructuredSelections();
+        reportSourceLocal(deferredSourceLocalCandidates);
       },
     };
   },

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-analysis.ts
@@ -97,8 +97,10 @@ export type SqlAnalysisFinding =
     }
   | {
       readonly capability: QueryCapability;
+      readonly coveredSourceKeys?: readonly string[];
       readonly kind: "query-builder";
       readonly node: TSESTree.Expression;
+      readonly sourceKey?: string;
     };
 
 export interface SqlCapabilityChecks {
@@ -301,6 +303,13 @@ type StructuralExpression = (
       readonly selectMarker: SqlMarker | undefined;
       readonly subselect: unknown;
     }
+  | {
+      readonly children: readonly StructuralExpression[];
+      readonly isBuilderShape: boolean;
+      readonly kind: "scalar-query";
+      readonly predicate: StructuralExpression | undefined;
+      readonly selection: StructuralExpression | undefined;
+    }
 ) & {
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 };
@@ -312,7 +321,7 @@ interface StructuralOrdering {
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 }
 
-type ClassifiedHelperFinding = (
+type ClassifiedLeafFinding = (
   | {
       readonly helper: SqlHelper;
       readonly kind: "helper";
@@ -329,15 +338,28 @@ type ClassifiedHelperFinding = (
   readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
 };
 
+type ClassifiedQueryFinding = {
+  readonly capability: "structured-scalar";
+  readonly isolationContext: "predicate";
+  readonly isPartial: false;
+  readonly kind: "query-builder";
+  readonly node: TSESTree.Expression;
+  readonly sourceChunks: ReadonlySet<SqlSourceChunk>;
+  readonly suppressedFindings: readonly ClassifiedLeafFinding[];
+};
+
+type ClassifiedFinding = ClassifiedLeafFinding | ClassifiedQueryFinding;
+
 interface ExpressionClassification {
   readonly anchor: TSESTree.Node | undefined;
-  readonly findings: readonly ClassifiedHelperFinding[];
+  readonly findings: readonly ClassifiedFinding[];
   readonly isWholeReplacement: boolean;
 }
 
 interface ClassificationContext {
   readonly allowsOptionalSql: boolean;
   readonly allowsRetainedSqlWrapper: boolean;
+  readonly allowsScalarQuery: boolean;
   readonly capabilities: SqlCapabilityChecks;
   readonly checker: TypeChecker;
   readonly ownsResultMapping: boolean;
@@ -660,6 +682,48 @@ function markerIsWrapper(
 ): boolean {
   const tsNode = services.esTreeNodeToTSNodeMap.get(node);
   return isDrizzleWrapperType(checker, checker.getTypeAtLocation(tsNode));
+}
+
+function isOptionalDrizzleWrapperType(
+  type: Type,
+  checker: TypeChecker,
+): boolean {
+  if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
+    return false;
+  }
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return (
+      constraint !== undefined &&
+      isOptionalDrizzleWrapperType(constraint, checker)
+    );
+  }
+  if (!type.isUnion()) {
+    return isDrizzleWrapperType(checker, type);
+  }
+  let hasWrapper = false;
+  for (const member of type.types) {
+    if ((member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0) {
+      continue;
+    }
+    if (!isDrizzleWrapperType(checker, member)) {
+      return false;
+    }
+    hasWrapper = true;
+  }
+  return hasWrapper;
+}
+
+function nodeIsOptionalDrizzleWrapper(
+  node: TSESTree.Expression,
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return isOptionalDrizzleWrapperType(
+    checker.getTypeAtLocation(tsNode),
+    checker,
+  );
 }
 
 function typeMayBeSqlWrapper(type: Type, checker: TypeChecker): boolean {
@@ -1546,6 +1610,61 @@ function structuralExpression(
 
   const sublink = recordProperty(value, "SubLink");
   if (
+    sublink?.subLinkType === "EXPR_SUBLINK" &&
+    sublink.subselect !== undefined
+  ) {
+    const select = recordProperty(sublink.subselect, "SelectStmt");
+    const targets = select === undefined ? undefined : targetValues(select);
+    const selectionValue = targets?.length === 1 ? targets[0] : undefined;
+    const selection =
+      selectionValue === undefined
+        ? undefined
+        : structuralExpression(selectionValue, markers, sourceRanges);
+    const predicate =
+      select?.whereClause === undefined
+        ? undefined
+        : structuralExpression(select.whereClause, markers, sourceRanges);
+    const children = collectStructuralExpressions(
+      sublink.subselect,
+      markers,
+      sourceRanges,
+    );
+    const from = select?.fromClause;
+    return {
+      children,
+      isBuilderShape:
+        hasOnlyKeys(
+          sublink,
+          new Set(["location", "subLinkType", "subselect"]),
+        ) &&
+        select !== undefined &&
+        select.limitOption === "LIMIT_OPTION_DEFAULT" &&
+        select.op === "SETOP_NONE" &&
+        hasOnlyKeys(
+          select,
+          new Set([
+            "fromClause",
+            "limitOption",
+            "op",
+            "targetList",
+            "whereClause",
+          ]),
+        ) &&
+        selection !== undefined &&
+        predicate !== undefined &&
+        Array.isArray(from) &&
+        from.length === 1 &&
+        relationMarker(from[0], markers)?.isTable === true,
+      kind: "scalar-query",
+      predicate,
+      selection,
+      sourceChunks: mergeSourceChunks(
+        ownSourceChunks(value, sourceRanges),
+        children,
+      ),
+    };
+  }
+  if (
     sublink?.subLinkType === "EXISTS_SUBLINK" &&
     sublink.subselect !== undefined
   ) {
@@ -1588,7 +1707,7 @@ function deduplicateFindings<T extends SqlAnalysisFinding>(
   for (const finding of findings) {
     const key =
       finding.kind === "query-builder"
-        ? finding.kind
+        ? `${finding.kind}:${finding.capability}:${finding.sourceKey ?? ""}`
         : finding.kind === "empty-fragment"
           ? finding.kind
           : `${finding.kind}:${finding.helper}`;
@@ -1852,7 +1971,7 @@ function classifiedFinding(
   sourceChunks: ReadonlySet<SqlSourceChunk>,
   isolationContext: "ordering" | "predicate" | "selection" = "predicate",
   isPartial = false,
-): ClassifiedHelperFinding {
+): ClassifiedLeafFinding {
   return {
     helper,
     isolationContext,
@@ -1861,6 +1980,19 @@ function classifiedFinding(
     node,
     sourceChunks,
   };
+}
+
+function isWholeHelperReplacement(
+  classification: ExpressionClassification,
+): boolean {
+  const finding = classification.findings[0];
+  return (
+    classification.isWholeReplacement &&
+    classification.findings.length === 1 &&
+    finding !== undefined &&
+    finding.kind !== "query-builder" &&
+    !finding.isPartial
+  );
 }
 
 function firstClassificationNode(
@@ -1916,6 +2048,82 @@ function classifyExistence(
     }),
     isWholeReplacement: false,
   };
+}
+
+function classifyScalarQuery(
+  expression: Extract<StructuralExpression, { readonly kind: "scalar-query" }>,
+  context: ClassificationContext,
+): ExpressionClassification {
+  const childContext = nestedClassificationContext(context);
+  function classifyChildren(): ExpressionClassification {
+    const children = expression.children.map((child) => {
+      return classifyExpression(child, childContext);
+    });
+    return {
+      anchor: children.map(firstClassificationNode).find((node) => {
+        return node !== undefined;
+      }),
+      findings: children.flatMap((child) => {
+        return child.findings;
+      }),
+      isWholeReplacement: false,
+    };
+  }
+  if (
+    !context.allowsScalarQuery ||
+    !expression.isBuilderShape ||
+    expression.selection === undefined ||
+    expression.predicate === undefined
+  ) {
+    return classifyChildren();
+  }
+  const selectionClassification = classifyExpression(
+    expression.selection,
+    childContext,
+  );
+  const predicateClassification = classifyExpression(
+    expression.predicate,
+    childContext,
+  );
+  const selectionSupported =
+    expression.selection.kind === "marker"
+      ? expression.selection.marker.isColumn ||
+        expression.selection.marker.isWrapper
+      : isWholeHelperReplacement(selectionClassification);
+  const predicateSupported =
+    expression.predicate.kind === "marker"
+      ? expression.predicate.marker.isWrapper ||
+        (context.allowsOptionalSql &&
+          nodeIsOptionalDrizzleWrapper(
+            expression.predicate.marker.node,
+            context.checker,
+            context.services,
+          ))
+      : isWholeHelperReplacement(predicateClassification);
+  if (selectionSupported && predicateSupported) {
+    const node = literalBoundaryNode(expression.sourceChunks, context.root);
+    return {
+      anchor: node,
+      findings: [
+        {
+          capability: "structured-scalar",
+          isolationContext: "predicate",
+          isPartial: false,
+          kind: "query-builder",
+          node,
+          sourceChunks: expression.sourceChunks,
+          suppressedFindings: [
+            ...(selectionClassification?.findings ?? []),
+            ...(predicateClassification?.findings ?? []),
+          ].filter((finding): finding is ClassifiedLeafFinding => {
+            return finding.kind !== "query-builder";
+          }),
+        },
+      ],
+      isWholeReplacement: true,
+    };
+  }
+  return classifyChildren();
 }
 
 function classifyExpression(
@@ -2249,6 +2457,9 @@ function classifyExpression(
 
   if (expression.kind === "existence") {
     return classifyExistence(expression, "exists", context);
+  }
+  if (expression.kind === "scalar-query") {
+    return classifyScalarQuery(expression, context);
   }
 
   const children = expression.children.map((child) => {
@@ -4396,6 +4607,14 @@ function sameStructuralExpression(
       sameStructuralOrderings(left.orderings, right.orderings)
     );
   }
+  if (left.kind === "scalar-query" && right.kind === "scalar-query") {
+    return (
+      left.isBuilderShape === right.isBuilderShape &&
+      sameOptionalExpression(left.selection, right.selection) &&
+      sameOptionalExpression(left.predicate, right.predicate) &&
+      sameStructuralExpressions(left.children, right.children)
+    );
+  }
   if (left.kind === "existence" && right.kind === "existence") {
     return (
       left.isHandBuiltSelect === right.isHandBuiltSelect &&
@@ -4664,9 +4883,33 @@ function findingSourceProvenance(
 }
 
 function publicFinding(
-  finding: ClassifiedHelperFinding,
+  finding: ClassifiedFinding,
   sourceLocalEligible: boolean,
 ): SqlAnalysisFinding {
+  if (finding.kind === "query-builder") {
+    const { sourceKey } = findingSourceProvenance(
+      finding.sourceChunks,
+      finding.node,
+    );
+    const coveredSourceKeys = [
+      ...new Set(
+        finding.suppressedFindings.map((suppressed) => {
+          const provenance = findingSourceProvenance(
+            suppressed.sourceChunks,
+            suppressed.node,
+          );
+          return `${suppressed.kind}:${suppressed.helper}:${provenance.sourceKey}`;
+        }),
+      ),
+    ];
+    return {
+      capability: finding.capability,
+      coveredSourceKeys,
+      kind: finding.kind,
+      node: finding.node,
+      sourceKey,
+    };
+  }
   const { sourceKey, sourceTemplateKey } = findingSourceProvenance(
     finding.sourceChunks,
     finding.node,
@@ -4703,13 +4946,14 @@ function sameSourceChunks(
 }
 
 function replacementBoundaryForFinding(
-  finding: ClassifiedHelperFinding,
+  finding: ClassifiedFinding,
   variant: SqlSourceVariant,
   root: TSESTree.Expression,
   checker: TypeChecker,
   services: ParserServicesWithTypeInformation,
   capabilities: SqlCapabilityChecks,
   allowsRetainedSqlWrapper: boolean,
+  allowsScalarQuery: boolean,
 ): TSESTree.Expression | undefined {
   // A parsed descendant can cross template boundaries because Drizzle inserts
   // nested SQL without parentheses. Reparse each editable boundary in
@@ -4744,6 +4988,7 @@ function replacementBoundaryForFinding(
     const classificationContext: ClassificationContext = {
       allowsOptionalSql: true,
       allowsRetainedSqlWrapper,
+      allowsScalarQuery,
       capabilities,
       checker,
       ownsResultMapping: false,
@@ -4772,7 +5017,12 @@ function replacementBoundaryForFinding(
       .find((candidateFinding) => {
         return (
           candidateFinding.kind === finding.kind &&
-          candidateFinding.helper === finding.helper &&
+          (candidateFinding.kind === "query-builder" &&
+          finding.kind === "query-builder"
+            ? candidateFinding.capability === finding.capability
+            : candidateFinding.kind !== "query-builder" &&
+              finding.kind !== "query-builder" &&
+              candidateFinding.helper === finding.helper) &&
           candidateFinding.isolationContext === finding.isolationContext &&
           candidateFinding.isPartial === finding.isPartial &&
           sameSourceChunks(candidateFinding.sourceChunks, finding.sourceChunks)
@@ -4878,6 +5128,8 @@ function analyzeParsed(
       context === "source-selection" ||
       context === "source-statement" ||
       context === "source-where-prefix",
+    allowsScalarQuery:
+      context === "predicate" || context === "optional-predicate",
     capabilities,
     checker,
     ownsResultMapping,
@@ -4927,9 +5179,10 @@ function analyzeParsed(
   const hasWholeReplacementBoundary = replacementBoundary !== undefined;
   const findingEntries = deduplicateFindingEntries(
     classifications.flatMap((classification) => {
-      function isSourceLocalEligible(
-        finding: ClassifiedHelperFinding,
-      ): boolean {
+      function isSourceLocalEligible(finding: ClassifiedFinding): boolean {
+        if (finding.kind === "query-builder") {
+          return false;
+        }
         return (
           (finding.helper !== "and" && finding.helper !== "or") ||
           !(
@@ -4956,11 +5209,15 @@ function analyzeParsed(
             signature: {
               boundaryIsRoot: publicResult.node === node,
               boundaryType: publicResult.node.type,
-              helper: finding.helper,
+              helper:
+                finding.kind === "query-builder" ? undefined : finding.helper,
               isPartial: finding.isPartial,
               kind: finding.kind,
               ownsResultMapping,
-              queryCapability: undefined,
+              queryCapability:
+                finding.kind === "query-builder"
+                  ? finding.capability
+                  : undefined,
             },
           };
         });
@@ -4977,11 +5234,15 @@ function analyzeParsed(
               signature: {
                 boundaryIsRoot: publicResult.node === node,
                 boundaryType: publicResult.node.type,
-                helper: finding.helper,
+                helper:
+                  finding.kind === "query-builder" ? undefined : finding.helper,
                 isPartial: finding.isPartial,
                 kind: finding.kind,
                 ownsResultMapping,
-                queryCapability: undefined,
+                queryCapability:
+                  finding.kind === "query-builder"
+                    ? finding.capability
+                    : undefined,
               },
             },
           ];
@@ -4994,6 +5255,7 @@ function analyzeParsed(
           services,
           capabilities,
           classificationContext.allowsRetainedSqlWrapper,
+          classificationContext.allowsScalarQuery,
         );
         if (boundary === undefined) {
           return [];
@@ -5008,11 +5270,15 @@ function analyzeParsed(
             signature: {
               boundaryIsRoot: boundary === node,
               boundaryType: boundary.type,
-              helper: finding.helper,
+              helper:
+                finding.kind === "query-builder" ? undefined : finding.helper,
               isPartial: finding.isPartial,
               kind: finding.kind,
               ownsResultMapping,
-              queryCapability: undefined,
+              queryCapability:
+                finding.kind === "query-builder"
+                  ? finding.capability
+                  : undefined,
             },
           },
         ];
@@ -5120,7 +5386,10 @@ function variantMightContainCapability(
     .join("");
   return (
     SQL_CAPABILITY_TOKEN.test(literalSource) ||
-    ((context === "statement" || context === "structured-selection") &&
+    ((context === "statement" ||
+      context === "structured-selection" ||
+      context === "predicate" ||
+      context === "optional-predicate") &&
       /\bSELECT\b/i.test(literalSource)) ||
     (allowsWriteQueryBuilder && WRITE_CAPABILITY_TOKEN.test(literalSource))
   );


### PR DESCRIPTION
## Summary

- replace the successful-run boundary's raw scalar `SELECT` with an aliased
  Drizzle select builder while retaining only the unsupported outer
  `COALESCE`
- teach `api/prefer-drizzle-apis` to report a conventional schema-backed
  scalar query as the maximal finding inside predicate SQL
- preserve smaller helper findings for unsupported scalar shapes and add
  type-aware lint coverage for composition, provenance, context, and fallback
- add a public callback/send-route journey covering a revoked late successful
  event

## Behavior and safety

- the boundary remains a correlated scalar subquery in one outer statement;
  there is no additional await, round trip, transaction, or result read
- rendered parameter values and order remain thread UUID followed by run UUID
- local PostgreSQL probes preserved the ordinary, no-row, and revoked-newest
  boundary results and produced the same plan shape, costs, indexes, anti-join,
  cardinality, and buffer path
- scalar-query lint is limited to predicate and optional-predicate contexts,
  one direct typed relation, one target, a present predicate, and no unsupported
  select clauses; it has no autofix
- no schema migration, persisted-data rewrite, API/protocol change, feature
  switch, compatibility shim, literal catalog, source allowlist, or blanket
  `sql` ban is included

## Validation

- `pnpm exec prettier --write <changed TypeScript files>`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-apis.test.ts`
  (221 passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=1`
  (32 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `git diff --check`
- pre-commit repository-wide Turbo type checks
- five alternating exact-base/candidate API ESLint pairs: median wall time
  `26630.92 ms` -> `25928.41 ms` (`-2.64%`), median aggregate process-tree
  peak RSS `3427476 KiB` -> `3448032 KiB` (`+0.60%`)

Closes #23764

Relates to #23047
