### PR TITLE
feat(api): add slug-named connector client contracts

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -99,6 +99,7 @@ export async function publishConnectorChangedForUserSafely(
   await tapError(
     publishUserSignal([userId], "connector:changed", {
       connectorRef: connectorSlug,
+      connectorSlug,
     } satisfies ConnectorChangedPayload),
     (error) => {
       L.warn("Failed to publish connector changed signal", {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -315,6 +315,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
     expect(session).toMatchObject({
       type: "aws",
+      connectorSlug: "aws",
       status: "pending",
       expiresIn: 600,
     });
@@ -377,6 +378,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     });
     expect(complete.connector).toMatchObject({
       type: "aws",
+      slug: "aws",
       authMethod: "cli",
       externalId: "123456789012",
       externalUsername:

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -50,7 +50,7 @@ async function startSteamOpenId(actor: TestActor): Promise<URL> {
   mockSession(actor);
   const response = await accept(
     setupApp({ context })(zeroConnectorOpenIdStartContract).start({
-      params: { type: "steam" },
+      params: { connectorSlug: "steam" },
       headers: authHeaders(),
       body: { authMethod: "openid" },
     }),
@@ -132,6 +132,7 @@ function expectConnectorErrorRedirect(
   const url = redirectLocation(response);
   expect(url.pathname).toBe("/connector/error");
   expect(url.searchParams.get("type")).toBe(args.connectorSlug);
+  expect(url.searchParams.get("connectorSlug")).toBe(args.connectorSlug);
   expect(url.searchParams.get("message")).toBe(args.message);
 }
 
@@ -141,7 +142,7 @@ async function completeSteamOpenIdCallback(
   mockSteamOpenIdVerification();
   await accept(
     setupApp({ context })(connectorsSlugCallbackContract).callback({
-      params: { type: "steam" },
+      params: { connectorSlug: "steam" },
       query: steamCallbackQuery(authorizationUrl),
       headers: {},
     }),
@@ -309,7 +310,7 @@ describe("Steam OpenID connector", () => {
 
     const response = await accept(
       setupApp({ context })(zeroConnectorOauthContinueContract).continue({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         query: { state: stateFromSteamAuthorizationUrl(authorizationUrl) },
       }),
       [404],
@@ -367,7 +368,7 @@ describe("Steam OpenID connector", () => {
     mockSession(actor);
     const connector = await accept(
       setupApp({ context })(zeroConnectorsBySlugContract).get({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         headers: authHeaders(),
       }),
       [200],
@@ -389,7 +390,7 @@ describe("Steam OpenID connector", () => {
 
     const response = await accept(
       setupApp({ context })(connectorsSlugCallbackContract).callback({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         query: steamCallbackQuery(authorizationUrl),
         headers: {},
       }),
@@ -404,7 +405,7 @@ describe("Steam OpenID connector", () => {
     mockSession(actor);
     const connector = await accept(
       setupApp({ context })(zeroConnectorsBySlugContract).get({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         headers: authHeaders(),
       }),
       [404],
@@ -418,7 +419,7 @@ describe("Steam OpenID connector", () => {
 
     const response = await accept(
       setupApp({ context })(zeroConnectorOpenIdStartContract).start({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         headers: authHeaders(),
         body: { authMethod: "oauth" },
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -101,6 +101,7 @@ function expectConnectorErrorRedirect(
   const url = redirectLocation(response);
   expect(url.pathname).toBe("/connector/error");
   expect(url.searchParams.get("type")).toBe(args.connectorSlug);
+  expect(url.searchParams.get("connectorSlug")).toBe(args.connectorSlug);
   expect(url.searchParams.get("message")).toBe(args.message);
 }
 
@@ -584,6 +585,7 @@ describe("CONN-02: OAuth device authorization", () => {
     );
     expect(session).toMatchObject({
       type: "test-oauth-device",
+      connectorSlug: "test-oauth-device",
       status: "pending",
       userCode: "TEST-DEVICE",
       verificationUri: "https://oauth-device.test/device",
@@ -2906,6 +2908,7 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
     const successUrl = redirectLocation(success);
     expect(successUrl.pathname).toBe("/connector/success");
     expect(successUrl.searchParams.get("type")).toBe("github");
+    expect(successUrl.searchParams.get("connectorSlug")).toBe("github");
     expect(successUrl.searchParams.get("username")).toBe("bdd-github-user");
 
     const connected = await connectorsApi.readConnectorBySlug(actor, "github");
@@ -3104,6 +3107,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     const successUrl = redirectLocation(success);
     expect(successUrl.pathname).toBe("/connector/success");
     expect(successUrl.searchParams.get("type")).toBe("test-oauth");
+    expect(successUrl.searchParams.get("connectorSlug")).toBe("test-oauth");
     expect(successUrl.searchParams.get("username")).toBe("bdd-test-oauth");
 
     expect(provider.tokenBodies).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1754,6 +1754,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(search.body.connectors).toStrictEqual([
       {
         id: release.connectorSlug,
+        slug: release.connectorSlug,
         label: "External Test",
         description: "An external connector used only by the sync fixture",
         authMethods: ["api-token"],
@@ -3929,6 +3930,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(readiness.body.connectors).toStrictEqual([
       {
         connectorRef: "gmail",
+        connectorSlug: "gmail",
         label: "Catalog Gmail",
         icon: {
           url: expect.stringMatching(

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1689,7 +1689,7 @@ describe("connector catalog valid lifecycle", () => {
 
     const detail = await accept(
       catalogClient.get({
-        params: { connectorRef: release.connectorSlug },
+        params: { connectorSlug: release.connectorSlug },
         headers,
       }),
       [200],
@@ -1710,7 +1710,7 @@ describe("connector catalog valid lifecycle", () => {
 
     const permissions = await accept(
       catalogClient.permissions({
-        params: { connectorRef: release.connectorSlug },
+        params: { connectorSlug: release.connectorSlug },
         headers,
       }),
       [200],
@@ -1801,7 +1801,7 @@ describe("connector catalog valid lifecycle", () => {
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const response = await accept(
       setupApp({ context })(zeroConnectorCatalogContract).permissions({
-        params: { connectorRef: release.connectorSlug },
+        params: { connectorSlug: release.connectorSlug },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -1828,7 +1828,7 @@ describe("connector catalog valid lifecycle", () => {
       accept(catalogClient.list({ headers }), [200]),
       accept(
         catalogClient.get({
-          params: { connectorRef: release.connectorSlug },
+          params: { connectorSlug: release.connectorSlug },
           headers,
         }),
         [200],
@@ -3387,7 +3387,7 @@ describe("connector catalog valid lifecycle", () => {
     const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
     const start = await accept(
       setupApp({ context })(zeroConnectorOpenIdStartContract).start({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         headers,
         body: { authMethod: "openid" },
       }),
@@ -3396,7 +3396,7 @@ describe("connector catalog valid lifecycle", () => {
     mockSteamOpenIdVerification();
     await accept(
       setupApp({ context })(connectorsSlugCallbackContract).callback({
-        params: { type: "steam" },
+        params: { connectorSlug: "steam" },
         headers: {},
         query: steamOpenIdCallbackQuery(start.body.authorizationUrl),
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
@@ -32,7 +32,7 @@ async function startGithubOauth(): Promise<URL> {
   mockAuthenticatedSession();
   const response = await accept(
     setupApp({ context })(zeroConnectorOauthStartContract).start({
-      params: { type: "github" },
+      params: { connectorSlug: "github" },
       headers: { authorization: "Bearer clerk-session" },
       body: { authMethod: "oauth" },
     }),
@@ -83,7 +83,7 @@ describe("connector OAuth state cleanup cron", () => {
     expect(cleanup.body.deleted).toBeGreaterThanOrEqual(1);
     const continuation = await accept(
       setupApp({ context })(zeroConnectorOauthContinueContract).continue({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         query: {
           state: usableContinuationUrl.searchParams.get("state") ?? "",
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
@@ -134,7 +134,7 @@ export function createAuthDeviceSupportApi(context: TestContext) {
     ): Promise<ConnectorResponse> {
       const response = await accept(
         authDeviceSupportApp(context)(zeroConnectorsBySlugContract).get({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(context, actor),
         }),
         [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1165,7 +1165,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(zeroConnectorsBySlugContract);
       return await accept(
         client.get({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
         }),
         statuses,
@@ -1193,7 +1193,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(zeroConnectorsBySlugContract);
       await accept(
         client.delete({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
         }),
         statuses,
@@ -1208,7 +1208,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(zeroConnectorScopeDiffContract);
       return await accept(
         client.getScopeDiff({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
         }),
         statuses,
@@ -1238,7 +1238,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(zeroConnectorManualGrantContract);
       return await accept(
         client.connect({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
           body: {
             authMethod,
@@ -1283,7 +1283,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(zeroConnectorOauthStartContract);
       return await accept(
         client.start({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
           body: {
             authMethod,
@@ -1322,7 +1322,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(connectorsSlugCallbackContract);
       return await accept(
         client.callback({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           query,
           headers: {},
         }),
@@ -1337,7 +1337,7 @@ export function createConnectorBddApi(context: TestContext) {
       const client = setupApp({ context })(connectorsSlugCallbackContract);
       const response = await accept(
         client.callback({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           query: { ...query, responseMode: "json" },
           headers: {},
         }),
@@ -1442,7 +1442,7 @@ export function createConnectorBddApi(context: TestContext) {
       );
       return await accept(
         client.create({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
           body: { authMethod, options },
         }),
@@ -1479,7 +1479,7 @@ export function createConnectorBddApi(context: TestContext) {
       );
       return await accept(
         client.poll({
-          params: { type: connectorSlug, sessionId },
+          params: { connectorSlug, sessionId },
           headers: authenticate(actor),
           body: { sessionToken },
         }),
@@ -1515,7 +1515,7 @@ export function createConnectorBddApi(context: TestContext) {
       );
       return await accept(
         client.create({
-          params: { type: connectorSlug },
+          params: { connectorSlug },
           headers: authenticate(actor),
           body: { authMethod },
         }),
@@ -1538,7 +1538,7 @@ export function createConnectorBddApi(context: TestContext) {
       );
       return await accept(
         client.complete({
-          params: { type: connectorSlug, sessionId: args.sessionId },
+          params: { connectorSlug, sessionId: args.sessionId },
           headers: authenticate(actor),
           body: { sessionToken: args.sessionToken, code: args.code },
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
@@ -407,7 +407,7 @@ export function createGithubBddApi(context: TestContext) {
       const response = await accept(
         client.get({
           headers: authenticate(actor),
-          params: { type: "github" },
+          params: { connectorSlug: "github" },
         }),
         [200],
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
@@ -61,6 +61,87 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     expect(new Set(response.body.enabledTypes)).toStrictEqual(
       new Set(["github", "test-oauth"]),
     );
+    expect(response.body.enabledConnectorSlugs).toStrictEqual(
+      response.body.enabledTypes,
+    );
     await deleteFeatureSwitchesForUser(context, actor);
+  });
+
+  it("accepts transitional update fields and rejects conflicting aliases", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+    context.mocks.s3.send.mockResolvedValue({});
+    const headers = { authorization: "Bearer clerk-session" };
+
+    const created = await accept(
+      setupApp({ context })(zeroAgentsMainContract).create({
+        headers,
+        body: {},
+      }),
+      [201],
+    );
+    const client = setupApp({ context })(zeroUserConnectorsContract);
+    const params = { id: created.body.agentId };
+
+    const legacy = await accept(
+      client.update({
+        params,
+        body: { enabledTypes: ["github"] },
+        headers,
+      }),
+      [200],
+    );
+    expect(legacy.body.enabledConnectorSlugs).toStrictEqual(
+      legacy.body.enabledTypes,
+    );
+
+    const canonical = await accept(
+      client.update({
+        params,
+        body: { enabledConnectorSlugs: ["slack"] },
+        headers,
+      }),
+      [200],
+    );
+    expect(canonical.body).toMatchObject({
+      enabledTypes: ["slack"],
+      enabledConnectorSlugs: ["slack"],
+    });
+
+    const dual = await accept(
+      client.update({
+        params,
+        body: {
+          enabledTypes: ["github"],
+          enabledConnectorSlugs: ["github"],
+          operation: "add",
+        },
+        headers,
+      }),
+      [200],
+    );
+    expect(dual.body.enabledConnectorSlugs).toStrictEqual(
+      dual.body.enabledTypes,
+    );
+
+    const conflicting = await accept(
+      client.update({
+        params,
+        body: {
+          enabledTypes: ["github"],
+          enabledConnectorSlugs: ["slack"],
+        },
+        headers,
+      }),
+      [400],
+    );
+    expect(conflicting.body.error.code).toBe("BAD_REQUEST");
+
+    const missing = await accept(
+      client.update({ params, body: {}, headers }),
+      [400],
+    );
+    expect(missing.body.error.code).toBe("BAD_REQUEST");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -206,6 +206,7 @@ describe("GET /api/zero/connector-catalog", () => {
       return connector.connectorRef === "openai";
     });
     expect(openai).toBeDefined();
+    expect(openai?.slug).toBe(openai?.connectorRef);
     expect(openai?.label).toBe("OpenAI");
     expect(openai?.generation).toContain("text");
     expect(openai?.tags).toContain("llm");
@@ -236,7 +237,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const listResponse = await accept(client.list({ headers }), [200]);
     const statusResponse = await accept(client.status({ headers }), [200]);
     const detailResponse = await accept(
-      client.get({ params: { connectorRef: "openai" }, headers }),
+      client.get({ params: { connectorSlug: "openai" }, headers }),
       [200],
     );
 
@@ -699,7 +700,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "openai" },
+        params: { connectorSlug: "openai" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -728,7 +729,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "parallel" },
+        params: { connectorSlug: "parallel" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -767,7 +768,7 @@ describe("GET /api/zero/connector-catalog", () => {
     for (const connector of listResponse.body.connectors) {
       const detailResponse = await accept(
         client.get({
-          params: { connectorRef: connector.connectorRef },
+          params: { connectorSlug: connector.connectorRef },
           headers: { authorization: "Bearer clerk-session" },
         }),
         [200],
@@ -784,7 +785,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "test-oauth-device" },
+        params: { connectorSlug: "test-oauth-device" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [404],
@@ -804,14 +805,14 @@ describe("GET /api/zero/connector-catalog", () => {
     const connectorSlug = "x".repeat(65);
     const detailResponse = await accept(
       client.get({
-        params: { connectorRef: connectorSlug },
+        params: { connectorSlug },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
     );
     const permissionResponse = await accept(
       client.permissions({
-        params: { connectorRef: connectorSlug },
+        params: { connectorSlug },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -832,7 +833,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "test-oauth-device" },
+        params: { connectorSlug: "test-oauth-device" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -865,7 +866,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "neon" },
+        params: { connectorSlug: "neon" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -890,7 +891,7 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.get({
-        params: { connectorRef: "neon" },
+        params: { connectorSlug: "neon" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -912,14 +913,14 @@ describe("GET /api/zero/connector-catalog", () => {
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.permissions({
-        params: { connectorRef: "notion" },
+        params: { connectorSlug: "notion" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
     const detailResponse = await accept(
       client.get({
-        params: { connectorRef: "notion" },
+        params: { connectorSlug: "notion" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -927,6 +928,9 @@ describe("GET /api/zero/connector-catalog", () => {
 
     assertPublicConnectorCatalogHasNoPrivateFields(response.body);
     expect(response.body.permissions.connectorRef).toBe("notion");
+    expect(response.body.permissions.connectorSlug).toBe(
+      response.body.permissions.connectorRef,
+    );
     expect(response.body.permissions.icon).toStrictEqual(
       detailResponse.body.connector.icon,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -261,7 +261,11 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     expect(allowed.body).toMatchObject({
       outcome: "resolved",
       mode: "url",
-      connector: { connectorRef: "slack", label: "Slack" },
+      connector: {
+        connectorRef: "slack",
+        connectorSlug: "slack",
+        label: "Slack",
+      },
       run: { status: "configured" },
       permission: {
         kind: "matched",
@@ -337,6 +341,54 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     });
   });
 
+  it("accepts canonical and matching dual connector identities but rejects conflicts", async () => {
+    const actor = bdd.user();
+    const base = {
+      mode: "url" as const,
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+    };
+
+    const canonical = await checkWithSession(actor, {
+      ...base,
+      connectorSlug: "github",
+    });
+    expect(canonical.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        connectorRef: "github",
+        connectorSlug: "github",
+      },
+    });
+
+    const dual = await checkWithSession(actor, {
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(dual.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        connectorRef: "github",
+        connectorSlug: "github",
+      },
+    });
+
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const conflicting = await accept(
+      client().check({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          ...base,
+          connectorRef: "github",
+          connectorSlug: "slack",
+        },
+      }),
+      [400],
+    );
+    expect(conflicting.body.error.code).toBe("BAD_REQUEST");
+  });
+
   it("supports a real PAT and resolves hidden server-authored metadata without private refs", async () => {
     const actor = bdd.user();
     const token = await issueDevicePat(actor);
@@ -405,6 +457,7 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       mode: "environment",
       connector: {
         connectorRef: "github",
+        connectorSlug: "github",
         label: "GitHub",
         visibility: "available",
         credentialResolution: "network-boundary",
@@ -441,9 +494,14 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     expect(ambiguous.body).toStrictEqual({
       outcome: "ambiguous",
       candidates: [
-        { connectorRef: "nintendo-store", label: "Nintendo Store" },
+        {
+          connectorRef: "nintendo-store",
+          connectorSlug: "nintendo-store",
+          label: "Nintendo Store",
+        },
         {
           connectorRef: "nintendo-switch-parental-controls",
+          connectorSlug: "nintendo-switch-parental-controls",
           label: "Nintendo Switch Parental Controls",
         },
       ],
@@ -496,6 +554,7 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       outcome: "environment-not-used",
       connector: {
         connectorRef: "nintendo-switch-parental-controls",
+        connectorSlug: "nintendo-switch-parental-controls",
         label: "Nintendo Switch Parental Controls",
         visibility: "available",
         credentialResolution: "network-boundary",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  CLIENT_VERSION_HEADER,
+} from "@vm0/api-contracts/contracts/client-headers";
+import {
   type ConnectorCheckRequest,
   zeroConnectorCheckContract,
 } from "@vm0/api-contracts/contracts/zero-connector-check";
@@ -37,6 +42,10 @@ const connectorsApi = createConnectorBddApi(context);
 const authDevice = createAuthDeviceApiActions(context);
 const runsApi = createRunsApi(context);
 const store = createStore();
+const CONNECTOR_SLUG_CAPABLE_CLIENT_VERSION = addClientCapabilityToVersion(
+  "0.0.0-test",
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+);
 
 interface ConnectedFixture {
   readonly actor: ApiTestUser;
@@ -77,6 +86,23 @@ async function checkWithSession(
   return await accept(
     client().check({
       headers: { authorization: "Bearer clerk-session" },
+      extraHeaders: {
+        [CLIENT_VERSION_HEADER]: CONNECTOR_SLUG_CAPABLE_CLIENT_VERSION,
+      },
+      body,
+    }),
+    [200],
+  );
+}
+
+async function checkWithLegacySession(
+  actor: ApiTestUser,
+  body: ConnectorCheckRequest,
+) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return await accept(
+    client().check({
+      headers: { authorization: "Bearer clerk-session" },
       body,
     }),
     [200],
@@ -87,6 +113,9 @@ async function checkWithToken(token: string, body: ConnectorCheckRequest) {
   return await accept(
     client().check({
       headers: { authorization: `Bearer ${token}` },
+      extraHeaders: {
+        [CLIENT_VERSION_HEADER]: CONNECTOR_SLUG_CAPABLE_CLIENT_VERSION,
+      },
       body,
     }),
     [200],
@@ -387,6 +416,46 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       [400],
     );
     expect(conflicting.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("preserves strict legacy CLI response shapes without the slug capability", async () => {
+    const actor = bdd.user();
+    const resolved = await checkWithLegacySession(actor, {
+      mode: "environment",
+      environmentName: "GH_TOKEN",
+    });
+    expect(resolved.body).toStrictEqual({
+      outcome: "resolved",
+      mode: "environment",
+      connector: {
+        connectorRef: "github",
+        label: "GitHub",
+        visibility: "available",
+        credentialResolution: "network-boundary",
+      },
+      environmentName: "GH_TOKEN",
+      run: { status: "not-scoped" },
+      permission: null,
+    });
+
+    const ambiguous = await checkWithLegacySession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.accounts.nintendo.com/2.0.0/users/me",
+    });
+    expect(ambiguous.body).toStrictEqual({
+      outcome: "ambiguous",
+      candidates: [
+        {
+          connectorRef: "nintendo-store",
+          label: "Nintendo Store",
+        },
+        {
+          connectorRef: "nintendo-switch-parental-controls",
+          label: "Nintendo Switch Parental Controls",
+        },
+      ],
+    });
   });
 
   it("supports a real PAT and resolves hidden server-authored metadata without private refs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
@@ -43,7 +43,7 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorManualGrantContract).connect({
-      params: { type: "openai" },
+      params: { connectorSlug: "openai" },
       body: {
         authMethod: "api-token",
         values: { apiKey: "sk-test-token" },
@@ -58,7 +58,7 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorManualGrantContract).connect({
-      params: { type: "gitlab" },
+      params: { connectorSlug: "gitlab" },
       body: {
         authMethod: "api-token",
         values: {
@@ -79,7 +79,7 @@ async function readExistingConnector(
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).get({
-      params: { type: connectorSlug },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     [200],
@@ -93,7 +93,7 @@ async function readMissingConnector(
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).get({
-      params: { type: connectorSlug },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     [404],
@@ -108,7 +108,7 @@ async function deleteConnector(
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).delete({
-      params: { type: connectorSlug },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     statuses,
@@ -121,13 +121,13 @@ async function cleanupFixture(fixture: AuthenticatedFixture): Promise<void> {
   }
 }
 
-describe("DELETE /api/zero/connectors/:type", () => {
+describe("DELETE /api/zero/connectors/:connectorSlug", () => {
   const track = createFixtureTracker<AuthenticatedFixture>(cleanupFixture);
 
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
-      client.delete({ params: { type: "github" }, headers: {} }),
+      client.delete({ params: { connectorSlug: "github" }, headers: {} }),
       [401],
     );
 
@@ -142,7 +142,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
       client.delete({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         headers: authHeaders(),
       }),
       [401],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
@@ -53,7 +53,7 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorManualGrantContract).connect({
-      params: { type: "openai" },
+      params: { connectorSlug: "openai" },
       body: {
         authMethod: "api-token",
         values: { apiKey: "sk-test-token" },
@@ -68,14 +68,14 @@ async function deleteOpenai(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).delete({
-      params: { type: "openai" },
+      params: { connectorSlug: "openai" },
       headers: authHeaders(),
     }),
     [204, 404],
   );
 }
 
-describe("GET /api/zero/connectors/:type", () => {
+describe("GET /api/zero/connectors/:connectorSlug", () => {
   const seededFixtures: AuthenticatedFixture[] = [];
 
   afterEach(async () => {
@@ -90,7 +90,7 @@ describe("GET /api/zero/connectors/:type", () => {
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
-      client.get({ params: { type: "github" }, headers: {} }),
+      client.get({ params: { connectorSlug: "github" }, headers: {} }),
       [401],
     );
 
@@ -103,7 +103,7 @@ describe("GET /api/zero/connectors/:type", () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
       client.get({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         headers: authHeaders(),
       }),
       [401],
@@ -119,7 +119,7 @@ describe("GET /api/zero/connectors/:type", () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
       client.get({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         headers: authHeaders(),
       }),
       [404],
@@ -137,7 +137,7 @@ describe("GET /api/zero/connectors/:type", () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
       client.get({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         headers: authHeaders(),
       }),
       [200],
@@ -145,6 +145,7 @@ describe("GET /api/zero/connectors/:type", () => {
 
     expect(response.body).toMatchObject({
       type: "openai",
+      slug: "openai",
       authMethod: "api-token",
       connectionStatus: "connected",
     });
@@ -169,7 +170,7 @@ describe("GET /api/zero/connectors/:type", () => {
     const client = setupApp({ context })(zeroConnectorsBySlugContract);
     const response = await accept(
       client.get({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         headers: { authorization: `Bearer ${token}` },
       }),
       [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -36,7 +36,7 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorManualGrantContract).connect({
-      params: { type: "gitlab" },
+      params: { connectorSlug: "gitlab" },
       body: {
         authMethod: "api-token",
         values: {
@@ -54,7 +54,7 @@ async function deleteGitlab(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).delete({
-      params: { type: "gitlab" },
+      params: { connectorSlug: "gitlab" },
       headers: authHeaders(),
     }),
     [204, 404],
@@ -85,6 +85,9 @@ describe("GET /api/zero/connectors", () => {
 
     expect(response.body.connectors).toStrictEqual([]);
     expect(Array.isArray(response.body.configuredTypes)).toBeTruthy();
+    expect(response.body.configuredConnectorSlugs).toStrictEqual(
+      response.body.configuredTypes,
+    );
     expect(Array.isArray(response.body.connectorProvidedBindings)).toBeTruthy();
   });
 
@@ -124,6 +127,7 @@ describe("GET /api/zero/connectors", () => {
     expect(response.body.connectors).toContainEqual(
       expect.objectContaining({
         type: "gitlab",
+        slug: "gitlab",
         authMethod: "api-token",
         connectionStatus: "connected",
       }),
@@ -131,6 +135,7 @@ describe("GET /api/zero/connectors", () => {
     expect(response.body.connectorProvidedBindings).toContainEqual(
       expect.objectContaining({
         connectorType: "gitlab",
+        connectorSlug: "gitlab",
         namespace: "secrets",
         name: "GITLAB_TOKEN",
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
@@ -85,7 +85,7 @@ async function deleteConnector(
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).delete({
-      params: { type: connectorSlug },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     [204, 404],
@@ -106,14 +106,14 @@ async function readConnector(
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return await accept(
     setupApp({ context })(zeroConnectorsBySlugContract).get({
-      params: { type: connectorSlug },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     [200],
   );
 }
 
-describe("POST /api/zero/connectors/:type/manual-grant", () => {
+describe("POST /api/zero/connectors/:connectorSlug/manual-grant", () => {
   const fixtures: AuthenticatedFixture[] = [];
 
   afterEach(async () => {
@@ -135,7 +135,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: {},
       }),
@@ -151,7 +151,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -188,7 +188,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: connectorSlug },
+        params: { connectorSlug },
         body: { authMethod, values: { apiKey: "secret" } },
         headers: authHeaders(),
       }),
@@ -235,7 +235,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
           values: { apiKey: " sk-test\n" },
@@ -266,7 +266,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "zendesk" },
+        params: { connectorSlug: "zendesk" },
         body: {
           authMethod: "api-token",
           values: {
@@ -317,7 +317,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const fixture = await seedFixture();
     await accept(
       setupApp({ context })(zeroConnectorManualGrantContract).connect({
-        params: { type: "zendesk" },
+        params: { connectorSlug: "zendesk" },
         body: {
           authMethod: "api-token",
           values: {
@@ -367,7 +367,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       setupApp({ context })(zeroConnectorManualGrantContract).connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         headers: authHeaders(),
         body: {
           authMethod: "api-token",
@@ -427,7 +427,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "insforge" },
+        params: { connectorSlug: "insforge" },
         body: {
           authMethod: "api-token",
           values: {
@@ -455,7 +455,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "lark" },
+        params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
           values: {
@@ -484,7 +484,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     await accept(
       client.connect({
-        params: { type: "lark" },
+        params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
           values: {
@@ -499,7 +499,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     await accept(
       client.connect({
-        params: { type: "lark" },
+        params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
           values: {
@@ -529,7 +529,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     await accept(
       client.connect({
-        params: { type: "test-oauth" },
+        params: { connectorSlug: "test-oauth" },
         body: {
           authMethod: "api-token",
           values: {
@@ -545,7 +545,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     await accept(
       client.connect({
-        params: { type: "test-oauth" },
+        params: { connectorSlug: "test-oauth" },
         body: {
           authMethod: "api-token",
           values: {
@@ -568,7 +568,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
     await accept(
       client.connect({
-        params: { type: "gitlab" },
+        params: { connectorSlug: "gitlab" },
         body: {
           authMethod: "api-token",
           values: {
@@ -583,7 +583,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     await accept(
       client.connect({
-        params: { type: "gitlab" },
+        params: { connectorSlug: "gitlab" },
         body: {
           authMethod: "api-token",
           values: { accessToken: "new-token" },
@@ -607,7 +607,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
           values: { OPENAI_TOKEN: "sk-private" },
@@ -628,7 +628,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
           values: {
@@ -654,7 +654,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: { authMethod: "api-token", values: {} },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -671,7 +671,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: { authMethod: "api-token", values: { apiKey: " \n\t " } },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -688,7 +688,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         body: { authMethod: "api-token", values: {} },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -706,7 +706,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "stripe" },
+        params: { connectorSlug: "stripe" },
         body: { authMethod: "oauth", values: { apiKey: "sk_test_key" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -724,7 +724,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "bentoml" },
+        params: { connectorSlug: "bentoml" },
         body: {
           authMethod: "api-token",
           values: {
@@ -750,7 +750,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "cloudflare" },
+        params: { connectorSlug: "cloudflare" },
         body: { authMethod: "api-token", values: {} },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -770,7 +770,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     await accept(
       client.connect({
-        params: { type: "openai" },
+        params: { connectorSlug: "openai" },
         body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -780,7 +780,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "connector:changed",
-      { connectorRef: "openai" },
+      { connectorRef: "openai", connectorSlug: "openai" },
     );
   });
 
@@ -793,7 +793,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
 
     const response = await accept(
       client.connect({
-        params: { type: "bentoml" },
+        params: { connectorSlug: "bentoml" },
         body: {
           authMethod: "api-token",
           values: {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -179,7 +179,7 @@ async function rejectProviderAuthorization(
   await app.request(callbackUrl.toString());
 }
 
-describe("POST /api/zero/connectors/:type/oauth/start", () => {
+describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
   beforeEach(() => {
     mockEnv("VM0_API_BACKEND_URL", API_ORIGIN);
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -49,7 +49,7 @@ async function connectGithub(actor: ApiTestUser): Promise<void> {
   });
 }
 
-describe("GET /api/zero/connectors/:type/scope-diff", () => {
+describe("GET /api/zero/connectors/:connectorSlug/scope-diff", () => {
   it("returns 401 when not authenticated", async () => {
     const response = await connectorsApi.requestScopeDiff(
       null,
@@ -87,7 +87,7 @@ describe("GET /api/zero/connectors/:type/scope-diff", () => {
     const client = setupApp({ context })(zeroConnectorScopeDiffContract);
     const response = await accept(
       client.getScopeDiff({
-        params: { type: "github" },
+        params: { connectorSlug: "github" },
         headers: { authorization: `Bearer ${token}` },
       }),
       [403],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -95,6 +95,7 @@ describe("GET /api/zero/connectors/search", () => {
     expect(response.body.connectors.length).toBeGreaterThan(0);
     for (const connector of response.body.connectors) {
       expect(connector).toHaveProperty("id");
+      expect(connector.slug).toBe(connector.id);
       expect(connector).toHaveProperty("label");
       expect(connector).toHaveProperty("description");
       expect(connector).toHaveProperty("authMethods");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -214,9 +214,73 @@ describe("zero user permission grants", () => {
     expect(listed[0]).toMatchObject({
       agentId,
       connectorRef: SLACK_CONNECTOR,
+      connectorSlug: SLACK_CONNECTOR,
       permission: SLACK_READ_PERMISSION,
       action: "allow",
     });
+  });
+
+  it("accepts transitional connector fields and rejects conflicting aliases", async () => {
+    const fixture = await createFixture();
+    const agentId = await seedAgent(fixture);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const base = {
+      agentId,
+      mode: "patch" as const,
+      grants: [
+        {
+          permission: SLACK_READ_PERMISSION,
+          action: "allow" as const,
+        },
+      ],
+    };
+
+    const canonical = await accept(
+      client().apply({
+        body: { ...base, connectorSlug: SLACK_CONNECTOR },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(canonical.body[0]).toMatchObject({
+      connectorRef: SLACK_CONNECTOR,
+      connectorSlug: SLACK_CONNECTOR,
+    });
+
+    const dual = await accept(
+      client().apply({
+        body: {
+          ...base,
+          connectorRef: SLACK_CONNECTOR,
+          connectorSlug: SLACK_CONNECTOR,
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [200],
+    );
+    expect(dual.body[0]).toMatchObject({
+      connectorRef: SLACK_CONNECTOR,
+      connectorSlug: SLACK_CONNECTOR,
+    });
+
+    const conflicting = await accept(
+      client().apply({
+        body: {
+          ...base,
+          connectorRef: SLACK_CONNECTOR,
+          connectorSlug: "notion",
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    expect(conflicting.body.error.code).toBe("BAD_REQUEST");
+
+    const missing = await accept(
+      client().apply({ body: base, headers: AUTH_HEADERS }),
+      [400],
+    );
+    expect(missing.body.error.code).toBe("BAD_REQUEST");
   });
 
   it("uses visible-agent scope for private and cross-org agents", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -327,6 +327,7 @@ describe("zero workflows", () => {
     expect(response.body.connectors).toStrictEqual([
       {
         connectorRef: "gmail",
+        connectorSlug: "gmail",
         label: "Gmail",
         icon: {
           url: "https://static.vm0.io/test-fixtures/connectors/gmail.svg",
@@ -337,6 +338,7 @@ describe("zero workflows", () => {
       },
       {
         connectorRef: "runtime",
+        connectorSlug: "runtime",
         label: "Runtime",
         icon: {
           url: "https://static.vm0.io/test-fixtures/connectors/runtime.svg",
@@ -347,6 +349,7 @@ describe("zero workflows", () => {
       },
       {
         connectorRef: "gitlab",
+        connectorSlug: "gitlab",
         label: "GitLab",
         icon: {
           url: "https://static.vm0.io/test-fixtures/connectors/gitlab.svg",

--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -151,8 +151,9 @@ function redirectWithError(
   clearCookies = false,
 ): Response {
   const errorUrl = new URL("/connector/error", origin);
-  // TODO(#23619): Rename this redirect query field with Platform consumers.
+  // TODO(#23821): Remove this legacy query field after Platform migrates.
   errorUrl.searchParams.set("type", connectorSlug);
+  errorUrl.searchParams.set("connectorSlug", connectorSlug);
   errorUrl.searchParams.set("message", message);
 
   const response = connectorOAuthRedirectResponse(errorUrl.toString());
@@ -442,8 +443,9 @@ function successRedirectResponse(args: {
   readonly username: string | null | undefined;
 }): Response {
   const successUrl = new URL("/connector/success", args.origin);
-  // TODO(#23619): Rename this redirect query field with Platform consumers.
+  // TODO(#23821): Remove this legacy query field after Platform migrates.
   successUrl.searchParams.set("type", args.connectorSlug);
+  successUrl.searchParams.set("connectorSlug", args.connectorSlug);
   successUrl.searchParams.set("username", args.username ?? "");
 
   const response = connectorOAuthRedirectResponse(successUrl.toString());
@@ -978,7 +980,7 @@ const handleAuthCodeConnectorCallback$ = command(
 
 const callbackConnectorInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const { type: connectorSlug } = get(
+    const { connectorSlug } = get(
       pathParamsOf(connectorsSlugCallbackContract.callback),
     );
     const query = get(queryOf(connectorsSlugCallbackContract.callback));

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -499,7 +499,10 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
   }
   return {
     status: 200 as const,
-    body: { enabledTypes: availableEnabledConnectorSlugs },
+    body: {
+      enabledTypes: availableEnabledConnectorSlugs,
+      enabledConnectorSlugs: availableEnabledConnectorSlugs,
+    },
   };
 });
 
@@ -817,7 +820,9 @@ const updateAgentUserConnectorsInner$ = command(
       return agentNotFound(params.id);
     }
 
-    const uniqueConnectorSlugs = Array.from(new Set(body.data.enabledTypes));
+    const uniqueConnectorSlugs = Array.from(
+      new Set(body.data.enabledConnectorSlugs),
+    );
     const operation = body.data.operation ?? "replace";
     if (operation !== "remove") {
       // Agent connector selection is persisted execution configuration, not a
@@ -868,9 +873,13 @@ const updateAgentUserConnectorsInner$ = command(
       return agentNotFound(params.id);
     }
 
+    const enabledConnectorSlugs = [...updated.enabledConnectorSlugs];
     return {
       status: 200 as const,
-      body: { enabledTypes: [...updated.enabledConnectorSlugs] },
+      body: {
+        enabledTypes: enabledConnectorSlugs,
+        enabledConnectorSlugs,
+      },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -160,7 +160,7 @@ const getConnectorCatalogInner$ = command(
     const connector = await settleConnectorCatalogRead(
       getPublicConnectorCatalogDetail({
         db: context.db,
-        connectorSlug: params.connectorRef,
+        connectorSlug: params.connectorSlug,
         featureStates: context.featureStates,
       }),
       signal,
@@ -185,7 +185,7 @@ const getConnectorCatalogPermissionsInner$ = command(
     const permissions = await settleConnectorCatalogRead(
       getPublicConnectorCatalogPermissionDetail({
         db: context.db,
-        connectorSlug: params.connectorRef,
+        connectorSlug: params.connectorSlug,
         featureStates: context.featureStates,
       }),
       signal,

--- a/turbo/apps/api/src/signals/routes/zero-connector-check.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-check.ts
@@ -1,4 +1,12 @@
-import { zeroConnectorCheckContract } from "@vm0/api-contracts/contracts/zero-connector-check";
+import {
+  clientVersionSupportsCapability,
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  CLIENT_VERSION_HEADER,
+} from "@vm0/api-contracts/contracts/client-headers";
+import {
+  type ConnectorCheckDiagnosticResult,
+  zeroConnectorCheckContract,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
 import { command } from "ccstate";
 
 import {
@@ -6,6 +14,7 @@ import {
   type AuthErrorResponse,
 } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { resolveConnectorCheck$ } from "../services/connector-check.service";
@@ -23,8 +32,65 @@ function missingAgentRunReadCapability(): AuthErrorResponse {
   };
 }
 
+type ConnectorCheckIdentity = Extract<
+  ConnectorCheckDiagnosticResult,
+  { readonly connector: unknown }
+>["connector"];
+
+type ConnectorCheckCandidate = Extract<
+  ConnectorCheckDiagnosticResult,
+  { readonly outcome: "ambiguous" }
+>["candidates"][number];
+
+function legacyConnectorCheckIdentity(
+  identity: ConnectorCheckIdentity,
+): ConnectorCheckIdentity {
+  return {
+    connectorRef: identity.connectorRef,
+    label: identity.label,
+    visibility: identity.visibility,
+    credentialResolution: identity.credentialResolution,
+  };
+}
+
+function legacyConnectorCheckCandidate(
+  candidate: ConnectorCheckCandidate,
+): ConnectorCheckCandidate {
+  return {
+    connectorRef: candidate.connectorRef,
+    label: candidate.label,
+  };
+}
+
+function projectConnectorCheckDiagnostic(
+  diagnostic: ConnectorCheckDiagnosticResult,
+  supportsCanonicalIdentity: boolean,
+): ConnectorCheckDiagnosticResult {
+  if (supportsCanonicalIdentity) {
+    return diagnostic;
+  }
+  // TODO(#23821): Remove this projection after strict legacy CLI clients expire.
+  if (diagnostic.outcome === "ambiguous") {
+    return {
+      ...diagnostic,
+      candidates: diagnostic.candidates.map(legacyConnectorCheckCandidate),
+    };
+  }
+  if ("connector" in diagnostic) {
+    return {
+      ...diagnostic,
+      connector: legacyConnectorCheckIdentity(diagnostic.connector),
+    };
+  }
+  return diagnostic;
+}
+
 const checkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const supportsCanonicalIdentity = clientVersionSupportsCapability(
+    get(request$).raw.headers.get(CLIENT_VERSION_HEADER),
+    CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  );
   const bodyResult = await get(bodyResultOf(zeroConnectorCheckContract.check));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -54,7 +120,13 @@ const checkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (result.kind === "not-found") {
     return notFound("Agent run not found");
   }
-  return { status: 200 as const, body: result.diagnostic };
+  return {
+    status: 200 as const,
+    body: projectConnectorCheckDiagnostic(
+      result.diagnostic,
+      supportsCanonicalIdentity,
+    ),
+  };
 });
 
 export const zeroConnectorCheckRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/zero-connectors-external-code.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-external-code.ts
@@ -36,7 +36,7 @@ const startConnectorExternalCodeSessionInner$ = command(
         userId: auth.userId,
         agentId: body.data.agentId,
         authorizeAgent: body.data.authorizeAgent,
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         authMethod: body.data.authMethod,
       },
       signal,
@@ -63,7 +63,7 @@ const completeConnectorExternalCodeSessionInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         sessionId: params.sessionId,
         sessionToken: body.data.sessionToken,
         code: body.data.code,

--- a/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors-oauth-device-auth.ts
@@ -36,7 +36,7 @@ const startConnectorOauthDeviceAuthSessionInner$ = command(
         userId: auth.userId,
         agentId: body.data.agentId,
         authorizeAgent: body.data.authorizeAgent,
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         authMethod: body.data.authMethod,
         options: body.data.options,
       },
@@ -64,7 +64,7 @@ const pollConnectorOauthDeviceAuthSessionInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         sessionId: params.sessionId,
         sessionToken: body.data.sessionToken,
       },

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -185,7 +185,7 @@ const getConnectorBySlugInner$ = computed(async (get) => {
   const params = get(pathParamsOf(zeroConnectorsBySlugContract.get));
   const resolver = await get(connectorActionResolver());
   const resolved = await resolver.resolveSlug({
-    connectorSlug: params.type,
+    connectorSlug: params.connectorSlug,
     requireExecutable: false,
   });
   if (!resolved.ok) {
@@ -213,7 +213,7 @@ const deleteConnectorBySlugInner$ = command(
     const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolved = await resolver.resolveSlug({
-      connectorSlug: params.type,
+      connectorSlug: params.connectorSlug,
       requireExecutable: false,
     });
     signal.throwIfAborted();
@@ -245,7 +245,7 @@ const getScopeDiffInner$ = computed(async (get) => {
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
   const resolver = await get(connectorActionResolver());
   const resolved = await resolver.resolveSlug({
-    connectorSlug: params.type,
+    connectorSlug: params.connectorSlug,
     requireExecutable: false,
   });
   if (!resolved.ok) {
@@ -320,14 +320,14 @@ const connectManualGrantConnectorInner$ = command(
     const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolved = await resolver.resolveNewActionMethod({
-      connectorSlug: params.type,
+      connectorSlug: params.connectorSlug,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "manual",
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
       return connectorMethodResolutionError(resolved, {
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         authMethodId: bodyResult.data.authMethod,
         expectedGrantKind: "manual",
         expectedGrantLabel: "a manual grant",
@@ -399,14 +399,14 @@ const connectNoAuthConnectorInner$ = command(
     const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolved = await resolver.resolveNewActionMethod({
-      connectorSlug: params.type,
+      connectorSlug: params.connectorSlug,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "none",
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
       return connectorMethodResolutionError(resolved, {
-        connectorSlug: params.type,
+        connectorSlug: params.connectorSlug,
         authMethodId: bodyResult.data.authMethod,
         expectedGrantKind: "none",
         expectedGrantLabel: "a no-auth grant",
@@ -457,7 +457,7 @@ const startConnectorOauthInner$ = command(
     }
     const request = get(request$).raw;
     const auth = get(authContext$);
-    const connectorSlug = params.type;
+    const connectorSlug = params.connectorSlug;
 
     if (!auth.orgId) {
       return badRequestMessage(
@@ -576,7 +576,7 @@ const continueConnectorOauthInner$ = command(
     const query = get(queryOf(zeroConnectorOauthContinueContract.continue));
     const resolution = await getConnectorOAuthAuthorizationUrl(
       get(db$),
-      { state: query.state, connectorSlug: params.type },
+      { state: query.state, connectorSlug: params.connectorSlug },
       signal,
     );
 
@@ -604,7 +604,7 @@ const startConnectorOpenIdInner$ = command(
     }
     const request = get(request$).raw;
     const auth = get(authContext$);
-    const connectorSlug = params.type;
+    const connectorSlug = params.connectorSlug;
 
     if (!auth.orgId) {
       return badRequestMessage(

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -680,6 +680,7 @@ function connectorCatalogItem(
 ): PublicConnectorCatalogItem {
   return {
     connectorRef: effective.connector.slug,
+    slug: effective.connector.slug,
     label: effective.connector.label,
     description: effective.connector.description,
     icon: iconForCatalog(effective.connector),
@@ -938,6 +939,7 @@ export async function searchExternalConnectorCatalog(
     return [
       {
         id: connector.slug,
+        slug: connector.slug,
         label: connector.label,
         description: connector.description,
         authMethods: entry.authMethods.map((method) => {
@@ -1014,6 +1016,7 @@ export async function getExternalPublicConnectorCatalogPermissionDetail(
   );
   return {
     connectorRef: entry.connector.slug,
+    connectorSlug: entry.connector.slug,
     label: entry.connector.label,
     icon: iconForCatalog(entry.connector),
     permissionCount: permissions.length,

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -1,7 +1,7 @@
 import type {
   ConnectorCheckDiagnosticResult,
   ConnectorCheckPolicy,
-  ConnectorCheckRequest,
+  NormalizedConnectorCheckRequest,
 } from "@vm0/api-contracts/contracts/zero-connector-check";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
@@ -51,8 +51,9 @@ import {
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ConnectorCheckIdentity {
-  // TODO(#23619): Rename this wire response field after API clients migrate.
+  // TODO(#23821): Remove this legacy response field after clients migrate.
   readonly connectorRef: ConnectorSlug;
+  readonly connectorSlug: ConnectorSlug;
   readonly label: string;
   readonly visibility: "available" | "unavailable";
   readonly credentialResolution: "network-boundary" | "none";
@@ -88,7 +89,7 @@ type ConnectorCheckTimeline =
   | { readonly kind: "run"; readonly context: RunContextResponse };
 
 interface ResolveConnectorCheckArgs {
-  readonly request: ConnectorCheckRequest;
+  readonly request: NormalizedConnectorCheckRequest;
   readonly orgId: string;
   readonly userId: string;
   readonly stateSource:
@@ -156,6 +157,7 @@ function connectorIdentity(
   }
   return {
     connectorRef: connectorSlug,
+    connectorSlug,
     label: connector.catalogConnector.label,
     visibility: catalogContext.visibleConnectorSlugs.has(connectorSlug)
       ? "available"
@@ -971,6 +973,7 @@ function ambiguousDiagnostic(
       }
       return {
         connectorRef: candidate,
+        connectorSlug: candidate,
         label: connector.catalogConnector.label,
       };
     }),
@@ -1046,7 +1049,10 @@ function selectUrlEnvironmentNames(args: {
 }
 
 interface ResolvedUrlDiagnosticArgs {
-  readonly request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>;
+  readonly request: Extract<
+    NormalizedConnectorCheckRequest,
+    { readonly mode: "url" }
+  >;
   readonly parsed: ParsedConnectorDiagnosticRequest;
   readonly decision: Exclude<
     FirewallRequestDecision,
@@ -1078,8 +1084,8 @@ function resolvedUrlDiagnostic(
   }
   const connectorSlug = decision.firewallName;
   if (
-    request.connectorRef !== undefined &&
-    connectorSlug !== request.connectorRef
+    request.connectorSlug !== undefined &&
+    connectorSlug !== request.connectorSlug
   ) {
     return {
       outcome: "connector-mismatch",
@@ -1121,12 +1127,12 @@ function resolvedUrlDiagnostic(
 }
 
 async function resolveUrlMode(
-  request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>,
+  request: Extract<NormalizedConnectorCheckRequest, { readonly mode: "url" }>,
   parsed: ParsedConnectorDiagnosticRequest,
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
 ): Promise<ConnectorCheckDiagnosticResult> {
-  const requestedConnectorSlug = request.connectorRef;
+  const requestedConnectorSlug = request.connectorSlug;
   if (
     requestedConnectorSlug !== undefined &&
     !isConnectorSlug(catalogContext.snapshot, requestedConnectorSlug)
@@ -1175,7 +1181,10 @@ async function resolveUrlMode(
 }
 
 async function resolveEnvironmentMode(
-  request: Extract<ConnectorCheckRequest, { readonly mode: "environment" }>,
+  request: Extract<
+    NormalizedConnectorCheckRequest,
+    { readonly mode: "environment" }
+  >,
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
 ): Promise<ConnectorCheckDiagnosticResult> {

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -841,6 +841,7 @@ export const startConnectorExternalCodeSession$ = command(
       sessionId: session.id,
       sessionToken,
       type: resolved.connectorSlug,
+      connectorSlug: resolved.connectorSlug,
       status: "pending",
       authorizationUrl: startResult.authorizationUrl,
       expiresIn: startResult.expiresIn,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -97,6 +97,7 @@ function deviceAuthStartResponse(args: {
     sessionId: args.sessionId,
     sessionToken: args.sessionToken,
     type: args.connectorSlug,
+    connectorSlug: args.connectorSlug,
     status: "pending",
     userCode: args.startResult.userCode,
     verificationUri: args.startResult.verificationUri,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -205,6 +205,7 @@ function storedConnectorRowToResponse(
   return {
     id: row.id,
     type: runtimeMethod.connectorSlug,
+    slug: runtimeMethod.connectorSlug,
     authMethod: runtimeMethod.authMethodId,
     externalId: row.externalId,
     externalUsername: row.externalUsername,
@@ -472,11 +473,13 @@ export function zeroConnectorList(args: {
     const connectorProvidedBindings =
       connectorProvidedBindingsForStoredConnectors(connectorList);
 
+    const configuredConnectorSlugs = [...visibleSlugs];
     return {
       connectors: connectorList.map((connector) => {
         return connector.response;
       }),
-      configuredTypes: [...visibleSlugs],
+      configuredTypes: configuredConnectorSlugs,
+      configuredConnectorSlugs,
       connectorProvidedBindings,
     };
   });
@@ -498,6 +501,7 @@ function connectorProvidedBindingsForStoredConnectors(
         case "connector-secret": {
           provided.push({
             connectorType: connector.response.type,
+            connectorSlug: connector.response.type,
             authMethod: connector.response.authMethod,
             namespace: "secrets",
             name: envName,
@@ -509,6 +513,7 @@ function connectorProvidedBindingsForStoredConnectors(
         case "connector-variable": {
           provided.push({
             connectorType: connector.response.type,
+            connectorSlug: connector.response.type,
             authMethod: connector.response.authMethod,
             namespace: "vars",
             name: envName,

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -32,7 +32,7 @@ import {
   type SQL,
 } from "drizzle-orm";
 import type {
-  ApplyUserPermissionGrantsRequest,
+  NormalizedApplyUserPermissionGrantsRequest,
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -102,16 +102,11 @@ type UserPermissionGrantScope = UserPermissionGrantBaseScope & {
   readonly agentId: string;
 };
 
-type ApplyUserPermissionGrantsAgentRequest =
-  ApplyUserPermissionGrantsRequest & {
-    readonly agentId: string;
-  };
-
 interface ApplyUserPermissionGrantsArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly role?: string;
-  readonly apply: ApplyUserPermissionGrantsRequest;
+  readonly apply: NormalizedApplyUserPermissionGrantsRequest;
 }
 
 type NotFoundResponse = ReturnType<typeof notFound>;
@@ -163,15 +158,6 @@ function validationError(message: string): ValidationErrorResponse {
 
 function visibleZeroAgentCondition(userId: string) {
   return or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId));
-}
-
-function requireAgentGrantApply(
-  apply: ApplyUserPermissionGrantsRequest,
-): ApplyUserPermissionGrantsAgentRequest {
-  if (apply.agentId === undefined) {
-    throw new Error("Expected agent permission grant scope");
-  }
-  return apply as ApplyUserPermissionGrantsAgentRequest;
 }
 
 async function findVisibleAgent(
@@ -597,6 +583,7 @@ function formatUserPermissionGrant(
   return {
     ...scope,
     connectorRef: row.connectorRef,
+    connectorSlug: row.connectorRef,
     permission: row.permission,
     action: row.action,
     expiresAt: row.expiresAt?.toISOString() ?? null,
@@ -680,12 +667,12 @@ async function lockVisibleAgentForUpdate(
 }
 
 async function validateApplyUserPermissionGrants(
-  apply: ApplyUserPermissionGrantsRequest,
+  apply: NormalizedApplyUserPermissionGrantsRequest,
   catalog: ConnectorServerFirewallCatalog,
 ): Promise<ValidationErrorResponse | null> {
-  const index = await catalog.loadPermissionIndex(apply.connectorRef);
+  const index = await catalog.loadPermissionIndex(apply.connectorSlug);
   if (!index) {
-    return validationError(`Unknown connector ref: ${apply.connectorRef}`);
+    return validationError(`Unknown connector ref: ${apply.connectorSlug}`);
   }
 
   const seenPermissions = new Set<string>();
@@ -700,7 +687,7 @@ async function validateApplyUserPermissionGrants(
       !index.hasPermission(grant.permission)
     ) {
       return validationError(
-        `Unknown permission "${grant.permission}" for connector "${apply.connectorRef}"`,
+        `Unknown permission "${grant.permission}" for connector "${apply.connectorSlug}"`,
       );
     }
 
@@ -716,11 +703,7 @@ async function applyVisibleGrantRows(
   db: Db,
   args: ApplyUserPermissionGrantsArgs,
 ): Promise<readonly StoredPermissionGrantRow[] | NotFoundResponse> {
-  return await applyVisibleAgentGrantRows(
-    db,
-    args,
-    requireAgentGrantApply(args.apply).agentId,
-  );
+  return await applyVisibleAgentGrantRows(db, args, args.apply.agentId);
 }
 
 async function applyVisibleAgentGrantRows(
@@ -744,7 +727,7 @@ async function applyVisibleAgentGrantRows(
       eq(userPermissionGrants.orgId, args.orgId),
       eq(userPermissionGrants.userId, args.userId),
       eq(userPermissionGrants.agentId, agentId),
-      eq(userPermissionGrants.connectorRef, args.apply.connectorRef),
+      eq(userPermissionGrants.connectorRef, args.apply.connectorSlug),
     );
 
     if (args.apply.mode === "replace") {
@@ -790,7 +773,7 @@ async function applyVisibleAgentGrantRows(
                 eq(userPermissionGrants.orgId, args.orgId),
                 eq(userPermissionGrants.userId, args.userId),
                 eq(userPermissionGrants.agentId, agentId),
-                eq(userPermissionGrants.connectorRef, args.apply.connectorRef),
+                eq(userPermissionGrants.connectorRef, args.apply.connectorSlug),
                 eq(userPermissionGrants.permission, grant.permission),
               ),
             )
@@ -801,7 +784,7 @@ async function applyVisibleAgentGrantRows(
               orgId: args.orgId,
               userId: args.userId,
               agentId,
-              connectorRef: args.apply.connectorRef,
+              connectorRef: args.apply.connectorSlug,
               permission: grant.permission,
               action: grant.action,
               expiresAt,
@@ -869,7 +852,7 @@ function permissionGrantResponseScope(scope: UserPermissionGrantScope): {
 function applyPermissionGrantResponseScope(
   args: ApplyUserPermissionGrantsArgs,
 ): { readonly agentId: string } {
-  return { agentId: requireAgentGrantApply(args.apply).agentId };
+  return { agentId: args.apply.agentId };
 }
 
 async function applyRowsAndPublishNetworkPolicyRefreshes(
@@ -882,7 +865,7 @@ async function applyRowsAndPublishNetworkPolicyRefreshes(
     return rows;
   }
 
-  if (!serverFirewalls.has(args.apply.connectorRef)) {
+  if (!serverFirewalls.has(args.apply.connectorSlug)) {
     return rows;
   }
 
@@ -894,7 +877,7 @@ async function applyRowsAndPublishNetworkPolicyRefreshes(
       userId: args.userId,
       agentId: responseScope.agentId,
     },
-    args.apply.connectorRef,
+    args.apply.connectorSlug,
   );
   return rows;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -353,6 +353,7 @@ export const detectWorkflowConnectorReadiness$ = command(
         }
         connectors.push({
           connectorRef: connectorSlug,
+          connectorSlug,
           label: fallbackMetadata.label,
           icon: fallbackMetadata.icon,
           reason,
@@ -362,6 +363,7 @@ export const detectWorkflowConnectorReadiness$ = command(
       }
       connectors.push({
         connectorRef: connectorSlug,
+        connectorSlug,
         label: catalogEntry.label,
         icon: catalogEntry.icon,
         reason,

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -176,9 +176,9 @@ export function stubConnectorCatalogPermissions(
     }),
   );
   return http.get(
-    `${origin}/api/zero/connector-catalog/:connectorRef/permissions`,
+    `${origin}/api/zero/connector-catalog/:connectorSlug/permissions`,
     ({ params }) => {
-      const connectorSlug = String(params.connectorRef);
+      const connectorSlug = String(params.connectorSlug);
       const permissions = detailsBySlug.get(connectorSlug);
       if (!permissions) {
         return HttpResponse.json(

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -60,10 +60,12 @@ describe("zero connector connect command", () => {
     let receivedBody: unknown;
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         async ({ params, request }) => {
           receivedBody = await request.json();
-          return HttpResponse.json(connectorResponse(String(params.type)));
+          return HttpResponse.json(
+            connectorResponse(String(params.connectorSlug)),
+          );
         },
       ),
     );
@@ -98,10 +100,12 @@ describe("zero connector connect command", () => {
     let receivedBody: unknown;
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         async ({ params, request }) => {
           receivedBody = await request.json();
-          return HttpResponse.json(connectorResponse(String(params.type)));
+          return HttpResponse.json(
+            connectorResponse(String(params.connectorSlug)),
+          );
         },
       ),
     );
@@ -138,9 +142,9 @@ describe("zero connector connect command", () => {
         }),
       ]),
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         async ({ params, request }) => {
-          receivedType = String(params.type);
+          receivedType = String(params.connectorSlug);
           receivedBody = await request.json();
           return HttpResponse.json(
             connectorResponse(connectorSlug, authMethod),
@@ -167,9 +171,11 @@ describe("zero connector connect command", () => {
   it("prints JSON output when requested", async () => {
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         ({ params }) => {
-          return HttpResponse.json(connectorResponse(String(params.type)));
+          return HttpResponse.json(
+            connectorResponse(String(params.connectorSlug)),
+          );
         },
       ),
     );
@@ -206,7 +212,7 @@ describe("zero connector connect command", () => {
     let requestCalled = false;
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         () => {
           requestCalled = true;
           return HttpResponse.json(connectorResponse("openai"));
@@ -228,7 +234,7 @@ describe("zero connector connect command", () => {
     let requestCalled = false;
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         () => {
           requestCalled = true;
           return HttpResponse.json(connectorResponse("github"));
@@ -260,7 +266,7 @@ describe("zero connector connect command", () => {
     let requestCalled = false;
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         () => {
           requestCalled = true;
           return HttpResponse.json(connectorResponse("stripe"));
@@ -291,7 +297,7 @@ describe("zero connector connect command", () => {
   it("surfaces API validation errors without printing secret values", async () => {
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         () => {
           return HttpResponse.json(
             {
@@ -324,7 +330,7 @@ describe("zero connector connect command", () => {
   it("surfaces unavailable connector errors without printing secret values", async () => {
     server.use(
       http.post(
-        "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+        "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
         () => {
           return HttpResponse.json(
             {

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -13,6 +13,7 @@ import { basename, join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
 import {
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -26,6 +27,7 @@ import chalk from "chalk";
 const PREPARE_URL = "http://localhost:3000/api/zero/uploads/prepare";
 const COMPLETE_URL = "http://localhost:3000/api/zero/uploads/complete";
 const PUT_URL = "https://mock-r2.test/upload-target";
+const CLI_VERSION = `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`;
 
 function requiredHeader(headers: Headers, name: string): string {
   const value = headers.get(name);
@@ -86,7 +88,7 @@ describe("zero web upload-file command", () => {
             "Bearer test-token",
           );
           expect(request.headers.get("content-type")).toBe("application/json");
-          expect(request.headers.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
+          expect(request.headers.get(CLIENT_VERSION_HEADER)).toBe(CLI_VERSION);
           expect(request.headers.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
           prepareSessionId = requiredHeader(
             request.headers,
@@ -120,7 +122,7 @@ describe("zero web upload-file command", () => {
           expect(request.headers.get("authorization")).toBe(
             "Bearer test-token",
           );
-          expect(request.headers.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
+          expect(request.headers.get(CLIENT_VERSION_HEADER)).toBe(CLI_VERSION);
           expect(request.headers.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
           expect(
             requiredHeader(request.headers, CLIENT_SESSION_ID_HEADER),

--- a/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/client-headers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -121,9 +122,13 @@ describe("CLI client headers", () => {
     expect(secondHeaders.get("x-vercel-protection-bypass")).toBe(
       "preview-bypass",
     );
-    expect(firstHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
+    expect(firstHeaders.get(CLIENT_VERSION_HEADER)).toBe(
+      `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`,
+    );
     expect(firstHeaders.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
-    expect(secondHeaders.get(CLIENT_VERSION_HEADER)).toBe("0.0.0-test");
+    expect(secondHeaders.get(CLIENT_VERSION_HEADER)).toBe(
+      `0.0.0-test+${CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES}`,
+    );
     expect(secondHeaders.get(CLIENT_TYPE_HEADER)).toBe(CLIENT_TYPE_CLI);
 
     const sessionId = requiredHeader(firstHeaders, CLIENT_SESSION_ID_HEADER);

--- a/turbo/apps/cli/src/lib/api/client-headers.ts
+++ b/turbo/apps/cli/src/lib/api/client-headers.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
+  addClientCapabilityToVersion,
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_REQUEST_ID_HEADER,
   CLIENT_SESSION_ID_HEADER,
   CLIENT_TYPE_CLI,
@@ -33,7 +35,10 @@ export function createCliClientHeaderInjector(options: {
 }
 
 const addDefaultCliClientHeaders = createCliClientHeaderInjector({
-  clientVersion: __CLI_VERSION__,
+  clientVersion: addClientCapabilityToVersion(
+    __CLI_VERSION__,
+    CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+  ),
 });
 
 function addCliClientHeaders(headers: Headers): void {

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -79,7 +79,7 @@ export async function getZeroConnectorCatalogPermissions(
   const client = initClient(zeroConnectorCatalogContract, config);
 
   const result = await client.permissions({
-    params: { connectorRef: connectorSlug },
+    params: { connectorSlug },
   });
 
   if (result.status === 200) {
@@ -120,7 +120,7 @@ export async function diagnoseZeroConnectorCheck(
 }
 
 /**
- * Get a connector by type (zero proxy)
+ * Get a connector by slug (zero proxy)
  * Returns null if not connected (404 response)
  */
 export async function getZeroConnector(
@@ -130,7 +130,7 @@ export async function getZeroConnector(
   const client = initClient(zeroConnectorsBySlugContract, config);
 
   const result = await client.get({
-    params: { type: connectorSlug },
+    params: { connectorSlug },
   });
 
   if (result.status === 200) {
@@ -153,7 +153,7 @@ export async function connectZeroConnectorManualGrant(
   const client = initClient(zeroConnectorManualGrantContract, config);
 
   const result = await client.connect({
-    params: { type: connectorSlug },
+    params: { connectorSlug },
     body: { authMethod, values },
   });
 

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -281,36 +281,36 @@ export const apiHandlers = [
     );
   }),
   http.post(
-    "http://localhost:3000/api/zero/connectors/:type/manual-grant",
+    "http://localhost:3000/api/zero/connectors/:connectorSlug/manual-grant",
     async ({ params, request }) => {
       const body: unknown = await request.json();
       return HttpResponse.json(
         connectorManualGrantResponse(
-          String(params.type),
+          String(params.connectorSlug),
           manualGrantAuthMethodFromBody(body),
         ),
       );
     },
   ),
   http.post(
-    "https://app.vm0.ai/api/zero/connectors/:type/manual-grant",
+    "https://app.vm0.ai/api/zero/connectors/:connectorSlug/manual-grant",
     async ({ params, request }) => {
       const body: unknown = await request.json();
       return HttpResponse.json(
         connectorManualGrantResponse(
-          String(params.type),
+          String(params.connectorSlug),
           manualGrantAuthMethodFromBody(body),
         ),
       );
     },
   ),
   http.post(
-    "https://www.vm0.ai/api/zero/connectors/:type/manual-grant",
+    "https://www.vm0.ai/api/zero/connectors/:connectorSlug/manual-grant",
     async ({ params, request }) => {
       const body: unknown = await request.json();
       return HttpResponse.json(
         connectorManualGrantResponse(
-          String(params.type),
+          String(params.connectorSlug),
           manualGrantAuthMethodFromBody(body),
         ),
       );

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -365,7 +365,7 @@ export const apiConnectorsHandlers = [
   }),
 
   mockApi(zeroConnectorCatalogContract.permissions, ({ params, respond }) => {
-    const permissions = mockPermissionDetail(params.connectorRef);
+    const permissions = mockPermissionDetail(params.connectorSlug);
     if (!permissions) {
       return respond(404, {
         error: { message: "Connector not found", code: "NOT_FOUND" },
@@ -375,7 +375,7 @@ export const apiConnectorsHandlers = [
   }),
 
   mockApi(zeroConnectorsBySlugContract.delete, ({ params, respond }) => {
-    const connectorSlug = params.type;
+    const connectorSlug = params.connectorSlug;
     const existing = mockConnectors.find((c) => {
       return c.type === connectorSlug;
     });
@@ -396,7 +396,7 @@ export const apiConnectorsHandlers = [
     zeroConnectorManualGrantContract.connect,
     ({ body, params, respond }) => {
       const connector = createMockLocalGrantConnector(
-        params.type,
+        params.connectorSlug,
         body.authMethod,
       );
       upsertMockConnector(connector);
@@ -408,7 +408,7 @@ export const apiConnectorsHandlers = [
     zeroConnectorNoAuthGrantContract.connect,
     ({ body, params, respond }) => {
       const connector = createMockLocalGrantConnector(
-        params.type,
+        params.connectorSlug,
         body.authMethod,
       );
       upsertMockConnector(connector);
@@ -429,9 +429,10 @@ export const apiConnectorsHandlers = [
     zeroConnectorOauthDeviceAuthSessionContract.create,
     ({ params, respond }) => {
       const response = {
-        ...defaultOauthDeviceAuthSessionStartResponse(params.type),
+        ...defaultOauthDeviceAuthSessionStartResponse(params.connectorSlug),
         ...mockOauthDeviceAuthSessionStartResponse,
-        type: mockOauthDeviceAuthSessionStartResponse?.type ?? params.type,
+        type:
+          mockOauthDeviceAuthSessionStartResponse?.type ?? params.connectorSlug,
       };
       if (
         mockOauthDeviceAuthSessionStartResponse &&
@@ -452,7 +453,7 @@ export const apiConnectorsHandlers = [
         mockOauthDeviceAuthSessionPollResponses.shift() ??
         ({
           status: "complete",
-          connector: createMockOauthDeviceAuthConnector(params.type),
+          connector: createMockOauthDeviceAuthConnector(params.connectorSlug),
         } satisfies ConnectorOauthDeviceAuthSessionPollResponse);
 
       if (response.status === "complete") {
@@ -466,9 +467,10 @@ export const apiConnectorsHandlers = [
     zeroConnectorExternalCodeSessionContract.create,
     ({ params, respond }) => {
       return respond(200, {
-        ...defaultExternalCodeSessionStartResponse(params.type),
+        ...defaultExternalCodeSessionStartResponse(params.connectorSlug),
         ...mockExternalCodeSessionStartResponse,
-        type: mockExternalCodeSessionStartResponse?.type ?? params.type,
+        type:
+          mockExternalCodeSessionStartResponse?.type ?? params.connectorSlug,
       });
     },
   ),
@@ -481,7 +483,10 @@ export const apiConnectorsHandlers = [
           error: { message: "Missing authorization code", code: "BAD_REQUEST" },
         });
       }
-      const connector = createMockExternalCodeConnector(params.type, "cli");
+      const connector = createMockExternalCodeConnector(
+        params.connectorSlug,
+        "cli",
+      );
       upsertMockConnector(connector);
       return respond(200, { status: "complete", connector });
     },

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -168,7 +168,7 @@ const completeConnectorCallback$ = command(
     });
     const response = await accept(
       client.callback({
-        params: { type: connectorSlug },
+        params: { connectorSlug },
         query: { ...query, responseMode: "json" },
         fetchOptions: { signal },
       }),

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -76,7 +76,7 @@ export const deleteConnector$ = command(
     const client = createClient(zeroConnectorsBySlugContract);
     await accept(
       client.delete({
-        params: { type: connectorSlug },
+        params: { connectorSlug },
         fetchOptions: { signal },
       }),
       [204],

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -28,7 +28,7 @@ export function firewallPermissionMetadataByConnector(
     const client = createClient(zeroConnectorCatalogContract);
     const result = await accept(
       client.permissions({
-        params: { connectorRef: key },
+        params: { connectorSlug: key },
       }),
       [200, 404],
     );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -759,7 +759,7 @@ export const scopeDiff$ = computed(async (get) => {
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorScopeDiffContract);
   const result = await accept(
-    client.getScopeDiff({ params: { type: connectorSlug } }),
+    client.getScopeDiff({ params: { connectorSlug } }),
     [200],
   );
   return result.body;
@@ -938,7 +938,7 @@ export const submitManualGrant$ = command(
         const connectorClient = createClient(zeroConnectorManualGrantContract);
         await accept(
           connectorClient.connect({
-            params: { type: connectorSlug },
+            params: { connectorSlug },
             body: {
               authMethod,
               authorizeAgent: true,
@@ -1011,7 +1011,7 @@ export const connectConnectorNoAuth$ = command(
         const connectorClient = createClient(zeroConnectorNoAuthGrantContract);
         await accept(
           connectorClient.connect({
-            params: { type: connectorSlug },
+            params: { connectorSlug },
             body: {
               authMethod,
               authorizeAgent: true,
@@ -1365,7 +1365,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
 
         const pollResponse = await accept(
           client.poll({
-            params: { type: connectorSlug, sessionId: current.sessionId },
+            params: { connectorSlug, sessionId: current.sessionId },
             body: { sessionToken: current.sessionToken },
             fetchOptions: { signal },
           }),
@@ -1557,7 +1557,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
         const startResponse = await tapError(
           accept(
             client.create({
-              params: { type: connectorSlug },
+              params: { connectorSlug },
               body: connectorOAuthDeviceAuthStartBody(args),
               fetchOptions: { signal: flowSignal },
             }),
@@ -1808,7 +1808,7 @@ export const connectConnectorExternalCode$ = command(
         const startResponse = await tapError(
           accept(
             client.create({
-              params: { type: connectorSlug },
+              params: { connectorSlug },
               body: {
                 authMethod,
                 authorizeAgent: true,
@@ -1923,7 +1923,7 @@ const completeConnectorExternalCode$ = command(
         });
         const completeResult = await accept(
           client.complete({
-            params: { type: connectorSlug, sessionId: current.sessionId },
+            params: { connectorSlug, sessionId: current.sessionId },
             body: {
               sessionToken: current.sessionToken,
               code,
@@ -2172,7 +2172,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 get(zeroClient$)(zeroConnectorOpenIdStartContract, {
                   apiBase: "api",
                 }).start({
-                  params: { type: args.connectorSlug },
+                  params: { connectorSlug: args.connectorSlug },
                   body: {
                     authMethod: args.method.id,
                     authorizeAgent: true,
@@ -2186,7 +2186,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 get(zeroClient$)(zeroConnectorOauthStartContract, {
                   apiBase: OAUTH_API_BASE,
                 }).start({
-                  params: { type: args.connectorSlug },
+                  params: { connectorSlug: args.connectorSlug },
                   body: {
                     authMethod: args.method.id,
                     authorizeAgent: true,

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -446,7 +446,7 @@ describe("onboarding flow", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ params, respond }) => {
-        expect(params.type).toBe("github");
+        expect(params.connectorSlug).toBe("github");
         return respond(200, {
           authorizationUrl: "https://oauth.test/github/authorize",
         });
@@ -502,7 +502,7 @@ describe("onboarding flow", () => {
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("ahrefs");
+        expect(params.connectorSlug).toBe("ahrefs");
         expect(body.authMethod).toBe("api-token");
         expect(body.authorizeAgent).toBeTruthy();
         expect(body.agentId).toBeUndefined();

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -98,7 +98,7 @@ describe("permission allow page", () => {
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
       ({ params, respond }) => {
-        expect(params.connectorRef).toBe("slack");
+        expect(params.connectorSlug).toBe("slack");
         return respond(200, {
           permissions: catalogPermissionDetail({
             connectorRef: "slack",
@@ -504,7 +504,7 @@ describe("permission allow page", () => {
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
       ({ params, respond }) => {
-        expect(params.connectorRef).toBe("slack");
+        expect(params.connectorSlug).toBe("slack");
         return respond(200, {
           permissions: catalogPermissionDetail({
             connectorRef: "slack",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -125,7 +125,7 @@ describe("chat composer connector connection", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("google-analytics");
+        expect(params.connectorSlug).toBe("google-analytics");
         expect(body.agentId).toBe(AGENT_ID);
         return respond(200, {
           authorizationUrl: "https://accounts.google.test/analytics/authorize",
@@ -174,7 +174,7 @@ describe("chat composer connector connection", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCount += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
           authMethod: "api",
           agentId: AGENT_ID,
@@ -182,7 +182,7 @@ describe("chat composer connector connection", () => {
         });
         return respond(200, {
           id: crypto.randomUUID(),
-          type: params.type,
+          type: params.connectorSlug,
           authMethod: body.authMethod,
           externalId: null,
           externalUsername: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1337,7 +1337,7 @@ describe("chat event action cards", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("gmail");
+        expect(params.connectorSlug).toBe("gmail");
         expect(body).toStrictEqual({
           authMethod: "oauth",
           agentId: AGENT_ID,
@@ -1559,7 +1559,7 @@ describe("chat event action cards", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCalls += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
           authMethod: "api",
           agentId: AGENT_ID,
@@ -1758,7 +1758,7 @@ describe("chat event action cards", () => {
       zeroConnectorOauthStartContract.start,
       ({ params, respond }) => {
         oauthStartRequests += 1;
-        expect(params.type).toBe("gmail");
+        expect(params.connectorSlug).toBe("gmail");
         return respond(200, {
           authorizationUrl: "https://accounts.google.test/oauth",
         });
@@ -1962,7 +1962,7 @@ describe("chat event action cards", () => {
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
       ({ params, respond }) => {
-        expect(params.connectorRef).toBe("slack");
+        expect(params.connectorSlug).toBe("slack");
         return respond(200, {
           permissions: catalogPermissionDetail({
             connectorRef: "slack",
@@ -2103,7 +2103,7 @@ describe("chat event action cards", () => {
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
       ({ params, respond }) => {
-        expect(params.connectorRef).toBe("google-sheets");
+        expect(params.connectorSlug).toBe("google-sheets");
         return respond(200, {
           permissions: catalogPermissionDetail({
             connectorRef: "google-sheets",
@@ -2500,7 +2500,7 @@ describe("chat event action cards", () => {
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("future-connector");
+        expect(params.connectorSlug).toBe("future-connector");
         expect(body.agentId).toBe(AGENT_ID);
         expect(body.authorizeAgent).toBeTruthy();
         connected = true;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -70,7 +70,7 @@ describe("connector callback page", () => {
     context.mocks.api(
       connectorsSlugCallbackContract.callback,
       ({ params, query, respond }) => {
-        expect(params.type).toBe("github");
+        expect(params.connectorSlug).toBe("github");
         observedQuery = query;
         return respond(200, {
           status: "success",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1034,7 +1034,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("meta-ads");
+        expect(params.connectorSlug).toBe("meta-ads");
         expect(body.callbackTarget).toBe("app");
         return respond(200, {
           authorizationUrl: "https://oauth.test/meta-ads/authorize",
@@ -1117,7 +1117,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorScopeDiffContract.getScopeDiff,
       ({ params, respond }) => {
-        expect(params.type).toBe("google-ads");
+        expect(params.connectorSlug).toBe("google-ads");
         return respond(200, {
           addedScopes,
           removedScopes: [],
@@ -1678,7 +1678,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("google-maps");
+        expect(params.connectorSlug).toBe("google-maps");
         expect(body.callbackTarget).toBe("app");
         return respond(200, {
           authorizationUrl: "https://oauth.test/google-maps/authorize",
@@ -1712,7 +1712,7 @@ describe("connectors page", () => {
       zeroConnectorOauthStartContract.start,
       ({ params, respond }) => {
         return respond(200, {
-          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+          authorizationUrl: `https://oauth.test/${params.connectorSlug}/authorize`,
         });
       },
     );
@@ -1785,7 +1785,7 @@ describe("connectors page", () => {
       context.mocks.api(
         zeroConnectorOauthStartContract.start,
         ({ body, params, respond }) => {
-          expect(params.type).toBe(connectorSlug);
+          expect(params.connectorSlug).toBe(connectorSlug);
           expect(body.callbackTarget).toBe("app");
           return respond(200, {
             authorizationUrl: `https://oauth.test/${connectorSlug}/authorize`,
@@ -1829,7 +1829,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("slack");
+        expect(params.connectorSlug).toBe("slack");
         expect(body.callbackTarget).toBeUndefined();
         return respond(200, {
           authorizationUrl: "https://oauth.test/slack/authorize",
@@ -1878,7 +1878,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorOpenIdStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe(connectorSlug);
+        expect(params.connectorSlug).toBe(connectorSlug);
         expect(body.authMethod).toBe(authMethod);
         return respond(200, {
           authorizationUrl: "https://openid.test/partner-steam/authorize",
@@ -1944,7 +1944,7 @@ describe("connectors page", () => {
       ({ params, respond }) => {
         startCount += 1;
         return respond(200, {
-          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+          authorizationUrl: `https://oauth.test/${params.connectorSlug}/authorize`,
         });
       },
     );
@@ -2111,7 +2111,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorOauthStartContract.start,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body?.authMethod).toBe("oauth");
         return respond(200, {
           authorizationUrl: "https://oauth.test/stripe/authorize",
@@ -2206,13 +2206,13 @@ describe("connectors page", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCount += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body.authMethod).toBe("api");
         expect(body.authorizeAgent).toBeTruthy();
         expect(body.agentId).toBeUndefined();
         return respond(200, {
           id: crypto.randomUUID(),
-          type: params.type,
+          type: params.connectorSlug,
           authMethod: body.authMethod,
           externalId: null,
           externalUsername: null,
@@ -2294,11 +2294,11 @@ describe("connectors page", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCount += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body.authMethod).toBe("api");
         return respond(200, {
           id: crypto.randomUUID(),
-          type: params.type,
+          type: params.connectorSlug,
           authMethod: body.authMethod,
           externalId: null,
           externalUsername: null,
@@ -2431,7 +2431,7 @@ describe("connectors page", () => {
       zeroConnectorOauthDeviceAuthSessionContract.create,
       ({ body, params, respond }) => {
         startCount += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         capturedOptions = body.options ?? null;
         return respond(200, {
           sessionId: "00000000-0000-4000-8000-000000000010",
@@ -2559,7 +2559,7 @@ describe("connectors page", () => {
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
         submitCount += 1;
-        expect(params.type).toBe("axiom");
+        expect(params.connectorSlug).toBe("axiom");
         submittedValues = body.values;
         return respond(200, {
           id: crypto.randomUUID(),
@@ -2649,7 +2649,7 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("axiom");
+        expect(params.connectorSlug).toBe("axiom");
         expect(body.values).toStrictEqual({ apiToken: "xaat-test" });
         catalogStatusItems = [
           {
@@ -2899,7 +2899,7 @@ describe("connectors page", () => {
         expect(body.agentId).toBeUndefined();
         return respond(200, {
           id: crypto.randomUUID(),
-          type: params.type,
+          type: params.connectorSlug,
           authMethod: body.authMethod,
           externalId: null,
           externalUsername: null,
@@ -3012,7 +3012,7 @@ describe("connectors page", () => {
       ({ body, params, respond }) => {
         return respond(200, {
           id: crypto.randomUUID(),
-          type: params.type,
+          type: params.connectorSlug,
           authMethod: body.authMethod,
           externalId: null,
           externalUsername: null,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -126,7 +126,7 @@ function mockConnectorOauthStart(): { readonly authWindow: Window } {
         callbackTarget: "app",
       });
       return respond(200, {
-        authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+        authorizationUrl: `https://oauth.test/${params.connectorSlug}/authorize`,
       });
     },
   );
@@ -154,7 +154,7 @@ function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
       });
       args?.onStart?.();
       return respond(200, {
-        authorizationUrl: `https://openid.test/${params.type}/authorize`,
+        authorizationUrl: `https://openid.test/${params.connectorSlug}/authorize`,
       });
     },
   );
@@ -344,7 +344,7 @@ describe("directed connector authorize page", () => {
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("axiom");
+        expect(params.connectorSlug).toBe("axiom");
         expect(body.agentId).toBe(AGENT_ID);
         expect(body.authorizeAgent).toBeTruthy();
         submittedValues = body.values;
@@ -404,7 +404,7 @@ describe("directed connector authorize page", () => {
       ({ params, respond }) => {
         startCalls += 1;
         return respond(200, {
-          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+          authorizationUrl: `https://oauth.test/${params.connectorSlug}/authorize`,
         });
       },
     );
@@ -522,7 +522,7 @@ describe("directed connector authorize page", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCalls += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
           authMethod: "api",
           agentId: AGENT_ID,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -253,7 +253,7 @@ function mockConnectorOauthStart(args?: {
     ({ body, params, respond }) => {
       args?.onStart?.(body.agentId, body.authorizeAgent);
       return respond(200, {
-        authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+        authorizationUrl: `https://oauth.test/${params.connectorSlug}/authorize`,
       });
     },
   );
@@ -279,7 +279,7 @@ function mockConnectorOpenIdStart(args?: {
     ({ params, respond }) => {
       args?.onStart?.();
       return respond(200, {
-        authorizationUrl: `https://openid.test/${params.type}/authorize`,
+        authorizationUrl: `https://openid.test/${params.connectorSlug}/authorize`,
       });
     },
   );
@@ -400,7 +400,7 @@ describe("directed connector connect page", () => {
       zeroConnectorNoAuthGrantContract.connect,
       ({ body, params, respond }) => {
         connectCalls += 1;
-        expect(params.type).toBe("stripe");
+        expect(params.connectorSlug).toBe("stripe");
         expect(body).toStrictEqual({
           authMethod: "api",
           agentId: AGENT_ID,
@@ -556,7 +556,7 @@ describe("directed connector connect page", () => {
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
-        expect(params.type).toBe("axiom");
+        expect(params.connectorSlug).toBe("axiom");
         expect(body.agentId).toBe(AGENT_ID);
         submittedValues = body.values;
         return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -198,7 +198,7 @@ function startGoogleDriveConnectAndRun(params: {
   detach(
     (async () => {
       const request = {
-        params: { type: params.connector.connectorRef },
+        params: { connectorSlug: params.connector.connectorRef },
         body: {
           authMethod: params.authMethod.id,
           agentId,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-compatibility.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-compatibility.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  connectorExternalCodeSessionStartResponseSchema,
+  connectorListResponseSchema,
+  connectorOauthDeviceAuthSessionStartResponseSchema,
+  connectorResponseSchema,
+} from "../connector-schemas";
+import { connectorsSlugCallbackContract } from "../connectors-slug-callback";
+import { connectorChangedPayloadSchema } from "../realtime";
+import {
+  userConnectorEnabledSlugsSchema,
+  userConnectorUpdateSchema,
+} from "../user-connectors";
+import { zeroConnectorCatalogContract } from "../zero-connector-catalog";
+import {
+  connectorCheckDiagnosticResultSchema,
+  connectorCheckRequestSchema,
+} from "../zero-connector-check";
+import {
+  zeroConnectorsBySlugContract,
+  zeroConnectorsSearchContract,
+} from "../zero-connectors";
+import {
+  applyUserPermissionGrantsRequestSchema,
+  userPermissionGrantResponseSchema,
+} from "../zero-user-permission-grants";
+import { zeroWorkflowConnectorReadinessResponseSchema } from "../zero-workflows";
+import { initClient } from "../trpc-contract";
+
+const AGENT_ID = "00000000-0000-4000-a000-000000000001";
+
+const legacyConnector = {
+  id: "00000000-0000-4000-a000-000000000002",
+  type: "github",
+  authMethod: "oauth",
+  externalId: null,
+  externalUsername: null,
+  externalEmail: null,
+  oauthScopes: null,
+  connectionStatus: "connected",
+  reconnectReason: null,
+  tokenExpiresAt: null,
+  createdAt: "2026-07-29T00:00:00.000Z",
+  updatedAt: "2026-07-29T00:00:00.000Z",
+} as const;
+
+const legacyCatalogItem = {
+  connectorRef: "github",
+  label: "GitHub",
+  description: "GitHub connector",
+  icon: {
+    url: "https://example.test/github.svg",
+    invertInDarkMode: false,
+  },
+  category: "development",
+  generation: [],
+  tags: [],
+  authMethods: [],
+  permissionSummary: {
+    hasPermissions: false,
+    permissionCount: 0,
+    hasCategories: false,
+    hasDefaultPolicyOverrides: false,
+  },
+} as const;
+
+describe("connector client response compatibility", () => {
+  it("keeps legacy-only response payloads readable", () => {
+    expect(connectorResponseSchema.safeParse(legacyConnector).success).toBe(
+      true,
+    );
+    expect(
+      connectorListResponseSchema.safeParse({
+        connectors: [legacyConnector],
+        configuredTypes: ["github"],
+        connectorProvidedBindings: [
+          {
+            connectorType: "github",
+            authMethod: "oauth",
+            namespace: "secrets",
+            name: "GITHUB_TOKEN",
+            optional: false,
+            source: { kind: "connector-secret", name: "accessToken" },
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorOauthDeviceAuthSessionStartResponseSchema.safeParse({
+        sessionId: "00000000-0000-4000-a000-000000000003",
+        sessionToken: "session-token",
+        type: "github",
+        status: "pending",
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://example.test/device",
+        expiresIn: 600,
+        interval: 5,
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorExternalCodeSessionStartResponseSchema.safeParse({
+        sessionId: "00000000-0000-4000-a000-000000000004",
+        sessionToken: "session-token",
+        type: "aws",
+        status: "pending",
+        authorizationUrl: "https://example.test/authorize",
+        expiresIn: 600,
+      }).success,
+    ).toBe(true);
+    expect(
+      zeroConnectorsSearchContract.search.responses[200].safeParse({
+        connectors: [
+          {
+            id: "github",
+            label: "GitHub",
+            description: "GitHub connector",
+            authMethods: ["oauth"],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      zeroConnectorCatalogContract.list.responses[200].safeParse({
+        connectors: [legacyCatalogItem],
+      }).success,
+    ).toBe(true);
+    expect(
+      zeroConnectorCatalogContract.permissions.responses[200].safeParse({
+        permissions: {
+          connectorRef: "github",
+          label: "GitHub",
+          icon: legacyCatalogItem.icon,
+          permissionCount: 0,
+          permissions: [],
+          categories: null,
+          defaultPolicy: {
+            permissionDefault: "ask",
+            unknownPolicy: "ask",
+          },
+        },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorCheckDiagnosticResultSchema.safeParse({
+        outcome: "resolved",
+        mode: "url",
+        connector: {
+          connectorRef: "github",
+          label: "GitHub",
+          visibility: "available",
+          credentialResolution: "network-boundary",
+        },
+        environmentNames: null,
+        run: { status: "not-scoped" },
+        method: "GET",
+        base: "https://api.github.com",
+        relativePath: "/user",
+        permission: {
+          kind: "unknown-endpoint",
+          policy: { outcome: "allow", basis: "no-policy" },
+        },
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorCheckDiagnosticResultSchema.safeParse({
+        outcome: "ambiguous",
+        candidates: [
+          { connectorRef: "github", label: "GitHub" },
+          { connectorRef: "gitlab", label: "GitLab" },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      userConnectorEnabledSlugsSchema.safeParse({
+        enabledTypes: ["github"],
+      }).success,
+    ).toBe(true);
+    expect(
+      userPermissionGrantResponseSchema.safeParse({
+        agentId: AGENT_ID,
+        connectorRef: "github",
+        permission: "contents:read",
+        action: "allow",
+        expiresAt: null,
+        createdAt: "2026-07-29T00:00:00.000Z",
+        updatedAt: "2026-07-29T00:00:00.000Z",
+      }).success,
+    ).toBe(true);
+    expect(
+      zeroWorkflowConnectorReadinessResponseSchema.safeParse({
+        connectors: [
+          {
+            connectorRef: "github",
+            label: "GitHub",
+            icon: legacyCatalogItem.icon,
+            reason: "Connect GitHub",
+            status: "not-connected",
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorChangedPayloadSchema.safeParse({
+        connectorRef: "github",
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("connector client request compatibility", () => {
+  it("normalizes legacy, canonical, and matching dual connector checks", () => {
+    const base = {
+      mode: "url" as const,
+      method: "GET",
+      url: "https://api.github.com/user",
+    };
+
+    expect(
+      connectorCheckRequestSchema.parse({
+        ...base,
+        connectorRef: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(
+      connectorCheckRequestSchema.parse({
+        ...base,
+        connectorSlug: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(
+      connectorCheckRequestSchema.parse({
+        ...base,
+        connectorRef: "github",
+        connectorSlug: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(connectorCheckRequestSchema.parse(base)).toStrictEqual(base);
+    expect(
+      connectorCheckRequestSchema.safeParse({
+        ...base,
+        connectorRef: "github",
+        connectorSlug: "gitlab",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("normalizes valid user connector updates and rejects ambiguous input", () => {
+    expect(
+      userConnectorUpdateSchema.parse({ enabledTypes: ["github"] }),
+    ).toStrictEqual({
+      enabledTypes: ["github"],
+      enabledConnectorSlugs: ["github"],
+    });
+    expect(
+      userConnectorUpdateSchema.parse({
+        enabledConnectorSlugs: ["github"],
+      }),
+    ).toStrictEqual({
+      enabledTypes: ["github"],
+      enabledConnectorSlugs: ["github"],
+    });
+    expect(
+      userConnectorUpdateSchema.parse({
+        enabledTypes: ["github"],
+        enabledConnectorSlugs: ["github"],
+        operation: "add",
+      }),
+    ).toStrictEqual({
+      enabledTypes: ["github"],
+      enabledConnectorSlugs: ["github"],
+      operation: "add",
+    });
+    expect(userConnectorUpdateSchema.safeParse({}).success).toBe(false);
+    expect(
+      userConnectorUpdateSchema.safeParse({
+        enabledTypes: ["github", "gitlab"],
+        enabledConnectorSlugs: ["gitlab", "github"],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("normalizes valid permission grant requests and rejects ambiguity", () => {
+    const base = {
+      agentId: AGENT_ID,
+      mode: "patch" as const,
+      grants: [{ permission: "contents:read", action: "allow" as const }],
+    };
+
+    expect(
+      applyUserPermissionGrantsRequestSchema.parse({
+        ...base,
+        connectorRef: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(
+      applyUserPermissionGrantsRequestSchema.parse({
+        ...base,
+        connectorSlug: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(
+      applyUserPermissionGrantsRequestSchema.parse({
+        ...base,
+        connectorRef: "github",
+        connectorSlug: "github",
+      }),
+    ).toStrictEqual({
+      ...base,
+      connectorRef: "github",
+      connectorSlug: "github",
+    });
+    expect(applyUserPermissionGrantsRequestSchema.safeParse(base).success).toBe(
+      false,
+    );
+    expect(
+      applyUserPermissionGrantsRequestSchema.safeParse({
+        ...base,
+        connectorRef: "github",
+        connectorSlug: "gitlab",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("connector path parameter compatibility", () => {
+  it("keeps concrete connector URLs unchanged", async () => {
+    const paths: string[] = [];
+    const config = {
+      baseUrl: "https://api.example.test",
+      api: async (args: { readonly path: string }) => {
+        paths.push(args.path);
+        return {
+          status: 204,
+          body: undefined,
+          headers: new Headers(),
+        };
+      },
+    };
+
+    await initClient(zeroConnectorsBySlugContract, config).delete({
+      params: { connectorSlug: "github" },
+      headers: {},
+    });
+    await initClient(zeroConnectorCatalogContract, config).permissions({
+      params: { connectorSlug: "github" },
+      headers: {},
+    });
+    await initClient(connectorsSlugCallbackContract, config).callback({
+      params: { connectorSlug: "github" },
+      query: { responseMode: "json" },
+      headers: {},
+    });
+
+    expect(paths).toStrictEqual([
+      "https://api.example.test/api/zero/connectors/github",
+      "https://api.example.test/api/zero/connector-catalog/github/permissions",
+      "https://api.example.test/api/connectors/github/callback?responseMode=json",
+    ]);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   addClientCapabilityToVersion,
   clientVersionSupportsCapability,
+  CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
   CLIENT_CAPABILITY_PT_BR_LOCALE,
   CLIENT_FORCE_UPGRADE_STATUS,
   CLIENT_HEADER_NAMES,
@@ -61,12 +62,20 @@ describe("client header contract", () => {
 
   it("advertises capabilities through backward-compatible version metadata", () => {
     const version = addClientCapabilityToVersion(
-      "0.636.1",
-      CLIENT_CAPABILITY_PT_BR_LOCALE,
+      addClientCapabilityToVersion("0.636.1", CLIENT_CAPABILITY_PT_BR_LOCALE),
+      CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
     );
-    expect(version).toBe("0.636.1+pt-br-locale-v1");
+    expect(version).toBe(
+      "0.636.1+pt-br-locale-v1.connector-slug-identities-v1",
+    );
     expect(
       clientVersionSupportsCapability(version, CLIENT_CAPABILITY_PT_BR_LOCALE),
+    ).toBe(true);
+    expect(
+      clientVersionSupportsCapability(
+        version,
+        CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES,
+      ),
     ).toBe(true);
     expect(
       clientVersionSupportsCapability(

--- a/turbo/packages/api-contracts/src/contracts/client-headers.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.ts
@@ -3,6 +3,8 @@ export const CLIENT_TYPE_HEADER = "X-Client-Type";
 export const CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id";
 export const CLIENT_REQUEST_ID_HEADER = "X-Client-Request-Id";
 export const CLIENT_CAPABILITY_PT_BR_LOCALE = "pt-br-locale-v1";
+export const CLIENT_CAPABILITY_CONNECTOR_SLUG_IDENTITIES =
+  "connector-slug-identities-v1";
 export const ZERO_MAIL_CLIENT_VERSION_HEADER = "X-Zero-Mail-Client-Version";
 export const ZERO_MAIL_CLIENT_VERSION = "3";
 export const CLIENT_FORCE_UPGRADE_STATUS = 426;

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -29,8 +29,9 @@ export type ConnectorReconnectReason = z.infer<
 
 export const connectorResponseSchema = z.object({
   id: z.uuid(),
-  // TODO(#23619): Rename this legacy wire field after API clients migrate.
+  // TODO(#23821): Remove this legacy wire field after API clients migrate.
   type: connectorSlugSchema,
+  slug: connectorSlugSchema.optional(),
   authMethod: connectorAuthMethodIdSchema,
   externalId: z.string().nullable(),
   externalUsername: z.string().nullable(),
@@ -65,8 +66,9 @@ export const connectorProvidedBindingSourceSchema = z.discriminatedUnion(
 );
 
 export const connectorProvidedBindingSchema = z.object({
-  // TODO(#23619): Rename this legacy wire field after API clients migrate.
+  // TODO(#23821): Remove this legacy wire field after API clients migrate.
   connectorType: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
   authMethod: connectorAuthMethodIdSchema,
   namespace: connectorProvidedBindingNamespaceSchema,
   name: z.string(),
@@ -104,8 +106,9 @@ export function guaranteedConnectorProvidedBindingNames(args: {
  */
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
-  // TODO(#23619): Rename this legacy wire field after API clients migrate.
+  // TODO(#23821): Remove this legacy wire field after API clients migrate.
   configuredTypes: z.array(connectorSlugSchema),
+  configuredConnectorSlugs: z.array(connectorSlugSchema).optional(),
   connectorProvidedBindings: z
     .array(connectorProvidedBindingSchema)
     .default([]),
@@ -136,8 +139,9 @@ export type ConnectorOauthStartResponse = z.infer<
 export const connectorOauthDeviceAuthSessionStartResponseSchema = z.object({
   sessionId: z.uuid(),
   sessionToken: z.string(),
-  // TODO(#23619): Rename this legacy wire field after API clients migrate.
+  // TODO(#23821): Remove this legacy wire field after API clients migrate.
   type: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
   status: z.literal("pending"),
   userCode: z.string(),
   verificationUri: z.string(),
@@ -192,8 +196,9 @@ export type ConnectorOauthDeviceAuthSessionPollResponse = z.infer<
 export const connectorExternalCodeSessionStartResponseSchema = z.object({
   sessionId: z.uuid(),
   sessionToken: z.string(),
-  // TODO(#23619): Rename this legacy wire field after API clients migrate.
+  // TODO(#23821): Remove this legacy wire field after API clients migrate.
   type: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
   status: z.literal("pending"),
   authorizationUrl: z.string(),
   expiresIn: z.number(),

--- a/turbo/packages/api-contracts/src/contracts/connectors-slug-callback.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors-slug-callback.ts
@@ -26,10 +26,9 @@ export type ConnectorOauthCallbackResult = z.infer<
 export const connectorsSlugCallbackContract = c.router({
   callback: {
     method: "GET",
-    // TODO(#23619): Rename this path parameter and route compatibly.
-    path: "/api/connectors/:type/callback",
+    path: "/api/connectors/:connectorSlug/callback",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     query: z
       .object({
         code: z.string().optional(),

--- a/turbo/packages/api-contracts/src/contracts/realtime.ts
+++ b/turbo/packages/api-contracts/src/contracts/realtime.ts
@@ -7,8 +7,9 @@ import { runnerGroupSchema } from "./runners";
 const c = initContract();
 
 export const connectorChangedPayloadSchema = z.object({
-  // TODO(#23619): Rename this realtime field after all deployed clients migrate.
+  // TODO(#23821): Remove this legacy field after deployed clients migrate.
   connectorRef: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
 });
 
 export type ConnectorChangedPayload = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/user-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-connectors.ts
@@ -11,19 +11,66 @@ const c = initContract();
  * agent.
  */
 export const userConnectorEnabledSlugsSchema = z.object({
-  // TODO(#23619): Rename this user-connector wire field after clients migrate.
+  // TODO(#23821): Remove this legacy wire field after clients migrate.
   enabledTypes: z.array(connectorSlugSchema),
+  enabledConnectorSlugs: z.array(connectorSlugSchema).optional(),
 });
 export type UserConnectorEnabledSlugs = z.infer<
   typeof userConnectorEnabledSlugsSchema
 >;
 
-export const userConnectorUpdateSchema = userConnectorEnabledSlugsSchema.extend(
-  {
+function sameConnectorSlugs(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+export const userConnectorUpdateSchema = z
+  .object({
+    // TODO(#23821): Remove this legacy wire field after clients migrate.
+    enabledTypes: z.array(connectorSlugSchema).optional(),
+    enabledConnectorSlugs: z.array(connectorSlugSchema).optional(),
     operation: z.enum(["replace", "add", "remove"]).optional(),
-  },
-);
-export type UserConnectorUpdate = z.infer<typeof userConnectorUpdateSchema>;
+  })
+  .superRefine((request, ctx) => {
+    if (
+      request.enabledTypes === undefined &&
+      request.enabledConnectorSlugs === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "enabledTypes or enabledConnectorSlugs is required",
+        path: ["enabledConnectorSlugs"],
+      });
+    }
+    if (
+      request.enabledTypes !== undefined &&
+      request.enabledConnectorSlugs !== undefined &&
+      !sameConnectorSlugs(request.enabledTypes, request.enabledConnectorSlugs)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "enabledTypes and enabledConnectorSlugs must match",
+        path: ["enabledConnectorSlugs"],
+      });
+    }
+  })
+  .transform(({ enabledTypes, enabledConnectorSlugs, ...request }) => {
+    const normalizedConnectorSlugs =
+      enabledConnectorSlugs ?? enabledTypes ?? [];
+    return {
+      ...request,
+      enabledTypes: normalizedConnectorSlugs,
+      enabledConnectorSlugs: normalizedConnectorSlugs,
+    };
+  });
+export type UserConnectorUpdate = z.input<typeof userConnectorUpdateSchema>;
 
 /**
  * Contract for GET/PUT /api/zero/agents/:id/user-connectors

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -58,8 +58,9 @@ const publicConnectorCatalogCategoryMetadataSchema = z.object({
 });
 
 const publicConnectorCatalogItemSchema = z.object({
-  // TODO(#23619): Rename catalog API fields after independent clients migrate.
+  // TODO(#23821): Remove this legacy API field after clients migrate.
   connectorRef: connectorSlugSchema,
+  slug: connectorSlugSchema.optional(),
   label: z.string(),
   description: z.string(),
   icon: publicConnectorCatalogIconSchema,
@@ -162,8 +163,9 @@ const publicConnectorCatalogDefaultPolicySchema = z.object({
 });
 
 const publicConnectorCatalogPermissionDetailSchema = z.object({
-  // TODO(#23619): Rename this catalog API field after clients migrate.
+  // TODO(#23821): Remove this legacy API field after clients migrate.
   connectorRef: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
   label: z.string(),
   icon: publicConnectorCatalogIconSchema,
   permissionCount: z.number().int().nonnegative(),
@@ -177,8 +179,7 @@ const publicConnectorCatalogPermissionDetailResponseSchema = z.object({
 });
 
 const connectorCatalogPathParamsSchema = z.object({
-  // TODO(#23619): Rename this path parameter and route in a compatible rollout.
-  connectorRef: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema,
 });
 
 export type PublicConnectorCatalogAuthMethodSummary = z.infer<
@@ -278,7 +279,7 @@ export const zeroConnectorCatalogContract = c.router({
   },
   get: {
     method: "GET",
-    path: "/api/zero/connector-catalog/:connectorRef",
+    path: "/api/zero/connector-catalog/:connectorSlug",
     headers: authHeadersSchema,
     pathParams: connectorCatalogPathParamsSchema,
     responses: {
@@ -293,7 +294,7 @@ export const zeroConnectorCatalogContract = c.router({
   },
   permissions: {
     method: "GET",
-    path: "/api/zero/connector-catalog/:connectorRef/permissions",
+    path: "/api/zero/connector-catalog/:connectorSlug/permissions",
     headers: authHeadersSchema,
     pathParams: connectorCatalogPathParamsSchema,
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
@@ -73,6 +73,7 @@ const connectorCheckIdentitySchema = z
   .object({
     // TODO(#23821): Remove this legacy response field after clients migrate.
     connectorRef: connectorSlugSchema,
+    // Capability-gated while supported legacy CLI schemas reject unknown fields.
     connectorSlug: connectorSlugSchema.optional(),
     label: z.string().min(1),
     visibility: z.enum(["available", "unavailable"]),
@@ -84,6 +85,7 @@ const connectorCheckCandidateSchema = z
   .object({
     // TODO(#23821): Remove this legacy response field after clients migrate.
     connectorRef: connectorSlugSchema,
+    // Capability-gated while supported legacy CLI schemas reject unknown fields.
     connectorSlug: connectorSlugSchema.optional(),
     label: z.string().min(1),
   })

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
@@ -13,8 +13,9 @@ const connectorCheckUrlRequestSchema = z
     mode: z.literal("url"),
     method: z.string().min(1).max(16),
     url: z.string().min(1).max(8192),
-    // TODO(#23619): Rename connector-check wire fields after clients migrate.
+    // TODO(#23821): Remove this legacy wire field after clients migrate.
     connectorRef: connectorSlugSchema.optional(),
+    connectorSlug: connectorSlugSchema.optional(),
     environmentName: boundedNameSchema.optional(),
   })
   .strict();
@@ -27,17 +28,52 @@ const connectorCheckEnvironmentRequestSchema = z
   })
   .strict();
 
-export const connectorCheckRequestSchema = z.discriminatedUnion("mode", [
-  connectorCheckUrlRequestSchema,
-  connectorCheckEnvironmentRequestSchema,
-]);
+export const connectorCheckRequestSchema = z
+  .discriminatedUnion("mode", [
+    connectorCheckUrlRequestSchema,
+    connectorCheckEnvironmentRequestSchema,
+  ])
+  .superRefine((request, ctx) => {
+    if (
+      request.mode === "url" &&
+      request.connectorRef !== undefined &&
+      request.connectorSlug !== undefined &&
+      request.connectorRef !== request.connectorSlug
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "connectorRef and connectorSlug must match",
+        path: ["connectorSlug"],
+      });
+    }
+  })
+  .transform((request) => {
+    if (request.mode === "environment") {
+      return request;
+    }
+    const { connectorRef, connectorSlug, ...rest } = request;
+    const normalizedConnectorSlug = connectorSlug ?? connectorRef;
+    return {
+      ...rest,
+      ...(normalizedConnectorSlug === undefined
+        ? {}
+        : {
+            connectorRef: normalizedConnectorSlug,
+            connectorSlug: normalizedConnectorSlug,
+          }),
+    };
+  });
 
-export type ConnectorCheckRequest = z.infer<typeof connectorCheckRequestSchema>;
+export type ConnectorCheckRequest = z.input<typeof connectorCheckRequestSchema>;
+export type NormalizedConnectorCheckRequest = z.output<
+  typeof connectorCheckRequestSchema
+>;
 
 const connectorCheckIdentitySchema = z
   .object({
-    // TODO(#23619): Rename with the connector-check response contract.
+    // TODO(#23821): Remove this legacy response field after clients migrate.
     connectorRef: connectorSlugSchema,
+    connectorSlug: connectorSlugSchema.optional(),
     label: z.string().min(1),
     visibility: z.enum(["available", "unavailable"]),
     credentialResolution: z.enum(["network-boundary", "none"]),
@@ -46,8 +82,9 @@ const connectorCheckIdentitySchema = z
 
 const connectorCheckCandidateSchema = z
   .object({
-    // TODO(#23619): Rename with the connector-check response contract.
+    // TODO(#23821): Remove this legacy response field after clients migrate.
     connectorRef: connectorSlugSchema,
+    connectorSlug: connectorSlugSchema.optional(),
     label: z.string().min(1),
   })
   .strict();

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -40,18 +40,15 @@ export const zeroConnectorsMainContract = c.router({
 });
 
 /**
- * Zero contract for GET/DELETE /api/zero/connectors/:type
- * Proxies to GET/DELETE /api/connectors/:type
- *
- * TODO(#23619): Rename connector `:type` path parameters and routes only in a
- * compatibility-safe API rollout. This applies to all connector routes below.
+ * Zero contract for GET/DELETE /api/zero/connectors/:connectorSlug
+ * Proxies to GET/DELETE /api/connectors/:connectorSlug
  */
 export const zeroConnectorsBySlugContract = c.router({
   get: {
     method: "GET",
-    path: "/api/zero/connectors/:type",
+    path: "/api/zero/connectors/:connectorSlug",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     responses: {
       200: connectorResponseSchema,
       401: apiErrorSchema,
@@ -62,9 +59,9 @@ export const zeroConnectorsBySlugContract = c.router({
   },
   delete: {
     method: "DELETE",
-    path: "/api/zero/connectors/:type",
+    path: "/api/zero/connectors/:connectorSlug",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     responses: {
       204: c.noBody(),
       401: apiErrorSchema,
@@ -75,15 +72,15 @@ export const zeroConnectorsBySlugContract = c.router({
 });
 
 /**
- * Zero contract for GET /api/zero/connectors/:type/scope-diff
+ * Zero contract for GET /api/zero/connectors/:connectorSlug/scope-diff
  * App-layer endpoint (direct service call, no proxy)
  */
 export const zeroConnectorScopeDiffContract = c.router({
   getScopeDiff: {
     method: "GET",
-    path: "/api/zero/connectors/:type/scope-diff",
+    path: "/api/zero/connectors/:connectorSlug/scope-diff",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     responses: {
       200: scopeDiffResponseSchema,
       401: apiErrorSchema,
@@ -97,9 +94,9 @@ export const zeroConnectorScopeDiffContract = c.router({
 export const zeroConnectorOauthStartContract = c.router({
   start: {
     method: "POST",
-    path: "/api/zero/connectors/:type/oauth/start",
+    path: "/api/zero/connectors/:connectorSlug/oauth/start",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -120,8 +117,8 @@ export const zeroConnectorOauthStartContract = c.router({
 export const zeroConnectorOauthContinueContract = c.router({
   continue: {
     method: "GET",
-    path: "/api/zero/connectors/:type/oauth/continue",
-    pathParams: z.object({ type: connectorSlugSchema }),
+    path: "/api/zero/connectors/:connectorSlug/oauth/continue",
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     query: z.object({ state: z.string().regex(/^[0-9a-f]{64}$/) }),
     responses: {
       307: c.noBody(),
@@ -135,9 +132,9 @@ export const zeroConnectorOauthContinueContract = c.router({
 export const zeroConnectorOpenIdStartContract = c.router({
   start: {
     method: "POST",
-    path: "/api/zero/connectors/:type/openid/start",
+    path: "/api/zero/connectors/:connectorSlug/openid/start",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -157,9 +154,9 @@ export const zeroConnectorOpenIdStartContract = c.router({
 export const zeroConnectorManualGrantContract = c.router({
   connect: {
     method: "POST",
-    path: "/api/zero/connectors/:type/manual-grant",
+    path: "/api/zero/connectors/:connectorSlug/manual-grant",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -181,9 +178,9 @@ export const zeroConnectorManualGrantContract = c.router({
 export const zeroConnectorNoAuthGrantContract = c.router({
   connect: {
     method: "POST",
-    path: "/api/zero/connectors/:type/no-auth",
+    path: "/api/zero/connectors/:connectorSlug/no-auth",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -204,9 +201,9 @@ export const zeroConnectorNoAuthGrantContract = c.router({
 export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
   create: {
     method: "POST",
-    path: "/api/zero/connectors/:type/oauth/device/sessions",
+    path: "/api/zero/connectors/:connectorSlug/oauth/device/sessions",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -224,10 +221,10 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
   },
   poll: {
     method: "POST",
-    path: "/api/zero/connectors/:type/oauth/device/sessions/:sessionId/poll",
+    path: "/api/zero/connectors/:connectorSlug/oauth/device/sessions/:sessionId/poll",
     headers: authHeadersSchema,
     pathParams: z.object({
-      type: connectorSlugSchema,
+      connectorSlug: connectorSlugSchema,
       sessionId: z.uuid(),
     }),
     body: connectorOauthDeviceAuthSessionPollRequestSchema,
@@ -246,9 +243,9 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
 export const zeroConnectorExternalCodeSessionContract = c.router({
   create: {
     method: "POST",
-    path: "/api/zero/connectors/:type/external-code/sessions",
+    path: "/api/zero/connectors/:connectorSlug/external-code/sessions",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorSlugSchema }),
+    pathParams: z.object({ connectorSlug: connectorSlugSchema }),
     body: z.object({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
@@ -265,10 +262,10 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
   },
   complete: {
     method: "POST",
-    path: "/api/zero/connectors/:type/external-code/sessions/:sessionId/complete",
+    path: "/api/zero/connectors/:connectorSlug/external-code/sessions/:sessionId/complete",
     headers: authHeadersSchema,
     pathParams: z.object({
-      type: connectorSlugSchema,
+      connectorSlug: connectorSlugSchema,
       sessionId: z.uuid(),
     }),
     body: connectorExternalCodeSessionCompleteRequestSchema,
@@ -285,7 +282,9 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
 });
 
 const connectorSearchItemSchema = z.object({
+  // TODO(#23821): Remove this legacy response field after clients migrate.
   id: connectorSlugSchema,
+  slug: connectorSlugSchema.optional(),
   label: z.string(),
   description: z.string(),
   authMethods: z.array(connectorAuthMethodIdSchema),

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -24,8 +24,9 @@ const agentPermissionGrantScopeSchema = z.object({
 export const userPermissionGrantScopeSchema = agentPermissionGrantScopeSchema;
 
 const userPermissionGrantResponseBaseSchema = z.object({
-  // TODO(#23619): Rename permission-grant wire fields with the DB migration.
+  // TODO(#23821): Remove this legacy wire field after clients migrate.
   connectorRef: connectorSlugSchema,
+  connectorSlug: connectorSlugSchema.optional(),
   permission: permissionSchema,
   action: userPermissionGrantActionSchema,
   expiresAt: z.string().nullable(),
@@ -55,15 +56,46 @@ export const applyUserPermissionGrantSchema = z.discriminatedUnion("action", [
   }),
 ]);
 
-export const applyUserPermissionGrantsRequestSchema =
-  userPermissionGrantScopeSchema.and(
-    z.object({
-      // TODO(#23619): Rename with the response and persisted grant field.
-      connectorRef: connectorSlugSchema,
-      mode: userPermissionGrantApplyModeSchema,
-      grants: z.array(applyUserPermissionGrantSchema),
-    }),
-  );
+export const applyUserPermissionGrantsRequestSchema = z
+  .object({
+    agentId: agentIdSchema,
+    // TODO(#23821): Remove this legacy wire field after clients migrate.
+    connectorRef: connectorSlugSchema.optional(),
+    connectorSlug: connectorSlugSchema.optional(),
+    mode: userPermissionGrantApplyModeSchema,
+    grants: z.array(applyUserPermissionGrantSchema),
+  })
+  .superRefine((request, ctx) => {
+    if (
+      request.connectorRef === undefined &&
+      request.connectorSlug === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "connectorRef or connectorSlug is required",
+        path: ["connectorSlug"],
+      });
+    }
+    if (
+      request.connectorRef !== undefined &&
+      request.connectorSlug !== undefined &&
+      request.connectorRef !== request.connectorSlug
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "connectorRef and connectorSlug must match",
+        path: ["connectorSlug"],
+      });
+    }
+  })
+  .transform(({ connectorRef, connectorSlug, ...request }) => {
+    const normalizedConnectorSlug = connectorSlug ?? connectorRef ?? "";
+    return {
+      ...request,
+      connectorRef: normalizedConnectorSlug,
+      connectorSlug: normalizedConnectorSlug,
+    };
+  });
 
 export const zeroUserPermissionGrantsContract = c.router({
   list: {
@@ -116,7 +148,10 @@ export type ListUserPermissionGrantsQuery = z.infer<
 export type ApplyUserPermissionGrant = z.infer<
   typeof applyUserPermissionGrantSchema
 >;
-export type ApplyUserPermissionGrantsRequest = z.infer<
+export type ApplyUserPermissionGrantsRequest = z.input<
+  typeof applyUserPermissionGrantsRequestSchema
+>;
+export type NormalizedApplyUserPermissionGrantsRequest = z.output<
   typeof applyUserPermissionGrantsRequestSchema
 >;
 export type ZeroUserPermissionGrantsContract =

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -1372,8 +1372,9 @@ export type ZeroWorkflowConnectorReadinessStatus = z.infer<
 
 export const zeroWorkflowConnectorReadinessEntrySchema = z
   .object({
-    // TODO(#23619): Rename this workflow readiness response field with clients.
+    // TODO(#23821): Remove this legacy response field after clients migrate.
     connectorRef: connectorSlugSchema,
+    connectorSlug: connectorSlugSchema.optional(),
     label: z.string().min(1),
     icon: publicConnectorCatalogIconSchema,
     reason: z.string().min(1),


### PR DESCRIPTION
## Summary

- add canonical slug-named aliases to connector-facing API responses, redirects, and realtime payloads while retaining legacy fields
- accept legacy-only, canonical-only, and matching dual request identities, normalize them for API services, and reject conflicting aliases
- rename shared contract path parameter identifiers to `connectorSlug` across API, Platform, CLI, mocks, and tests without changing concrete URLs
- add compatibility and producer integration coverage for dual emission, request normalization, path interpolation, and strict legacy CLI responses

## Deployment compatibility

- old Platform and CLI clients continue sending and reading the required legacy fields
- most expanded API responses emit both aliases unconditionally
- connector-check identities and candidates are dual-emitted only when the client advertises `connector-slug-identities-v1` through `X-Client-Version` build metadata, because released CLI schemas reject unknown nested fields
- the new CLI advertises that capability before #23777 switches its production consumer fields; old APIs ignore the build metadata
- current Platform and CLI production request bodies remain legacy-shaped until #23776 and #23777
- legacy fields and the connector-check compatibility projection remain deferred to #23821
- no database, persisted-state, runner, or registered OAuth callback URL changes

## Validation

- `pnpm format`
- `pnpm turbo run lint --filter=@vm0/api-contracts --filter=api --filter=@vm0/app --filter=@vm0/cli`
- API-contract, API, Platform, and CLI type checking
- `pnpm knip`
- focused API connector route integration tests (14 files, 210 tests)
- focused CLI connector tests (6 files, 163 tests)
- full Platform test suite (120 files, 1,216 tests)
- full CLI test suite (113 passed files and 955 passed tests)
- post-rebase API-contract compatibility tests (2 files, 10 tests)
- post-rebase connector-check and catalog API tests (2 files, 110 tests)
- post-rebase CLI header and upload tests (2 files, 15 tests)
- pre-commit formatting, Knip, repository-wide Turbo type checking, file-size validation, and commitlint

Closes #23771

Parent context: #23814, #23619
