### PR TITLE
fix: remove legacy network policy connector fields

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1020,11 +1020,7 @@ impl ApiClient {
                 &self.token,
             )
             .timeout(NETWORK_POLICY_REFRESH_TIMEOUT)
-            .json(&serde_json::json!({
-                "connectorSlugs": connector_slugs,
-                // TODO(#23827): Remove after every pre-bridge API has retired.
-                "connectorRefs": connector_slugs,
-            }))
+            .json(&serde_json::json!({ "connectorSlugs": connector_slugs }))
     }
 
     pub(super) async fn resolve_builtin_firewall_catalog(
@@ -1477,7 +1473,7 @@ mod tests {
                 .body()
                 .and_then(reqwest::Body::as_bytes)
                 .expect("request should include JSON body"),
-            br#"{"connectorSlugs":["slack"],"connectorRefs":["slack"]}"#
+            br#"{"connectorSlugs":["slack"]}"#
         );
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -835,31 +835,14 @@ fn parse_network_policy_refresh_notification(
             return None;
         }
     };
-    let connector_slug =
-        match parse_network_policy_refresh_identity_field(&msg.data, "connectorSlug") {
-            Ok(value) => value,
-            Err(()) => {
-                warn!("ably: network-policy-refresh message has invalid connectorSlug");
-                return None;
-            }
-        };
-    let connector_ref = match parse_network_policy_refresh_identity_field(&msg.data, "connectorRef")
-    {
-        Ok(value) => value,
-        Err(()) => {
-            warn!("ably: network-policy-refresh message has invalid connectorRef");
+    let connector_slug = match msg.data.get("connectorSlug") {
+        Some(serde_json::Value::String(value)) if !value.is_empty() => value,
+        Some(_) => {
+            warn!("ably: network-policy-refresh message has invalid connectorSlug");
             return None;
         }
-    };
-    let connector_slug = match (connector_slug, connector_ref) {
-        (Some(connector_slug), Some(connector_ref)) if connector_slug != connector_ref => {
-            warn!("ably: network-policy-refresh connectorSlug and connectorRef do not match");
-            return None;
-        }
-        (Some(connector_slug), _) => connector_slug,
-        (None, Some(connector_ref)) => connector_ref,
-        (None, None) => {
-            warn!("ably: network-policy-refresh message missing connector identity");
+        None => {
+            warn!("ably: network-policy-refresh message missing connectorSlug");
             return None;
         }
     };
@@ -868,17 +851,6 @@ fn parse_network_policy_refresh_notification(
         run_id,
         connector_slug: connector_slug.to_string(),
     })
-}
-
-fn parse_network_policy_refresh_identity_field<'a>(
-    data: &'a serde_json::Value,
-    field: &str,
-) -> Result<Option<&'a str>, ()> {
-    match data.get(field) {
-        None => Ok(None),
-        Some(serde_json::Value::String(value)) if !value.is_empty() => Ok(Some(value)),
-        Some(_) => Err(()),
-    }
 }
 
 fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotification<'_>> {
@@ -1142,77 +1114,40 @@ mod tests {
 
     fn malformed_network_policy_refresh_messages(
         unrelated_name: &'static str,
-    ) -> [(&'static str, Option<&'static str>, serde_json::Value); 10] {
+    ) -> [(&'static str, Option<&'static str>, serde_json::Value); 6] {
         [
             (
                 "invalid runId",
                 Some("network-policy-refresh"),
                 serde_json::json!({
                     "runId": "not-a-uuid",
-                    "connectorRef": "github"
+                    "connectorSlug": "github"
                 }),
             ),
             (
                 "missing runId",
                 Some("network-policy-refresh"),
-                serde_json::json!({ "connectorRef": "github" }),
+                serde_json::json!({ "connectorSlug": "github" }),
             ),
             (
-                "missing connector identity",
+                "missing connectorSlug",
                 Some("network-policy-refresh"),
                 serde_json::json!({ "runId": "00000000-0000-0000-0000-000000000003" }),
             ),
             (
-                "empty connectorRef",
+                "empty connectorSlug",
                 Some("network-policy-refresh"),
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorRef": ""
+                    "connectorSlug": ""
                 }),
             ),
             (
-                "empty connectorSlug with valid connectorRef",
+                "invalid connectorSlug",
                 Some("network-policy-refresh"),
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "",
-                    "connectorRef": "github"
-                }),
-            ),
-            (
-                "invalid connectorSlug with valid connectorRef",
-                Some("network-policy-refresh"),
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": 1,
-                    "connectorRef": "github"
-                }),
-            ),
-            (
-                "invalid connectorRef with valid connectorSlug",
-                Some("network-policy-refresh"),
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "github",
-                    "connectorRef": null
-                }),
-            ),
-            (
-                "conflicting connector identities",
-                Some("network-policy-refresh"),
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "github",
-                    "connectorRef": "slack"
-                }),
-            ),
-            (
-                "empty connectorRef with valid connectorSlug",
-                Some("network-policy-refresh"),
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "github",
-                    "connectorRef": ""
+                    "connectorSlug": 1
                 }),
             ),
             (
@@ -1220,7 +1155,7 @@ mod tests {
                 Some(unrelated_name),
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorRef": "github"
+                    "connectorSlug": "github"
                 }),
             ),
         ]
@@ -2176,24 +2111,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_network_policy_refresh_notification_accepts_compatible_identities() {
+    fn parse_network_policy_refresh_notification_accepts_cleanup_and_bridge_messages() {
         for (case, data) in [
             (
-                "canonical only",
+                "cleanup message",
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
                     "connectorSlug": "github"
                 }),
             ),
             (
-                "legacy only",
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorRef": "github"
-                }),
-            ),
-            (
-                "matching dual identities",
+                "bridge message",
                 serde_json::json!({
                     "runId": "00000000-0000-0000-0000-000000000003",
                     "connectorSlug": "github",

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -2111,13 +2111,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_network_policy_refresh_notification_accepts_bridge_message() {
+    fn parse_network_policy_refresh_notification_valid() {
         let msg = make_message(
             Some("network-policy-refresh"),
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000003",
-                "connectorSlug": "github",
-                "connectorRef": "github"
+                "connectorSlug": "github"
             }),
         );
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -2111,35 +2111,23 @@ mod tests {
     }
 
     #[test]
-    fn parse_network_policy_refresh_notification_accepts_cleanup_and_bridge_messages() {
-        for (case, data) in [
-            (
-                "cleanup message",
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "github"
-                }),
-            ),
-            (
-                "bridge message",
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000003",
-                    "connectorSlug": "github",
-                    "connectorRef": "github"
-                }),
-            ),
-        ] {
-            let msg = make_message(Some("network-policy-refresh"), data);
+    fn parse_network_policy_refresh_notification_accepts_bridge_message() {
+        let msg = make_message(
+            Some("network-policy-refresh"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000003",
+                "connectorSlug": "github",
+                "connectorRef": "github"
+            }),
+        );
 
-            let notification = parse_network_policy_refresh_notification(&msg).unwrap();
+        let notification = parse_network_policy_refresh_notification(&msg).unwrap();
 
-            assert_eq!(
-                notification.run_id.to_string(),
-                "00000000-0000-0000-0000-000000000003",
-                "{case}"
-            );
-            assert_eq!(notification.connector_slug, "github", "{case}");
-        }
+        assert_eq!(
+            notification.run_id.to_string(),
+            "00000000-0000-0000-0000-000000000003"
+        );
+        assert_eq!(notification.connector_slug, "github");
     }
 
     #[test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -2111,12 +2111,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_network_policy_refresh_notification_valid() {
+    fn parse_network_policy_refresh_notification_ignores_additional_fields() {
         let msg = make_message(
             Some("network-policy-refresh"),
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000003",
-                "connectorSlug": "github"
+                "connectorSlug": "github",
+                "additionalField": true
             }),
         );
 

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1769,33 +1769,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bridge_network_policy_refresh_response_applies_policy() {
-        let server = MockServer::start();
-        let run_id = RunId::nil();
-        let refresh_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(network_policy_refresh_response(json!({
-                    "connectorSlug": "slack",
-                    "connectorRef": "slack",
-                })));
-        });
-        let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
-
-        harness.refresh_slack().await;
-
-        refresh_mock.assert_calls(1);
-        let policy = harness.slack_policy().await;
-        assert_eq!(policy["allow"], json!(["chat:write", "files:write"]));
-        assert_eq!(policy["deny"], json!([]));
-        assert_eq!(policy["ask"], json!(["channels:read"]));
-        assert_eq!(policy["unknownPolicy"], json!("allow"));
-        harness.shutdown().await;
-    }
-
-    #[tokio::test]
     async fn malformed_canonical_network_policy_refresh_identities_fail_closed() {
         for (_, identity) in [
             ("missing identity", json!({})),

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1724,7 +1724,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successful_network_policy_refresh_emits_canonical_slug_fields() {
+    async fn successful_network_policy_refresh_ignores_additional_response_fields() {
         let server = MockServer::start();
         let run_id = RunId::nil();
         let refresh_mock = server.mock(|when, then| {
@@ -1742,6 +1742,7 @@ mod tests {
                             "unknownPolicy": "allow",
                         },
                         "nextRefreshAt": null,
+                        "additionalField": true,
                     }],
                 }));
         });

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1734,7 +1734,7 @@ mod tests {
                 .header("content-type", "application/json")
                 .json_body(json!({
                     "refreshes": [{
-                        "connectorRef": "slack",
+                        "connectorSlug": "slack",
                         "networkPolicy": {
                             "allow": ["chat:write"],
                             "deny": ["files:write"],

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1769,22 +1769,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compatible_network_policy_refresh_identities_apply_policy() {
+    async fn cleanup_and_bridge_network_policy_refresh_responses_apply_policy() {
         for (case, identity) in [
             (
-                "canonical only",
+                "cleanup response",
                 json!({
                     "connectorSlug": "slack",
                 }),
             ),
             (
-                "legacy only",
-                json!({
-                    "connectorRef": "slack",
-                }),
-            ),
-            (
-                "matching dual identities",
+                "bridge response",
                 json!({
                     "connectorSlug": "slack",
                     "connectorRef": "slack",
@@ -1819,28 +1813,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_network_policy_refresh_identities_fail_closed() {
+    async fn malformed_canonical_network_policy_refresh_identities_fail_closed() {
         for (_, identity) in [
-            (
-                "conflicting identities",
-                json!({
-                    "connectorSlug": "slack",
-                    "connectorRef": "github",
-                }),
-            ),
             ("missing identity", json!({})),
             (
-                "invalid canonical identity with valid legacy identity",
+                "invalid canonical identity",
                 json!({
                     "connectorSlug": null,
-                    "connectorRef": "slack",
                 }),
             ),
             (
-                "empty legacy identity with valid canonical identity",
+                "empty canonical identity",
                 json!({
-                    "connectorSlug": "slack",
-                    "connectorRef": "",
+                    "connectorSlug": "",
                 }),
             ),
         ] {
@@ -1876,7 +1861,7 @@ mod tests {
                 .json_body(json!({
                     "refreshes": [
                         {
-                            "connectorRef": "slack",
+                            "connectorSlug": "slack",
                             "networkPolicy": {
                                 "allow": ["chat:write", "files:write"],
                                 "deny": [],
@@ -1886,7 +1871,7 @@ mod tests {
                             "nextRefreshAt": null,
                         },
                         {
-                            "connectorRef": "slack",
+                            "connectorSlug": "slack",
                             "networkPolicy": {
                                 "allow": ["channels:read"],
                                 "deny": ["files:write"],
@@ -1920,7 +1905,7 @@ mod tests {
                 .json_body(json!({
                     "refreshes": [
                         {
-                            "connectorRef": "slack",
+                            "connectorSlug": "slack",
                             "networkPolicy": {
                                 "allow": ["chat:write", "files:write"],
                                 "deny": [],
@@ -1982,10 +1967,7 @@ mod tests {
         let first_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"))
-                .json_body(json!({
-                    "connectorSlugs": first_batch,
-                    "connectorRefs": first_batch,
-                }));
+                .json_body(json!({ "connectorSlugs": first_batch }));
             then.status(500)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -1998,10 +1980,7 @@ mod tests {
         let second_mock = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"))
-                .json_body(json!({
-                    "connectorSlugs": second_batch,
-                    "connectorRefs": second_batch,
-                }));
+                .json_body(json!({ "connectorSlugs": second_batch }));
             then.status(500)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2065,7 +2044,7 @@ mod tests {
                 .json_body(json!({
                     "refreshes": [
                         {
-                            "connectorRef": "github",
+                            "connectorSlug": "github",
                             "networkPolicy": {
                                 "allow": ["repos:read"],
                                 "deny": [],

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1769,47 +1769,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cleanup_and_bridge_network_policy_refresh_responses_apply_policy() {
-        for (case, identity) in [
-            (
-                "cleanup response",
-                json!({
-                    "connectorSlug": "slack",
-                }),
-            ),
-            (
-                "bridge response",
-                json!({
+    async fn bridge_network_policy_refresh_response_applies_policy() {
+        let server = MockServer::start();
+        let run_id = RunId::nil();
+        let refresh_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(network_policy_refresh_response(json!({
                     "connectorSlug": "slack",
                     "connectorRef": "slack",
-                }),
-            ),
-        ] {
-            let server = MockServer::start();
-            let run_id = RunId::nil();
-            let refresh_mock = server.mock(|when, then| {
-                when.method(POST)
-                    .path(format!("/api/runners/runs/{run_id}/network-policy-refresh"));
-                then.status(200)
-                    .header("content-type", "application/json")
-                    .json_body(network_policy_refresh_response(identity));
-            });
-            let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
+                })));
+        });
+        let harness = NetworkPolicyRefreshHarness::new(&server, run_id).await;
 
-            harness.refresh_slack().await;
+        harness.refresh_slack().await;
 
-            refresh_mock.assert_calls(1);
-            let policy = harness.slack_policy().await;
-            assert_eq!(
-                policy["allow"],
-                json!(["chat:write", "files:write"]),
-                "{case}"
-            );
-            assert_eq!(policy["deny"], json!([]), "{case}");
-            assert_eq!(policy["ask"], json!(["channels:read"]), "{case}");
-            assert_eq!(policy["unknownPolicy"], json!("allow"), "{case}");
-            harness.shutdown().await;
-        }
+        refresh_mock.assert_calls(1);
+        let policy = harness.slack_policy().await;
+        assert_eq!(policy["allow"], json!(["chat:write", "files:write"]));
+        assert_eq!(policy["deny"], json!([]));
+        assert_eq!(policy["ask"], json!(["channels:read"]));
+        assert_eq!(policy["unknownPolicy"], json!("allow"));
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1108,78 +1108,11 @@ pub struct NetworkPolicyRefresh {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(try_from = "NetworkPolicyRefreshResponseWire")]
+#[serde(rename_all = "camelCase")]
 pub struct NetworkPolicyRefreshResponse {
     pub connector_slug: String,
     pub network_policy: NetworkPolicy,
     pub next_refresh_at: Option<String>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct NetworkPolicyRefreshResponseWire {
-    #[serde(default)]
-    connector_slug: OptionalWireConnectorSlug,
-    // TODO(#23827): Remove after every pre-bridge runner has drained.
-    #[serde(default)]
-    connector_ref: OptionalWireConnectorSlug,
-    network_policy: NetworkPolicy,
-    next_refresh_at: Option<String>,
-}
-
-#[derive(Default)]
-enum OptionalWireConnectorSlug {
-    #[default]
-    Missing,
-    Present(String),
-}
-
-impl<'de> Deserialize<'de> for OptionalWireConnectorSlug {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        String::deserialize(deserializer).map(Self::Present)
-    }
-}
-
-impl OptionalWireConnectorSlug {
-    fn as_deref(&self) -> Option<&str> {
-        match self {
-            Self::Missing => None,
-            Self::Present(value) => Some(value),
-        }
-    }
-}
-
-impl TryFrom<NetworkPolicyRefreshResponseWire> for NetworkPolicyRefreshResponse {
-    type Error = &'static str;
-
-    fn try_from(value: NetworkPolicyRefreshResponseWire) -> Result<Self, Self::Error> {
-        let connector_slug = match (
-            value.connector_slug.as_deref(),
-            value.connector_ref.as_deref(),
-        ) {
-            (Some(""), _) | (_, Some("")) => {
-                return Err("network policy refresh connector identity must not be empty");
-            }
-            (Some(connector_slug), Some(connector_ref)) if connector_slug != connector_ref => {
-                return Err("network policy refresh connectorSlug and connectorRef must match");
-            }
-            (Some(connector_slug), _) => connector_slug,
-            (None, Some(connector_ref)) => connector_ref,
-            (None, None) => {
-                return Err("network policy refresh connector identity is required");
-            }
-        }
-        .to_string();
-
-        Ok(Self {
-            connector_slug,
-            network_policy: value.network_policy,
-            next_refresh_at: value.next_refresh_at,
-        })
-    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -337,8 +337,6 @@ export async function publishNetworkPolicyRefreshToRunnerGroup(
   await channel.publish("network-policy-refresh", {
     runId,
     connectorSlug,
-    // TODO(#23827): Remove after every pre-bridge runner has drained.
-    connectorRef: connectorSlug,
   });
   L.debug(
     `Published network policy refresh ${runId}/${connectorSlug} to runner-group:${group}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -452,7 +452,6 @@ export function createRunsApi(context: TestContext) {
           params: { runId },
           body: {
             connectorSlugs: [connectorSlug],
-            connectorRefs: [connectorSlug],
           },
         }),
         [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8476,9 +8476,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(sameUserRefresh.body.refreshes[0]).toMatchObject({
       connectorSlug: "slack",
     });
-    expect(sameUserRefresh.body.refreshes[0]).not.toHaveProperty(
-      "connectorRef",
-    );
     const canonicalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${actorRunnerKey.token}`,
       snapshotRun.runId,
@@ -8491,9 +8488,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(canonicalRefresh.body.refreshes[0]).toMatchObject({
       connectorSlug: "slack",
     });
-    expect(canonicalRefresh.body.refreshes[0]).not.toHaveProperty(
-      "connectorRef",
-    );
     const otherUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${memberRunnerKey.token}`,
       snapshotRun.runId,
@@ -8530,10 +8524,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(refreshedPolicy.networkPolicy.allow).not.toContain("chat:write");
     expect(refreshedPolicy.networkPolicy.allow).toContain("files:write");
     expect(refreshedPolicy.nextRefreshAt).toStrictEqual(expect.any(String));
-    expect(refreshedPolicy).toMatchObject({
-      connectorSlug: "slack",
-    });
-    expect(refreshedPolicy).not.toHaveProperty("connectorRef");
 
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("network policy refresh publish failed"),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8457,14 +8457,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const actorRunnerKey = await api.createCliToken(actor);
     const memberRunnerKey = await api.createCliToken(member);
-    const bridgeRunnerRefreshRequest = {
-      connectorSlugs: ["slack"],
-      connectorRefs: ["slack"],
-    };
     const sameUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${actorRunnerKey.token}`,
       snapshotRun.runId,
-      bridgeRunnerRefreshRequest,
+      { connectorSlugs: ["slack"] },
       [200],
     );
     if (sameUserRefresh.status !== 200) {
@@ -8474,18 +8470,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       "chat:write",
     );
     expect(sameUserRefresh.body.refreshes[0]).toMatchObject({
-      connectorSlug: "slack",
-    });
-    const canonicalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
-      `Bearer ${actorRunnerKey.token}`,
-      snapshotRun.runId,
-      { connectorSlugs: ["slack", "slack"] },
-      [200],
-    );
-    if (canonicalRefresh.status !== 200) {
-      throw new Error("Expected canonical network policy refresh to succeed");
-    }
-    expect(canonicalRefresh.body.refreshes[0]).toMatchObject({
       connectorSlug: "slack",
     });
     const otherUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8457,10 +8457,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const actorRunnerKey = await api.createCliToken(actor);
     const memberRunnerKey = await api.createCliToken(member);
+    const bridgeRunnerRefreshRequest = {
+      connectorSlugs: ["slack"],
+      connectorRefs: ["slack"],
+    };
     const sameUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${actorRunnerKey.token}`,
       snapshotRun.runId,
-      { connectorRefs: ["slack"] },
+      bridgeRunnerRefreshRequest,
       [200],
     );
     if (sameUserRefresh.status !== 200) {
@@ -8471,12 +8475,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     expect(sameUserRefresh.body.refreshes[0]).toMatchObject({
       connectorSlug: "slack",
-      connectorRef: "slack",
     });
+    expect(sameUserRefresh.body.refreshes[0]).not.toHaveProperty(
+      "connectorRef",
+    );
     const canonicalRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${actorRunnerKey.token}`,
       snapshotRun.runId,
-      { connectorSlugs: ["slack"] },
+      { connectorSlugs: ["slack", "slack"] },
       [200],
     );
     if (canonicalRefresh.status !== 200) {
@@ -8484,50 +8490,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     }
     expect(canonicalRefresh.body.refreshes[0]).toMatchObject({
       connectorSlug: "slack",
-      connectorRef: "slack",
     });
-    const matchingDualRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
-      `Bearer ${actorRunnerKey.token}`,
-      snapshotRun.runId,
-      {
-        connectorSlugs: ["slack", "github", "slack"],
-        connectorRefs: ["github", "slack"],
-      },
-      [200],
-    );
-    if (matchingDualRefresh.status !== 200) {
-      throw new Error(
-        "Expected matching dual network policy refresh to succeed",
-      );
-    }
-    expect(matchingDualRefresh.body.refreshes[0]).toMatchObject({
-      connectorSlug: "slack",
-      connectorRef: "slack",
-    });
-    const conflictingRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
-      `Bearer ${actorRunnerKey.token}`,
-      snapshotRun.runId,
-      {
-        connectorSlugs: ["slack"],
-        connectorRefs: ["github"],
-      },
-      [400],
-    );
-    if (conflictingRefresh.status !== 400) {
-      throw new Error(
-        "Expected conflicting network policy refresh to be rejected",
-      );
-    }
-    expect(conflictingRefresh.body.error.message).toBe(
-      "connectorSlugs: must identify the same connectors as connectorRefs",
+    expect(canonicalRefresh.body.refreshes[0]).not.toHaveProperty(
+      "connectorRef",
     );
     const otherUserRefresh = await api.requestRefreshRunnerNetworkPolicyAs(
       `Bearer ${memberRunnerKey.token}`,
       snapshotRun.runId,
-      {
-        connectorSlugs: ["slack"],
-        connectorRefs: ["slack"],
-      },
+      { connectorSlugs: ["slack"] },
       [403],
     );
     if (otherUserRefresh.status !== 403) {
@@ -8550,7 +8520,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       {
         runId: snapshotRun.runId,
         connectorSlug: "slack",
-        connectorRef: "slack",
       },
     );
     const refreshedPolicy = await api.refreshRunnerNetworkPolicy(
@@ -8563,8 +8532,8 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(refreshedPolicy.nextRefreshAt).toStrictEqual(expect.any(String));
     expect(refreshedPolicy).toMatchObject({
       connectorSlug: "slack",
-      connectorRef: "slack",
     });
+    expect(refreshedPolicy).not.toHaveProperty("connectorRef");
 
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("network policy refresh publish failed"),
@@ -8798,7 +8767,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       {
         runId: parent.runId,
         connectorSlug: "slack",
-        connectorRef: "slack",
       },
     );
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2353,8 +2353,6 @@ const networkPolicyRefreshInner$ = command(
         refreshes: refreshes.map((refresh) => {
           return {
             connectorSlug: refresh.connectorSlug,
-            // TODO(#23827): Remove after every pre-bridge runner has drained.
-            connectorRef: refresh.connectorSlug,
             networkPolicy: refresh.networkPolicy,
             nextRefreshAt: refresh.nextRefreshAt,
           };

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -896,18 +896,8 @@ describe("runner network policy refresh contract", () => {
     ).toEqual({ connectorSlugs: ["slack", "github"] });
   });
 
-  it("accepts a bridge request while discarding its legacy field", () => {
-    expect(
-      bodySchema.parse({
-        connectorSlugs: ["github", "slack", "github"],
-        connectorRefs: ["slack", "github"],
-      }),
-    ).toEqual({ connectorSlugs: ["github", "slack"] });
-  });
-
   it.each([
     ["missing canonical field", {}],
-    ["legacy-only field", { connectorRefs: ["slack"] }],
     ["empty canonical field", { connectorSlugs: [] }],
     ["invalid canonical slug", { connectorSlugs: ["invalid/slack"] }],
     [

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -888,10 +888,11 @@ describe("runner poll request contract", () => {
 describe("runner network policy refresh contract", () => {
   const bodySchema = runnersNetworkPolicyRefreshContract.refresh.body;
 
-  it("de-duplicates canonical connector slugs", () => {
+  it("normalizes canonical connector slugs and ignores additional fields", () => {
     expect(
       bodySchema.parse({
         connectorSlugs: ["slack", "github", "slack"],
+        additionalField: true,
       }),
     ).toEqual({ connectorSlugs: ["slack", "github"] });
   });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -10,6 +10,7 @@ import {
   heartbeatBodySchema,
   heldSessionStateSchema,
   jobSchema,
+  NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -887,43 +888,37 @@ describe("runner poll request contract", () => {
 describe("runner network policy refresh contract", () => {
   const bodySchema = runnersNetworkPolicyRefreshContract.refresh.body;
 
-  it.each([
-    [
-      "canonical",
-      { connectorSlugs: ["slack", "github", "slack"] },
-      ["slack", "github"],
-    ],
-    [
-      "legacy",
-      { connectorRefs: ["slack", "github", "slack"] },
-      ["slack", "github"],
-    ],
-    [
-      "matching dual",
-      {
+  it("de-duplicates canonical connector slugs", () => {
+    expect(
+      bodySchema.parse({
+        connectorSlugs: ["slack", "github", "slack"],
+      }),
+    ).toEqual({ connectorSlugs: ["slack", "github"] });
+  });
+
+  it("accepts a bridge request while discarding its legacy field", () => {
+    expect(
+      bodySchema.parse({
         connectorSlugs: ["github", "slack", "github"],
         connectorRefs: ["slack", "github"],
-      },
-      ["github", "slack"],
-    ],
-  ])(
-    "normalizes %s input to canonical connector slugs",
-    (_, body, expected) => {
-      expect(bodySchema.parse(body)).toEqual({ connectorSlugs: expected });
-    },
-  );
+      }),
+    ).toEqual({ connectorSlugs: ["github", "slack"] });
+  });
 
   it.each([
-    ["missing both fields", {}],
+    ["missing canonical field", {}],
+    ["legacy-only field", { connectorRefs: ["slack"] }],
+    ["empty canonical field", { connectorSlugs: [] }],
+    ["invalid canonical slug", { connectorSlugs: ["invalid/slack"] }],
     [
-      "different connector sets",
-      { connectorSlugs: ["slack"], connectorRefs: ["github"] },
-    ],
-    [
-      "different connector counts",
+      "oversized canonical field",
       {
-        connectorSlugs: ["slack", "github"],
-        connectorRefs: ["slack"],
+        connectorSlugs: Array.from(
+          { length: NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX + 1 },
+          () => {
+            return "slack";
+          },
+        ),
       },
     ],
   ])("rejects %s", (_, body) => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -715,66 +715,20 @@ export const runnersNetworkPolicyRefreshContract = c.router({
     pathParams: z.object({
       runId: z.uuid(),
     }),
-    body: z
-      .object({
-        connectorSlugs: z
-          .array(connectorSlugSchema)
-          .min(1)
-          .max(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX)
-          .optional(),
-        // TODO(#23827): Remove after every pre-bridge runner has drained.
-        connectorRefs: z
-          .array(connectorSlugSchema)
-          .min(1)
-          .max(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX)
-          .optional(),
-      })
-      .superRefine((body, context) => {
-        if (
-          body.connectorSlugs === undefined &&
-          body.connectorRefs === undefined
-        ) {
-          context.addIssue({
-            code: "custom",
-            path: ["connectorSlugs"],
-            message: "connectorSlugs or connectorRefs is required",
-          });
-          return;
-        }
-        if (
-          body.connectorSlugs !== undefined &&
-          body.connectorRefs !== undefined
-        ) {
-          const connectorSlugs = new Set(body.connectorSlugs);
-          const connectorRefs = new Set(body.connectorRefs);
-          if (
-            connectorSlugs.size !== connectorRefs.size ||
-            [...connectorSlugs].some((connectorSlug) => {
-              return !connectorRefs.has(connectorSlug);
-            })
-          ) {
-            context.addIssue({
-              code: "custom",
-              path: ["connectorSlugs"],
-              message: "must identify the same connectors as connectorRefs",
-            });
-          }
-        }
-      })
-      .transform((body) => {
-        return {
-          connectorSlugs: [
-            ...new Set(body.connectorSlugs ?? body.connectorRefs ?? []),
-          ],
-        };
-      }),
+    body: z.object({
+      connectorSlugs: z
+        .array(connectorSlugSchema)
+        .min(1)
+        .max(NETWORK_POLICY_REFRESH_CONNECTOR_SLUGS_MAX)
+        .transform((connectorSlugs) => {
+          return [...new Set(connectorSlugs)];
+        }),
+    }),
     responses: {
       200: z.object({
         refreshes: z.array(
           z.object({
             connectorSlug: connectorSlugSchema,
-            // TODO(#23827): Remove after every pre-bridge runner has drained.
-            connectorRef: connectorSlugSchema,
             networkPolicy: networkPolicySchema,
             nextRefreshAt: z.string().datetime({ offset: true }).nullable(),
           }),


### PR DESCRIPTION
## Summary

- make `connectorSlugs` / `connectorSlug` the only identities declared, emitted,
  and read by the runner network-policy refresh HTTP and Ably protocol
- remove the API dual-field normalization and output projections, plus the
  runner fallback DTO, disagreement checks, and alternate request emission
- remove migration-only fixtures and assertions so the current source and tests
  describe only the canonical protocol
- preserve request de-duplication, authorization, batching, scheduling, and
  fail-closed behavior

## Deployment compatibility

This is the final protocol cleanup. Producers emit only the canonical shape,
while API and runner readers remain generically tolerant of additional object
properties for additive rolling deployments. No named legacy fallback or
migration fixture remains.

Compatibility with pre-bridge peers is intentionally removed and depends on the
operational merge gate below.

## Scope exclusions

- ref-named observability aliases remain a separate tracing cleanup
- the unrelated frontend `connector:changed` payload and permission,
  credential, and persistence contracts are unchanged

## Validation

- Prettier
- API-contract tests: 497 passed
- API lifecycle integration test: 129 passed
- Rust formatting
- focused runner network-policy tests: 26 passed
- pre-commit hooks: Knip, full Turbo type checks, Rust formatting, Clippy,
  documentation, file-size validation, and commitlint

## Merge gate — do not queue or merge yet

A fresh pre-merge check must record all of the following:

- [ ] bridge API and runner releases are healthy in production
- [ ] every pre-bridge runner has stopped or fully drained
- [ ] the supported rollback floor is the bridge release or newer

Re-check current state immediately before merge.

Closes #23827

Parent context: #23772
