### PR TITLE
fix(platform): keep enter as a newline while a software keyboard is open

### DIFF
--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -81,6 +81,25 @@ function viewportHasKeyboardOcclusion(
   return occludedHeight > keyboardThreshold;
 }
 
+/**
+ * Reports whether a software keyboard currently occludes the visual viewport.
+ *
+ * WebKit reports `any-pointer: fine` and `any-hover: hover` on iPhones, so
+ * pointer media queries cannot tell a trackpad-and-keyboard tablet apart from
+ * a phone. A shrunk visual viewport over an unchanged layout viewport is the
+ * device's own evidence that the on-screen keyboard produced the keystroke.
+ */
+export function softwareKeyboardOccludesViewport(): boolean {
+  const viewport = window.visualViewport;
+  if (!viewport) {
+    return false;
+  }
+  return viewportHasKeyboardOcclusion(
+    readLayoutViewportHeight(viewport),
+    viewport,
+  );
+}
+
 function setKeyboardOpen(keyboardOcclusion: number): void {
   const root = document.documentElement;
   root.dataset.keyboardOpen = "true";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -1,11 +1,38 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
+
+const SOFTWARE_KEYBOARD_HEIGHT_PX = 336;
+
+// A software keyboard shrinks the visual viewport while the layout viewport
+// keeps its height.
+function occludeVisualViewport(): void {
+  const original = Object.getOwnPropertyDescriptor(window, "visualViewport");
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: Object.assign(new EventTarget(), {
+      height: window.innerHeight - SOFTWARE_KEYBOARD_HEIGHT_PX,
+      offsetLeft: 0,
+      offsetTop: 0,
+      pageLeft: 0,
+      pageTop: 0,
+      scale: 1,
+      width: window.innerWidth,
+    }),
+  });
+  onTestFinished(() => {
+    if (original) {
+      Object.defineProperty(window, "visualViewport", original);
+      return;
+    }
+    Reflect.deleteProperty(window, "visualViewport");
+  });
+}
 
 async function openComposer(sendMode: "enter" | "cmd-enter") {
   context.mocks.data.userPreferences({ sendMode });
@@ -125,6 +152,31 @@ describe("zero send key", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Send from Magic Keyboard")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps plain Enter as a newline while the software keyboard is open", async () => {
+    const user = userEvent.setup({ delay: null });
+    // WebKit reports a fine pointer on iPhones, including standalone PWAs.
+    context.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)" || query === "(any-pointer: fine)";
+    });
+    occludeVisualViewport();
+    const softwareKeyboardTextarea = await openComposer("enter");
+
+    await fill(softwareKeyboardTextarea, "Software keyboard draft");
+    await user.keyboard("{Enter}");
+
+    expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+    expect(softwareKeyboardTextarea.textContent ?? "").toContain(
+      "Software keyboard draft",
+    );
+
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Software keyboard draft")).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -22,6 +22,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { i18n } from "../../i18n/index.ts";
 import { equalArrays } from "../../lib/equality.ts";
 import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
+import { softwareKeyboardOccludesViewport } from "../../lib/visual-viewport-keyboard.ts";
 import {
   IconAdjustmentsHorizontal,
   IconAlertTriangle,
@@ -7672,8 +7673,14 @@ export function useZeroChatComposer(
 
   const handleKeyDown = (e: KeyboardEventLike) => {
     const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
+    // A fine pointer stands in for a hardware keyboard on tablets, but WebKit
+    // also reports one on iPhones, where every keystroke comes from the
+    // on-screen keyboard. An occluded visual viewport overrides that claim so
+    // plain Enter stays a newline there.
     const isTouchOnlyDevice =
-      isTouchDevice && !window.matchMedia("(any-pointer: fine)").matches;
+      isTouchDevice &&
+      (!window.matchMedia("(any-pointer: fine)").matches ||
+        softwareKeyboardOccludesViewport());
     const send = () => {
       handleSend();
     };


### PR DESCRIPTION
## Problem

On an iPhone (measured on iOS 18.7, home-screen PWA), pressing the on-screen keyboard's return key in the chat composer sends the message instead of inserting a newline.

The composer decides this in `zero-chat-composer.tsx`:

```ts
const isTouchOnlyDevice =
  isTouchDevice && !window.matchMedia("(any-pointer: fine)").matches;
```

Measured values on that device:

| query | value |
| --- | --- |
| `(display-mode: standalone)` | true |
| `(pointer: coarse)` | true |
| `(pointer: fine)` | false |
| `(any-pointer: coarse)` | true |
| `(any-pointer: fine)` | **true** |
| `(hover: hover)` | false |
| `(any-hover: hover)` | **true** |

WebKit reports a fine pointer and hover support even though the only input device is the touchscreen, so `isTouchOnlyDevice` evaluates to `false`, the composer takes the desktop path, and `sendMode` (default `enter`) binds plain Enter to send. The return key arrives as `key="Enter"`, `keyCode=13`, `isComposing=false`, no modifiers, so it matches that binding directly.

This has been latent since #20950 added the `any-pointer: fine` exception for iPad keyboards. It is not a dependency issue: `@tiptap/*` is pinned to 3.21.0 by exact versions plus 28 `pnpm-workspace.yaml` overrides, `prosemirror-view` has been 1.41.8 for weeks, and every install path uses `--frozen-lockfile`.

## Change

A fine pointer can no longer stand alone as evidence of a hardware keyboard. A software keyboard shrinks the visual viewport while leaving the layout viewport untouched, so `softwareKeyboardOccludesViewport()` (new export from `visual-viewport-keyboard.ts`, reusing the existing occlusion thresholds) overrides the pointer claim:

```ts
const isTouchOnlyDevice =
  isTouchDevice &&
  (!window.matchMedia("(any-pointer: fine)").matches ||
    softwareKeyboardOccludesViewport());
```

Resulting behavior:

- iPhone / iPad using the on-screen keyboard: Enter is a newline, ⌘/Ctrl+Enter sends
- iPad with a Magic Keyboard: unchanged, Enter sends from the first keystroke, no persisted state or warm-up needed
- Android phones: unchanged, they never reported a fine pointer and the condition is an OR
- Desktop: unchanged, the primary pointer is fine so the branch is not reached

## Tests

`zero-send-key.test.tsx` gains a coarse-pointer + fine-pointer + occluded-viewport case asserting Enter keeps the draft and Ctrl+Enter sends. The existing iPad keyboard cases stay as the regression guard for #20950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
