### PR TITLE
feat(cli): show custom connectors in list and search

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -1,0 +1,53 @@
+import { http, HttpResponse } from "msw";
+import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+
+export function customConnector(
+  overrides: Partial<CustomConnectorResponse> = {},
+): CustomConnectorResponse {
+  return {
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "_acme-search",
+    displayName: "Acme Search",
+    prefixes: ["https://api.acme.test/v1/"],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{apiKey}}",
+    prefixTemplates: ["https://api.acme.test/v1/"],
+    fields: [
+      {
+        key: "apiKey",
+        label: "API key",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [],
+    queryInjections: [],
+    authMode: "manual",
+    revision: 1,
+    connected: false,
+    missingRequiredFields: ["apiKey"],
+    configuredFieldKeys: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    hasSecret: false,
+    ...overrides,
+  };
+}
+
+export function stubCustomConnectors(
+  connectors: readonly CustomConnectorResponse[],
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/custom-connectors`, () => {
+    return HttpResponse.json({ connectors });
+  });
+}
+
+export function stubAgentCustomConnectors(
+  enabledIds: readonly string[],
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/agents/:id/custom-connectors`, () => {
+    return HttpResponse.json({ enabledIds });
+  });
+}

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -17,6 +17,11 @@ import {
   catalogStatusItem,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubAgentCustomConnectors,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
@@ -121,6 +126,7 @@ describe("zero connector list command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-token");
+    server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
   afterEach(() => {
@@ -168,6 +174,37 @@ describe("zero connector list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("@octocat (reconnect needed)");
+    });
+
+    it("renders custom connectors with their connection status", async () => {
+      server.use(
+        stubAvailableConnectors(["github"]),
+        stubCustomConnectors([
+          customConnector({
+            connected: true,
+            missingRequiredFields: [],
+            configuredFieldKeys: ["secret:apiKey"],
+            hasSecret: true,
+          }),
+          customConnector({
+            id: "44444444-4444-4444-8444-444444444444",
+            slug: "_weather-api",
+            displayName: "Weather API",
+          }),
+        ]),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const connectedRow = lines.find((line) => {
+        return line.startsWith("_acme-search");
+      });
+      const missingRow = lines.find((line) => {
+        return line.startsWith("_weather-api");
+      });
+      expect(connectedRow).toContain("connected");
+      expect(missingRow).toContain("missing apiKey");
     });
   });
 
@@ -250,6 +287,26 @@ describe("zero connector list command", () => {
       expect(logCalls).toContain("AUTHORIZED FOR maya");
       expect(logCalls).not.toContain("✓");
       expect(logCalls).toContain("-");
+    });
+
+    it("renders custom connector authorization for the agent", async () => {
+      const connector = customConnector();
+      server.use(
+        stubAvailableConnectors(["github"]),
+        stubCustomConnectors([connector]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+        stubAgentCustomConnectors([connector.id]),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const customRow = (mockConsoleLog.mock.calls.flat() as string[]).find(
+        (line) => {
+          return line.startsWith(connector.slug);
+        },
+      );
+      expect(customRow).toMatch(/✓$/u);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -17,6 +17,11 @@ import {
   catalogStatusItem,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubAgentCustomConnectors,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
@@ -144,6 +149,7 @@ describe("zero connector search command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-token");
+    server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
   afterEach(() => {
@@ -247,6 +253,36 @@ describe("zero connector search command", () => {
       expect(output).toContain("No matches found.");
       const dataRows = findDataRows(lines);
       expect(dataRows).toHaveLength(0);
+    });
+
+    it("finds a custom connector by display name", async () => {
+      const connector = customConnector({
+        connected: true,
+        missingRequiredFields: [],
+        configuredFieldKeys: ["secret:apiKey"],
+        hasSecret: true,
+      });
+      server.use(stubCustomConnectors([connector]));
+
+      await searchCommand.parseAsync(["node", "cli", "Acme Search"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      const customRow = findDataRows(lines).find((line) => {
+        return line.startsWith(connector.slug);
+      });
+      expect(customRow).toContain("connected");
+    });
+
+    it("finds org connectors with the custom keyword", async () => {
+      const connector = customConnector();
+      server.use(stubCustomConnectors([connector]));
+
+      await searchCommand.parseAsync(["node", "cli", "custom"]);
+
+      const lines = mockConsoleLog.mock.calls.flat() as string[];
+      expect(findDataRows(lines)).toContainEqual(
+        expect.stringMatching(new RegExp(`^${connector.slug}\\s`, "u")),
+      );
     });
 
     it("caps at --limit and prefixes with Too many results", async () => {
@@ -367,6 +403,31 @@ describe("zero connector search command", () => {
       const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
       expect(output).toContain("AUTHORIZED FOR from-flag");
       expect(output).not.toContain(ALT_AGENT_UUID);
+    });
+
+    it("renders custom connector authorization for the agent", async () => {
+      const connector = customConnector();
+      server.use(
+        stubCustomConnectors([connector]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+        stubAgentCustomConnectors([connector.id]),
+      );
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        connector.slug,
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const customRow = findDataRows(
+        mockConsoleLog.mock.calls.flat() as string[],
+      ).find((line) => {
+        return line.startsWith(connector.slug);
+      });
+      expect(customRow).toMatch(/✓$/u);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
@@ -1,9 +1,17 @@
-import { getZeroAgent, getZeroAgentUserConnectors } from "../../../lib/api";
+import {
+  getZeroAgent,
+  getZeroAgentCustomConnectors,
+  getZeroAgentUserConnectors,
+} from "../../../lib/api";
 
 interface AgentContext {
   agentId: string;
   displayName: string;
   authorizedConnectorSlugs: Set<string>;
+}
+
+export interface ConnectorDiscoveryAgentContext extends AgentContext {
+  authorizedCustomConnectorIds: Set<string>;
 }
 
 export async function resolveAgentContext(
@@ -21,5 +29,26 @@ export async function resolveAgentContext(
     agentId: agent.agentId,
     displayName: agent.displayName ?? agent.agentId,
     authorizedConnectorSlugs: new Set(enabledConnectorSlugs),
+  };
+}
+
+export async function resolveConnectorDiscoveryAgentContext(
+  flagAgentId: string | undefined,
+): Promise<ConnectorDiscoveryAgentContext | null> {
+  const agentId = flagAgentId ?? process.env.ZERO_AGENT_ID;
+  if (!agentId) return null;
+
+  const [agent, enabledConnectorSlugs, enabledCustomConnectorIds] =
+    await Promise.all([
+      getZeroAgent(agentId),
+      getZeroAgentUserConnectors(agentId),
+      getZeroAgentCustomConnectors(agentId),
+    ]);
+
+  return {
+    agentId: agent.agentId,
+    displayName: agent.displayName ?? agent.agentId,
+    authorizedConnectorSlugs: new Set(enabledConnectorSlugs),
+    authorizedCustomConnectorIds: new Set(enabledCustomConnectorIds),
   };
 }

--- a/turbo/apps/cli/src/commands/zero/connector/discovery.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/discovery.ts
@@ -1,0 +1,96 @@
+import chalk from "chalk";
+import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ConnectorDiscoveryAgentContext } from "./agent-context";
+import { renderConnectedAsCell } from "./connected-as";
+
+interface CatalogConnectorDiscoveryItem {
+  readonly kind: "catalog";
+  readonly connectorRef: string;
+  readonly label: string;
+  readonly description: string;
+  readonly category: string;
+  readonly tags: readonly string[];
+  readonly generation: readonly string[];
+  readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
+  readonly catalogConnector: PublicConnectorCatalogStatusItem;
+}
+
+interface CustomConnectorDiscoveryItem {
+  readonly kind: "custom";
+  readonly connectorRef: string;
+  readonly label: string;
+  readonly description: string;
+  readonly category: string;
+  readonly tags: readonly string[];
+  readonly generation: readonly string[];
+  readonly authMethods: readonly [];
+  readonly customConnector: CustomConnectorResponse;
+}
+
+type ConnectorDiscoveryItem =
+  | CatalogConnectorDiscoveryItem
+  | CustomConnectorDiscoveryItem;
+
+export function connectorDiscoveryItems(
+  catalogConnectors: readonly PublicConnectorCatalogStatusItem[],
+  customConnectors: readonly CustomConnectorResponse[],
+): readonly ConnectorDiscoveryItem[] {
+  return [
+    ...catalogConnectors.map((connector): CatalogConnectorDiscoveryItem => {
+      return {
+        kind: "catalog",
+        connectorRef: connector.connectorRef,
+        label: connector.label,
+        description: connector.description,
+        category: connector.category,
+        tags: connector.tags,
+        generation: connector.generation,
+        authMethods: connector.authMethods,
+        catalogConnector: connector,
+      };
+    }),
+    ...customConnectors.map((connector): CustomConnectorDiscoveryItem => {
+      return {
+        kind: "custom",
+        connectorRef: connector.slug,
+        label: connector.displayName,
+        description: "",
+        category: "custom",
+        tags: [],
+        generation: [],
+        authMethods: [],
+        customConnector: connector,
+      };
+    }),
+  ];
+}
+
+export function renderConnectorDiscoveryConnectedAsCell(
+  connector: ConnectorDiscoveryItem,
+): string {
+  if (connector.kind === "catalog") {
+    return renderConnectedAsCell(connector.catalogConnector);
+  }
+  if (connector.customConnector.connected) {
+    return chalk.green("connected");
+  }
+  if (connector.customConnector.missingRequiredFields.length === 0) {
+    return chalk.dim("(not connected)");
+  }
+  return chalk.yellow(
+    `missing ${connector.customConnector.missingRequiredFields.join(", ")}`,
+  );
+}
+
+export function isConnectorDiscoveryAuthorized(
+  connector: ConnectorDiscoveryItem,
+  agentContext: ConnectorDiscoveryAgentContext,
+): boolean {
+  if (connector.kind === "catalog") {
+    return agentContext.authorizedConnectorSlugs.has(connector.connectorRef);
+  }
+  return agentContext.authorizedCustomConnectorIds.has(
+    connector.customConnector.id,
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -1,9 +1,17 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listZeroConnectorCatalogStatus } from "../../../lib/api";
+import {
+  listZeroConnectorCatalogStatus,
+  listZeroCustomConnectors,
+} from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import { resolveAgentContext } from "./agent-context";
-import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
+import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
+import { padEndAnsi, stripAnsi } from "./connected-as";
+import {
+  connectorDiscoveryItems,
+  isConnectorDiscoveryAuthorized,
+  renderConnectorDiscoveryConnectedAsCell,
+} from "./discovery";
 
 export const listCommand = new Command()
   .name("list")
@@ -12,12 +20,17 @@ export const listCommand = new Command()
   .option("--agent <id>", "Show per-agent authorization column")
   .action(
     withErrorHandler(async (options: { agent?: string }) => {
-      const [{ connectors }, agentCtx] = await Promise.all([
+      const [{ connectors }, customConnectors, agentCtx] = await Promise.all([
         listZeroConnectorCatalogStatus(),
-        resolveAgentContext(options.agent),
+        listZeroCustomConnectors(),
+        resolveConnectorDiscoveryAgentContext(options.agent),
       ]);
+      const discoveredConnectors = connectorDiscoveryItems(
+        connectors,
+        customConnectors,
+      );
 
-      const connectorSlugs = connectors.map((connector) => {
+      const connectorSlugs = discoveredConnectors.map((connector) => {
         return connector.connectorRef;
       });
 
@@ -29,8 +42,8 @@ export const listCommand = new Command()
       );
 
       const connectedAsHeader = "CONNECTED AS";
-      const connectedCells = connectors.map((connector) => {
-        return renderConnectedAsCell(connector);
+      const connectedCells = discoveredConnectors.map((connector) => {
+        return renderConnectorDiscoveryConnectedAsCell(connector);
       });
       const connectedAsWidth = Math.max(
         connectedAsHeader.length,
@@ -53,12 +66,13 @@ export const listCommand = new Command()
 
       // Print rows
       for (let i = 0; i < connectorSlugs.length; i++) {
+        const connector = discoveredConnectors[i]!;
         const connectorSlug = connectorSlugs[i]!;
         const connectedCell = padEndAnsi(connectedCells[i]!, connectedAsWidth);
         const parts = [connectorSlug.padEnd(connectorSlugWidth), connectedCell];
         if (agentCtx) {
           parts.push(
-            agentCtx.authorizedConnectorSlugs.has(connectorSlug)
+            isConnectorDiscoveryAuthorized(connector, agentCtx)
               ? chalk.green("✓")
               : chalk.dim("-"),
           );

--- a/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
@@ -1,19 +1,32 @@
 import type {
   PublicConnectorCatalogAuthMethodDetail,
-  PublicConnectorCatalogItem,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 
 export type PublicConnectorStatus = PublicConnectorCatalogStatusItem;
 
-interface PublicConnectorSearchResult {
-  readonly connector: PublicConnectorStatus;
+interface ConnectorSearchItem {
+  readonly connectorRef: string;
+  readonly label: string;
+  readonly description: string;
+  readonly category: string;
+  readonly tags: readonly string[];
+  readonly generation: readonly string[];
+  readonly authMethods: readonly {
+    readonly id: string;
+    readonly label: string;
+    readonly description: string | null;
+  }[];
+}
+
+interface ConnectorSearchResult<T extends ConnectorSearchItem> {
+  readonly connector: T;
   readonly score: number;
   readonly matchedField: string;
 }
 
-interface PublicConnectorSearchOutput {
-  readonly results: readonly PublicConnectorSearchResult[];
+interface ConnectorSearchOutput<T extends ConnectorSearchItem> {
+  readonly results: readonly ConnectorSearchResult<T>[];
   readonly total: number;
 }
 
@@ -33,7 +46,7 @@ function tokenize(input: string): Set<string> {
   return tokens;
 }
 
-function publicStrings(connector: PublicConnectorCatalogItem): string[] {
+function publicStrings(connector: ConnectorSearchItem): string[] {
   return [
     connector.connectorRef,
     connector.label,
@@ -64,7 +77,7 @@ function best(candidates: readonly (ScoreHit | null)[]): ScoreHit | null {
 function scoreExact(
   keywordLower: string,
   skipPrivateIdentifierMatches: boolean,
-  connector: PublicConnectorStatus,
+  connector: ConnectorSearchItem,
 ): ScoreHit | null {
   if (connector.connectorRef.toLowerCase() === keywordLower) {
     return { score: 100, matchedField: "connectorRef" };
@@ -100,7 +113,7 @@ function scoreExact(
 function scoreSubstring(
   keywordLower: string,
   skipPrivateIdentifierMatches: boolean,
-  connector: PublicConnectorStatus,
+  connector: ConnectorSearchItem,
 ): ScoreHit | null {
   const candidates: ScoreHit[] = [];
   if (connector.connectorRef.toLowerCase().includes(keywordLower)) {
@@ -146,7 +159,7 @@ function scoreSubstring(
 
 function scoreTokens(
   keywordTokens: ReadonlySet<string>,
-  connector: PublicConnectorStatus,
+  connector: ConnectorSearchItem,
 ): ScoreHit | null {
   const candidateTokens = new Set<string>();
   for (const source of publicStrings(connector)) {
@@ -171,7 +184,7 @@ function scoreConnector(
   keywordLower: string,
   keyword: string,
   keywordTokens: ReadonlySet<string>,
-  connector: PublicConnectorStatus,
+  connector: ConnectorSearchItem,
 ): ScoreHit | null {
   const skipPrivateIdentifierMatches =
     /^[A-Za-z0-9_]+$/.test(keyword) && keyword.includes("_");
@@ -187,34 +200,27 @@ function scoreConnector(
   return hit;
 }
 
-export function searchPublicConnectorCatalog(
-  connectors: readonly PublicConnectorStatus[],
+export function searchConnectorCatalog<T extends ConnectorSearchItem>(
+  connectors: readonly T[],
   keyword: string,
   limit: number,
-): PublicConnectorSearchOutput {
+): ConnectorSearchOutput<T> {
   const trimmed = keyword.trim();
   if (!trimmed) return { results: [], total: 0 };
 
   const keywordLower = trimmed.toLowerCase();
   const keywordTokens = tokenize(trimmed);
-  const hits = connectors.flatMap(
-    (connector): PublicConnectorSearchResult[] => {
-      const hit = scoreConnector(
-        keywordLower,
-        trimmed,
-        keywordTokens,
+  const hits = connectors.flatMap((connector): ConnectorSearchResult<T>[] => {
+    const hit = scoreConnector(keywordLower, trimmed, keywordTokens, connector);
+    if (!hit) return [];
+    return [
+      {
         connector,
-      );
-      if (!hit) return [];
-      return [
-        {
-          connector,
-          score: hit.score,
-          matchedField: hit.matchedField,
-        },
-      ];
-    },
-  );
+        score: hit.score,
+        matchedField: hit.matchedField,
+      },
+    ];
+  });
 
   hits.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -1,10 +1,18 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listZeroConnectorCatalogStatus } from "../../../lib/api";
+import {
+  listZeroConnectorCatalogStatus,
+  listZeroCustomConnectors,
+} from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import { resolveAgentContext } from "./agent-context";
-import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
-import { searchPublicConnectorCatalog } from "./public-catalog";
+import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
+import { padEndAnsi, stripAnsi } from "./connected-as";
+import {
+  connectorDiscoveryItems,
+  isConnectorDiscoveryAuthorized,
+  renderConnectorDiscoveryConnectedAsCell,
+} from "./discovery";
+import { searchConnectorCatalog } from "./public-catalog";
 
 const DEFAULT_LIMIT = 5;
 const EXACT_MATCH_THRESHOLD = 80;
@@ -39,12 +47,13 @@ export const searchCommand = new Command()
           throw new Error("Keyword cannot be empty.");
         }
 
-        const [{ connectors }, agentCtx] = await Promise.all([
+        const [{ connectors }, customConnectors, agentCtx] = await Promise.all([
           listZeroConnectorCatalogStatus(),
-          resolveAgentContext(options.agent),
+          listZeroCustomConnectors(),
+          resolveConnectorDiscoveryAgentContext(options.agent),
         ]);
-        const { results, total } = searchPublicConnectorCatalog(
-          connectors,
+        const { results, total } = searchConnectorCatalog(
+          connectorDiscoveryItems(connectors, customConnectors),
           trimmed,
           options.limit,
         );
@@ -66,7 +75,7 @@ export const searchCommand = new Command()
         const connectedAsHeader = "CONNECTED AS";
 
         const connectedCells = results.map((r) => {
-          return renderConnectedAsCell(r.connector);
+          return renderConnectorDiscoveryConnectedAsCell(r.connector);
         });
 
         const connectorSlugWidth = Math.max(
@@ -99,9 +108,7 @@ export const searchCommand = new Command()
           ];
           if (agentCtx) {
             parts.push(
-              agentCtx.authorizedConnectorSlugs.has(
-                result.connector.connectorRef,
-              )
+              isConnectorDiscoveryAuthorized(result.connector, agentCtx)
                 ? chalk.green("✓")
                 : chalk.dim("-"),
             );


### PR DESCRIPTION
## Summary

- combine org custom connectors with public catalog entries in `zero connector list` and `zero connector search`
- render custom connection or missing-field status and resolve per-agent custom connector authorization
- preserve existing catalog search scoring while adding custom connector slug, display name, and `custom` keyword discovery

## User impact

Users can now discover org custom connectors from the primary connector commands without switching to `zero connector custom list`. Existing public connector ordering, output columns, and search ranking remain unchanged.

## Verification

- `pnpm exec prettier --write ...` with the lockfile-pinned Prettier 3.8.1
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/list.test.ts src/commands/zero/connector/__tests__/search.test.ts` (41 tests)
- `pnpm knip --workspace @vm0/cli`
