### PR TITLE
refactor(cli): consume connector slug contracts

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -77,6 +77,7 @@ export function catalogItem(
 ): PublicConnectorCatalogItem {
   return {
     connectorRef: overrides.connectorSlug,
+    slug: overrides.connectorSlug,
     label: overrides.label ?? overrides.connectorSlug,
     description:
       overrides.description ?? `${overrides.connectorSlug} connector`,
@@ -102,6 +103,7 @@ export function catalogStatusItem(
     overrides.connectionStatus ?? (connection ? "connected" : "not-connected");
   return {
     connectorRef: overrides.connectorSlug,
+    slug: overrides.connectorSlug,
     label: overrides.label ?? overrides.connectorSlug,
     description:
       overrides.description ?? `${overrides.connectorSlug} connector`,
@@ -134,6 +136,7 @@ export function catalogPermissionDetail(
   const permissions = overrides.permissions ?? [];
   return {
     connectorRef: overrides.connectorSlug,
+    connectorSlug: overrides.connectorSlug,
     label: overrides.label ?? overrides.connectorSlug,
     icon: overrides.icon ?? {
       url: `https://icons.example.test/${overrides.connectorSlug}.svg`,
@@ -172,7 +175,7 @@ export function stubConnectorCatalogPermissions(
 ) {
   const detailsBySlug = new Map(
     details.map((detail) => {
-      return [detail.connectorRef, detail] as const;
+      return [detail.connectorSlug ?? detail.connectorRef, detail] as const;
     }),
   );
   return http.get(

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -522,6 +522,8 @@ describe("zero whoami command", () => {
             action: "allow",
           }),
           makePermissionGrant({
+            connectorRef: "legacy-slack",
+            connectorSlug: "slack",
             permission: "chat:write",
             action: "deny",
           }),

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -230,7 +230,8 @@ describe("zero whoami command", () => {
             connectors: [
               {
                 id: "1",
-                type: "github",
+                type: "legacy-github",
+                slug: "github",
                 authMethod: "oauth",
                 externalId: "12345",
                 externalUsername: "octocat",
@@ -270,7 +271,10 @@ describe("zero whoami command", () => {
       expect(
         output.some((line) => {
           return (
-            line.includes("@octocat") && line.includes("(octocat@github.com)")
+            line.includes("github") &&
+            line.includes("@octocat") &&
+            line.includes("(octocat@github.com)") &&
+            !line.includes("legacy-github")
           );
         }),
       ).toBe(true);

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -66,7 +66,7 @@ describe("zero agent create command", () => {
         "zero connector search <keyword> --agent comp_xyz789",
       );
       expect(logCalls).toContain(
-        "zero connector status <type> --agent comp_xyz789",
+        "zero connector status <slug> --agent comp_xyz789",
       );
     });
 

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -106,7 +106,7 @@ Examples:
           "  - Check authorization status (prints an authorize URL if not authorized):",
         );
         console.log(
-          `      zero connector status <type> --agent ${agent.agentId}`,
+          `      zero connector status <slug> --agent ${agent.agentId}`,
         );
       },
     ),

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -8,12 +8,12 @@ import {
   listZeroConnectors,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
-import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type { ZeroConnector } from "../../../lib/api/domains/zero-connectors";
 import { policyIcon } from "../../../lib/utils/format-utils";
 import { formatAvatar } from "./avatar";
 import {
   loadConnectorPermissionInfos,
+  connectorPermissionGrantsToFirewallPolicies,
   type ConnectorPermissionInfo,
 } from "../shared/firewall-permissions";
 
@@ -45,9 +45,7 @@ function printDetailedPermissions(info: ConnectorPermissionInfo): void {
   );
 }
 
-function formatConnectorIdentity(
-  connector: ConnectorResponse | undefined,
-): string {
+function formatConnectorIdentity(connector: ZeroConnector | undefined): string {
   if (!connector) return "";
   if (connector.externalUsername) return `@${connector.externalUsername}`;
   if (connector.externalEmail) return connector.externalEmail;
@@ -56,7 +54,7 @@ function formatConnectorIdentity(
 
 function formatConnectorSummary(
   info: ConnectorPermissionInfo,
-  identity?: ConnectorResponse,
+  identity?: ZeroConnector,
 ): string {
   const id = formatConnectorIdentity(identity);
   const idStr = id ? ` ${id}` : "";
@@ -65,9 +63,7 @@ function formatConnectorSummary(
   return `${info.connectorSlug}${idStr} (${info.allowed}/${info.total} allowed)`;
 }
 
-function formatDetailIdentity(
-  connector: ConnectorResponse | undefined,
-): string {
+function formatDetailIdentity(connector: ZeroConnector | undefined): string {
   if (!connector) return "";
   let identity = "";
   if (connector.externalUsername && connector.externalEmail) {
@@ -109,13 +105,13 @@ Examples:
           getZeroAgent(agentId),
           getZeroAgentUserConnectors(agentId),
           listZeroConnectors().catch(() => {
-            return { connectors: [] as ConnectorResponse[] };
+            return { connectors: [] as ZeroConnector[] };
           }),
         ]);
 
-        const identityMap = new Map<string, ConnectorResponse>(
+        const identityMap = new Map<string, ZeroConnector>(
           connectorIdentities.connectors.map((c) => {
-            return [c.type, c];
+            return [c.slug, c];
           }),
         );
 
@@ -125,7 +121,7 @@ Examples:
         console.log(`Agent ID:     ${agent.agentId}`);
 
         const storedPolicies = options.permissions
-          ? permissionGrantsToFirewallPolicies(
+          ? connectorPermissionGrantsToFirewallPolicies(
               await listZeroUserPermissionGrants(agent.agentId),
             )
           : null;

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
@@ -58,8 +58,11 @@ function buildZeroToken(
 function connectorIdentity(
   overrides: Partial<ConnectorIdentity> = {},
 ): ConnectorIdentity {
+  const connectorSlug =
+    overrides.connectorSlug ?? overrides.connectorRef ?? "github";
   return {
-    connectorRef: "github",
+    connectorRef: connectorSlug,
+    connectorSlug,
     label: "GitHub",
     visibility: "available",
     credentialResolution: "network-boundary",
@@ -133,6 +136,7 @@ function connectorResponse(
   return {
     id: "00000000-0000-4000-8000-000000000002",
     type: connectorSlug,
+    slug: connectorSlug,
     authMethod: "oauth",
     externalId: "external-1",
     externalUsername: "user",
@@ -268,7 +272,7 @@ describe("zero connector check command", () => {
       stubDiagnostic(
         resolvedUrl({
           connector: connectorIdentity({
-            connectorRef: "server-only",
+            connectorSlug: "server-only",
             label: "Server Only",
           }),
           environmentNames: ["SERVER_ONLY_TOKEN"],
@@ -299,7 +303,7 @@ describe("zero connector check command", () => {
         mode: "url",
         method: "POST",
         url: "https://service.example.com/api/items",
-        connectorRef: "server-only",
+        connectorSlug: "server-only",
         environmentName: "SERVER_ONLY_TOKEN",
       } satisfies ConnectorCheckRequest);
       expect(getOutput()).toContain(
@@ -373,6 +377,29 @@ describe("zero connector check command", () => {
         "zero connector permission-request github --permission contents:write",
       );
       expect(getOutput()).not.toContain("--callback-prompt");
+    });
+
+    it("normalizes a legacy-only diagnostic connector identity", async () => {
+      stubDiagnostic(
+        resolvedEnvironment({
+          connector: {
+            ...connectorIdentity(),
+            connectorSlug: undefined,
+          },
+        }),
+      );
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).toContain(
+        "GH_TOKEN is managed by the GitHub connector (slug: github).",
+      );
     });
 
     it("prints a callback permission command example in the current web chat", async () => {
@@ -465,7 +492,7 @@ describe("zero connector check command", () => {
   describe("resolved identities and local responsibilities", () => {
     it("uses a server-only connector slug for local presence, connection, and authorization checks", async () => {
       const serverOnlyIdentity = connectorIdentity({
-        connectorRef: "server-only",
+        connectorSlug: "server-only",
         label: "Server Only Connector",
       });
       let connectorCalls = 0;
@@ -500,7 +527,7 @@ describe("zero connector check command", () => {
 
       const output = getOutput();
       expect(output).toContain(
-        "SERVER_ONLY_TOKEN is managed by the Server Only Connector connector (type: server-only).",
+        "SERVER_ONLY_TOKEN is managed by the Server Only Connector connector (slug: server-only).",
       );
       expect(output).toContain(
         "Checking process.env.SERVER_ONLY_TOKEN: present",
@@ -757,7 +784,7 @@ describe("zero connector check command", () => {
       stubDiagnostic({
         outcome: "unresolved-dynamic-base",
         connector: connectorIdentity({
-          connectorRef: "reap",
+          connectorSlug: "reap",
           label: "Reap",
         }),
       });
@@ -1027,7 +1054,7 @@ describe("zero connector check command", () => {
           "missing-connector",
         ],
         result: { outcome: "unknown-connector" },
-        expected: "Unknown connector type: missing-connector",
+        expected: "Unknown connector slug: missing-connector",
       },
       {
         name: "unknown environment",
@@ -1103,7 +1130,7 @@ describe("zero connector check command", () => {
         result: {
           outcome: "unresolved-dynamic-base",
           connector: connectorIdentity({
-            connectorRef: "reap",
+            connectorSlug: "reap",
             label: "Reap",
           }),
         },
@@ -1134,8 +1161,8 @@ describe("zero connector check command", () => {
       stubDiagnostic({
         outcome: "ambiguous",
         candidates: [
-          { connectorRef: "zeta", label: "Zeta" },
-          { connectorRef: "alpha", label: "Alpha" },
+          { connectorRef: "zeta", connectorSlug: "zeta", label: "Zeta" },
+          { connectorRef: "alpha", connectorSlug: "alpha", label: "Alpha" },
         ],
       });
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -23,6 +23,7 @@ function connectorResponse(connectorSlug: string, authMethod = "api-token") {
   return {
     id: "00000000-0000-4000-8000-000000000001",
     type: connectorSlug,
+    slug: connectorSlug,
     authMethod,
     externalId: null,
     externalUsername: null,
@@ -191,7 +192,7 @@ describe("zero connector connect command", () => {
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(JSON.parse(output)).toMatchObject({
-      type: "openai",
+      slug: "openai",
       authMethod: "api-token",
     });
   });

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -137,13 +137,13 @@ describe("zero connector list command", () => {
   });
 
   describe("without agent context", () => {
-    it("renders TYPE and CONNECTED AS columns for a connected connector", async () => {
+    it("renders SLUG and CONNECTED AS columns for a connected connector", async () => {
       server.use(stubConnectors([connectedGithub]));
 
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("TYPE");
+      expect(logCalls).toContain("SLUG");
       expect(logCalls).toContain("CONNECTED AS");
       expect(logCalls).not.toContain("ACCOUNT");
       expect(logCalls).not.toContain("STATUS");
@@ -152,7 +152,29 @@ describe("zero connector list command", () => {
       expect(logCalls).toContain("@octocat");
     });
 
-    it("renders (not connected) for types with no connector", async () => {
+    it("prefers canonical catalog slugs and falls back to legacy-only responses", async () => {
+      server.use(
+        stubConnectorCatalogStatus([
+          {
+            ...catalogStatusItem({ connectorSlug: "legacy-canonical" }),
+            slug: "canonical",
+          },
+          {
+            ...catalogStatusItem({ connectorSlug: "legacy-only" }),
+            slug: undefined,
+          },
+        ]),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("canonical");
+      expect(logCalls).toContain("legacy-only");
+      expect(logCalls).not.toContain("legacy-canonical");
+    });
+
+    it("renders (not connected) for slugs with no connector", async () => {
       server.use(stubConnectors([]));
 
       await listCommand.parseAsync(["node", "cli"]);

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -245,6 +245,28 @@ describe("zero connector list command", () => {
       expect(logCalls).toContain("✓");
     });
 
+    it("prefers canonical enabled connector slugs", async () => {
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "maya"),
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_UUID}/user-connectors`,
+          () => {
+            return HttpResponse.json({
+              enabledTypes: [],
+              enabledConnectorSlugs: ["github"],
+            });
+          },
+        ),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("github");
+      expect(logCalls).toContain("✓");
+    });
+
     it("renders AUTHORIZED FOR column when $ZERO_AGENT_ID is set", async () => {
       vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
       server.use(

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -355,7 +355,7 @@ describe("zero connector permission-request command", () => {
     expect(logCalls).toContain("permission=records.read");
   });
 
-  it("exits with an error for an unknown connector type", async () => {
+  it("exits with an error for an unknown connector slug", async () => {
     await expect(async () => {
       await permissionRequestCommand.parseAsync([
         "node",
@@ -367,7 +367,7 @@ describe("zero connector permission-request command", () => {
     }).rejects.toThrow("process.exit called");
 
     expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining("Unknown connector type: unknown-service"),
+      expect.stringContaining("Unknown connector slug: unknown-service"),
     );
   });
 
@@ -442,7 +442,7 @@ describe("zero connector permission-request command", () => {
 
     const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorOutput).toContain("Failed to fetch");
-    expect(errorOutput).not.toContain("Unknown connector type");
+    expect(errorOutput).not.toContain("Unknown connector slug");
   });
 
   it("rejects permission metadata for a different connector slug", async () => {
@@ -452,11 +452,14 @@ describe("zero connector permission-request command", () => {
         "https://app.vm0.ai/api/zero/connector-catalog/slack/permissions",
         () => {
           return HttpResponse.json({
-            permissions: catalogPermissionDetail({
-              connectorSlug: "github",
-              label: "GitHub",
-              permissions: [{ name: SLACK_READ_PERMISSION }],
-            }),
+            permissions: {
+              ...catalogPermissionDetail({
+                connectorSlug: "github",
+                label: "GitHub",
+                permissions: [{ name: SLACK_READ_PERMISSION }],
+              }),
+              connectorRef: "legacy-github",
+            },
           });
         },
       ),
@@ -474,7 +477,7 @@ describe("zero connector permission-request command", () => {
 
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Permission metadata connectorRef mismatch: expected slack, got github",
+        "Permission metadata connector slug mismatch: expected slack, got github",
       ),
     );
   });

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -128,7 +128,7 @@ function findDataRows(lines: readonly string[]): string[] {
   return lines.filter((line) => {
     const trimmed = line.trim();
     if (!trimmed) return false;
-    if (trimmed.startsWith("TYPE")) return false;
+    if (trimmed.startsWith("SLUG")) return false;
     if (trimmed.startsWith("No exact match")) return false;
     if (trimmed.startsWith("Too many results")) return false;
     if (trimmed.startsWith("No matches found")) return false;
@@ -172,7 +172,7 @@ describe("zero connector search command", () => {
   });
 
   describe("without agent context", () => {
-    it("returns github first for an exact type match with no banner", async () => {
+    it("returns github first for an exact slug match with no banner", async () => {
       await searchCommand.parseAsync(["node", "cli", "github"]);
 
       const lines = mockConsoleLog.mock.calls.flat() as string[];
@@ -214,31 +214,31 @@ describe("zero connector search command", () => {
       const output = lines.join("\n");
       expect(output).toContain("No exact match. Showing closest:");
       const dataRows = findDataRows(lines);
-      const types = dataRows.map((row) => {
+      const slugs = dataRows.map((row) => {
         return row.split(/\s+/)[0];
       });
-      expect(types).toContain("github");
-      expect(types).toContain("gitlab");
+      expect(slugs).toContain("github");
+      expect(slugs).toContain("gitlab");
     });
 
-    it("ranks tag-exact above type-substring above tag-substring", async () => {
+    it("ranks tag-exact above slug-substring above tag-substring", async () => {
       // Keyword "chat" exercises three scoring tiers against the real catalog
       // and pins the priority ordering contract so future refactors of
       // scoreConnector cannot silently reorder them:
-      //   - microsoft-365, slack: tag-exact "chat" => 70, sorted by type
-      //   - chatwoot: type-substring "chatwoot"    => 50
+      //   - microsoft-365, slack: tag-exact "chat" => 70, sorted by slug
+      //   - chatwoot: slug-substring "chatwoot"    => 50
       //   - openai:   tag-substring "chatgpt"      => 25
       await searchCommand.parseAsync(["node", "cli", "chat", "--limit", "10"]);
 
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const dataRows = findDataRows(lines);
-      const types = dataRows.map((row) => {
+      const slugs = dataRows.map((row) => {
         return row.split(/\s+/)[0];
       });
-      const microsoft365Idx = types.indexOf("microsoft-365");
-      const slackIdx = types.indexOf("slack");
-      const chatwootIdx = types.indexOf("chatwoot");
-      const openaiIdx = types.indexOf("openai");
+      const microsoft365Idx = slugs.indexOf("microsoft-365");
+      const slackIdx = slugs.indexOf("slack");
+      const chatwootIdx = slugs.indexOf("chatwoot");
+      const openaiIdx = slugs.indexOf("openai");
       expect(microsoft365Idx).toBe(0);
       expect(slackIdx).toBe(1);
       expect(chatwootIdx).toBeGreaterThan(slackIdx);
@@ -432,7 +432,7 @@ describe("zero connector search command", () => {
   });
 
   describe("CONNECTED AS column", () => {
-    it("renders @username for a connected type", async () => {
+    it("renders @username for a connected slug", async () => {
       server.use(stubConnectors([connectedGithub]));
 
       await searchCommand.parseAsync(["node", "cli", "github"]);
@@ -443,7 +443,7 @@ describe("zero connector search command", () => {
       expect(output).toContain("@octocat");
     });
 
-    it("renders (not connected) for a type with no connector", async () => {
+    it("renders (not connected) for a slug with no connector", async () => {
       server.use(stubConnectors([]));
 
       await searchCommand.parseAsync(["node", "cli", "github"]);
@@ -496,10 +496,10 @@ describe("zero connector search command", () => {
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const output = lines.join("\n");
       const dataRows = findDataRows(lines);
-      const types = dataRows.map((row) => {
+      const slugs = dataRows.map((row) => {
         return row.split(/\s+/)[0];
       });
-      expect(types).not.toContain("zapier");
+      expect(slugs).not.toContain("zapier");
       expect(output).not.toContain("zapier");
     });
 
@@ -520,11 +520,11 @@ describe("zero connector search command", () => {
 
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const dataRows = findDataRows(lines);
-      const types = dataRows.map((row) => {
+      const slugs = dataRows.map((row) => {
         return row.split(/\s+/)[0];
       });
       // mercury has an ungated api-token auth method, so it is always visible.
-      expect(types).toContain("mercury");
+      expect(slugs).toContain("mercury");
     });
 
     it("uses the server-visible catalog for feature-gated oauth connectors", async () => {

--- a/turbo/apps/cli/src/commands/zero/connector/check.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/check.ts
@@ -1,7 +1,6 @@
 import { Command, Option } from "commander";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
-  ConnectorCheckDiagnosticResult,
   ConnectorCheckPolicy,
   ConnectorCheckRequest,
 } from "@vm0/api-contracts/contracts/zero-connector-check";
@@ -10,6 +9,7 @@ import { getApiUrl } from "../../../lib/api/config";
 import {
   diagnoseZeroConnectorCheck,
   getZeroConnector,
+  type ZeroConnectorCheckDiagnosticResult,
 } from "../../../lib/api/domains/zero-connectors";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { withErrorHandler } from "../../../lib/command";
@@ -40,7 +40,7 @@ type ValidatedCheckConnectorOptions = CheckConnectorOptions &
   );
 
 type ResolvedDiagnostic = Extract<
-  ConnectorCheckDiagnosticResult,
+  ZeroConnectorCheckDiagnosticResult,
   { readonly outcome: "resolved" }
 >;
 type ResolvedUrlDiagnostic = Extract<
@@ -170,7 +170,9 @@ function buildDiagnosticRequest(
       mode: "url",
       method,
       url: stripUrlQueryAndFragment(opts.url),
-      ...(opts.connector !== undefined ? { connectorRef: opts.connector } : {}),
+      ...(opts.connector !== undefined
+        ? { connectorSlug: opts.connector }
+        : {}),
       ...(opts.envName !== undefined ? { environmentName: opts.envName } : {}),
     };
   }
@@ -206,7 +208,7 @@ function requestedEnvironmentName(request: ConnectorCheckRequest): string {
 
 function unsafeInputError(
   reason: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "unsafe-input" }
   >["reason"],
 ): Error {
@@ -229,29 +231,29 @@ function unsafeInputError(
 function ambiguousConnectorError(
   request: UrlDiagnosticRequest,
   result: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "ambiguous" }
   >,
 ): Error {
   const candidates = [...result.candidates].sort((left, right) => {
-    return left.connectorRef.localeCompare(right.connectorRef);
+    return left.connectorSlug.localeCompare(right.connectorSlug);
   });
   const commands = candidates.map((candidate) => {
-    return `  ${connectorSelectionCommand(request.url, request.method, candidate.connectorRef)}`;
+    return `  ${connectorSelectionCommand(request.url, request.method, candidate.connectorSlug)}`;
   });
   return new Error(
     `Multiple connectors match ${request.method} ${request.url}: ${candidates
       .map((candidate) => {
-        return candidate.connectorRef;
+        return candidate.connectorSlug;
       })
       .join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
   );
 }
 
 function unknownConnectorError(request: ConnectorCheckRequest): Error {
-  if (request.mode === "url" && request.connectorRef !== undefined) {
+  if (request.mode === "url" && request.connectorSlug !== undefined) {
     return new Error(
-      `Unknown connector type: ${request.connectorRef}\nRun: zero connector search ${shellQuoteArg(request.connectorRef)}`,
+      `Unknown connector slug: ${request.connectorSlug}\nRun: zero connector search ${shellQuoteArg(request.connectorSlug)}`,
     );
   }
   return new Error("The requested connector is unknown.");
@@ -259,7 +261,7 @@ function unknownConnectorError(request: ConnectorCheckRequest): Error {
 
 function noMatchError(
   result: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "no-match" }
   >,
 ): Error {
@@ -273,20 +275,20 @@ function noMatchError(
 function connectorMismatchError(
   request: UrlDiagnosticRequest,
   result: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "connector-mismatch" }
   >,
 ): Error {
-  const requestedSlug = request.connectorRef ?? "the requested connector";
+  const requestedSlug = request.connectorSlug ?? "the requested connector";
   return new Error(
-    `Connector ${requestedSlug} does not own ${request.method} ${request.url}; the matching connector is ${result.connector.connectorRef}\nRun: ${connectorSelectionCommand(request.url, request.method, result.connector.connectorRef)}`,
+    `Connector ${requestedSlug} does not own ${request.method} ${request.url}; the matching connector is ${result.connector.connectorSlug}\nRun: ${connectorSelectionCommand(request.url, request.method, result.connector.connectorSlug)}`,
   );
 }
 
 function environmentNotOwnedError(
   request: ConnectorCheckRequest,
   result: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "environment-not-owned" }
   >,
 ): Error {
@@ -299,7 +301,7 @@ function environmentNotOwnedError(
 function environmentNotUsedError(
   request: ConnectorCheckRequest,
   result: Extract<
-    ConnectorCheckDiagnosticResult,
+    ZeroConnectorCheckDiagnosticResult,
     { readonly outcome: "environment-not-used" }
   >,
 ): Error {
@@ -311,7 +313,7 @@ function environmentNotUsedError(
 
 function resolvedDiagnostic(
   request: ConnectorCheckRequest,
-  result: ConnectorCheckDiagnosticResult,
+  result: ZeroConnectorCheckDiagnosticResult,
 ): ResolvedDiagnostic {
   switch (result.outcome) {
     case "resolved":
@@ -336,7 +338,7 @@ function resolvedDiagnostic(
       throw environmentNotUsedError(request, result);
     case "unresolved-dynamic-base":
       throw new Error(
-        `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${result.connector.connectorRef} connector configuration for the affected context and retry.`,
+        `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${result.connector.connectorSlug} connector configuration for the affected context and retry.`,
       );
     case "run-context-unavailable":
       throw new Error(
@@ -352,7 +354,7 @@ function printDiagnosticSummary(
   if (result.mode === "url") {
     const urlRequest = requireUrlRequest(request);
     console.log(
-      `URL ${urlRequest.url} matches the ${result.connector.label} connector (type: ${result.connector.connectorRef}).`,
+      `URL ${urlRequest.url} matches the ${result.connector.label} connector (slug: ${result.connector.connectorSlug}).`,
     );
     console.log(`  Matched base URL: ${result.base}`);
     console.log(`  Relative path:    ${result.relativePath}`);
@@ -367,7 +369,7 @@ function printDiagnosticSummary(
   }
 
   console.log(
-    `${result.environmentName} is managed by the ${result.connector.label} connector (type: ${result.connector.connectorRef}).`,
+    `${result.environmentName} is managed by the ${result.connector.label} connector (slug: ${result.connector.connectorSlug}).`,
   );
 }
 
@@ -773,7 +775,7 @@ function printUrlPermissionDiagnostic(
     console.log("");
     for (const permission of result.permission.permissions) {
       printNamedPolicyResult(
-        result.connector.connectorRef,
+        result.connector.connectorSlug,
         permission.name,
         permission.policy,
         agentId,
@@ -785,7 +787,7 @@ function printUrlPermissionDiagnostic(
     );
     console.log("");
     printUnknownEndpointPolicy(
-      result.connector.connectorRef,
+      result.connector.connectorSlug,
       result.permission.policy,
       agentId,
     );
@@ -813,7 +815,7 @@ function printEnvironmentPermissionDiagnostic(
   );
   console.log("");
   printNamedPolicyResult(
-    result.connector.connectorRef,
+    result.connector.connectorSlug,
     permissionName,
     result.permission,
     agentId,
@@ -866,9 +868,8 @@ export const checkConnectorCommand = new Command()
     ),
   )
   .addOption(
-    // TODO(#23619): Rename this stable CLI option value label in the CLI rollout.
     new Option(
-      "--connector <type>",
+      "--connector <slug>",
       "Select the connector when multiple connectors own the same URL route",
     ),
   )
@@ -920,7 +921,7 @@ How connectors work:
       const platformUrl = toPlatformUrl(await getApiUrl());
       const ctx: DiagContext = {
         environmentNames: diagnosticEnvironmentNames(result),
-        connectorSlug: result.connector.connectorRef,
+        connectorSlug: result.connector.connectorSlug,
         label: result.connector.label,
         connectorAvailable: result.connector.visibility === "available",
         credentialResolution: result.connector.credentialResolution,

--- a/turbo/apps/cli/src/commands/zero/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connect.ts
@@ -55,8 +55,7 @@ function parseConnectorValues(rawValues: readonly string[] | undefined) {
 export const connectCommand = new Command()
   .name("connect")
   .description("Connect a connector with manual grant values")
-  // TODO(#23619): Rename this stable CLI argument label in the CLI rollout.
-  .argument("<type>", "Connector type (e.g., zendesk)")
+  .argument("<slug>", "Connector slug (e.g., zendesk)")
   .option("--auth-method <method>", "Connector auth method to use")
   .option(
     "--value <name=value>",
@@ -86,7 +85,7 @@ export const connectCommand = new Command()
         options.authMethod,
       );
       const connector = await connectZeroConnectorManualGrant(
-        connectorMetadata.connectorRef,
+        connectorMetadata.slug,
         authMethod.id,
         values,
       );
@@ -97,8 +96,8 @@ export const connectCommand = new Command()
       }
 
       console.log(chalk.green(`✓ ${connectorMetadata.label} connected`));
-      console.log(chalk.dim(`  Type: ${connector.type}`));
+      console.log(chalk.dim(`  Slug: ${connector.slug}`));
       console.log(chalk.dim(`  Auth Method: ${connector.authMethod}`));
-      console.log(chalk.dim(`  Run: zero connector status ${connector.type}`));
+      console.log(chalk.dim(`  Run: zero connector status ${connector.slug}`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/connector/discovery.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/discovery.ts
@@ -1,24 +1,24 @@
 import chalk from "chalk";
 import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-connectors";
 import type { ConnectorDiscoveryAgentContext } from "./agent-context";
 import { renderConnectedAsCell } from "./connected-as";
 
 interface CatalogConnectorDiscoveryItem {
   readonly kind: "catalog";
-  readonly connectorRef: string;
+  readonly slug: string;
   readonly label: string;
   readonly description: string;
   readonly category: string;
   readonly tags: readonly string[];
   readonly generation: readonly string[];
-  readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
-  readonly catalogConnector: PublicConnectorCatalogStatusItem;
+  readonly authMethods: ZeroConnectorCatalogStatus["authMethods"];
+  readonly catalogConnector: ZeroConnectorCatalogStatus;
 }
 
 interface CustomConnectorDiscoveryItem {
   readonly kind: "custom";
-  readonly connectorRef: string;
+  readonly slug: string;
   readonly label: string;
   readonly description: string;
   readonly category: string;
@@ -33,14 +33,14 @@ type ConnectorDiscoveryItem =
   | CustomConnectorDiscoveryItem;
 
 export function connectorDiscoveryItems(
-  catalogConnectors: readonly PublicConnectorCatalogStatusItem[],
+  catalogConnectors: readonly ZeroConnectorCatalogStatus[],
   customConnectors: readonly CustomConnectorResponse[],
 ): readonly ConnectorDiscoveryItem[] {
   return [
     ...catalogConnectors.map((connector): CatalogConnectorDiscoveryItem => {
       return {
         kind: "catalog",
-        connectorRef: connector.connectorRef,
+        slug: connector.slug,
         label: connector.label,
         description: connector.description,
         category: connector.category,
@@ -53,7 +53,7 @@ export function connectorDiscoveryItems(
     ...customConnectors.map((connector): CustomConnectorDiscoveryItem => {
       return {
         kind: "custom",
-        connectorRef: connector.slug,
+        slug: connector.slug,
         label: connector.displayName,
         description: "",
         category: "custom",
@@ -88,7 +88,7 @@ export function isConnectorDiscoveryAuthorized(
   agentContext: ConnectorDiscoveryAgentContext,
 ): boolean {
   if (connector.kind === "catalog") {
-    return agentContext.authorizedConnectorSlugs.has(connector.connectorRef);
+    return agentContext.authorizedConnectorSlugs.has(connector.slug);
   }
   return agentContext.authorizedCustomConnectorIds.has(
     connector.customConnector.id,

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -31,7 +31,7 @@ export const listCommand = new Command()
       );
 
       const connectorSlugs = discoveredConnectors.map((connector) => {
-        return connector.connectorRef;
+        return connector.slug;
       });
 
       const connectorSlugWidth = Math.max(
@@ -58,7 +58,7 @@ export const listCommand = new Command()
 
       // Print header
       const headerParts = [
-        "TYPE".padEnd(connectorSlugWidth),
+        "SLUG".padEnd(connectorSlugWidth),
         connectedAsHeader.padEnd(connectedAsWidth),
       ];
       if (authorizedHeader) headerParts.push(authorizedHeader);

--- a/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import { findFirewallMetadataPermission } from "@vm0/connectors/firewall-metadata/policy";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "../doctor/platform-url";
@@ -22,6 +21,7 @@ import {
   connectorActionCallbackAvailable,
   printCallbackTurnInstruction,
 } from "./action-url";
+import { hasConnectorFirewallMetadataPermission } from "../shared/firewall-permissions";
 
 function permissionDescription(permission: string): string {
   return permission === UNKNOWN_PERMISSION_GRANT
@@ -205,8 +205,7 @@ const callbackPromptNotes = callbackPromptAvailable
 export const permissionRequestCommand = new Command()
   .name("permission-request")
   .description("Request permission to use a connector capability")
-  // TODO(#23619): Rename this stable CLI argument label in the CLI rollout.
-  .argument("<connector-ref>", "The connector type (e.g. github)")
+  .argument("<slug>", "The connector slug (e.g. github)")
   .addOption(
     new Option(
       "--permission <name>",
@@ -281,12 +280,12 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
         const metadata =
           await getZeroConnectorCatalogPermissions(connectorSlug);
         if (!metadata) {
-          throw new Error(`Unknown connector type: ${connectorSlug}`);
+          throw new Error(`Unknown connector slug: ${connectorSlug}`);
         }
 
         if (
           opts.permission !== UNKNOWN_PERMISSION_GRANT &&
-          !findFirewallMetadataPermission(metadata, opts.permission)
+          !hasConnectorFirewallMetadataPermission(metadata, opts.permission)
         ) {
           throw new Error(
             `Unknown permission "${opts.permission}" for ${connectorSlug}`,

--- a/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
@@ -1,12 +1,10 @@
-import type {
-  PublicConnectorCatalogAuthMethodDetail,
-  PublicConnectorCatalogStatusItem,
-} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogAuthMethodDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-connectors";
 
-export type PublicConnectorStatus = PublicConnectorCatalogStatusItem;
+export type PublicConnectorStatus = ZeroConnectorCatalogStatus;
 
 interface ConnectorSearchItem {
-  readonly connectorRef: string;
+  readonly slug: string;
   readonly label: string;
   readonly description: string;
   readonly category: string;
@@ -48,7 +46,7 @@ function tokenize(input: string): Set<string> {
 
 function publicStrings(connector: ConnectorSearchItem): string[] {
   return [
-    connector.connectorRef,
+    connector.slug,
     connector.label,
     connector.description,
     connector.category,
@@ -79,8 +77,8 @@ function scoreExact(
   skipPrivateIdentifierMatches: boolean,
   connector: ConnectorSearchItem,
 ): ScoreHit | null {
-  if (connector.connectorRef.toLowerCase() === keywordLower) {
-    return { score: 100, matchedField: "connectorRef" };
+  if (connector.slug.toLowerCase() === keywordLower) {
+    return { score: 100, matchedField: "slug" };
   }
   if (connector.label.toLowerCase() === keywordLower) {
     return { score: 80, matchedField: "label" };
@@ -116,8 +114,8 @@ function scoreSubstring(
   connector: ConnectorSearchItem,
 ): ScoreHit | null {
   const candidates: ScoreHit[] = [];
-  if (connector.connectorRef.toLowerCase().includes(keywordLower)) {
-    candidates.push({ score: 50, matchedField: "connectorRef" });
+  if (connector.slug.toLowerCase().includes(keywordLower)) {
+    candidates.push({ score: 50, matchedField: "slug" });
   }
   if (connector.label.toLowerCase().includes(keywordLower)) {
     candidates.push({ score: 50, matchedField: "label" });
@@ -224,7 +222,7 @@ export function searchConnectorCatalog<T extends ConnectorSearchItem>(
 
   hits.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
-    return a.connector.connectorRef.localeCompare(b.connector.connectorRef);
+    return a.connector.slug.localeCompare(b.connector.slug);
   });
 
   return {
@@ -238,14 +236,14 @@ export function findConnectorStatusItem(
   connectorSlug: string,
 ): PublicConnectorStatus | null {
   const exact = connectors.find((connector) => {
-    return connector.connectorRef === connectorSlug;
+    return connector.slug === connectorSlug;
   });
   if (exact) return exact;
 
   const lower = connectorSlug.toLowerCase();
   return (
     connectors.find((connector) => {
-      return connector.connectorRef.toLowerCase() === lower;
+      return connector.slug.toLowerCase() === lower;
     }) ?? null
   );
 }
@@ -255,7 +253,7 @@ export function availableConnectorSlugs(
 ): string {
   return connectors
     .map((connector) => {
-      return connector.connectorRef;
+      return connector.slug;
     })
     .join(", ");
 }
@@ -270,7 +268,7 @@ export function resolveManualGrantAuthMethod(
     });
     if (!authMethod) {
       throw new Error(
-        `${connector.connectorRef} connector does not have ${rawAuthMethod} auth method`,
+        `${connector.slug} connector does not have ${rawAuthMethod} auth method`,
         {
           cause: new Error(
             `Available auth methods: ${connector.authMethods
@@ -288,7 +286,7 @@ export function resolveManualGrantAuthMethod(
     }
 
     throw new Error(
-      `${connector.connectorRef} ${authMethod.id} auth method does not use a manual grant`,
+      `${connector.slug} ${authMethod.id} auth method does not use a manual grant`,
     );
   }
 
@@ -300,13 +298,11 @@ export function resolveManualGrantAuthMethod(
     return authMethod;
   }
   if (manualAuthMethods.length === 0) {
-    throw new Error(
-      `${connector.connectorRef} connector does not use a manual grant`,
-    );
+    throw new Error(`${connector.slug} connector does not use a manual grant`);
   }
 
   throw new Error(
-    `${connector.connectorRef} connector has multiple manual grant auth methods`,
+    `${connector.slug} connector has multiple manual grant auth methods`,
     {
       cause: new Error(
         `Pass --auth-method ${manualAuthMethods

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -29,7 +29,7 @@ function parseLimit(raw: string): number {
 export const searchCommand = new Command()
   .name("search")
   .description(
-    "Search connectors by type, label, category, generation type, or tag",
+    "Search connectors by slug, label, category, generation type, or tag",
   )
   .argument("<keyword>", "Search keyword (case-insensitive)")
   .option("--agent <id>", "Show per-agent authorization column")
@@ -71,7 +71,7 @@ export const searchCommand = new Command()
           console.log(`Too many results (top ${options.limit} of ${total}):`);
         }
 
-        const connectorSlugHeader = "TYPE";
+        const connectorSlugHeader = "SLUG";
         const connectedAsHeader = "CONNECTED AS";
 
         const connectedCells = results.map((r) => {
@@ -81,7 +81,7 @@ export const searchCommand = new Command()
         const connectorSlugWidth = Math.max(
           connectorSlugHeader.length,
           ...results.map((r) => {
-            return r.connector.connectorRef.length;
+            return r.connector.slug.length;
           }),
         );
         const connectedAsWidth = Math.max(
@@ -103,7 +103,7 @@ export const searchCommand = new Command()
         for (let i = 0; i < results.length; i++) {
           const result = results[i]!;
           const parts = [
-            result.connector.connectorRef.padEnd(connectorSlugWidth),
+            result.connector.slug.padEnd(connectorSlugWidth),
             padEndAnsi(connectedCells[i]!, connectedAsWidth),
           ];
           if (agentCtx) {

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -65,7 +65,7 @@ async function printAgentAction(
   connector: PublicConnectorStatus,
   agentCtx: AgentContext,
 ): Promise<void> {
-  const connectorSlug = connector.connectorRef;
+  const connectorSlug = connector.slug;
   const authorized = agentCtx.authorizedConnectorSlugs.has(connectorSlug);
   const isConnected = connector.connected;
   const needsReconnect = connector.connectionStatus === "reconnect-required";
@@ -135,7 +135,7 @@ async function printAgentAction(
 async function printStandaloneAction(
   connector: PublicConnectorStatus,
 ): Promise<void> {
-  const connectorSlug = connector.connectorRef;
+  const connectorSlug = connector.slug;
   if (
     connector.connectionStatus === "connected" ||
     connector.connectionStatus === "scope-mismatch"
@@ -160,8 +160,7 @@ async function printStandaloneAction(
 export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a connector")
-  // TODO(#23619): Rename this stable CLI argument label in the CLI rollout.
-  .argument("<type>", "Connector type (e.g., github)")
+  .argument("<slug>", "Connector slug (e.g., github)")
   .option("--agent <id>", "Show authorization state for the given agent")
   .action(
     withErrorHandler(
@@ -185,7 +184,7 @@ export const statusCommand = new Command()
           );
         }
 
-        console.log(`Connector: ${chalk.cyan(connector.connectorRef)}`);
+        console.log(`Connector: ${chalk.cyan(connector.slug)}`);
         console.log();
 
         printConnectorDetails(connector);

--- a/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
@@ -1,5 +1,5 @@
-import type { PublicConnectorCatalogItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { listZeroConnectorCatalog } from "../../../../lib/api";
+import type { ZeroConnectorCatalogItem } from "../../../../lib/api/domains/zero-connectors";
 import type { GenerationType } from "./lister";
 
 function toConnectorGenerationType(
@@ -29,18 +29,18 @@ function toConnectorGenerationType(
 }
 
 function findConnector(
-  connectors: readonly PublicConnectorCatalogItem[],
+  connectors: readonly ZeroConnectorCatalogItem[],
   provider: string,
-): PublicConnectorCatalogItem | null {
+): ZeroConnectorCatalogItem | null {
   const exact = connectors.find((connector) => {
-    return connector.connectorRef === provider;
+    return connector.slug === provider;
   });
   if (exact) return exact;
 
   const lower = provider.toLowerCase();
   return (
     connectors.find((connector) => {
-      return connector.connectorRef.toLowerCase() === lower;
+      return connector.slug.toLowerCase() === lower;
     }) ?? null
   );
 }
@@ -66,7 +66,7 @@ async function resolveConnector(
       return entry === connectorGenerationType;
     });
   return {
-    connectorSlug: connector.connectorRef,
+    connectorSlug: connector.slug,
     label: connector.label,
     supportsGenerationType: supports,
   };

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ZeroConnectorCatalogStatus } from "../../../../lib/api/domains/zero-connectors";
 import {
   getZeroBillingStatus,
   getZeroAgentUserConnectors,
@@ -319,19 +319,19 @@ function getGenerationContext(
 
 function getGenerationConnectors(
   generationType: ConnectorGenerationType,
-  connectors: readonly PublicConnectorCatalogStatusItem[],
-): PublicConnectorCatalogStatusItem[] {
+  connectors: readonly ZeroConnectorCatalogStatus[],
+): ZeroConnectorCatalogStatus[] {
   return connectors
     .filter((connector) => {
       return connector.generation.includes(generationType);
     })
     .sort((a, b) => {
-      return a.connectorRef.localeCompare(b.connectorRef);
+      return a.slug.localeCompare(b.slug);
     });
 }
 
 function formatAccount(
-  connector: PublicConnectorCatalogStatusItem,
+  connector: ZeroConnectorCatalogStatus,
 ): string | undefined {
   if (connector.connection?.externalUsername) {
     return `@${connector.connection.externalUsername}`;
@@ -381,14 +381,14 @@ function getAction(
 }
 
 function toCandidate(params: {
-  connector: PublicConnectorCatalogStatusItem;
+  connector: ZeroConnectorCatalogStatus;
   authorizedConnectorSlugs: Set<string> | null;
   agentId: string | undefined;
   platformOrigin: string;
 }): GenerationCandidate {
   const { connector, authorizedConnectorSlugs, agentId, platformOrigin } =
     params;
-  const connectorSlug = connector.connectorRef;
+  const connectorSlug = connector.slug;
 
   let status: CandidateStatus;
   let reason: string;

--- a/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
@@ -1,16 +1,21 @@
-import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { resolveFirewallMetadataPolicies } from "@vm0/connectors/firewall-metadata/policy";
+import {
+  findFirewallMetadataPermission,
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallMetadataPolicies,
+} from "@vm0/connectors/firewall-metadata/policy";
 import type {
   FirewallPolicies,
   FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import { getZeroConnectorCatalogPermissions } from "../../../lib/api";
+import type { ZeroUserPermissionGrant } from "../../../lib/api/domains/zero-agents";
+import type { ZeroConnectorCatalogPermissionDetail } from "../../../lib/api/domains/zero-connectors";
 
 export interface ConnectorPermissionInfo {
   readonly connectorSlug: string;
   readonly hasPermissions: boolean;
   readonly hasPolicyEntry: boolean;
-  readonly permissions: readonly PublicConnectorCatalogPermissionDetail["permissions"][number][];
+  readonly permissions: readonly ZeroConnectorCatalogPermissionDetail["permissions"][number][];
   readonly policies: Readonly<Record<string, FirewallPolicyValue>> | null;
   readonly unknownPolicy: FirewallPolicyValue;
   readonly allowed: number;
@@ -19,7 +24,7 @@ export interface ConnectorPermissionInfo {
 
 type PermissionMetadataBySlug = Map<
   string,
-  PublicConnectorCatalogPermissionDetail | null
+  ZeroConnectorCatalogPermissionDetail | null
 >;
 
 async function loadPermissionMetadataBySlug(
@@ -39,7 +44,7 @@ async function loadPermissionMetadataBySlug(
 
 function connectorPermissionInfo(args: {
   readonly connectorSlug: string;
-  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
+  readonly metadata: ZeroConnectorCatalogPermissionDetail | null;
   readonly resolvedPolicies: FirewallPolicies | null;
 }): ConnectorPermissionInfo {
   if (!args.metadata) {
@@ -55,7 +60,7 @@ function connectorPermissionInfo(args: {
     };
   }
 
-  const connectorPolicy = args.resolvedPolicies?.[args.metadata.connectorRef];
+  const connectorPolicy = args.resolvedPolicies?.[args.metadata.connectorSlug];
   const policies =
     connectorPolicy && Object.keys(connectorPolicy.policies).length > 0
       ? connectorPolicy.policies
@@ -96,7 +101,9 @@ export async function loadConnectorPermissionInfos(args: {
   );
   const resolvedPolicies = resolveFirewallMetadataPolicies(
     args.storedPolicies,
-    defaultPolicyMetadata,
+    defaultPolicyMetadata.map(({ connectorSlug, ...metadata }) => {
+      return { ...metadata, connectorRef: connectorSlug };
+    }),
   );
 
   return args.displayConnectorSlugs.map((connectorSlug) => {
@@ -106,4 +113,26 @@ export async function loadConnectorPermissionInfos(args: {
       resolvedPolicies,
     });
   });
+}
+
+export function connectorPermissionGrantsToFirewallPolicies(
+  grants: readonly ZeroUserPermissionGrant[],
+): FirewallPolicies | null {
+  return permissionGrantsToFirewallPolicies(
+    grants.map(({ connectorSlug, ...grant }) => {
+      return { ...grant, connectorRef: connectorSlug };
+    }),
+  );
+}
+
+export function hasConnectorFirewallMetadataPermission(
+  metadata: ZeroConnectorCatalogPermissionDetail,
+  permission: string,
+): boolean {
+  return (
+    findFirewallMetadataPermission(
+      { ...metadata, connectorRef: metadata.connectorSlug },
+      permission,
+    ) !== null
+  );
 }

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -12,10 +12,10 @@ import {
   listZeroUserPermissionGrants,
 } from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import { policyIcon } from "../../lib/utils/format-utils";
 import {
   loadConnectorPermissionInfos,
+  connectorPermissionGrantsToFirewallPolicies,
   type ConnectorPermissionInfo,
 } from "./shared/firewall-permissions";
 
@@ -125,10 +125,10 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
       if (permissionDataAvailable) {
         const permissionInfos = await loadConnectorPermissionInfos({
           displayConnectorSlugs: identities.map((connector) => {
-            return connector.type;
+            return connector.slug;
           }),
           defaultPolicyConnectorSlugs: enabledResult.value,
-          storedPolicies: permissionGrantsToFirewallPolicies(
+          storedPolicies: connectorPermissionGrantsToFirewallPolicies(
             grantsResult.value,
           ),
         });
@@ -143,10 +143,10 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
       console.log(chalk.bold("Connectors:"));
       for (const connector of identities) {
         const identity = formatConnectorIdentity(connector);
-        console.log(`  ${connector.type.padEnd(14)}${identity}`);
+        console.log(`  ${connector.slug.padEnd(14)}${identity}`);
 
         if (permissionDataAvailable) {
-          const info = permissionInfoBySlug.get(connector.type);
+          const info = permissionInfoBySlug.get(connector.slug);
           if (info) {
             printConnectorPermissions(info);
           }
@@ -165,7 +165,7 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
       console.log(chalk.bold("Connectors:"));
       for (const connector of identities) {
         const identity = formatConnectorIdentity(connector);
-        console.log(`  ${connector.type.padEnd(14)}${identity}`);
+        console.log(`  ${connector.slug.padEnd(14)}${identity}`);
       }
     }
   } catch {

--- a/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
@@ -11,9 +11,17 @@ import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { getClientConfig, handleError } from "../core/client-factory";
+
+export type ZeroUserPermissionGrant = Omit<
+  UserPermissionGrantResponse,
+  "connectorRef" | "connectorSlug"
+> & {
+  readonly connectorSlug: ConnectorSlug;
+};
 
 export async function createZeroAgent(
   body: ZeroAgentRequest,
@@ -72,11 +80,13 @@ export async function getZeroAgentInstructions(
 
 export async function getZeroAgentUserConnectors(
   id: string,
-): Promise<string[]> {
+): Promise<ConnectorSlug[]> {
   const config = await getClientConfig();
   const client = initClient(zeroUserConnectorsContract, config);
   const result = await client.get({ params: { id } });
-  if (result.status === 200) return result.body.enabledTypes;
+  if (result.status === 200) {
+    return result.body.enabledConnectorSlugs ?? result.body.enabledTypes;
+  }
   handleError(
     result,
     `Failed to get connector permissions for zero agent "${id}"`,
@@ -98,11 +108,18 @@ export async function getZeroAgentCustomConnectors(
 
 export async function listZeroUserPermissionGrants(
   agentId: string,
-): Promise<UserPermissionGrantResponse[]> {
+): Promise<ZeroUserPermissionGrant[]> {
   const config = await getClientConfig();
   const client = initClient(zeroUserPermissionGrantsContract, config);
   const result = await client.list({ query: { agentId } });
-  if (result.status === 200) return result.body;
+  if (result.status === 200) {
+    return result.body.map(({ connectorRef, connectorSlug, ...grant }) => {
+      return {
+        ...grant,
+        connectorSlug: connectorSlug ?? connectorRef,
+      };
+    });
+  }
   handleError(
     result,
     `Failed to get permission grants for zero agent "${agentId}"`,

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -12,6 +12,7 @@ import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogListResponse,
   type PublicConnectorCatalogPermissionDetail,
+  type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
@@ -25,48 +26,218 @@ import {
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type {
+  ConnectorProvidedBinding,
   ConnectorListResponse,
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import { getClientConfig, handleError } from "../core/client-factory";
 
+export type ZeroConnector = Omit<ConnectorResponse, "type" | "slug"> & {
+  readonly slug: ConnectorSlug;
+};
+
+type ZeroConnectorProvidedBinding = Omit<
+  ConnectorProvidedBinding,
+  "connectorType" | "connectorSlug"
+> & {
+  readonly connectorSlug: ConnectorSlug;
+};
+
+type ZeroConnectorListResponse = Omit<
+  ConnectorListResponse,
+  | "connectors"
+  | "configuredTypes"
+  | "configuredConnectorSlugs"
+  | "connectorProvidedBindings"
+> & {
+  readonly connectors: readonly ZeroConnector[];
+  readonly configuredConnectorSlugs: readonly ConnectorSlug[];
+  readonly connectorProvidedBindings: readonly ZeroConnectorProvidedBinding[];
+};
+
+type CanonicalCatalogItem<T extends { readonly connectorRef: ConnectorSlug }> =
+  Omit<T, "connectorRef" | "slug"> & {
+    readonly slug: ConnectorSlug;
+  };
+
+export type ZeroConnectorCatalogItem = CanonicalCatalogItem<
+  PublicConnectorCatalogListResponse["connectors"][number]
+>;
+
+export type ZeroConnectorCatalogStatus =
+  CanonicalCatalogItem<PublicConnectorCatalogStatusItem>;
+
+type ZeroConnectorCatalogListResponse = Omit<
+  PublicConnectorCatalogListResponse,
+  "connectors"
+> & {
+  readonly connectors: readonly ZeroConnectorCatalogItem[];
+};
+
+type ZeroConnectorCatalogStatusResponse = Omit<
+  PublicConnectorCatalogStatusResponse,
+  "connectors"
+> & {
+  readonly connectors: readonly ZeroConnectorCatalogStatus[];
+};
+
+export type ZeroConnectorCatalogPermissionDetail = Omit<
+  PublicConnectorCatalogPermissionDetail,
+  "connectorRef" | "connectorSlug"
+> & {
+  readonly connectorSlug: ConnectorSlug;
+};
+
+interface RawCheckIdentity {
+  readonly connectorRef: ConnectorSlug;
+  readonly connectorSlug?: ConnectorSlug;
+}
+
+type ZeroCheckIdentity<T extends RawCheckIdentity> = Omit<
+  T,
+  "connectorRef" | "connectorSlug"
+> & {
+  readonly connectorSlug: ConnectorSlug;
+};
+
+type ZeroConnectorCheckResult<T> = T extends {
+  readonly connector: infer Identity extends RawCheckIdentity;
+}
+  ? Omit<T, "connector"> & {
+      readonly connector: ZeroCheckIdentity<Identity>;
+    }
+  : T extends {
+        readonly candidates: infer Candidates extends
+          readonly RawCheckIdentity[];
+      }
+    ? Omit<T, "candidates"> & {
+        readonly candidates: {
+          readonly [Index in keyof Candidates]: ZeroCheckIdentity<
+            Candidates[Index]
+          >;
+        };
+      }
+    : T;
+
+export type ZeroConnectorCheckDiagnosticResult =
+  ZeroConnectorCheckResult<ConnectorCheckDiagnosticResult>;
+
+function normalizeConnector(connector: ConnectorResponse): ZeroConnector {
+  const { type, slug, ...rest } = connector;
+  return { ...rest, slug: slug ?? type };
+}
+
+function normalizeBinding(
+  binding: ConnectorProvidedBinding,
+): ZeroConnectorProvidedBinding {
+  const { connectorType, connectorSlug, ...rest } = binding;
+  return { ...rest, connectorSlug: connectorSlug ?? connectorType };
+}
+
+function normalizeConnectorList(
+  response: ConnectorListResponse,
+): ZeroConnectorListResponse {
+  const {
+    connectors,
+    configuredTypes,
+    configuredConnectorSlugs,
+    connectorProvidedBindings,
+    ...rest
+  } = response;
+  return {
+    ...rest,
+    connectors: connectors.map(normalizeConnector),
+    configuredConnectorSlugs: configuredConnectorSlugs ?? configuredTypes,
+    connectorProvidedBindings: connectorProvidedBindings.map(normalizeBinding),
+  };
+}
+
+function normalizeCatalogItem<
+  T extends {
+    readonly connectorRef: ConnectorSlug;
+    readonly slug?: ConnectorSlug;
+  },
+>(connector: T): CanonicalCatalogItem<T> {
+  const { connectorRef, slug, ...rest } = connector;
+  return { ...rest, slug: slug ?? connectorRef };
+}
+
+function normalizeCheckIdentity<T extends RawCheckIdentity>(
+  identity: T,
+): ZeroCheckIdentity<T> {
+  const { connectorRef, connectorSlug, ...rest } = identity;
+  return { ...rest, connectorSlug: connectorSlug ?? connectorRef };
+}
+
+function normalizeConnectorCheck(
+  result: ConnectorCheckDiagnosticResult,
+): ZeroConnectorCheckDiagnosticResult {
+  switch (result.outcome) {
+    case "resolved":
+    case "connector-mismatch":
+    case "environment-not-owned":
+    case "environment-not-used":
+    case "unresolved-dynamic-base":
+      return { ...result, connector: normalizeCheckIdentity(result.connector) };
+    case "ambiguous":
+      return {
+        ...result,
+        candidates: result.candidates.map(normalizeCheckIdentity),
+      };
+    case "unsafe-input":
+    case "unknown-connector":
+    case "unknown-environment":
+    case "no-match":
+    case "run-context-unavailable":
+      return result;
+  }
+}
+
 /**
  * List all connectors for the authenticated user (zero proxy)
  */
-export async function listZeroConnectors(): Promise<ConnectorListResponse> {
+export async function listZeroConnectors(): Promise<ZeroConnectorListResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorsMainContract, config);
 
   const result = await client.list({ headers: {} });
 
   if (result.status === 200) {
-    return result.body;
+    return normalizeConnectorList(result.body);
   }
 
   handleError(result, "Failed to list connectors");
 }
 
-export async function listZeroConnectorCatalog(): Promise<PublicConnectorCatalogListResponse> {
+export async function listZeroConnectorCatalog(): Promise<ZeroConnectorCatalogListResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorCatalogContract, config);
 
   const result = await client.list({ headers: {} });
 
   if (result.status === 200) {
-    return result.body;
+    const { connectors, ...response } = result.body;
+    return {
+      ...response,
+      connectors: connectors.map(normalizeCatalogItem),
+    };
   }
 
   handleError(result, "Failed to list connector catalog");
 }
 
-export async function listZeroConnectorCatalogStatus(): Promise<PublicConnectorCatalogStatusResponse> {
+export async function listZeroConnectorCatalogStatus(): Promise<ZeroConnectorCatalogStatusResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorCatalogContract, config);
 
   const result = await client.status({ headers: {} });
 
   if (result.status === 200) {
-    return result.body;
+    const { connectors, ...response } = result.body;
+    return {
+      ...response,
+      connectors: connectors.map(normalizeCatalogItem),
+    };
   }
 
   handleError(result, "Failed to list connector catalog status");
@@ -74,7 +245,7 @@ export async function listZeroConnectorCatalogStatus(): Promise<PublicConnectorC
 
 export async function getZeroConnectorCatalogPermissions(
   connectorSlug: string,
-): Promise<PublicConnectorCatalogPermissionDetail | null> {
+): Promise<ZeroConnectorCatalogPermissionDetail | null> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorCatalogContract, config);
 
@@ -83,12 +254,18 @@ export async function getZeroConnectorCatalogPermissions(
   });
 
   if (result.status === 200) {
-    if (result.body.permissions.connectorRef !== connectorSlug) {
+    const {
+      connectorRef,
+      connectorSlug: canonicalSlug,
+      ...permissions
+    } = result.body.permissions;
+    const normalizedConnectorSlug = canonicalSlug ?? connectorRef;
+    if (normalizedConnectorSlug !== connectorSlug) {
       throw new Error(
-        `Permission metadata connectorRef mismatch: expected ${connectorSlug}, got ${result.body.permissions.connectorRef}`,
+        `Permission metadata connector slug mismatch: expected ${connectorSlug}, got ${normalizedConnectorSlug}`,
       );
     }
-    return result.body.permissions;
+    return { ...permissions, connectorSlug: normalizedConnectorSlug };
   }
 
   if (result.status === 404) {
@@ -103,7 +280,7 @@ export async function getZeroConnectorCatalogPermissions(
 
 export async function diagnoseZeroConnectorCheck(
   request: ConnectorCheckRequest,
-): Promise<ConnectorCheckDiagnosticResult> {
+): Promise<ZeroConnectorCheckDiagnosticResult> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorCheckContract, {
     ...config,
@@ -113,7 +290,7 @@ export async function diagnoseZeroConnectorCheck(
   const result = await client.check({ body: request });
 
   if (result.status === 200) {
-    return result.body;
+    return normalizeConnectorCheck(result.body);
   }
 
   handleError(result, "Failed to diagnose connector");
@@ -125,7 +302,7 @@ export async function diagnoseZeroConnectorCheck(
  */
 export async function getZeroConnector(
   connectorSlug: ConnectorSlug,
-): Promise<ConnectorResponse | null> {
+): Promise<ZeroConnector | null> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorsBySlugContract, config);
 
@@ -134,7 +311,7 @@ export async function getZeroConnector(
   });
 
   if (result.status === 200) {
-    return result.body;
+    return normalizeConnector(result.body);
   }
 
   if (result.status === 404) {
@@ -148,7 +325,7 @@ export async function connectZeroConnectorManualGrant(
   connectorSlug: ConnectorSlug,
   authMethod: ConnectorAuthMethodId,
   values: Record<string, string>,
-): Promise<ConnectorResponse> {
+): Promise<ZeroConnector> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorManualGrantContract, config);
 
@@ -158,7 +335,7 @@ export async function connectZeroConnectorManualGrant(
   });
 
   if (result.status === 200) {
-    return result.body;
+    return normalizeConnector(result.body);
   }
 
   handleError(result, `Failed to connect connector "${connectorSlug}"`);

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -61,6 +61,7 @@ function defaultPublicCatalogStatusItem(args: {
 }): PublicConnectorCatalogStatusItem {
   return {
     connectorRef: args.connectorSlug,
+    slug: args.connectorSlug,
     label: args.label,
     description: args.description,
     icon: {
@@ -172,6 +173,7 @@ function defaultPublicCatalog(): PublicConnectorCatalogItem[] {
   return defaultPublicCatalogStatus.map((item) => {
     return {
       connectorRef: item.connectorRef,
+      slug: item.slug,
       label: item.label,
       description: item.description,
       icon: item.icon,
@@ -205,6 +207,7 @@ function connectorManualGrantResponse(
   return {
     id: "00000000-0000-4000-8000-000000000001",
     type: connectorSlug,
+    slug: connectorSlug,
     authMethod,
     externalId: null,
     externalUsername: null,
@@ -230,13 +233,23 @@ export const apiHandlers = [
   // GET /api/zero/connectors - listZeroConnectors
   http.get("http://localhost:3000/api/zero/connectors", () => {
     return HttpResponse.json(
-      { connectors: [], configuredTypes: [], connectorProvidedBindings: [] },
+      {
+        connectors: [],
+        configuredTypes: [],
+        configuredConnectorSlugs: [],
+        connectorProvidedBindings: [],
+      },
       { status: 200 },
     );
   }),
   http.get("https://www.vm0.ai/api/zero/connectors", () => {
     return HttpResponse.json(
-      { connectors: [], configuredTypes: [], connectorProvidedBindings: [] },
+      {
+        connectors: [],
+        configuredTypes: [],
+        configuredConnectorSlugs: [],
+        connectorProvidedBindings: [],
+      },
       { status: 200 },
     );
   }),


### PR DESCRIPTION
## Summary

- normalize transitional connector responses at the CLI API-domain boundary, preferring canonical slug fields with legacy-only fallbacks
- send the canonical connector-check request field and consume canonical identities across connector commands, generation guidance, `whoami`, and agent output
- replace user-facing connector ref/type placeholders, table headers, and output labels with slug terminology
- keep the existing connector-check client capability and explicit compatibility fixtures for deployment overlap

## Compatibility

- requires the deployed API expansion from #23771 or later
- keeps older installed CLI versions supported by the expanded API
- does not change API, Platform, runner, database, persisted state, test-only auth contracts, or the cleanup owned by #23821 and #23822

## Validation

- `pnpm format`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
- `pnpm -F @vm0/cli build`
- pre-commit repository-wide TypeScript checks

Closes #23777

Parent: #23814

Umbrella: #23619
