### PR TITLE
test(app): gate flaky auth recovery replay assertions on the replayed request

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -19,6 +19,7 @@ import {
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { clearMockNow, mockNow } from "../../../lib/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -903,6 +904,11 @@ describe("zero sidebar account menu", () => {
 
     let modelProviderRequests = 0;
     let forcedTokenRefreshes = 0;
+    // Gate on the replayed request itself instead of polling the counters:
+    // `detachedSetupPage` runs the page bootstrap concurrently, so a single
+    // `waitFor` would have to cover bootstrap *and* the recovery chain within
+    // one asyncUtilTimeout.
+    const recoveredRequest = createDeferredPromise<void>(context.signal);
     context.mocks.http.get("*/api/zero/me/model-providers", () => {
       modelProviderRequests += 1;
       if (modelProviderRequests === 1) {
@@ -918,6 +924,9 @@ describe("zero sidebar account menu", () => {
       }
       if (modelProviderRequests === 2) {
         return HttpResponse.error();
+      }
+      if (modelProviderRequests === 3) {
+        recoveredRequest.resolve();
       }
       return HttpResponse.json({ modelProviders: [provider] });
     });
@@ -950,10 +959,11 @@ describe("zero sidebar account menu", () => {
       featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
     });
 
-    await waitFor(() => {
-      expect(modelProviderRequests).toBe(3);
-      expect(forcedTokenRefreshes).toBe(3);
-    });
+    await recoveredRequest.promise;
+    // Both refresh failures are retried before the token that replays the
+    // request resolves, so the counts are settled once the replay arrives.
+    expect(modelProviderRequests).toBe(3);
+    expect(forcedTokenRefreshes).toBe(3);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
 
     const menu = await openAccountMenu();


### PR DESCRIPTION
## Problem

`test-app (3)` went red on `main` ([run 30507499747](https://github.com/vm0-ai/vm0/actions/runs/30507499747)) with a single real failure:

```
FAIL src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
  > zero sidebar account menu > retries auth recovery network failures before replaying the request
AssertionError: expected 1 to be 3   (:954)
```

`test-app (5)` was only `The operation was canceled.` (fail-fast), and `ci-gate-turbo` is the aggregate gate — neither is a separate cause.

## Root cause

Test synchronization, not a product race. The test asserted its counters in a bare `waitFor` placed immediately after `detachedSetupPage`:

```ts
detachedSetupPage({ ... });          // fire-and-forget bootstrap

await waitFor(() => {
  expect(modelProviderRequests).toBe(3);
  expect(forcedTokenRefreshes).toBe(3);
});
```

`apps/platform` never calls testing-library's `configure()`, so that is the default **1000 ms** `asyncUtilTimeout` — and it had to cover the full page bootstrap **plus** the 401, three forced `getToken({ skipCache: true })` attempts, and two request replays.

The recovery chain itself is cheap: every `retryWithFibonacciBackoff` / `setLoop` backoff collapses to `delay(0)` under `IN_VITEST` (`signals/utils.ts:361`, `:442`). So bootstrap owns the entire variable cost, and it is invisible to the assertion. Instrumented timeline on an idle 2-core box:

```
setup returned @1ms
req#1 @284ms      <- bootstrap
refresh#1 @286ms / #2 @333ms / #3 @337ms
req#2 @338ms / req#3 @341ms      (chain itself: ~57ms)
```

Under shard contention the bootstrap slips past 1000 ms and the window expires having seen only the first request. Reproduced locally against the unpatched test by running the file with 4 `node` busy loops on 2 cores:

```
req#1 @1012ms     <- already over the 1000ms budget
AssertionError: expected 1 to be 3   (:954)
```

## Fix

Gate on the domain event rather than polling the counters: the MSW handler resolves a `createDeferredPromise(context.signal)` when the successful replay (request #3) arrives, the test awaits that deferred, then asserts the counters synchronously.

This preserves the product contract exactly. `forcedTokenRefreshes === 3` is already causally settled when the replay arrives — the third token must resolve before the replay can be issued — so the assertion is event-ordered instead of clock-ordered, not weakened. The exact attempt counts, the `redirectToSignIn` check, and the Codex subscription rendering are all unchanged. The counter assertions stay **before** `openAccountMenu()`, since opening the menu triggers a fourth request (measured at `req#4 @434ms`).

No sleeps, no timeout increase, no retries, no `clearAllDetached()`, no skipped test. `createDeferredPromise` is the same gate used by `org-billing-tab.test.tsx` and `chat-composer-template-picker.test.tsx` in this directory.

## Verification

| Check | Result |
| --- | --- |
| Repro (4x load, before fix) | fails reliably, `expected 1 to be 3` |
| Same 4x load (after fix) x2 | 16/16 pass (1712 ms, 1731 ms) |
| 8x load (2 cores, 4x oversubscribed) | target test passes (2808 ms) |
| Clean full-file runs x5 | 16/16 pass every run |
| `prettier --check` | pass |
| `eslint` | pass |
| `tsc -p tsconfig.tests.json` | exit 0 |

## Follow-up (not in this PR)

At 8x artificial load — far beyond real CI pressure — two unrelated tests in the same file (`opens credit balance and export data from the account menu`, `keeps the user profile inside settings and changes debug capture`) hit the same class of 1000 ms `waitFor`/`findBy` budget problem. Both are green on CI, so they are left out to keep this change narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
