### PR TITLE
test(runner): use canonical network policy refresh fixture

### DIFF
--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -1734,7 +1734,7 @@ mod tests {
                 .header("content-type", "application/json")
                 .json_body(json!({
                     "refreshes": [{
-                        "connectorRef": "slack",
+                        "connectorSlug": "slack",
                         "networkPolicy": {
                             "allow": ["chat:write"],
                             "deny": ["files:write"],


### PR DESCRIPTION
## Summary

- use the canonical `connectorSlug` response field in the canonical network policy refresh logging test
- keep legacy-only response coverage isolated in the dedicated compatibility test
- prevent the #23866 cleanup merge group from combining a canonical-only decoder with a legacy-only success fixture

## Scope

This changes test data only. It does not change runner production behavior or the temporary deployment compatibility bridge.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `CARGO_TARGET_DIR=/tmp/vm0-cargo-doc-target RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps --all-features`
- target test repeated 30 times
- target test passed after locally merging `origin/refactor/issue-23827-network-policy-cleanup`
