### PR TITLE
feat(platform): add public agent mentions to chat composer

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/composer-agent-mention-node.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-agent-mention-node.ts
@@ -1,0 +1,179 @@
+import { Node } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { NodeView } from "@tiptap/pm/view";
+
+import {
+  resolveAvatarSvgConfig,
+  resolveAvatarUrl,
+} from "../../views/zero-page/avatar-utils.ts";
+import { avatarSvgLayerUrls } from "../../views/zero-page/avatar-svg-utils.ts";
+import { serializeAgentMention } from "./composer-agent-suggestion-domain.ts";
+import { AGENT_MENTION_NODE_NAME } from "./user-message-document-codec.ts";
+
+interface AgentMentionAttributes {
+  readonly agentId: string;
+  readonly name: string;
+  readonly avatarUrl: string | null;
+}
+
+function agentMentionAttributes(node: ProseMirrorNode): AgentMentionAttributes {
+  const agentId: unknown = node.attrs.agentId;
+  const name: unknown = node.attrs.name;
+  const avatarUrl: unknown = node.attrs.avatarUrl;
+  if (
+    typeof agentId !== "string" ||
+    typeof name !== "string" ||
+    (avatarUrl !== null && typeof avatarUrl !== "string")
+  ) {
+    throw new Error("Agent mention node attributes are invalid");
+  }
+  return { agentId, name, avatarUrl };
+}
+
+export function agentMentionText(node: ProseMirrorNode): string {
+  const { agentId, name } = agentMentionAttributes(node);
+  return serializeAgentMention(agentId, name);
+}
+
+function renderAgentMentionAvatar(
+  container: HTMLElement,
+  avatarUrl: string | null,
+): void {
+  container.replaceChildren();
+  const svgConfig = resolveAvatarSvgConfig(avatarUrl);
+  if (svgConfig) {
+    const urls = avatarSvgLayerUrls(svgConfig);
+    const layers = document.createElement("span");
+    layers.className = "absolute inset-0 scale-[1.25]";
+    for (const src of [urls.head, urls.face, urls.hair]) {
+      const image = document.createElement("img");
+      image.alt = "";
+      image.src = src;
+      image.className = "absolute inset-0 h-full w-full object-cover";
+      layers.append(image);
+    }
+    container.append(layers);
+    return;
+  }
+
+  const src = resolveAvatarUrl(avatarUrl);
+  if (src) {
+    const image = document.createElement("img");
+    image.alt = "";
+    image.src = src;
+    image.className = "h-full w-full object-cover";
+    container.append(image);
+  }
+}
+
+function createAgentMentionNodeView(
+  node: ProseMirrorNode,
+  className: string,
+): NodeView {
+  const dom = document.createElement("span");
+  dom.className = className;
+  dom.contentEditable = "false";
+  dom.style.outline = "none";
+  dom.style.userSelect = "none";
+
+  const avatar = document.createElement("span");
+  avatar.className =
+    "relative h-4 w-4 shrink-0 overflow-hidden rounded-full bg-muted";
+  avatar.ariaHidden = "true";
+  const name = document.createElement("span");
+  name.className = "min-w-0 select-none truncate";
+  dom.append(avatar, name);
+
+  let currentNode = node;
+  let currentAvatarUrl: string | null | undefined;
+  function render(nextNode: ProseMirrorNode): void {
+    const attributes = agentMentionAttributes(nextNode);
+    dom.dataset.agentMention = attributes.agentId;
+    dom.dataset.agentName = attributes.name;
+    if (attributes.avatarUrl === null) {
+      delete dom.dataset.agentAvatarUrl;
+    } else {
+      dom.dataset.agentAvatarUrl = attributes.avatarUrl;
+    }
+    name.textContent = attributes.name;
+    if (attributes.avatarUrl !== currentAvatarUrl) {
+      currentAvatarUrl = attributes.avatarUrl;
+      renderAgentMentionAvatar(avatar, attributes.avatarUrl);
+    }
+  }
+  render(node);
+
+  return {
+    dom,
+    update(nextNode) {
+      if (nextNode.type !== currentNode.type) {
+        return false;
+      }
+      currentNode = nextNode;
+      render(nextNode);
+      return true;
+    },
+    selectNode() {
+      dom.dataset.selected = "";
+    },
+    deselectNode() {
+      delete dom.dataset.selected;
+    },
+    ignoreMutation() {
+      return true;
+    },
+  };
+}
+
+export function createAgentMentionNode(
+  className: string,
+): Node<undefined, unknown> {
+  return Node.create({
+    name: AGENT_MENTION_NODE_NAME,
+    group: "inline",
+    inline: true,
+    atom: true,
+    addAttributes() {
+      return {
+        agentId: { default: "" },
+        name: { default: "" },
+        avatarUrl: { default: null },
+      };
+    },
+    parseHTML() {
+      return [
+        {
+          tag: "span[data-agent-mention]",
+          getAttrs: (element) => {
+            return {
+              agentId: element.dataset.agentMention ?? "",
+              name: element.dataset.agentName ?? "",
+              avatarUrl: element.dataset.agentAvatarUrl ?? null,
+            };
+          },
+        },
+      ];
+    },
+    renderHTML({ node }) {
+      const { agentId, name, avatarUrl } = agentMentionAttributes(node);
+      return [
+        "span",
+        {
+          "data-agent-mention": agentId,
+          "data-agent-name": name,
+          ...(avatarUrl === null ? {} : { "data-agent-avatar-url": avatarUrl }),
+          class: className,
+        },
+        name,
+      ];
+    },
+    renderText({ node }) {
+      return agentMentionText(node);
+    },
+    addNodeView() {
+      return ({ node }) => {
+        return createAgentMentionNodeView(node, className);
+      };
+    },
+  });
+}

--- a/turbo/apps/platform/src/signals/zero-page/composer-agent-mention-node.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-agent-mention-node.ts
@@ -16,6 +16,42 @@ interface AgentMentionAttributes {
   readonly avatarUrl: string | null;
 }
 
+interface AgentMentionAvatarSource {
+  readonly id: string;
+  readonly avatarUrl: string | null;
+}
+
+export interface AgentMentionAvatarRuntime {
+  readonly resolve: (agentId: string, fallback: string | null) => string | null;
+  readonly replaceAgents: (agents: readonly AgentMentionAvatarSource[]) => void;
+  readonly subscribe: (listener: () => void) => () => void;
+}
+
+export function createAgentMentionAvatarRuntime(): AgentMentionAvatarRuntime {
+  let agents: readonly AgentMentionAvatarSource[] = [];
+  const listeners = new Set<() => void>();
+  return {
+    resolve(agentId, fallback) {
+      const agent = agents.find((candidate) => {
+        return candidate.id === agentId;
+      });
+      return agent ? agent.avatarUrl : fallback;
+    },
+    replaceAgents(nextAgents) {
+      agents = nextAgents;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
 function agentMentionAttributes(node: ProseMirrorNode): AgentMentionAttributes {
   const agentId: unknown = node.attrs.agentId;
   const name: unknown = node.attrs.name;
@@ -69,6 +105,7 @@ function renderAgentMentionAvatar(
 function createAgentMentionNodeView(
   node: ProseMirrorNode,
   className: string,
+  avatarRuntime: AgentMentionAvatarRuntime,
 ): NodeView {
   const dom = document.createElement("span");
   dom.className = className;
@@ -88,20 +125,27 @@ function createAgentMentionNodeView(
   let currentAvatarUrl: string | null | undefined;
   function render(nextNode: ProseMirrorNode): void {
     const attributes = agentMentionAttributes(nextNode);
+    const avatarUrl = avatarRuntime.resolve(
+      attributes.agentId,
+      attributes.avatarUrl,
+    );
     dom.dataset.agentMention = attributes.agentId;
     dom.dataset.agentName = attributes.name;
-    if (attributes.avatarUrl === null) {
+    if (avatarUrl === null) {
       delete dom.dataset.agentAvatarUrl;
     } else {
-      dom.dataset.agentAvatarUrl = attributes.avatarUrl;
+      dom.dataset.agentAvatarUrl = avatarUrl;
     }
     name.textContent = attributes.name;
-    if (attributes.avatarUrl !== currentAvatarUrl) {
-      currentAvatarUrl = attributes.avatarUrl;
-      renderAgentMentionAvatar(avatar, attributes.avatarUrl);
+    if (avatarUrl !== currentAvatarUrl) {
+      currentAvatarUrl = avatarUrl;
+      renderAgentMentionAvatar(avatar, avatarUrl);
     }
   }
   render(node);
+  const unsubscribe = avatarRuntime.subscribe(() => {
+    render(currentNode);
+  });
 
   return {
     dom,
@@ -122,11 +166,15 @@ function createAgentMentionNodeView(
     ignoreMutation() {
       return true;
     },
+    destroy() {
+      unsubscribe();
+    },
   };
 }
 
 export function createAgentMentionNode(
   className: string,
+  avatarRuntime: AgentMentionAvatarRuntime,
 ): Node<undefined, unknown> {
   return Node.create({
     name: AGENT_MENTION_NODE_NAME,
@@ -172,7 +220,7 @@ export function createAgentMentionNode(
     },
     addNodeView() {
       return ({ node }) => {
-        return createAgentMentionNodeView(node, className);
+        return createAgentMentionNodeView(node, className, avatarRuntime);
       };
     },
   });

--- a/turbo/apps/platform/src/signals/zero-page/composer-agent-suggestion-domain.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-agent-suggestion-domain.ts
@@ -1,0 +1,51 @@
+export interface ComposerAgentSuggestion {
+  readonly id: string;
+  readonly name: string;
+  readonly avatarUrl: string | null;
+}
+
+interface AgentMentionTextSegment {
+  readonly type: "text";
+  readonly text: string;
+}
+
+interface AgentMentionSegment {
+  readonly type: "mention";
+  readonly agentId: string;
+  readonly name: string;
+}
+
+type AgentMentionLineSegment = AgentMentionTextSegment | AgentMentionSegment;
+
+// Matches `[name](/agents/<uuid>/chat)` where the name backslash-escapes
+// `\`, `[` and `]`.
+const AGENT_MENTION_PATTERN =
+  /\[((?:\\[\\[\]]|[^[\]\\])+)\]\(\/agents\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/chat\)/g;
+
+export function serializeAgentMention(agentId: string, name: string): string {
+  const escapedName = name.replace(/[\\[\]]/g, String.raw`\$&`);
+  return `[${escapedName}](/agents/${agentId}/chat)`;
+}
+
+export function splitAgentMentionSegments(
+  line: string,
+): readonly AgentMentionLineSegment[] {
+  const segments: AgentMentionLineSegment[] = [];
+  let lastIndex = 0;
+  for (const match of line.matchAll(AGENT_MENTION_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ type: "text", text: line.slice(lastIndex, index) });
+    }
+    segments.push({
+      type: "mention",
+      agentId: match[2] ?? "",
+      name: (match[1] ?? "").replace(/\\([\\[\]])/g, "$1"),
+    });
+    lastIndex = index + match[0].length;
+  }
+  if (lastIndex < line.length) {
+    segments.push({ type: "text", text: line.slice(lastIndex) });
+  }
+  return segments;
+}

--- a/turbo/apps/platform/src/signals/zero-page/composer-chat-thread-suggestions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-chat-thread-suggestions.ts
@@ -1,15 +1,21 @@
 import { computed, type Computed } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { agents$ } from "../agent.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { eventDrivenChatThreads$ } from "../chat-page/chat-thread-event-sourcing.ts";
+import type { ComposerAgentSuggestion } from "./composer-agent-suggestion-domain.ts";
 import type {
   ChatThreadSuggestionRange,
   ComposerChatThreadSuggestion,
 } from "./chat-thread-suggestion-domain.ts";
 
+const MAX_DEFAULT_AGENT_SUGGESTIONS = 3;
 const MAX_VISIBLE_CHAT_THREAD_SUGGESTIONS = 25;
 
 export interface ComposerChatThreadSuggestionResult {
   readonly agentId: string | null;
   readonly query: string | null;
+  readonly agents: readonly ComposerAgentSuggestion[];
   readonly chatThreads: readonly ComposerChatThreadSuggestion[];
 }
 
@@ -23,16 +29,50 @@ export function createComposerChatThreadSuggestions(
       return {
         agentId: null,
         query: null,
+        agents: [],
         chatThreads: [],
       };
     }
 
     const agentId = await get(agentId$);
     if (!agentId) {
-      return { agentId: null, query: range.query, chatThreads: [] };
+      return {
+        agentId: null,
+        query: range.query,
+        agents: [],
+        chatThreads: [],
+      };
     }
 
     const query = range.query.toLowerCase();
+    const agentSuggestions: ComposerAgentSuggestion[] = [];
+    const zeroChatMessagingEnabled =
+      get(featureSwitch$)[FeatureSwitchKey.ZeroChatMessaging] ?? false;
+    if (zeroChatMessagingEnabled) {
+      const visibleAgents = await get(agents$);
+      for (const agent of visibleAgents) {
+        const name = agent.displayName ?? agent.id;
+        if (
+          agent.id === agentId ||
+          agent.visibility !== "public" ||
+          !name.toLowerCase().includes(query)
+        ) {
+          continue;
+        }
+        agentSuggestions.push({
+          id: agent.id,
+          name,
+          avatarUrl: agent.avatarUrl,
+        });
+        if (
+          range.query.length === 0 &&
+          agentSuggestions.length === MAX_DEFAULT_AGENT_SUGGESTIONS
+        ) {
+          break;
+        }
+      }
+    }
+
     const chatThreads: ComposerChatThreadSuggestion[] = [];
     for (const thread of get(eventDrivenChatThreads$)) {
       const title = thread.title;
@@ -49,6 +89,11 @@ export function createComposerChatThreadSuggestions(
       }
     }
 
-    return { agentId, query: range.query, chatThreads };
+    return {
+      agentId,
+      query: range.query,
+      agents: agentSuggestions,
+      chatThreads,
+    };
   });
 }

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -24,6 +24,7 @@ import {
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
+import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { onRef, resetSignal } from "../utils.ts";
 import type { DraftInputSyncTarget, DraftSignals } from "./chat-draft.ts";
@@ -46,7 +47,9 @@ import {
 } from "./composer-agent-suggestion-domain.ts";
 import {
   agentMentionText,
+  createAgentMentionAvatarRuntime,
   createAgentMentionNode,
+  type AgentMentionAvatarRuntime,
 } from "./composer-agent-mention-node.ts";
 import {
   createComposerChatThreadSuggestions,
@@ -80,6 +83,7 @@ type WorkflowNamesSyncCommand = Command<
   Promise<void>,
   [AbortSignal, AbortSignal]
 >;
+type AgentMentionAvatarsSyncCommand = Command<Promise<void>, [AbortSignal]>;
 
 interface MountedWorkflowNamesSync {
   readonly command$: WorkflowNamesSyncCommand;
@@ -286,10 +290,6 @@ const COMPOSER_INLINE_REFERENCE_CLASS =
   "data-[selected]:ring-1 data-[selected]:ring-inset " +
   "data-[selected]:ring-orange-500/40 dark:data-[selected]:bg-orange-400/20 " +
   "dark:data-[selected]:ring-orange-300/40";
-
-const AgentMentionNode = createAgentMentionNode(
-  COMPOSER_INLINE_REFERENCE_CLASS,
-);
 
 interface ChatThreadMentionAttributes {
   readonly threadId: string;
@@ -1478,7 +1478,10 @@ function createFeedbackItemNode(
   });
 }
 
-function createWorkflowEditor(runtime: WorkflowComposerRuntime): Editor {
+function createWorkflowEditor(
+  runtime: WorkflowComposerRuntime,
+  agentMentionAvatarRuntime: AgentMentionAvatarRuntime,
+): Editor {
   return new Editor({
     element: null,
     extensions: [
@@ -1486,7 +1489,10 @@ function createWorkflowEditor(runtime: WorkflowComposerRuntime): Editor {
       createTemplateAttachmentNode(runtime),
       createInlineTemplateNode(runtime),
       createFeedbackItemNode(runtime),
-      AgentMentionNode,
+      createAgentMentionNode(
+        COMPOSER_INLINE_REFERENCE_CLASS,
+        agentMentionAvatarRuntime,
+      ),
       ChatThreadMentionNode,
       WorkflowHighlight,
     ],
@@ -1666,6 +1672,16 @@ function createSyncWorkflowNamesCommand(
   );
 }
 
+function createSyncAgentMentionAvatarsCommand(
+  avatarRuntime: AgentMentionAvatarRuntime,
+): AgentMentionAvatarsSyncCommand {
+  return command(async ({ get }, signal: AbortSignal): Promise<void> => {
+    const agents = await get(agents$);
+    signal.throwIfAborted();
+    avatarRuntime.replaceAgents(agents);
+  });
+}
+
 function mountCompositionListeners(
   editor: Editor,
   compositionGate: CompositionGate,
@@ -1693,6 +1709,7 @@ interface MountEditorOptions {
   feedback: FeedbackSignals;
   compositionGate: CompositionGate;
   syncWorkflowNames$: WorkflowNamesSyncCommand;
+  syncAgentMentionAvatars$: AgentMentionAvatarsSyncCommand;
   inlineTemplatesEnabled: boolean;
   autoFocus: boolean;
   singleLineOnMobile: boolean;
@@ -1708,6 +1725,7 @@ function createMountEditorCommand({
   feedback,
   compositionGate,
   syncWorkflowNames$,
+  syncAgentMentionAvatars$,
   inlineTemplatesEnabled,
   autoFocus,
   singleLineOnMobile,
@@ -1817,7 +1835,10 @@ function createMountEditorCommand({
         set(editorFocusedState$, false);
         editor.unmount();
       });
-      await set(syncWorkflowNames$, signal, signal);
+      await Promise.all([
+        set(syncWorkflowNames$, signal, signal),
+        set(syncAgentMentionAvatars$, signal),
+      ]);
     }),
   );
 }
@@ -2237,15 +2258,19 @@ export function createWorkflowComposerSignals<
   const editorFocusedState$ = state(false);
   const selectedSuggestionIndexState$ = state(0);
   const runtime = createWorkflowComposerRuntime();
+  const agentMentionAvatarRuntime = createAgentMentionAvatarRuntime();
   const templatePreview = createTemplatePreviewRuntime();
   const compositionGate = createCompositionGate();
   const { agentId$, workflows$ } = createComposerAgentResources(agentIdSource$);
 
-  const editor = createWorkflowEditor(runtime);
+  const editor = createWorkflowEditor(runtime, agentMentionAvatarRuntime);
   const syncWorkflowNames$ = createSyncWorkflowNamesCommand(
     editor,
     agentId$,
     workflows$,
+  );
+  const syncAgentMentionAvatars$ = createSyncAgentMentionAvatarsCommand(
+    agentMentionAvatarRuntime,
   );
   const templateAttachment = createTemplateAttachmentControls(editor, runtime);
   const feedback = createComposerFeedback(threadId, editor);
@@ -2300,6 +2325,7 @@ export function createWorkflowComposerSignals<
       feedback,
       compositionGate,
       syncWorkflowNames$,
+      syncAgentMentionAvatars$,
       inlineTemplatesEnabled,
       autoFocus,
       singleLineOnMobile,

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -41,6 +41,14 @@ import {
   type ComposerChatThreadSuggestion,
 } from "./chat-thread-suggestion-domain.ts";
 import {
+  splitAgentMentionSegments,
+  type ComposerAgentSuggestion,
+} from "./composer-agent-suggestion-domain.ts";
+import {
+  agentMentionText,
+  createAgentMentionNode,
+} from "./composer-agent-mention-node.ts";
+import {
   createComposerChatThreadSuggestions,
   type ComposerChatThreadSuggestionResult,
 } from "./composer-chat-thread-suggestions.ts";
@@ -52,6 +60,7 @@ import {
   type SlashWorkflowRange,
 } from "./workflow-composer-domain.ts";
 import {
+  AGENT_MENTION_NODE_NAME,
   CHAT_THREAD_MENTION_NODE_NAME,
   createEditorDocumentSnapshot,
   INLINE_TEMPLATE_NODE_NAME,
@@ -192,6 +201,7 @@ export interface WorkflowComposerSignals {
   readonly setSelectedSuggestionIndex$: Command<void, [number]>;
   readonly closeSuggestionMenu$: Command<void, []>;
   readonly insertWorkflow$: Command<void, [ComposerSlashWorkflow]>;
+  readonly insertAgent$: Command<void, [ComposerAgentSuggestion]>;
   readonly insertChatThread$: Command<void, [ComposerChatThreadSuggestion]>;
   readonly insertPromptMarkdown$: Command<void, [string]>;
   readonly insertUserMessage$: Command<void, [UserMessageDocument]>;
@@ -276,6 +286,10 @@ const COMPOSER_INLINE_REFERENCE_CLASS =
   "data-[selected]:ring-1 data-[selected]:ring-inset " +
   "data-[selected]:ring-orange-500/40 dark:data-[selected]:bg-orange-400/20 " +
   "dark:data-[selected]:ring-orange-300/40";
+
+const AgentMentionNode = createAgentMentionNode(
+  COMPOSER_INLINE_REFERENCE_CLASS,
+);
 
 interface ChatThreadMentionAttributes {
   readonly threadId: string;
@@ -1074,22 +1088,41 @@ function setTemplateAttachmentNode(
   );
 }
 
+function agentMentionInlineContent(value: string): JSONContent[] {
+  return splitAgentMentionSegments(value).map((segment): JSONContent => {
+    return segment.type === "text"
+      ? { type: "text", text: segment.text }
+      : {
+          type: AGENT_MENTION_NODE_NAME,
+          attrs: {
+            agentId: segment.agentId,
+            name: segment.name,
+            avatarUrl: null,
+          },
+        };
+  });
+}
+
+function composerInlineReferenceContent(line: string): JSONContent[] {
+  const content: JSONContent[] = [];
+  for (const segment of splitChatThreadMentionSegments(line)) {
+    if (segment.type === "text") {
+      content.push(...agentMentionInlineContent(segment.text));
+      continue;
+    }
+    content.push({
+      type: CHAT_THREAD_MENTION_NODE_NAME,
+      attrs: { threadId: segment.threadId, title: segment.title },
+    });
+  }
+  return content;
+}
+
 function valueToWorkflowComposerDoc(value: string): JSONContent {
   const content: JSONContent[] = value.split("\n").map((line) => {
-    if (line.length === 0) {
-      return { type: "paragraph" };
-    }
-    const inlineContent = splitChatThreadMentionSegments(line).map(
-      (segment): JSONContent => {
-        return segment.type === "text"
-          ? { type: "text", text: segment.text }
-          : {
-              type: CHAT_THREAD_MENTION_NODE_NAME,
-              attrs: { threadId: segment.threadId, title: segment.title },
-            };
-      },
-    );
-    return { type: "paragraph", content: inlineContent };
+    return line.length === 0
+      ? { type: "paragraph" }
+      : { type: "paragraph", content: composerInlineReferenceContent(line) };
   });
   return { type: "doc", content };
 }
@@ -1099,6 +1132,9 @@ function nodeText(
   to: number = node.content.size,
 ): string {
   return node.textBetween(0, to, "\n", (leafNode) => {
+    if (leafNode.type.name === AGENT_MENTION_NODE_NAME) {
+      return agentMentionText(leafNode);
+    }
     if (leafNode.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
       return chatThreadMentionText(leafNode);
     }
@@ -1450,6 +1486,7 @@ function createWorkflowEditor(runtime: WorkflowComposerRuntime): Editor {
       createTemplateAttachmentNode(runtime),
       createInlineTemplateNode(runtime),
       createFeedbackItemNode(runtime),
+      AgentMentionNode,
       ChatThreadMentionNode,
       WorkflowHighlight,
     ],
@@ -1815,6 +1852,43 @@ function createInsertWorkflowCommand(
   });
 }
 
+function createInsertAgentCommand(
+  editor: Editor,
+  activeRange$: Computed<ChatThreadSuggestionRange | null>,
+) {
+  return command(({ get }, agent: ComposerAgentSuggestion) => {
+    const range = get(activeRange$);
+    if (!range) {
+      return;
+    }
+    const textblock = activeTextblock(editor);
+    if (!textblock) {
+      return;
+    }
+    const head = editor.state.selection.head;
+    const from = head - (range.end - range.start);
+    const content: JSONContent[] = [
+      {
+        type: AGENT_MENTION_NODE_NAME,
+        attrs: {
+          agentId: agent.id,
+          name: agent.name,
+          avatarUrl: agent.avatarUrl,
+        },
+      },
+    ];
+    if (!textblock.value.slice(range.end).startsWith(" ")) {
+      content.push({ type: "text", text: " " });
+    }
+    editor
+      .chain()
+      .focus()
+      .insertContentAt({ from, to: head }, content)
+      .setTextSelection(from + 2)
+      .run();
+  });
+}
+
 function createInsertChatThreadCommand(
   editor: Editor,
   activeRange$: Computed<ChatThreadSuggestionRange | null>,
@@ -1848,6 +1922,21 @@ function createInsertChatThreadCommand(
       .setTextSelection(from + 2)
       .run();
   });
+}
+
+function createSuggestionInsertionCommands(
+  editor: Editor,
+  activeSlashRange$: Computed<SlashWorkflowRange | null>,
+  activeMentionRange$: Computed<ChatThreadSuggestionRange | null>,
+) {
+  return {
+    insertWorkflow$: createInsertWorkflowCommand(editor, activeSlashRange$),
+    insertAgent$: createInsertAgentCommand(editor, activeMentionRange$),
+    insertChatThread$: createInsertChatThreadCommand(
+      editor,
+      activeMentionRange$,
+    ),
+  };
 }
 
 function createInsertTextCommands(editor: Editor) {
@@ -2216,12 +2305,9 @@ export function createWorkflowComposerSignals<
       singleLineOnMobile,
     });
   };
-  const insertWorkflow$ = createInsertWorkflowCommand(
+  const suggestionInsertionCommands = createSuggestionInsertionCommands(
     editor,
     activeSlashRange$,
-  );
-  const insertChatThread$ = createInsertChatThreadCommand(
-    editor,
     activeChatThreadSuggestionRange$,
   );
   const textCommands = createInsertTextCommands(editor);
@@ -2256,8 +2342,7 @@ export function createWorkflowComposerSignals<
     selectedSuggestionIndex$,
     setSelectedSuggestionIndex$,
     closeSuggestionMenu$,
-    insertWorkflow$,
-    insertChatThread$,
+    ...suggestionInsertionCommands,
     ...textCommands,
     ...templateCommands,
     insertUserMessage$,

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -13,7 +13,12 @@ import {
 
 import { formatFeedbackPrompt, type FeedbackSource } from "./chat-feedback.ts";
 import { serializeChatThreadMention } from "./chat-thread-suggestion-domain.ts";
+import {
+  serializeAgentMention,
+  splitAgentMentionSegments,
+} from "./composer-agent-suggestion-domain.ts";
 
+export const AGENT_MENTION_NODE_NAME = "agentMention";
 export const CHAT_THREAD_MENTION_NODE_NAME = "chatThreadMention";
 export const TEMPLATE_ATTACHMENT_NODE_NAME = "templateAttachment";
 export const INLINE_TEMPLATE_NODE_NAME = "inlineTemplate";
@@ -72,6 +77,15 @@ function chatThreadPart(
   };
 }
 
+function agentMentionText(node: ProseMirrorNode): string | null {
+  const agentId: unknown = node.attrs.agentId;
+  const name: unknown = node.attrs.name;
+  if (typeof agentId !== "string" || typeof name !== "string") {
+    return null;
+  }
+  return serializeAgentMention(agentId, name);
+}
+
 function legacyTemplatePart(
   node: ProseMirrorNode,
   generationTemplate: GenerationTemplateRequest | undefined,
@@ -124,6 +138,14 @@ function appendParagraphParts(
     }
     if (node.type.name === "hardBreak") {
       appendTextPart(parts, "\n");
+      continue;
+    }
+    if (node.type.name === AGENT_MENTION_NODE_NAME) {
+      const text = agentMentionText(node);
+      if (!text) {
+        return false;
+      }
+      appendTextPart(parts, text);
       continue;
     }
     if (node.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
@@ -413,6 +435,21 @@ function legacyTemplateNode(
   } satisfies JSONContent;
 }
 
+function agentMentionInlineContent(line: string): JSONContent[] {
+  return splitAgentMentionSegments(line).map((segment): JSONContent => {
+    return segment.type === "text"
+      ? { type: "text", text: segment.text }
+      : {
+          type: AGENT_MENTION_NODE_NAME,
+          attrs: {
+            agentId: segment.agentId,
+            name: segment.name,
+            avatarUrl: null,
+          },
+        };
+  });
+}
+
 function feedbackNoteToPrompt(note: readonly FeedbackNotePart[]): string {
   return note
     .map((part) => {
@@ -461,7 +498,7 @@ function feedbackNoteContent(note: readonly FeedbackNotePart[]): JSONContent[] {
     const lines = part.text.split("\n");
     for (const [index, line] of lines.entries()) {
       if (line.length > 0) {
-        paragraphContent.push({ type: "text", text: line });
+        paragraphContent.push(...agentMentionInlineContent(line));
         trailingParagraph = false;
       }
       if (index < lines.length - 1) {
@@ -511,7 +548,7 @@ function appendRestoredText(state: RestoredEditorState, text: string): void {
   const lines = text.split("\n");
   for (const [index, line] of lines.entries()) {
     if (line.length > 0) {
-      state.paragraphContent.push({ type: "text", text: line });
+      state.paragraphContent.push(...agentMentionInlineContent(line));
       state.trailingParagraph = false;
     }
     if (index < lines.length - 1) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -1,7 +1,10 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  chatThreadByIdContract,
+  chatThreadDraftContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -626,6 +629,54 @@ describe("chat composer models", () => {
         expect.objectContaining({
           draftContent: `[Zeta Agent](/agents/${zetaAgentId}/chat)`,
         }),
+      );
+    });
+  });
+
+  it("restores a persisted agent item with its current avatar", async () => {
+    const mentionedAgentId = "a1000000-0000-4000-a000-000000000006";
+    const mentionedAgentAvatarUrl =
+      "https://example.com/restored-agent-avatar.png";
+    const mention = `[Restored Agent](/agents/${mentionedAgentId}/chat)`;
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    context.mocks.data.team([
+      suggestionAgent({ id: AGENT_ID, displayName: "Scout" }),
+      suggestionAgent({
+        id: mentionedAgentId,
+        displayName: "Restored Agent",
+        avatarUrl: mentionedAgentAvatarUrl,
+      }),
+    ]);
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftContent: mention,
+        draftUserMessage: {
+          version: 1,
+          parts: [{ type: "text", text: mention }],
+        },
+        draftAttachments: null,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroChatMessaging]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await waitFor(() => {
+      const item = editor.querySelector(
+        `span[data-agent-mention="${mentionedAgentId}"]`,
+      );
+      expect(item).toHaveTextContent("Restored Agent");
+      expect(item?.querySelector("img")).toHaveAttribute(
+        "src",
+        mentionedAgentAvatarUrl,
       );
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -1,6 +1,8 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { chatThreadByIdContract } from "@vm0/api-contracts/contracts/chat-threads";
+import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { pathname } from "../../../signals/location.ts";
@@ -27,6 +29,29 @@ import {
   placeCaretAfterText,
   workflowSummary,
 } from "./chat-composer-test-helpers.ts";
+
+function suggestionAgent({
+  id,
+  displayName,
+  avatarUrl = null,
+  visibility = "public",
+}: {
+  readonly id: string;
+  readonly displayName: string;
+  readonly avatarUrl?: string | null;
+  readonly visibility?: "public" | "private";
+}): TeamComposeItem {
+  return {
+    id,
+    displayName,
+    description: null,
+    sound: null,
+    avatarUrl,
+    visibility,
+    headVersionId: id,
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
 
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
@@ -464,6 +489,145 @@ describe("chat composer models", () => {
       `span[data-chat-thread-mention="${SUGGESTED_THREAD_ID}"]`,
     );
     expect(chip).toHaveTextContent("Project Alpha");
+  });
+
+  it("keeps public agent suggestions behind zero chat messaging", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    context.mocks.data.team([
+      suggestionAgent({ id: AGENT_ID, displayName: "Scout" }),
+      suggestionAgent({
+        id: OTHER_AGENT_ID,
+        displayName: "Other Agent",
+      }),
+    ]);
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: null },
+      {
+        id: SUGGESTED_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Other thread",
+      },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("@other");
+
+    const menu = await screen.findByTestId("chat-thread-suggestion-menu");
+    expect(within(menu).getByText("Other thread")).toBeInTheDocument();
+    expect(within(menu).queryByText("Other Agent")).not.toBeInTheDocument();
+  });
+
+  it("suggests public agents above chat threads and inserts an agent item", async () => {
+    const alphaAgentId = "a1000000-0000-4000-a000-000000000001";
+    const betaAgentId = "a1000000-0000-4000-a000-000000000002";
+    const gammaAgentId = "a1000000-0000-4000-a000-000000000003";
+    const zetaAgentId = "a1000000-0000-4000-a000-000000000004";
+    const privateAgentId = "a1000000-0000-4000-a000-000000000005";
+    const zetaAvatarUrl = "https://example.com/zeta-avatar.png";
+    const draftPatches: Record<string, unknown>[] = [];
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    context.mocks.data.team([
+      suggestionAgent({ id: AGENT_ID, displayName: "Scout" }),
+      suggestionAgent({
+        id: alphaAgentId,
+        displayName: "Alpha Agent",
+        avatarUrl: "preset:0",
+      }),
+      suggestionAgent({
+        id: betaAgentId,
+        displayName: "Beta Agent",
+        avatarUrl: "preset:1",
+      }),
+      suggestionAgent({
+        id: gammaAgentId,
+        displayName: "Gamma Agent",
+        avatarUrl: "preset:2",
+      }),
+      suggestionAgent({
+        id: zetaAgentId,
+        displayName: "Zeta Agent",
+        avatarUrl: zetaAvatarUrl,
+      }),
+      suggestionAgent({
+        id: privateAgentId,
+        displayName: "Private Agent",
+        visibility: "private",
+      }),
+    ]);
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: null },
+      {
+        id: SUGGESTED_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Project Alpha",
+      },
+    ]);
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ZeroChatMessaging]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("@");
+
+    const menu = await screen.findByTestId("chat-thread-suggestion-menu");
+    expect(
+      queryAllByRoleFast("button", menu).map((button) => {
+        return button.textContent;
+      }),
+    ).toStrictEqual([
+      "Alpha Agent",
+      "Beta Agent",
+      "Gamma Agent",
+      "Project Alpha",
+    ]);
+    expect(within(menu).queryByText("Scout")).not.toBeInTheDocument();
+    expect(within(menu).queryByText("Zeta Agent")).not.toBeInTheDocument();
+    expect(within(menu).queryByText("Private Agent")).not.toBeInTheDocument();
+
+    await user.keyboard("zeta");
+    await waitFor(() => {
+      const filteredMenu = screen.getByTestId("chat-thread-suggestion-menu");
+      expect(within(filteredMenu).getByText("Zeta Agent")).toBeInTheDocument();
+      expect(
+        within(filteredMenu).queryByText("Project Alpha"),
+      ).not.toBeInTheDocument();
+    });
+    await user.keyboard("{Enter}");
+
+    const item = editor.querySelector(
+      `span[data-agent-mention="${zetaAgentId}"]`,
+    );
+    expect(item).toHaveTextContent("Zeta Agent");
+    expect(item?.querySelector("img")).toHaveAttribute("src", zetaAvatarUrl);
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual(
+        expect.objectContaining({
+          draftContent: `[Zeta Agent](/agents/${zetaAgentId}/chat)`,
+        }),
+      );
+    });
   });
 
   it("hides @ suggestions when no titled thread matches", async () => {

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-suggestion.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-suggestion.tsx
@@ -1,36 +1,36 @@
 import { cn, PopoverContent } from "@vm0/ui";
+import type { ComposerAgentSuggestion } from "../../signals/zero-page/composer-agent-suggestion-domain.ts";
 import type { ComposerChatThreadSuggestion } from "../../signals/zero-page/chat-thread-suggestion-domain.ts";
 import { composerSuggestionCollisionPadding } from "./slash-workflow.tsx";
+import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 
-function chatThreadSuggestionOptionId(threadId: string): string {
-  return `chat-thread-suggestion-option-${threadId}`;
-}
-
-export function scrollChatThreadSuggestionIntoView(
-  chatThread: ComposerChatThreadSuggestion | undefined,
+function scrollSelectedSuggestionIntoView(
+  option: HTMLButtonElement | null,
 ): void {
-  if (!chatThread) {
+  if (!option) {
     return;
   }
-
   window.requestAnimationFrame(() => {
-    const option = document.getElementById(
-      chatThreadSuggestionOptionId(chatThread.id),
-    );
-    if (option && typeof option.scrollIntoView === "function") {
+    if (typeof option.scrollIntoView === "function") {
       option.scrollIntoView({ block: "nearest" });
     }
   });
 }
 
-export function ChatThreadSuggestionMenu({
+export function ComposerMentionSuggestionMenu({
+  agents,
   chatThreads,
   selectedIndex,
-  onSelect,
+  onSelectAgent,
+  onSelectChatThread,
 }: {
+  readonly agents: readonly ComposerAgentSuggestion[];
   readonly chatThreads: readonly ComposerChatThreadSuggestion[];
   readonly selectedIndex: number;
-  readonly onSelect: (chatThread: ComposerChatThreadSuggestion) => void;
+  readonly onSelectAgent: (agent: ComposerAgentSuggestion) => void;
+  readonly onSelectChatThread: (
+    chatThread: ComposerChatThreadSuggestion,
+  ) => void;
 }) {
   return (
     <PopoverContent
@@ -45,16 +45,53 @@ export function ChatThreadSuggestionMenu({
       className="flex h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--radix-popover-content-available-height))]"
       data-testid="chat-thread-suggestion-menu"
     >
-      <div className="px-2.5 pt-2 pb-1 text-xs font-medium text-muted-foreground">
-        Chat threads
-      </div>
       <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
+        {agents.length > 0 && (
+          <>
+            <div className="px-1 pt-2 pb-1 text-xs font-medium text-muted-foreground">
+              Agents
+            </div>
+            {agents.map((agent, index) => {
+              const selected = index === selectedIndex;
+              return (
+                <button
+                  key={agent.id}
+                  ref={selected ? scrollSelectedSuggestionIntoView : undefined}
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors",
+                    selected ? "bg-accent" : "hover:bg-accent/60",
+                  )}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    onSelectAgent(agent);
+                  }}
+                >
+                  <AvatarFromUrl
+                    avatarUrl={agent.avatarUrl}
+                    alt=""
+                    className="h-5 w-5 shrink-0 rounded-full bg-muted"
+                    size={20}
+                  />
+                  <span className="truncate text-sm text-popover-foreground">
+                    {agent.name}
+                  </span>
+                </button>
+              );
+            })}
+          </>
+        )}
+        {chatThreads.length > 0 && (
+          <div className="px-1 pt-2 pb-1 text-xs font-medium text-muted-foreground">
+            Chat threads
+          </div>
+        )}
         {chatThreads.map((chatThread, index) => {
-          const selected = index === selectedIndex;
+          const selected = agents.length + index === selectedIndex;
           return (
             <button
-              id={chatThreadSuggestionOptionId(chatThread.id)}
               key={chatThread.id}
+              ref={selected ? scrollSelectedSuggestionIntoView : undefined}
               type="button"
               className={cn(
                 "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
@@ -62,7 +99,7 @@ export function ChatThreadSuggestionMenu({
               )}
               onMouseDown={(event) => {
                 event.preventDefault();
-                onSelect(chatThread);
+                onSelectChatThread(chatThread);
               }}
             >
               <span className="truncate text-sm text-popover-foreground">

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -11,13 +11,11 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { useTranslation } from "react-i18next";
 
 import { i18n } from "../../i18n/index.ts";
+import type { ComposerAgentSuggestion } from "../../signals/zero-page/composer-agent-suggestion-domain.ts";
 import type { ComposerChatThreadSuggestion } from "../../signals/zero-page/chat-thread-suggestion-domain.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import type { WorkflowComposerSignals } from "../../signals/zero-page/tiptap-workflow-composer.ts";
-import {
-  ChatThreadSuggestionMenu,
-  scrollChatThreadSuggestionIntoView,
-} from "./chat-thread-suggestion.tsx";
+import { ComposerMentionSuggestionMenu } from "./chat-thread-suggestion.tsx";
 import {
   buildComposerSlashWorkflows,
   findWorkflowQueryMatches,
@@ -272,9 +270,11 @@ interface ComposerSuggestionMenuState {
   readonly workflowQuery: string;
   readonly workflowsLoading: boolean;
   readonly showWorkflows: boolean;
+  readonly agents: readonly ComposerAgentSuggestion[];
   readonly chatThreads: readonly ComposerChatThreadSuggestion[];
-  readonly showChatThreads: boolean;
+  readonly showMentions: boolean;
   readonly selectWorkflow: (workflow: ComposerSlashWorkflow) => void;
+  readonly selectAgent: (agent: ComposerAgentSuggestion) => void;
   readonly selectChatThread: (chatThread: ComposerChatThreadSuggestion) => void;
   readonly handleKeyDown: (event: KeyboardEvent) => boolean;
 }
@@ -296,6 +296,7 @@ function useComposerSuggestionMenu({
   const setSelectedIndex = useSet(composer.setSelectedSuggestionIndex$);
   const close = useSet(composer.closeSuggestionMenu$);
   const insertWorkflow = useSet(composer.insertWorkflow$);
+  const insertAgent = useSet(composer.insertAgent$);
   const insertChatThread = useSet(composer.insertChatThread$);
   const currentAgentId = useLastResolved(composer.agentId$);
   const workflowsLoadable = useLastLoadable(composer.workflows$);
@@ -312,27 +313,35 @@ function useComposerSuggestionMenu({
       )
     : [];
   const showWorkflows = slashRange !== null;
-  const chatThreads =
+  const mentionResult =
     chatThreadRange &&
     chatThreadResult &&
     chatThreadResult.agentId === currentAgentId &&
     chatThreadResult.query === chatThreadRange.query
-      ? chatThreadResult.chatThreads
-      : [];
-  const showChatThreads =
-    slashRange === null && chatThreadRange !== null && chatThreads.length > 0;
-  const open = showWorkflows || showChatThreads;
+      ? chatThreadResult
+      : null;
+  const agents = mentionResult?.agents ?? [];
+  const chatThreads = mentionResult?.chatThreads ?? [];
+  const showMentions =
+    slashRange === null &&
+    chatThreadRange !== null &&
+    agents.length + chatThreads.length > 0;
+  const open = showWorkflows || showMentions;
   const range = showWorkflows
     ? slashRange
-    : showChatThreads
+    : showMentions
       ? chatThreadRange
       : null;
   const suggestionCount = showWorkflows
     ? workflowSuggestions.length
-    : chatThreads.length;
+    : agents.length + chatThreads.length;
 
   function selectWorkflow(workflow: ComposerSlashWorkflow): void {
     insertWorkflow(workflow);
+  }
+
+  function selectAgent(agent: ComposerAgentSuggestion): void {
+    insertAgent(agent);
   }
 
   function selectChatThread(chatThread: ComposerChatThreadSuggestion): void {
@@ -347,7 +356,12 @@ function useComposerSuggestionMenu({
       }
       return;
     }
-    const chatThread = chatThreads[index];
+    const agent = agents[index];
+    if (agent) {
+      selectAgent(agent);
+      return;
+    }
+    const chatThread = chatThreads[index - agents.length];
     if (chatThread) {
       selectChatThread(chatThread);
     }
@@ -356,9 +370,7 @@ function useComposerSuggestionMenu({
   function scrollSuggestionIntoView(index: number): void {
     if (showWorkflows) {
       scrollSlashWorkflowIntoView(workflowSuggestions[index]);
-      return;
     }
-    scrollChatThreadSuggestionIntoView(chatThreads[index]);
   }
 
   function handleKeyDown(event: KeyboardEvent): boolean {
@@ -384,9 +396,11 @@ function useComposerSuggestionMenu({
     workflowQuery: slashRange?.query ?? "",
     workflowsLoading: workflowsLoadable.state === "loading",
     showWorkflows,
+    agents,
     chatThreads,
-    showChatThreads,
+    showMentions,
     selectWorkflow,
+    selectAgent,
     selectChatThread,
     handleKeyDown,
   };
@@ -506,11 +520,13 @@ export function TiptapWorkflowComposer({
           onSelect={suggestionMenu.selectWorkflow}
         />
       )}
-      {suggestionMenu.showChatThreads && (
-        <ChatThreadSuggestionMenu
+      {suggestionMenu.showMentions && (
+        <ComposerMentionSuggestionMenu
+          agents={suggestionMenu.agents}
           chatThreads={suggestionMenu.chatThreads}
           selectedIndex={suggestionMenu.selectedIndex}
-          onSelect={suggestionMenu.selectChatThread}
+          onSelectAgent={suggestionMenu.selectAgent}
+          onSelectChatThread={suggestionMenu.selectChatThread}
         />
       )}
     </Popover>


### PR DESCRIPTION
## Summary

- Show up to three public agents above chat threads in the `@` menu when `zeroChatMessaging` is enabled, excluding the current agent and all private agents.
- Search all other public agents by display name once the user types after `@`.
- Insert the selected agent as an atomic composer item with its avatar and name while serializing it as `[AGENT_NAME](/agents/:id/chat)`.
- Restore serialized agent links as composer items without changing the existing chat-thread suggestion behavior when the feature switch is off.

## Verification

- `pnpm --filter @vm0/app exec prettier --check <touched files>`
- `pnpm --filter @vm0/app exec eslint <touched files> --max-warnings 0`
- `pnpm --filter @vm0/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json <touched files>`
- `pnpm --filter @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx --maxWorkers=1` — 22 tests passed

Local browser verification and a dev server were intentionally not run; the PR pipeline will provide the repository-standard checks and preview.
