### PR TITLE
fix(slack): deliver terminal callbacks after realtime publish failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3511,6 +3511,22 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
 
     integrations.mockSlackRunResultOutput("SLACK_BDD_OUTPUT");
+    let failedMessagePublishCount = 0;
+    let failedThreadListPublishCount = 0;
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (
+        typeof topic === "string" &&
+        topic.startsWith("chatThreadMessageCreated:")
+      ) {
+        failedMessagePublishCount++;
+        return Promise.reject(new Error("message realtime publish failed"));
+      }
+      if (topic === "threadListChanged") {
+        failedThreadListPublishCount++;
+        return Promise.reject(new Error("thread list publish failed"));
+      }
+      return Promise.resolve(undefined);
+    });
     await completeSlackTriggeredRun({
       runId: run1Id,
       sandboxToken: claim1.sandboxToken,
@@ -3525,6 +3541,9 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       );
     });
+    expect(failedMessagePublishCount).toBeGreaterThan(0);
+    expect(failedThreadListPublishCount).toBeGreaterThan(0);
+    context.mocks.ably.publish.mockResolvedValue(undefined);
     const auditedBlocks = slackPostMessageCallsJson();
     expect(auditedBlocks).toContain("Audit");
     expect(auditedBlocks).toContain(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -49,6 +49,7 @@ import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadMessageCreatedSafely,
   publishThreadListChanged,
+  publishThreadListChangedSafely,
   publishUserSignal,
 } from "../external/realtime";
 import {
@@ -1348,11 +1349,8 @@ async function insertAssistantErrorMessage(args: {
     return { inserted: false };
   }
 
-  await publishUserSignal(
-    [args.userId],
-    `chatThreadMessageCreated:${args.threadId}`,
-  );
-  await publishThreadListChanged(args.userId);
+  await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
+  await publishThreadListChangedSafely(args.userId);
   return {
     displayErrorMessage,
     inserted: true,
@@ -1602,11 +1600,8 @@ async function insertRunLifecycleMarker(
   if (!inserted) {
     return { inserted: false };
   }
-  await publishUserSignal(
-    [args.userId],
-    `chatThreadMessageCreated:${args.threadId}`,
-  );
-  await publishThreadListChanged(args.userId);
+  await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
+  await publishThreadListChangedSafely(args.userId);
   return {
     inserted: true,
     slackDeliveryCallbackId: inserted.slackDeliveryCallbackId,

--- a/turbo/apps/api/src/signals/services/zero-chat-first-assistant-message-metric.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-first-assistant-message-metric.service.ts
@@ -68,7 +68,7 @@ async function recordFirstAssistantMessageAcknowledgement(args: {
   });
 }
 
-export async function publishFirstAssistantMessageCreated(args: {
+async function publishFirstAssistantMessageCreated(args: {
   readonly db: Db;
   readonly threadId: string;
   readonly userId: string;
@@ -94,4 +94,19 @@ export async function publishFirstAssistantMessageCreated(args: {
       },
     ),
   );
+}
+
+export async function publishFirstAssistantMessageCreatedSafely(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly runId: string;
+}): Promise<void> {
+  await tapError(publishFirstAssistantMessageCreated(args), (error) => {
+    L.warn("Failed to publish first assistant message created signal", {
+      runId: args.runId,
+      threadId: args.threadId,
+      error,
+    });
+  });
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
@@ -17,15 +17,15 @@ import {
 } from "../../lib/file-url";
 import { writeDb$, type Db } from "../external/db";
 import {
-  publishThreadListChanged,
-  publishUserSignal,
+  publishChatThreadMessageCreatedSafely,
+  publishThreadListChangedSafely,
 } from "../external/realtime";
 import { listS3Objects } from "../external/s3";
 import { nowDate } from "../external/time";
 import { assistantMessageIdForRunEvent } from "./assistant-message-id";
 import { insertChatEvents } from "./zero-chat-event.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
-import { publishFirstAssistantMessageCreated } from "./zero-chat-first-assistant-message-metric.service";
+import { publishFirstAssistantMessageCreatedSafely } from "./zero-chat-first-assistant-message-metric.service";
 import {
   appendChatThreadEvent,
   type ChatThreadEventTransaction,
@@ -309,21 +309,18 @@ export async function insertAssistantEventMessages(
 
   if (insertedRowCount > 0) {
     if (runContext.shouldAttemptFirstAssistantMessageClaim) {
-      await publishFirstAssistantMessageCreated({
+      await publishFirstAssistantMessageCreatedSafely({
         db: writeDb,
         userId: args.userId,
         threadId: args.threadId,
         runId: args.runId,
       });
     } else {
-      await publishUserSignal(
-        [args.userId],
-        `chatThreadMessageCreated:${args.threadId}`,
-      );
+      await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
     }
     signal.throwIfAborted();
 
-    await publishThreadListChanged(args.userId);
+    await publishThreadListChangedSafely(args.userId);
     signal.throwIfAborted();
   }
 


### PR DESCRIPTION
## Summary

- Treat post-commit chat message and thread-list realtime invalidations as best effort so Ably failures cannot abort terminal callback preparation.
- Preserve first-assistant-message metric semantics: acknowledgement is recorded only after the realtime publish succeeds, while request aborts still propagate.
- Extend the canonical Slack callback scenario to inject message and thread-list publish failures and verify the final Slack response is still delivered.

## User impact

Slack users still receive the canonical final response when the shared realtime channel is rate-limited or temporarily unavailable. The committed chat state remains authoritative and clients can recover it by refetching.

## Failure evidence

- [Turbo run 30466855778](https://github.com/vm0-ai/vm0/actions/runs/30466855778), [job 90628845338](https://github.com/vm0-ai/vm0/actions/runs/30466855778/job/90628845338): `t40-slack-roundtrip.bats` timed out waiting for `chat.postMessage`.
- At the callback timestamp, Ably rejected the shared user-channel publish with `channel.maxRate` / code `42913`; callback preparation stopped before Slack delivery was dispatched.
- [The next merge-group run](https://github.com/vm0-ai/vm0/actions/runs/30466891539) passed the same E2E, confirming the trigger was intermittent and unrelated to the queued PR change.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=2304 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- Staged workspace, App, and API type checks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "delivers canonical Slack callbacks for progress, audit footers, failures, and Slack errors"` (8 passing runs, including after rebasing onto latest `main`)
- Repository pre-commit and commit-message hooks passed