### PR TITLE
fix(api): stop seeding input content in the chat thread bench

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -608,7 +608,7 @@ async function seedTargetThreadRuns(
     chatThreadId: string;
     runId: string;
     eventType: "input.prompt" | "output.message";
-    content: string;
+    content?: string;
     sequenceNumber: number;
     seqId: number;
     attachFiles?: string[];
@@ -643,12 +643,13 @@ async function seedTargetThreadRuns(
         chatThreadId: fixture.threadId,
         runId,
         eventType: m === 0 ? "input.prompt" : "output.message",
-        content,
         sequenceNumber: m,
         seqId: i * TARGET_MESSAGES_PER_RUN + m + 1,
+        // Input events carry their text in user_message only; chat_events
+        // rejects a non-null content projection for them.
         ...(m === 0
           ? { userMessage: benchUserMessage(content, attachmentId) }
-          : {}),
+          : { content }),
         ...(attachmentId ? { attachFiles: [attachmentId] } : {}),
         createdAt: new Date(now + i * 1000 + m),
       });


### PR DESCRIPTION
## Problem

`bench-api` has been red on every `main` run since `6fd0683` (#23829, "retire legacy user message storage"). Both run [30501379238](https://github.com/vm0-ai/vm0/actions/runs/30501379238) and run [30506217540](https://github.com/vm0-ai/vm0/actions/runs/30506217540) fail while seeding the bench fixture:

```
ERROR: new row for relation "chat_events" violates check constraint
       "chat_events_input_content_check"
```

The suite never loads, so `Bench API` and `Print bench summary` both fail and no benchmark numbers are published for `main`.

## Root cause

Migration `0730_switch-canonical-user-message-constraints.sql` requires `content IS NULL` when `event_type` is `input.prompt` or `input.rejected`. The bench fixture in `zero-chat-threads.bench.ts` wrote `content` for every seeded row, including the `input.prompt` row of each run, and only passed because the compatibility trigger `bridge_chat_user_message_0727` (migration `0729`) set `NEW."content" := NULL` for input events on insert. Migration `0739_retire_legacy_user_message_storage.sql` dropped that trigger, which exposed the fixture to the constraint directly.

## Change

Seed the `input.prompt` row with `userMessage` only and keep the markdown payload on `output.message` rows. The rows persisted are identical to what the trigger used to write, so the benchmark workload, payload weight, and attachment coverage are unchanged.

## Verification

Bench correctness is validated by the PR pipeline's `bench-api` job, which reproduces the exact failing insert on a migrated database.
