### PR TITLE
fix(platform): prevent clerk satellite login redirect loop

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -63,6 +63,11 @@ let internalMockedInvitations: MockedInvitation[] = [];
 let internalMockedMemberships: MockedMembership[] = [{ id: "org_default" }];
 let internalMockedClientSessions: MockedClientSession[] = [];
 let internalMockedClerkLoadOptions: MockedClerkLoadOptions = {};
+let internalMockedClerkLoaded = true;
+
+export function mockClerkLoaded(loaded: boolean): void {
+  internalMockedClerkLoaded = loaded;
+}
 
 export function mockUser(
   user: {
@@ -154,6 +159,7 @@ export function clearMockedAuth() {
   internalMockedMemberships = [{ id: "org_default" }];
   internalMockedClientSessions = [];
   internalMockedClerkLoadOptions = {};
+  internalMockedClerkLoaded = true;
   clerkListeners.length = 0;
   mockedClerk.on = defaultClerkStatusOn;
   mockedClerk.signOut.mockReset();
@@ -222,6 +228,10 @@ interface MockedSignInRedirectOptions {
 const defaultBuildSignInUrlImpl = (
   options?: MockedSignInRedirectOptions,
 ): string => {
+  if (!internalMockedClerkLoaded) {
+    return "";
+  }
+
   const signInUrl = new URL(
     internalMockedClerkLoadOptions.signInUrl ?? "/sign-in",
     window.location.origin,
@@ -284,6 +294,9 @@ interface MockedUserProfileOptions {
 
 export const mockedClerk = {
   initialize,
+  get loaded() {
+    return internalMockedClerkLoaded;
+  },
   get user() {
     return internalMockedUser;
   },

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,8 +1,12 @@
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { detachedSetupPage } from "../../__tests__/page-helper.ts";
-import { mockedClerk, mockedClerkLoad } from "../../__tests__/mock-auth.ts";
+import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
+import {
+  mockClerkLoaded,
+  mockedClerk,
+  mockedClerkLoad,
+} from "../../__tests__/mock-auth.ts";
 import {
   deriveServiceOrigin,
   getAllowedAuthRedirectOrigins,
@@ -150,6 +154,22 @@ describe("platform auth URLs", () => {
 });
 
 describe("platform auth redirects", () => {
+  it("does not override Clerk satellite auto-sync navigation", async () => {
+    const url = "https://app.okou.ai/agents?utm_source=okou-launch";
+    setBrowserUrl(url);
+    mockClerkLoaded(false);
+
+    await setupPage({
+      context,
+      path: "/agents",
+      session: null,
+      user: null,
+      withoutRender: true,
+    });
+
+    expect(window.location.href).toBe(url);
+  });
+
   it("redirects unauthenticated users to app auth on the current origin", async () => {
     setBrowserUrl("https://pr-18532-app.omby.ai/agents");
 

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -295,10 +295,13 @@ export const setupAuthPageWrapper = (
     const clerk = await get(clerk$);
     signal.throwIfAborted();
 
+    if (!clerk.loaded) {
+      return;
+    }
+
     if (!clerk.user) {
       const signInUrl = new URL(
         clerk.buildSignInUrl({ redirectUrl: location.href }),
-        location.origin,
       );
       L.info("redirect unauthenticated user to app sign-in", {
         currentUrl: location.href,


### PR DESCRIPTION
## Summary

- let Clerk finish its satellite auto-sync navigation before evaluating the authenticated user
- stop resolving an unavailable Clerk sign-in URL against the current origin, which previously turned it into the app root
- model Clerk's loading state in the test boundary and cover the `app.okou.ai` regression

## User impact

First-time visits to `app.okou.ai` can complete Clerk's cross-domain session sync instead of repeatedly reloading the app root. Seamless SSO from the primary VM0 domain remains enabled.

## Root cause

With `satelliteAutoSync: true`, Clerk can return from `load()` while its `/v1/client/sync` top-level navigation is pending and `clerk.loaded` is still false. The unauthenticated route guard then called `buildSignInUrl()`, received an empty string, and resolved it against `location.origin`. That second navigation returned the browser to `https://app.okou.ai/` and canceled Clerk's sync request.

## Verification

- `NODE_OPTIONS=--max-old-space-size=4096 pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm knip`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vm0/app run check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types`
- `pnpm --dir apps/platform exec vitest run src/signals/__tests__/auth-url.test.ts` (13 tests passed)
