### PR TITLE
fix(platform): stabilize auth recovery retry test

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -903,6 +903,7 @@ describe("zero sidebar account menu", () => {
 
     let modelProviderRequests = 0;
     let forcedTokenRefreshes = 0;
+    const authRecoveryCompleted = context.mocks.deferred<void>();
     context.mocks.http.get("*/api/zero/me/model-providers", () => {
       modelProviderRequests += 1;
       if (modelProviderRequests === 1) {
@@ -918,6 +919,9 @@ describe("zero sidebar account menu", () => {
       }
       if (modelProviderRequests === 2) {
         return HttpResponse.error();
+      }
+      if (modelProviderRequests === 3) {
+        authRecoveryCompleted.resolve();
       }
       return HttpResponse.json({ modelProviders: [provider] });
     });
@@ -950,10 +954,9 @@ describe("zero sidebar account menu", () => {
       featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
     });
 
-    await waitFor(() => {
-      expect(modelProviderRequests).toBe(3);
-      expect(forcedTokenRefreshes).toBe(3);
-    });
+    await authRecoveryCompleted.promise;
+    expect(modelProviderRequests).toBe(3);
+    expect(forcedTokenRefreshes).toBe(3);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
 
     const menu = await openAccountMenu();


### PR DESCRIPTION
## Summary

- replace the account-menu auth recovery test's default `waitFor` polling window with a test-owned deferred completion boundary
- resolve that boundary from the third model-provider request, after the expected initial 401 and transient network failure
- preserve the existing request-count, forced-refresh, redirect, and rendered-menu assertions

## Failure evidence

- Trigger: [Turbo run 30507499747](https://github.com/vm0-ai/vm0/actions/runs/30507499747), `push` on `main` at `0cc4a7aaf6c9ddba993925eacc08f3021a1782ef`
- First causal job: [`test-app (3)`](https://github.com/vm0-ai/vm0/actions/runs/30507499747/job/90761068280)
- Failure: `zero-sidebar-account-menu.test.tsx` expected `modelProviderRequests` to be 3 but observed 1 after the default Testing Library polling window
- Intermittency: the same commit passed the same Turbo shard in [run 30507280913](https://github.com/vm0-ai/vm0/actions/runs/30507280913); an adjacent merge-group run [30507485434](https://github.com/vm0-ai/vm0/actions/runs/30507485434) failed with the identical assertion, then its requeued run passed without relevant app/test/auth changes

## Root cause

This is missing test synchronization, not a product retry failure. The fixture starts page bootstrap asynchronously while auth recovery deliberately yields across macrotasks between retries. Under CI load, the default approximately one-second `waitFor` deadline can expire before those retry callbacks run. The lower-level request test awaits the retry chain directly and remains green.

The deferred is resolved by the third MSW request, making the domain completion event explicit without adding sleeps, longer timeouts, retry wrappers, or weaker assertions.

## Verification

- target test passed in 5 consecutive independent runs before rebase
- full `zero-sidebar-account-menu.test.tsx`: 16/16 passed
- full `api-client-headers.test.ts`: 8/8 passed
- target test passed again after rebasing onto latest `origin/main`
- Prettier
- Knip
- full repository `check-types`
- Oxlint and ESLint
- `git diff --check`

No production behavior changes.
