### PR TITLE
refactor(cli): remove unused resource candidate groups

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -155,6 +155,13 @@ describe("zero generate source-backed artifact commands", () => {
     );
   });
 
+  it("omits unused empty candidate groups", () => {
+    const selection = selectResourceCandidates();
+
+    expect(selection.candidates).not.toHaveProperty("audioStyles");
+    expect(selection.candidates).not.toHaveProperty("bundleTemplates");
+  });
+
   it("filters template candidates by target when requested", () => {
     const websiteSelection = selectResourceCandidates("website");
     const presentationSelection = selectResourceCandidates("presentation");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -42,9 +42,7 @@ interface HtmlArtifactAuthoringPacket {
       readonly template: "string";
       readonly designSystem: "string | null";
       readonly imageStyle: "string | null";
-      readonly audioStyle: "string | null";
       readonly videoTemplate: "string | null";
-      readonly bundleTemplate: "string | null";
       readonly rationale: "string";
     };
   };
@@ -116,9 +114,7 @@ export function createHtmlArtifactAuthoringPacket(
     template: "string",
     designSystem: "string | null",
     imageStyle: "string | null",
-    audioStyle: "string | null",
     videoTemplate: "string | null",
-    bundleTemplate: "string | null",
     rationale: "string",
   } as const;
   const artifact = {

--- a/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
@@ -85,9 +85,7 @@ export function createVideoTemplateAuthoringPacket(
       templates: [],
       designSystems: [],
       imageStyles: [],
-      audioStyles: [],
       videoTemplates: [options.template],
-      bundleTemplates: [],
     },
   };
   const selectionSchema = {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -98,9 +98,7 @@ export interface ResourceCandidateSlice {
     readonly templates: readonly RegistryEntry[];
     readonly designSystems: readonly RegistryEntry[];
     readonly imageStyles: readonly RegistryEntry[];
-    readonly audioStyles: readonly RegistryEntry[];
     readonly videoTemplates: readonly VideoTemplateRegistryEntry[];
-    readonly bundleTemplates: readonly RegistryEntry[];
   };
 }
 
@@ -3986,9 +3984,7 @@ export function selectResourceCandidates(
       templates: listTemplates(target),
       designSystems: filterByKind("design-system"),
       imageStyles: filterByKind("image-style"),
-      audioStyles: filterByKind("audio-style"),
       videoTemplates: listVideoTemplates(),
-      bundleTemplates: filterByKind("bundle-template"),
     },
   };
 }


### PR DESCRIPTION
## Summary

- keep `imageStyles`: it has 33 registered entries and is exposed through the HTML artifact selection packet
- keep `videoTemplates`: it has 10 registered entries and is consumed by the Video Template authoring path
- remove `audioStyles` and `bundleTemplates`: neither has registry entries or an independent consumer, so both were always serialized as empty arrays
- remove the corresponding unused `audioStyle` and `bundleTemplate` selection-schema fields

## Scope

This intentionally leaves `selectResourceCandidates` and the existing resource-selection flow unchanged. There is no selector rename, candidate compaction, required-resource restructuring, or Video pipeline refactor.

## Verification

- added a regression test confirming the two empty candidate groups are absent
- formatted the four touched files with Prettier 3.8.1
- linted the touched Core and CLI files with Oxlint 1.75.0
- ran a standalone TypeScript 6.0.3 strict check for the affected registry and authoring modules
- ran a runtime smoke check confirming `imageStyles` and `videoTemplates` remain populated while `audioStyles` and `bundleTemplates` are absent
- ran `git diff --check`

The fresh checkout has no installed `node_modules`, so the prescribed `pnpm format` stopped with `prettier: not found`; package checks and Vitest are deferred to the PR pipeline.
