### PR TITLE
fix(db): preserve migration boundaries during reset

### DIFF
--- a/turbo/packages/db/scripts/migrate.ts
+++ b/turbo/packages/db/scripts/migrate.ts
@@ -1,62 +1,7 @@
 #!/usr/bin/env tsx
 
-import { readMigrationFiles } from "drizzle-orm/migrator";
 import postgres from "postgres";
-import { DRIZZLE_MIGRATE_OUT } from "../drizzle.config";
-
-type DbMigration = {
-  readonly id: number;
-  readonly hash: string;
-  readonly created_at: string | number | null;
-};
-
-async function migrateWithoutGlobalTransaction(
-  sql: postgres.Sql,
-): Promise<void> {
-  const migrations = readMigrationFiles({
-    migrationsFolder: DRIZZLE_MIGRATE_OUT,
-  });
-
-  await sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`;
-  await sql`
-    CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
-      id SERIAL PRIMARY KEY,
-      hash text NOT NULL,
-      created_at bigint
-    )
-  `;
-
-  const dbMigrations = await sql<DbMigration[]>`
-    SELECT id, hash, created_at
-    FROM "drizzle"."__drizzle_migrations"
-    ORDER BY created_at DESC
-    LIMIT 1
-  `;
-  const lastDbMigration = dbMigrations[0];
-
-  for (const migration of migrations) {
-    if (
-      lastDbMigration &&
-      Number(lastDbMigration.created_at) >= migration.folderMillis
-    ) {
-      continue;
-    }
-
-    await sql.begin(async (transaction) => {
-      for (const statement of migration.sql) {
-        if (statement.trim().length === 0) {
-          continue;
-        }
-        await transaction.unsafe(statement);
-      }
-
-      await transaction`
-        INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at")
-        VALUES (${migration.hash}, ${migration.folderMillis})
-      `;
-    });
-  }
-}
+import { applyPendingMigrations } from "./migration-runner";
 
 async function runMigrations() {
   if (!process.env.DATABASE_URL) {
@@ -66,7 +11,7 @@ async function runMigrations() {
   const sql = postgres(process.env.DATABASE_URL, { max: 1 });
 
   try {
-    await migrateWithoutGlobalTransaction(sql);
+    await applyPendingMigrations(sql);
     console.log("Migrations complete");
   } finally {
     await sql.end();

--- a/turbo/packages/db/scripts/migration-runner.ts
+++ b/turbo/packages/db/scripts/migration-runner.ts
@@ -1,0 +1,55 @@
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import type postgres from "postgres";
+import { DRIZZLE_MIGRATE_OUT } from "../drizzle.config";
+
+type DbMigration = {
+  readonly id: number;
+  readonly hash: string;
+  readonly created_at: string | number | null;
+};
+
+export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
+  const migrations = readMigrationFiles({
+    migrationsFolder: DRIZZLE_MIGRATE_OUT,
+  });
+
+  await sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`;
+  await sql`
+    CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at bigint
+    )
+  `;
+
+  const dbMigrations = await sql<DbMigration[]>`
+    SELECT id, hash, created_at
+    FROM "drizzle"."__drizzle_migrations"
+    ORDER BY created_at DESC
+    LIMIT 1
+  `;
+  const lastDbMigration = dbMigrations[0];
+
+  for (const migration of migrations) {
+    if (
+      lastDbMigration &&
+      Number(lastDbMigration.created_at) >= migration.folderMillis
+    ) {
+      continue;
+    }
+
+    await sql.begin(async (transaction) => {
+      for (const statement of migration.sql) {
+        if (statement.trim().length === 0) {
+          continue;
+        }
+        await transaction.unsafe(statement);
+      }
+
+      await transaction`
+        INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at")
+        VALUES (${migration.hash}, ${migration.folderMillis})
+      `;
+    });
+  }
+}

--- a/turbo/packages/db/scripts/reset-db.ts
+++ b/turbo/packages/db/scripts/reset-db.ts
@@ -1,10 +1,7 @@
 #!/usr/bin/env tsx
 
-import { drizzle } from "drizzle-orm/postgres-js";
-import { migrate } from "drizzle-orm/postgres-js/migrator";
-import { sql as rawSql } from "drizzle-orm";
 import postgres from "postgres";
-import { DRIZZLE_MIGRATE_OUT } from "../drizzle.config";
+import { applyPendingMigrations } from "./migration-runner";
 
 async function resetDatabase() {
   if (!process.env.DATABASE_URL) {
@@ -12,18 +9,15 @@ async function resetDatabase() {
   }
 
   const sql = postgres(process.env.DATABASE_URL, { max: 1 });
-  const db = drizzle(sql);
 
   try {
     console.log("Dropping all tables...");
-    await db.execute(rawSql`DROP SCHEMA public CASCADE`);
-    await db.execute(rawSql`CREATE SCHEMA public`);
-    await db.execute(rawSql`DROP SCHEMA IF EXISTS drizzle CASCADE`);
+    await sql`DROP SCHEMA public CASCADE`;
+    await sql`CREATE SCHEMA public`;
+    await sql`DROP SCHEMA IF EXISTS drizzle CASCADE`;
 
     console.log("Running migrations...");
-    await migrate(db, {
-      migrationsFolder: DRIZZLE_MIGRATE_OUT,
-    });
+    await applyPendingMigrations(sql);
 
     console.log("Database reset complete");
   } finally {

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -133,6 +133,14 @@ async function runMigrations(dbUrl: string): Promise<void> {
   });
 }
 
+async function resetDatabase(dbUrl: string): Promise<void> {
+  console.log(`♻️  Resetting database...`);
+  execCommand(`tsx ${path.join(dirname, "reset-db.ts")}`, {
+    env: { DATABASE_URL: dbUrl },
+    cwd: PACKAGE_DIR,
+  });
+}
+
 async function validateCurrentBrowserApiBeforeBillingMigration(): Promise<void> {
   console.log(
     "=== Phase 1.95: Validate current browser API before billing migration ===\n",
@@ -8934,6 +8942,12 @@ async function main(): Promise<void> {
     await runMigrations(dbUrl1);
     console.log("   ✅ Migrations applied successfully\n");
 
+    console.log("=== Phase 2.1: Validate database reset ===\n");
+    await resetDatabase(dbUrl1);
+    await resetDatabase(dbUrl1);
+    await runMigrations(dbUrl1);
+    console.log("   ✅ Consecutive database resets completed successfully\n");
+
     await validatePreviousBrowserApiAfterBillingMigration(dbUrl1);
     await validateChatEventSourcesAreAppendOnly(dbUrl1);
     await validateConnectorCatalogFinalConstraints(dbUrl1);
@@ -8978,6 +8992,7 @@ async function main(): Promise<void> {
       console.log(
         "   ✅ Custom connector OAuth mode constraints reject mismatched configuration",
       );
+      console.log("   ✅ Consecutive database resets replay all migrations");
       console.log("   ✅ Schemas are functionally equivalent");
       console.log("   ✅ All migrations match the schema definitions");
 


### PR DESCRIPTION
## Summary

- extract the existing per-migration transaction loop into one shared database migration runner
- make both `db:migrate` and `db:reset` use the shared runner
- run reset schema statements through the existing PostgreSQL connection instead of Drizzle's global-transaction migrator
- cover two consecutive resets and a subsequent migrate through the migration-consistency integration entry point

Each migration body and its journal insert remain atomic in one transaction. Committing between migration files allows `ON COMMIT DROP` objects from migration 0714 to disappear before migration 0719 removes their legacy enum.

## Scope

- no historical migration SQL or snapshot changes
- no schema declaration or persisted-data changes
- no API, runtime service, or deployment compatibility changes
- production `db:migrate` semantics are moved without intentional behavior changes

## Validation

- `pnpm -F @vm0/db db:reset` twice against the same disposable PostgreSQL database
- `pnpm -F @vm0/db db:migrate` against the reset result
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F @vm0/db test`
- `pnpm knip --workspace @vm0/db`
- `pnpm -F @vm0/db test:migration-consistency`
- pre-commit full-workspace Knip and TypeScript checks

Closes #23883
