### PR TITLE
test(api): synchronize pending goal chat admission

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -195,6 +195,7 @@ async function startChatRun(
   body: {
     readonly agentId: string;
     readonly prompt: string;
+    readonly clientEventId?: string;
     readonly threadId?: string;
     readonly selectedModel?: string;
     readonly attachFiles?: readonly AttachFile[];
@@ -207,7 +208,7 @@ async function startChatRun(
   readonly threadId: string;
   readonly messageId: string;
 }> {
-  const messageId = randomUUID();
+  const messageId = body.clientEventId ?? randomUUID();
   const requestBody = {
     agentId: body.agentId,
     prompt: body.prompt,
@@ -1788,11 +1789,10 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       context.signal,
     );
     const releaseGoalRunPreparation = deferredGate();
-    const kms = useSecretKmsProbe((command, callNumber) => {
-      if (callNumber !== 1) {
-        return undefined;
+    useSecretKmsProbe((command) => {
+      if (!goalRunPreparationStarted.settled()) {
+        goalRunPreparationStarted.resolve(undefined);
       }
-      goalRunPreparationStarted.resolve(undefined);
       return releaseGoalRunPreparation.wait().then(() => {
         return generateDataKeyOutput(command);
       });
@@ -1803,14 +1803,25 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       lastEventSequence: 0,
     });
     await goalRunPreparationStarted.promise;
-    expect(kms.generateDataKeyCalls).toBe(1);
 
-    const userRun = await startChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      prompt: "user message admitted during goal run preparation",
-    });
-    releaseGoalRunPreparation.release();
+    const userMessageId = randomUUID();
+    const [userRun] = await Promise.all([
+      startChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        prompt: "user message admitted during goal run preparation",
+        clientEventId: userMessageId,
+      }),
+      waitForThreadMessages(actor, first.threadId, (events) => {
+        return events.some((event) => {
+          return (
+            event.id === userMessageId && event.eventType === "input.prompt"
+          );
+        });
+      }).finally(() => {
+        releaseGoalRunPreparation.release();
+      }),
+    ]);
 
     let goalEventId: string | undefined;
     await expect


### PR DESCRIPTION
## Summary

- gate every competing run preparation in the pending-goal admission scenario
- observe the known pending user event through the public thread event API before releasing the gate
- preserve the shared test helper's direct-run and queued-replacement recovery behavior

## Root cause

The test blocked only the first KMS preparation even though multiple legitimate drain owners can prepare the same pending goal event. If another preparation created a goal run first, the user send returned `runId: null` and `startChatRun()` waited for its replacement before the test released the KMS gate. That test-owned dependency cycle exhausted the 10-second poll.

The updated scenario holds all preparation attempts until its known `input.prompt` is durably visible. It then releases the gate and lets the existing transactional user-first claim decide the winner.

## Scope

This is a test-only change. It does not modify production queue behavior, API contracts, persisted state, schemas, migrations, or deployment behavior.

## Verification

- affected scenario passed 7 post-fix runs, including 5 consecutive diagnostic runs
- `chat-callbacks.bdd.test.ts`: 29/29 tests passed
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full Knip and workspace type checks
- `git diff --check`

Closes #23841
