### PR TITLE
fix(guest-agent): checkpoint user cancellations before completion

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use serde_json::{Map, Value, json};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 
 use crate::env::Framework;
 use crate::error::AgentError;
@@ -102,11 +103,13 @@ enum CodexRunEvent {
 enum AppServerRunOutcome {
     Completed(Box<Result<CliExecutionResult, AgentError>>),
     ExecutionTimedOut { timeout_secs: u64 },
+    UserCancelled,
 }
 
 async fn run_with_execution_deadline(
     run: impl Future<Output = Result<CliExecutionResult, AgentError>>,
     deadline: Option<AgentExecutionDeadline>,
+    user_cancellation: &CancellationToken,
 ) -> AppServerRunOutcome {
     tokio::pin!(run);
 
@@ -118,12 +121,19 @@ async fn run_with_execution_deadline(
             tokio::select! {
                 biased;
                 result = &mut run => AppServerRunOutcome::Completed(Box::new(result)),
+                () = user_cancellation.cancelled() => AppServerRunOutcome::UserCancelled,
                 () = &mut deadline_sleep => AppServerRunOutcome::ExecutionTimedOut {
                     timeout_secs: deadline.timeout_secs,
                 },
             }
         }
-        None => AppServerRunOutcome::Completed(Box::new(run.await)),
+        None => {
+            tokio::select! {
+                biased;
+                result = &mut run => AppServerRunOutcome::Completed(Box::new(result)),
+                () = user_cancellation.cancelled() => AppServerRunOutcome::UserCancelled,
+            }
+        }
     }
 }
 
@@ -132,6 +142,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
     active_input: ActiveInputWriter,
+    user_cancellation: CancellationToken,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting codex app-server execution...");
@@ -149,6 +160,7 @@ pub(super) async fn execute_codex_app_server_for_runtime(
         should_send_events,
         event_delivery.sender(),
         active_input,
+        user_cancellation,
         runtime,
     )
     .await;
@@ -175,6 +187,7 @@ async fn run_codex_app_server(
     should_send_events: bool,
     event_tx: &EventDeliverySender,
     mut active_input: ActiveInputWriter,
+    user_cancellation: CancellationToken,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
     let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
@@ -359,14 +372,16 @@ async fn run_codex_app_server(
             cli_termination: None,
         })
     };
-    let run_outcome = run_with_execution_deadline(run, runtime.agent_execution_deadline).await;
+    let run_outcome =
+        run_with_execution_deadline(run, runtime.agent_execution_deadline, &user_cancellation)
+            .await;
     active_input.close_terminal();
 
     let shutdown_result = match &run_outcome {
         AppServerRunOutcome::Completed(result) if result.is_ok() => client.shutdown().await,
-        AppServerRunOutcome::Completed(_) | AppServerRunOutcome::ExecutionTimedOut { .. } => {
-            client.terminate().await
-        }
+        AppServerRunOutcome::Completed(_)
+        | AppServerRunOutcome::ExecutionTimedOut { .. }
+        | AppServerRunOutcome::UserCancelled => client.terminate().await,
     };
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
     // Complete the final event-log write after the child is stopped and
@@ -414,6 +429,28 @@ async fn run_codex_app_server(
                 ))),
                 cli_termination: Some(CliTerminationDiagnostic::new(
                     CliTerminationReason::ExecutionTimeout,
+                )),
+            })
+        }
+        AppServerRunOutcome::UserCancelled => {
+            if let Err(shutdown_error) = shutdown_result {
+                let shutdown_error = masker.mask_string(&shutdown_error.to_string());
+                log_warn!(
+                    LOG_TAG,
+                    "codex app-server termination failed after user cancellation: {shutdown_error}"
+                );
+            }
+            Ok(CliExecutionResult {
+                exit_code: 1,
+                cli_observed_exit: None,
+                stderr_lines,
+                last_event_sequence: None,
+                claude_result: None,
+                post_result_cleanup_result: None,
+                failure_diagnostic: ingestor.failure_diagnostic(),
+                control_error: Some(AgentError::Execution("Run cancelled by user".to_string())),
+                cli_termination: Some(CliTerminationDiagnostic::new(
+                    CliTerminationReason::UserCancellation,
                 )),
             })
         }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -67,6 +67,7 @@ use termination::{
 use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 use tokio::time::Sleep;
+use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
@@ -646,8 +647,59 @@ pub async fn execute_cli_with_active_input_for_config_started_at(
     paths: &paths::GuestPaths,
     execution_started_at: Instant,
 ) -> Result<CliExecutionResult, AgentError> {
+    execute_cli_with_controls_for_config_started_at(
+        masker,
+        heartbeat_monitor,
+        http,
+        CliExecutionControls::new(active_input, CancellationToken::new()),
+        config,
+        paths,
+        execution_started_at,
+    )
+    .await
+}
+
+/// Run-scoped controls observed while the inner CLI is executing.
+pub struct CliExecutionControls {
+    active_input: ActiveInputWriter,
+    user_cancellation: CancellationToken,
+}
+
+impl CliExecutionControls {
+    /// Create controls for active input and explicit user cancellation.
+    #[must_use]
+    pub fn new(active_input: ActiveInputWriter, user_cancellation: CancellationToken) -> Self {
+        Self {
+            active_input,
+            user_cancellation,
+        }
+    }
+}
+
+/// Execute the CLI while observing run-scoped controls.
+pub async fn execute_cli_with_controls_for_config_started_at(
+    masker: &SecretMasker,
+    heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+    controls: CliExecutionControls,
+    config: &env::GuestConfig,
+    paths: &paths::GuestPaths,
+    execution_started_at: Instant,
+) -> Result<CliExecutionResult, AgentError> {
+    let CliExecutionControls {
+        active_input,
+        user_cancellation,
+    } = controls;
     let runtime = CliRuntimeConfig::from_config(config, paths, execution_started_at)?;
-    execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
+    execute_cli_inner(
+        masker,
+        heartbeat_monitor,
+        http,
+        active_input,
+        user_cancellation,
+        &runtime,
+    )
+    .await
 }
 
 async fn execute_cli_inner(
@@ -655,6 +707,7 @@ async fn execute_cli_inner(
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
     active_input: ActiveInputWriter,
+    user_cancellation: CancellationToken,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
     if matches!(runtime.framework, env::Framework::Codex) && runtime.use_codex_app_server_backend {
@@ -663,6 +716,7 @@ async fn execute_cli_inner(
             heartbeat_monitor,
             http,
             active_input,
+            user_cancellation,
             runtime,
         )
         .await;
@@ -883,12 +937,39 @@ async fn execute_cli_inner(
     )?;
 
     let mut heartbeat_done = false;
+    let mut user_cancellation_handled = false;
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
     let mut event_ingestor = CliEventIngestor::new(runtime);
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
+            () = user_cancellation.cancelled(), if !user_cancellation_handled && cli_status.is_none() => {
+                match try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_closed,
+                    drain_deadline.as_mut(),
+                )? {
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => {
+                        user_cancellation_handled = true;
+                        continue;
+                    }
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
+                }
+                user_cancellation_handled = true;
+                active_input_controller.close_terminal();
+                termination_runtime.begin_control_failure(
+                    TerminationReason::UserCancellation,
+                    AgentError::Execution("Run cancelled by user".to_string()),
+                    ControlTerminationLog::UserCancellation,
+                    termination_deadline.as_mut(),
+                );
+            }
             () = &mut agent_execution_deadline, if agent_execution_deadline_armed && cli_status.is_none() => {
                 match try_observe_cli_exit(
                     &mut child,

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -65,6 +65,7 @@ enum TerminationState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TerminationReason {
     ExecutionTimeout,
+    UserCancellation,
     PostResult,
     InitialPromptStdin,
     StuckTool,
@@ -79,6 +80,7 @@ impl TerminationReason {
     fn label(self) -> &'static str {
         match self {
             TerminationReason::ExecutionTimeout => "agent execution timeout",
+            TerminationReason::UserCancellation => "user cancellation",
             TerminationReason::PostResult => "post-result reap",
             TerminationReason::InitialPromptStdin => "initial-prompt stdin",
             TerminationReason::StuckTool => "stuck-tool watchdog",
@@ -225,6 +227,7 @@ impl PostResultCleanupState {
 
 pub(super) enum ControlTerminationLog {
     ExecutionTimeout { timeout_secs: u64 },
+    UserCancellation,
     ClaudeStdinWriterFailed { error: String },
     ClaudeStdinWriterTaskFailed { error: String },
     StuckTool { name: String, elapsed: u64 },
@@ -244,6 +247,9 @@ impl ControlTerminationLog {
                     LOG_TAG,
                     "Agent execution timed out after {timeout_secs}s, SIGTERM pgid={pgid}"
                 );
+            }
+            Self::UserCancellation => {
+                log_warn!(LOG_TAG, "User cancelled run, SIGTERM pgid={pgid}");
             }
             Self::ClaudeStdinWriterFailed { error } => {
                 log_warn!(
@@ -660,6 +666,7 @@ fn record_cli_termination_signal(
 fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
     match reason {
         TerminationReason::ExecutionTimeout => DiagnosticTerminationReason::ExecutionTimeout,
+        TerminationReason::UserCancellation => DiagnosticTerminationReason::UserCancellation,
         TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
         TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
         TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -2,9 +2,8 @@
 //!
 //! The runner also posts `/complete` after it observes the VM exit, but by
 //! then the run has incurred `final_telemetry`, VM teardown, stop/destroy,
-//! and host observation delays. Firing the webhook from the guest the
-//! instant `POST /checkpoints` returns closes that gap: the host transitions
-//! the run to `completed` as soon as the checkpoint row is visible, and the
+//! and host observation delays. The guest calls it after a successful
+//! checkpoint, or after a cancelled run's recovery attempt has returned. The
 //! runner's subsequent call is absorbed by the route's idempotency check.
 //!
 //! Fire-and-forget semantics: a failure is logged and swallowed because the
@@ -55,10 +54,50 @@ fn as_optional(value: &str) -> Option<&str> {
 ///
 /// Fire-and-forget. Returns `()` and never propagates errors — the runner's
 /// fallback call covers any failure here.
-/// Report a successful run using an explicitly supplied run id.
 pub async fn report_success_for_run(
     http: &HttpClient,
     run_id: &str,
+    sandbox_id: &str,
+    sandbox_reuse_result: &str,
+    last_event_sequence: Option<u32>,
+) {
+    report_for_run(
+        http,
+        run_id,
+        0,
+        sandbox_id,
+        sandbox_reuse_result,
+        last_event_sequence,
+    )
+    .await;
+}
+
+/// Report an explicit user cancellation after its recovery-checkpoint attempt.
+///
+/// Fire-and-forget. A failed request is logged and swallowed so runner
+/// completion remains the fallback.
+pub async fn report_user_cancellation_for_run(
+    http: &HttpClient,
+    run_id: &str,
+    sandbox_id: &str,
+    sandbox_reuse_result: &str,
+    last_event_sequence: Option<u32>,
+) {
+    report_for_run(
+        http,
+        run_id,
+        1,
+        sandbox_id,
+        sandbox_reuse_result,
+        last_event_sequence,
+    )
+    .await;
+}
+
+async fn report_for_run(
+    http: &HttpClient,
+    run_id: &str,
+    exit_code: i32,
     sandbox_id: &str,
     sandbox_reuse_result: &str,
     last_event_sequence: Option<u32>,
@@ -69,7 +108,7 @@ pub async fn report_success_for_run(
 
     let payload = CompletePayload {
         run_id,
-        exit_code: 0,
+        exit_code,
         last_event_sequence,
         sandbox_id: as_optional(sandbox_id),
         sandbox_reuse_result: as_optional(sandbox_reuse_result),

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -1,4 +1,4 @@
-//! Guest-agent process-control sink for active input.
+//! Guest-agent process-control sink for active input and user cancellation.
 //!
 //! The `process-control-ipc` crate owns the local wire protocol and transport
 //! framing. This module owns the guest-agent side of that channel: starting the
@@ -24,6 +24,20 @@ use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const CONTROL_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const USER_CANCELLATION_PAYLOAD_TYPE: &str = "user-cancellation";
+
+#[derive(serde::Deserialize)]
+struct ControlPayloadType {
+    #[serde(rename = "type")]
+    payload_type: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UserCancellationPayload {
+    #[serde(rename = "type")]
+    _payload_type: String,
+}
 
 /// Handle for the guest-agent process-control worker.
 ///
@@ -70,25 +84,38 @@ impl ControlHandle {
     /// Incoming control requests are dispatched to the provided
     /// [`ActiveInputController`], and its outcome is mapped back to a local
     /// process-control response.
-    pub fn spawn(shutdown: CancellationToken, active_input: ActiveInputController) -> Option<Self> {
+    pub fn spawn(
+        shutdown: CancellationToken,
+        active_input: ActiveInputController,
+        cli_cancellation: CancellationToken,
+    ) -> Option<Self> {
         let endpoint = match std::env::var(process_control_ipc::BOOTSTRAP_ENV) {
             Ok(endpoint) if !endpoint.is_empty() => endpoint,
             _ => return None,
         };
-        Self::spawn_endpoint(endpoint, shutdown, active_input)
+        Self::spawn_endpoint(endpoint, shutdown, active_input, cli_cancellation)
     }
 
     fn spawn_endpoint(
         endpoint: String,
         shutdown: CancellationToken,
         active_input: ActiveInputController,
+        cli_cancellation: CancellationToken,
     ) -> Option<Self> {
         let stream = Arc::new(Mutex::new(None));
         let worker_stream = Arc::clone(&stream);
         let worker_shutdown = shutdown.clone();
         let join = thread::Builder::new()
             .name("guest-agent-process-control".to_owned())
-            .spawn(move || run(endpoint, worker_shutdown, worker_stream, active_input))
+            .spawn(move || {
+                run(
+                    endpoint,
+                    worker_shutdown,
+                    worker_stream,
+                    active_input,
+                    cli_cancellation,
+                );
+            })
             .map_err(|error| {
                 log_warn!(LOG_TAG, "Process control task failed to start: {error}");
             })
@@ -137,8 +164,15 @@ fn run(
     shutdown: CancellationToken,
     stream_slot: Arc<Mutex<Option<UnixStream>>>,
     active_input: ActiveInputController,
+    cli_cancellation: CancellationToken,
 ) {
-    match run_inner(&endpoint, shutdown, stream_slot, active_input) {
+    match run_inner(
+        &endpoint,
+        shutdown,
+        stream_slot,
+        active_input,
+        cli_cancellation,
+    ) {
         Ok(()) => log_info!(LOG_TAG, "Process control task stopped"),
         Err(error) => log_warn!(LOG_TAG, "Process control task stopped: {error}"),
     }
@@ -149,6 +183,7 @@ fn run_inner(
     shutdown: CancellationToken,
     stream_slot: Arc<Mutex<Option<UnixStream>>>,
     active_input: ActiveInputController,
+    cli_cancellation: CancellationToken,
 ) -> io::Result<()> {
     let mut stream = process_control_ipc::connect_abstract(endpoint)?;
     let shutdown_stream = stream.try_clone()?;
@@ -163,9 +198,12 @@ fn run_inner(
     while !shutdown.is_cancelled() {
         match process_control_ipc::read_request(&mut stream) {
             Ok(request) => {
-                let outcome =
-                    active_input.handle_control_payload(&request.message_id, &request.payload);
-                let (status, diagnostic) = control_response_from_active_input(outcome);
+                let (status, diagnostic) = handle_control_payload(
+                    &request.message_id,
+                    &request.payload,
+                    &active_input,
+                    &cli_cancellation,
+                );
                 process_control_ipc::write_response(
                     &mut stream,
                     &process_control_ipc::ControlResponse {
@@ -191,6 +229,34 @@ fn run_inner(
     }
 
     Ok(())
+}
+
+fn handle_control_payload(
+    message_id: &str,
+    payload: &[u8],
+    active_input: &ActiveInputController,
+    cli_cancellation: &CancellationToken,
+) -> (process_control_ipc::ControlResponseStatus, String) {
+    if serde_json::from_slice::<ControlPayloadType>(payload)
+        .is_ok_and(|payload| payload.payload_type == USER_CANCELLATION_PAYLOAD_TYPE)
+    {
+        return match serde_json::from_slice::<UserCancellationPayload>(payload) {
+            Ok(_) => {
+                active_input.close_terminal();
+                cli_cancellation.cancel();
+                (
+                    process_control_ipc::ControlResponseStatus::Accepted,
+                    String::new(),
+                )
+            }
+            Err(error) => (
+                process_control_ipc::ControlResponseStatus::Rejected,
+                format!("user cancellation payload is invalid: {error}"),
+            ),
+        };
+    }
+
+    control_response_from_active_input(active_input.handle_control_payload(message_id, payload))
 }
 
 fn control_response_from_active_input(
@@ -250,7 +316,15 @@ mod tests {
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
+            move || {
+                run_inner(
+                    &endpoint,
+                    worker_shutdown,
+                    stream_slot,
+                    active_input,
+                    CancellationToken::new(),
+                )
+            }
         });
 
         let mut stream = accept_control_stream_and_read_hello(&listener);
@@ -276,6 +350,81 @@ mod tests {
     }
 
     #[test]
+    fn control_task_accepts_duplicate_user_cancellation_and_rejects_extra_fields() {
+        let nonce = *b"cancel-repeat-01";
+        let endpoint = process_control_ipc::endpoint_name(48, &nonce);
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let shutdown = CancellationToken::new();
+        let worker_shutdown = shutdown.clone();
+        let stream_slot = Arc::new(Mutex::new(None));
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
+        let active_input = active_runtime.controller();
+        let cli_cancellation = CancellationToken::new();
+        let worker_cli_cancellation = cli_cancellation.clone();
+        let worker = thread::spawn({
+            let endpoint = endpoint.clone();
+            move || {
+                run_inner(
+                    &endpoint,
+                    worker_shutdown,
+                    stream_slot,
+                    active_input,
+                    worker_cli_cancellation,
+                )
+            }
+        });
+
+        let mut stream = accept_control_stream_and_read_hello(&listener);
+        for message_id in ["cancel-1", "cancel-2"] {
+            process_control_ipc::write_request(
+                &mut stream,
+                &process_control_ipc::ControlRequest {
+                    message_id: message_id.to_string(),
+                    payload: br#"{"type":"user-cancellation"}"#.to_vec(),
+                },
+            )
+            .unwrap();
+            let response = process_control_ipc::read_response(&mut stream)
+                .expect("control task should send response");
+            assert_eq!(response.message_id, message_id);
+            assert_eq!(
+                response.status,
+                process_control_ipc::ControlResponseStatus::Accepted
+            );
+        }
+        assert!(cli_cancellation.is_cancelled());
+
+        process_control_ipc::write_request(
+            &mut stream,
+            &process_control_ipc::ControlRequest {
+                message_id: "cancel-invalid".to_string(),
+                payload: br#"{"type":"user-cancellation","extra":true}"#.to_vec(),
+            },
+        )
+        .unwrap();
+        let response = process_control_ipc::read_response(&mut stream)
+            .expect("control task should send response");
+        assert_eq!(response.message_id, "cancel-invalid");
+        assert_eq!(
+            response.status,
+            process_control_ipc::ControlResponseStatus::Rejected
+        );
+        assert!(
+            response
+                .diagnostic
+                .starts_with("user cancellation payload is invalid:")
+        );
+
+        shutdown.cancel();
+        drop(stream);
+        worker.join().unwrap().unwrap();
+    }
+
+    #[test]
     fn control_task_rejects_invalid_active_input_payload() {
         let nonce = *b"0123456789abcdee";
         let endpoint = process_control_ipc::endpoint_name(46, &nonce);
@@ -291,7 +440,15 @@ mod tests {
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
+            move || {
+                run_inner(
+                    &endpoint,
+                    worker_shutdown,
+                    stream_slot,
+                    active_input,
+                    CancellationToken::new(),
+                )
+            }
         });
 
         let mut stream = accept_control_stream_and_read_hello(&listener);
@@ -336,7 +493,15 @@ mod tests {
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
+            move || {
+                run_inner(
+                    &endpoint,
+                    worker_shutdown,
+                    stream_slot,
+                    active_input,
+                    CancellationToken::new(),
+                )
+            }
         });
 
         let mut stream = accept_control_stream_and_read_hello(&listener);
@@ -397,7 +562,13 @@ mod tests {
             "initial",
         );
         let active_input = active_runtime.controller();
-        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
+        let handle = ControlHandle::spawn_endpoint(
+            endpoint,
+            shutdown,
+            active_input,
+            CancellationToken::new(),
+        )
+        .unwrap();
 
         let stream = accept_control_stream_and_read_hello(&listener);
 
@@ -427,7 +598,13 @@ mod tests {
             "initial",
         );
         let active_input = active_runtime.controller();
-        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
+        let handle = ControlHandle::spawn_endpoint(
+            endpoint,
+            shutdown,
+            active_input,
+            CancellationToken::new(),
+        )
+        .unwrap();
 
         let stream = accept_control_stream_and_read_hello(&listener);
 
@@ -461,7 +638,15 @@ mod tests {
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, shutdown, worker_slot, active_input)
+            move || {
+                run_inner(
+                    &endpoint,
+                    shutdown,
+                    worker_slot,
+                    active_input,
+                    CancellationToken::new(),
+                )
+            }
         });
 
         let stream = accept_control_stream_and_read_hello(&listener);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -217,6 +217,7 @@ async fn run(runtime: GuestRuntime) -> i32 {
     let http = runtime.http.clone();
     let masker = Arc::new(masker::SecretMasker::from_config(&runtime.config));
     let shutdown = CancellationToken::new();
+    let cli_cancellation = CancellationToken::new();
     let framework_supports_active_input = framework_supports_active_input(
         runtime.config.framework,
         runtime.config.use_codex_app_server_backend,
@@ -230,7 +231,11 @@ async fn run(runtime: GuestRuntime) -> i32 {
         framework_supports_active_input && has_process_control_endpoint,
         &runtime.config.prompt,
     );
-    let control_handle = control::ControlHandle::spawn(shutdown.clone(), active_input.controller());
+    let control_handle = control::ControlHandle::spawn(
+        shutdown.clone(),
+        active_input.controller(),
+        cli_cancellation.clone(),
+    );
     log_info!(
         LOG_TAG,
         "Working directory: {}",
@@ -278,6 +283,7 @@ async fn run(runtime: GuestRuntime) -> i32 {
         Some(heartbeat_status_rx),
         &telemetry,
         active_input.into_writer(),
+        cli_cancellation,
         &runtime,
     )
     .await;
@@ -318,6 +324,7 @@ async fn execute(
     heartbeat_monitor: cli::HeartbeatMonitor,
     telemetry: &Telemetry,
     active_input: guest_agent::active_input::ActiveInputWriter,
+    cli_cancellation: CancellationToken,
     runtime: &GuestRuntime,
 ) -> i32 {
     let config = &runtime.config;
@@ -394,11 +401,11 @@ async fn execute(
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
         cli_execution_succeeded,
-    ) = match cli::execute_cli_with_active_input_for_config_started_at(
+    ) = match cli::execute_cli_with_controls_for_config_started_at(
         masker,
         heartbeat_monitor,
         http.clone(),
-        active_input,
+        cli::CliExecutionControls::new(active_input, cli_cancellation),
         config,
         runtime_paths,
         start,
@@ -743,6 +750,22 @@ async fn complete_execution(
         }
 
         log_info!(LOG_TAG, "▷ Cleanup");
+    }
+
+    if state
+        .failure_diagnostic
+        .as_ref()
+        .and_then(|diagnostic| diagnostic.cli_termination.as_ref())
+        .is_some_and(|termination| termination.reason == CliTerminationReason::UserCancellation)
+    {
+        complete::report_user_cancellation_for_run(
+            http,
+            &config.run_id,
+            &config.sandbox_id,
+            &config.sandbox_reuse_result,
+            state.last_event_sequence,
+        )
+        .await;
     }
 
     exit_code

--- a/crates/guest-agent/tests/codex_app_server_backend_user_cancellation.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_user_cancellation.rs
@@ -1,0 +1,69 @@
+//! Explicit user cancellation must terminate a hung Codex app-server request.
+
+mod common;
+
+use std::time::Duration;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::CliTerminationReason;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn codex_app_server_user_cancellation_interrupts_hung_turn_start()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-user-cancellation-test",
+                prompt: "drive the app-server user cancellation path",
+                scenario: Some("hang-on-turn-start"),
+                resume_session_id: None,
+            },
+        )?;
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = SecretMasker::from_raw("");
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_with_cancellation_for_runtime(
+            &runtime,
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            cancellation,
+        ),
+    )
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "user cancellation did not interrupt the app-server request",
+        )
+    })??;
+
+    assert_eq!(result.exit_code, 1);
+    let error = result
+        .control_error
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("user cancellation omitted its controlled error"))?;
+    assert!(
+        error.to_string().contains("Run cancelled by user"),
+        "unexpected cancellation error: {error}"
+    );
+    let cli_termination = result.cli_termination.ok_or_else(|| {
+        std::io::Error::other("user cancellation omitted its termination diagnostic")
+    })?;
+    assert_eq!(
+        cli_termination.reason,
+        CliTerminationReason::UserCancellation
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -963,6 +963,29 @@ pub async fn execute_cli_with_active_input_for_runtime(
     .await
 }
 
+pub async fn execute_cli_with_cancellation_for_runtime(
+    runtime: &guest_agent::run_context::GuestRuntime,
+    masker: &guest_agent::masker::SecretMasker,
+    heartbeat: guest_agent::cli::HeartbeatMonitor,
+    cancellation: tokio_util::sync::CancellationToken,
+) -> Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError> {
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
+    guest_agent::cli::execute_cli_with_controls_for_config_started_at(
+        masker,
+        heartbeat,
+        runtime.http.clone(),
+        guest_agent::cli::CliExecutionControls::new(active_input.into_writer(), cancellation),
+        &runtime.config,
+        &runtime.paths,
+        Instant::now(),
+    )
+    .await
+}
+
 pub struct VirtualTimeCheckpoint<'a> {
     pub file: &'a str,
     pub needle: &'a str,

--- a/crates/guest-agent/tests/integration/complete.rs
+++ b/crates/guest-agent/tests/integration/complete.rs
@@ -1,6 +1,7 @@
 use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
+use std::time::Duration;
 
 const TEST_RUN_ID: &str = "test-run-001";
 const TEST_SANDBOX_ID: &str = "00000000-0000-4000-8000-000000000abc";
@@ -123,6 +124,43 @@ async fn complete_report_success_swallows_4xx_auth_error() {
         None,
     )
     .await;
+
+    mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn complete_report_user_cancellation_posts_nonzero_and_swallows_server_error() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .json_body(json!({
+                "runId": TEST_RUN_ID,
+                "exitCode": 1,
+                "lastEventSequence": 9,
+                "sandboxId": TEST_SANDBOX_ID,
+                "sandboxReuseResult": TEST_SANDBOX_REUSE_RESULT,
+            }));
+        then.status(500);
+    });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        guest_agent::complete::report_user_cancellation_for_run(
+            &http_client!(),
+            TEST_RUN_ID,
+            TEST_SANDBOX_ID,
+            TEST_SANDBOX_REUSE_RESULT,
+            Some(9),
+        ),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "failed cancellation completion must not hang guest shutdown"
+    );
 
     mock.assert_calls_async(1).await;
 }

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -1,0 +1,299 @@
+//! Explicit user cancellation must stop the inner CLI while leaving
+//! guest-agent alive long enough to finish recovery and report completion.
+
+mod common;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use guest_contracts::diagnostics::{CliTerminationReason, FailureDiagnostic};
+use httpmock::prelude::*;
+use process_control_ipc::{
+    ControlRequest, ControlResponseStatus, accept_with_timeout, bind_abstract_listener,
+    endpoint_name, read_hello, read_response, write_request,
+};
+use serde_json::json;
+use tokio::process::Command;
+
+const SUCCESS_RUN_ID: &str = "user-cancellation-recovery-success";
+const SUCCESS_THREAD_ID: &str = "019fac13-2355-74d3-8414-b467fbb80c61";
+const FAILURE_RUN_ID: &str = "user-cancellation-recovery-failure";
+const FAILURE_THREAD_ID: &str = "019fac13-2355-74d3-8414-b467fbb80c62";
+
+struct Scenario {
+    run_id: &'static str,
+    thread_id: &'static str,
+    endpoint_nonce: &'static [u8; 16],
+    checkpoint_status: u16,
+    recovery_log: &'static str,
+}
+
+#[tokio::test]
+async fn user_cancellation_checkpoints_before_reporting_completion()
+-> Result<(), Box<dyn std::error::Error>> {
+    run_scenario(Scenario {
+        run_id: SUCCESS_RUN_ID,
+        thread_id: SUCCESS_THREAD_ID,
+        endpoint_nonce: b"cancel-success01",
+        checkpoint_status: 200,
+        recovery_log: "Recovery checkpoint created",
+    })
+    .await
+}
+
+#[tokio::test]
+async fn user_cancellation_reports_completion_after_recovery_failure()
+-> Result<(), Box<dyn std::error::Error>> {
+    run_scenario(Scenario {
+        run_id: FAILURE_RUN_ID,
+        thread_id: FAILURE_THREAD_ID,
+        endpoint_nonce: b"cancel-failure01",
+        checkpoint_status: 400,
+        recovery_log: "Recovery checkpoint skipped:",
+    })
+    .await
+}
+
+async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Error>> {
+    common::ensure_canonical_workspace_for_test()?;
+    let server = MockServer::start();
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path().join("home");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let history = format!(
+        "{{\"type\":\"thread.started\",\"thread_id\":\"{}\"}}\n\
+         {{\"type\":\"turn.started\"}}\n",
+        scenario.thread_id
+    );
+    let child_pid_file = tmp.path().join("codex.pid");
+    let mock_codex =
+        write_stalled_codex(tmp.path(), scenario.thread_id, &history, &child_pid_file)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "keep working until the user cancels".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+
+    let _heartbeat = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/heartbeat")
+            .json_body_includes(format!(r#"{{"runId":"{}"}}"#, scenario.run_id));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _telemetry = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(format!(r#"{{"runId":"{}"}}"#, scenario.run_id));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/user-cancellation-history"),
+                "existing": false
+            }));
+    });
+    let upload = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/user-cancellation-history")
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionId":"{}"}}"#,
+                scenario.thread_id
+            ));
+        then.status(scenario.checkpoint_status)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "user-cancellation-recovery-checkpoint"}));
+    });
+    let complete = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .header("Authorization", "Bearer test-token")
+            .json_body_includes(format!(r#"{{"runId":"{}","exitCode":1}}"#, scenario.run_id));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"success": true, "status": "failed"}));
+    });
+
+    let endpoint = endpoint_name(std::process::id(), scenario.endpoint_nonce);
+    let listener = bind_abstract_listener(&endpoint)?;
+    let control_paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir.clone());
+    let session_id_file = PathBuf::from(control_paths.session_id_file());
+    let control_pid_file = child_pid_file.clone();
+    let control = tokio::task::spawn_blocking(move || {
+        let mut stream = accept_with_timeout(&listener, Duration::from_secs(5))?;
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        read_hello(&mut stream)?;
+        wait_for_file(&control_pid_file, Duration::from_secs(5))?;
+        wait_for_file(&session_id_file, Duration::from_secs(5))?;
+        write_request(
+            &mut stream,
+            &ControlRequest {
+                message_id: "cancel-running-cli".to_string(),
+                payload: br#"{"type":"user-cancellation"}"#.to_vec(),
+            },
+        )?;
+        read_response(&mut stream)
+    });
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(20),
+        Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+            .env_clear()
+            .env(
+                "PATH",
+                std::env::var("PATH")
+                    .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string()),
+            )
+            .env("SHELL", "/bin/sh")
+            .env("HOME", &home)
+            .env(guest_contracts::env::API_URL_ENV, server.base_url())
+            .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+            .env(guest_contracts::env::RUN_ID_ENV, scenario.run_id)
+            .env(
+                guest_contracts::env::SANDBOX_ID_ENV,
+                "00000000-0000-4000-8000-000000000abc",
+            )
+            .env(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused")
+            .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
+            .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
+            .env(guest_contracts::env::MOCK_CODEX_PATH_ENV, &mock_codex)
+            .env(
+                guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                "1",
+            )
+            .env(
+                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                "1",
+            )
+            .env(
+                guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+                &run_payload_file,
+            )
+            .env(
+                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            )
+            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint)
+            .output(),
+    )
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "guest-agent did not finish within its finalization budget",
+        )
+    })??;
+    let response = control.await??;
+
+    assert_eq!(response.message_id, "cancel-running-cli");
+    assert_eq!(response.status, ControlResponseStatus::Accepted);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "guest-agent output:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    prepare.assert_calls_async(1).await;
+    upload.assert_calls_async(1).await;
+    checkpoint.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let recovery_index = stderr
+        .find(scenario.recovery_log)
+        .ok_or_else(|| std::io::Error::other(format!("missing recovery log:\n{stderr}")))?;
+    let complete_index = stderr
+        .find("Complete webhook acknowledged")
+        .ok_or_else(|| std::io::Error::other(format!("missing completion log:\n{stderr}")))?;
+    assert!(
+        recovery_index < complete_index,
+        "recovery must finish before /complete:\n{stderr}"
+    );
+
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
+    let diagnostic: FailureDiagnostic =
+        serde_json::from_slice(&std::fs::read(paths.failure_diagnostic_file())?)?;
+    let cli_termination = diagnostic
+        .cli_termination
+        .ok_or_else(|| std::io::Error::other("cancellation diagnostic omitted CLI termination"))?;
+    assert_eq!(
+        cli_termination.reason,
+        CliTerminationReason::UserCancellation
+    );
+    assert_eq!(
+        std::fs::read_to_string(paths.session_id_file())?.trim(),
+        scenario.thread_id
+    );
+    let child_pid = std::fs::read_to_string(child_pid_file)?;
+    assert!(
+        !Path::new(&format!("/proc/{}", child_pid.trim())).exists(),
+        "cancelled Codex process should be gone before guest-agent exits"
+    );
+
+    Ok(())
+}
+
+fn wait_for_file(path: &Path, timeout: Duration) -> std::io::Result<()> {
+    let deadline = Instant::now() + timeout;
+    while !path.exists() {
+        if Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("timed out waiting for {}", path.display()),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+fn write_stalled_codex(
+    root: &Path,
+    thread_id: &str,
+    history: &str,
+    child_pid_file: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = root.join("stalled-codex");
+    let script = format!(
+        "#!/bin/sh\n\
+         set -eu\n\
+         history_dir=\"$HOME/.codex/sessions/2026/07/30\"\n\
+         mkdir -p \"$history_dir\"\n\
+         printf '%s' '{}' > \"$history_dir/{thread_id}.jsonl\"\n\
+         printf '%s\\n' '{{\"type\":\"thread.started\",\"thread_id\":\"{thread_id}\"}}'\n\
+         printf '%s\\n' '{{\"type\":\"turn.started\"}}'\n\
+         printf '%s\\n' \"$$\" > '{}'\n\
+         while :; do sleep 1; done\n",
+        history.replace('\'', "'\\''"),
+        child_pid_file.display(),
+    );
+    std::fs::write(&path, script)?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -5,6 +5,7 @@ mod common;
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use guest_contracts::diagnostics::{CliTerminationReason, FailureDiagnostic};
@@ -77,6 +78,7 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             ..guest_contracts::env::RunPayload::default()
         },
     )?;
+    let request_order = Arc::new(Mutex::new(Vec::new()));
 
     let _heartbeat = server.mock(|when, then| {
         when.method(POST)
@@ -116,25 +118,43 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
             .body(history.as_str());
         then.status(200);
     });
-    let checkpoint = server.mock(|when, then| {
+    let checkpoint_order = Arc::clone(&request_order);
+    let checkpoint = server.mock(move |when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints")
             .json_body_includes(format!(
                 r#"{{"cliAgentSessionId":"{}"}}"#,
                 scenario.thread_id
             ));
-        then.status(scenario.checkpoint_status)
-            .header("Content-Type", "application/json")
-            .json_body(json!({"checkpointId": "user-cancellation-recovery-checkpoint"}));
+        then.respond_with(move |_| {
+            checkpoint_order
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push("checkpoint");
+            HttpMockResponse::builder()
+                .status(scenario.checkpoint_status)
+                .header("Content-Type", "application/json")
+                .body(r#"{"checkpointId":"user-cancellation-recovery-checkpoint"}"#)
+                .build()
+        });
     });
-    let complete = server.mock(|when, then| {
+    let complete_order = Arc::clone(&request_order);
+    let complete = server.mock(move |when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
             .header("Authorization", "Bearer test-token")
             .json_body_includes(format!(r#"{{"runId":"{}","exitCode":1}}"#, scenario.run_id));
-        then.status(200)
-            .header("Content-Type", "application/json")
-            .json_body(json!({"success": true, "status": "failed"}));
+        then.respond_with(move |_| {
+            complete_order
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push("complete");
+            HttpMockResponse::builder()
+                .status(200)
+                .header("Content-Type", "application/json")
+                .body(r#"{"success":true,"status":"failed"}"#)
+                .build()
+        });
     });
 
     let endpoint = endpoint_name(std::process::id(), scenario.endpoint_nonce);
@@ -221,6 +241,14 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
     upload.assert_calls_async(1).await;
     checkpoint.assert_calls_async(1).await;
     complete.assert_calls_async(1).await;
+    assert_eq!(
+        request_order
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .as_slice(),
+        ["checkpoint", "complete"],
+        "recovery checkpoint request must arrive before /complete"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let recovery_index = stderr

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -328,6 +328,8 @@ impl CliTerminationInitiator {
 pub enum CliTerminationReason {
     /// The runner-owned agent execution budget elapsed.
     ExecutionTimeout,
+    /// The user explicitly cancelled the active run.
+    UserCancellation,
     /// The guest agent reaped the process after receiving a final result.
     PostResultReap,
     /// The stuck-tool watchdog terminated the process.
@@ -352,6 +354,7 @@ impl CliTerminationReason {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::ExecutionTimeout => "execution_timeout",
+            Self::UserCancellation => "user_cancellation",
             Self::PostResultReap => "post_result_reap",
             Self::StuckToolWatchdog => "stuck_tool_watchdog",
             Self::CodexResumeStartupTimeout => "codex_resume_startup_timeout",
@@ -731,6 +734,21 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_value::<CliTerminationReason>(serde_json::json!("execution_timeout"))
+                .unwrap(),
+            reason
+        );
+    }
+
+    #[test]
+    fn user_cancellation_reason_has_stable_serialization() {
+        let reason = CliTerminationReason::UserCancellation;
+        assert_eq!(reason.as_str(), "user_cancellation");
+        assert_eq!(
+            serde_json::to_value(reason).unwrap(),
+            serde_json::json!("user_cancellation")
+        );
+        assert_eq!(
+            serde_json::from_value::<CliTerminationReason>(serde_json::json!("user_cancellation"))
                 .unwrap(),
             reason
         );


### PR DESCRIPTION
## Summary

- accept a strict, idempotent `user-cancellation` process-control message in guest-agent
- terminate normal CLI and Codex app-server executions with a dedicated diagnostic reason
- attempt the existing recovery checkpoint before guest-agent reports failed completion
- cover successful and failed recovery ordering with process-level integration tests

## Implementation notes

- User cancellation uses a dedicated run-scoped token, separate from guest background shutdown.
- The normal CLI reuses the existing bounded SIGTERM/SIGKILL/reap state machine.
- The Codex app-server backend terminates its client and returns the same structured cancellation diagnostic.
- Cancellation completion is derived from `FailureDiagnostic.cli_termination`, avoiding a second boolean state.
- Existing normal-CLI `select!` fairness is preserved; the cancellation branch observes an already-exited child before initiating termination.

## Exclusions

- This PR does not add the runner-side cancellation sender or change runner capabilities.
- It does not change API routes, database schemas, persisted data, or non-cancellation failure completion behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-contracts --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent -p guest-contracts --all-features --no-deps`
- `cargo test -p guest-contracts --all-targets --all-features`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo check -p runner --all-targets --all-features`

Closes #23868

Parent context: #23867
