### PR TITLE
perf(runner): move workspace images into cache

### DIFF
--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
 use crate::resource_budget::ResourceBudget;
-use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+use crate::workspace_image_cache::{WorkspaceCacheCheckoutResult, WorkspaceImagePromotionContext};
 use crate::workspace_promotion::test_support::WorkspacePromotionFixture;
 use sandbox::{ResourceLimits, SandboxConfig};
 use sandbox_mock::{MockSandboxFactory, MockSandboxOverrides};
@@ -177,6 +177,21 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
     let states = fixture.cache.held_session_states().await;
     assert_eq!(states.len(), 1);
     assert_eq!(states[0].session_id, fixture.session_id);
+    let paths = RunnerPaths::new(fixture._dir.path().join("runner"));
+    assert!(
+        !tokio::fs::try_exists(paths.active_workspace_image(&fixture.sandbox_id))
+            .await
+            .unwrap(),
+        "successful promotion must move the image out before sandbox destruction"
+    );
+    tokio::fs::remove_dir_all(paths.workspace_dir(&fixture.sandbox_id))
+        .await
+        .unwrap();
+    assert_eq!(
+        WorkspacePromotionFixture::checkout_result(&fixture.cache, &fixture.session_id).await,
+        WorkspaceCacheCheckoutResult::Hit,
+        "removing the destroyed sandbox workspace must not remove the promoted cache entry"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use nix::fcntl::Flock;
@@ -8,6 +9,7 @@ use tokio::fs;
 use tracing::debug;
 use tracing::{info, warn};
 
+use crate::duration::duration_ms;
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::storage_fingerprints::StorageFingerprints;
@@ -718,6 +720,7 @@ impl SessionWorkspaceCache {
         &self,
         input: WorkspaceImagePromotionInput<'_>,
     ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
+        let promotion_started = Instant::now();
         let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
         if remove_non_directory_workspace_cache_entry(&cache_dir).await? {
             info!(
@@ -827,40 +830,52 @@ impl SessionWorkspaceCache {
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
-        if !has_copy_headroom(stats, budget, active_allocated) {
-            match self.gc_locked(false).await {
-                Ok(freed) if freed > 0 => {
-                    stats = self.fs_stats().await?;
-                    budget = CacheBudget::from_fs_stats(stats);
-                }
-                Ok(_) => {}
-                Err(e) => warn!(
-                    run_id = %input.run_id,
-                    cache_key = input.cache_key,
-                    error = %e,
-                    "workspace image cache GC failed before promotion copy"
-                ),
-            }
-        }
-        if !has_copy_headroom(stats, budget, active_allocated) {
-            info!(
-                run_id = %input.run_id,
-                cache_key = input.cache_key,
-                allocated_bytes = active_allocated,
-                available_bytes = stats.available_bytes,
-                min_free_bytes = budget.min_free_bytes,
-                "workspace image cache promotion skipped due to copy free-space pressure"
-            );
-            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
-        }
-
         ensure_workspace_cache_entry_dir(&cache_dir).await?;
         let tmp = self.session_workspace_cache_tmp_image(input.cache_key, input.run_id);
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
-        if let Err(e) = sparse_copy(input.active_image, &tmp).await {
-            let _ = remove_workspace_cache_path_if_exists(&tmp).await;
-            return Err(e);
-        }
+        let rename_started = Instant::now();
+        let (transfer_mode, transfer_duration) = match fs::rename(input.active_image, &tmp).await {
+            Ok(()) => ("rename", rename_started.elapsed()),
+            Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+                if !has_copy_headroom(stats, budget, active_allocated) {
+                    match self.gc_locked(false).await {
+                        Ok(freed) if freed > 0 => {
+                            stats = self.fs_stats().await?;
+                            budget = CacheBudget::from_fs_stats(stats);
+                        }
+                        Ok(_) => {}
+                        Err(e) => warn!(
+                            run_id = %input.run_id,
+                            cache_key = input.cache_key,
+                            error = %e,
+                            "workspace image cache GC failed before promotion copy"
+                        ),
+                    }
+                }
+                if !has_copy_headroom(stats, budget, active_allocated) {
+                    info!(
+                        run_id = %input.run_id,
+                        cache_key = input.cache_key,
+                        allocated_bytes = active_allocated,
+                        available_bytes = stats.available_bytes,
+                        min_free_bytes = budget.min_free_bytes,
+                        "workspace image cache promotion skipped due to copy free-space pressure"
+                    );
+                    return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
+                }
+
+                let copy_started = Instant::now();
+                if let Err(e) = sparse_copy(input.active_image, &tmp).await {
+                    let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+                    return Err(e);
+                }
+                ("sparse_copy", copy_started.elapsed())
+            }
+            Err(e) => {
+                let _ = remove_workspace_cache_path_if_exists(&tmp).await;
+                return Err(e.into());
+            }
+        };
         let tmp_metadata = match fs::symlink_metadata(&tmp).await {
             Ok(metadata) => metadata,
             Err(e) => {
@@ -883,7 +898,7 @@ impl SessionWorkspaceCache {
                 cache_key = input.cache_key,
                 actual_image_size_bytes = logical_image_size_bytes,
                 expected_image_size_bytes = input.image_size_bytes,
-                "workspace image cache promotion skipped because copied image size does not match cache key"
+                "workspace image cache promotion skipped because transferred image size does not match cache key"
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
@@ -895,7 +910,7 @@ impl SessionWorkspaceCache {
                 cache_key = input.cache_key,
                 allocated_bytes = tmp_allocated,
                 max_entry_bytes = budget.max_entry_bytes,
-                "workspace image cache promotion skipped because copied image is too large"
+                "workspace image cache promotion skipped because transferred image is too large"
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
@@ -974,6 +989,12 @@ impl SessionWorkspaceCache {
         info!(
             run_id = %input.run_id,
             cache_key = input.cache_key,
+            outcome = "promoted",
+            transfer_mode,
+            transfer_ms = duration_ms(transfer_duration),
+            promotion_ms = duration_ms(promotion_started.elapsed()),
+            logical_image_size_bytes,
+            source_allocated_bytes = active_allocated,
             allocated_bytes = allocated,
             "workspace image cache promoted"
         );

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -25,6 +25,9 @@
 //!   nested lock acquisition.
 //! - A checkout hit removes `metadata.json` before returning the current image as
 //!   a move seed, so the cache entry is not reusable while the image is active.
+//! - Promotion may move the active image into the cache. Callers must stop all
+//!   image writers before promotion and must not depend on the active path
+//!   afterward.
 //! - Metadata is reusable only when it matches the cache key inputs, workspace
 //!   drive layout, terminal status, trust/state, and current image identity.
 //! - GC refreshes a candidate and compares the current image identity before

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -345,7 +345,7 @@ async fn shared_cache_is_scoped_by_runner_group() {
 }
 
 #[tokio::test]
-async fn cache_hit_checkout_does_not_require_copy_headroom() {
+async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_headroom() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -442,12 +442,11 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
     tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
         .await
         .unwrap();
-    tokio::fs::rename(&current, paths.active_workspace_image(&sandbox_id))
-        .await
-        .unwrap();
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    tokio::fs::rename(&current, &active_image).await.unwrap();
 
     assert!(
-        !lease
+        lease
             .promote(
                 run_id,
                 None,
@@ -457,11 +456,15 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
             )
             .await
             .unwrap(),
-        "checkout does not need copy headroom, but publishing an independent cache copy still does"
+        "same-filesystem ownership transfer must not require duplicate-copy headroom"
     );
     assert!(
-        !tokio::fs::try_exists(&current).await.unwrap(),
-        "failed copy promotion must not publish reusable metadata for the consumed cache hit"
+        tokio::fs::try_exists(&current).await.unwrap(),
+        "same-filesystem promotion must publish the moved image"
+    );
+    assert!(
+        !tokio::fs::try_exists(&active_image).await.unwrap(),
+        "same-filesystem promotion must consume the active image"
     );
 }
 

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -4,10 +4,11 @@ use tokio::fs;
 
 use super::super::fs::local_timestamp;
 use super::super::{
-    SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
-    WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
+    CacheBudget, FsStats, SessionWorkspaceCache, TEST_FS_AVAILABLE_BYTES, TEST_FS_TOTAL_BYTES,
+    WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionOutcome,
+    WorkspaceImagePromotionRequest,
 };
 use super::support::{
     TEST_PROFILE_NAME, local_cache, promote_current_cache_entry, write_current_cache_entry,
@@ -16,6 +17,37 @@ use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, session_workspace_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
+
+async fn cross_filesystem_cache(
+    fs_stats: FsStats,
+) -> (
+    tempfile::TempDir,
+    tempfile::TempDir,
+    RunnerPaths,
+    SessionWorkspaceCache,
+) {
+    let runner_dir = tempfile::tempdir_in("/tmp").unwrap();
+    let cache_dir = tempfile::tempdir_in("/dev/shm").unwrap();
+    let paths = RunnerPaths::new(runner_dir.path().join("runner"));
+    fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache_root = cache_dir.path().join("workspace-image-cache");
+    fs::create_dir_all(&cache_root).await.unwrap();
+    let runner_device = fs::metadata(paths.base_dir()).await.unwrap().dev();
+    let cache_device = fs::metadata(&cache_root).await.unwrap().dev();
+    assert_ne!(
+        runner_device, cache_device,
+        "cross-filesystem promotion tests require /tmp and /dev/shm on distinct devices"
+    );
+    let lock_dir = runner_dir.path().join("locks");
+    let cache = SessionWorkspaceCache::with_cache_dirs_and_fs_stats(
+        paths.clone(),
+        cache_root,
+        lock_dir,
+        "",
+        fs_stats,
+    );
+    (runner_dir, cache_dir, paths, cache)
+}
 
 #[tokio::test]
 async fn promotion_does_not_overwrite_newer_cache_entry() {
@@ -447,7 +479,7 @@ async fn no_lock_promotion_context_abandonment_preserves_existing_entry() {
 }
 
 #[tokio::test]
-async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
+async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
@@ -484,6 +516,8 @@ async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
     fs::rename(&current, &active_image).await.unwrap();
     let updated = vec![b'x'; image_size as usize];
     fs::write(&active_image, &updated).await.unwrap();
+    let active_metadata = fs::metadata(&active_image).await.unwrap();
+    let active_identity = (active_metadata.dev(), active_metadata.ino());
 
     assert!(
         lease
@@ -498,14 +532,16 @@ async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
             .unwrap()
     );
 
-    assert_eq!(fs::read(&active_image).await.unwrap(), updated);
+    assert!(
+        !fs::try_exists(&active_image).await.unwrap(),
+        "same-filesystem promotion must transfer ownership out of the sandbox workspace"
+    );
     assert_eq!(fs::read(&current).await.unwrap(), updated);
-    let active_metadata = fs::metadata(&active_image).await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
-    assert_ne!(
-        (active_metadata.dev(), active_metadata.ino()),
+    assert_eq!(
+        active_identity,
         (current_metadata.dev(), current_metadata.ino()),
-        "published cache image must not share an inode with a sandbox that has not been destroyed yet"
+        "same-filesystem promotion must publish the moved image without copying its extents"
     );
     let metadata = cache
         .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
@@ -513,6 +549,130 @@ async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
         .unwrap();
     assert_eq!(metadata.logical_image_size_bytes, image_size);
     assert_eq!(metadata.last_completed_at, "2026-05-02T00:00:00.000Z");
+}
+
+#[tokio::test]
+async fn cross_filesystem_promotion_falls_back_to_sparse_copy() {
+    let (_runner_dir, _cache_dir, paths, cache) = cross_filesystem_cache(FsStats {
+        total_bytes: TEST_FS_TOTAL_BYTES,
+        available_bytes: TEST_FS_AVAILABLE_BYTES,
+    })
+    .await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let session_id = "sess-cross-filesystem";
+    let image = vec![b'x'; 4096];
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    fs::write(&active_image, &image).await.unwrap();
+
+    assert!(
+        lease
+            .promote(
+                run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-05-02T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        fs::read(&active_image).await.unwrap(),
+        image,
+        "cross-filesystem fallback must retain the source image"
+    );
+    let cache_key = cache.scoped_cache_key(
+        TEST_PROFILE_NAME,
+        session_id,
+        "/workspace",
+        image.len() as u64,
+    );
+    let current = cache.session_workspace_cache_current_image(&cache_key);
+    assert_eq!(fs::read(&current).await.unwrap(), image);
+    assert_ne!(
+        fs::metadata(&active_image).await.unwrap().dev(),
+        fs::metadata(&current).await.unwrap().dev()
+    );
+}
+
+#[tokio::test]
+async fn cross_filesystem_promotion_still_requires_copy_headroom() {
+    let min_free = CacheBudget::from_fs_stats(FsStats {
+        total_bytes: TEST_FS_TOTAL_BYTES,
+        available_bytes: TEST_FS_AVAILABLE_BYTES,
+    })
+    .min_free_bytes;
+    let (_runner_dir, _cache_dir, paths, cache) = cross_filesystem_cache(FsStats {
+        total_bytes: TEST_FS_TOTAL_BYTES,
+        available_bytes: min_free,
+    })
+    .await;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let session_id = "sess-cross-filesystem-headroom";
+    let image = vec![b'x'; 4096];
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    fs::write(&active_image, &image).await.unwrap();
+
+    assert!(
+        !lease
+            .promote(
+                run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-05-02T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap(),
+        "cross-filesystem sparse-copy fallback must preserve duplicate-copy headroom admission"
+    );
+    assert!(fs::try_exists(&active_image).await.unwrap());
+    let cache_key = cache.scoped_cache_key(
+        TEST_PROFILE_NAME,
+        session_id,
+        "/workspace",
+        image.len() as u64,
+    );
+    assert!(
+        !fs::try_exists(cache.session_workspace_cache_current_image(&cache_key))
+            .await
+            .unwrap()
+    );
 }
 
 #[tokio::test]
@@ -915,9 +1075,8 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
         .await
         .unwrap();
-    tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
-        .await
-        .unwrap();
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    tokio::fs::write(&active_image, b"image").await.unwrap();
 
     let cache_key = session_workspace_cache_key("sess-1", "/workspace");
     let metadata_path = paths.session_workspace_cache_metadata(&cache_key);
@@ -935,6 +1094,10 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
         .unwrap_err();
 
     assert!(matches!(err, RunnerError::Io(_)));
+    assert!(
+        !active_image.exists(),
+        "metadata failure after ownership transfer must not leave a second active image"
+    );
     assert!(
         !paths
             .session_workspace_cache_current_image(&cache_key)
@@ -1049,7 +1212,7 @@ async fn promote_replaces_stale_current_directory_before_rename() {
 }
 
 #[tokio::test]
-async fn promote_skips_copied_image_with_unexpected_logical_size() {
+async fn promote_skips_transferred_image_with_unexpected_logical_size() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -1116,7 +1116,7 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
 }
 
 #[tokio::test]
-async fn promote_removes_stale_temporary_directory_before_copy() {
+async fn promote_removes_stale_temporary_directory_before_transfer() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -331,6 +331,30 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     .await;
 
     assert!(promoted);
+    let promotion_event = captured_event(&events, "workspace image cache promoted");
+    assert_eq!(
+        promotion_event
+            .fields
+            .get("transfer_mode")
+            .map(String::as_str),
+        Some("rename")
+    );
+    assert_eq!(
+        promotion_event.fields.get("outcome").map(String::as_str),
+        Some("promoted")
+    );
+    assert_eq!(
+        promotion_event
+            .fields
+            .get("logical_image_size_bytes")
+            .and_then(|value| value.parse::<u64>().ok()),
+        Some(TEST_WORKSPACE_IMAGE_SIZE_BYTES)
+    );
+    for field in ["transfer_ms", "promotion_ms"] {
+        promotion_event.fields[field]
+            .parse::<u64>()
+            .unwrap_or_else(|error| panic!("invalid {field}: {error}; event={promotion_event:#?}"));
+    }
     let exec_calls = sandbox.exec_calls();
     assert_eq!(exec_calls.len(), 3);
     assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));


### PR DESCRIPTION
## Summary

- transfer a stopped sandbox's active workspace image into the unpublished cache path with a same-filesystem rename
- fall back to the existing sparse copy only for `EXDEV`, retaining copy-headroom admission for that branch
- preserve cache keys, metadata, locking, generation ordering, validation, and atomic publication
- report transfer mode, source/published allocation, transfer duration, and total promotion duration
- cover same-filesystem inode transfer, real cross-filesystem fallback, fallback headroom, publication cleanup, and sandbox destruction

## Compatibility

This does not change the cache key, metadata version, on-disk layout, reader protocol, API, database, or runner deployment configuration. Old and new runners continue to share the same cache and lock format.

The pre-existing reverse-path limitation for a cache checkout across filesystems is intentionally not changed here and is tracked in #23819.

## Performance evidence

The production case recorded in #23803 copied `2,451,103,744` allocated bytes and spent approximately `10.18s` after sandbox stop.

An isolated benchmark on dev-1's ext4 filesystem used a `17,179,869,184`-byte logical image with `2,684,358,656` allocated bytes:

- existing `cp --sparse=always --no-dereference`: `0.55s`, producing a different inode with the same allocation
- same-filesystem rename: `0.00s` at `/usr/bin/time` display resolution, preserving device, inode, and allocation

The benchmark directory was removed after measurement.

## Validation

- `scripts/prepare.sh`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p runner workspace_image_cache`
- `cd crates && cargo test -p runner workspace_promotion`
- `cd crates && cargo test -p runner` (`2869 passed`, `14 ignored`)

Closes #23803
