### PR TITLE
fix: bridge network policy connector slug fields

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -100,9 +100,9 @@ pub mod model_provider_env {
 
 /// Runner contract constants shared by TypeScript and Rust.
 pub mod runners {
-    /// Maximum connector refs accepted by the runner network policy refresh endpoint.
+    /// Maximum connector slugs accepted by the runner network policy refresh endpoint.
     /// Rust runners use this shared contract value to split refresh requests before calling the API.
-    pub const NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX: u64 = 256;
+    pub const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX: u64 = 256;
 
     /// Maximum resume session history blob size accepted by the API, runner, and guest verifier.
     /// Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1020,8 +1020,11 @@ impl ApiClient {
                 &self.token,
             )
             .timeout(NETWORK_POLICY_REFRESH_TIMEOUT)
-            // TODO(#23619): Rename this key with the runner API wire contract.
-            .json(&serde_json::json!({ "connectorRefs": connector_slugs }))
+            .json(&serde_json::json!({
+                "connectorSlugs": connector_slugs,
+                // TODO(#23827): Remove after every pre-bridge API has retired.
+                "connectorRefs": connector_slugs,
+            }))
     }
 
     pub(super) async fn resolve_builtin_firewall_catalog(
@@ -1474,7 +1477,7 @@ mod tests {
                 .body()
                 .and_then(reqwest::Body::as_bytes)
                 .expect("request should include JSON body"),
-            br#"{"connectorRefs":["slack"]}"#
+            br#"{"connectorSlugs":["slack"],"connectorRefs":["slack"]}"#
         );
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -835,21 +835,50 @@ fn parse_network_policy_refresh_notification(
             return None;
         }
     };
-    // TODO(#23619): Rename this key with the realtime notification contract.
-    let Some(connector_slug) = msg
-        .data
-        .get("connectorRef")
-        .and_then(|v| v.as_str())
-        .filter(|value| !value.is_empty())
-    else {
-        warn!("ably: network-policy-refresh message missing connectorRef");
-        return None;
+    let connector_slug =
+        match parse_network_policy_refresh_identity_field(&msg.data, "connectorSlug") {
+            Ok(value) => value,
+            Err(()) => {
+                warn!("ably: network-policy-refresh message has invalid connectorSlug");
+                return None;
+            }
+        };
+    let connector_ref = match parse_network_policy_refresh_identity_field(&msg.data, "connectorRef")
+    {
+        Ok(value) => value,
+        Err(()) => {
+            warn!("ably: network-policy-refresh message has invalid connectorRef");
+            return None;
+        }
+    };
+    let connector_slug = match (connector_slug, connector_ref) {
+        (Some(connector_slug), Some(connector_ref)) if connector_slug != connector_ref => {
+            warn!("ably: network-policy-refresh connectorSlug and connectorRef do not match");
+            return None;
+        }
+        (Some(connector_slug), _) => connector_slug,
+        (None, Some(connector_ref)) => connector_ref,
+        (None, None) => {
+            warn!("ably: network-policy-refresh message missing connector identity");
+            return None;
+        }
     };
 
     Some(NetworkPolicyRefreshNotification {
         run_id,
         connector_slug: connector_slug.to_string(),
     })
+}
+
+fn parse_network_policy_refresh_identity_field<'a>(
+    data: &'a serde_json::Value,
+    field: &str,
+) -> Result<Option<&'a str>, ()> {
+    match data.get(field) {
+        None => Ok(None),
+        Some(serde_json::Value::String(value)) if !value.is_empty() => Ok(Some(value)),
+        Some(_) => Err(()),
+    }
 }
 
 fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotification<'_>> {
@@ -1113,7 +1142,7 @@ mod tests {
 
     fn malformed_network_policy_refresh_messages(
         unrelated_name: &'static str,
-    ) -> [(&'static str, Option<&'static str>, serde_json::Value); 5] {
+    ) -> [(&'static str, Option<&'static str>, serde_json::Value); 10] {
         [
             (
                 "invalid runId",
@@ -1129,7 +1158,7 @@ mod tests {
                 serde_json::json!({ "connectorRef": "github" }),
             ),
             (
-                "missing connectorRef",
+                "missing connector identity",
                 Some("network-policy-refresh"),
                 serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000003" }),
             ),
@@ -1138,6 +1167,51 @@ mod tests {
                 Some("network-policy-refresh"),
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorRef": ""
+                }),
+            ),
+            (
+                "empty connectorSlug with valid connectorRef",
+                Some("network-policy-refresh"),
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "",
+                    "connectorRef": "github"
+                }),
+            ),
+            (
+                "invalid connectorSlug with valid connectorRef",
+                Some("network-policy-refresh"),
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": 1,
+                    "connectorRef": "github"
+                }),
+            ),
+            (
+                "invalid connectorRef with valid connectorSlug",
+                Some("network-policy-refresh"),
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "github",
+                    "connectorRef": null
+                }),
+            ),
+            (
+                "conflicting connector identities",
+                Some("network-policy-refresh"),
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "github",
+                    "connectorRef": "slack"
+                }),
+            ),
+            (
+                "empty connectorRef with valid connectorSlug",
+                Some("network-policy-refresh"),
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "github",
                     "connectorRef": ""
                 }),
             ),
@@ -2102,22 +2176,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_network_policy_refresh_notification_valid() {
-        let msg = make_message(
-            Some("network-policy-refresh"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000003",
-                "connectorRef": "github"
-            }),
-        );
+    fn parse_network_policy_refresh_notification_accepts_compatible_identities() {
+        for (case, data) in [
+            (
+                "canonical only",
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "github"
+                }),
+            ),
+            (
+                "legacy only",
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorRef": "github"
+                }),
+            ),
+            (
+                "matching dual identities",
+                serde_json::json!({
+                    "runId": "00000000-0000-0000-0000-000000000003",
+                    "connectorSlug": "github",
+                    "connectorRef": "github"
+                }),
+            ),
+        ] {
+            let msg = make_message(Some("network-policy-refresh"), data);
 
-        let notification = parse_network_policy_refresh_notification(&msg).unwrap();
+            let notification = parse_network_policy_refresh_notification(&msg).unwrap();
 
-        assert_eq!(
-            notification.run_id.to_string(),
-            "00000000-0000-0000-0000-000000000003"
-        );
-        assert_eq!(notification.connector_slug, "github");
+            assert_eq!(
+                notification.run_id.to_string(),
+                "00000000-0000-0000-0000-000000000003",
+                "{case}"
+            );
+            assert_eq!(notification.connector_slug, "github", "{case}");
+        }
     }
 
     #[test]

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -12,7 +12,7 @@
 //! run, replacing older tasks for the same connector and coalescing nearby due
 //! connectors for that same run before enqueueing work. The worker drains a
 //! bounded queue, deduplicates active connector slugs, splits API requests by
-//! `NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX`, validates each API response
+//! `NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX`, validates each API response
 //! against the requested active connector set, patches the proxy registry, and
 //! replaces the next schedule from the returned `nextRefreshAt`.
 //!
@@ -45,7 +45,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
-use api_contracts::generated::constants::runners::NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX;
+use api_contracts::generated::constants::runners::NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX;
 use chrono::{DateTime, Utc};
 use tokio::sync::{
     Mutex, mpsc,
@@ -60,7 +60,7 @@ use crate::proxy::ProxyRegistryHandle;
 use crate::types::{NetworkPolicy, NetworkPolicyRefresh};
 
 const REFRESH_REQUEST_QUEUE_CAPACITY: usize = 256;
-const NETWORK_POLICY_REFRESH_BATCH_MAX: usize = NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX as usize;
+const NETWORK_POLICY_REFRESH_BATCH_MAX: usize = NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX as usize;
 const EXPIRED_REFRESH_DEADLINE_RETRY_DELAY: Duration = Duration::from_millis(250);
 const SCHEDULED_REFRESH_COALESCE_WINDOW: Duration = Duration::from_millis(100);
 
@@ -435,8 +435,7 @@ impl NetworkPolicyRefreshCore {
         let mut responses_by_connector = HashMap::new();
         let mut duplicate_connector_slugs = HashSet::new();
         for refresh in response.refreshes {
-            // TODO(#23619): Rename this generated field with the runner wire contract.
-            let response_connector_slug = refresh.connector_ref.clone();
+            let response_connector_slug = refresh.connector_slug.clone();
             if !requested_connector_slugs.contains(response_connector_slug.as_str()) {
                 warn!(
                     run_id = %run_id,
@@ -993,6 +992,23 @@ mod tests {
         );
         assert_eq!(policy["ask"], json!([]));
         assert_eq!(policy["unknownPolicy"], json!("deny"));
+    }
+
+    fn network_policy_refresh_response(mut identity: serde_json::Value) -> serde_json::Value {
+        let refresh = identity
+            .as_object_mut()
+            .expect("network policy refresh identity fixture should be an object");
+        refresh.insert(
+            "networkPolicy".to_string(),
+            json!({
+                "allow": ["chat:write", "files:write"],
+                "deny": [],
+                "ask": ["channels:read"],
+                "unknownPolicy": "allow",
+            }),
+        );
+        refresh.insert("nextRefreshAt".to_string(), serde_json::Value::Null);
+        json!({ "refreshes": [identity] })
     }
 
     fn active_run_network_policy_state(
@@ -1593,6 +1609,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn compatible_network_policy_refresh_identities_apply_policy() {
+        for (case, identity) in [
+            (
+                "canonical only",
+                json!({
+                    "connectorSlug": "slack",
+                }),
+            ),
+            (
+                "legacy only",
+                json!({
+                    "connectorRef": "slack",
+                }),
+            ),
+            (
+                "matching dual identities",
+                json!({
+                    "connectorSlug": "slack",
+                    "connectorRef": "slack",
+                }),
+            ),
+        ] {
+            let server = MockServer::start();
+            let run_id = RunId::nil();
+            let refresh_mock = server.mock(|when, then| {
+                when.method(POST)
+                    .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(network_policy_refresh_response(identity));
+            });
+            let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
+
+            harness.refresh_slack().await;
+
+            refresh_mock.assert_calls(1);
+            let policy = harness.slack_policy().await;
+            assert_eq!(
+                policy["allow"],
+                json!(["chat:write", "files:write"]),
+                "{case}"
+            );
+            assert_eq!(policy["deny"], json!([]), "{case}");
+            assert_eq!(policy["ask"], json!(["channels:read"]), "{case}");
+            assert_eq!(policy["unknownPolicy"], json!("allow"), "{case}");
+            harness.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_network_policy_refresh_identities_fail_closed() {
+        for (_, identity) in [
+            (
+                "conflicting identities",
+                json!({
+                    "connectorSlug": "slack",
+                    "connectorRef": "github",
+                }),
+            ),
+            ("missing identity", json!({})),
+            (
+                "invalid canonical identity with valid legacy identity",
+                json!({
+                    "connectorSlug": null,
+                    "connectorRef": "slack",
+                }),
+            ),
+            (
+                "empty legacy identity with valid canonical identity",
+                json!({
+                    "connectorSlug": "slack",
+                    "connectorRef": "",
+                }),
+            ),
+        ] {
+            let server = MockServer::start();
+            let run_id = RunId::nil();
+            let refresh_mock = server.mock(|when, then| {
+                when.method(POST)
+                    .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(network_policy_refresh_response(identity));
+            });
+            let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
+
+            harness.refresh_slack().await;
+
+            refresh_mock.assert_calls(1);
+            let policy = harness.slack_policy().await;
+            assert_fail_closed_policy(&policy);
+            harness.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
     async fn duplicate_network_policy_refresh_fails_closed() {
         let server = MockServer::start();
         let run_id = RunId::nil();
@@ -1710,7 +1822,10 @@ mod tests {
         let first_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"))
-                .json_body(json!({ "connectorRefs": first_batch }));
+                .json_body(json!({
+                    "connectorSlugs": first_batch,
+                    "connectorRefs": first_batch,
+                }));
             then.status(500)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -1723,7 +1838,10 @@ mod tests {
         let second_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"))
-                .json_body(json!({ "connectorRefs": second_batch }));
+                .json_body(json!({
+                    "connectorSlugs": second_batch,
+                    "connectorRefs": second_batch,
+                }));
             then.status(500)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1107,16 +1107,82 @@ pub struct NetworkPolicyRefresh {
     pub next_refresh_at: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(try_from = "NetworkPolicyRefreshResponseWire")]
 pub struct NetworkPolicyRefreshResponse {
-    /// TODO(#23619): Rename only with the runner API response wire contract.
-    pub connector_ref: String,
+    pub connector_slug: String,
     pub network_policy: NetworkPolicy,
     pub next_refresh_at: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NetworkPolicyRefreshResponseWire {
+    #[serde(default)]
+    connector_slug: OptionalWireConnectorSlug,
+    // TODO(#23827): Remove after every pre-bridge runner has drained.
+    #[serde(default)]
+    connector_ref: OptionalWireConnectorSlug,
+    network_policy: NetworkPolicy,
+    next_refresh_at: Option<String>,
+}
+
+#[derive(Default)]
+enum OptionalWireConnectorSlug {
+    #[default]
+    Missing,
+    Present(String),
+}
+
+impl<'de> Deserialize<'de> for OptionalWireConnectorSlug {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+impl OptionalWireConnectorSlug {
+    fn as_deref(&self) -> Option<&str> {
+        match self {
+            Self::Missing => None,
+            Self::Present(value) => Some(value),
+        }
+    }
+}
+
+impl TryFrom<NetworkPolicyRefreshResponseWire> for NetworkPolicyRefreshResponse {
+    type Error = &'static str;
+
+    fn try_from(value: NetworkPolicyRefreshResponseWire) -> Result<Self, Self::Error> {
+        let connector_slug = match (
+            value.connector_slug.as_deref(),
+            value.connector_ref.as_deref(),
+        ) {
+            (Some(""), _) | (_, Some("")) => {
+                return Err("network policy refresh connector identity must not be empty");
+            }
+            (Some(connector_slug), Some(connector_ref)) if connector_slug != connector_ref => {
+                return Err("network policy refresh connectorSlug and connectorRef must match");
+            }
+            (Some(connector_slug), _) => connector_slug,
+            (None, Some(connector_ref)) => connector_ref,
+            (None, None) => {
+                return Err("network policy refresh connector identity is required");
+            }
+        }
+        .to_string();
+
+        Ok(Self {
+            connector_slug,
+            network_policy: value.network_policy,
+            next_refresh_at: value.next_refresh_at,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkPolicyRefreshBatchResponse {
     pub refreshes: Vec<NetworkPolicyRefreshResponse>,

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -354,9 +354,10 @@ export async function publishNetworkPolicyRefreshToRunnerGroup(
   connectorSlug: string,
 ): Promise<void> {
   const channel = ablyClient().channels.get(`runner-group:${group}`);
-  // TODO(#23619): Rename with the runner realtime notification contract.
   await channel.publish("network-policy-refresh", {
     runId,
+    connectorSlug,
+    // TODO(#23827): Remove after every pre-bridge runner has drained.
     connectorRef: connectorSlug,
   });
   L.debug(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -89,6 +89,9 @@ type RunsListQuery = z.input<(typeof runsMainContract.list)["query"]>;
 type RunnerJobClaimRequest = z.infer<
   (typeof runnersJobClaimContract.claim)["body"]
 >;
+type RunnerNetworkPolicyRefreshRequest = z.input<
+  (typeof runnersNetworkPolicyRefreshContract.refresh)["body"]
+>;
 type ComposeContent = z.infer<
   (typeof composesMainContract.create)["body"]
 >["content"];
@@ -447,7 +450,10 @@ export function createRunsApi(context: TestContext) {
         runApp(context)(runnersNetworkPolicyRefreshContract).refresh({
           headers: runnerHeaders(true),
           params: { runId },
-          body: { connectorRefs: [connectorSlug] },
+          body: {
+            connectorSlugs: [connectorSlug],
+            connectorRefs: [connectorSlug],
+          },
         }),
         [200],
       );
@@ -463,14 +469,14 @@ export function createRunsApi(context: TestContext) {
     async requestRefreshRunnerNetworkPolicyAs(
       authorization: string | undefined,
       runId: string,
-      connectorSlug: string,
+      body: RunnerNetworkPolicyRefreshRequest,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
     ) {
       return await accept(
         runApp(context)(runnersNetworkPolicyRefreshContract).refresh({
           headers: authorization === undefined ? {} : { authorization },
           params: { runId },
-          body: { connectorRefs: [connectorSlug] },
+          body,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8460,7 +8460,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const sameUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${actorRunnerKey.token}`,
       snapshotRun.runId,
-      "slack",
+      { connectorRefs: ["slack"] },
       [200],
     );
     if (sameUserRefresh.status !== 200) {
@@ -8469,10 +8469,65 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(sameUserRefresh.body.refreshes[0]?.networkPolicy.deny).toContain(
       "chat:write",
     );
+    expect(sameUserRefresh.body.refreshes[0]).toMatchObject({
+      connectorSlug: "slack",
+      connectorRef: "slack",
+    });
+    const canonicalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      snapshotRun.runId,
+      { connectorSlugs: ["slack"] },
+      [200],
+    );
+    if (canonicalRefresh.status !== 200) {
+      throw new Error("Expected canonical network policy refresh to succeed");
+    }
+    expect(canonicalRefresh.body.refreshes[0]).toMatchObject({
+      connectorSlug: "slack",
+      connectorRef: "slack",
+    });
+    const matchingDualRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      snapshotRun.runId,
+      {
+        connectorSlugs: ["slack", "github", "slack"],
+        connectorRefs: ["github", "slack"],
+      },
+      [200],
+    );
+    if (matchingDualRefresh.status !== 200) {
+      throw new Error(
+        "Expected matching dual network policy refresh to succeed",
+      );
+    }
+    expect(matchingDualRefresh.body.refreshes[0]).toMatchObject({
+      connectorSlug: "slack",
+      connectorRef: "slack",
+    });
+    const conflictingRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
+      `Bearer ${actorRunnerKey.token}`,
+      snapshotRun.runId,
+      {
+        connectorSlugs: ["slack"],
+        connectorRefs: ["github"],
+      },
+      [400],
+    );
+    if (conflictingRefresh.status !== 400) {
+      throw new Error(
+        "Expected conflicting network policy refresh to be rejected",
+      );
+    }
+    expect(conflictingRefresh.body.error.message).toBe(
+      "connectorSlugs: must identify the same connectors as connectorRefs",
+    );
     const otherUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${memberRunnerKey.token}`,
       snapshotRun.runId,
-      "slack",
+      {
+        connectorSlugs: ["slack"],
+        connectorRefs: ["slack"],
+      },
       [403],
     );
     if (otherUserRefresh.status !== 403) {
@@ -8492,7 +8547,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "network-policy-refresh",
-      { runId: snapshotRun.runId, connectorRef: "slack" },
+      {
+        runId: snapshotRun.runId,
+        connectorSlug: "slack",
+        connectorRef: "slack",
+      },
     );
     const refreshedPolicy = await api.refreshRunnerNetworkPolicy(
       snapshotRun.runId,
@@ -8502,6 +8561,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(refreshedPolicy.networkPolicy.allow).not.toContain("chat:write");
     expect(refreshedPolicy.networkPolicy.allow).toContain("files:write");
     expect(refreshedPolicy.nextRefreshAt).toStrictEqual(expect.any(String));
+    expect(refreshedPolicy).toMatchObject({
+      connectorSlug: "slack",
+      connectorRef: "slack",
+    });
 
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("network policy refresh publish failed"),
@@ -8732,7 +8795,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "network-policy-refresh",
-      { runId: parent.runId, connectorRef: "slack" },
+      {
+        runId: parent.runId,
+        connectorSlug: "slack",
+        connectorRef: "slack",
+      },
     );
 
     const refreshed = await api.refreshRunnerNetworkPolicy(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2332,7 +2332,7 @@ const networkPolicyRefreshInner$ = command(
       return authError;
     }
 
-    const connectorSlugs = [...new Set(body.data.connectorRefs)];
+    const { connectorSlugs } = body.data;
     const refreshes = await resolveActiveNetworkPolicyRefreshes(
       db,
       {
@@ -2352,7 +2352,8 @@ const networkPolicyRefreshInner$ = command(
       body: {
         refreshes: refreshes.map((refresh) => {
           return {
-            // TODO(#23619): Rename with the runner response wire contract.
+            connectorSlug: refresh.connectorSlug,
+            // TODO(#23827): Remove after every pre-bridge runner has drained.
             connectorRef: refresh.connectorSlug,
             networkPolicy: refresh.networkPolicy,
             nextRefreshAt: refresh.nextRefreshAt,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -17,6 +17,7 @@ import {
   resumeSessionSchema,
   runnersBuiltinFirewallsResolveContract,
   runnersJobClaimContract,
+  runnersNetworkPolicyRefreshContract,
   runnersPollContract,
   storageMountEntrySchema,
   storageManifestSchema,
@@ -880,6 +881,53 @@ describe("runner poll request contract", () => {
     });
 
     expect(body.telemetry).toEqual({});
+  });
+});
+
+describe("runner network policy refresh contract", () => {
+  const bodySchema = runnersNetworkPolicyRefreshContract.refresh.body;
+
+  it.each([
+    [
+      "canonical",
+      { connectorSlugs: ["slack", "github", "slack"] },
+      ["slack", "github"],
+    ],
+    [
+      "legacy",
+      { connectorRefs: ["slack", "github", "slack"] },
+      ["slack", "github"],
+    ],
+    [
+      "matching dual",
+      {
+        connectorSlugs: ["github", "slack", "github"],
+        connectorRefs: ["slack", "github"],
+      },
+      ["github", "slack"],
+    ],
+  ])(
+    "normalizes %s input to canonical connector slugs",
+    (_, body, expected) => {
+      expect(bodySchema.parse(body)).toEqual({ connectorSlugs: expected });
+    },
+  );
+
+  it.each([
+    ["missing both fields", {}],
+    [
+      "different connector sets",
+      { connectorSlugs: ["slack"], connectorRefs: ["github"] },
+    ],
+    [
+      "different connector counts",
+      {
+        connectorSlugs: ["slack", "github"],
+        connectorRefs: ["slack"],
+      },
+    ],
+  ])("rejects %s", (_, body) => {
+    expect(bodySchema.safeParse(body).success).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -35,9 +35,7 @@ export const SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT =
 export const SESSION_HISTORY_DOWNLOAD_SOURCE_DEFAULT_R2_ENDPOINT =
   "default_r2_endpoint";
 export const SESSION_HISTORY_GZIP_MIN_BYTES = 64 * 1024;
-// TODO(#23619): Rename with the generated runner constant in a compatible
-// runner/API rollout.
-export const NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX = 256;
+export const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX = 256;
 export const RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX = 512;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,
@@ -717,18 +715,65 @@ export const runnersNetworkPolicyRefreshContract = c.router({
     pathParams: z.object({
       runId: z.uuid(),
     }),
-    body: z.object({
-      // TODO(#23619): Rename runner wire fields in a compatibility-safe rollout.
-      connectorRefs: z
-        .array(connectorSlugSchema)
-        .min(1)
-        .max(NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX),
-    }),
+    body: z
+      .object({
+        connectorSlugs: z
+          .array(connectorSlugSchema)
+          .min(1)
+          .max(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX)
+          .optional(),
+        // TODO(#23827): Remove after every pre-bridge runner has drained.
+        connectorRefs: z
+          .array(connectorSlugSchema)
+          .min(1)
+          .max(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX)
+          .optional(),
+      })
+      .superRefine((body, context) => {
+        if (
+          body.connectorSlugs === undefined &&
+          body.connectorRefs === undefined
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["connectorSlugs"],
+            message: "connectorSlugs or connectorRefs is required",
+          });
+          return;
+        }
+        if (
+          body.connectorSlugs !== undefined &&
+          body.connectorRefs !== undefined
+        ) {
+          const connectorSlugs = new Set(body.connectorSlugs);
+          const connectorRefs = new Set(body.connectorRefs);
+          if (
+            connectorSlugs.size !== connectorRefs.size ||
+            [...connectorSlugs].some((connectorSlug) => {
+              return !connectorRefs.has(connectorSlug);
+            })
+          ) {
+            context.addIssue({
+              code: "custom",
+              path: ["connectorSlugs"],
+              message: "must identify the same connectors as connectorRefs",
+            });
+          }
+        }
+      })
+      .transform((body) => {
+        return {
+          connectorSlugs: [
+            ...new Set(body.connectorSlugs ?? body.connectorRefs ?? []),
+          ],
+        };
+      }),
     responses: {
       200: z.object({
         refreshes: z.array(
           z.object({
-            // TODO(#23619): Keep the response aligned with the request rollout.
+            connectorSlug: connectorSlugSchema,
+            // TODO(#23827): Remove after every pre-bridge runner has drained.
             connectorRef: connectorSlugSchema,
             networkPolicy: networkPolicySchema,
             nextRefreshAt: z.string().datetime({ offset: true }).nullable(),

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -28,7 +28,7 @@ import {
 import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
-  NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX,
+  NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -57,7 +57,7 @@ const resumeSessionHistoryMaxBytesDoc = [
   "Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.",
 ] as const;
 const networkPolicyRefreshConnectorSlugsMaxDoc = [
-  "Maximum connector refs accepted by the runner network policy refresh endpoint.",
+  "Maximum connector slugs accepted by the runner network policy refresh endpoint.",
   "Rust runners use this shared contract value to split refresh requests before calling the API.",
 ] as const;
 const runnerPollExcludedRunIdsMaxDoc = [
@@ -179,8 +179,8 @@ const expectedBindings = [
   },
   {
     rustModulePath: ["runners"],
-    rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX",
-    value: rustU64(NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX),
+    rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX",
+    value: rustU64(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX),
     rustDoc: networkPolicyRefreshConnectorSlugsMaxDoc,
   },
   {
@@ -411,7 +411,7 @@ describe("Rust constant bindings", () => {
       `pub const RUNNER_POLL_EXCLUDED_RUN_IDS_MAX: u64 = ${RUNNER_POLL_EXCLUDED_RUN_IDS_MAX};`,
     );
     expect(firstRender).toContain(
-      `pub const NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX: u64 = ${NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX};`,
+      `pub const NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX: u64 = ${NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX};`,
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_ENCODING_GZIP: &str = "${SESSION_HISTORY_ENCODING_GZIP}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -17,7 +17,7 @@ import {
 import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
-  NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX,
+  NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -254,10 +254,10 @@ export const rustConstantBindings = [
   },
   {
     rustModulePath: ["runners"],
-    rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX",
-    value: rustU64(NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX),
+    rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX",
+    value: rustU64(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX),
     rustDoc: [
-      "Maximum connector refs accepted by the runner network policy refresh endpoint.",
+      "Maximum connector slugs accepted by the runner network policy refresh endpoint.",
       "Rust runners use this shared contract value to split refresh requests before calling the API.",
     ],
   },


### PR DESCRIPTION
## Summary

- add canonical `connectorSlug` and `connectorSlugs` fields to network policy refresh requests, responses, and realtime notifications
- keep legacy `connectorRef` and `connectorRefs` fields during the mixed-version rollout, with dual writes at outbound boundaries
- normalize canonical-only, legacy-only, and matching dual payloads while rejecting conflicting or malformed identities before applying policy state
- rename the generated TypeScript/Rust batch-size constant to use connector slug terminology

## Compatibility

- new API accepts old runner requests and returns both response fields
- new runner sends requests that old and new APIs accept, and reads responses or notifications from either version
- legacy field removal remains explicitly deferred to #23827 after older deployments have drained

Parent delivery issue: #23772

Closes #23826

## Validation

- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts test -- --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only`
- `pnpm knip --workspace @vm0/api-contracts --workspace api`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner -p api-contracts --all-targets --all-features`
- `cargo doc -p runner -p api-contracts --all-features --no-deps`
- `cargo test -p api-contracts`
- `cargo test -p runner --bin runner --quiet`
