### PR TITLE
fix: restore paid onboarding events

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/posthog.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/posthog.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const posthogMock = vi.hoisted(() => {
+  return {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  };
+});
+
+vi.mock("posthog-js", () => {
+  return { posthog: posthogMock };
+});
+
+async function loadPostHog(posthogKey: string) {
+  vi.resetModules();
+  vi.stubGlobal("location", { hostname: "vm0.ai" });
+  vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY_PROD", "test-clerk-key");
+  vi.stubEnv("VITE_POSTHOG_KEY", posthogKey);
+  return await import("../posthog.ts");
+}
+
+describe("posthog analytics helpers", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+    posthogMock.capture.mockClear();
+  });
+
+  it("skips paid onboarding captures when PostHog is disabled", async () => {
+    const {
+      capturePaidOnboardingPageViewed,
+      capturePaidOnboardingStepCompleted,
+      capturePaidOnboardingStepViewed,
+    } = await loadPostHog("");
+
+    capturePaidOnboardingPageViewed();
+    capturePaidOnboardingStepViewed("make");
+    capturePaidOnboardingStepCompleted({
+      stepKey: "make",
+      completionMethod: "workflow",
+    });
+
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+  });
+
+  it("captures the paid onboarding event contract", async () => {
+    const {
+      capturePaidOnboardingPageViewed,
+      capturePaidOnboardingStepCompleted,
+      capturePaidOnboardingStepViewed,
+    } = await loadPostHog("test-posthog-key");
+
+    capturePaidOnboardingPageViewed();
+    capturePaidOnboardingStepViewed("make");
+    capturePaidOnboardingStepCompleted({
+      stepKey: "make",
+      completionMethod: "workflow",
+    });
+
+    expect(posthogMock.capture).toHaveBeenNthCalledWith(
+      1,
+      "PaidOnboarding: PageViewed",
+      expect.objectContaining({
+        surface: "vm0_make_onboarding",
+      }),
+    );
+    expect(posthogMock.capture).toHaveBeenNthCalledWith(
+      2,
+      "PaidOnboarding: StepViewed",
+      expect.objectContaining({
+        step_key: "make",
+      }),
+    );
+    expect(posthogMock.capture).toHaveBeenNthCalledWith(
+      3,
+      "PaidOnboarding: StepCompleted",
+      expect.objectContaining({
+        completion_method: "workflow",
+        step_key: "make",
+      }),
+    );
+  });
+});

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -58,6 +58,47 @@ export function clearPostHogUser(): void {
   });
 }
 
+function currentRoutePath(): string | undefined {
+  return typeof window === "undefined" ? undefined : window.location.pathname;
+}
+
+function capturePaidOnboarding(
+  event:
+    | "PaidOnboarding: PageViewed"
+    | "PaidOnboarding: StepViewed"
+    | "PaidOnboarding: StepCompleted",
+  properties: {
+    readonly step_key?: string;
+    readonly completion_method?: string;
+  } = {},
+): void {
+  runPostHog(() => {
+    posthog.capture(event, {
+      surface: "vm0_make_onboarding",
+      route_path: currentRoutePath(),
+      ...properties,
+    });
+  });
+}
+
+export function capturePaidOnboardingPageViewed(): void {
+  capturePaidOnboarding("PaidOnboarding: PageViewed");
+}
+
+export function capturePaidOnboardingStepViewed(stepKey: string): void {
+  capturePaidOnboarding("PaidOnboarding: StepViewed", { step_key: stepKey });
+}
+
+export function capturePaidOnboardingStepCompleted(args: {
+  readonly stepKey: string;
+  readonly completionMethod?: string;
+}): void {
+  capturePaidOnboarding("PaidOnboarding: StepCompleted", {
+    step_key: args.stepKey,
+    completion_method: args.completionMethod,
+  });
+}
+
 export function captureTaskCompletedSuccessfully(): void {
   runPostHog(() => {
     posthog.capture("task_completed_successfully", { surface: "chat_thread" });

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
@@ -10,6 +10,10 @@ import {
   hasOnboardingWorkflow,
 } from "../../views/onboarding/onboarding-data.ts";
 import { i18n } from "../../i18n/index.ts";
+import {
+  capturePaidOnboardingPageViewed,
+  capturePaidOnboardingStepViewed,
+} from "../../lib/posthog.ts";
 import { OnboardingMakePage } from "../../views/onboarding/onboarding-make-page.tsx";
 import { OnboardingWorkflowPickerPage } from "../../views/onboarding/onboarding-workflow-picker-page.tsx";
 import { OnboardingWorkflowRunPage } from "../../views/onboarding/onboarding-workflow-run-page.tsx";
@@ -149,6 +153,8 @@ function createOnboardingPageSetup(
     set(updatePage$, createElement(config.Page), "none");
     set(updateDocumentTitle$, title);
     await set(hideAppSkeleton$, signal);
+    capturePaidOnboardingPageViewed();
+    capturePaidOnboardingStepViewed(config.step);
   });
 }
 

--- a/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
@@ -2,6 +2,7 @@ import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
+import { capturePaidOnboardingStepCompleted } from "../../lib/posthog.ts";
 import { completeOnboarding$ } from "../../signals/onboarding/onboarding-actions.ts";
 import {
   onboardingDraft$,
@@ -66,6 +67,10 @@ function PromptOnboarding() {
     const redeemCode = searchParams.get("redeemCode")?.trim() || null;
     const completeAndRun = async (): Promise<void> => {
       await complete(redeemCode, pageSignal);
+      capturePaidOnboardingStepCompleted({
+        stepKey: "make",
+        completionMethod: "prompt",
+      });
       runPrompt(draft.prompt);
     };
     detach(completeAndRun(), Reason.DomCallback);
@@ -130,11 +135,19 @@ export function OnboardingMakePage() {
       const redeemCode = searchParams.get("redeemCode")?.trim() || null;
       const completeAndOpenHome = async (): Promise<void> => {
         await complete(redeemCode, pageSignal);
+        capturePaidOnboardingStepCompleted({
+          stepKey: "make",
+          completionMethod: draft.choice,
+        });
         navigateTo(ROUTES.home, { preserve: false, replace: true });
       };
       detach(completeAndOpenHome(), Reason.DomCallback);
       return;
     }
+    capturePaidOnboardingStepCompleted({
+      stepKey: "make",
+      completionMethod: draft.choice,
+    });
     navigateTo(choicePath(draft.choice), {
       remove: BRANCH_STATE_PARAMS,
       updates: { choice: draft.choice },

--- a/turbo/apps/platform/src/views/onboarding/onboarding-run-action.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-run-action.tsx
@@ -1,6 +1,7 @@
 import { useGet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
+import { capturePaidOnboardingStepCompleted } from "../../lib/posthog.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
 import {
   completeOnboarding$,
@@ -18,6 +19,7 @@ export function OnboardingRunAction({
   template,
   templateSlug,
   requiresPaidPlan = false,
+  stepKey,
   disabled = false,
   runLabel,
   onBack,
@@ -27,6 +29,7 @@ export function OnboardingRunAction({
   readonly template?: string;
   readonly templateSlug?: string;
   readonly requiresPaidPlan?: boolean;
+  readonly stepKey: string;
   readonly disabled?: boolean;
   readonly runLabel?: string;
   readonly onBack: () => void;
@@ -66,6 +69,10 @@ export function OnboardingRunAction({
 
   const completeAndRun = async (): Promise<void> => {
     await complete(redeemCode, pageSignal);
+    capturePaidOnboardingStepCompleted({
+      stepKey,
+      completionMethod: templateSlug ?? template,
+    });
     runPrompt(prompt, template);
   };
 

--- a/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
@@ -14,6 +14,7 @@ import {
 } from "@vm0/core";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
+import { capturePaidOnboardingStepCompleted } from "../../lib/posthog.ts";
 import {
   onboardingDraft$,
   onboardingUi$,
@@ -247,6 +248,10 @@ export function OnboardingPresentationTemplatePage() {
     if (!selectedSlug) {
       return;
     }
+    capturePaidOnboardingStepCompleted({
+      stepKey: "presentation-template",
+      completionMethod: selectedSlug,
+    });
     setDraft({ presentationTemplateSlug: selectedSlug });
     navigateTo(ROUTES.onboardingPresentationRun, {
       updates: { template: selectedSlug },
@@ -427,6 +432,10 @@ export function OnboardingImageTemplatePage() {
     if (!selectedSlug) {
       return;
     }
+    capturePaidOnboardingStepCompleted({
+      stepKey: "image-template",
+      completionMethod: selectedSlug,
+    });
     setDraft({ imageTemplateSlug: selectedSlug });
     navigateTo(ROUTES.onboardingImageRun, {
       updates: { template: selectedSlug },
@@ -558,6 +567,10 @@ export function OnboardingVideoTemplatePage() {
     if (!selectedSlug) {
       return;
     }
+    capturePaidOnboardingStepCompleted({
+      stepKey: "video-template",
+      completionMethod: selectedSlug,
+    });
     setDraft({ videoTemplateSlug: selectedSlug });
     navigateTo(ROUTES.onboardingVideoRun, {
       updates: { template: selectedSlug },

--- a/turbo/apps/platform/src/views/onboarding/onboarding-template-run-pages.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-template-run-pages.tsx
@@ -294,6 +294,7 @@ function OnboardingTemplateRunPage({
       footer={
         <OnboardingRunAction
           prompt={config.prompt}
+          stepKey={`${kind}-run`}
           note={config.note}
           template={config.templateId}
           templateSlug={config.templateSlug}

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
+import { capturePaidOnboardingStepCompleted } from "../../lib/posthog.ts";
 import {
   onboardingDraft$,
   onboardingUi$,
@@ -56,6 +57,13 @@ const CATEGORY_ICONS: Readonly<Record<OnboardingWorkflowCategoryId, Icon>> = {
   operations: IconSun,
   everyone: IconSparkles,
 };
+
+function captureWorkflowPickerCompletion(completionMethod: string): void {
+  capturePaidOnboardingStepCompleted({
+    stepKey: "workflow-picker",
+    completionMethod,
+  });
+}
 
 function WorkflowConnectorIcon({
   connectorSlug,
@@ -399,11 +407,13 @@ export function OnboardingWorkflowPickerPage() {
       const redeemCode = searchParams.get("redeemCode")?.trim() || null;
       const completeAndOpenHome = async (): Promise<void> => {
         await complete(redeemCode, pageSignal);
+        captureWorkflowPickerCompletion("custom");
         navigateTo(ROUTES.home, { preserve: false, replace: true });
       };
       detach(completeAndOpenHome(), Reason.DomCallback);
       return;
     }
+    captureWorkflowPickerCompletion(selectedWorkflowId);
     navigateTo(ROUTES.onboardingWorkflowRun, {
       updates: {
         choice: "workflow",

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -72,6 +72,7 @@ export function OnboardingWorkflowRunPage() {
         footer={
           <OnboardingRunAction
             prompt={prompt}
+            stepKey="workflow-run"
             disabled={custom && !draft.workflowNote.trim()}
             runLabel={
               custom


### PR DESCRIPTION
## Summary

- restore PaidOnboarding PageViewed and StepViewed events for named onboarding routes
- capture StepCompleted for make, workflow, template, and run steps
- keep the existing attribution and navigation flow unchanged

## Validation

- `pnpm --filter @vm0/app exec vitest run src/lib/__tests__/posthog.test.ts`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app lint`
- Prettier check on changed files

This fixes the post-route-rewrite measurement gap. It does not create synthetic conversions or change billing behavior.