### PR TITLE
fix(app): synchronize satellite sessions after primary sign-in

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -62,6 +62,7 @@ let internalMockedOrganization: {
 let internalMockedInvitations: MockedInvitation[] = [];
 let internalMockedMemberships: MockedMembership[] = [{ id: "org_default" }];
 let internalMockedClientSessions: MockedClientSession[] = [];
+let internalMockedClerkLoadOptions: MockedClerkLoadOptions = {};
 
 export function mockUser(
   user: {
@@ -152,6 +153,7 @@ export function clearMockedAuth() {
   internalMockedInvitations = [];
   internalMockedMemberships = [{ id: "org_default" }];
   internalMockedClientSessions = [];
+  internalMockedClerkLoadOptions = {};
   clerkListeners.length = 0;
   mockedClerk.on = defaultClerkStatusOn;
   mockedClerk.signOut.mockReset();
@@ -173,6 +175,8 @@ export function clearMockedAuth() {
   });
   mockedClerk.buildUrlWithAuth.mockReset();
   mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
+  mockedClerk.buildSignInUrl.mockReset();
+  mockedClerk.buildSignInUrl.mockImplementation(defaultBuildSignInUrlImpl);
   mockedClerk.initialize.mockReset();
 }
 
@@ -205,7 +209,36 @@ const clientSignInCreate = vi.fn(
 const defaultBuildUrlWithAuthImpl = (to: string) => {
   return to;
 };
-const defaultLoadImpl = () => {
+
+interface MockedClerkLoadOptions {
+  isSatellite?: boolean;
+  signInUrl?: string;
+}
+
+interface MockedSignInRedirectOptions {
+  redirectUrl?: string | null;
+}
+
+const defaultBuildSignInUrlImpl = (
+  options?: MockedSignInRedirectOptions,
+): string => {
+  const signInUrl = new URL(
+    internalMockedClerkLoadOptions.signInUrl ?? "/sign-in",
+    window.location.origin,
+  );
+  const redirectUrl = new URL(
+    options?.redirectUrl ?? window.location.href,
+    window.location.origin,
+  );
+  if (internalMockedClerkLoadOptions.isSatellite) {
+    redirectUrl.searchParams.set("__clerk_synced", "false");
+  }
+  signInUrl.searchParams.set("redirect_url", redirectUrl.toString());
+  return signInUrl.toString();
+};
+
+const defaultLoadImpl = (options?: MockedClerkLoadOptions) => {
+  internalMockedClerkLoadOptions = options ?? {};
   return Promise.resolve();
 };
 export const mockedClerkLoad = vi.fn<typeof defaultLoadImpl>(defaultLoadImpl);
@@ -293,6 +326,9 @@ export const mockedClerk = {
     };
   },
   redirectToSignIn: vi.fn(),
+  buildSignInUrl: vi.fn<typeof defaultBuildSignInUrlImpl>(
+    defaultBuildSignInUrlImpl,
+  ),
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.
   buildUrlWithAuth: vi.fn(defaultBuildUrlWithAuthImpl),

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -237,7 +237,7 @@ describe("platform auth redirects", () => {
       expect(url.origin).toBe("https://app.vm0.ai");
       expect(url.pathname).toBe("/sign-in");
       expect(url.searchParams.get("redirect_url")).toBe(
-        "https://app.okou.ai/agents?utm_source=okou-launch",
+        "https://app.okou.ai/agents?utm_source=okou-launch&__clerk_synced=false",
       );
     });
 

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -297,7 +297,7 @@ export const setupAuthPageWrapper = (
 
     if (!clerk.user) {
       const signInUrl = new URL(
-        resolveAppAuthUrl("/sign-in", { redirectUrl: location.href }),
+        clerk.buildSignInUrl({ redirectUrl: location.href }),
         location.origin,
       );
       L.info("redirect unauthenticated user to app sign-in", {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -869,6 +869,33 @@ describe("zero sidebar account menu", () => {
     });
   });
 
+  it("preserves satellite session sync after signing out", async () => {
+    prepareDefaultAgent();
+    window.location.href = "https://app.okou.ai/";
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    const menu = await openAccountMenu();
+    click(within(menu).getByText("Sign out"));
+
+    await waitFor(() => {
+      expect(mockedClerk.signOut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "test-session-id",
+          redirectUrl: expect.stringMatching(/__clerk_synced%3Dfalse/),
+        }),
+      );
+    });
+  });
+
   it("retries auth recovery network failures before replaying the request", async () => {
     mockAdminAccountSidebar();
     const provider = connectedPersonalCodexProvider();

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -29,11 +29,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
 } from "@vm0/ui";
-import {
-  clerk$,
-  currentUserInfo$,
-  resolveAppAuthUrl,
-} from "../../signals/auth.ts";
+import { clerk$, currentUserInfo$ } from "../../signals/auth.ts";
 import { suppressUnauthorizedRedirectForAuthTransition$ } from "../../signals/auth-retry.ts";
 import {
   reloadAccountMenuSubscriptionUsageRows$,
@@ -664,10 +660,9 @@ export function AccountDropdown({
   const handleAccountAction = (action: ZeroAccountAction) => {
     if (action === "signout") {
       const sessionId = clerk?.session?.id;
-      const signInUrl = new URL(resolveAppAuthUrl("/sign-in"));
-      signInUrl.searchParams.set("redirect_url", location.href);
+      const signInUrl = clerk?.buildSignInUrl({ redirectUrl: location.href });
       detach(
-        clerk?.signOut({ sessionId, redirectUrl: signInUrl.toString() }),
+        clerk?.signOut({ sessionId, redirectUrl: signInUrl }),
         Reason.DomCallback,
       );
       return;


### PR DESCRIPTION
## Summary

- build protected-route sign-in redirects through Clerk instead of manually assembling the primary-domain URL
- use the same Clerk-built URL after sign-out
- extend the Clerk test boundary and add regressions for the `app.okou.ai` satellite return flow

## User impact

Users can complete Google OAuth on `app.vm0.ai` and return to `app.okou.ai` without being redirected back to sign-in. Clerk now adds its satellite sync trigger and runs the session handshake instead of relying on a potentially stale satellite cookie.

## Scope

This keeps the existing Clerk satellite configuration, including `satelliteAutoSync`. It does not change canonicalization for direct visits to `app.okou.ai/sign-in`.

## Verification

- `pnpm --filter @vm0/app exec vitest run src/signals/__tests__/auth-url.test.ts src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx` (28 tests passed)
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- Prettier 3.8.1 check on all five touched files
