### PR TITLE
fix(chat): return the complete per-thread event stream to the frontend

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -75,6 +75,7 @@ import {
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
+  insertRetiredQueuePauseEventsFixture,
   replaceBddVm0ApiKeys,
   replaceThreadSessionBindingFixture,
 } from "../../../test-fixtures/chat-messages";
@@ -2555,11 +2556,9 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(
       (await readThreadProjection(actor, fast.threadId)).serviceTier,
     ).toBeNull();
-    const updatedFastThreadEvents = await chat.requestThreadEvents(
-      actor,
-      {},
-      [200],
-    );
+    const updatedFastThreadEvents = await chat.requestThreadEvents(actor, {}, [
+      200,
+    ]);
     expect(updatedFastThreadEvents.status).toBe(200);
     if (updatedFastThreadEvents.status !== 200) {
       throw new Error("Expected chat thread events to load");
@@ -6570,5 +6569,71 @@ describe("CHAT-02: shared user message queue", () => {
     const followUp = await api.readRun(actor, fired.runId);
     expect(followUp.prompt).toContain("queue-first fires after cancel");
     await cancelChatRun(actor, fired.runId);
+  }, 90_000);
+});
+
+describe("CHAT-02: complete event stream", () => {
+  it("serves retired queue pause markers instead of skipping their seqIds", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const prompt = "list the full historical event stream";
+    const model = await chat.getDefaultCreateThreadModel(actor);
+    const sent = await accept(
+      chatEventsClient().send({
+        headers: sessionHeaders(actor),
+        body: {
+          agentId,
+          prompt,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: prompt }],
+          },
+          model,
+        },
+      }),
+      [201],
+    );
+    if (sent.status !== 201) {
+      throw new Error("Expected the chat send to create a thread");
+    }
+    const threadId = sent.body.threadId;
+
+    const { pausedSeqId, resumedSeqId } =
+      await insertRetiredQueuePauseEventsFixture({
+        threadId,
+        pauseReason: "historical pause fixture",
+      });
+
+    const page = await chat.listThreadEvents(actor, threadId);
+    const seqIds = page.events
+      .map((event) => {
+        return event.seqId;
+      })
+      .sort((left, right) => {
+        return left - right;
+      });
+    const lowest = seqIds[0];
+    const highest = seqIds.at(-1);
+    if (lowest === undefined || highest === undefined) {
+      throw new Error("Expected the thread to have events");
+    }
+    expect(highest - lowest + 1).toBe(seqIds.length);
+
+    const paused = page.events.find((event) => {
+      return event.seqId === pausedSeqId;
+    });
+    expect(paused).toMatchObject({
+      eventType: "queue.automation_paused",
+      content: null,
+      pauseReason: "historical pause fixture",
+    });
+    const resumed = page.events.find((event) => {
+      return event.seqId === resumedSeqId;
+    });
+    expect(resumed).toMatchObject({
+      eventType: "queue.automation_resumed",
+      content: null,
+    });
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2556,9 +2556,11 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(
       (await readThreadProjection(actor, fast.threadId)).serviceTier,
     ).toBeNull();
-    const updatedFastThreadEvents = await chat.requestThreadEvents(actor, {}, [
-      200,
-    ]);
+    const updatedFastThreadEvents = await chat.requestThreadEvents(
+      actor,
+      {},
+      [200],
+    );
     expect(updatedFastThreadEvents.status).toBe(200);
     if (updatedFastThreadEvents.status !== 200) {
       throw new Error("Expected chat thread events to load");

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1,6 +1,5 @@
 import { command, computed, type Computed } from "ccstate";
 import {
-  CHAT_EVENT_TYPES,
   chatEventCompatibilityRole,
   type ChatEventType,
 } from "@vm0/api-contracts/contracts/chat-events";
@@ -829,7 +828,7 @@ type ChatEventBuilder = (
   row: ChatEventRow,
   event: ChatEventBase,
   attachFiles: readonly ResolvedAttachFile[] | undefined,
-) => ChatEvent;
+) => ChatEventResponse;
 
 const chatEventBuilders = {
   "input.prompt": (row, event, attachFiles) => {
@@ -1028,7 +1027,25 @@ const chatEventBuilders = {
       ),
     };
   },
-} satisfies Record<ChatEvent["eventType"], ChatEventBuilder>;
+  // Historical rows from the retired queue pause/resume behavior. These have
+  // no writer anymore but still occupy seqIds, so the read path serves them
+  // as-is instead of filtering and leaving holes in the event stream.
+  "queue.automation_paused": (row, event) => {
+    return {
+      ...event,
+      eventType: "queue.automation_paused",
+      content: null,
+      pauseReason: row.error ?? null,
+    };
+  },
+  "queue.automation_resumed": (_row, event) => {
+    return {
+      ...event,
+      eventType: "queue.automation_resumed",
+      content: null,
+    };
+  },
+} satisfies Record<ChatEventResponse["eventType"], ChatEventBuilder>;
 
 function toChatEvent(
   userId: string,
@@ -2204,10 +2221,7 @@ export function zeroChatThreadEventsPage(args: {
       args.sinceSeqId ?? (args.sinceId ? legacyCursor?.seqId : undefined);
     const beforeSeqId =
       args.beforeSeqId ?? (args.beforeId ? legacyCursor?.seqId : undefined);
-    const threadFilter = and(
-      eq(chatMessages.chatThreadId, args.threadId),
-      chatEventTypeIn(CHAT_EVENT_TYPES),
-    );
+    const threadFilter = eq(chatMessages.chatThreadId, args.threadId);
     let rows: ChatEventRow[];
     let hasHistoryBefore = false;
 
@@ -2283,7 +2297,6 @@ export function zeroChatThreadEventById(args: {
         and(
           eq(chatMessages.id, args.eventId),
           eq(chatMessages.chatThreadId, args.threadId),
-          chatEventTypeIn(CHAT_EVENT_TYPES),
         ),
       )
       .limit(1);

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -920,3 +920,47 @@ export async function insertOutputEventWithConflictingLegacyPayloadFixture(args:
   });
   return event;
 }
+
+/**
+ * Appends the retired queue pause/resume marker rows exactly as the 0714
+ * cutover backfill persisted them (reason in the error column). Product
+ * writers intentionally cannot create these event types anymore; the fixture
+ * proves the transcript read path serves the complete historical event stream
+ * instead of skipping their seqIds.
+ */
+export async function insertRetiredQueuePauseEventsFixture(args: {
+  readonly threadId: string;
+  readonly pauseReason: string;
+}): Promise<{ readonly pausedSeqId: number; readonly resumedSeqId: number }> {
+  return await db().transaction(async (tx) => {
+    const [thread] = await tx
+      .update(chatThreads)
+      .set({
+        lastChatMessageSeqId: sql`${chatThreads.lastChatMessageSeqId} + 2`,
+      })
+      .where(eq(chatThreads.id, args.threadId))
+      .returning({ lastSeqId: chatThreads.lastChatMessageSeqId });
+    if (!thread) {
+      throw new Error(`Chat thread ${args.threadId} not found`);
+    }
+    const pausedSeqId = thread.lastSeqId - 1;
+    const resumedSeqId = thread.lastSeqId;
+    const retiredEventType = (eventType: string) => {
+      return eventType as (typeof chatMessages.$inferInsert)["eventType"];
+    };
+    await tx.insert(chatMessages).values([
+      {
+        chatThreadId: args.threadId,
+        eventType: retiredEventType("queue.automation_paused"),
+        error: args.pauseReason,
+        seqId: pausedSeqId,
+      },
+      {
+        chatThreadId: args.threadId,
+        eventType: retiredEventType("queue.automation_resumed"),
+        seqId: resumedSeqId,
+      },
+    ]);
+    return { pausedSeqId, resumedSeqId };
+  });
+}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -575,10 +575,10 @@ const runCancelledEventSchema = chatEventBaseSchema
   })
   .strict();
 
-// Read-only rollout compatibility for browser bundles that may reach the
-// previous API while historical queue pause markers still exist. These leaves
-// deliberately stay outside CHAT_EVENT_TYPES and chatEventSchema so no current
-// writer or fold can recreate the retired pause/resume behavior.
+// Read-only leaves for historical queue pause markers, which the API serves
+// as part of the complete per-thread event stream. These deliberately stay
+// outside CHAT_EVENT_TYPES and chatEventSchema so no current writer or fold
+// can recreate the retired pause/resume behavior.
 const legacyQueueAutomationPausedEventSchema = chatEventBaseSchema
   .extend({
     eventType: z.literal("queue.automation_paused"),
@@ -1618,7 +1618,7 @@ export function isCanonicalChatEventResponse(
   );
 }
 
-export function chatEventResponse(event: ChatEvent): ChatEventResponse {
+export function chatEventResponse(event: ChatEventResponse): ChatEventResponse {
   return chatEventResponseSchema.parse(event);
 }
 


### PR DESCRIPTION
## Summary

The thread transcript read paths in `zero-chat-thread.service.ts` (event pagination at the former `threadFilter` and the event-by-id lookup) applied `chatEventTypeIn(CHAT_EVENT_TYPES)`, a whitelist that today only excludes the two retired legacy types `queue.automation_paused` / `queue.automation_resumed`. Those rows still exist in `chat_messages` and occupy seqIds, so the filter left silent holes in the event stream the client observes — which breaks any seqId-coverage reasoning (e.g. the upcoming client-generated snapshot design) and forces every completeness check to replicate the exact same type filter on both sides.

This PR removes the whitelist from both transcript read paths so the API returns every row of the per-thread log, and adds read-only serialization for the two retired pause-marker types (`pauseReason` is read from the `error` column, matching the 0714 queue-cutover projection and trigger).

## User-visible impact

None in rendering: `chatEventResponseSchema` already includes the legacy read-only leaves, and the platform, IDB read path, and CLI all filter them via `isCanonicalChatEventResponse` before folding, so legacy rows are parsed and dropped client-side exactly as they are for cached IDB rows today. The observable change is that threads with historical pause markers no longer have API-invisible seqIds.

## Implementation notes

- `chatEventBuilders` now covers `ChatEventResponse["eventType"]` (19 canonical + 2 legacy read-only types); `ChatEventBuilder`/`chatEventResponse` are widened to `ChatEventResponse` accordingly.
- The write schema (`chatEventSchema`) still excludes the legacy types — no writer or fold can recreate the retired pause/resume behavior; the contract comment is updated to say the API serves the historical rows.
- Prompt-context consumers (`zero-chat-events.ts` prior-run messages, morning brief) keep their own type filters; those are semantic selections for LLM context, not wire-level filtering, and are out of scope.

## Verification

Relying on the PR pipeline for typecheck/tests per repo convention. Remaining seqId hole source (batch `insertChatEvents` reservation not returned on conflict) is unchanged and documented in the snapshot design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)