### PR TITLE
refactor(api): use stable grouping expressions

### DIFF
--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -142,12 +142,17 @@ function modelStatModelExpression() {
   )} ELSE ${sql`${modelColumn}`} END`.mapWith(pgTextDecoder);
 }
 
-function modelStatWindowSum(value: SQLWrapper, start: string, end: string) {
+function modelStatWindowSum(
+  value: SQLWrapper,
+  hourStart: SQLWrapper,
+  start: string,
+  end: string,
+) {
   return sql`COALESCE(
     ${sum(value)} FILTER (
       WHERE ${and(
-        gte(modelStat.hourStart, sql`${start}::timestamp`),
-        lt(modelStat.hourStart, sql`${end}::timestamp`),
+        gte(hourStart, sql`${start}::timestamp`),
+        lt(hourStart, sql`${end}::timestamp`),
       )}
     ),
     0
@@ -278,42 +283,57 @@ async function selectModelRankings(
   const previousStartParam = utcTimestampParam(previousStart);
   const previousEndParam = utcTimestampParam(previousEnd);
 
+  const normalizedModelStats = db
+    .select({
+      model: modelExpr.as("normalized_model"),
+      hourStart: modelStat.hourStart,
+      inputTokens: modelStat.inputTokens,
+      outputTokens: modelStat.outputTokens,
+      cacheReadInputTokens: modelStat.cacheReadInputTokens,
+      cacheCreationInputTokens: modelStat.cacheCreationInputTokens,
+      totalTokens: modelStat.totalTokens,
+    })
+    .from(modelStat)
+    .where(
+      and(
+        gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
+        lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
+        inArray(modelStat.model, modelStatsModelIds),
+      ),
+    )
+    .as("normalized_model_stats");
+
   const rankingPeriods = db.$with("ranking_periods").as(
     db
       .select({
-        model: modelExpr.as("ranking_model"),
+        model: normalizedModelStats.model,
         inputTokens: modelStatWindowSum(
-          sql`${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}`,
+          sql`${normalizedModelStats.inputTokens} + ${normalizedModelStats.cacheReadInputTokens} + ${normalizedModelStats.cacheCreationInputTokens}`,
+          normalizedModelStats.hourStart,
           windowStartParam,
           windowEndParam,
         ).as("input_tokens"),
         outputTokens: modelStatWindowSum(
-          modelStat.outputTokens,
+          normalizedModelStats.outputTokens,
+          normalizedModelStats.hourStart,
           windowStartParam,
           windowEndParam,
         ).as("output_tokens"),
         totalTokens: modelStatWindowSum(
-          modelStat.totalTokens,
+          normalizedModelStats.totalTokens,
+          normalizedModelStats.hourStart,
           windowStartParam,
           windowEndParam,
         ).as("total_tokens"),
         previousTotalTokens: modelStatWindowSum(
-          modelStat.totalTokens,
+          normalizedModelStats.totalTokens,
+          normalizedModelStats.hourStart,
           previousStartParam,
           previousEndParam,
         ).as("previous_total_tokens"),
       })
-      .from(modelStat)
-      .where(
-        and(
-          gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
-          lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
-          inArray(modelStat.model, modelStatsModelIds),
-        ),
-      )
-      .groupBy(({ model }) => {
-        return model;
-      }),
+      .from(normalizedModelStats)
+      .groupBy(normalizedModelStats.model),
   );
 
   const rows: ModelRankingRow[] = await db

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -311,7 +311,9 @@ async function selectModelRankings(
           inArray(modelStat.model, modelStatsModelIds),
         ),
       )
-      .groupBy(sql`1`),
+      .groupBy(({ model }) => {
+        return model;
+      }),
   );
 
   const rows: ModelRankingRow[] = await db

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -58,9 +58,10 @@ async function queryAgentRunsDaily(
     return [];
   }
 
+  const dateExpr = sql`DATE(${agentRuns.createdAt})`.mapWith(pgTextDecoder);
   const rows = await db
     .select({
-      date: sql`DATE(${agentRuns.createdAt})`.mapWith(pgTextDecoder).as("date"),
+      date: dateExpr.as("date"),
       run_count: count().as("run_count"),
       run_time_ms: sql`COALESCE(${sum(
         sql`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`,
@@ -78,9 +79,7 @@ async function queryAgentRunsDaily(
         isNotNull(agentRuns.completedAt),
       ),
     )
-    .groupBy(({ date }) => {
-      return date;
-    });
+    .groupBy(dateExpr);
 
   return rows;
 }

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -78,7 +78,9 @@ async function queryAgentRunsDaily(
         isNotNull(agentRuns.completedAt),
       ),
     )
-    .groupBy(sql`DATE(${agentRuns.createdAt})`);
+    .groupBy(({ date }) => {
+      return date;
+    });
 
   return rows;
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -913,6 +913,17 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       errors: [{ messageId: "unstableGrouping" }],
     },
     {
+      name: "bound computed output alias grouping",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const bucket = sql\`DATE(\${users.deletedAt})\`.mapWith(String);
+        db.select({
+          bucket: bucket.as("bucket"),
+        }).from(users).groupBy(({ bucket: selectedBucket }) => selectedBucket);
+      `,
+      errors: [{ messageId: "unstableGrouping" }],
+    },
+    {
       name: "positional grouping of a direct column",
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -769,8 +769,202 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .where(sql\`boundary_matches(\${conditional}, \${hidden})\`);
       `,
     },
+    {
+      name: "selected grouping keeps ambiguous selections opaque",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fields = {
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        };
+        const bucket = sql\`DATE(\${users.deletedAt})\`
+          .mapWith(String)
+          .as("bucket");
+
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("id"),
+          normalized: sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("normalized"),
+        }).from(users).groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("ctid"),
+        }).from(users).groupBy(sql\`1\`);
+        db.select({
+          first: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+          second: sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`.mapWith(String),
+        }).from(users).groupBy(sql\`1\`);
+        db.select({ ...fields }).from(users).groupBy(sql\`1\`);
+        db.select({ bucket }).from(users).groupBy(sql\`1\`);
+        db.select({
+          ["bucket"]: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`1\`);
+      `,
+    },
+    {
+      name: "selected grouping keeps indirect and multi-source chains opaque",
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        import { alias } from "drizzle-orm/pg-core";
+        const otherUsers = alias(users, "other_users");
+        const rawSource: SQL = sql\`users\`;
+        const selectedUsers = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        const query = db
+          .select({
+            bucket: sql\`DATE(\${users.deletedAt})\`
+              .mapWith(String)
+              .as("bucket"),
+          })
+          .from(users);
+
+        query.groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(rawSource).groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        })
+          .from(users)
+          .innerJoin(otherUsers, eq(otherUsers.id, users.id))
+          .groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(selectedUsers).groupBy(sql\`1\`);
+      `,
+    },
+    {
+      name: "selected grouping keeps non-equivalent and invalid forms opaque",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const selection = {
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        };
+
+        db.select(selection).from(users).groupBy(sql\`1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(({ bucket }) => bucket);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`0\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`-1\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`1.5\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`2\`);
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`DATE(\${users.id})\`);
+        db.select({
+          bucket: sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("bucket"),
+        }).from(users).groupBy(sql\`UPPER(\${users.name})\`);
+        db.select().from(users).orderBy(sql\`random()\`);
+
+        function fakeSql(
+          strings: TemplateStringsArray,
+          ...values: unknown[]
+        ): unknown {
+          return { strings, values };
+        }
+        const builder = {
+          groupBy(value: unknown): unknown {
+            return value;
+          },
+        };
+        builder.groupBy(fakeSql\`1\`);
+      `,
+    },
   ],
   invalid: [
+    {
+      name: "repeated selected grouping expression",
+      code: `${drizzlePreamble}
+        import { isNotNull, sql } from "drizzle-orm";
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+          normalized: sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("normalized"),
+        })
+          .from(users)
+          .where(isNotNull(users.deletedAt))
+          .groupBy(sql\`DATE(\${users.deletedAt})\`);
+      `,
+      errors: [{ messageId: "selectedGrouping" }],
+    },
+    {
+      name: "positional selected grouping with renamed sql import",
+      code: `${drizzlePreamble}
+        import { sql as query } from "drizzle-orm";
+        db.select({
+          model: query\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("ranking_model"),
+          id: users.id,
+        }).from(users).groupBy(query\`1\`);
+      `,
+      errors: [{ messageId: "selectedGrouping" }],
+    },
+    {
+      name: "positional selected grouping with namespace sql import",
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        db.select({
+          model: drizzle.sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("ranking_model"),
+          weight: drizzle.sql\`LENGTH(\${users.name})\`
+            .mapWith(Number)
+            .as("weight"),
+        }).from(users).groupBy(drizzle.sql\`1\`);
+      `,
+      errors: [{ messageId: "selectedGrouping" }],
+    },
     {
       name: "identity column wrappers use direct structured fields",
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -770,76 +770,39 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
       `,
     },
     {
-      name: "selected grouping keeps ambiguous selections opaque",
+      name: "stable grouping expressions and input fields stay valid",
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
-        const fields = {
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        };
-        const bucket = sql\`DATE(\${users.deletedAt})\`
-          .mapWith(String)
-          .as("bucket");
+        const bucket = sql\`DATE(\${users.deletedAt})\`.mapWith(String);
+        const selectedUsers = db
+          .select({ name: users.name })
+          .from(users)
+          .as("selected_users");
 
         db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("id"),
-          normalized: sql\`LOWER(\${users.name})\`
-            .mapWith(String)
-            .as("normalized"),
-        }).from(users).groupBy(sql\`1\`);
+          bucket: bucket.as("bucket"),
+        }).from(users).groupBy(bucket);
         db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("ctid"),
-        }).from(users).groupBy(sql\`1\`);
-        db.select({
-          first: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-          second: sql\`LOWER(\${users.name})\`
-            .mapWith(String)
-            .as("bucket"),
-        }).from(users).groupBy(sql\`1\`);
-        db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`.mapWith(String),
-        }).from(users).groupBy(sql\`1\`);
-        db.select({ ...fields }).from(users).groupBy(sql\`1\`);
-        db.select({ bucket }).from(users).groupBy(sql\`1\`);
-        db.select({
-          ["bucket"]: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        }).from(users).groupBy(sql\`1\`);
+          name: selectedUsers.name,
+        }).from(selectedUsers).groupBy(({ name }) => name);
       `,
     },
     {
-      name: "selected grouping keeps indirect and multi-source chains opaque",
+      name: "unusual grouping shapes stay opaque",
       code: `${drizzlePreamble}
         import { eq, sql, type SQL } from "drizzle-orm";
         import { alias } from "drizzle-orm/pg-core";
         const otherUsers = alias(users, "other_users");
-        const rawSource: SQL = sql\`users\`;
-        const selectedUsers = db
-          .select({ id: users.id })
-          .from(users)
-          .as("selected_users");
-        const query = db
-          .select({
-            bucket: sql\`DATE(\${users.deletedAt})\`
-              .mapWith(String)
-              .as("bucket"),
-          })
-          .from(users);
-
-        query.groupBy(sql\`1\`);
-        db.select({
+        const selection = {
           bucket: sql\`DATE(\${users.deletedAt})\`
             .mapWith(String)
             .as("bucket"),
-        }).from(rawSource).groupBy(sql\`1\`);
+        };
+        const query = db.select(selection).from(users);
+        const rawSource: SQL = sql\`users\`;
+
+        query.groupBy(sql\`1\`);
+        db.select(selection).from(rawSource).groupBy(sql\`1\`);
         db.select({
           bucket: sql\`DATE(\${users.deletedAt})\`
             .mapWith(String)
@@ -852,40 +815,18 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           bucket: sql\`DATE(\${users.deletedAt})\`
             .mapWith(String)
             .as("bucket"),
-        }).from(selectedUsers).groupBy(sql\`1\`);
+        }).from(users).groupBy(({ bucket }) => sql\`LOWER(\${bucket})\`);
       `,
     },
     {
-      name: "selected grouping keeps non-equivalent and invalid forms opaque",
+      name: "non-equivalent and invalid grouping tags stay valid",
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
-        const selection = {
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        };
-
-        db.select(selection).from(users).groupBy(sql\`1\`);
-        db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        }).from(users).groupBy(({ bucket }) => bucket);
         db.select({
           bucket: sql\`DATE(\${users.deletedAt})\`
             .mapWith(String)
             .as("bucket"),
         }).from(users).groupBy(sql\`0\`);
-        db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        }).from(users).groupBy(sql\`-1\`);
-        db.select({
-          bucket: sql\`DATE(\${users.deletedAt})\`
-            .mapWith(String)
-            .as("bucket"),
-        }).from(users).groupBy(sql\`1.5\`);
         db.select({
           bucket: sql\`DATE(\${users.deletedAt})\`
             .mapWith(String)
@@ -902,19 +843,6 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             .as("bucket"),
         }).from(users).groupBy(sql\`UPPER(\${users.name})\`);
         db.select().from(users).orderBy(sql\`random()\`);
-
-        function fakeSql(
-          strings: TemplateStringsArray,
-          ...values: unknown[]
-        ): unknown {
-          return { strings, values };
-        }
-        const builder = {
-          groupBy(value: unknown): unknown {
-            return value;
-          },
-        };
-        builder.groupBy(fakeSql\`1\`);
       `,
     },
   ],
@@ -935,7 +863,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .where(isNotNull(users.deletedAt))
           .groupBy(sql\`DATE(\${users.deletedAt})\`);
       `,
-      errors: [{ messageId: "selectedGrouping" }],
+      errors: [{ messageId: "unstableGrouping" }],
     },
     {
       name: "positional selected grouping with renamed sql import",
@@ -948,7 +876,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           id: users.id,
         }).from(users).groupBy(query\`1\`);
       `,
-      errors: [{ messageId: "selectedGrouping" }],
+      errors: [{ messageId: "unstableGrouping" }],
     },
     {
       name: "positional selected grouping with namespace sql import",
@@ -963,7 +891,37 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
             .as("weight"),
         }).from(users).groupBy(drizzle.sql\`1\`);
       `,
-      errors: [{ messageId: "selectedGrouping" }],
+      errors: [{ messageId: "unstableGrouping" }],
+    },
+    {
+      name: "computed output alias grouping",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          bucket: sql\`DATE(\${users.deletedAt})\`
+            .mapWith(String)
+            .as("bucket"),
+          normalized: sql\`LOWER(\${users.name})\`
+            .mapWith(String)
+            .as("normalized"),
+        })
+          .from(users)
+          .groupBy(({ bucket: selectedBucket, normalized }) => {
+            return [selectedBucket, normalized];
+          });
+      `,
+      errors: [{ messageId: "unstableGrouping" }],
+    },
+    {
+      name: "positional grouping of a direct column",
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          id: users.id,
+          name: users.name,
+        }).from(users).groupBy(sql\`1\`);
+      `,
+      errors: [{ messageId: "unstableGrouping" }],
     },
     {
       name: "identity column wrappers use direct structured fields",

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -568,15 +568,22 @@ function getDrizzleTableMetadata(
   return concreteDrizzleTableMetadata(checker, type, location);
 }
 
-export function getDrizzleTableMetadataForWrite(
+export function getDrizzleTableMetadataForRead(
   checker: TypeChecker,
   node: Node,
 ): DrizzleTableMetadata | undefined {
-  const metadata = getDrizzleTableMetadata(
+  return getDrizzleTableMetadata(
     checker,
     checker.getTypeAtLocation(node),
     node,
   );
+}
+
+export function getDrizzleTableMetadataForWrite(
+  checker: TypeChecker,
+  node: Node,
+): DrizzleTableMetadata | undefined {
+  const metadata = getDrizzleTableMetadataForRead(checker, node);
   if (metadata === undefined) {
     return undefined;
   }

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -568,22 +568,15 @@ function getDrizzleTableMetadata(
   return concreteDrizzleTableMetadata(checker, type, location);
 }
 
-export function getDrizzleTableMetadataForRead(
-  checker: TypeChecker,
-  node: Node,
-): DrizzleTableMetadata | undefined {
-  return getDrizzleTableMetadata(
-    checker,
-    checker.getTypeAtLocation(node),
-    node,
-  );
-}
-
 export function getDrizzleTableMetadataForWrite(
   checker: TypeChecker,
   node: Node,
 ): DrizzleTableMetadata | undefined {
-  const metadata = getDrizzleTableMetadataForRead(checker, node);
+  const metadata = getDrizzleTableMetadata(
+    checker,
+    checker.getTypeAtLocation(node),
+    node,
+  );
   if (metadata === undefined) {
     return undefined;
   }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -30,11 +30,9 @@ import {
 
 import {
   getDrizzleColumnMetadata,
-  getDrizzleTableMetadataForRead,
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
   isDrizzleSqlTag,
-  isDrizzleSqlType,
   isDrizzleSymbol,
   isNamedDrizzleSignature,
   resolvedSymbol,
@@ -113,17 +111,6 @@ const STRUCTURED_RESULT_ARGUMENT = new Map<string, number>([
 
 const RELATIONAL_QUERY_METHODS = new Set(["findFirst", "findMany"]);
 
-// PostgreSQL resolves these implicit input columns before an identically named
-// output alias in GROUP BY, but Drizzle table metadata does not list them.
-const POSTGRES_SYSTEM_COLUMN_NAMES = new Set([
-  "cmax",
-  "cmin",
-  "ctid",
-  "tableoid",
-  "xmax",
-  "xmin",
-]);
-
 // This lint models the conventional, type-correct Drizzle patterns used in this
 // repository. It assumes bindings remain unchanged after creation and uses the
 // project's default identifier casing. Unusual TypeScript or runtime
@@ -164,8 +151,8 @@ export const preferDrizzleApis = createRule({
         "Use a Drizzle select builder for this complete schema-backed query.",
       scalarCteQueryBuilder:
         "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
-      selectedGrouping:
-        "Group by the selected Drizzle field instead of repeating its SQL expression or positional ordinal.",
+      unstableGrouping:
+        "Group by a reusable expression or real input field instead of a repeated expression, positional ordinal, or computed output alias.",
       structuredScalarQuery:
         "Use a Drizzle select builder for this complete raw scalar query.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
@@ -984,9 +971,11 @@ export const preferDrizzleApis = createRule({
 
     interface DirectGroupingQuery {
       readonly selection: TSESTree.ObjectExpression;
-      readonly source: TSESTree.Expression;
     }
 
+    // Grouping lint intentionally follows only the normal direct query shape
+    // used in this repository. Query factories, joins, spreads, computed
+    // properties, and transformed callback results remain opaque.
     function directGroupingQuery(
       node: TSESTree.CallExpression,
     ): DirectGroupingQuery | undefined {
@@ -1027,59 +1016,42 @@ export const preferDrizzleApis = createRule({
       const database = select === undefined ? undefined : callReceiver(select);
       return selection?.type === AST_NODE_TYPES.ObjectExpression &&
         database?.type === AST_NODE_TYPES.Identifier
-        ? { selection, source }
+        ? { selection }
         : undefined;
     }
 
-    interface AliasedSelectedSql {
-      readonly alias: string;
-      readonly source: TSESTree.Expression;
+    interface DirectSelectionField {
+      readonly propertyName: string;
+      readonly sqlTemplate: TSESTree.TaggedTemplateExpression | undefined;
     }
 
-    function directAliasedSelectedSql(
-      property: TSESTree.Property,
-    ): AliasedSelectedSql | undefined {
-      const value = property.value;
-      if (
-        value.type !== AST_NODE_TYPES.CallExpression ||
-        value.callee.type !== AST_NODE_TYPES.MemberExpression ||
-        memberName(value.callee) !== "as" ||
-        !isDrizzleMethodCall(value, "as")
-      ) {
-        return undefined;
-      }
-      const alias = singleCallArgument(value);
-      const aliasedSource = callReceiver(value);
+    function directSelectedSqlTemplate(
+      node: TSESTree.Expression,
+    ): TSESTree.TaggedTemplateExpression | undefined {
+      const asCall = directDrizzleCall(node, "as");
+      const alias =
+        asCall === undefined ? undefined : singleCallArgument(asCall);
+      let source = asCall === undefined ? undefined : callReceiver(asCall);
       if (
         alias?.type !== AST_NODE_TYPES.Literal ||
         typeof alias.value !== "string" ||
         alias.value === "" ||
-        aliasedSource === undefined
-      ) {
-        return undefined;
-      }
-      const tsAliasedSource = services.esTreeNodeToTSNodeMap.get(aliasedSource);
-      if (
-        !isDrizzleSqlType(
-          checker,
-          checker.getTypeAtLocation(tsAliasedSource),
-          tsAliasedSource,
-        )
+        source === undefined
       ) {
         return undefined;
       }
 
-      const mapWith = directDrizzleCall(aliasedSource, "mapWith");
-      const source =
-        mapWith !== undefined && singleCallArgument(mapWith) !== undefined
-          ? callReceiver(mapWith)
-          : aliasedSource;
-      return source === undefined ? undefined : { alias: alias.value, source };
-    }
-
-    interface DirectSelectionField {
-      readonly aliasedSql: AliasedSelectedSql | undefined;
-      readonly outputName: string;
+      const mapWith = directDrizzleCall(source, "mapWith");
+      if (mapWith !== undefined) {
+        if (singleCallArgument(mapWith) === undefined) {
+          return undefined;
+        }
+        source = callReceiver(mapWith);
+      }
+      return source?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        isDrizzleSqlTag(checker, services, source.tag)
+        ? source
+        : undefined;
     }
 
     function directSelectionFields(
@@ -1092,72 +1064,20 @@ export const preferDrizzleApis = createRule({
           property.kind !== "init" ||
           property.computed ||
           property.method ||
-          property.shorthand ||
           property.key.type !== AST_NODE_TYPES.Identifier
         ) {
           return undefined;
         }
 
-        const aliasedSql = directAliasedSelectedSql(property);
-        if (aliasedSql !== undefined) {
-          fields.push({
-            aliasedSql,
-            outputName: aliasedSql.alias,
-          });
-          continue;
-        }
-
-        const value = property.value;
-        if (
-          value.type !== AST_NODE_TYPES.Identifier &&
-          value.type !== AST_NODE_TYPES.MemberExpression
-        ) {
-          return undefined;
-        }
-        const metadata = columnMetadata(value);
-        if (!isConventionalColumnExpression(value) || metadata === undefined) {
-          return undefined;
-        }
         fields.push({
-          aliasedSql: undefined,
-          outputName: metadata.databaseName,
+          propertyName: property.key.name,
+          sqlTemplate:
+            property.value.type === AST_NODE_TYPES.CallExpression
+              ? directSelectedSqlTemplate(property.value)
+              : undefined,
         });
       }
       return fields;
-    }
-
-    function conventionalColumnSymbol(
-      node: TSESTree.Expression,
-    ): TypeScriptSymbol | undefined {
-      if (!isConventionalColumnExpression(node)) {
-        return undefined;
-      }
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      const location = isPropertyAccessExpression(tsNode)
-        ? tsNode.name
-        : isIdentifier(tsNode)
-          ? tsNode
-          : undefined;
-      return location === undefined
-        ? undefined
-        : resolvedSymbol(checker, checker.getSymbolAtLocation(location));
-    }
-
-    function isSameGroupingColumn(
-      left: TSESTree.Expression,
-      right: TSESTree.Expression,
-    ): boolean {
-      const leftMetadata = columnMetadata(left);
-      const rightMetadata = columnMetadata(right);
-      const leftSymbol = conventionalColumnSymbol(left);
-      return (
-        leftMetadata !== undefined &&
-        rightMetadata !== undefined &&
-        leftSymbol !== undefined &&
-        leftSymbol === conventionalColumnSymbol(right) &&
-        leftMetadata.databaseName === rightMetadata.databaseName &&
-        leftMetadata.tableName === rightMetadata.tableName
-      );
     }
 
     function templateElementText(node: TSESTree.TemplateElement): string {
@@ -1183,40 +1103,83 @@ export const preferDrizzleApis = createRule({
       return Number.isSafeInteger(ordinal) ? ordinal : undefined;
     }
 
+    function directGroupingCallbackFields(
+      node: TSESTree.Expression,
+    ): readonly string[] | undefined {
+      if (
+        (node.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+          node.type !== AST_NODE_TYPES.FunctionExpression) ||
+        node.params.length !== 1
+      ) {
+        return undefined;
+      }
+      const parameter = node.params[0];
+      if (parameter?.type !== AST_NODE_TYPES.ObjectPattern) {
+        return undefined;
+      }
+
+      const selectedFieldByLocalName = new Map<string, string>();
+      for (const property of parameter.properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.kind !== "init" ||
+          property.computed ||
+          property.method ||
+          property.key.type !== AST_NODE_TYPES.Identifier ||
+          property.value.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return undefined;
+        }
+        selectedFieldByLocalName.set(property.value.name, property.key.name);
+      }
+
+      const result =
+        node.body.type === AST_NODE_TYPES.BlockStatement
+          ? node.body.body.length === 1 &&
+            node.body.body[0]?.type === AST_NODE_TYPES.ReturnStatement
+            ? node.body.body[0].argument
+            : undefined
+          : node.body;
+      if (result === undefined || result === null) {
+        return undefined;
+      }
+      const returned =
+        result.type === AST_NODE_TYPES.Identifier
+          ? [result]
+          : result.type === AST_NODE_TYPES.ArrayExpression &&
+              result.elements.every((element) => {
+                return element?.type === AST_NODE_TYPES.Identifier;
+              })
+            ? result.elements
+            : undefined;
+      if (returned === undefined) {
+        return undefined;
+      }
+
+      const selectedFields = returned.map((identifier) => {
+        return identifier === null ||
+          identifier.type !== AST_NODE_TYPES.Identifier
+          ? undefined
+          : selectedFieldByLocalName.get(identifier.name);
+      });
+      return selectedFields.every(
+        (field): field is string => field !== undefined,
+      )
+        ? selectedFields
+        : undefined;
+    }
+
     function isSameDirectSqlTemplate(
       left: TSESTree.TaggedTemplateExpression,
-      right: TSESTree.Expression,
+      right: TSESTree.TaggedTemplateExpression,
     ): boolean {
-      if (
-        right.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
-        left.quasi.expressions.length === 0 ||
-        left.quasi.expressions.length !== right.quasi.expressions.length ||
-        left.quasi.quasis.length !== right.quasi.quasis.length ||
-        !isDrizzleSqlTag(checker, services, left.tag) ||
-        !isDrizzleSqlTag(checker, services, right.tag)
-      ) {
-        return false;
-      }
       return (
-        left.quasi.quasis.every((quasi, index) => {
-          const compared = right.quasi.quasis[index];
-          return (
-            compared !== undefined &&
-            templateElementText(quasi) === templateElementText(compared)
-          );
-        }) &&
-        left.quasi.expressions.every((expression, index) => {
-          const compared = right.quasi.expressions[index];
-          return (
-            compared !== undefined && isSameGroupingColumn(expression, compared)
-          );
-        })
+        left.quasi.expressions.length > 0 &&
+        context.sourceCode.getText(left) === context.sourceCode.getText(right)
       );
     }
 
-    function inspectSelectedFieldGroupingCall(
-      node: TSESTree.CallExpression,
-    ): void {
+    function inspectUnstableGroupingCall(node: TSESTree.CallExpression): void {
       if (
         node.callee.type !== AST_NODE_TYPES.MemberExpression ||
         memberName(node.callee) !== "groupBy" ||
@@ -1225,15 +1188,15 @@ export const preferDrizzleApis = createRule({
         return;
       }
       const grouping = node.arguments[0];
-      if (grouping?.type !== AST_NODE_TYPES.TaggedTemplateExpression) {
+      if (
+        grouping === undefined ||
+        grouping.type === AST_NODE_TYPES.SpreadElement
+      ) {
         return;
       }
 
       structuralCallInspections.push(() => {
-        if (
-          !isDrizzleMethodCall(node, "groupBy") ||
-          !isDrizzleSqlTag(checker, services, grouping.tag)
-        ) {
+        if (!isDrizzleMethodCall(node, "groupBy")) {
           return;
         }
         const query = directGroupingQuery(node);
@@ -1244,15 +1207,28 @@ export const preferDrizzleApis = createRule({
         if (query === undefined || fields === undefined) {
           return;
         }
-        const tsSource = services.esTreeNodeToTSNodeMap.get(query.source);
-        const sourceMetadata = getDrizzleTableMetadataForRead(
-          checker,
-          tsSource,
-        );
-        if (sourceMetadata === undefined) {
+
+        const callbackFields = directGroupingCallbackFields(grouping);
+        if (
+          callbackFields?.some((propertyName) => {
+            return fields.some((field) => {
+              return (
+                field.propertyName === propertyName &&
+                field.sqlTemplate !== undefined
+              );
+            });
+          }) === true
+        ) {
+          context.report({ node: grouping, messageId: "unstableGrouping" });
           return;
         }
 
+        if (
+          grouping.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+          !isDrizzleSqlTag(checker, services, grouping.tag)
+        ) {
+          return;
+        }
         const ordinal = selectedGroupingOrdinal(grouping);
         const ordinalField =
           ordinal === undefined ? undefined : fields[ordinal - 1];
@@ -1260,26 +1236,15 @@ export const preferDrizzleApis = createRule({
           ordinal === undefined
             ? fields.filter((field) => {
                 return (
-                  field.aliasedSql !== undefined &&
-                  isSameDirectSqlTemplate(grouping, field.aliasedSql.source)
+                  field.sqlTemplate !== undefined &&
+                  isSameDirectSqlTemplate(grouping, field.sqlTemplate)
                 );
               })
             : [];
-        const selectedField =
-          ordinalField ??
-          (matchingFields.length === 1 ? matchingFields[0] : undefined);
-        const alias = selectedField?.aliasedSql?.alias;
-        if (
-          alias === undefined ||
-          sourceMetadata.columns.has(alias) ||
-          POSTGRES_SYSTEM_COLUMN_NAMES.has(alias) ||
-          fields.filter((field) => {
-            return field.outputName === alias;
-          }).length !== 1
-        ) {
+        if (ordinalField === undefined && matchingFields.length !== 1) {
           return;
         }
-        context.report({ node: grouping, messageId: "selectedGrouping" });
+        context.report({ node: grouping, messageId: "unstableGrouping" });
       });
     }
 
@@ -2162,7 +2127,7 @@ export const preferDrizzleApis = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
-        inspectSelectedFieldGroupingCall(node);
+        inspectUnstableGroupingCall(node);
         inspectAdditionalContextCall(node);
         inspectConflictUpdateCall(node);
         inspectLateralJoin(node);

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -33,6 +33,7 @@ import {
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
   isDrizzleSqlTag,
+  isDrizzleSqlType,
   isDrizzleSymbol,
   isNamedDrizzleSignature,
   resolvedSymbol,
@@ -1021,13 +1022,18 @@ export const preferDrizzleApis = createRule({
     }
 
     interface DirectSelectionField {
+      readonly isComputedSql: boolean;
       readonly propertyName: string;
       readonly sqlTemplate: TSESTree.TaggedTemplateExpression | undefined;
     }
 
-    function directSelectedSqlTemplate(
+    interface DirectSelectedSql {
+      readonly template: TSESTree.TaggedTemplateExpression | undefined;
+    }
+
+    function directSelectedSql(
       node: TSESTree.Expression,
-    ): TSESTree.TaggedTemplateExpression | undefined {
+    ): DirectSelectedSql | undefined {
       const asCall = directDrizzleCall(node, "as");
       const alias =
         asCall === undefined ? undefined : singleCallArgument(asCall);
@@ -1041,6 +1047,17 @@ export const preferDrizzleApis = createRule({
         return undefined;
       }
 
+      const tsSource = services.esTreeNodeToTSNodeMap.get(source);
+      if (
+        !isDrizzleSqlType(
+          checker,
+          checker.getTypeAtLocation(tsSource),
+          tsSource,
+        )
+      ) {
+        return undefined;
+      }
+
       const mapWith = directDrizzleCall(source, "mapWith");
       if (mapWith !== undefined) {
         if (singleCallArgument(mapWith) === undefined) {
@@ -1048,10 +1065,13 @@ export const preferDrizzleApis = createRule({
         }
         source = callReceiver(mapWith);
       }
-      return source?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
-        isDrizzleSqlTag(checker, services, source.tag)
-        ? source
-        : undefined;
+      return {
+        template:
+          source?.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+          isDrizzleSqlTag(checker, services, source.tag)
+            ? source
+            : undefined,
+      };
     }
 
     function directSelectionFields(
@@ -1069,12 +1089,14 @@ export const preferDrizzleApis = createRule({
           return undefined;
         }
 
+        const selectedSql =
+          property.value.type === AST_NODE_TYPES.CallExpression
+            ? directSelectedSql(property.value)
+            : undefined;
         fields.push({
+          isComputedSql: selectedSql !== undefined,
           propertyName: property.key.name,
-          sqlTemplate:
-            property.value.type === AST_NODE_TYPES.CallExpression
-              ? directSelectedSqlTemplate(property.value)
-              : undefined,
+          sqlTemplate: selectedSql?.template,
         });
       }
       return fields;
@@ -1212,10 +1234,7 @@ export const preferDrizzleApis = createRule({
         if (
           callbackFields?.some((propertyName) => {
             return fields.some((field) => {
-              return (
-                field.propertyName === propertyName &&
-                field.sqlTemplate !== undefined
-              );
+              return field.propertyName === propertyName && field.isComputedSql;
             });
           }) === true
         ) {

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -30,9 +30,11 @@ import {
 
 import {
   getDrizzleColumnMetadata,
+  getDrizzleTableMetadataForRead,
   isDrizzleDeclaration,
   isDrizzlePgCoreDeclaration,
   isDrizzleSqlTag,
+  isDrizzleSqlType,
   isDrizzleSymbol,
   isNamedDrizzleSignature,
   resolvedSymbol,
@@ -111,6 +113,17 @@ const STRUCTURED_RESULT_ARGUMENT = new Map<string, number>([
 
 const RELATIONAL_QUERY_METHODS = new Set(["findFirst", "findMany"]);
 
+// PostgreSQL resolves these implicit input columns before an identically named
+// output alias in GROUP BY, but Drizzle table metadata does not list them.
+const POSTGRES_SYSTEM_COLUMN_NAMES = new Set([
+  "cmax",
+  "cmin",
+  "ctid",
+  "tableoid",
+  "xmax",
+  "xmin",
+]);
+
 // This lint models the conventional, type-correct Drizzle patterns used in this
 // repository. It assumes bindings remain unchanged after creation and uses the
 // project's default identifier casing. Unusual TypeScript or runtime
@@ -151,6 +164,8 @@ export const preferDrizzleApis = createRule({
         "Use a Drizzle select builder for this complete schema-backed query.",
       scalarCteQueryBuilder:
         "Use Drizzle $with(...), select(), and joins for this complete scalar CTE projection.",
+      selectedGrouping:
+        "Group by the selected Drizzle field instead of repeating its SQL expression or positional ordinal.",
       structuredScalarQuery:
         "Use a Drizzle select builder for this complete raw scalar query.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
@@ -930,6 +945,342 @@ export const preferDrizzleApis = createRule({
         leftMetadata.tableName === rightMetadata.tableName &&
         context.sourceCode.getText(left) === context.sourceCode.getText(right)
       );
+    }
+
+    function callReceiver(
+      node: TSESTree.CallExpression,
+    ): TSESTree.Expression | undefined {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        node.callee.object.type === AST_NODE_TYPES.Super
+      ) {
+        return undefined;
+      }
+      return node.callee.object;
+    }
+
+    function directDrizzleCall(
+      node: TSESTree.Expression,
+      method: string,
+    ): TSESTree.CallExpression | undefined {
+      return node.type === AST_NODE_TYPES.CallExpression &&
+        node.callee.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(node.callee) === method &&
+        isDrizzleMethodCall(node, method)
+        ? node
+        : undefined;
+    }
+
+    function singleCallArgument(
+      node: TSESTree.CallExpression,
+    ): TSESTree.Expression | undefined {
+      const argument = node.arguments[0];
+      return node.arguments.length === 1 &&
+        argument !== undefined &&
+        argument.type !== AST_NODE_TYPES.SpreadElement
+        ? argument
+        : undefined;
+    }
+
+    interface DirectGroupingQuery {
+      readonly selection: TSESTree.ObjectExpression;
+      readonly source: TSESTree.Expression;
+    }
+
+    function directGroupingQuery(
+      node: TSESTree.CallExpression,
+    ): DirectGroupingQuery | undefined {
+      let previous = callReceiver(node);
+      if (previous === undefined) {
+        return undefined;
+      }
+
+      if (
+        previous.type === AST_NODE_TYPES.CallExpression &&
+        previous.callee.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(previous.callee) === "where"
+      ) {
+        const where = directDrizzleCall(previous, "where");
+        if (
+          where === undefined ||
+          singleCallArgument(where) === undefined ||
+          callReceiver(where) === undefined
+        ) {
+          return undefined;
+        }
+        previous = callReceiver(where);
+        if (previous === undefined) {
+          return undefined;
+        }
+      }
+
+      const from = directDrizzleCall(previous, "from");
+      const source = from === undefined ? undefined : singleCallArgument(from);
+      const beforeFrom = from === undefined ? undefined : callReceiver(from);
+      if (source === undefined || beforeFrom === undefined) {
+        return undefined;
+      }
+
+      const select = directDrizzleCall(beforeFrom, "select");
+      const selection =
+        select === undefined ? undefined : singleCallArgument(select);
+      const database = select === undefined ? undefined : callReceiver(select);
+      return selection?.type === AST_NODE_TYPES.ObjectExpression &&
+        database?.type === AST_NODE_TYPES.Identifier
+        ? { selection, source }
+        : undefined;
+    }
+
+    interface AliasedSelectedSql {
+      readonly alias: string;
+      readonly source: TSESTree.Expression;
+    }
+
+    function directAliasedSelectedSql(
+      property: TSESTree.Property,
+    ): AliasedSelectedSql | undefined {
+      const value = property.value;
+      if (
+        value.type !== AST_NODE_TYPES.CallExpression ||
+        value.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(value.callee) !== "as" ||
+        !isDrizzleMethodCall(value, "as")
+      ) {
+        return undefined;
+      }
+      const alias = singleCallArgument(value);
+      const aliasedSource = callReceiver(value);
+      if (
+        alias?.type !== AST_NODE_TYPES.Literal ||
+        typeof alias.value !== "string" ||
+        alias.value === "" ||
+        aliasedSource === undefined
+      ) {
+        return undefined;
+      }
+      const tsAliasedSource = services.esTreeNodeToTSNodeMap.get(aliasedSource);
+      if (
+        !isDrizzleSqlType(
+          checker,
+          checker.getTypeAtLocation(tsAliasedSource),
+          tsAliasedSource,
+        )
+      ) {
+        return undefined;
+      }
+
+      const mapWith = directDrizzleCall(aliasedSource, "mapWith");
+      const source =
+        mapWith !== undefined && singleCallArgument(mapWith) !== undefined
+          ? callReceiver(mapWith)
+          : aliasedSource;
+      return source === undefined ? undefined : { alias: alias.value, source };
+    }
+
+    interface DirectSelectionField {
+      readonly aliasedSql: AliasedSelectedSql | undefined;
+      readonly outputName: string;
+    }
+
+    function directSelectionFields(
+      node: TSESTree.ObjectExpression,
+    ): readonly DirectSelectionField[] | undefined {
+      const fields: DirectSelectionField[] = [];
+      for (const property of node.properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.kind !== "init" ||
+          property.computed ||
+          property.method ||
+          property.shorthand ||
+          property.key.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return undefined;
+        }
+
+        const aliasedSql = directAliasedSelectedSql(property);
+        if (aliasedSql !== undefined) {
+          fields.push({
+            aliasedSql,
+            outputName: aliasedSql.alias,
+          });
+          continue;
+        }
+
+        const value = property.value;
+        if (
+          value.type !== AST_NODE_TYPES.Identifier &&
+          value.type !== AST_NODE_TYPES.MemberExpression
+        ) {
+          return undefined;
+        }
+        const metadata = columnMetadata(value);
+        if (!isConventionalColumnExpression(value) || metadata === undefined) {
+          return undefined;
+        }
+        fields.push({
+          aliasedSql: undefined,
+          outputName: metadata.databaseName,
+        });
+      }
+      return fields;
+    }
+
+    function conventionalColumnSymbol(
+      node: TSESTree.Expression,
+    ): TypeScriptSymbol | undefined {
+      if (!isConventionalColumnExpression(node)) {
+        return undefined;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const location = isPropertyAccessExpression(tsNode)
+        ? tsNode.name
+        : isIdentifier(tsNode)
+          ? tsNode
+          : undefined;
+      return location === undefined
+        ? undefined
+        : resolvedSymbol(checker, checker.getSymbolAtLocation(location));
+    }
+
+    function isSameGroupingColumn(
+      left: TSESTree.Expression,
+      right: TSESTree.Expression,
+    ): boolean {
+      const leftMetadata = columnMetadata(left);
+      const rightMetadata = columnMetadata(right);
+      const leftSymbol = conventionalColumnSymbol(left);
+      return (
+        leftMetadata !== undefined &&
+        rightMetadata !== undefined &&
+        leftSymbol !== undefined &&
+        leftSymbol === conventionalColumnSymbol(right) &&
+        leftMetadata.databaseName === rightMetadata.databaseName &&
+        leftMetadata.tableName === rightMetadata.tableName
+      );
+    }
+
+    function templateElementText(node: TSESTree.TemplateElement): string {
+      return node.value.cooked ?? node.value.raw;
+    }
+
+    function selectedGroupingOrdinal(
+      node: TSESTree.TaggedTemplateExpression,
+    ): number | undefined {
+      const quasi = node.quasi.quasis[0];
+      if (
+        node.quasi.expressions.length !== 0 ||
+        node.quasi.quasis.length !== 1 ||
+        quasi === undefined
+      ) {
+        return undefined;
+      }
+      const text = templateElementText(quasi).trim();
+      if (!/^[1-9]\d*$/u.test(text)) {
+        return undefined;
+      }
+      const ordinal = Number(text);
+      return Number.isSafeInteger(ordinal) ? ordinal : undefined;
+    }
+
+    function isSameDirectSqlTemplate(
+      left: TSESTree.TaggedTemplateExpression,
+      right: TSESTree.Expression,
+    ): boolean {
+      if (
+        right.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        left.quasi.expressions.length === 0 ||
+        left.quasi.expressions.length !== right.quasi.expressions.length ||
+        left.quasi.quasis.length !== right.quasi.quasis.length ||
+        !isDrizzleSqlTag(checker, services, left.tag) ||
+        !isDrizzleSqlTag(checker, services, right.tag)
+      ) {
+        return false;
+      }
+      return (
+        left.quasi.quasis.every((quasi, index) => {
+          const compared = right.quasi.quasis[index];
+          return (
+            compared !== undefined &&
+            templateElementText(quasi) === templateElementText(compared)
+          );
+        }) &&
+        left.quasi.expressions.every((expression, index) => {
+          const compared = right.quasi.expressions[index];
+          return (
+            compared !== undefined && isSameGroupingColumn(expression, compared)
+          );
+        })
+      );
+    }
+
+    function inspectSelectedFieldGroupingCall(
+      node: TSESTree.CallExpression,
+    ): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "groupBy" ||
+        node.arguments.length !== 1
+      ) {
+        return;
+      }
+      const grouping = node.arguments[0];
+      if (grouping?.type !== AST_NODE_TYPES.TaggedTemplateExpression) {
+        return;
+      }
+
+      structuralCallInspections.push(() => {
+        if (
+          !isDrizzleMethodCall(node, "groupBy") ||
+          !isDrizzleSqlTag(checker, services, grouping.tag)
+        ) {
+          return;
+        }
+        const query = directGroupingQuery(node);
+        const fields =
+          query === undefined
+            ? undefined
+            : directSelectionFields(query.selection);
+        if (query === undefined || fields === undefined) {
+          return;
+        }
+        const tsSource = services.esTreeNodeToTSNodeMap.get(query.source);
+        const sourceMetadata = getDrizzleTableMetadataForRead(
+          checker,
+          tsSource,
+        );
+        if (sourceMetadata === undefined) {
+          return;
+        }
+
+        const ordinal = selectedGroupingOrdinal(grouping);
+        const ordinalField =
+          ordinal === undefined ? undefined : fields[ordinal - 1];
+        const matchingFields =
+          ordinal === undefined
+            ? fields.filter((field) => {
+                return (
+                  field.aliasedSql !== undefined &&
+                  isSameDirectSqlTemplate(grouping, field.aliasedSql.source)
+                );
+              })
+            : [];
+        const selectedField =
+          ordinalField ??
+          (matchingFields.length === 1 ? matchingFields[0] : undefined);
+        const alias = selectedField?.aliasedSql?.alias;
+        if (
+          alias === undefined ||
+          sourceMetadata.columns.has(alias) ||
+          POSTGRES_SYSTEM_COLUMN_NAMES.has(alias) ||
+          fields.filter((field) => {
+            return field.outputName === alias;
+          }).length !== 1
+        ) {
+          return;
+        }
+        context.report({ node: grouping, messageId: "selectedGrouping" });
+      });
     }
 
     function unwrapDirectColumnResult(node: TSESTree.Expression): {
@@ -1811,6 +2162,7 @@ export const preferDrizzleApis = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
+        inspectSelectedFieldGroupingCall(node);
         inspectAdditionalContextCall(node);
         inspectConflictUpdateCall(node);
         inspectLateralJoin(node);


### PR DESCRIPTION
## Summary

- reuse the unaliased daily date expression for both selection and grouping
- normalize model names in a derived relation and aggregate by its real input field
- extend `api/prefer-drizzle-apis` to reject repeated grouping expressions, positional ordinals, and computed output aliases in conventional direct queries, including SQL expressions bound to variables

## Why

Drizzle selected-field callbacks render computed fields as PostgreSQL output
aliases. Although that works with the current schema, `GROUP BY` resolves an
identically named input column before the output alias. A future additive
migration could therefore make already-deployed API code fail during rollout.

The stable forms avoid that schema dependency:

- daily usage keeps `GROUP BY DATE(agent_runs.created_at)` by reusing one SQL expression
- model rankings calculate `normalized_model` in a derived relation and group by that relation's input field

The lint rule encodes the stable invariant instead of trying to prove that an
output alias happens not to collide with today's schema. It intentionally
recognizes only normal direct `select(...).from(...).where(...).groupBy(...)`
shapes and leaves query factories, joins, spreads, computed properties, and
transformed callbacks opaque.

## Validation

- `pnpm -F @vm0/eslint-rules test` — 969 tests passed
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/usage.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts --maxWorkers=4 --silent=passed-only` — 28 tests passed
- `pnpm knip`
- pre-commit repository type checks — 12 workspaces passed
- `git diff --check`

The daily query keeps the exact grouping expression and four parameters. The
complete old and new model queries each use 66 parameters. A seeded,
rollback-only comparison covering canonical and legacy model identifiers
returned identical rows, and PostgreSQL produced the same
`Limit -> Sort -> Hash Aggregate -> Seq Scan` node sequence, one grouping key,
and 24 KiB aggregate memory for both forms.

## Scope

No schema, migration, persisted-data, API, protocol, feature-switch, or rollout
change.

Closes #23833

Parent: #23047
Unblocks: #22901
