### PR TITLE
refactor(observability): migrate connector diagnostics to slug

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -127,7 +127,7 @@ def record_allow_context(
         return
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         return
-    if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:
+    if metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG in flow.metadata:
         return
 
     vm_info = classification.vm_info
@@ -429,7 +429,7 @@ def _candidate_from_flow(
     flow: http.HTTPFlow,
 ) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
     meta = flow.metadata
-    connector_slug = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE)
+    connector_slug = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG)
     reason = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_REASON)
     base = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_BASE)
     if not (
@@ -562,7 +562,7 @@ def _set_failure_metadata(
     flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = ""
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
     flow.metadata[metadata_keys.FIREWALL_ERROR] = "connector_not_configured_for_run"
-    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] = candidate.connector_slug
+    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] = candidate.connector_slug
     flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] = candidate.reason
     flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] = list(candidate.env_names)
     flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] = candidate.base

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -83,8 +83,8 @@ Firewall and auth context
 - ``FIREWALL_ERROR``: optional ``str`` error code for auth, forwarding, or
   registry failures. It is orthogonal to ``FIREWALL_ACTION``: an ``ALLOW``
   decision can still have an auth or forwarding error.
-- ``CONNECTOR_DIAGNOSTIC_TYPE``: optional ``str`` connector slug stored under
-  the legacy type key for a generic connector availability diagnostic. HTTP
+- ``CONNECTOR_DIAGNOSTIC_SLUG``: optional ``str`` connector slug stored under
+  the canonical slug key for a generic connector availability diagnostic. HTTP
   request classification records this for an inactive built-in connector
   candidate from the request-header stream path or the request hook; network
   logs expose it only after the response/error hook turns the candidate into an
@@ -205,8 +205,7 @@ FIREWALL_PARAMS: Final = "firewall_params"
 FIREWALL_BILLABLE: Final = "firewall_billable"
 FIREWALL_ACTION: Final = "firewall_action"
 FIREWALL_ERROR: Final = "firewall_error"
-# TODO(#23619): Rename only with the flow-metadata and network-log schemas.
-CONNECTOR_DIAGNOSTIC_TYPE: Final = "connector_diagnostic_type"
+CONNECTOR_DIAGNOSTIC_SLUG: Final = "connector_diagnostic_slug"
 CONNECTOR_DIAGNOSTIC_REASON: Final = "connector_diagnostic_reason"
 CONNECTOR_DIAGNOSTIC_ENV_NAMES: Final = "connector_diagnostic_env_names"
 CONNECTOR_DIAGNOSTIC_BASE: Final = "connector_diagnostic_base"

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -175,6 +175,10 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Copy firewall and auth metadata from flow into a log entry."""
     # [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     meta = flow.metadata
+    connector_diagnostic_slug = _metadata_optional_str(
+        meta,
+        metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG,
+    )
     log_entry["firewall_base"] = flow_metadata.firewall_base(meta)
     log_entry["firewall_name"] = flow_metadata.firewall_name(meta)
     log_entry["firewall_permission"] = flow_metadata.firewall_permission(meta)
@@ -185,8 +189,13 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     for log_key, value in (
         ("firewall_params", _metadata_str_record(meta, metadata_keys.FIREWALL_PARAMS)),
         (
+            "connector_diagnostic_slug",
+            connector_diagnostic_slug,
+        ),
+        (
+            # TODO(#23838): Remove this legacy projection after the rollout gate.
             "connector_diagnostic_type",
-            _metadata_optional_str(meta, metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE),
+            connector_diagnostic_slug,
         ),
         (
             "connector_diagnostic_reason",

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/allowed.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/allowed.base.py.txt
@@ -48,7 +48,7 @@ flow.metadata.update(dict.fromkeys(dict({metadata_keys.VM_RUN_ID: "run-1"}), "ru
 flow.metadata.update(dict.fromkeys(dict({metadata_keys.FIREWALL_ACTION: "ALLOW"}).keys(), "ALLOW"))
 flow.metadata.update(dict.fromkeys(tuple(dict({metadata_keys.FIREWALL_BILLABLE: True})), False))
 flow.metadata.update(set([(metadata_keys.FIREWALL_PERMISSION, "read")]))
-flow.metadata.update(frozenset([(metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE, "github")]))
+flow.metadata.update(frozenset([(metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG, "github")]))
 flow.metadata.update(sorted([(metadata_keys.CONNECTOR_DIAGNOSTIC_REASON, "missing")]))
 flow.metadata.update(reversed([(metadata_keys.CONNECTOR_DIAGNOSTIC_BASE, "https://api.example.com")]))
 flow.metadata.update({metadata_keys.VM_RUN_ID: "run-1"}.copy())

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
@@ -185,7 +185,7 @@ def later_with_item_failure_is_suppressible(flow, outer_manager):
     metadata = flow.metadata
     with outer_manager, manager_factory():
         metadata = {}
-    return metadata["connector_diagnostic_type"]
+    return metadata["connector_diagnostic_slug"]
 
 
 def truth_test_failure_under_with(flow, manager, condition):
@@ -465,7 +465,7 @@ def local_annotation_is_deferred(flow, manager):
     with manager:
         value: operation() = None
         metadata = {}
-    return metadata["connector_diagnostic_type"]
+    return metadata["connector_diagnostic_slug"]
 
 
 def nested_definition_annotation_is_deferred(flow, manager):

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
@@ -16,7 +16,7 @@ implicit_exception_flow.py:154: use metadata_keys.REQUEST_STREAM_COMPLETE for fl
 implicit_exception_flow.py:163: use metadata_keys.REQUEST_STREAM_BUFFER for flow.metadata access
 implicit_exception_flow.py:172: use metadata_keys.RESPONSE_STREAM_STATE for flow.metadata access
 implicit_exception_flow.py:181: use metadata_keys.STREAM_BUFFER_STATE for flow.metadata access
-implicit_exception_flow.py:188: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+implicit_exception_flow.py:188: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 implicit_exception_flow.py:197: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 implicit_exception_flow.py:222: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access
 implicit_exception_flow.py:231: use metadata_keys.TRUSTED_AUTHORITY_HOST for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.base.py.txt
@@ -30,7 +30,7 @@ flow.metadata.update({"firewall_params": {}}.items())
 flow.metadata.update({("firewall_billable", True)})
 flow.metadata.update(tuple([("trusted_authority_host", "api.example.com")]))
 flow.metadata.update(set([("firewall_permission", "read")]))
-flow.metadata.update(frozenset([("connector_diagnostic_type", "github")]))
+flow.metadata.update(frozenset([("connector_diagnostic_slug", "github")]))
 flow.metadata.update(sorted([("connector_diagnostic_reason", "missing")]))
 flow.metadata.update(reversed([("connector_diagnostic_base", "https://api.example.com")]))
 flow.metadata = {**({"vm_run_id": "run-1"} if condition else {})}
@@ -176,7 +176,7 @@ copy_meta["vm_run_id"] = "run-1"
 "firewall_name" in (flow.metadata if condition else {})
 (merged_named_expr_meta := flow.metadata | {"firewall_name": "github"})
 (inline_conditional_meta := flow.metadata if condition else {})["vm_run_id"] = "run-1"
-(inline_meta := flow.metadata)["connector_diagnostic_type"] = "github"
+(inline_meta := flow.metadata)["connector_diagnostic_slug"] = "github"
 (call_meta := flow.metadata).get("connector_diagnostic_reason")
 def function_default_meta(default_meta=flow.metadata):
     default_meta["vm_run_id"] = "run-1"

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py310.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py310.txt
@@ -33,7 +33,7 @@ violations.py:29: use metadata_keys.FIREWALL_PARAMS for flow.metadata access
 violations.py:30: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access
 violations.py:31: use metadata_keys.TRUSTED_AUTHORITY_HOST for flow.metadata access
 violations.py:32: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
-violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:34: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:35: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access
 violations.py:36: use metadata_keys.VM_RUN_ID for flow.metadata access
@@ -138,7 +138,7 @@ violations.py:175: use metadata_keys.FIREWALL_ACTION for flow.metadata access
 violations.py:176: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:177: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:178: use metadata_keys.VM_RUN_ID for flow.metadata access
-violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:180: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:182: use metadata_keys.VM_RUN_ID for flow.metadata access
 violations.py:183: use metadata_keys.VM_NETWORK_LOG_PATH for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py311.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py311.txt
@@ -33,7 +33,7 @@ violations.py:29: use metadata_keys.FIREWALL_PARAMS for flow.metadata access
 violations.py:30: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access
 violations.py:31: use metadata_keys.TRUSTED_AUTHORITY_HOST for flow.metadata access
 violations.py:32: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
-violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:34: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:35: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access
 violations.py:36: use metadata_keys.VM_RUN_ID for flow.metadata access
@@ -138,7 +138,7 @@ violations.py:175: use metadata_keys.FIREWALL_ACTION for flow.metadata access
 violations.py:176: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:177: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:178: use metadata_keys.VM_RUN_ID for flow.metadata access
-violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:180: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:182: use metadata_keys.VM_RUN_ID for flow.metadata access
 violations.py:183: use metadata_keys.VM_NETWORK_LOG_PATH for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py312.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/violations.expected.py312.txt
@@ -33,7 +33,7 @@ violations.py:29: use metadata_keys.FIREWALL_PARAMS for flow.metadata access
 violations.py:30: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access
 violations.py:31: use metadata_keys.TRUSTED_AUTHORITY_HOST for flow.metadata access
 violations.py:32: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
-violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:33: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:34: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:35: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access
 violations.py:36: use metadata_keys.VM_RUN_ID for flow.metadata access
@@ -138,7 +138,7 @@ violations.py:175: use metadata_keys.FIREWALL_ACTION for flow.metadata access
 violations.py:176: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:177: use metadata_keys.FIREWALL_NAME for flow.metadata access
 violations.py:178: use metadata_keys.VM_RUN_ID for flow.metadata access
-violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE for flow.metadata access
+violations.py:179: use metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG for flow.metadata access
 violations.py:180: use metadata_keys.CONNECTOR_DIAGNOSTIC_REASON for flow.metadata access
 violations.py:182: use metadata_keys.VM_RUN_ID for flow.metadata access
 violations.py:183: use metadata_keys.VM_NETWORK_LOG_PATH for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -413,7 +413,7 @@ async def test_unavailable_flow_stays_unavailable_after_cache_recovers(
 
     assert unavailable_flow.response.status_code == 401
     assert unavailable_flow.response.content == b"upstream auth error"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in unavailable_flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in unavailable_flow.metadata
     assert _response_connector(recovered_flow) == "recovered"
 
 
@@ -473,4 +473,4 @@ async def test_untrusted_or_invalid_cache_has_no_generated_diagnostic_fallback(
 
     assert flow.response.status_code == 401
     assert flow.response.content == b"upstream auth error"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -136,6 +136,7 @@ class TestErrorHandler:
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_slug"] == "fal"
         assert entry["connector_diagnostic_type"] == "fal"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert entry["connector_diagnostic_base"] == "https://fal.run"
@@ -175,6 +176,7 @@ class TestErrorHandler:
         assert entry["request_size"] == len(request_chunk)
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_slug"] == "fal"
         assert entry["connector_diagnostic_type"] == "fal"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
@@ -217,6 +219,7 @@ class TestErrorHandler:
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_slug"] == "fal"
         assert entry["connector_diagnostic_type"] == "fal"
 
         [proxy_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -406,7 +406,7 @@ class TestAddFirewallMetadata:
         flow = real_flow(with_response=False)
         flow.metadata.update(
             {
-                metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE: "fal",
+                metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG: "fal",
                 metadata_keys.CONNECTOR_DIAGNOSTIC_REASON: "not_configured_for_run",
                 metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES: ["FAL_TOKEN"],
                 metadata_keys.CONNECTOR_DIAGNOSTIC_BASE: "https://fal.run",
@@ -422,6 +422,7 @@ class TestAddFirewallMetadata:
             "firewall_permission": "",
             "firewall_rule_match": "",
             "firewall_billable": False,
+            "connector_diagnostic_slug": "fal",
             "connector_diagnostic_type": "fal",
             "connector_diagnostic_reason": "not_configured_for_run",
             "connector_diagnostic_env_names": ["FAL_TOKEN"],
@@ -500,7 +501,7 @@ class TestAddFirewallMetadata:
                 metadata_keys.AUTH_REFRESHED_SECRETS: [1],
                 metadata_keys.AUTH_CACHE_HIT: "false",
                 metadata_keys.AUTH_URL_REWRITE: 1,
-                metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE: 1,
+                metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG: 1,
                 metadata_keys.CONNECTOR_DIAGNOSTIC_REASON: None,
                 metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES: ["FAL_TOKEN", None],
                 metadata_keys.CONNECTOR_DIAGNOSTIC_BASE: False,

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -43,7 +43,7 @@ def _assert_fal_local_connector_diagnostic(flow):
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "fal"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured_for_run"
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] == "fal"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
     assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] == "not_configured_for_run"
     assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] == ["FAL_TOKEN"]
     assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] == "https://fal.run"
@@ -154,7 +154,7 @@ def _assert_shared_base_inactive_diagnostic(flow):
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "inactive-shared"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured_for_run"
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] == "inactive-shared"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "inactive-shared"
 
 
 async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_auth(
@@ -258,7 +258,7 @@ async def test_shared_base_active_connector_intent_keeps_active_auth_path(
     assert "X-VM0-Connector-Intent" not in flow.request.headers
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "active-shared"
     assert metadata_keys.FIREWALL_ERROR not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 @pytest.mark.parametrize(
@@ -314,7 +314,7 @@ async def test_shared_base_unknown_endpoint_with_configured_auth_keeps_active_au
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert "X-VM0-Connector-Intent" not in flow.request.headers
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
@@ -344,7 +344,7 @@ async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert "X-VM0-Connector-Intent" not in flow.request.headers
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
@@ -374,7 +374,7 @@ async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "active-shared"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "active-read"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
@@ -441,6 +441,7 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
     assert entry["action"] == "ALLOW"
     assert entry["status"] == 424
     assert entry["firewall_error"] == "connector_not_configured_for_run"
+    assert entry["connector_diagnostic_slug"] == "fal"
     assert entry["connector_diagnostic_type"] == "fal"
     [proxy_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
     assert proxy_entry["type"] == "connector_diagnostic"
@@ -505,7 +506,7 @@ async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 @pytest.mark.parametrize(
@@ -568,7 +569,7 @@ async def test_inactive_connector_url_with_configured_auth_allows_upstream(
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_streamed_inactive_builtin_connector_request_waits_for_response_fallback(
@@ -597,7 +598,7 @@ async def test_streamed_inactive_builtin_connector_request_waits_for_response_fa
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert metadata_keys.FIREWALL_ERROR not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
     assert request_streaming.streamed_request_size(flow) == len(b"partial request")
     assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
 
@@ -628,7 +629,7 @@ async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidat
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_asterisk_form_without_active_firewall_skips_connector_diagnostic(
@@ -653,7 +654,7 @@ async def test_asterisk_form_without_active_firewall_skips_connector_diagnostic(
     assert flow.request.path == "*"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.openweathermap.org"
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_active_builtin_connector_url_uses_firewall_path(
@@ -689,4 +690,4 @@ async def test_active_builtin_connector_url_uses_firewall_path(
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://fal.run"
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "fal"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -546,7 +546,7 @@ async def test_asterisk_form_policy_allow_preserves_target_without_connector_sid
     assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == ""
     assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
     assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_asterisk_form_policy_allow_still_enforces_public_destination(

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -70,6 +70,7 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert entry["action"] == "ALLOW"
     assert entry["status"] == 401
     assert entry["firewall_error"] == "connector_not_configured_for_run"
+    assert entry["connector_diagnostic_slug"] == "fal"
     assert entry["connector_diagnostic_type"] == "fal"
     assert entry["connector_diagnostic_reason"] == "not_configured_for_run"
     assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
@@ -326,6 +327,7 @@ def test_streamed_connector_401_before_request_gets_diagnostic(tmp_path, real_fl
     assert entry["status"] == 401
     assert entry["request_size"] == len(b"partial request")
     assert entry["firewall_error"] == "connector_not_configured_for_run"
+    assert entry["connector_diagnostic_slug"] == "fal"
     assert entry["connector_diagnostic_type"] == "fal"
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
@@ -666,7 +668,7 @@ async def test_preserves_connector_401_body_when_user_auth_is_present(
             content=b"upstream auth error",
         )
         mitm_addon.responseheaders(flow)
-        assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
         assert metadata_keys.CONNECTOR_DIAGNOSTIC_REASON not in flow.metadata
         assert metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES not in flow.metadata
         assert metadata_keys.CONNECTOR_DIAGNOSTIC_BASE not in flow.metadata
@@ -693,7 +695,7 @@ async def test_preserves_model_provider_401_body_without_connector_diagnostic(
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         await mitm_addon.request(flow)
-        assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
         flow.response = tutils.tresp(
             status_code=401,
             headers=header_map({"content-type": "application/json"}),
@@ -758,7 +760,7 @@ async def test_cached_connector_candidate_keeps_specific_query_auth_hint(
             content=b"upstream query auth error",
         )
         mitm_addon.responseheaders(flow)
-        flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] = "openweather"
+        flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] = "openweather"
         flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] = "not_configured_for_run"
         flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] = ["OPENWEATHER_TOKEN"]
         flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] = "https://api.openweathermap.org"

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -215,8 +215,8 @@ _NETWORK_LOG_JQ='.networkLogs[] |
     (.error // empty),
     (.firewall_error // empty),
     (if .dns_result then "-> \(.dns_result)" else empty end),
-    (if (.connector_diagnostic_type or .connector_diagnostic_reason) then
-      "[connector diagnostic: \([(.connector_diagnostic_type // empty), (.connector_diagnostic_reason // empty),
+    (if (.connector_diagnostic_slug or .connector_diagnostic_type or .connector_diagnostic_reason) then
+      "[connector diagnostic: \([(.connector_diagnostic_slug // .connector_diagnostic_type // empty), (.connector_diagnostic_reason // empty),
         (if ((.connector_diagnostic_env_names // []) | length) > 0 then "env: \(.connector_diagnostic_env_names | join(", "))" else empty end),
         (if .connector_diagnostic_base then "base: \(.connector_diagnostic_base)" else empty end)] | join("; "))]"
       else empty end),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11466,6 +11466,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             model_catalog_cache_status: "model_catalog_cold_stored",
             model_catalog_cache_upstream_encoding: "br",
             model_catalog_cache_entry_age_ms: 4000,
+            connector_diagnostic_type: "github",
           },
           {
             timestamp: nowDate().toISOString(),
@@ -11481,6 +11482,8 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             response_size: 128,
             firewall_name: "blocked-service",
             firewall_error: "connector_not_configured",
+            connector_diagnostic_slug: "slack",
+            connector_diagnostic_type: "slack",
           },
         ],
         sandboxOperations: [
@@ -11522,14 +11525,43 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         model_catalog_cache_status: "model_catalog_cold_stored",
         model_catalog_cache_upstream_encoding: "br",
         model_catalog_cache_entry_age_ms: 4000,
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
       }),
       expect.objectContaining({
         runId: created.runId,
         action: "BLOCK",
         host: "blocked.example.test",
         firewall_error: "connector_not_configured",
+        connector_diagnostic_slug: "slack",
+        connector_diagnostic_type: "slack",
       }),
     ]);
+    const networkIngestCallCount = context.mocks.axiom.ingest.mock.calls.filter(
+      ([dataset]) => {
+        return dataset === "sandbox-telemetry-network";
+      },
+    ).length;
+    const conflictingTelemetry = await webhooks.requestAgentTelemetryUnchecked(
+      {
+        runId: created.runId,
+        networkLogs: [
+          {
+            timestamp: nowDate().toISOString(),
+            connector_diagnostic_slug: "github",
+            connector_diagnostic_type: "gitlab",
+          },
+        ],
+      },
+      sandboxHeaders,
+      [400],
+    );
+    expectApiError(conflictingTelemetry.body);
+    expect(
+      context.mocks.axiom.ingest.mock.calls.filter(([dataset]) => {
+        return dataset === "sandbox-telemetry-network";
+      }),
+    ).toHaveLength(networkIngestCallCount);
     expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
       "vm0-sandbox-op-log-dev",
       [

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2361,6 +2361,82 @@ describe("RUN-04: agent run telemetry families", () => {
     });
   });
 
+  it("normalizes connector diagnostic identity from axiom", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(
+      actor,
+      "bdd-network-diagnostic-identity",
+    );
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "read connector diagnostic identity",
+    });
+
+    dispatchAxiomQueries({
+      [run.runId]: {
+        network: [
+          {
+            _time: "2026-07-30T04:00:00Z",
+            runId: run.runId,
+            userId: actor.userId,
+            connector_diagnostic_type: "legacy",
+          },
+          {
+            _time: "2026-07-30T04:01:00Z",
+            runId: run.runId,
+            userId: actor.userId,
+            connector_diagnostic_slug: "canonical",
+          },
+          {
+            _time: "2026-07-30T04:02:00Z",
+            runId: run.runId,
+            userId: actor.userId,
+            connector_diagnostic_slug: "dual",
+            connector_diagnostic_type: "dual",
+          },
+          {
+            _time: "2026-07-30T04:03:00Z",
+            runId: run.runId,
+            userId: actor.userId,
+            connector_diagnostic_slug: "github",
+            connector_diagnostic_type: "gitlab",
+          },
+        ],
+      },
+    });
+
+    const network = await reads.requestZeroRunNetworkLogs(
+      actor,
+      run.runId,
+      { limit: 10, order: "asc" },
+      [200],
+    );
+    if (network.status !== 200) {
+      throw new Error("Expected the zero network log read to succeed");
+    }
+
+    expect(network.body).toStrictEqual({
+      networkLogs: [
+        {
+          timestamp: "2026-07-30T04:00:00Z",
+          connector_diagnostic_slug: "legacy",
+          connector_diagnostic_type: "legacy",
+        },
+        {
+          timestamp: "2026-07-30T04:01:00Z",
+          connector_diagnostic_slug: "canonical",
+          connector_diagnostic_type: "canonical",
+        },
+        {
+          timestamp: "2026-07-30T04:02:00Z",
+          connector_diagnostic_slug: "dual",
+          connector_diagnostic_type: "dual",
+        },
+      ],
+      hasMore: false,
+    });
+  });
+
   it("keeps same-timestamp telemetry rows reachable across time cursor pages", async () => {
     const actor = await entitledActor();
     const compose = await createClaudeCompose(actor, "bdd-time-cursor-ties");
@@ -3160,6 +3236,7 @@ describe("RUN-04: agent run telemetry families", () => {
       request_size: 100,
       response_size: 2048,
       firewall_params: { owner: "vm0-ai" },
+      connector_diagnostic_slug: "fal",
       connector_diagnostic_type: "fal",
       connector_diagnostic_reason: "not_configured_for_run",
       connector_diagnostic_env_names: ["FAL_TOKEN"],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
@@ -562,6 +562,13 @@ describe("POST /api/zero/report-error", () => {
       connector_diagnostic_slug: "github",
       connector_diagnostic_type: "gitlab",
     } satisfies AxiomNetworkEvent;
+    const identityFreeNetworkEntry = {
+      ...networkEntry,
+      _time: "2026-04-28T07:00:03.123Z",
+      host: "example.com",
+      url: "https://example.com/health",
+      connector_diagnostic_type: undefined,
+    } satisfies AxiomNetworkEvent;
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = String(args[0]);
@@ -587,6 +594,7 @@ describe("POST /api/zero/report-error", () => {
           networkEntry,
           canonicalNetworkEntry,
           conflictingNetworkEntry,
+          identityFreeNetworkEntry,
         ]);
       }
       return Promise.resolve([]);
@@ -615,7 +623,13 @@ describe("POST /api/zero/report-error", () => {
         connector_diagnostic_slug: "slack",
         connector_diagnostic_type: "slack",
       }),
+      expect.objectContaining({
+        _time: "2026-04-28T07:00:03.123Z",
+        host: "example.com",
+      }),
     ]);
+    expect(networkLogs[2]).not.toHaveProperty("connector_diagnostic_slug");
+    expect(networkLogs[2]).not.toHaveProperty("connector_diagnostic_type");
 
     const activityLogEntry = zip.getEntries().find((entry) => {
       return entry.entryName.startsWith("activity-log-");
@@ -679,13 +693,23 @@ describe("POST /api/zero/report-error", () => {
       response_body_encoding: networkBodyUtf8Encoding,
       response_body_truncated: false,
     });
-    expect(activityLog.networkLogs).toHaveLength(2);
+    expect(activityLog.networkLogs).toHaveLength(3);
     expect(activityLog.networkLogs?.[1]).toMatchObject({
       timestamp: "2026-04-28T07:00:01.123Z",
       host: "api.slack.com",
       connector_diagnostic_slug: "slack",
       connector_diagnostic_type: "slack",
     });
+    expect(activityLog.networkLogs?.[2]).toMatchObject({
+      timestamp: "2026-04-28T07:00:03.123Z",
+      host: "example.com",
+    });
+    expect(activityLog.networkLogs?.[2]).not.toHaveProperty(
+      "connector_diagnostic_slug",
+    );
+    expect(activityLog.networkLogs?.[2]).not.toHaveProperty(
+      "connector_diagnostic_type",
+    );
   });
 
   it("includes run context when a same-org non-owner submits the report", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
@@ -529,6 +529,7 @@ describe("POST /api/zero/report-error", () => {
       upstream_binding_reason: "connector_auth",
       upstream_binding_server_connected: false,
       upstream_binding_client_binding_count: 0,
+      connector_diagnostic_type: "github",
       connector_route_reason: "connector_intent_required",
       connector_route_candidates: ["auditor", "primary"],
       auth_resolved_secrets: ["GITHUB_TOKEN"],
@@ -545,6 +546,21 @@ describe("POST /api/zero/report-error", () => {
       response_body: '{"ok":true}',
       response_body_encoding: networkBodyUtf8Encoding,
       response_body_truncated: false,
+    } satisfies AxiomNetworkEvent;
+    const canonicalNetworkEntry = {
+      ...networkEntry,
+      _time: "2026-04-28T07:00:01.123Z",
+      host: "api.slack.com",
+      url: "https://api.slack.com/methods/auth.test",
+      connector_diagnostic_slug: "slack",
+      connector_diagnostic_type: undefined,
+    } satisfies AxiomNetworkEvent;
+    const conflictingNetworkEntry = {
+      ...networkEntry,
+      _time: "2026-04-28T07:00:02.123Z",
+      host: "conflict.example.com",
+      connector_diagnostic_slug: "github",
+      connector_diagnostic_type: "gitlab",
     } satisfies AxiomNetworkEvent;
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
@@ -567,7 +583,11 @@ describe("POST /api/zero/report-error", () => {
         ]);
       }
       if (apl.includes("sandbox-telemetry-network")) {
-        return Promise.resolve([networkEntry]);
+        return Promise.resolve([
+          networkEntry,
+          canonicalNetworkEntry,
+          conflictingNetworkEntry,
+        ]);
       }
       return Promise.resolve([]);
     });
@@ -576,11 +596,26 @@ describe("POST /api/zero/report-error", () => {
 
     const zip = uploadedZip();
     expect(zipText(zip, "system-log.txt")).toBe("booting sandbox\nready\n");
-    const networkLog = JSON.parse(zipText(zip, "network-log.jsonl")) as {
-      readonly method: string;
-      readonly firewall_action?: string;
-    };
-    expect(networkLog.method).toBe("POST");
+    const networkLogs = zipText(zip, "network-log.jsonl")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        return JSON.parse(line) as Record<string, unknown>;
+      });
+    expect(networkLogs).toStrictEqual([
+      expect.objectContaining({
+        _time: "2026-04-28T07:00:00.123Z",
+        method: "POST",
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
+      }),
+      expect.objectContaining({
+        _time: "2026-04-28T07:00:01.123Z",
+        host: "api.slack.com",
+        connector_diagnostic_slug: "slack",
+        connector_diagnostic_type: "slack",
+      }),
+    ]);
 
     const activityLogEntry = zip.getEntries().find((entry) => {
       return entry.entryName.startsWith("activity-log-");
@@ -625,6 +660,8 @@ describe("POST /api/zero/report-error", () => {
       upstream_binding_reason: "connector_auth",
       upstream_binding_server_connected: false,
       upstream_binding_client_binding_count: 0,
+      connector_diagnostic_slug: "github",
+      connector_diagnostic_type: "github",
       connector_route_reason: "connector_intent_required",
       connector_route_candidates: ["auditor", "primary"],
       auth_resolved_secrets: ["GITHUB_TOKEN"],
@@ -641,6 +678,13 @@ describe("POST /api/zero/report-error", () => {
       response_body: '{"ok":true}',
       response_body_encoding: networkBodyUtf8Encoding,
       response_body_truncated: false,
+    });
+    expect(activityLog.networkLogs).toHaveLength(2);
+    expect(activityLog.networkLogs?.[1]).toMatchObject({
+      timestamp: "2026-04-28T07:00:01.123Z",
+      host: "api.slack.com",
+      connector_diagnostic_slug: "slack",
+      connector_diagnostic_type: "slack",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -604,7 +604,7 @@ function collectNetworkLog(
 | where runId in (${runIdList})
 | order by _time asc`;
 
-    return (
+    const networkLogs =
       (await tapError(
         (async (): Promise<Record<string, unknown>[]> => {
           return (await get(queryAxiom(apl))) as Record<string, unknown>[];
@@ -614,8 +614,35 @@ function collectNetworkLog(
             error: String(error),
           });
         },
-      )) ?? []
-    );
+      )) ?? [];
+
+    return networkLogs.flatMap((event) => {
+      const canonical = event.connector_diagnostic_slug;
+      const legacy = event.connector_diagnostic_type;
+      if (
+        typeof canonical === "string" &&
+        typeof legacy === "string" &&
+        canonical !== legacy
+      ) {
+        return [];
+      }
+
+      const connectorDiagnosticSlug =
+        typeof canonical === "string"
+          ? canonical
+          : typeof legacy === "string"
+            ? legacy
+            : undefined;
+      return connectorDiagnosticSlug === undefined
+        ? [event]
+        : [
+            {
+              ...event,
+              connector_diagnostic_slug: connectorDiagnosticSlug,
+              connector_diagnostic_type: connectorDiagnosticSlug,
+            },
+          ];
+    });
   });
 }
 

--- a/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
+++ b/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
@@ -244,6 +244,7 @@ function sanitizeAxiomNetworkEvent(event: unknown): NetworkLogEntry | null {
     firewall_billable: booleanValue(event.firewall_billable),
     firewall_error: stringValue(event.firewall_error),
     ...sanitizeUpstreamBindingFields(event),
+    connector_diagnostic_slug: stringValue(event.connector_diagnostic_slug),
     connector_diagnostic_type: stringValue(event.connector_diagnostic_type),
     connector_diagnostic_reason: stringValue(event.connector_diagnostic_reason),
     connector_diagnostic_env_names: stringArrayValue(

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
@@ -128,6 +128,19 @@ function inspectFile(
       firewall_name: "github",
       firewall_permission: "read-repos",
       browser_user_agent: true,
+      connector_diagnostic_slug: "github-connector",
+    },
+    {
+      timestamp: "2026-03-10T14:56:04.000Z",
+      type: "http",
+      action: "ALLOW",
+      method: "POST",
+      url: "https://slack.com/api/auth.test",
+      status: 401,
+      latency_ms: 87,
+      request_size: 24,
+      response_size: 512,
+      connector_diagnostic_type: "slack-connector",
     },
   ];
 
@@ -484,6 +497,32 @@ describe("activity inspect page", () => {
     expect(within(networkTable).getByText("200")).toBeInTheDocument();
     expect(within(networkTable).getByText("123ms")).toBeInTheDocument();
     expect(within(networkTable).getByText("github")).toBeInTheDocument();
+
+    const networkRows = within(networkTable).getAllByRole("row");
+    const networkRow = networkRows[1];
+    if (!networkRow) {
+      throw new Error("Expected a network log row");
+    }
+    await user.click(networkRow);
+    await waitFor(() => {
+      expect(screen.getByText("github-connector")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Connector Diagnostic")).toHaveLength(1);
+
+    await user.click(networkRow);
+    await waitFor(() => {
+      expect(screen.queryByText("github-connector")).not.toBeInTheDocument();
+    });
+
+    const legacyNetworkRow = networkRows[2];
+    if (!legacyNetworkRow) {
+      throw new Error("Expected a legacy network log row");
+    }
+    await user.click(legacyNetworkRow);
+    await waitFor(() => {
+      expect(screen.getByText("slack-connector")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Connector Diagnostic")).toHaveLength(1);
   });
 
   it("ignores debug tab query params when debug tabs are disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -861,10 +861,19 @@ const networkLogDetailFields = {
     "Upstream Client Binding Hosts",
     "upstream_binding_client_binding_hosts",
   ),
-  connector_diagnostic_type: detailField(
-    "Connector Diagnostic",
-    "connector_diagnostic_type",
-  ),
+  connector_diagnostic_slug: {
+    label: "Connector Diagnostic",
+    value: (entry) => {
+      return entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
+    },
+    format: (entry) => {
+      return formatValue(
+        entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type,
+      );
+    },
+  },
+  // TODO(#23838): Remove after the diagnostic compatibility window.
+  connector_diagnostic_type: null,
   connector_diagnostic_reason: detailField(
     "Connector Reason",
     "connector_diagnostic_reason",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
@@ -100,3 +100,62 @@ describe("network log model catalog cache telemetry", () => {
     }
   });
 });
+
+describe("network log connector diagnostic identity", () => {
+  const timestamp = "2026-07-30T03:00:00.000Z";
+
+  it.each([
+    {
+      name: "absent",
+      identity: {},
+      expected: {
+        connector_diagnostic_slug: undefined,
+        connector_diagnostic_type: undefined,
+      },
+    },
+    {
+      name: "legacy-only",
+      identity: { connector_diagnostic_type: "github" },
+      expected: {
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
+      },
+    },
+    {
+      name: "canonical-only",
+      identity: { connector_diagnostic_slug: "github" },
+      expected: {
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
+      },
+    },
+    {
+      name: "equal dual",
+      identity: {
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
+      },
+      expected: {
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "github",
+      },
+    },
+  ])("normalizes $name input", ({ identity, expected }) => {
+    const parsed = networkLogEntrySchema.parse({ timestamp, ...identity });
+
+    expect({
+      connector_diagnostic_slug: parsed.connector_diagnostic_slug,
+      connector_diagnostic_type: parsed.connector_diagnostic_type,
+    }).toStrictEqual(expected);
+  });
+
+  it("rejects conflicting dual identity", () => {
+    expect(
+      networkLogEntrySchema.safeParse({
+        timestamp,
+        connector_diagnostic_slug: "github",
+        connector_diagnostic_type: "gitlab",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -773,7 +773,7 @@ const modelCatalogCacheEvictionCountSchema = z.number().int().min(0).max(32);
  * Network log entry schema.
  * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
  */
-const networkLogEntrySchema = z.object({
+const networkLogEntryInputSchema = z.object({
   timestamp: z.string(),
   type: z.string().optional(),
   action: networkLogActionSchema.optional(),
@@ -828,6 +828,8 @@ const networkLogEntrySchema = z.object({
   upstream_binding_client_binding_match: z.boolean().optional(),
   upstream_binding_client_binding_endpoint_match: z.boolean().optional(),
   upstream_binding_client_binding_hosts: z.string().optional(),
+  connector_diagnostic_slug: z.string().optional(),
+  // TODO(#23838): Remove after the diagnostic compatibility window.
   connector_diagnostic_type: z.string().optional(),
   connector_diagnostic_reason: z.string().optional(),
   connector_diagnostic_env_names: z.array(z.string()).optional(),
@@ -850,6 +852,34 @@ const networkLogEntrySchema = z.object({
   response_body_encoding: z.enum(["utf-8", "base64", "binary"]).optional(),
   response_body_truncated: z.boolean().optional(),
 });
+
+const networkLogEntrySchema = networkLogEntryInputSchema
+  .superRefine((entry, context) => {
+    if (
+      entry.connector_diagnostic_slug !== undefined &&
+      entry.connector_diagnostic_type !== undefined &&
+      entry.connector_diagnostic_slug !== entry.connector_diagnostic_type
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["connector_diagnostic_slug"],
+        message:
+          "connector_diagnostic_slug and connector_diagnostic_type must match",
+      });
+    }
+  })
+  .transform((entry) => {
+    const connectorDiagnosticSlug =
+      entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
+    if (connectorDiagnosticSlug === undefined) {
+      return entry;
+    }
+    return {
+      ...entry,
+      connector_diagnostic_slug: connectorDiagnosticSlug,
+      connector_diagnostic_type: connectorDiagnosticSlug,
+    };
+  });
 
 /**
  * Network logs response schema

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -868,7 +868,7 @@ const networkLogEntrySchema = networkLogEntryInputSchema
       });
     }
   })
-  .transform((entry) => {
+  .overwrite((entry) => {
     const connectorDiagnosticSlug =
       entry.connector_diagnostic_slug ?? entry.connector_diagnostic_type;
     if (connectorDiagnosticSlug === undefined) {


### PR DESCRIPTION
## Summary

- use `connector_diagnostic_slug` as the mitm addon's canonical diagnostic identity
- dual-project the canonical and legacy fields across runner/API deployment boundaries
- normalize legacy-only, canonical-only, and equal dual-field telemetry while rejecting conflicts
- preserve normalized identity in Axiom reads, diagnostic bundles, Platform details, and E2E output

## Compatibility

- new runners retain `connector_diagnostic_type` for old APIs
- new APIs derive the canonical field from old-runner telemetry
- new APIs retain the legacy field for old Platform clients
- new Platform clients prefer the canonical field and fall back to legacy responses

After deployment, #23838 must verify continuous canonical Axiom ingestion and record a conservative production start timestamp. Its seven-day removal gate starts from that timestamp, not this PR's merge time.

## Exclusions

- no firewall identity or decision changes
- no daily-insights, runner-protocol, connector-column, or model-provider-owner changes
- no removal of `connector_diagnostic_type`; that remains gated by #23838

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,454 passed)
- focused mitm diagnostic tests after rebase (212 passed)
- focused API-contract, telemetry webhook, Axiom read, diagnostic bundle, and Platform tests
- affected API-contract, API, and Platform lint/type checks
- runtime API schema build
- `pnpm knip`
- `bash -n e2e/helpers/setup.bash`
- pre-commit hooks

The local full Turbo run completed 7,540 tests successfully and reported 10 existing shared-state/resource-contention failures. Every failed file passed on a clean or serialized rerun; all PR-affected test files pass.

Closes #23830

Parent context: #23774
