### PR TITLE
refactor: reduce fallback slop in slack auth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
@@ -143,6 +143,22 @@ describe("connector/providers/slack", () => {
       expect(result.email).toBe("test@example.com");
     });
 
+    it("preserves a missing Slack username as null", async () => {
+      const handler = http.get("https://slack.com/api/users.info", () => {
+        return HttpResponse.json({
+          ok: true,
+          user: {
+            id: "U-test",
+          },
+        });
+      });
+      server.use(handler);
+
+      const result = await fetchSlackUserInfo("U-test", "xoxp-token");
+
+      expect(result.username).toBeNull();
+    });
+
     it("throws when Slack returns ok=false", async () => {
       const handler = http.get("https://slack.com/api/users.info", () => {
         return HttpResponse.json({

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
@@ -15,7 +15,7 @@ interface SlackTokenResult {
 
 interface SlackUserInfo {
   id: string;
-  username: string;
+  username: string | null;
   email: string | null;
 }
 
@@ -140,7 +140,7 @@ export async function fetchSlackUserInfo(
 
   return {
     id: data.user?.id ?? userId,
-    username: data.user?.real_name ?? data.user?.name ?? "",
+    username: data.user?.real_name ?? data.user?.name ?? null,
     email: data.user?.profile?.email ?? null,
   };
 }


### PR DESCRIPTION
## Summary

- Preserve a missing Slack display name as `null` instead of manufacturing an empty username.
- Align the Slack adapter with the canonical connector grant contract, where `username` is nullable.
- Add a focused regression test for a successful `users.info` response without `real_name` or `name`.

## Scan and budget

- Base commit: `72cf017631d599f09d2acc91baf61f19aa92fc3f`
- Files scanned: 3,815
- Raw matches: 19,718
- Scanner-actionable matches: 4,262
- High-confidence production matches: 231
- Manually confirmed safe actionable items: 1
- Initial suggested 5% budget: 12
- Context-adjusted 5% budget: 1 (`max(1, ceil(1 * 0.05))`)
- Items changed: 1

The remaining scanner candidates stay for later runs. Context review found them to be external compatibility fields, display fallbacks, protocol-level optionality, or otherwise not safe enough for this pass.

## Safety

- `slack/oauth.ts`: only changes the absent-name representation from `""` to `null`; token exchange, user ID fallback, scopes, email handling, and failure behavior are unchanged.
- `slack.test.ts`: covers the missing-name response without broadening the production change.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (11/12 tasks passed; API ESLint hit the default Node heap limit)
- `NODE_OPTIONS=--max-old-space-size=2304 pnpm --filter api run lint` (retry passed)
- `pnpm knip` (passed; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types` (passed after syncing the frozen lockfile dependency tree)
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/slack.test.ts` (11 tests passed)
- `git diff --check`