### PR TITLE
feat(platform): show custom connectors in chat composer

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -25,6 +25,7 @@ import {
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { FEATURE_SWITCH_CACHE_KEY } from "../../signals/external/feature-switch.ts";
 import { mockApi } from "../msw-contract.ts";
@@ -320,6 +321,10 @@ export const apiConnectorsHandlers = [
       connectors,
       categoryMetadata: testConnectorCatalogCategoryMetadata,
     });
+  }),
+
+  mockApi(zeroCustomConnectorsContract.list, ({ respond }) => {
+    return respond(200, { connectors: [] });
   }),
 
   mockApi(zeroConnectorCatalogContract.diagnostics, ({ respond }) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -119,25 +119,37 @@ const bumpReload$ = command(({ set }) => {
   });
 });
 
-const authorizeCustomConnectorForVisibleAgents$ = command(
+type CustomConnectorAuthorizationTarget =
+  | { readonly kind: "visible-agents" }
+  | { readonly kind: "agent"; readonly agentId: string };
+
+const authorizeCustomConnectorForTarget$ = command(
   async (
     { get, set },
-    connectorId: string,
+    args: {
+      readonly connectorId: string;
+      readonly target: CustomConnectorAuthorizationTarget;
+    },
     signal: AbortSignal,
   ): Promise<void> => {
-    const visibleAgents = await get(agents$);
+    const agentIds =
+      args.target.kind === "agent"
+        ? [args.target.agentId]
+        : (await get(agents$)).map((agent) => {
+            return agent.id;
+          });
     signal.throwIfAborted();
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
     await withCleanup(
       Promise.all(
-        visibleAgents.map(async (agent) => {
+        agentIds.map(async (agentId) => {
           await accept(
             client.update({
-              params: { id: agent.id },
-              body: { enabledIds: [connectorId], operation: "add" },
+              params: { id: agentId },
+              body: { enabledIds: [args.connectorId], operation: "add" },
               fetchOptions: { signal },
             }),
-            [200, 404],
+            args.target.kind === "agent" ? [200] : [200, 404],
           );
         }),
       ),
@@ -253,10 +265,14 @@ export const renameCustomConnector$ = command(
   },
 );
 
-export const setCustomConnectorSecret$ = command(
+const setCustomConnectorSecretForTarget$ = command(
   async (
     { get, set },
-    args: { id: string; value: string },
+    args: {
+      readonly id: string;
+      readonly value: string;
+      readonly authorizationTarget: CustomConnectorAuthorizationTarget;
+    },
     signal: AbortSignal,
   ): Promise<void> => {
     const createClient = get(zeroClient$);
@@ -271,11 +287,57 @@ export const setCustomConnectorSecret$ = command(
     );
     signal.throwIfAborted();
     set(bumpReload$);
-    await set(authorizeCustomConnectorForVisibleAgents$, args.id, signal);
+    await set(
+      authorizeCustomConnectorForTarget$,
+      {
+        connectorId: args.id,
+        target: args.authorizationTarget,
+      },
+      signal,
+    );
     toast.success(
       i18n.t(($) => {
         return $.connectors.custom.toasts.connected;
       }),
+    );
+  },
+);
+
+export const setCustomConnectorSecret$ = command(
+  async (
+    { set },
+    args: { readonly id: string; readonly value: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      setCustomConnectorSecretForTarget$,
+      {
+        ...args,
+        authorizationTarget: { kind: "visible-agents" },
+      },
+      signal,
+    );
+  },
+);
+
+export const setCustomConnectorSecretForAgent$ = command(
+  async (
+    { set },
+    args: {
+      readonly id: string;
+      readonly value: string;
+      readonly agentId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      setCustomConnectorSecretForTarget$,
+      {
+        id: args.id,
+        value: args.value,
+        authorizationTarget: { kind: "agent", agentId: args.agentId },
+      },
+      signal,
     );
   },
 );
@@ -300,8 +362,15 @@ export const clearCustomConnectorSecret$ = command(
   },
 );
 
-export const connectCustomConnectorOAuth2$ = command(
-  async ({ get, set }, id: string, signal: AbortSignal): Promise<void> => {
+const connectCustomConnectorOAuth2ForTarget$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly id: string;
+      readonly authorizationTarget: CustomConnectorAuthorizationTarget;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
     const authWindow = window.open(
       "about:blank",
       "_blank",
@@ -320,7 +389,7 @@ export const connectCustomConnectorOAuth2$ = command(
         });
         const result = await accept(
           client.start({
-            params: { id },
+            params: { id: args.id },
             body: {},
             fetchOptions: { signal },
           }),
@@ -350,11 +419,48 @@ export const connectCustomConnectorOAuth2$ = command(
     signal.throwIfAborted();
     if (
       connectors.some((connector) => {
-        return connector.id === id && connector.connected;
+        return connector.id === args.id && connector.connected;
       })
     ) {
-      await set(authorizeCustomConnectorForVisibleAgents$, id, signal);
+      await set(
+        authorizeCustomConnectorForTarget$,
+        {
+          connectorId: args.id,
+          target: args.authorizationTarget,
+        },
+        signal,
+      );
     }
+  },
+);
+
+export const connectCustomConnectorOAuth2$ = command(
+  async ({ set }, id: string, signal: AbortSignal): Promise<void> => {
+    await set(
+      connectCustomConnectorOAuth2ForTarget$,
+      {
+        id,
+        authorizationTarget: { kind: "visible-agents" },
+      },
+      signal,
+    );
+  },
+);
+
+export const connectCustomConnectorOAuth2ForAgent$ = command(
+  async (
+    { set },
+    args: { readonly id: string; readonly agentId: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      connectCustomConnectorOAuth2ForTarget$,
+      {
+        id: args.id,
+        authorizationTarget: { kind: "agent", agentId: args.agentId },
+      },
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -25,6 +25,10 @@ const internalAuthorizedAgentsReload$ = state(0);
 
 export type CustomConnectorAuthMethodType = "api" | "oauth2";
 
+export const customConnectorAuthorizationReloadVersion$ = computed((get) => {
+  return get(internalAuthorizedAgentsReload$);
+});
+
 // ---------------------------------------------------------------------------
 // Active tab on the Connectors settings page
 // ---------------------------------------------------------------------------
@@ -65,7 +69,7 @@ export const customConnectors$ = computed(
 
 export const customConnectorAuthorizedAgentsById$ = computed(
   async (get): Promise<ReadonlyMap<string, readonly TeamComposeItem[]>> => {
-    get(internalAuthorizedAgentsReload$);
+    get(customConnectorAuthorizationReloadVersion$);
     const connectors = await get(customConnectors$);
     if (
       !connectors.some((connector) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -3,6 +3,7 @@ import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-ident
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
@@ -14,11 +15,23 @@ import {
   type AgentConnectorAuthorizations,
 } from "./agent-connector-authorizations.ts";
 import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
+import {
+  customConnectorAuthorizationReloadVersion$,
+  reloadCustomConnectorAuthorizedAgents$,
+} from "./settings/custom-connectors.ts";
+
+export interface AgentCustomConnectorAuthorizations {
+  readonly agentId: string;
+  readonly enabledIds: readonly string[];
+}
 
 export interface ComposerConnectorAuthorizationSignals {
   readonly agentId$: Computed<Promise<string | null>>;
   readonly authorizations$: Computed<
     Promise<AgentConnectorAuthorizations | null>
+  >;
+  readonly customAuthorizations$: Computed<
+    Promise<AgentCustomConnectorAuthorizations | null>
   >;
 }
 
@@ -31,6 +44,14 @@ export interface ComposerConnectorSignals extends ComposerConnectorAuthorization
     Promise<void>,
     [ConnectorSlug, AbortSignal]
   >;
+  readonly authorizeCustomConnector$: Command<
+    Promise<void>,
+    [string, AbortSignal]
+  >;
+  readonly deauthorizeCustomConnector$: Command<
+    Promise<void>,
+    [string, AbortSignal]
+  >;
   readonly showAddDialog$: Computed<boolean>;
   readonly setShowAddDialog$: Command<void, [boolean]>;
   readonly pendingConnectorSlug$: Computed<ConnectorSlug | null>;
@@ -39,15 +60,16 @@ export interface ComposerConnectorSignals extends ComposerConnectorAuthorization
   readonly setSelectedConnectorSlug$: Command<void, [ConnectorSlug | null]>;
   readonly savingConnectorSlug$: Computed<ConnectorSlug | null>;
   readonly setSavingConnectorSlug$: Command<void, [ConnectorSlug | null]>;
+  readonly selectedCustomConnectorId$: Computed<string | null>;
+  readonly setSelectedCustomConnectorId$: Command<void, [string | null]>;
+  readonly savingCustomConnectorId$: Computed<string | null>;
+  readonly setSavingCustomConnectorId$: Command<void, [string | null]>;
   readonly addDialogSearch$: Computed<string>;
   readonly setAddDialogSearch$: Command<void, [string]>;
   readonly popoverSearch$: Computed<string>;
   readonly setPopoverSearch$: Command<void, [string]>;
-  readonly popoverSortOrder$: Computed<readonly ConnectorSlug[] | null>;
-  readonly setPopoverSortOrder$: Command<
-    void,
-    [readonly ConnectorSlug[] | null]
-  >;
+  readonly popoverSortOrder$: Computed<readonly string[] | null>;
+  readonly setPopoverSortOrder$: Command<void, [readonly string[] | null]>;
   readonly computerUseDownloadDialogOpen$: Computed<boolean>;
   readonly setComputerUseDownloadDialogOpen$: Command<void, [boolean]>;
   readonly permissionConnectorSlug$: Computed<ConnectorSlug | null>;
@@ -79,9 +101,11 @@ interface ComposerConnectorUiState {
   readonly pendingConnectorSlug: ConnectorSlug | null;
   readonly selectedConnectorSlug: ConnectorSlug | null;
   readonly savingConnectorSlug: ConnectorSlug | null;
+  readonly selectedCustomConnectorId: string | null;
+  readonly savingCustomConnectorId: string | null;
   readonly addDialogSearch: string;
   readonly popoverSearch: string;
-  readonly popoverSortOrder: readonly ConnectorSlug[] | null;
+  readonly popoverSortOrder: readonly string[] | null;
   readonly computerUseDownloadDialogOpen: boolean;
   readonly permissionConnectorSlug: ConnectorSlug | null;
 }
@@ -92,6 +116,8 @@ function initialComposerConnectorUiState(): ComposerConnectorUiState {
     pendingConnectorSlug: null,
     selectedConnectorSlug: null,
     savingConnectorSlug: null,
+    selectedCustomConnectorId: null,
+    savingCustomConnectorId: null,
     addDialogSearch: "",
     popoverSearch: "",
     popoverSortOrder: null,
@@ -115,7 +141,25 @@ export function createComposerConnectorAuthorizationSignals<
       return await get(agentConnectorAuthorizations({ agentId }));
     },
   );
-  return { agentId$, authorizations$ };
+  const customAuthorizations$ = computed(
+    async (get): Promise<AgentCustomConnectorAuthorizations | null> => {
+      const agentId = await get(agentId$);
+      if (!agentId) {
+        return null;
+      }
+      get(customConnectorAuthorizationReloadVersion$);
+      const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
+      const result = await accept(
+        client.get({ params: { id: agentId } }),
+        [200],
+      );
+      return {
+        agentId,
+        enabledIds: result.body.enabledIds,
+      };
+    },
+  );
+  return { agentId$, authorizations$, customAuthorizations$ };
 }
 
 function createConnectorAuthorizationCommands(
@@ -184,6 +228,74 @@ function createConnectorAuthorizationCommands(
   };
 }
 
+function createCustomConnectorAuthorizationCommands(
+  agentId$: Computed<Promise<string | null>>,
+): Pick<
+  ComposerConnectorSignals,
+  "authorizeCustomConnector$" | "deauthorizeCustomConnector$"
+> {
+  const updateAuthorizedCustomConnectors$ = command(
+    async (
+      { get, set },
+      operation: "add" | "remove",
+      connectorId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const agentId = await get(agentId$);
+      signal.throwIfAborted();
+      if (!agentId) {
+        throw new Error("No agent available");
+      }
+
+      const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
+      await withCleanup(
+        accept(
+          client.update({
+            params: { id: agentId },
+            body: { enabledIds: [connectorId], operation },
+            fetchOptions: { signal },
+          }),
+          [200],
+        ),
+        () => {
+          set(reloadCustomConnectorAuthorizedAgents$);
+        },
+      );
+      signal.throwIfAborted();
+    },
+  );
+
+  const authorizeCustomConnector$ = command(
+    async (
+      { set },
+      connectorId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await set(updateAuthorizedCustomConnectors$, "add", connectorId, signal);
+    },
+  );
+
+  const deauthorizeCustomConnector$ = command(
+    async (
+      { set },
+      connectorId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await set(
+        updateAuthorizedCustomConnectors$,
+        "remove",
+        connectorId,
+        signal,
+      );
+    },
+  );
+
+  return {
+    authorizeCustomConnector$,
+    deauthorizeCustomConnector$,
+  };
+}
+
 export function createComposerConnectorSignals<T extends AgentIdValue>(
   agentIdSource$: Computed<T>,
   authorization?: ComposerConnectorAuthorizationSignals,
@@ -195,6 +307,8 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
     authorization ?? createComposerConnectorAuthorizationSignals(localAgentId$);
   const authorizationCommands =
     createConnectorAuthorizationCommands(localAgentId$);
+  const customAuthorizationCommands =
+    createCustomConnectorAuthorizationCommands(localAgentId$);
   const initial = initialComposerConnectorUiState();
   const showAddDialog = createStateBinding(initial.showAddDialog);
   const pendingConnectorSlug = createStateBinding(initial.pendingConnectorSlug);
@@ -202,6 +316,12 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
     initial.selectedConnectorSlug,
   );
   const savingConnectorSlug = createStateBinding(initial.savingConnectorSlug);
+  const selectedCustomConnectorId = createStateBinding(
+    initial.selectedCustomConnectorId,
+  );
+  const savingCustomConnectorId = createStateBinding(
+    initial.savingCustomConnectorId,
+  );
   const addDialogSearch = createStateBinding(initial.addDialogSearch);
   const popoverSearch = createStateBinding(initial.popoverSearch);
   const popoverSortOrder = createStateBinding(initial.popoverSortOrder);
@@ -232,6 +352,7 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
   return {
     ...resolvedAuthorization,
     ...authorizationCommands,
+    ...customAuthorizationCommands,
     showAddDialog$: showAddDialog.value$,
     setShowAddDialog$: showAddDialog.set$,
     pendingConnectorSlug$: pendingConnectorSlug.value$,
@@ -240,6 +361,10 @@ export function createComposerConnectorSignals<T extends AgentIdValue>(
     setSelectedConnectorSlug$: selectedConnectorSlug.set$,
     savingConnectorSlug$: savingConnectorSlug.value$,
     setSavingConnectorSlug$: savingConnectorSlug.set$,
+    selectedCustomConnectorId$: selectedCustomConnectorId.value$,
+    setSelectedCustomConnectorId$: selectedCustomConnectorId.set$,
+    savingCustomConnectorId$: savingCustomConnectorId.value$,
+    setSavingCustomConnectorId$: savingCustomConnectorId.set$,
     addDialogSearch$: addDialogSearch.value$,
     setAddDialogSearch$: addDialogSearch.set$,
     popoverSearch$: popoverSearch.value$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -4,6 +4,11 @@ import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  zeroCustomConnectorsContract,
+  type CustomConnectorResponse,
+} from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
   zeroConnectorNoAuthGrantContract,
@@ -62,6 +67,42 @@ function connectorStatus({
   };
 }
 
+function customConnector(
+  overrides: Partial<CustomConnectorResponse> = {},
+): CustomConnectorResponse {
+  return {
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "_acme-search",
+    displayName: "Acme Search",
+    prefixes: ["https://api.acme.test/v1/"],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{secret}}",
+    prefixTemplates: ["https://api.acme.test/v1/"],
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    connected: false,
+    missingRequiredFields: ["secret"],
+    configuredFieldKeys: [],
+    hasSecret: false,
+    createdAt: "2026-07-30T00:00:00.000Z",
+    updatedAt: "2026-07-30T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 function mockCatalog(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
@@ -101,6 +142,77 @@ beforeEach(() => {
 });
 
 describe("chat composer connector connection", () => {
+  it("shows connected custom connectors and toggles agent access", async () => {
+    const user = userEvent.setup({ delay: null });
+    const connector = customConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      hasSecret: true,
+    });
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    let enabledIds: string[] = [];
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.get,
+      ({ params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        return respond(200, { enabledIds });
+      },
+    );
+    let updateCount = 0;
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        updateCount += 1;
+        expect(params.id).toBe(AGENT_ID);
+        expect(body).toStrictEqual({
+          enabledIds: [connector.id],
+          operation: "add",
+        });
+        enabledIds = [connector.id];
+        return respond(200, { enabledIds });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    await user.click(within(composer).getByLabelText("Connectors"));
+    await user.click(await screen.findByLabelText("Add Acme Search"));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(1);
+      expect(screen.getByLabelText("Remove Acme Search")).toBeInTheDocument();
+    });
+  });
+
+  it("shows unconnected custom connectors in the add dialog", async () => {
+    const user = userEvent.setup({ delay: null });
+    const connector = customConnector();
+    mockCatalog([]);
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const dialog = await openAddConnectorsDialog(user);
+    await user.click(
+      within(dialog).getByLabelText(`Connect ${connector.displayName}`),
+    );
+
+    await expect(
+      screen.findByRole("dialog", {
+        name: `Connect ${connector.displayName}`,
+      }),
+    ).resolves.toBeInTheDocument();
+    expect(dialog).not.toBeInTheDocument();
+  });
+
   it("starts a single OAuth connector without an intermediate modal", async () => {
     const user = userEvent.setup({ delay: null });
     mockCatalog([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -5,6 +5,7 @@ import {
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
+  zeroCustomConnectorSecretContract,
   zeroCustomConnectorsContract,
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
@@ -15,7 +16,10 @@ import {
   zeroConnectorOauthStartContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { beforeEach, describe, expect, it } from "vitest";
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import {
   AGENT_ID,
@@ -190,14 +194,48 @@ describe("chat composer connector connection", () => {
     });
   });
 
-  it("shows unconnected custom connectors in the add dialog", async () => {
+  it("connects a custom connector for only the active agent", async () => {
     const user = userEvent.setup({ delay: null });
     const connector = customConnector();
+    mockAgent({ includeOtherAgent: true });
     mockCatalog([]);
+    let connected = false;
     context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
-      return respond(200, { connectors: [connector] });
+      return respond(200, {
+        connectors: [
+          connected
+            ? {
+                ...connector,
+                connected: true,
+                missingRequiredFields: [],
+                configuredFieldKeys: ["secret"],
+                hasSecret: true,
+              }
+            : connector,
+        ],
+      });
     });
-
+    context.mocks.api(
+      zeroCustomConnectorSecretContract.set,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(connector.id);
+        expect(body).toStrictEqual({ value: "acme-secret" });
+        connected = true;
+        return respond(204);
+      },
+    );
+    const updatedAgentIds: string[] = [];
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(body).toStrictEqual({
+          enabledIds: [connector.id],
+          operation: "add",
+        });
+        updatedAgentIds.push(params.id);
+        return respond(200, { enabledIds: [connector.id] });
+      },
+    );
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
     const dialog = await openAddConnectorsDialog(user);
@@ -205,12 +243,28 @@ describe("chat composer connector connection", () => {
       within(dialog).getByLabelText(`Connect ${connector.displayName}`),
     );
 
-    await expect(
-      screen.findByRole("dialog", {
-        name: `Connect ${connector.displayName}`,
-      }),
-    ).resolves.toBeInTheDocument();
+    const connectDialog = await screen.findByRole("dialog", {
+      name: `Connect ${connector.displayName}`,
+    });
     expect(dialog).not.toBeInTheDocument();
+    await user.type(
+      within(connectDialog).getByLabelText("Secret"),
+      "acme-secret",
+    );
+    const saveButton = queryAllByRoleFast("button", connectDialog).find(
+      (button) => {
+        return button.textContent === "Save";
+      },
+    );
+    if (!saveButton) {
+      throw new Error("Save button not found");
+    }
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updatedAgentIds).toStrictEqual([AGENT_ID]);
+      expect(connectDialog).not.toBeInTheDocument();
+    });
   });
 
   it("starts a single OAuth connector without an intermediate modal", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -194,8 +194,10 @@ function ConnectDialogFooter({
 
 export function CustomConnectorConnectDialog({
   connector,
+  onClose,
 }: {
   readonly connector: CustomConnectorResponse;
+  readonly onClose?: () => void;
 }) {
   const { t } = useTranslation();
   const form = useGet(customConnectorConnectForm$);
@@ -229,7 +231,11 @@ export function CustomConnectorConnectDialog({
 
   const close = () => {
     resetForm();
-    closeDialog();
+    if (onClose) {
+      onClose();
+    } else {
+      closeDialog();
+    }
   };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -20,10 +20,12 @@ import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   closeCustomConnectorDialog$,
   connectCustomConnectorOAuth2$,
+  connectCustomConnectorOAuth2ForAgent$,
   customConnectorConnectForm$,
   resetCustomConnectorConnectInput$,
   setCustomConnectorConnectField$,
   setCustomConnectorSecret$,
+  setCustomConnectorSecretForAgent$,
 } from "../../../../signals/zero-page/settings/custom-connectors.ts";
 import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token-input.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -148,6 +150,50 @@ function submitButtonLabel(
   return submitting ? "Saving…" : "Save";
 }
 
+function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
+  const [apiLoadable, submitApi] = useLoadableSet(setCustomConnectorSecret$);
+  const [agentApiLoadable, submitAgentApi] = useLoadableSet(
+    setCustomConnectorSecretForAgent$,
+  );
+  const [oauthLoadable, submitOAuth2] = useLoadableSet(
+    connectCustomConnectorOAuth2$,
+  );
+  const [agentOAuthLoadable, submitAgentOAuth2] = useLoadableSet(
+    connectCustomConnectorOAuth2ForAgent$,
+  );
+
+  const submitSecret = async (
+    args: { readonly id: string; readonly value: string },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (agentId) {
+      await submitAgentApi({ ...args, agentId }, signal);
+    } else {
+      await submitApi(args, signal);
+    }
+  };
+  const submitOAuth = async (
+    connectorId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (agentId) {
+      await submitAgentOAuth2({ id: connectorId, agentId }, signal);
+    } else {
+      await submitOAuth2(connectorId, signal);
+    }
+  };
+
+  return {
+    submitting:
+      apiLoadable.state === "loading" ||
+      agentApiLoadable.state === "loading" ||
+      oauthLoadable.state === "loading" ||
+      agentOAuthLoadable.state === "loading",
+    submitSecret,
+    submitOAuth,
+  };
+}
+
 function ConnectDialogFooter({
   selectedMethod,
   multipleMethods,
@@ -194,9 +240,11 @@ function ConnectDialogFooter({
 
 export function CustomConnectorConnectDialog({
   connector,
+  agentId,
   onClose,
 }: {
   readonly connector: CustomConnectorResponse;
+  readonly agentId?: string;
   readonly onClose?: () => void;
 }) {
   const { t } = useTranslation();
@@ -215,14 +263,10 @@ export function CustomConnectorConnectDialog({
   const setField = useSet(setCustomConnectorConnectField$);
   const resetForm = useSet(resetCustomConnectorConnectInput$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
-  const [apiLoadable, submitApi] = useLoadableSet(setCustomConnectorSecret$);
-  const [oauthLoadable, submitOAuth2] = useLoadableSet(
-    connectCustomConnectorOAuth2$,
-  );
+  const { submitting, submitSecret, submitOAuth } =
+    useCustomConnectorConnectionSubmitters(agentId);
   const signal = useGet(pageSignal$);
 
-  const submitting =
-    apiLoadable.state === "loading" || oauthLoadable.state === "loading";
   const canSubmit =
     !submitting &&
     (selectedMethod?.type === "api"
@@ -246,9 +290,12 @@ export function CustomConnectorConnectDialog({
     detach(
       (async () => {
         if (selectedMethod.type === "api") {
-          await submitApi({ id: connector.id, value: form.apiSecret }, signal);
+          await submitSecret(
+            { id: connector.id, value: form.apiSecret },
+            signal,
+          );
         } else {
-          await submitOAuth2(connector.id, signal);
+          await submitOAuth(connector.id, signal);
         }
         close();
       })(),

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -8250,9 +8250,10 @@ export function useZeroChatComposer(
           }}
         />
       )}
-      {selectedCustomConnector && (
+      {selectedCustomConnector && agentRecordId && (
         <CustomConnectorConnectDialog
           connector={selectedCustomConnector}
+          agentId={agentRecordId}
           onClose={() => {
             setSelectedCustomConnectorId(null);
           }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -139,6 +139,7 @@ import {
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
@@ -147,6 +148,8 @@ import {
 } from "./components/model-provider-picker.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectorCard } from "./components/settings/connector-card.tsx";
+import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
+import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
 import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
@@ -159,6 +162,7 @@ import {
   pollingOAuthAuthCodeConnectorSlug$,
   pollingOAuthDeviceAuthConnectorSlug$,
 } from "../../signals/zero-page/settings/connectors.ts";
+import { customConnectors$ } from "../../signals/zero-page/settings/custom-connectors.ts";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
@@ -169,7 +173,10 @@ import {
   featureSwitch$,
 } from "../../signals/external/feature-switch.ts";
 import { zeroDesktopDownloadSupportStatus$ } from "../../signals/zero-page/computer-use-hosts.ts";
-import type { ComposerConnectorSignals } from "../../signals/zero-page/zero-connectors.ts";
+import type {
+  AgentCustomConnectorAuthorizations,
+  ComposerConnectorSignals,
+} from "../../signals/zero-page/zero-connectors.ts";
 import type { AgentConnectorAuthorizations } from "../../signals/zero-page/agent-connector-authorizations.ts";
 import { applyUserPermissionGrants$ } from "../../signals/permission-allow/permission-allow-signals.ts";
 import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission-grants.ts";
@@ -355,8 +362,10 @@ export interface ZeroChatComposerProps {
 
 export interface ComposerConnectorReadState {
   readonly catalogItems: Loadable<readonly PublicConnectorCatalogStatusItem[]>;
+  readonly customConnectors: Loadable<readonly CustomConnectorResponse[]>;
   readonly agentId: Loadable<string | null>;
   readonly authorizations: Loadable<AgentConnectorAuthorizations | null>;
+  readonly customAuthorizations: Loadable<AgentCustomConnectorAuthorizations | null>;
 }
 
 export interface QueuedComposerItem {
@@ -426,6 +435,10 @@ type TemplatePreviewImageSize = Parameters<typeof r2ImageTransformUrl>[1];
 // ---------------------------------------------------------------------------
 
 type ComposerConnectorItem = PublicConnectorCatalogStatusItem & {
+  readonly authorized: boolean;
+};
+
+type ComposerCustomConnectorItem = CustomConnectorResponse & {
   readonly authorized: boolean;
 };
 
@@ -5720,28 +5733,51 @@ function ComposerWorkflowPromptSlot({
 
 function ConnectorTriggerIcons({
   connectors,
+  customConnectors,
   hasComputerUse,
   hasCloudBrowser,
 }: {
   connectors: ComposerConnectorItem[];
+  customConnectors: ComposerCustomConnectorItem[];
   hasComputerUse: boolean;
   hasCloudBrowser: boolean;
 }) {
-  const enabled = connectors
-    .filter((c) => {
-      return c.authorized;
-    })
-    .slice(0, 3);
+  const enabledConnectors = connectors.filter((connector) => {
+    return connector.authorized;
+  });
+  const enabledCustomConnectors = customConnectors.filter((connector) => {
+    return connector.authorized;
+  });
+  const enabled = [
+    ...enabledConnectors.map((connector) => {
+      return { kind: "builtin" as const, connector };
+    }),
+    ...enabledCustomConnectors.map((connector) => {
+      return { kind: "custom" as const, connector };
+    }),
+  ].slice(0, 3);
   if (enabled.length === 0 && !hasComputerUse && !hasCloudBrowser) {
     return <IconPlug size={18} stroke={1.5} />;
   }
   return (
     <span className="flex items-center -space-x-2 sm:-space-x-1.5">
-      {enabled.map((c) => {
+      {enabled.map((item) => {
+        const key =
+          item.kind === "builtin"
+            ? item.connector.connectorRef
+            : item.connector.id;
         return (
-          <span key={c.connectorRef} className="relative shrink-0">
+          <span key={key} className="relative shrink-0">
             <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background zero-border sm:h-7 sm:w-7">
-              <ConnectorIcon icon={c.icon} size={16} />
+              {item.kind === "builtin" ? (
+                <ConnectorIcon icon={item.connector.icon} size={16} />
+              ) : (
+                <CustomConnectorIcon
+                  id={item.connector.id}
+                  displayName={item.connector.displayName}
+                  size={16}
+                />
+              )}
             </span>
           </span>
         );
@@ -5764,19 +5800,85 @@ function ConnectorTriggerIcons({
   );
 }
 
+function matchesCustomConnectorSearch(
+  search: string,
+  connector: CustomConnectorResponse,
+): boolean {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) {
+    return true;
+  }
+  return [connector.displayName, connector.slug, ...connector.prefixes].some(
+    (value) => {
+      return value.toLowerCase().includes(normalizedSearch);
+    },
+  );
+}
+
+function CustomConnectorCatalogCard({
+  connector,
+  onConnect,
+}: {
+  connector: CustomConnectorResponse;
+  onConnect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`Connect ${connector.displayName}`}
+      className="zero-card cursor-pointer overflow-hidden text-left"
+      onClick={onConnect}
+    >
+      <span className="flex items-center gap-2.5 px-5 pb-1 pt-4">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <CustomConnectorIcon
+            id={connector.id}
+            displayName={connector.displayName}
+            size={20}
+          />
+        </span>
+        <span
+          data-testid="connector-card-label"
+          className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
+        >
+          {connector.displayName}
+        </span>
+        <span
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground"
+          aria-hidden="true"
+        >
+          <IconPlus size={14} stroke={1.5} />
+        </span>
+      </span>
+      <span className="block px-5 pb-4 pt-1">
+        <span
+          data-testid="connector-help-text"
+          className="line-clamp-2 text-xs text-muted-foreground"
+        >
+          {connector.prefixes[0]}
+        </span>
+      </span>
+    </button>
+  );
+}
+
 function AddConnectorsDialog({
   signals,
   unconnected,
+  unconnectedCustom,
   busyConnectorSlug,
   connectHandlers,
+  onConnectCustom,
   onClose,
 }: {
   signals: ComposerConnectorSignals;
   unconnected: PublicConnectorCatalogStatusItem[];
+  unconnectedCustom: CustomConnectorResponse[];
   busyConnectorSlug: ConnectorSlug | null;
   connectHandlers: (
     connector: PublicConnectorCatalogStatusItem,
   ) => ConnectorConnectHandlers;
+  onConnectCustom: (connector: CustomConnectorResponse) => void;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
@@ -5785,6 +5887,10 @@ function AddConnectorsDialog({
   const filtered = unconnected.filter((item) => {
     return matchesConnectorSearch(search, item);
   });
+  const filteredCustom = unconnectedCustom.filter((item) => {
+    return matchesCustomConnectorSearch(search, item);
+  });
+  const connectorCount = unconnected.length + unconnectedCustom.length;
 
   return (
     <Dialog
@@ -5804,7 +5910,7 @@ function AddConnectorsDialog({
                 return $.chat.connectors.available;
               },
               {
-                count: unconnected.length,
+                count: connectorCount,
               },
             )}
           </DialogTitle>
@@ -5832,6 +5938,17 @@ function AddConnectorsDialog({
                   connector={item}
                   busy={busyConnectorSlug === item.connectorRef}
                   connect={connectHandlers(item)}
+                />
+              );
+            })}
+            {filteredCustom.map((item) => {
+              return (
+                <CustomConnectorCatalogCard
+                  key={item.id}
+                  connector={item}
+                  onConnect={() => {
+                    onConnectCustom(item);
+                  }}
                 />
               );
             })}
@@ -6086,27 +6203,63 @@ function ComposerConnectorPermissionDialog({
   );
 }
 
+type ComposerPopoverConnectorItem =
+  | {
+      readonly kind: "builtin";
+      readonly connector: ComposerConnectorItem;
+    }
+  | {
+      readonly kind: "custom";
+      readonly connector: ComposerCustomConnectorItem;
+    };
+
+function composerPopoverConnectorId(
+  item: ComposerPopoverConnectorItem,
+): string {
+  return item.kind === "builtin"
+    ? item.connector.connectorRef
+    : item.connector.id;
+}
+
+function matchesComposerPopoverConnectorSearch(
+  search: string,
+  item: ComposerPopoverConnectorItem,
+): boolean {
+  return item.kind === "builtin"
+    ? matchesConnectorSearch(search, item.connector)
+    : matchesCustomConnectorSearch(search, item.connector);
+}
+
 function ConnectorsPopoverButton({
   signals,
   agentId,
   agentDisplayName,
   agentConnectors,
+  agentCustomConnectors,
   connectorsLoading,
   savingConnectorSlug,
+  savingCustomConnectorId,
   computerUse,
   onOpenAddDialog,
   onToggle,
+  onToggleCustom,
 }: {
   signals: ComposerConnectorSignals;
   agentId: string | null;
   agentDisplayName: string;
   agentConnectors: ComposerConnectorItem[];
+  agentCustomConnectors: ComposerCustomConnectorItem[];
   connectorsLoading: boolean;
   savingConnectorSlug: ConnectorSlug | null;
+  savingCustomConnectorId: string | null;
   computerUse: ComposerComputerUse | undefined;
   onOpenAddDialog: () => void;
   onToggle: (
     connectorSlug: ConnectorSlug,
+    checked: boolean,
+  ) => void | Promise<void>;
+  onToggleCustom: (
+    connectorId: string,
     checked: boolean,
   ) => void | Promise<void>;
 }) {
@@ -6124,7 +6277,15 @@ function ConnectorsPopoverButton({
   const setPermissionConnectorSlug = useSet(
     signals.setPermissionConnectorSlug$,
   );
-  const showSearch = agentConnectors.length > 20;
+  const connectorItems: ComposerPopoverConnectorItem[] = [
+    ...agentConnectors.map((connector) => {
+      return { kind: "builtin" as const, connector };
+    }),
+    ...agentCustomConnectors.map((connector) => {
+      return { kind: "custom" as const, connector };
+    }),
+  ];
+  const showSearch = connectorItems.length > 20;
   const permissionConnector =
     permissionEntryEnabled && permissionConnectorSlug
       ? agentConnectors.find((c) => {
@@ -6134,9 +6295,9 @@ function ConnectorsPopoverButton({
 
   // Use snapshot order if available, otherwise preserve catalog order.
   const sorted = sortOrder
-    ? [...agentConnectors].sort((a, b) => {
-        const ai = sortOrder.indexOf(a.connectorRef);
-        const bi = sortOrder.indexOf(b.connectorRef);
+    ? [...connectorItems].sort((a, b) => {
+        const ai = sortOrder.indexOf(composerPopoverConnectorId(a));
+        const bi = sortOrder.indexOf(composerPopoverConnectorId(b));
         if (ai === -1 && bi === -1) {
           return 0;
         }
@@ -6148,21 +6309,19 @@ function ConnectorsPopoverButton({
         }
         return ai - bi;
       })
-    : agentConnectors;
+    : connectorItems;
 
   const visibleConnectors =
     showSearch && search.trim()
-      ? sorted.filter((c) => {
-          return matchesConnectorSearch(search, c);
+      ? sorted.filter((item) => {
+          return matchesComposerPopoverConnectorSearch(search, item);
         })
       : sorted;
 
   const handleOpenChange = (open: boolean) => {
     if (open) {
       // Snapshot the sort order when popover opens
-      const freshSort = agentConnectors.map((c) => {
-        return c.connectorRef;
-      });
+      const freshSort = connectorItems.map(composerPopoverConnectorId);
       setSortOrder(freshSort);
     } else {
       setSortOrder(null);
@@ -6188,6 +6347,7 @@ function ConnectorsPopoverButton({
               >
                 <ConnectorTriggerIcons
                   connectors={agentConnectors}
+                  customConnectors={agentCustomConnectors}
                   hasComputerUse={Boolean(computerUse?.selectedHostId)}
                   hasCloudBrowser={Boolean(computerUse?.cloudBrowserEnabled)}
                 />
@@ -6206,7 +6366,7 @@ function ConnectorsPopoverButton({
         align="start"
         className="flex max-h-[var(--radix-popover-content-available-height)] w-72 flex-col overflow-hidden rounded-lg p-0"
       >
-        {(agentConnectors.length > 0 || connectorsLoading) && (
+        {(connectorItems.length > 0 || connectorsLoading) && (
           <div className="flex min-h-0 flex-col py-1">
             {showSearch && (
               <div className="px-3 py-1 border-b border-border/50">
@@ -6238,33 +6398,83 @@ function ConnectorsPopoverButton({
             ) : (
               <div className="flex max-h-64 min-h-0 flex-col overflow-y-auto">
                 {visibleConnectors.map((item) => {
+                  if (item.kind === "custom") {
+                    const connector = item.connector;
+                    return (
+                      <label
+                        key={connector.id}
+                        className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
+                      >
+                        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                          <CustomConnectorIcon
+                            id={connector.id}
+                            displayName={connector.displayName}
+                            size={16}
+                          />
+                        </span>
+                        <span className="text-sm flex-1 truncate text-foreground">
+                          {connector.displayName}
+                        </span>
+                        <LoadingSwitch
+                          checked={connector.authorized}
+                          onCheckedChange={onDomEventFn(async (checked) => {
+                            await onToggleCustom(connector.id, checked);
+                          })}
+                          loading={savingCustomConnectorId === connector.id}
+                          ariaLabel={
+                            connector.authorized
+                              ? t(
+                                  ($) => {
+                                    return $.chat.connectors.remove;
+                                  },
+                                  {
+                                    connectorName: connector.displayName,
+                                  },
+                                )
+                              : t(
+                                  ($) => {
+                                    return $.chat.connectors.add;
+                                  },
+                                  {
+                                    connectorName: connector.displayName,
+                                  },
+                                )
+                          }
+                          size="sm"
+                        />
+                      </label>
+                    );
+                  }
+                  const connector = item.connector;
                   return (
                     <label
-                      key={item.connectorRef}
+                      key={connector.connectorRef}
                       className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
                     >
                       <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-                        <ConnectorIcon icon={item.icon} size={16} />
+                        <ConnectorIcon icon={connector.icon} size={16} />
                       </span>
                       <span className="text-sm flex-1 truncate text-foreground">
-                        {item.label}
+                        {connector.label}
                       </span>
                       {permissionEntryEnabled &&
                         agentId &&
-                        item.authorized &&
-                        item.permissionSummary.hasPermissions && (
+                        connector.authorized &&
+                        connector.permissionSummary.hasPermissions && (
                           <button
                             type="button"
                             onClick={(event) => {
                               event.preventDefault();
                               event.stopPropagation();
-                              setPermissionConnectorSlug(item.connectorRef);
+                              setPermissionConnectorSlug(
+                                connector.connectorRef,
+                              );
                             }}
                             aria-label={t(
                               ($) => {
                                 return $.chat.connectors.configurePermissions;
                               },
-                              { connectorName: item.label },
+                              { connectorName: connector.label },
                             )}
                             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                           >
@@ -6272,19 +6482,19 @@ function ConnectorsPopoverButton({
                           </button>
                         )}
                       <LoadingSwitch
-                        checked={item.authorized}
+                        checked={connector.authorized}
                         onCheckedChange={onDomEventFn(async (checked) => {
-                          await onToggle(item.connectorRef, checked);
+                          await onToggle(connector.connectorRef, checked);
                         })}
-                        loading={savingConnectorSlug === item.connectorRef}
+                        loading={savingConnectorSlug === connector.connectorRef}
                         ariaLabel={
-                          item.authorized
+                          connector.authorized
                             ? t(
                                 ($) => {
                                   return $.chat.connectors.remove;
                                 },
                                 {
-                                  connectorName: item.label,
+                                  connectorName: connector.label,
                                 },
                               )
                             : t(
@@ -6292,7 +6502,7 @@ function ConnectorsPopoverButton({
                                   return $.chat.connectors.add;
                                 },
                                 {
-                                  connectorName: item.label,
+                                  connectorName: connector.label,
                                 },
                               )
                         }
@@ -6306,7 +6516,7 @@ function ConnectorsPopoverButton({
           </div>
         )}
         <div className="flex shrink-0 flex-col p-1">
-          {(agentConnectors.length > 0 || connectorsLoading) && (
+          {(connectorItems.length > 0 || connectorsLoading) && (
             <div className="mx-2 mb-1 border-t border-border/50" />
           )}
           <button
@@ -7194,15 +7404,35 @@ function equalAgentConnectorAuthorizations(
   );
 }
 
+function equalAgentCustomConnectorAuthorizations(
+  left: AgentCustomConnectorAuthorizations | null,
+  right: AgentCustomConnectorAuthorizations | null,
+): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return (
+    left.agentId === right.agentId &&
+    equalArrays(left.enabledIds, right.enabledIds)
+  );
+}
+
 export function useComposerConnectorReadState(
   composerConnectors: ComposerConnectorSignals,
 ): ComposerConnectorReadState {
   return {
     catalogItems: useLastLoadable(allConnectorCatalogItems$),
+    customConnectors: useLastLoadable(customConnectors$),
     agentId: useLoadable(composerConnectors.agentId$),
     authorizations: useLastLoadable(composerConnectors.authorizations$, {
       equalityFn: equalAgentConnectorAuthorizations,
     }),
+    customAuthorizations: useLastLoadable(
+      composerConnectors.customAuthorizations$,
+      {
+        equalityFn: equalAgentCustomConnectorAuthorizations,
+      },
+    ),
   };
 }
 
@@ -7220,6 +7450,109 @@ function matchingAuthorizedConnectorSlugs(
     return null;
   }
   return authorizations.data.enabledConnectorSlugs;
+}
+
+function matchingAuthorizedCustomConnectorIds(
+  agentId: Loadable<string | null>,
+  authorizations: Loadable<AgentCustomConnectorAuthorizations | null>,
+): readonly string[] | null {
+  if (agentId.state !== "hasData" || authorizations.state !== "hasData") {
+    return null;
+  }
+  if (agentId.data === null) {
+    return authorizations.data === null ? [] : null;
+  }
+  if (authorizations.data?.agentId !== agentId.data) {
+    return null;
+  }
+  return authorizations.data.enabledIds;
+}
+
+interface ResolvedComposerConnectorCollections {
+  readonly authorizedSet: ReadonlySet<ConnectorSlug>;
+  readonly connectorMap: ReadonlyMap<
+    ConnectorSlug,
+    PublicConnectorCatalogStatusItem
+  >;
+  readonly unconnectedConnectors: PublicConnectorCatalogStatusItem[];
+  readonly unconnectedCustomConnectors: CustomConnectorResponse[];
+  readonly agentConnectors: ComposerConnectorItem[];
+  readonly agentCustomConnectors: ComposerCustomConnectorItem[];
+  readonly selectedCustomConnector: CustomConnectorResponse | undefined;
+}
+
+function resolveComposerConnectorCollections({
+  catalogItems,
+  customConnectors,
+  authorizedConnectorSlugs,
+  authorizedCustomConnectorIds,
+  optimisticConnected,
+  selectedCustomConnectorId,
+}: {
+  catalogItems: Loadable<readonly PublicConnectorCatalogStatusItem[]>;
+  customConnectors: Loadable<readonly CustomConnectorResponse[]>;
+  authorizedConnectorSlugs: readonly ConnectorSlug[] | null;
+  authorizedCustomConnectorIds: readonly string[] | null;
+  optimisticConnected: ReadonlySet<ConnectorSlug>;
+  selectedCustomConnectorId: string | null;
+}): ResolvedComposerConnectorCollections {
+  const resolvedCatalogItems =
+    catalogItems.state === "hasData" ? catalogItems.data : [];
+  const resolvedCustomConnectors =
+    customConnectors.state === "hasData" ? customConnectors.data : [];
+  const authorizedSet = new Set(authorizedConnectorSlugs ?? []);
+  const authorizedCustomSet = new Set(authorizedCustomConnectorIds ?? []);
+  const connectorMap = new Map(
+    resolvedCatalogItems.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  const unconnectedConnectors = resolvedCatalogItems.filter((connector) => {
+    return (
+      !connector.connected && !optimisticConnected.has(connector.connectorRef)
+    );
+  });
+  const unconnectedCustomConnectors = resolvedCustomConnectors.filter(
+    (connector) => {
+      return !connector.connected;
+    },
+  );
+  const agentConnectors = resolvedCatalogItems
+    .filter((connector) => {
+      return (
+        connector.connected || optimisticConnected.has(connector.connectorRef)
+      );
+    })
+    .map((connector) => {
+      return {
+        ...connector,
+        authorized: authorizedSet.has(connector.connectorRef),
+      };
+    });
+  const agentCustomConnectors = resolvedCustomConnectors
+    .filter((connector) => {
+      return connector.connected;
+    })
+    .map((connector) => {
+      return {
+        ...connector,
+        authorized: authorizedCustomSet.has(connector.id),
+      };
+    });
+  const selectedCustomConnector = selectedCustomConnectorId
+    ? resolvedCustomConnectors.find((connector) => {
+        return connector.id === selectedCustomConnectorId;
+      })
+    : undefined;
+  return {
+    authorizedSet,
+    connectorMap,
+    unconnectedConnectors,
+    unconnectedCustomConnectors,
+    agentConnectors,
+    agentCustomConnectors,
+    selectedCustomConnector,
+  };
 }
 
 // The thread route invokes this hook from its ccstate-connected composer so
@@ -7425,8 +7758,10 @@ export function useZeroChatComposer(
 
   // Connectors: connected (org-level) + authorized (agent-level) → available
   const connectorCatalogItemsLoadable = connectorReadState.catalogItems;
+  const customConnectorsLoadable = connectorReadState.customConnectors;
   const agentIdLoadable = connectorReadState.agentId;
   const authorizationsLoadable = connectorReadState.authorizations;
+  const customAuthorizationsLoadable = connectorReadState.customAuthorizations;
   const pageSignal = useGet(pageSignal$);
   const selectedConnectorSlug = useGet(
     composerConnectors.selectedConnectorSlug$,
@@ -7438,6 +7773,12 @@ export function useZeroChatComposer(
   const setSelectedConnectorSlug = useSet(
     composerConnectors.setSelectedConnectorSlug$,
   );
+  const selectedCustomConnectorId = useGet(
+    composerConnectors.selectedCustomConnectorId$,
+  );
+  const setSelectedCustomConnectorId = useSet(
+    composerConnectors.setSelectedCustomConnectorId$,
+  );
   const pollingAuthCodeSlug = useGet(pollingOAuthAuthCodeConnectorSlug$);
   const pollingDeviceAuthSlug = useGet(pollingOAuthDeviceAuthConnectorSlug$);
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
@@ -7447,11 +7788,23 @@ export function useZeroChatComposer(
   const connectNoAuth = useSet(connectConnectorNoAuth$);
   const authorizeFn = useSet(composerConnectors.authorizeConnector$);
   const deauthorizeFn = useSet(composerConnectors.deauthorizeConnector$);
+  const authorizeCustomFn = useSet(
+    composerConnectors.authorizeCustomConnector$,
+  );
+  const deauthorizeCustomFn = useSet(
+    composerConnectors.deauthorizeCustomConnector$,
+  );
   const optimisticConnected = useGet(justConnectedSlugs$);
 
   const savingConnectorSlug = useGet(composerConnectors.savingConnectorSlug$);
   const setSavingConnectorSlug = useSet(
     composerConnectors.setSavingConnectorSlug$,
+  );
+  const savingCustomConnectorId = useGet(
+    composerConnectors.savingCustomConnectorId$,
+  );
+  const setSavingCustomConnectorId = useSet(
+    composerConnectors.setSavingCustomConnectorId$,
   );
   const agentRecordId = loadableDataOrNull(agentIdLoadable);
 
@@ -7459,40 +7812,33 @@ export function useZeroChatComposer(
     agentIdLoadable,
     authorizationsLoadable,
   );
+  const authorizedCustomConnectors = matchingAuthorizedCustomConnectorIds(
+    agentIdLoadable,
+    customAuthorizationsLoadable,
+  );
 
   const connectorsLoading =
     connectorCatalogItemsLoadable.state !== "hasData" ||
-    authorizedConnectors === null;
+    customConnectorsLoadable.state !== "hasData" ||
+    authorizedConnectors === null ||
+    authorizedCustomConnectors === null;
 
-  const connectorCatalogItems =
-    connectorCatalogItemsLoadable.state === "hasData"
-      ? connectorCatalogItemsLoadable.data
-      : [];
-  const connectorMap = new Map(
-    connectorCatalogItems.map((connector) => {
-      return [connector.connectorRef, connector];
-    }),
-  );
-  const authorizedSet = new Set(authorizedConnectors ?? []);
-
-  const unconnectedConnectors = connectorCatalogItems.filter((connector) => {
-    return (
-      !connector.connected && !optimisticConnected.has(connector.connectorRef)
-    );
+  const {
+    authorizedSet,
+    connectorMap,
+    unconnectedConnectors,
+    unconnectedCustomConnectors,
+    agentConnectors,
+    agentCustomConnectors,
+    selectedCustomConnector,
+  } = resolveComposerConnectorCollections({
+    catalogItems: connectorCatalogItemsLoadable,
+    customConnectors: customConnectorsLoadable,
+    authorizedConnectorSlugs: authorizedConnectors,
+    authorizedCustomConnectorIds: authorizedCustomConnectors,
+    optimisticConnected,
+    selectedCustomConnectorId,
   });
-
-  // Show all org-connected services so user can toggle authorization on/off per agent.
-  const connectedCatalogItems = connectorCatalogItems.filter((connector) => {
-    return (
-      connector.connected || optimisticConnected.has(connector.connectorRef)
-    );
-  });
-  const agentConnectors: ComposerConnectorItem[] = connectedCatalogItems.map(
-    (connector) => {
-      const authorized = authorizedSet.has(connector.connectorRef);
-      return { ...connector, authorized };
-    },
-  );
 
   const handleConnectSuccess = async (connectorSlug: ConnectorSlug) => {
     const label = connectorMap.get(connectorSlug)?.label ?? connectorSlug;
@@ -7614,6 +7960,16 @@ export function useZeroChatComposer(
         : deauthorizeFn(connectorSlug, pageSignal),
     );
     setSavingConnectorSlug(null);
+  };
+
+  const handleCustomToggle = async (connectorId: string, checked: boolean) => {
+    setSavingCustomConnectorId(connectorId);
+    await bestEffort(
+      checked
+        ? authorizeCustomFn(connectorId, pageSignal)
+        : deauthorizeCustomFn(connectorId, pageSignal),
+    );
+    setSavingCustomConnectorId(null);
   };
 
   const handleSend = () => {
@@ -7829,13 +8185,16 @@ export function useZeroChatComposer(
                     agentId={agentRecordId}
                     agentDisplayName={displayName}
                     agentConnectors={agentConnectors}
+                    agentCustomConnectors={agentCustomConnectors}
                     connectorsLoading={connectorsLoading}
                     savingConnectorSlug={savingConnectorSlug}
+                    savingCustomConnectorId={savingCustomConnectorId}
                     computerUse={computerUse}
                     onOpenAddDialog={() => {
                       return setShowAddDialog(true);
                     }}
                     onToggle={handleToggle}
+                    onToggleCustom={handleCustomToggle}
                   />
                 </div>
                 <div className="flex items-center gap-1 sm:gap-2">
@@ -7891,12 +8250,25 @@ export function useZeroChatComposer(
           }}
         />
       )}
+      {selectedCustomConnector && (
+        <CustomConnectorConnectDialog
+          connector={selectedCustomConnector}
+          onClose={() => {
+            setSelectedCustomConnectorId(null);
+          }}
+        />
+      )}
       {showAddDialog && (
         <AddConnectorsDialog
           signals={composerConnectors}
           unconnected={unconnectedConnectors}
+          unconnectedCustom={unconnectedCustomConnectors}
           busyConnectorSlug={busyConnectorSlug}
           connectHandlers={connectorConnectHandlers}
+          onConnectCustom={(connector) => {
+            setShowAddDialog(false);
+            setSelectedCustomConnectorId(connector.id);
+          }}
           onClose={() => {
             setPendingConnectorSlug(null);
             return setShowAddDialog(false);


### PR DESCRIPTION
## Summary

- show connected custom connectors in the chat composer connector menu, including their icons and per-agent access toggles
- include unconnected custom connectors in the Add connectors dialog and open the existing custom connector connection flow
- keep custom connector authorization state scoped to the active agent and refresh composer state after access changes

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx` (5 tests passed)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/app`

Local browser verification was not run, following the repository preference for PR submissions.