### PR TITLE
fix(platform): close remaining pt-br localization gaps

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -10,8 +10,9 @@
     "test": "vitest run",
     "i18n:extract": "i18next-cli extract",
     "i18n:check": "i18next-cli extract --ci --quiet && i18next-cli status",
+    "lint:localized-ui": "node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
-    "lint": "pnpm lint:static-assets && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "pnpm lint:static-assets && pnpm lint:localized-ui && pnpm i18n:check && oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {

--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -1,0 +1,364 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(__dirname, "..");
+
+function getCheckedFiles() {
+  return [
+    "src/signals/connectors-page/connector-callback-page-setup.ts",
+    "src/signals/external/org-model-policies.ts",
+    "src/signals/zero-page/settings/connectors.ts",
+    "src/signals/zero-page/strapi-settings-page.ts",
+    "src/signals/zero-page/zero-strapi.ts",
+    "src/views/zero-page/components/model-provider-picker.tsx",
+    "src/views/zero-page/components/org-manage/org-model-policies-section.tsx",
+    "src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx",
+    "src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx",
+    "src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx",
+    "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx",
+    "src/views/zero-page/components/settings/custom-connector-update-confirm.tsx",
+    "src/views/zero-page/components/settings/custom-connectors-panel.tsx",
+    "src/views/zero-page/components/settings/provider-ui-config.ts",
+    "src/views/zero-page/feishu-card.tsx",
+    "src/views/zero-page/strapi-settings-page.tsx",
+    "src/views/zero-page/zero-chat-thread-page.tsx",
+    "src/views/zero-page/zero-sidebar-account.tsx",
+    "src/views/zero-page/zero-sidebar-subscriptions.tsx",
+  ];
+}
+
+function isUserVisibleAttribute(value) {
+  return [
+    "alt",
+    "aria-description",
+    "aria-label",
+    "description",
+    "label",
+    "placeholder",
+    "title",
+  ].includes(value);
+}
+
+function isUserVisibleProperty(value) {
+  return [
+    "ariaLabel",
+    "description",
+    "errorMessage",
+    "label",
+    "message",
+    "placeholder",
+    "title",
+  ].includes(value);
+}
+
+function isToastMethod(value) {
+  return ["error", "info", "success", "warning"].includes(value);
+}
+
+// These literals are intentionally shown as protocol identifiers, provider or
+// product names, or example input values. Keep exclusions exact and explain why
+// each value must remain untranslated.
+function getAllowedLiterals() {
+  return new Map([
+    [
+      "src/views/zero-page/components/model-provider-picker.tsx\u0000BYOK",
+      "bring-your-own-key product acronym",
+    ],
+    [
+      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Azure foundry portal",
+      "provider product name",
+    ],
+    [
+      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Claude Code (OAuth token)",
+      "provider product name with OAuth credential type",
+    ],
+    [
+      "src/views/zero-page/components/settings/provider-ui-config.ts\u0000Deepseek",
+      "provider brand name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx\u0000OAuth 2.0",
+      "OAuth protocol name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000Acme API",
+      "example connector name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000Authorization",
+      "example HTTP header name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000Bearer {{secret}}",
+      "example HTTP authorization value",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000{{secret}}",
+      "header-template interpolation token",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000API credential",
+      "locale-neutral persisted field metadata",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000OAuth 2.0",
+      "OAuth protocol name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000PKCE",
+      "OAuth protocol extension name",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000S256",
+      "OAuth PKCE method identifier",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000Secret",
+      "locale-neutral persisted field metadata",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000cli_...",
+      "example provider application identifier",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000consent",
+      "example OAuth prompt value",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.acme.com/v1/",
+      "example API URL",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example",
+      "example OAuth audience",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example/authorize",
+      "example OAuth authorization URL",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://api.provider.example/token",
+      "example OAuth token URL",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://provider.example.com/oauth/authorize",
+      "example OAuth authorization URL",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000https://provider.example.com/oauth/token",
+      "example OAuth token URL",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000offline",
+      "example OAuth access type",
+    ],
+    [
+      "src/views/zero-page/components/settings/custom-connector-create-dialog.tsx\u0000read\nwrite",
+      "example OAuth scopes",
+    ],
+    [
+      "src/views/zero-page/feishu-card.tsx\u0000cli_...",
+      "example Feishu application identifier",
+    ],
+    ["src/views/zero-page/feishu-card.tsx\u0000Feishu", "provider name"],
+    [
+      "src/views/zero-page/feishu-card.tsx\u0000im.message.receive_v1",
+      "Feishu event identifier",
+    ],
+    [
+      "src/views/zero-page/strapi-settings-page.tsx\u0000https://cms.example.com",
+      "example Strapi URL",
+    ],
+    [
+      "src/views/zero-page/zero-chat-thread-page.tsx\u0000Feishu",
+      "provider name",
+    ],
+    [
+      "src/views/zero-page/zero-chat-thread-page.tsx\u0000Slack",
+      "provider name",
+    ],
+  ]);
+}
+
+function getLiteralValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function getPropertyName(node) {
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function hasHumanText(value) {
+  return /\p{L}/u.test(value);
+}
+
+function checkJsxText(node, record) {
+  if (ts.isJsxText(node)) {
+    record(node, node.text, "JSX text");
+  }
+}
+
+function checkJsxAttribute(node, record) {
+  if (!ts.isJsxAttribute(node)) {
+    return;
+  }
+  const attributeName = node.name.text;
+  if (
+    typeof attributeName !== "string" ||
+    !isUserVisibleAttribute(attributeName) ||
+    !node.initializer
+  ) {
+    return;
+  }
+  if (ts.isStringLiteral(node.initializer)) {
+    record(node.initializer, node.initializer.text, attributeName);
+    return;
+  }
+  if (ts.isJsxExpression(node.initializer) && node.initializer.expression) {
+    const value = getLiteralValue(node.initializer.expression);
+    if (value !== null) {
+      record(node.initializer.expression, value, attributeName);
+    }
+  }
+}
+
+function checkJsxExpression(node, record) {
+  if (
+    ts.isJsxExpression(node) &&
+    node.expression &&
+    (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent))
+  ) {
+    const value = getLiteralValue(node.expression);
+    if (value !== null) {
+      record(node.expression, value, "JSX expression");
+    }
+  }
+}
+
+function checkPropertyAssignment(node, record) {
+  if (!ts.isPropertyAssignment(node)) {
+    return;
+  }
+  const propertyName = getPropertyName(node.name);
+  if (!propertyName || !isUserVisibleProperty(propertyName)) {
+    return;
+  }
+  const value = getLiteralValue(node.initializer);
+  if (value !== null) {
+    record(node.initializer, value, propertyName);
+  }
+}
+
+function checkDocumentTitle(node, record) {
+  if (
+    !ts.isCallExpression(node) ||
+    node.arguments.length < 2 ||
+    !ts.isIdentifier(node.arguments[0]) ||
+    node.arguments[0].text !== "updateDocumentTitle$"
+  ) {
+    return;
+  }
+  const value = getLiteralValue(node.arguments[1]);
+  if (value !== null) {
+    record(node.arguments[1], value, "document title");
+  }
+}
+
+function checkToastCall(node, record) {
+  if (
+    !ts.isCallExpression(node) ||
+    node.arguments.length === 0 ||
+    !ts.isPropertyAccessExpression(node.expression) ||
+    !ts.isIdentifier(node.expression.expression) ||
+    node.expression.expression.text !== "toast" ||
+    !isToastMethod(node.expression.name.text)
+  ) {
+    return;
+  }
+  const value = getLiteralValue(node.arguments[0]);
+  if (value !== null) {
+    record(node.arguments[0], value, "toast");
+  }
+}
+
+function checkFile(relativePath, allowedLiterals) {
+  const absolutePath = path.join(appRoot, relativePath);
+  const sourceText = readFileSync(absolutePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const violations = [];
+
+  function record(node, value, kind) {
+    const normalizedValue = value.trim();
+    if (!hasHumanText(normalizedValue)) {
+      return;
+    }
+    const exclusionKey = `${relativePath}\u0000${normalizedValue}`;
+    if (allowedLiterals.has(exclusionKey)) {
+      return;
+    }
+    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    violations.push({
+      column: position.character + 1,
+      kind,
+      line: position.line + 1,
+      value: normalizedValue,
+    });
+  }
+
+  function visit(node) {
+    checkJsxText(node, record);
+    checkJsxAttribute(node, record);
+    checkJsxExpression(node, record);
+    checkPropertyAssignment(node, record);
+    checkDocumentTitle(node, record);
+    checkToastCall(node, record);
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations;
+}
+
+function main() {
+  const allowedLiterals = getAllowedLiterals();
+  const checkedFiles = getCheckedFiles();
+  const violations = checkedFiles.flatMap((relativePath) => {
+    return checkFile(relativePath, allowedLiterals).map((violation) => {
+      return { relativePath, ...violation };
+    });
+  });
+
+  if (violations.length > 0) {
+    process.stderr.write(`Platform localized UI lint failed.
+
+Move these user-visible literals into the typed i18n resources. If a literal is
+an intentional protocol identifier, provider/product name, or example value,
+add a narrow file-and-value exclusion with a reason.
+
+${violations
+  .map((violation) => {
+    return `  - ${violation.relativePath}:${violation.line}:${violation.column} (${violation.kind}) ${JSON.stringify(violation.value)}`;
+  })
+  .join("\n")}
+`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1528,11 +1528,15 @@
       "connectedDescription": "Your account has been connected. You can close this window.",
       "connecting": "Connecting {{connector}}…",
       "connectingDescription": "Please wait while we finish connecting your account.",
+      "customConnectorLabel": "Custom connector",
+      "documentTitle": "Connect {{connector}}",
       "errorDescription": "{{error}} Close this window and try again.",
       "errorFallback": "An error occurred during connection.",
       "failed": "Connection failed",
       "failedTitle": "Couldn’t connect {{connector}}",
       "finishing": "Finishing the secure connection",
+      "genericLabel": "Connector",
+      "invalidUrl": "Invalid connector callback URL.",
       "success": "Connected"
     },
     "card": {
@@ -1654,6 +1658,14 @@
         "verificationCode": "Verification code",
         "waiting": "Waiting for approval. Keep this dialog open."
       },
+      "errors": {
+        "authorizationWindow": "Failed to open authorization window",
+        "codeRequired": "Enter the code from {{connector}}.",
+        "denied": "Connection was denied. Start again to retry.",
+        "expired": "Connection session expired. Start again to retry.",
+        "failed": "Connection failed. Start again to retry.",
+        "verificationOpen": "Could not open the verification page. Try again."
+      },
       "external": {
         "code": "Code",
         "complete": "Complete connection",
@@ -1677,19 +1689,68 @@
       }
     },
     "custom": {
+      "agentUsage": {
+        "none": "Not used by any agents",
+        "usedBy": "Used by {{agents}}",
+        "usedByOverflow_one": "Used by {{agents}} +{{value}}",
+        "usedByOverflow_other": "Used by {{agents}} +{{value}}"
+      },
       "connect": {
+        "apiAuthentication": "API authentication",
+        "apiDescription": "Enter the API secret issued by the provider.",
+        "back": "Back",
+        "connecting": "Connecting…",
+        "continue": "Continue",
+        "continueToProvider": "Continue to the provider to authorize access.",
         "description": "Your secret is encrypted at rest and injected into outbound requests by the firewall. It's never exposed to the agent as an environment variable.",
+        "oauthDescription": "Authorize access with the connector's OAuth app.",
+        "save": "Save",
+        "saving": "Saving…",
         "secret": "Secret",
         "title": "Connect {{connector}}"
       },
       "create": {
+        "addAuthentication": "Add authentication",
+        "advancedApiPreserved": "Advanced API fields and injections are preserved when you save.",
+        "advancedSettings": "Advanced settings",
+        "apiAuthentication": "API authentication",
+        "apiAuthenticationDescription": "Inject a user-provided secret into every matching request.",
+        "authorizationParameters": "Authorization parameters",
+        "authorizationParametersDescription": "Add only the parameters your provider requires.",
+        "authorizationUrl": "Authorization URL",
+        "clientId": "Client ID",
+        "clientSecret": "Client secret",
         "displayName": "Display name",
         "headerName": "Header name",
         "headerTemplate": "Header template",
         "headerTemplateHint": "(must contain {{placeholder}})",
+        "httpBasicAuthentication": "HTTP Basic authentication",
+        "keepClientSecret": "Leave the client secret blank to keep the stored value.",
+        "keepClientSecretPlaceholder": "Leave blank to keep current",
+        "newClientSecret": "New client secret",
+        "none": "None",
+        "oauthChangesDisconnect": "Changing OAuth settings or client credentials disconnects existing OAuth connections.",
+        "oauthDescription": "Configure one OAuth app for members to authorize.",
+        "optional": "(optional)",
+        "parameters": {
+          "accessType": "Access type",
+          "audience": "Audience",
+          "prompt": "Prompt",
+          "resource": "Resource"
+        },
         "prefixes": "Prefixes",
         "prefixesHint": "(one per line, https only)",
-        "title": "New custom connector"
+        "redirectCopy": "Copy Redirect URL",
+        "redirectHint": "(Register this URL in the provider's OAuth application.)",
+        "redirectUrl": "Redirect URL",
+        "removeApiAuthentication": "Remove API authentication",
+        "removeOauth": "Remove OAuth 2.0",
+        "scopes": "Scopes",
+        "scopesHint": "(one per line)",
+        "secretInRequestBody": "Client secret in request body",
+        "title": "New custom connector",
+        "tokenEndpointAuthentication": "Token endpoint authentication",
+        "tokenUrl": "Token URL"
       },
       "delete": {
         "description": "This removes the connector and every member's stored secret for it. Agents authorized for this connector will lose access immediately. This can't be undone.",
@@ -1712,6 +1773,11 @@
         "deleted": "Custom connector deleted",
         "disconnected": "Disconnected",
         "renamed": "Renamed to \"{{connector}}\""
+      },
+      "updateConfirm": {
+        "action": "Save and disconnect",
+        "description": "These OAuth changes will disconnect every member currently connected with OAuth. They'll need to connect this custom connector again.",
+        "title": "Disconnect existing OAuth connections?"
       }
     },
     "customProposal": {
@@ -1922,6 +1988,66 @@
         "sendVerification": "Send verification",
         "verificationSent": "Verification text sent to {{phone}}. Open the link in that text to finish connecting."
       },
+      "catalogDiagnostics": {
+        "fields": {
+          "activated": "Activated",
+          "activeCatalogDigest": "Active catalog digest",
+          "activeVersion": "Active version",
+          "evaluated": "Evaluated",
+          "evaluation": "Evaluation",
+          "executableCapabilityDigest": "Executable capability digest",
+          "failureCode": "Failure code",
+          "filteredAuthMethods": "Filtered auth methods",
+          "lastAttempt": "Last attempt",
+          "lastAttemptAt": "Last attempt at",
+          "lastSuccess": "Last success",
+          "missingVersions": "Missing versions",
+          "rejectedCatalogDigest": "Rejected catalog digest",
+          "rejectedVersion": "Rejected version",
+          "rejectingBackend": "Rejecting backend",
+          "rejectionCache": "Rejection cache",
+          "rejectionFailure": "Rejection failure",
+          "syncState": "Sync state",
+          "unownedSecrets": "Unowned secrets",
+          "unownedVariables": "Unowned variables",
+          "unresolvedBridgeCredentials": "Unresolved bridge credentials"
+        },
+        "loading": "Loading",
+        "none": "None",
+        "notReused": "Not reused",
+        "reused": "Reused",
+        "sections": {
+          "compatibility": "Compatibility",
+          "credentialStorage": "Credential storage",
+          "rejectedCandidate": "Rejected candidate"
+        },
+        "title": "Connector catalog",
+        "unavailable": "Unavailable",
+        "values": {
+          "accepted": "Accepted",
+          "current": "Current",
+          "digestMismatch": "Digest mismatch",
+          "invalidArtifact": "Invalid artifact",
+          "invalidCompression": "Invalid compression",
+          "invalidJson": "Invalid JSON",
+          "invalidPointer": "Invalid pointer",
+          "invalidReference": "Invalid reference",
+          "missingAccessProvider": "Missing access provider",
+          "missingGrantProvider": "Missing grant provider",
+          "missingPlatformConfiguration": "Missing platform configuration",
+          "missingRevokeProvider": "Missing revoke provider",
+          "neverSynced": "Never synced",
+          "objectTooLarge": "Object too large",
+          "providerContractMismatch": "Provider contract mismatch",
+          "publicLeakage": "Public leakage",
+          "rejected": "Rejected",
+          "relationshipMismatch": "Relationship mismatch",
+          "sourceUnavailable": "Source unavailable",
+          "stale": "Stale",
+          "unchanged": "Unchanged",
+          "unsupportedSchema": "Unsupported schema"
+        }
+      },
       "errors": {
         "agentphonePhone": "Enter a phone number with country code, like +1 555 555 1212.",
         "githubAuthorizationWindow": "Failed to open authorization window",
@@ -1953,12 +2079,15 @@
           "title": "Create an enterprise custom app"
         },
         "credentials": {
+          "appId": "App ID",
+          "appSecret": "App Secret",
           "description": "Copy the App ID and App Secret from Credentials & Basic Information.",
           "imageAlt": "Feishu app creation result showing where to find the App ID and App Secret",
           "title": "Add the app credentials"
         },
         "defaultAgent": "Default agent",
         "defaultAgentAria": "Default agent for {{appId}}",
+        "developerConsole": "Feishu developer console",
         "dialogAdminRequired": "An organization admin must configure the app. You can connect your own account from the Feishu bot list after setup is complete.",
         "emptyAdmin": "Add a custom app to route Feishu messages to an agent.",
         "emptyMember": "Ask an organization admin to add a Feishu bot.",
@@ -2032,12 +2161,53 @@
         "tokens": {
           "descriptionAfter": ", select the app you just created, and enter its configuration page. Open Event Configuration → Encryption Strategy, then copy the Encrypt Key and Verification Token.",
           "descriptionBefore": "Open the ",
+          "encryptKey": "Encrypt Key",
           "imageAlt": "Feishu Encryption Strategy screen showing the Encrypt Key and Verification Token",
-          "title": "Add the event verification tokens"
+          "title": "Add the event verification tokens",
+          "verificationToken": "Verification Token"
         },
         "uninstallDescription": "This uninstalls {{bot}} from the workspace and disconnects every {{brandName}} account using it. This action cannot be undone.",
         "uninstallTargetFallback": "this bot",
         "uninstallTitle": "Uninstall Feishu bot?"
+      },
+      "strapi": {
+        "actions": {
+          "cancel": "Cancel",
+          "checkTest": "Check test",
+          "copy": "Copy",
+          "create": "Create integration",
+          "remove": "Remove",
+          "revealAuthorization": "Reveal authorization header"
+        },
+        "addDescription": "One integration can serve multiple workflow automations.",
+        "addTitle": "Add Strapi instance",
+        "adminRequired": "Ask an organization admin to add or update Strapi integrations.",
+        "authorizationHeader": "Authorization header",
+        "copied": "{{label}} copied",
+        "description": "Let Zero react to published Strapi entries and automate downstream work.",
+        "documentTitle": "Strapi",
+        "empty": "No Strapi instances connected yet.",
+        "form": {
+          "name": "Name",
+          "namePlaceholder": "Company CMS",
+          "url": "Strapi URL"
+        },
+        "instructions": "In Strapi, open Settings → Webhooks, add this URL and Authorization header, select entry.publish, then click Trigger to send a Strapi test webhook.",
+        "lastPublish": "Last publish: {{date}}",
+        "lastTest": "Last test: {{date}}",
+        "notReceived": "Not received",
+        "removeDescription": "Remove its workflow automations first. Strapi webhook requests to this URL will stop working.",
+        "removeTitle": "Remove Strapi integration?",
+        "tested": "Webhook tested",
+        "title": "Strapi",
+        "toasts": {
+          "created": "Strapi integration created",
+          "noTestReceived": "No Strapi test webhook received yet",
+          "removed": "Strapi integration removed",
+          "testReceived": "Strapi test webhook received"
+        },
+        "webhookUrl": "Webhook URL",
+        "whereZeroWorks": "Where Zero works"
       },
       "telegram": {
         "addBot": "Add bot",
@@ -3676,10 +3846,18 @@
   "settings": {
     "accountMenu": {
       "addAccount": "Add account",
+      "creditBalance_one": "{{value}} credit",
+      "creditBalance_other": "{{value}} credits",
       "exportData": "Export data",
       "lab": "Lab",
       "settings": "Settings",
       "signOut": "Sign out",
+      "subscriptions": {
+        "reset": "Reset",
+        "resetTimeUnavailable": "Reset time unavailable",
+        "usage": "{{provider}} usage",
+        "usageRemaining": "{{provider}} {{window}} remaining"
+      },
       "switchAccount": "Switch account",
       "userFallback": "User"
     },
@@ -3868,6 +4046,28 @@
           "week": "Week"
         }
       },
+      "picker": {
+        "balancedUse": "Balanced use",
+        "builtInModel": "Built-in model",
+        "byokHelp": "Uses your configured provider",
+        "fast": "Fast",
+        "inheritDefault": "Inherit from org default",
+        "loadError": "Unable to load models.",
+        "loading": "Loading models...",
+        "models": "Models",
+        "moreCodexCredits": "Uses more Codex credits.",
+        "noConfiguredModels": "No configured models",
+        "priceTiers": {
+          "balanced": "Balanced cost and performance",
+          "economy": "Economy tier for everyday simple tasks",
+          "frontier": "Frontier flagship model",
+          "premium": "Premium frontier model for the hardest tasks"
+        },
+        "prioritizeSpeed": "Prioritize speed",
+        "pro": "Pro",
+        "runSpeed": "Run speed",
+        "standard": "Standard"
+      },
       "policies": {
         "actionsFor": "Actions for {{model}}",
         "apiKey": "API key",
@@ -3901,8 +4101,8 @@
       "reset": {
         "confirmDescription": "Use one Codex reset to reset your current usage windows. You have {{remaining}}.",
         "progress": "Resetting...",
-        "remaining_one": "{{count}} reset left",
-        "remaining_other": "{{count}} resets left",
+        "remaining_one": "{{value}} reset left",
+        "remaining_other": "{{value}} resets left",
         "remainingUnavailable": "Resets left unavailable",
         "title": "Reset Codex usage?"
       },
@@ -3918,6 +4118,7 @@
       },
       "toasts": {
         "disconnected": "{{provider}} disconnected",
+        "policiesUpdated": "Model provider settings updated",
         "reset": "Codex usage reset",
         "resetUnavailable": "No Codex usage resets available",
         "resetUnneeded": "Codex usage does not need a reset right now"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -313,8 +313,8 @@
       "telegram": "Telegram",
       "web": "Web",
       "webhook": "Webhook",
-      "workflowEvent": "Evento de workflow",
-      "workflowSchedule": "Agendamento de workflow"
+      "workflowEvent": "Evento de fluxo de trabalho",
+      "workflowSchedule": "Agendamento de fluxo de trabalho"
     },
     "statuses": {
       "cancelled": "Cancelado",
@@ -456,7 +456,7 @@
       "rail": {
         "activity": "Atividade",
         "new": "Novo",
-        "workflows": "Fluxos",
+        "workflows": "Fluxos de trabalho",
         "works": "Trabalha"
       },
       "searchConversations": "Buscar conversas",
@@ -1067,7 +1067,7 @@
       "disabled": "Desativada",
       "displaysIn": "Exibido em {{timezone}}",
       "edit": "Editar automação",
-      "editDescription": "Atualize esta automação de workflow.",
+      "editDescription": "Atualize esta automação de fluxo de trabalho.",
       "empty": "Ainda não há automações.",
       "event": "Evento",
       "events": {
@@ -1075,8 +1075,8 @@
         "githubIssueComment": "Comentário em issue do GitHub criado",
         "githubLabelApplied": "Label do GitHub aplicada",
         "githubReviewSubmitted": "Revisão de pull request do GitHub enviada",
-        "githubWorkflowCompleted": "Workflow do GitHub concluído",
-        "githubWorkflowJobCompleted": "Job de workflow do GitHub concluído",
+        "githubWorkflowCompleted": "Fluxo de trabalho do GitHub concluído",
+        "githubWorkflowJobCompleted": "Job de fluxo de trabalho do GitHub concluído",
         "gmailLabelApplied": "Label do Gmail aplicada",
         "gmailNewMessage": "Nova mensagem do Gmail",
         "googleCalendarCancelled": "Evento do Google Calendar cancelado",
@@ -1179,20 +1179,20 @@
     "composer": {
       "agentSuggestions": "Agentes",
       "configureModel": "Configurar modelo",
-      "createWorkflow": "Criar workflow",
+      "createWorkflow": "Criar fluxo de trabalho",
       "message": "Mensagem",
       "modelConfigureAction": "Configurar modelo",
-      "placeholder": "Peça para automatizar workflows, gerenciar tarefas...",
+      "placeholder": "Peça para automatizar fluxos de trabalho, gerenciar tarefas...",
       "selectedModelUnavailable": "O modelo selecionado não está disponível. Configure-o antes de enviar.",
       "selectedModelUnavailableToast": "O modelo selecionado não está disponível",
       "selectModel": "Selecionar modelo",
       "threadSuggestions": "Conversas",
       "visualAttachmentsUnsupported": "{{modelName}} não reconhece imagens nem vídeos. Troque para um modelo com visão para anexá-los.",
       "workflows": {
-        "empty": "Nenhum workflow correspondente",
-        "loading": "Carregando workflows...",
-        "title": "Workflows",
-        "viewAll": "Ver todos os workflows"
+        "empty": "Nenhum fluxo de trabalho correspondente",
+        "loading": "Carregando fluxos de trabalho...",
+        "title": "Fluxos de trabalho",
+        "viewAll": "Ver todos os fluxos de trabalho"
       }
     },
     "computerUse": {
@@ -1359,7 +1359,7 @@
       "skipAutomationEvent": "Ignorar evento de automação"
     },
     "replaceDraft": {
-      "description": "Continuar limpará o rascunho atual do editor e iniciará um prompt de workflow.",
+      "description": "Continuar limpará o rascunho atual do editor e iniciará um prompt de fluxo de trabalho.",
       "title": "Substituir rascunho do editor?"
     },
     "run": {
@@ -1455,17 +1455,17 @@
         "presentation": "Apresentação",
         "video": "Vídeo",
         "website": "Site",
-        "workflow": "Workflow"
+        "workflow": "Fluxo de trabalho"
       },
       "messageTemplate": "Template da mensagem: {{title}}",
       "previewTemplate": "Visualizar template {{title}}",
       "previewVideo": "Visualizar template de vídeo {{title}}",
       "previewWebsite": "Visualizar template de site {{title}}",
-      "previewWorkflow": "Visualizar template de workflow {{title}}",
+      "previewWorkflow": "Visualizar template de fluxo de trabalho {{title}}",
       "removeTemplate": "Remover template {{title}}",
       "removeVideo": "Remover template de vídeo {{title}}",
       "removeWebsite": "Remover template de site {{title}}",
-      "removeWorkflow": "Remover template de workflow {{title}}"
+      "removeWorkflow": "Remover template de fluxo de trabalho {{title}}"
     },
     "thread": {
       "ariaLabel": "Conversa",
@@ -1512,8 +1512,8 @@
       "transcriptionFailed": "Falha na transcrição de voz. Tente novamente."
     },
     "workflows": {
-      "named": "Workflow {{title}}",
-      "open": "Abrir workflow {{title}}"
+      "named": "Fluxo de trabalho {{title}}",
+      "open": "Abrir fluxo de trabalho {{title}}"
     }
   },
   "connectors": {
@@ -1564,11 +1564,15 @@
       "connectedDescription": "Sua conta foi conectada. Você pode fechar esta janela.",
       "connecting": "Conectando {{connector}}…",
       "connectingDescription": "Aguarde enquanto terminamos de conectar sua conta.",
+      "customConnectorLabel": "Conector personalizado",
+      "documentTitle": "Conectar {{connector}}",
       "errorDescription": "{{error}} Feche esta janela e tente novamente.",
       "errorFallback": "Ocorreu um erro durante a conexão.",
       "failed": "Falha na conexão",
       "failedTitle": "Não foi possível conectar {{connector}}",
       "finishing": "Finalizando a conexão segura",
+      "genericLabel": "Conector",
+      "invalidUrl": "A URL de callback do conector é inválida.",
       "success": "Conectado"
     },
     "card": {
@@ -1690,6 +1694,14 @@
         "verificationCode": "Código de verificação",
         "waiting": "Aguardando aprovação. Mantenha esta caixa de diálogo aberta."
       },
+      "errors": {
+        "authorizationWindow": "Falha ao abrir a janela de autorização",
+        "codeRequired": "Insira o código do {{connector}}.",
+        "denied": "A conexão foi negada. Inicie novamente para tentar de novo.",
+        "expired": "A sessão de conexão expirou. Inicie novamente para tentar de novo.",
+        "failed": "Falha na conexão. Inicie novamente para tentar de novo.",
+        "verificationOpen": "Não foi possível abrir a página de verificação. Tente novamente."
+      },
       "external": {
         "code": "Código",
         "complete": "Concluir conexão",
@@ -1713,19 +1725,69 @@
       }
     },
     "custom": {
+      "agentUsage": {
+        "none": "Não é usado por nenhum agente",
+        "usedBy": "Usado por {{agents}}",
+        "usedByOverflow_one": "Usado por {{agents}} +{{value}}",
+        "usedByOverflow_many": "Usado por {{agents}} +{{value}}",
+        "usedByOverflow_other": "Usado por {{agents}} +{{value}}"
+      },
       "connect": {
+        "apiAuthentication": "Autenticação por API",
+        "apiDescription": "Insira o segredo de API fornecido pelo provedor.",
+        "back": "Voltar",
+        "connecting": "Conectando…",
+        "continue": "Continuar",
+        "continueToProvider": "Continue no provedor para autorizar o acesso.",
         "description": "Seu segredo é criptografado em repouso e injetado nas solicitações de saída pelo firewall. Ele nunca é exposto ao agente como uma variável de ambiente.",
+        "oauthDescription": "Autorize o acesso com o app OAuth do conector.",
+        "save": "Salvar",
+        "saving": "Salvando…",
         "secret": "Segredo",
         "title": "Conectar {{connector}}"
       },
       "create": {
+        "addAuthentication": "Adicionar autenticação",
+        "advancedApiPreserved": "Os campos e as injeções avançadas de API são preservados ao salvar.",
+        "advancedSettings": "Configurações avançadas",
+        "apiAuthentication": "Autenticação por API",
+        "apiAuthenticationDescription": "Injete um segredo fornecido pelo usuário em cada solicitação correspondente.",
+        "authorizationParameters": "Parâmetros de autorização",
+        "authorizationParametersDescription": "Adicione somente os parâmetros exigidos pelo provedor.",
+        "authorizationUrl": "URL de autorização",
+        "clientId": "ID do cliente",
+        "clientSecret": "Segredo do cliente",
         "displayName": "Nome de exibição",
         "headerName": "Nome do header",
         "headerTemplate": "Modelo do header",
         "headerTemplateHint": "(deve conter {{placeholder}})",
+        "httpBasicAuthentication": "Autenticação HTTP Basic",
+        "keepClientSecret": "Deixe o segredo do cliente em branco para manter o valor armazenado.",
+        "keepClientSecretPlaceholder": "Deixe em branco para manter o atual",
+        "newClientSecret": "Novo segredo do cliente",
+        "none": "Nenhum",
+        "oauthChangesDisconnect": "Alterar as configurações OAuth ou as credenciais do cliente desconecta as conexões OAuth existentes.",
+        "oauthDescription": "Configure um app OAuth para os membros autorizarem.",
+        "optional": "(opcional)",
+        "parameters": {
+          "accessType": "Tipo de acesso",
+          "audience": "Público",
+          "prompt": "Prompt",
+          "resource": "Recurso"
+        },
         "prefixes": "Prefixos",
         "prefixesHint": "(um por linha, somente https)",
-        "title": "Novo conector personalizado"
+        "redirectCopy": "Copiar URL de redirecionamento",
+        "redirectHint": "(Cadastre esta URL no app OAuth do provedor.)",
+        "redirectUrl": "URL de redirecionamento",
+        "removeApiAuthentication": "Remover autenticação por API",
+        "removeOauth": "Remover OAuth 2.0",
+        "scopes": "Escopos",
+        "scopesHint": "(um por linha)",
+        "secretInRequestBody": "Segredo do cliente no corpo da solicitação",
+        "title": "Novo conector personalizado",
+        "tokenEndpointAuthentication": "Autenticação do endpoint de token",
+        "tokenUrl": "URL do token"
       },
       "delete": {
         "description": "Isso remove o conector e o segredo armazenado de cada membro. Os agentes autorizados para este conector perderão o acesso imediatamente. Esta ação não pode ser desfeita.",
@@ -1748,6 +1810,11 @@
         "deleted": "Conector personalizado excluído",
         "disconnected": "Desconectado",
         "renamed": "Renomeado para \"{{connector}}\""
+      },
+      "updateConfirm": {
+        "action": "Salvar e desconectar",
+        "description": "Estas alterações OAuth desconectarão todos os membros conectados atualmente via OAuth. Eles precisarão conectar este conector personalizado novamente.",
+        "title": "Desconectar as conexões OAuth existentes?"
       }
     },
     "customProposal": {
@@ -1961,6 +2028,66 @@
         "sendVerification": "Enviar verificação",
         "verificationSent": "Mensagem de verificação enviada para {{phone}}. Abra o link dessa mensagem para concluir a conexão."
       },
+      "catalogDiagnostics": {
+        "fields": {
+          "activated": "Ativado",
+          "activeCatalogDigest": "Digest do catálogo ativo",
+          "activeVersion": "Versão ativa",
+          "evaluated": "Avaliado",
+          "evaluation": "Avaliação",
+          "executableCapabilityDigest": "Digest de recursos executáveis",
+          "failureCode": "Código da falha",
+          "filteredAuthMethods": "Métodos de autenticação filtrados",
+          "lastAttempt": "Última tentativa",
+          "lastAttemptAt": "Data da última tentativa",
+          "lastSuccess": "Último sucesso",
+          "missingVersions": "Versões ausentes",
+          "rejectedCatalogDigest": "Digest do catálogo rejeitado",
+          "rejectedVersion": "Versão rejeitada",
+          "rejectingBackend": "Backend que rejeitou",
+          "rejectionCache": "Cache de rejeição",
+          "rejectionFailure": "Falha da rejeição",
+          "syncState": "Estado da sincronização",
+          "unownedSecrets": "Segredos sem proprietário",
+          "unownedVariables": "Variáveis sem proprietário",
+          "unresolvedBridgeCredentials": "Credenciais de ponte não resolvidas"
+        },
+        "loading": "Carregando",
+        "none": "Nenhum",
+        "notReused": "Não reutilizado",
+        "reused": "Reutilizado",
+        "sections": {
+          "compatibility": "Compatibilidade",
+          "credentialStorage": "Armazenamento de credenciais",
+          "rejectedCandidate": "Candidato rejeitado"
+        },
+        "title": "Catálogo de conectores",
+        "unavailable": "Indisponível",
+        "values": {
+          "accepted": "Aceito",
+          "current": "Atual",
+          "digestMismatch": "Digest incompatível",
+          "invalidArtifact": "Artefato inválido",
+          "invalidCompression": "Compactação inválida",
+          "invalidJson": "JSON inválido",
+          "invalidPointer": "Ponteiro inválido",
+          "invalidReference": "Referência inválida",
+          "missingAccessProvider": "Provedor de acesso ausente",
+          "missingGrantProvider": "Provedor de concessão ausente",
+          "missingPlatformConfiguration": "Configuração da plataforma ausente",
+          "missingRevokeProvider": "Provedor de revogação ausente",
+          "neverSynced": "Nunca sincronizado",
+          "objectTooLarge": "Objeto grande demais",
+          "providerContractMismatch": "Contrato do provedor incompatível",
+          "publicLeakage": "Vazamento público",
+          "rejected": "Rejeitado",
+          "relationshipMismatch": "Relacionamento incompatível",
+          "sourceUnavailable": "Origem indisponível",
+          "stale": "Desatualizado",
+          "unchanged": "Sem alterações",
+          "unsupportedSchema": "Schema não compatível"
+        }
+      },
       "errors": {
         "agentphonePhone": "Digite um número de telefone com código do país, como +1 555 555 1212.",
         "githubAuthorizationWindow": "Falha ao abrir a janela de autorização",
@@ -1979,7 +2106,7 @@
         "callbackStatusVerified": "Callback verificado",
         "callbackStatusWaiting": "Aguardando callback",
         "configured": "Configurado",
-        "copied": "{{label}} copiado",
+        "copied": "Copiado: {{label}}",
         "copy": "Copiar",
         "create": {
           "descriptionAfter": ", crie um app personalizado empresarial chamado {{brandName}}, envie o ícone do {{brandName}} e adicione o recurso Bot.",
@@ -1992,12 +2119,15 @@
           "title": "Criar um app personalizado empresarial"
         },
         "credentials": {
-          "description": "Copie o App ID e o App Secret de Credentials & Basic Information.",
+          "appId": "ID do app",
+          "appSecret": "Segredo do app",
+          "description": "Copie o ID e o segredo do app em Credentials & Basic Information.",
           "imageAlt": "Resultado da criação do app do Feishu mostrando onde encontrar o App ID e o App Secret",
           "title": "Adicionar as credenciais do app"
         },
         "defaultAgent": "Agente padrão",
         "defaultAgentAria": "Agente padrão para {{appId}}",
+        "developerConsole": "console de desenvolvedor do Feishu",
         "dialogAdminRequired": "Um administrador da organização deve configurar o app. Você poderá conectar sua própria conta pela lista de bots do Feishu após a conclusão da configuração.",
         "emptyAdmin": "Adicione um app personalizado para encaminhar mensagens do Feishu a um agente.",
         "emptyMember": "Peça a um administrador da organização para adicionar um bot do Feishu.",
@@ -2071,12 +2201,53 @@
         "tokens": {
           "descriptionAfter": ", selecione o app que você acabou de criar e abra sua página de configuração. Acesse Event Configuration → Encryption Strategy e copie o Encrypt Key e o Verification Token.",
           "descriptionBefore": "Abra o ",
+          "encryptKey": "Chave de criptografia",
           "imageAlt": "Tela Encryption Strategy do Feishu mostrando o Encrypt Key e o Verification Token",
-          "title": "Adicionar os tokens de verificação de eventos"
+          "title": "Adicionar os tokens de verificação de eventos",
+          "verificationToken": "Token de verificação"
         },
         "uninstallDescription": "Isso desinstala {{bot}} do workspace e desconecta todas as contas do {{brandName}} que o utilizam. Esta ação não pode ser desfeita.",
         "uninstallTargetFallback": "este bot",
         "uninstallTitle": "Desinstalar o bot do Feishu?"
+      },
+      "strapi": {
+        "actions": {
+          "cancel": "Cancelar",
+          "checkTest": "Verificar teste",
+          "copy": "Copiar",
+          "create": "Criar integração",
+          "remove": "Remover",
+          "revealAuthorization": "Revelar header de autorização"
+        },
+        "addDescription": "Uma integração pode atender a várias automações de fluxos de trabalho.",
+        "addTitle": "Adicionar instância do Strapi",
+        "adminRequired": "Peça a um administrador da organização para adicionar ou atualizar integrações do Strapi.",
+        "authorizationHeader": "Header de autorização",
+        "copied": "{{label}} copiado",
+        "description": "Permita que o Zero reaja a entradas publicadas no Strapi e automatize o trabalho subsequente.",
+        "documentTitle": "Strapi",
+        "empty": "Ainda não há instâncias do Strapi conectadas.",
+        "form": {
+          "name": "Nome",
+          "namePlaceholder": "CMS da empresa",
+          "url": "URL do Strapi"
+        },
+        "instructions": "No Strapi, abra Settings → Webhooks, adicione esta URL e o header Authorization, selecione entry.publish e clique em Trigger para enviar um webhook de teste do Strapi.",
+        "lastPublish": "Última publicação: {{date}}",
+        "lastTest": "Último teste: {{date}}",
+        "notReceived": "Não recebido",
+        "removeDescription": "Remova primeiro as automações de fluxos de trabalho. As solicitações de webhook do Strapi para esta URL deixarão de funcionar.",
+        "removeTitle": "Remover a integração do Strapi?",
+        "tested": "Webhook testado",
+        "title": "Strapi",
+        "toasts": {
+          "created": "Integração do Strapi criada",
+          "noTestReceived": "Nenhum webhook de teste do Strapi foi recebido ainda",
+          "removed": "Integração do Strapi removida",
+          "testReceived": "Webhook de teste do Strapi recebido"
+        },
+        "webhookUrl": "URL do webhook",
+        "whereZeroWorks": "Onde o Zero funciona"
       },
       "telegram": {
         "addBot": "Adicionar bot",
@@ -3738,10 +3909,19 @@
   "settings": {
     "accountMenu": {
       "addAccount": "Adicionar conta",
+      "creditBalance_one": "{{value}} crédito",
+      "creditBalance_many": "{{value}} créditos",
+      "creditBalance_other": "{{value}} créditos",
       "exportData": "Exportar dados",
       "lab": "Lab",
       "settings": "Configurações",
       "signOut": "Sair",
+      "subscriptions": {
+        "reset": "Redefinir",
+        "resetTimeUnavailable": "Horário de redefinição indisponível",
+        "usage": "Uso de {{provider}}",
+        "usageRemaining": "{{provider}}: {{window}} restante"
+      },
       "switchAccount": "Trocar de conta",
       "userFallback": "Usuário"
     },
@@ -3930,6 +4110,28 @@
           "week": "Semana"
         }
       },
+      "picker": {
+        "balancedUse": "Uso equilibrado",
+        "builtInModel": "Modelo integrado",
+        "byokHelp": "Usa seu provedor configurado",
+        "fast": "Rápido",
+        "inheritDefault": "Herdar o padrão da organização",
+        "loadError": "Não foi possível carregar os modelos.",
+        "loading": "Carregando modelos...",
+        "models": "Modelos",
+        "moreCodexCredits": "Usa mais créditos do Codex.",
+        "noConfiguredModels": "Nenhum modelo configurado",
+        "priceTiers": {
+          "balanced": "Custo e desempenho equilibrados",
+          "economy": "Nível econômico para tarefas simples do dia a dia",
+          "frontier": "Modelo principal de ponta",
+          "premium": "Modelo premium de ponta para as tarefas mais difíceis"
+        },
+        "prioritizeSpeed": "Prioriza a velocidade",
+        "pro": "Pro",
+        "runSpeed": "Velocidade de execução",
+        "standard": "Padrão"
+      },
       "policies": {
         "actionsFor": "Ações para {{model}}",
         "apiKey": "Chave de API",
@@ -3963,9 +4165,9 @@
       "reset": {
         "confirmDescription": "Use uma redefinição do Codex para redefinir suas janelas de uso atuais. Você tem {{remaining}}.",
         "progress": "Redefinindo...",
-        "remaining_one": "{{count}} redefinição restante",
-        "remaining_many": "{{count}} redefinições restantes",
-        "remaining_other": "{{count}} redefinições restantes",
+        "remaining_one": "{{value}} redefinição restante",
+        "remaining_many": "{{value}} redefinições restantes",
+        "remaining_other": "{{value}} redefinições restantes",
         "remainingUnavailable": "Redefinições restantes indisponíveis",
         "title": "Redefinir o uso do Codex?"
       },
@@ -3981,6 +4183,7 @@
       },
       "toasts": {
         "disconnected": "{{provider}} desconectado",
+        "policiesUpdated": "Configurações dos provedores de modelo atualizadas",
         "reset": "Uso do Codex redefinido",
         "resetUnavailable": "Nenhuma redefinição de uso do Codex disponível",
         "resetUnneeded": "O uso do Codex não precisa ser redefinido agora"
@@ -4413,11 +4616,11 @@
         "addWebhookAction": "Adicionar automação",
         "addWebhookAria": "Adicionar automação de {{title}}",
         "addWebhookDescription": "Execute este fluxo de trabalho quando chegar um evento de webhook correspondente do GitHub.",
-        "addWorkflowAction": "Adicionar automação de workflow",
-        "addWorkflowAria": "Adicionar automação de workflow do GitHub",
+        "addWorkflowAction": "Adicionar automação de fluxo de trabalho",
+        "addWorkflowAria": "Adicionar automação de fluxo de trabalho do GitHub",
         "addWorkflowDescription": "Execute este fluxo de trabalho quando uma execução correspondente do GitHub Actions for concluída.",
-        "addWorkflowTitle": "Adicionar automação de workflow do GitHub",
-        "aJob": "um job de workflow do GitHub",
+        "addWorkflowTitle": "Adicionar automação de fluxo de trabalho do GitHub",
+        "aJob": "um job de fluxo de trabalho do GitHub",
         "any": "Qualquer",
         "anyAuthor": "Qualquer autor",
         "anyComment": "Qualquer comentário",
@@ -4429,10 +4632,10 @@
         "anyResult": "Qualquer resultado",
         "anyReview": "Qualquer revisão",
         "anyReviewState": "Qualquer status de revisão",
-        "anyWorkflow": "Qualquer workflow",
+        "anyWorkflow": "Qualquer fluxo de trabalho",
         "apps": "GitHub Apps",
         "authorsSummary": "Autores {{values}}",
-        "aWorkflow": "um workflow do GitHub",
+        "aWorkflow": "um fluxo de trabalho do GitHub",
         "baseBranches": "Branches base",
         "branches": "Branches",
         "commentPrefixes": "Prefixos de comentário",
@@ -4446,7 +4649,7 @@
         "deploymentStatusTitle": "Status de implantação do GitHub criado",
         "editLabel": "Editar rótulo",
         "editWebhookFilters": "Editar filtros de {{title}}",
-        "editWorkflowFilters": "Editar filtros do workflow do GitHub",
+        "editWorkflowFilters": "Editar filtros do fluxo de trabalho do GitHub",
         "environments": "Ambientes",
         "environmentsSummary": "Ambientes {{values}}",
         "events": "Eventos de acionamento",
@@ -4508,16 +4711,16 @@
         "trustedAuthors": "Autores confiáveis",
         "updateLabelAria": "Atualizar automação de rótulo do GitHub",
         "updateWebhookAria": "Atualizar automação de {{title}}",
-        "updateWorkflowAria": "Atualizar automação de workflow do GitHub",
+        "updateWorkflowAria": "Atualizar automação de fluxo de trabalho do GitHub",
         "withConclusions": " com {{values}}",
         "workflowJobDescription": "Execute quando um job correspondente do Actions for concluído.",
         "workflowJobRule": "Quando {{jobs}} for concluído",
-        "workflowJobTitle": "Job do workflow do GitHub concluído",
+        "workflowJobTitle": "Job do fluxo de trabalho do GitHub concluído",
         "workflowRunDescription": "Execute quando uma execução correspondente do Actions for concluída.",
         "workflowRunRule": "Quando {{workflows}} for concluído{{conclusions}}",
-        "workflowRunTitle": "Workflow do GitHub concluído",
-        "workflows": "Workflows do GitHub",
-        "workflowsSummary": "Workflows {{values}}"
+        "workflowRunTitle": "Fluxo de trabalho do GitHub concluído",
+        "workflows": "Fluxos de trabalho do GitHub",
+        "workflowsSummary": "Fluxos de trabalho {{values}}"
       },
       "gmail": {
         "addCondition": "Adicionar condição",

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -24,6 +24,7 @@ import { updatePage$ } from "../react-router.ts";
 import { pathParams$, replacePathSilently$, searchParams$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 import { jsonParseOr } from "../utils.ts";
+import { i18n } from "../../i18n/index.ts";
 
 type ConnectorCallbackPageResult =
   | { readonly status: "loading" }
@@ -48,12 +49,25 @@ function connectorTypeFromPath(
 
 function connectorLabel(connectorType: ConnectorCallbackType | null): string {
   if (!connectorType) {
-    return "Connector";
+    return i18n.t(($) => {
+      return $.connectors.callback.genericLabel;
+    });
   }
   if (connectorType === "custom") {
-    return "Custom connector";
+    return i18n.t(($) => {
+      return $.connectors.callback.customConnectorLabel;
+    });
   }
   return connectorType === "github" ? "GitHub" : connectorType.toUpperCase();
+}
+
+function connectorCallbackDocumentTitle(label: string): string {
+  return i18n.t(
+    ($) => {
+      return $.connectors.callback.documentTitle;
+    },
+    { connector: label },
+  );
 }
 
 function connectorIconFromSearchParams(
@@ -136,7 +150,10 @@ function resultFromPath(
     return {
       status,
       message:
-        searchParams.get("message") || "An error occurred during connection.",
+        searchParams.get("message") ||
+        i18n.t(($) => {
+          return $.connectors.callback.errorFallback;
+        }),
     };
   }
   return null;
@@ -222,7 +239,7 @@ export const setupConnectorCallbackPage$ = command(
 
     if (pathResult) {
       set(updatePage$, callbackPageElement(connectorIcon, label, pathResult));
-      set(updateDocumentTitle$, `Connect ${label}`);
+      set(updateDocumentTitle$, connectorCallbackDocumentTitle(label));
       await set(hideAppSkeleton$, signal);
       return;
     }
@@ -232,10 +249,12 @@ export const setupConnectorCallbackPage$ = command(
         updatePage$,
         callbackPageElement(connectorIcon, label, {
           status: "error",
-          message: "Invalid connector callback URL.",
+          message: i18n.t(($) => {
+            return $.connectors.callback.invalidUrl;
+          }),
         }),
       );
-      set(updateDocumentTitle$, `Connect ${label}`);
+      set(updateDocumentTitle$, connectorCallbackDocumentTitle(label));
       await set(hideAppSkeleton$, signal);
       return;
     }
@@ -244,7 +263,7 @@ export const setupConnectorCallbackPage$ = command(
       updatePage$,
       callbackPageElement(connectorIcon, label, { status: "loading" }),
     );
-    set(updateDocumentTitle$, `Connect ${label}`);
+    set(updateDocumentTitle$, connectorCallbackDocumentTitle(label));
     await set(hideAppSkeleton$, signal);
 
     const query = Object.fromEntries(searchParams);

--- a/turbo/apps/platform/src/signals/external/org-model-policies.ts
+++ b/turbo/apps/platform/src/signals/external/org-model-policies.ts
@@ -3,6 +3,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
 import type { UpdateOrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroClient$ } from "../api-client.ts";
+import { i18n } from "../../i18n/index.ts";
 import { accept } from "../../lib/accept.ts";
 
 const internalReloadOrgModelPolicies$ = state(0);
@@ -55,7 +56,11 @@ export const updateOrgModelPolicies$ = command(
       return value + 1;
     });
     if (params.toast !== false) {
-      toast.success("Model provider settings updated");
+      toast.success(
+        i18n.t(($) => {
+          return $.settings.models.toasts.policiesUpdated;
+        }),
+      );
     }
     return result.body;
   },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1245,13 +1245,19 @@ function getOAuthDeviceAuthTerminalMessage(
   }
   switch (result.status) {
     case "denied": {
-      return "Connection was denied. Start again to retry.";
+      return i18n.t(($) => {
+        return $.connectors.connectDialog.errors.denied;
+      });
     }
     case "expired": {
-      return "Connection session expired. Start again to retry.";
+      return i18n.t(($) => {
+        return $.connectors.connectDialog.errors.expired;
+      });
     }
     case "error": {
-      return "Connection failed. Start again to retry.";
+      return i18n.t(($) => {
+        return $.connectors.connectDialog.errors.failed;
+      });
     }
   }
 }
@@ -1301,7 +1307,9 @@ export const openConnectorOAuthDeviceAuthVerificationPage$ = command(
     if (!verificationWindow) {
       set(internalConnectorOAuthDeviceAuthState$, {
         ...current,
-        errorMessage: "Could not open the verification page. Try again.",
+        errorMessage: i18n.t(($) => {
+          return $.connectors.connectDialog.errors.verificationOpen;
+        }),
       });
       return false;
     }
@@ -1507,7 +1515,9 @@ const pollConnectorOAuthDeviceAuth$ = command(
         status: "expired",
         connectorSlug,
         authMethod,
-        message: "Connection session expired. Start again to retry.",
+        message: i18n.t(($) => {
+          return $.connectors.connectDialog.errors.expired;
+        }),
       });
     }
     return completed;
@@ -1574,7 +1584,9 @@ const connectConnectorOAuthDeviceAuth$ = command(
             status: "error",
             connectorSlug,
             authMethod,
-            message: "Connection failed. Start again to retry.",
+            message: i18n.t(($) => {
+              return $.connectors.connectDialog.errors.failed;
+            }),
           });
         }
         flowSignal.throwIfAborted();
@@ -1829,7 +1841,9 @@ export const connectConnectorExternalCode$ = command(
             status: "error",
             connectorSlug,
             authMethod,
-            message: "Connection failed. Start again to retry.",
+            message: i18n.t(($) => {
+              return $.connectors.connectDialog.errors.failed;
+            }),
           });
         }
         flowSignal.throwIfAborted();
@@ -1893,7 +1907,9 @@ const completeConnectorExternalCode$ = command(
         status: "expired",
         connectorSlug,
         authMethod,
-        message: "Connection session expired. Start again to retry.",
+        message: i18n.t(($) => {
+          return $.connectors.connectDialog.errors.expired;
+        }),
       });
       return false;
     }
@@ -1902,7 +1918,12 @@ const completeConnectorExternalCode$ = command(
     if (!code) {
       set(internalConnectorExternalCodeState$, {
         ...current,
-        errorMessage: `Enter the code from ${options.connectorLabel ?? connectorSlug}.`,
+        errorMessage: i18n.t(
+          ($) => {
+            return $.connectors.connectDialog.errors.codeRequired;
+          },
+          { connector: options.connectorLabel ?? connectorSlug },
+        ),
       });
       return false;
     }
@@ -2148,7 +2169,11 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     const authWindow = window.open(redirectingPath, "_blank", popupFeatures);
 
     if (!authWindow && !standalone) {
-      throw new Error("Failed to open authorization window");
+      throw new Error(
+        i18n.t(($) => {
+          return $.connectors.connectDialog.errors.authorizationWindow;
+        }),
+      );
     }
     if (authWindow) {
       authWindow.opener = null;

--- a/turbo/apps/platform/src/signals/zero-page/strapi-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/strapi-settings-page.ts
@@ -11,6 +11,7 @@ import { ROUTES } from "../route-paths.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { resetStrapiSettings$ } from "./zero-strapi.ts";
+import { i18n } from "../../i18n/index.ts";
 
 export const setupStrapiSettingsPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -23,7 +24,12 @@ export const setupStrapiSettingsPage$ = command(
     }
     set(resetStrapiSettings$);
     set(updatePage$, createElement(ZeroStrapiSettingsPage), "sidebar");
-    set(updateDocumentTitle$, "Strapi");
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.connectors.providerSettings.strapi.documentTitle;
+      }),
+    );
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-strapi.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-strapi.ts
@@ -6,6 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
+import { i18n } from "../../i18n/index.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 
@@ -63,7 +64,11 @@ export const createStrapiIntegration$ = command(
     set(reload$, (value) => {
       return value + 1;
     });
-    toast.success("Strapi integration created");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.strapi.toasts.created;
+      }),
+    );
     return result.body;
   },
 );
@@ -99,9 +104,17 @@ export const checkStrapiIntegrationTest$ = command(
       return value + 1;
     });
     if (result.body.received) {
-      toast.success("Strapi test webhook received");
+      toast.success(
+        i18n.t(($) => {
+          return $.connectors.providerSettings.strapi.toasts.testReceived;
+        }),
+      );
     } else {
-      toast.info("No Strapi test webhook received yet");
+      toast.info(
+        i18n.t(($) => {
+          return $.connectors.providerSettings.strapi.toasts.noTestReceived;
+        }),
+      );
     }
     return result.body;
   },
@@ -124,7 +137,11 @@ export const removeStrapiIntegration$ = command(
     set(reload$, (value) => {
       return value + 1;
     });
-    toast.success("Strapi integration removed");
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.strapi.toasts.removed;
+      }),
+    );
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -20,9 +20,11 @@ import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { emitMockedClerkEvent } from "../../../__tests__/mock-auth.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { orgModelPolicies$ } from "../../../signals/external/org-model-policies.ts";
 import {
   reloadUserModelPreference$,
@@ -77,6 +79,11 @@ import {
 
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
+});
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
 });
 
 async function navigateToChatThread(threadId: string): Promise<void> {
@@ -243,6 +250,69 @@ describe("chat composer models", () => {
         codexServiceTier: "fast",
       });
     });
+  });
+
+  it("localizes model routes, price guidance, and Codex speed controls in Portuguese", async () => {
+    const user = userEvent.setup({ delay: null });
+    const codexProvider = buildProvider({
+      id: "00000000-0000-4000-a000-000000000913",
+      type: "codex-oauth-token",
+      framework: "codex",
+      secretName: null,
+      authMethod: "auth_json",
+      secretNames: ["CODEX_AUTH_JSON"],
+    });
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        id: "00000000-0000-4000-a000-000000000914",
+        model: "gpt-5.6-sol",
+        modelLabel: "GPT 5.6 Sol",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+      }),
+      buildModelPolicy({
+        id: "00000000-0000-4000-a000-000000000915",
+        model: "deepseek-v4-pro",
+        modelLabel: "DeepSeek V4 Pro",
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+      }),
+    ]);
+    context.mocks.data.personalModelProviders([codexProvider]);
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.CodexFastMode]: true,
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    click(await findComposerModel("GPT 5.6 Sol"));
+    const runSpeed = await screen.findByRole("group", {
+      name: "Velocidade de execução",
+    });
+    expect(buttonContainingText("Padrão", runSpeed)).toBeInTheDocument();
+    expect(buttonContainingText("Rápido", runSpeed)).toBeInTheDocument();
+    expect(within(runSpeed).getByText("Uso equilibrado")).toBeInTheDocument();
+    expect(
+      within(runSpeed).getByText("Prioriza a velocidade"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Usa mais créditos do Codex.")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("$"));
+    await expect(
+      screen.findAllByText("Nível econômico para tarefas simples do dia a dia"),
+    ).resolves.not.toHaveLength(0);
+
+    await user.hover(screen.getByText("BYOK"));
+    await expect(
+      screen.findAllByText("Usa seu provedor configurado"),
+    ).resolves.not.toHaveLength(0);
   });
 
   it("remembers Codex fast mode for new chats in the current browser account", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1,12 +1,15 @@
 import { screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   chatEventResponse,
   chatThreadByIdContract,
   chatThreadMarkReadContract,
   chatThreadEventsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { click } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { mockChatLifecycle, mockSubagentThread } from "./chat-test-helpers.ts";
 import {
   context,
@@ -18,6 +21,11 @@ import {
   buttonByText,
   buttonByLabel,
 } from "./chat-lifecycle-test-helpers.ts";
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 describe("chat lifecycle", () => {
   it("shows run credit usage with friendly popover details", async () => {
@@ -896,6 +904,67 @@ describe("chat lifecycle", () => {
       "bg-border/40",
     );
     expect(finishedLabelRow!.lastElementChild).not.toHaveClass("hidden");
+  });
+
+  it("formats completed-run timestamps with the selected Portuguese locale", async () => {
+    const completedAt = "2026-06-09T10:00:21Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("pt-BR", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    mockChatLifecycle(context, {
+      threadId: "thread-localized-completed-run",
+      chatEvents: [
+        {
+          role: "user",
+          content: "Prepare o plano de lançamento",
+          runId: "run-localized-completed-run",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "O plano de lançamento está pronto.",
+          runId: "run-localized-completed-run",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-localized-completed-run",
+          runLifecycleEvent: "completed",
+          createdAt: completedAt,
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-localized-completed-run",
+          recommendedFollowups: [
+            {
+              prompt: "Transforme em uma apresentação",
+              kind: "generate",
+              generationType: "presentation",
+            },
+          ],
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-localized-completed-run",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText(`Continuar · ${completedAtLabel}`),
+    ).resolves.toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("pt-BR");
   });
 
   it("does not let an attached lifecycle marker hide the final answer", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -9,8 +9,9 @@ import type {
   ModelProviderResponse,
   OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -18,9 +19,16 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 function staleCodexProvider(): ModelProviderResponse {
   return {
@@ -293,6 +301,54 @@ function dialogContaining(element: HTMLElement): HTMLElement {
 }
 
 describe("organization model providers settings", () => {
+  it("localizes built-in model policy updates in Portuguese", async () => {
+    mockAdminOrg();
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    context.mocks.data.orgModelProviders([]);
+    context.mocks.data.orgModelPolicies([
+      builtInPolicy(
+        "00000000-0000-4000-a000-000000000214",
+        "deepseek-v4-pro",
+        "DeepSeek V4 Pro",
+        true,
+      ),
+      builtInPolicy(
+        "00000000-0000-4000-a000-000000000215",
+        "gpt-5.5",
+        "GPT 5.5",
+        false,
+      ),
+    ]);
+    mockBillingCapabilities({
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=model",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Modelos" }),
+    ).resolves.toBeInTheDocument();
+    const deepseekRow = await screen.findByTestId(
+      "org-model-policy-row-deepseek-v4-pro",
+    );
+    expect(within(deepseekRow).getByText("Integrado")).toBeInTheDocument();
+
+    const defaultRow = screen.getByTestId("default-model-row");
+    click(within(defaultRow).getByRole("combobox"));
+    click(await screen.findByRole("option", { name: "GPT 5.5" }));
+
+    await expect(
+      screen.findByText("Configurações dos provedores de modelo atualizadas"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("only offers OpenAI and Anthropic models when adding a model", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -3289,6 +3289,77 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("localizes the custom connector OAuth entry flow in Portuguese", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000033";
+    const connector = customConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      hasSecret: true,
+    });
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "admin",
+    });
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    context.mocks.data.team([teamAgent(researchAgentId, "Research")]);
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledIds: [connector.id] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors?tab=custom",
+      featureSwitches: {
+        [FeatureSwitchKey.CustomConnectorOAuth2]: true,
+        [FeatureSwitchKey.LanguagePreference]: true,
+      },
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("Acme Search");
+      expect(within(card).getByText("Conectado")).toBeInTheDocument();
+      expect(
+        within(card).getByTestId("custom-connector-card-agent-usage"),
+      ).toHaveTextContent("Usado por Research");
+    });
+
+    click(await screen.findByText("Novo conector"));
+    const createDialog = await screen.findByRole("dialog", {
+      name: "Novo conector personalizado",
+    });
+    expect(
+      within(createDialog).getByLabelText("Nome de exibição"),
+    ).toBeInTheDocument();
+    expect(within(createDialog).getByLabelText("Fechar")).toBeInTheDocument();
+
+    click(buttonByText("Adicionar autenticação", createDialog));
+    click(menuItemByText("OAuth 2.0"));
+
+    expect(
+      within(createDialog).getByText(
+        "Configure um app OAuth para os membros autorizarem.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(createDialog).getByLabelText("URL do token"),
+    ).toBeInTheDocument();
+    expect(
+      within(createDialog).getByLabelText("ID do cliente"),
+    ).toBeInTheDocument();
+    expect(
+      within(createDialog).getByText("Configurações avançadas"),
+    ).toBeInTheDocument();
+    expect(within(createDialog).getByLabelText("PKCE")).toHaveTextContent(
+      "Nenhum",
+    );
+  });
+
   it("configures OAuth app credentials at creation and authorizes on connect", async () => {
     const defaultAgentId = "c0000000-0000-4000-a000-000000000001";
     const researchAgentId = "c0000000-0000-4000-a000-000000000041";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -20,7 +20,7 @@ import { i18n } from "../../../i18n/index.ts";
 
 const context = testContext();
 const PT_BR_PLACEHOLDER =
-  "Peça para automatizar workflows, gerenciar tarefas...";
+  "Peça para automatizar fluxos de trabalho, gerenciar tarefas...";
 
 afterEach(async () => {
   await i18n.changeLanguage("en-US");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -16,6 +16,8 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { clearMockNow, mockNow } from "../../../lib/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -24,8 +26,10 @@ const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
-afterEach(() => {
+afterEach(async () => {
   clearMockNow();
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
 });
 
 function connectedPersonalCodexProvider(
@@ -1103,6 +1107,9 @@ describe("zero sidebar account menu", () => {
 
   it("localizes account actions without changing account data or routes", async () => {
     mockAdminAccountSidebar();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
     context.mocks.data.userPreferences({
       locale: "pt-BR",
       supportedLocales: ["en-US", "pt-BR"],
@@ -1139,7 +1146,10 @@ describe("zero sidebar account menu", () => {
           },
         ],
       },
-      featureSwitches: { [FeatureSwitchKey.LanguagePreference]: true },
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+        [FeatureSwitchKey.SidebarSubscriptionUsage]: true,
+      },
     });
 
     let menu = await openAccountMenu();
@@ -1149,6 +1159,19 @@ describe("zero sidebar account menu", () => {
     expect(within(menu).getByText("Trocar de conta")).toBeVisible();
     expect(within(menu).getByText("Exportar dados")).toBeVisible();
     expect(within(menu).getByText("Sair")).toBeVisible();
+    expect(within(menu).getByText("12.500 créditos")).toBeVisible();
+    const subscriptions = await within(menu).findByTestId(
+      "account-menu-subscriptions",
+    );
+    expect(
+      within(subscriptions).getByText("2 redefinições restantes"),
+    ).toBeVisible();
+    expect(
+      within(subscriptions).getByRole("progressbar", {
+        name: "Codex: 5h restante",
+      }),
+    ).toHaveAttribute("aria-valuenow", "82");
+    expect(within(subscriptions).getByText("Redefinir")).toBeInTheDocument();
 
     click(within(menu).getByText("Exportar dados"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2495,7 +2495,7 @@ describe("zero sidebar", () => {
       within(rail).getByRole("navigation", { name: "Barra lateral" }),
     ).toBeInTheDocument();
     expect(within(rail).getByText("Agentes")).toBeInTheDocument();
-    expect(within(rail).getByText("Fluxos")).toBeInTheDocument();
+    expect(within(rail).getByText("Fluxos de trabalho")).toBeInTheDocument();
     expect(within(rail).getByText("Conectores")).toBeInTheDocument();
     expect(within(rail).getByText("Artefatos")).toBeInTheDocument();
     expect(within(rail).getByText("Atividade")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -13,7 +13,7 @@ import {
 import { zeroStrapiIntegrationsContract } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   click,
@@ -21,9 +21,16 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { initializeI18n } from "../../../i18n/index.ts";
+import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+afterEach(async () => {
+  document.documentElement.lang = DEFAULT_LOCALE;
+  await initializeI18n(DEFAULT_LOCALE);
+});
 
 function queryRole(role: "button" | "link", name: string): HTMLElement | null {
   return (
@@ -383,6 +390,61 @@ describe("works page", () => {
     await expect(
       screen.findByText("Webhook tested"),
     ).resolves.toBeInTheDocument();
+  });
+
+  it("localizes Strapi settings in Portuguese while preserving integration data", async () => {
+    const integrationId = "00000000-0000-4000-8000-000000000092";
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    context.mocks.api(zeroStrapiIntegrationsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          id: integrationId,
+          name: "Marketing CMS",
+          baseUrl: "https://cms.example.com",
+          webhookUrl: `https://www.vm0.test/api/zero/strapi/events/${integrationId}`,
+          secretLastFour: "abcd",
+          lastTestedAt: "2026-07-28T04:00:00.000Z",
+          lastReceivedAt: null,
+          createdAt: "2026-07-28T03:00:00.000Z",
+        },
+      ]);
+    });
+    context.mocks.api(
+      zeroStrapiIntegrationsContract.checkTest,
+      ({ respond }) => {
+        return respond(200, {
+          received: true,
+          lastTestedAt: "2026-07-28T04:00:00.000Z",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/settings/strapi",
+      featureSwitches: {
+        [FeatureSwitchKey.LanguagePreference]: true,
+        [FeatureSwitchKey.StrapiIntegration]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText("Marketing CMS"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Permita que o Zero reaja a entradas publicadas no Strapi e automatize o trabalho subsequente.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Webhook testado")).toBeInTheDocument();
+    expect(getRole("button", "Verificar teste")).toBeInTheDocument();
+    expect(screen.getByText(/^Último teste:/u)).toBeInTheDocument();
+    expect(screen.getByText("https://cms.example.com")).toBeInTheDocument();
+    click(getRole("button", "Verificar teste"));
+    await expect(
+      screen.findByText("Webhook de teste do Strapi recebido"),
+    ).resolves.toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("pt-BR");
   });
 
   it("redirects direct Feishu settings navigation when the switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -32,6 +32,7 @@ import {
   type OrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
+import { useTranslation } from "react-i18next";
 import { orgModelPolicies$ } from "../../../signals/external/org-model-policies";
 import { userModelPreference$ } from "../../../signals/external/user-model-preference";
 import {
@@ -127,6 +128,7 @@ function PriceTierBadge({ tier }: { tier: Vm0ModelPriceTier }) {
 }
 
 function ByokBadge() {
+  const { t } = useTranslation();
   return (
     <TooltipProvider delayDuration={300}>
       <Tooltip>
@@ -136,7 +138,9 @@ function ByokBadge() {
           </span>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
-          Uses your configured provider
+          {t(($) => {
+            return $.settings.models.picker.byokHelp;
+          })}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -144,9 +148,12 @@ function ByokBadge() {
 }
 
 function ProBadge() {
+  const { t } = useTranslation();
   return (
     <span className="shrink-0 rounded bg-primary px-1.5 py-0.5 text-[11px] font-medium leading-none text-primary-foreground">
-      Pro
+      {t(($) => {
+        return $.settings.models.picker.pro;
+      })}
     </span>
   );
 }
@@ -327,6 +334,7 @@ function ModelFirstTriggerLabel({
   placeholder: string;
   mobileIcon: boolean;
 }) {
+  const { t } = useTranslation();
   if (!selectedModel) {
     return (
       <ResponsiveTriggerContent
@@ -349,7 +357,9 @@ function ModelFirstTriggerLabel({
           {codexServiceTier === "fast" && (
             <span className="inline-flex h-5 shrink-0 items-center gap-1 rounded bg-amber-500/10 px-1.5 text-[11px] font-medium leading-none text-amber-700 dark:text-amber-300">
               <IconBolt size={12} stroke={1.8} />
-              Fast
+              {t(($) => {
+                return $.settings.models.picker.fast;
+              })}
             </span>
           )}
         </span>
@@ -484,6 +494,7 @@ function ModelFirstPolicyItems({
   modelCapabilities: ModelPlanCapabilities;
   showSeparator?: boolean;
 }) {
+  const { t } = useTranslation();
   const hasExplicitSelectedPolicy =
     explicitSelectedModel === null ||
     policies.some((policy) => {
@@ -506,12 +517,16 @@ function ModelFirstPolicyItems({
       )}
       {policies.length === 0 ? (
         <div className="px-2 py-2 text-sm text-muted-foreground">
-          No configured models
+          {t(($) => {
+            return $.settings.models.picker.noConfiguredModels;
+          })}
         </div>
       ) : (
         <SelectGroup>
           <SelectLabel className="pl-2 pr-8 py-1.5 text-xs font-medium text-muted-foreground">
-            Models
+            {t(($) => {
+              return $.settings.models.picker.models;
+            })}
           </SelectLabel>
           {policies.map((policy) => {
             return (
@@ -537,20 +552,27 @@ function CodexFastModeSplitPanel({
   selectedModel: string;
   onCheckedChange: (checked: boolean) => void;
 }) {
+  const { t } = useTranslation();
   const stopSelectDismiss = (event: SyntheticEvent) => {
     event.stopPropagation();
   };
   return (
     <div className="w-[132px] border-l border-border/70 p-2">
       <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
-        <span className="text-xs font-medium text-foreground">Run speed</span>
+        <span className="text-xs font-medium text-foreground">
+          {t(($) => {
+            return $.settings.models.picker.runSpeed;
+          })}
+        </span>
         <span className="truncate text-[11px] text-muted-foreground">
           {getCanonicalModelDisplayName(selectedModel)}
         </span>
       </div>
       <div
         role="group"
-        aria-label="Run speed"
+        aria-label={t(($) => {
+          return $.settings.models.picker.runSpeed;
+        })}
         className="grid gap-1.5"
         onClick={stopSelectDismiss}
         onPointerDown={stopSelectDismiss}
@@ -568,9 +590,15 @@ function CodexFastModeSplitPanel({
             onCheckedChange(false);
           }}
         >
-          <span className="text-xs font-medium">Standard</span>
+          <span className="text-xs font-medium">
+            {t(($) => {
+              return $.settings.models.picker.standard;
+            })}
+          </span>
           <span className="mt-0.5 text-[11px] leading-3 text-muted-foreground">
-            Balanced use
+            {t(($) => {
+              return $.settings.models.picker.balancedUse;
+            })}
           </span>
         </button>
         <button
@@ -588,15 +616,21 @@ function CodexFastModeSplitPanel({
         >
           <span className="inline-flex items-center gap-1 text-xs font-medium">
             <IconBolt size={12} stroke={1.8} />
-            Fast
+            {t(($) => {
+              return $.settings.models.picker.fast;
+            })}
           </span>
           <span className="mt-0.5 text-[11px] leading-3 text-muted-foreground">
-            Prioritize speed
+            {t(($) => {
+              return $.settings.models.picker.prioritizeSpeed;
+            })}
           </span>
         </button>
       </div>
       <p className="mt-2 text-[11px] leading-4 text-muted-foreground">
-        Uses more Codex credits.
+        {t(($) => {
+          return $.settings.models.picker.moreCodexCredits;
+        })}
       </p>
     </div>
   );
@@ -952,6 +986,7 @@ function LoadingModelFirstModelPickerContent({
   value: ModelProviderSelection | null;
   placeholder: string;
 }) {
+  const { t } = useTranslation();
   const selectValue = value?.selectedModel ?? INHERIT_SENTINEL;
   return (
     <SelectContent className="min-w-[260px]">
@@ -966,7 +1001,9 @@ function LoadingModelFirstModelPickerContent({
           : placeholder}
       </SelectItem>
       <div className="px-2 py-2 text-sm text-muted-foreground">
-        Loading models...
+        {t(($) => {
+          return $.settings.models.picker.loading;
+        })}
       </div>
     </SelectContent>
   );
@@ -979,6 +1016,7 @@ function ErrorModelFirstModelPickerContent({
   value: ModelProviderSelection | null;
   placeholder: string;
 }) {
+  const { t } = useTranslation();
   const selectValue = value?.selectedModel ?? INHERIT_SENTINEL;
   return (
     <SelectContent className="min-w-[260px]">
@@ -993,7 +1031,9 @@ function ErrorModelFirstModelPickerContent({
           : placeholder}
       </SelectItem>
       <div className="px-2 py-2 text-sm text-muted-foreground">
-        Unable to load models.
+        {t(($) => {
+          return $.settings.models.picker.loadError;
+        })}
       </div>
     </SelectContent>
   );
@@ -1162,7 +1202,7 @@ function ModelFirstModelPickerWithDefaultSelection(
 export function ModelProviderPicker({
   value,
   onChange,
-  placeholder = "Inherit from org default",
+  placeholder,
   triggerClassName,
   compactTrigger = false,
   mobileIconTrigger = false,
@@ -1172,10 +1212,16 @@ export function ModelProviderPicker({
   disabled = false,
   resolveDefaultSelection = true,
 }: ModelProviderPickerProps) {
+  const { t } = useTranslation();
+  const resolvedPlaceholder =
+    placeholder ??
+    t(($) => {
+      return $.settings.models.picker.inheritDefault;
+    });
   const props = {
     value,
     onChange,
-    placeholder,
+    placeholder: resolvedPlaceholder,
     triggerClassName,
     compactTrigger,
     mobileIconTrigger,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -265,9 +265,12 @@ function filterPolicyUpdatesForPlan(
 }
 
 function ProBadge() {
+  const { t } = useTranslation();
   return (
     <span className="shrink-0 rounded bg-primary px-1.5 py-0.5 text-[11px] font-medium leading-none text-primary-foreground">
-      Pro
+      {t(($) => {
+        return $.settings.models.picker.pro;
+      })}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx
@@ -8,14 +8,26 @@ import {
   DialogTitle,
 } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
+import { formatLocalizedNumber } from "../../../../i18n/format.ts";
+import { i18n } from "../../../../i18n/index.ts";
 
 export function formatCodexResetCredits(
   value: number | null | undefined,
 ): string {
   if (value === null || value === undefined) {
-    return "Resets left unavailable";
+    return i18n.t(($) => {
+      return $.settings.models.reset.remainingUnavailable;
+    });
   }
-  return `${value} ${value === 1 ? "reset" : "resets"} left`;
+  return i18n.t(
+    ($) => {
+      return $.settings.models.reset.remaining;
+    },
+    {
+      count: value,
+      value: formatLocalizedNumber(value),
+    },
+  );
 }
 
 export function CodexResetUsageDialog({
@@ -32,19 +44,7 @@ export function CodexResetUsageDialog({
   onConfirm: () => void;
 }) {
   const { t } = useTranslation();
-  const remaining =
-    resetCredits === null
-      ? t(($) => {
-          return $.settings.models.reset.remainingUnavailable;
-        })
-      : t(
-          ($) => {
-            return $.settings.models.reset.remaining;
-          },
-          {
-            count: resetCredits,
-          },
-        );
+  const remaining = formatCodexResetCredits(resetCredits);
 
   return (
     <Dialog

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -33,7 +33,10 @@ import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dia
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 import { DropdownMenuModalItem } from "../../../components/dropdown-menu-modal-item.tsx";
 import { formatSubscriptionUsageReset } from "../../subscription-usage-format.ts";
-import { CodexResetUsageDialog } from "./codex-reset-usage-dialog.tsx";
+import {
+  CodexResetUsageDialog,
+  formatCodexResetCredits,
+} from "./codex-reset-usage-dialog.tsx";
 
 type OAuthStatus = "connected" | "stale" | "missing";
 type SubscriptionUsage = NonNullable<
@@ -273,19 +276,7 @@ function CodexOAuthCredentialRow({
   onOpenReset: () => void;
 }) {
   const { t } = useTranslation();
-  const resetCreditLabel =
-    resetCredits === null
-      ? t(($) => {
-          return $.settings.models.reset.remainingUnavailable;
-        })
-      : t(
-          ($) => {
-            return $.settings.models.reset.remaining;
-          },
-          {
-            count: resetCredits,
-          },
-        );
+  const resetCreditLabel = formatCodexResetCredits(resetCredits);
   return (
     <OAuthCredentialRow
       type="codex-oauth-token"
@@ -493,7 +484,7 @@ function SubscriptionUsageMeter({
             window.remainingPercent ??
             (window.usedPercent === null ? null : 100 - window.usedPercent);
           const displayPercent = formatUsagePercent(remainingPercent);
-          const reset = formatSubscriptionUsageReset(window.resetAt, true);
+          const reset = formatSubscriptionUsageReset(window.resetAt);
           const tone = usageTone(remainingPercent);
           return (
             <div key={label} className="space-y-1">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -1,22 +1,173 @@
-import type { ConnectorCatalogDiagnostics } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
+import type {
+  ConnectorCatalogCompatibilityReason,
+  ConnectorCatalogDiagnostics,
+  ConnectorCatalogSyncFailureCode,
+} from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
 import { IconDatabase } from "@tabler/icons-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
+import {
+  formatLocalizedNumber,
+  resolvedAppLocale,
+} from "../../../../i18n/format.ts";
+import { i18n } from "../../../../i18n/index.ts";
 import { connectorCatalogDiagnostics$ } from "../../../../signals/zero-page/settings/connector-catalog-diagnostics.ts";
 
-const EMPTY_VALUE = "None";
+type DiagnosticEnumValue =
+  | ConnectorCatalogDiagnostics["state"]
+  | NonNullable<ConnectorCatalogDiagnostics["lastAttempt"]>["outcome"]
+  | ConnectorCatalogSyncFailureCode
+  | ConnectorCatalogCompatibilityReason;
 
-function formatEnumValue(value: string): string {
-  const words = value.replaceAll("-", " ");
-  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+function emptyValue(): string {
+  return i18n.t(($) => {
+    return $.connectors.providerSettings.catalogDiagnostics.none;
+  });
+}
+
+const DIAGNOSTIC_ENUM_VALUE_TRANSLATIONS: Readonly<
+  Record<DiagnosticEnumValue, () => string>
+> = {
+  accepted: () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values.accepted;
+    });
+  },
+  current: () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values.current;
+    });
+  },
+  "digest-mismatch": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .digestMismatch;
+    });
+  },
+  "invalid-artifact": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .invalidArtifact;
+    });
+  },
+  "invalid-compression": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .invalidCompression;
+    });
+  },
+  "invalid-json": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .invalidJson;
+    });
+  },
+  "invalid-pointer": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .invalidPointer;
+    });
+  },
+  "invalid-reference": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .invalidReference;
+    });
+  },
+  "missing-access-provider": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .missingAccessProvider;
+    });
+  },
+  "missing-grant-provider": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .missingGrantProvider;
+    });
+  },
+  "missing-platform-configuration": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .missingPlatformConfiguration;
+    });
+  },
+  "missing-revoke-provider": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .missingRevokeProvider;
+    });
+  },
+  "never-synced": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .neverSynced;
+    });
+  },
+  "object-too-large": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .objectTooLarge;
+    });
+  },
+  "provider-contract-mismatch": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .providerContractMismatch;
+    });
+  },
+  "public-leakage": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .publicLeakage;
+    });
+  },
+  rejected: () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values.rejected;
+    });
+  },
+  "relationship-mismatch": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .relationshipMismatch;
+    });
+  },
+  "source-unavailable": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .sourceUnavailable;
+    });
+  },
+  stale: () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values.stale;
+    });
+  },
+  unchanged: () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values.unchanged;
+    });
+  },
+  "unsupported-schema": () => {
+    return i18n.t(($) => {
+      return $.connectors.providerSettings.catalogDiagnostics.values
+        .unsupportedSchema;
+    });
+  },
+};
+
+function formatEnumValue(value: DiagnosticEnumValue): string {
+  return DIAGNOSTIC_ENUM_VALUE_TRANSLATIONS[value]();
 }
 
 function formatTimestamp(value: string | null): string {
   if (!value) {
-    return EMPTY_VALUE;
+    return emptyValue();
   }
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(resolvedAppLocale(), {
     dateStyle: "medium",
     timeStyle: "medium",
   }).format(new Date(value));
@@ -26,9 +177,15 @@ function formatRejectedAttemptCacheUse(
   lastAttempt: ConnectorCatalogDiagnostics["lastAttempt"],
 ): string {
   if (!lastAttempt || lastAttempt.outcome !== "rejected") {
-    return EMPTY_VALUE;
+    return emptyValue();
   }
-  return lastAttempt.reusedCachedRejection ? "Reused" : "Not reused";
+  return lastAttempt.reusedCachedRejection
+    ? i18n.t(($) => {
+        return $.connectors.providerSettings.catalogDiagnostics.reused;
+      })
+    : i18n.t(($) => {
+        return $.connectors.providerSettings.catalogDiagnostics.notReused;
+      });
 }
 
 function DiagnosticField({
@@ -67,28 +224,43 @@ function RejectedCandidateDiagnostics({
   return (
     <div className="border-t border-border/60 pt-4">
       <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Rejected candidate
+        {i18n.t(($) => {
+          return $.connectors.providerSettings.catalogDiagnostics.sections
+            .rejectedCandidate;
+        })}
       </div>
       <div className="grid min-w-0 gap-4 sm:grid-cols-2">
         <DiagnosticField
-          label="Rejected version"
-          value={candidate.catalogVersion ?? EMPTY_VALUE}
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .rejectedVersion;
+          })}
+          value={candidate.catalogVersion ?? emptyValue()}
           code={candidate.catalogVersion !== null}
         />
         <DiagnosticField
-          label="Rejecting backend"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .rejectingBackend;
+          })}
           value={candidate.backendVersion}
           code
         />
         <DiagnosticField
-          label="Rejection failure"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .rejectionFailure;
+          })}
           value={formatEnumValue(candidate.failureCode)}
         />
       </div>
       <div className="mt-4">
         <DiagnosticField
-          label="Rejected catalog digest"
-          value={candidate.catalogDigest ?? EMPTY_VALUE}
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .rejectedCatalogDigest;
+          })}
+          value={candidate.catalogDigest ?? emptyValue()}
           code={candidate.catalogDigest !== null}
         />
       </div>
@@ -107,49 +279,76 @@ function CatalogSyncDiagnostics({
     <>
       <div className="grid min-w-0 gap-4 sm:grid-cols-2">
         <DiagnosticField
-          label="Sync state"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .syncState;
+          })}
           value={formatEnumValue(diagnostics.state)}
         />
         <DiagnosticField
-          label="Last attempt"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .lastAttempt;
+          })}
           value={
-            lastAttempt ? formatEnumValue(lastAttempt.outcome) : EMPTY_VALUE
+            lastAttempt ? formatEnumValue(lastAttempt.outcome) : emptyValue()
           }
         />
         <DiagnosticField
-          label="Active version"
-          value={active?.catalogVersion ?? EMPTY_VALUE}
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .activeVersion;
+          })}
+          value={active?.catalogVersion ?? emptyValue()}
           code={active !== null}
         />
         <DiagnosticField
-          label="Activated"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .activated;
+          })}
           value={formatTimestamp(active?.activatedAt ?? null)}
         />
         <DiagnosticField
-          label="Last attempt at"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .lastAttemptAt;
+          })}
           value={formatTimestamp(lastAttempt?.at ?? null)}
         />
         <DiagnosticField
-          label="Last success"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .lastSuccess;
+          })}
           value={formatTimestamp(diagnostics.lastSuccessAt)}
         />
         <DiagnosticField
-          label="Failure code"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .failureCode;
+          })}
           value={
             lastAttempt?.failureCode
               ? formatEnumValue(lastAttempt.failureCode)
-              : EMPTY_VALUE
+              : emptyValue()
           }
         />
         <DiagnosticField
-          label="Rejection cache"
+          label={i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.fields
+              .rejectionCache;
+          })}
           value={formatRejectedAttemptCacheUse(lastAttempt)}
         />
       </div>
 
       <DiagnosticField
-        label="Active catalog digest"
-        value={active?.catalogDigest ?? EMPTY_VALUE}
+        label={i18n.t(($) => {
+          return $.connectors.providerSettings.catalogDiagnostics.fields
+            .activeCatalogDigest;
+        })}
+        value={active?.catalogDigest ?? emptyValue()}
         code={active !== null}
       />
 
@@ -175,32 +374,49 @@ function DiagnosticsContent({
 
       <div className="border-t border-border/60 pt-4">
         <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Compatibility
+          {i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.sections
+              .compatibility;
+          })}
         </div>
         <div className="grid min-w-0 gap-4 sm:grid-cols-2">
           <DiagnosticField
-            label="Evaluation"
-            value={diagnostics.filtering.stale ? "Stale" : "Current"}
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .evaluation;
+            })}
+            value={formatEnumValue(
+              diagnostics.filtering.stale ? "stale" : "current",
+            )}
           />
           <DiagnosticField
-            label="Evaluated"
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .evaluated;
+            })}
             value={formatTimestamp(diagnostics.filtering.evaluatedAt)}
           />
         </div>
         <div className="mt-4">
           <DiagnosticField
-            label="Executable capability digest"
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .executableCapabilityDigest;
+            })}
             value={diagnostics.filtering.capabilityDigest}
             code
           />
         </div>
         <div className="mt-4 flex min-w-0 flex-col gap-2">
           <div className="text-xs text-muted-foreground">
-            Filtered auth methods
+            {i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .filteredAuthMethods;
+            })}
           </div>
           {filteredAuthMethods.length === 0 ? (
             <div className="text-sm font-medium text-foreground">
-              {EMPTY_VALUE}
+              {emptyValue()}
             </div>
           ) : (
             <div className="flex min-w-0 flex-col gap-2">
@@ -226,24 +442,47 @@ function DiagnosticsContent({
 
       <div className="border-t border-border/60 pt-4">
         <div className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Credential storage
+          {i18n.t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.sections
+              .credentialStorage;
+          })}
         </div>
         <div className="grid grid-cols-2 gap-4">
           <DiagnosticField
-            label="Missing versions"
-            value={diagnostics.credentialStorage.missingConnectorVersions}
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .missingVersions;
+            })}
+            value={formatLocalizedNumber(
+              diagnostics.credentialStorage.missingConnectorVersions,
+            )}
           />
           <DiagnosticField
-            label="Unowned secrets"
-            value={diagnostics.credentialStorage.unownedConnectorSecrets}
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .unownedSecrets;
+            })}
+            value={formatLocalizedNumber(
+              diagnostics.credentialStorage.unownedConnectorSecrets,
+            )}
           />
           <DiagnosticField
-            label="Unowned variables"
-            value={diagnostics.credentialStorage.unownedConnectorVariables}
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .unownedVariables;
+            })}
+            value={formatLocalizedNumber(
+              diagnostics.credentialStorage.unownedConnectorVariables,
+            )}
           />
           <DiagnosticField
-            label="Unresolved bridge credentials"
-            value={diagnostics.credentialStorage.unresolvedBridgeCredentials}
+            label={i18n.t(($) => {
+              return $.connectors.providerSettings.catalogDiagnostics.fields
+                .unresolvedBridgeCredentials;
+            })}
+            value={formatLocalizedNumber(
+              diagnostics.credentialStorage.unresolvedBridgeCredentials,
+            )}
           />
         </div>
       </div>
@@ -252,6 +491,7 @@ function DiagnosticsContent({
 }
 
 export function ConnectorCatalogDiagnosticsBlock() {
+  const { t } = useTranslation();
   const diagnosticsLoadable = useLoadable(connectorCatalogDiagnostics$);
   const loading = diagnosticsLoadable.state === "loading";
   const diagnostics =
@@ -276,13 +516,23 @@ export function ConnectorCatalogDiagnosticsBlock() {
           id="connector-catalog-diagnostics-title"
           className="text-sm font-medium text-foreground"
         >
-          Connector catalog
+          {t(($) => {
+            return $.connectors.providerSettings.catalogDiagnostics.title;
+          })}
         </div>
         {diagnostics ? (
           <DiagnosticsContent diagnostics={diagnostics} />
         ) : (
           <div className="text-sm text-muted-foreground">
-            {loading ? "Loading" : "Unavailable"}
+            {loading
+              ? t(($) => {
+                  return $.connectors.providerSettings.catalogDiagnostics
+                    .loading;
+                })
+              : t(($) => {
+                  return $.connectors.providerSettings.catalogDiagnostics
+                    .unavailable;
+                })}
           </div>
         )}
       </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -40,6 +40,7 @@ function AuthenticationMethodChoice({
   readonly methods: readonly CustomConnectorAuthMethod[];
   readonly onSelect: (type: CustomConnectorAuthMethod["type"]) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="grid gap-3 sm:grid-cols-2">
       {methods.map((method) => {
@@ -54,12 +55,20 @@ function AuthenticationMethodChoice({
             }}
           >
             <span className="block text-sm font-medium text-foreground">
-              {oauth2 ? "OAuth 2.0" : "API authentication"}
+              {oauth2
+                ? "OAuth 2.0"
+                : t(($) => {
+                    return $.connectors.custom.connect.apiAuthentication;
+                  })}
             </span>
             <span className="mt-1 block text-xs text-muted-foreground">
               {oauth2
-                ? "Authorize access with the connector's OAuth app."
-                : "Enter the API secret issued by the provider."}
+                ? t(($) => {
+                    return $.connectors.custom.connect.oauthDescription;
+                  })
+                : t(($) => {
+                    return $.connectors.custom.connect.apiDescription;
+                  })}
             </span>
           </button>
         );
@@ -113,6 +122,7 @@ function CredentialFields({
     value: CustomConnectorAuthMethod["type"] | string | null,
   ) => void;
 }) {
+  const { t } = useTranslation();
   if (!selectedMethod) {
     return (
       <AuthenticationMethodChoice
@@ -135,19 +145,11 @@ function CredentialFields({
   }
   return (
     <p className="text-sm text-muted-foreground">
-      Continue to the provider to authorize access.
+      {t(($) => {
+        return $.connectors.custom.connect.continueToProvider;
+      })}
     </p>
   );
-}
-
-function submitButtonLabel(
-  selectedMethod: CustomConnectorAuthMethod,
-  submitting: boolean,
-) {
-  if (selectedMethod.type === "oauth2") {
-    return submitting ? "Connecting…" : "Continue";
-  }
-  return submitting ? "Saving…" : "Save";
 }
 
 function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
@@ -209,6 +211,23 @@ function ConnectDialogFooter({
   readonly onBack: () => void;
   readonly onClose: () => void;
 }) {
+  const { t } = useTranslation();
+  const submitLabel =
+    selectedMethod?.type === "oauth2"
+      ? submitting
+        ? t(($) => {
+            return $.connectors.custom.connect.connecting;
+          })
+        : t(($) => {
+            return $.connectors.custom.connect.continue;
+          })
+      : submitting
+        ? t(($) => {
+            return $.connectors.custom.connect.saving;
+          })
+        : t(($) => {
+            return $.connectors.custom.connect.save;
+          });
   return (
     <DialogFooter>
       {multipleMethods && selectedMethod && (
@@ -218,7 +237,9 @@ function ConnectDialogFooter({
           onClick={onBack}
           disabled={submitting}
         >
-          Back
+          {t(($) => {
+            return $.connectors.custom.connect.back;
+          })}
         </Button>
       )}
       <Button
@@ -227,11 +248,13 @@ function ConnectDialogFooter({
         onClick={onClose}
         disabled={submitting}
       >
-        Cancel
+        {t(($) => {
+          return $.connectors.actions.cancel;
+        })}
       </Button>
       {selectedMethod && (
         <Button type="submit" disabled={!canSubmit}>
-          {submitButtonLabel(selectedMethod, submitting)}
+          {submitLabel}
         </Button>
       )}
     </DialogFooter>
@@ -310,7 +333,13 @@ export function CustomConnectorConnectDialog({
         return !open && close();
       }}
     >
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent
+        className="max-w-md"
+        aria-describedby={undefined}
+        closeLabel={t(($) => {
+          return $.connectors.actions.close;
+        })}
+      >
         <DialogHeader>
           <div className="flex items-center gap-3">
             <CustomConnectorIcon

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -83,27 +83,22 @@ function parseScopes(raw: string): string[] {
 const OAUTH_AUTHORIZATION_PARAM_FIELDS = [
   {
     field: "oauthResource",
-    label: "Resource",
     placeholder: "https://api.provider.example",
   },
   {
     field: "oauthAudience",
-    label: "Audience",
     placeholder: "https://api.provider.example",
   },
   {
     field: "oauthAccessType",
-    label: "Access type",
     placeholder: "offline",
   },
   {
     field: "oauthPrompt",
-    label: "Prompt",
     placeholder: "consent",
   },
 ] as const satisfies readonly {
   readonly field: CreateField;
-  readonly label: string;
   readonly placeholder: string;
 }[];
 
@@ -175,10 +170,14 @@ function ApiAuthenticationFields({
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm font-medium text-foreground">
-            API authentication
+            {t(($) => {
+              return $.connectors.custom.create.apiAuthentication;
+            })}
           </p>
           <p className="text-xs text-muted-foreground">
-            Inject a user-provided secret into every matching request.
+            {t(($) => {
+              return $.connectors.custom.create.apiAuthenticationDescription;
+            })}
           </p>
         </div>
         {removable && (
@@ -186,7 +185,9 @@ function ApiAuthenticationFields({
             type="button"
             variant="ghost"
             size="icon"
-            aria-label="Remove API authentication"
+            aria-label={t(($) => {
+              return $.connectors.custom.create.removeApiAuthentication;
+            })}
             onClick={onRemove}
           >
             <IconTrash size={16} />
@@ -242,7 +243,9 @@ function ApiAuthenticationFields({
         </>
       ) : (
         <p className="text-xs text-muted-foreground">
-          Advanced API fields and injections are preserved when you save.
+          {t(($) => {
+            return $.connectors.custom.create.advancedApiPreserved;
+          })}
         </p>
       )}
     </div>
@@ -261,6 +264,7 @@ function OAuth2ClientFields({
   setField,
   editing,
 }: CreateFormFieldProps & { readonly editing: boolean }) {
+  const { t } = useTranslation();
   return (
     <>
       <div className="flex flex-col gap-2">
@@ -268,7 +272,9 @@ function OAuth2ClientFields({
           htmlFor="cc-oauth-client-id"
           className="text-sm font-medium text-foreground"
         >
-          Client ID
+          {t(($) => {
+            return $.connectors.custom.create.clientId;
+          })}
         </label>
         <Input
           id="cc-oauth-client-id"
@@ -283,7 +289,13 @@ function OAuth2ClientFields({
           htmlFor="cc-oauth-client-secret"
           className="text-sm font-medium text-foreground"
         >
-          {editing ? "New client secret" : "Client secret"}
+          {editing
+            ? t(($) => {
+                return $.connectors.custom.create.newClientSecret;
+              })
+            : t(($) => {
+                return $.connectors.custom.create.clientSecret;
+              })}
         </label>
         <Input
           id="cc-oauth-client-secret"
@@ -292,12 +304,20 @@ function OAuth2ClientFields({
           onChange={(event) => {
             setField("oauthClientSecret", event.target.value);
           }}
-          placeholder={editing ? "Leave blank to keep current" : undefined}
+          placeholder={
+            editing
+              ? t(($) => {
+                  return $.connectors.custom.create.keepClientSecretPlaceholder;
+                })
+              : undefined
+          }
         />
       </div>
       {editing && (
         <p className="text-xs text-muted-foreground">
-          Leave the client secret blank to keep the stored value.
+          {t(($) => {
+            return $.connectors.custom.create.keepClientSecret;
+          })}
         </p>
       )}
     </>
@@ -305,6 +325,7 @@ function OAuth2ClientFields({
 }
 
 function OAuth2RedirectUrlField() {
+  const { t } = useTranslation();
   const redirectUrl = customConnectorOAuthCallbackUrl();
   return (
     <div className="flex flex-col gap-2">
@@ -312,9 +333,13 @@ function OAuth2RedirectUrlField() {
         htmlFor="cc-oauth-callback-url"
         className="text-sm font-medium text-foreground"
       >
-        Redirect URL
+        {t(($) => {
+          return $.connectors.custom.create.redirectUrl;
+        })}
         <span className="ml-1 font-normal text-amber-600 dark:text-amber-400">
-          (Register this URL in the provider&apos;s OAuth application.)
+          {t(($) => {
+            return $.connectors.custom.create.redirectHint;
+          })}
         </span>
       </label>
       <div className="relative">
@@ -327,7 +352,9 @@ function OAuth2RedirectUrlField() {
         <CopyButton
           type="button"
           text={redirectUrl}
-          aria-label="Copy Redirect URL"
+          aria-label={t(($) => {
+            return $.connectors.custom.create.redirectCopy;
+          })}
           className="absolute top-1/2 right-1 -translate-y-1/2 p-1.5 hover:bg-accent"
         />
       </div>
@@ -336,6 +363,7 @@ function OAuth2RedirectUrlField() {
 }
 
 function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
+  const { t } = useTranslation();
   return (
     <details className="group rounded-lg border border-border">
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-sm font-medium text-foreground">
@@ -343,7 +371,11 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
           size={16}
           className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
         />
-        <span>Advanced settings</span>
+        <span>
+          {t(($) => {
+            return $.connectors.custom.create.advancedSettings;
+          })}
+        </span>
       </summary>
       <div className="flex flex-col gap-4 border-t border-border px-3 py-4">
         <div className="flex flex-col gap-2">
@@ -358,7 +390,11 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">None</SelectItem>
+              <SelectItem value="none">
+                {t(($) => {
+                  return $.connectors.custom.create.none;
+                })}
+              </SelectItem>
               <SelectItem value="S256">S256</SelectItem>
             </SelectContent>
           </Select>
@@ -366,10 +402,15 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
         <div className="flex flex-col gap-2">
           <div>
             <p className="text-sm font-medium text-foreground">
-              Authorization parameters
+              {t(($) => {
+                return $.connectors.custom.create.authorizationParameters;
+              })}
             </p>
             <p className="text-xs text-muted-foreground">
-              Add only the parameters your provider requires.
+              {t(($) => {
+                return $.connectors.custom.create
+                  .authorizationParametersDescription;
+              })}
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
@@ -380,9 +421,28 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
                     htmlFor={`cc-${parameter.field}`}
                     className="text-sm font-medium text-foreground"
                   >
-                    {parameter.label}
+                    {parameter.field === "oauthResource"
+                      ? t(($) => {
+                          return $.connectors.custom.create.parameters.resource;
+                        })
+                      : parameter.field === "oauthAudience"
+                        ? t(($) => {
+                            return $.connectors.custom.create.parameters
+                              .audience;
+                          })
+                        : parameter.field === "oauthAccessType"
+                          ? t(($) => {
+                              return $.connectors.custom.create.parameters
+                                .accessType;
+                            })
+                          : t(($) => {
+                              return $.connectors.custom.create.parameters
+                                .prompt;
+                            })}
                     <span className="text-muted-foreground font-normal ml-1">
-                      (optional)
+                      {t(($) => {
+                        return $.connectors.custom.create.optional;
+                      })}
                     </span>
                   </label>
                   <Input
@@ -403,40 +463,18 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
   );
 }
 
-function OAuth2AuthenticationFields({
-  form,
-  setField,
-  editing,
-  onRemove,
-}: CreateFormFieldProps & {
-  readonly editing: boolean;
-  readonly onRemove: () => void;
-}) {
+function OAuth2EndpointFields({ form, setField }: CreateFormFieldProps) {
+  const { t } = useTranslation();
   return (
-    <div className="rounded-xl border border-border p-4 flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-medium text-foreground">OAuth 2.0</p>
-          <p className="text-xs text-muted-foreground">
-            Configure one OAuth app for members to authorize.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Remove OAuth 2.0"
-          onClick={onRemove}
-        >
-          <IconTrash size={16} />
-        </Button>
-      </div>
+    <>
       <div className="flex flex-col gap-2">
         <label
           htmlFor="cc-oauth-authorization-url"
           className="text-sm font-medium text-foreground"
         >
-          Authorization URL
+          {t(($) => {
+            return $.connectors.custom.create.authorizationUrl;
+          })}
         </label>
         <Input
           id="cc-oauth-authorization-url"
@@ -452,7 +490,9 @@ function OAuth2AuthenticationFields({
           htmlFor="cc-oauth-token-url"
           className="text-sm font-medium text-foreground"
         >
-          Token URL
+          {t(($) => {
+            return $.connectors.custom.create.tokenUrl;
+          })}
         </label>
         <Input
           id="cc-oauth-token-url"
@@ -463,15 +503,57 @@ function OAuth2AuthenticationFields({
           placeholder="https://provider.example.com/oauth/token"
         />
       </div>
+    </>
+  );
+}
+
+function OAuth2AuthenticationFields({
+  form,
+  setField,
+  editing,
+  onRemove,
+}: CreateFormFieldProps & {
+  readonly editing: boolean;
+  readonly onRemove: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-xl border border-border p-4 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-foreground">OAuth 2.0</p>
+          <p className="text-xs text-muted-foreground">
+            {t(($) => {
+              return $.connectors.custom.create.oauthDescription;
+            })}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={t(($) => {
+            return $.connectors.custom.create.removeOauth;
+          })}
+          onClick={onRemove}
+        >
+          <IconTrash size={16} />
+        </Button>
+      </div>
+      <OAuth2EndpointFields form={form} setField={setField} />
       <OAuth2ClientFields form={form} setField={setField} editing={editing} />
       <div className="flex flex-col gap-2">
         <label
           htmlFor="cc-oauth-scopes"
           className="text-sm font-medium text-foreground"
         >
-          Scopes
+          {t(($) => {
+            return $.connectors.custom.create.scopes;
+          })}
           <span className="text-muted-foreground font-normal ml-1">
-            (one per line)
+            {t(($) => {
+              return $.connectors.custom.create.scopesHint;
+            })}
           </span>
         </label>
         <textarea
@@ -487,7 +569,9 @@ function OAuth2AuthenticationFields({
       </div>
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-foreground">
-          Token endpoint authentication
+          {t(($) => {
+            return $.connectors.custom.create.tokenEndpointAuthentication;
+          })}
         </label>
         <Select
           value={form.oauthClientAuthentication}
@@ -495,15 +579,23 @@ function OAuth2AuthenticationFields({
             setField("oauthClientAuthentication", value);
           }}
         >
-          <SelectTrigger aria-label="Token endpoint authentication">
+          <SelectTrigger
+            aria-label={t(($) => {
+              return $.connectors.custom.create.tokenEndpointAuthentication;
+            })}
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="client_secret_post">
-              Client secret in request body
+              {t(($) => {
+                return $.connectors.custom.create.secretInRequestBody;
+              })}
             </SelectItem>
             <SelectItem value="client_secret_basic">
-              HTTP Basic authentication
+              {t(($) => {
+                return $.connectors.custom.create.httpBasicAuthentication;
+              })}
             </SelectItem>
           </SelectContent>
         </Select>
@@ -512,8 +604,9 @@ function OAuth2AuthenticationFields({
       <OAuth2AdvancedFields form={form} setField={setField} />
       {editing && (
         <p className="text-xs text-muted-foreground">
-          Changing OAuth settings or client credentials disconnects existing
-          OAuth connections.
+          {t(($) => {
+            return $.connectors.custom.create.oauthChangesDisconnect;
+          })}
         </p>
       )}
     </div>
@@ -793,6 +886,7 @@ function AuthenticationFields({
   addAuthMethod,
   removeAuthMethod,
 }: AuthenticationFieldsProps) {
+  const { t } = useTranslation();
   if (!oauth2Enabled && !editing) {
     return <LegacyApiFields form={form} setField={setField} />;
   }
@@ -833,7 +927,9 @@ function AuthenticationFields({
             disabled={availableAuthMethods.length === 0}
           >
             <IconPlus size={16} />
-            Add authentication
+            {t(($) => {
+              return $.connectors.custom.create.addAuthentication;
+            })}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -843,7 +939,9 @@ function AuthenticationFields({
                 addAuthMethod("api");
               }}
             >
-              API authentication
+              {t(($) => {
+                return $.connectors.custom.create.apiAuthentication;
+              })}
             </DropdownMenuItem>
           )}
           {availableAuthMethods.includes("oauth2") && (
@@ -945,6 +1043,7 @@ export function CustomConnectorCreateDialog({
 }: {
   readonly connector?: CustomConnectorResponse;
 }) {
+  const { t } = useTranslation();
   const form = useGet(customConnectorCreateForm$);
   const featureSwitches = useGet(featureSwitch$);
   const oauth2Enabled =
@@ -1038,6 +1137,9 @@ export function CustomConnectorCreateDialog({
         <DialogContent
           className="max-w-2xl max-h-[90vh] overflow-y-auto"
           aria-describedby={undefined}
+          closeLabel={t(($) => {
+            return $.connectors.actions.close;
+          })}
         >
           <DialogHeader>
             <CustomConnectorDialogTitle editing={editing} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-update-confirm.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-update-confirm.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 
 export function CustomConnectorUpdateConfirm({
   submitting,
@@ -16,6 +17,7 @@ export function CustomConnectorUpdateConfirm({
   readonly onCancel: () => void;
   readonly onConfirm: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <Dialog
       open
@@ -23,24 +25,43 @@ export function CustomConnectorUpdateConfirm({
         return !open && onCancel();
       }}
     >
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent
+        className="max-w-md"
+        aria-describedby={undefined}
+        closeLabel={t(($) => {
+          return $.connectors.actions.close;
+        })}
+      >
         <DialogHeader>
-          <DialogTitle>Disconnect existing OAuth connections?</DialogTitle>
+          <DialogTitle>
+            {t(($) => {
+              return $.connectors.custom.updateConfirm.title;
+            })}
+          </DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">
-          These OAuth changes will disconnect every member currently connected
-          with OAuth. They&apos;ll need to connect this custom connector again.
+          {t(($) => {
+            return $.connectors.custom.updateConfirm.description;
+          })}
         </p>
         <DialogFooter>
           <Button variant="outline" onClick={onCancel} disabled={submitting}>
-            Cancel
+            {t(($) => {
+              return $.connectors.actions.cancel;
+            })}
           </Button>
           <Button
             variant="destructive"
             onClick={onConfirm}
             disabled={submitting}
           >
-            {submitting ? "Saving…" : "Save and disconnect"}
+            {submitting
+              ? t(($) => {
+                  return $.connectors.actions.savingEllipsis;
+                })
+              : t(($) => {
+                  return $.connectors.custom.updateConfirm.action;
+                })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -6,6 +6,8 @@ import {
 } from "ccstate-react";
 import { IconDotsVertical } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
+
+import { formatLocalizedNumber } from "../../../../i18n/format.ts";
 import {
   Button,
   DropdownMenu,
@@ -50,8 +52,11 @@ function connectsDirectlyWithOAuth(
   return oauth2Enabled && connector.authMode === "oauth";
 }
 
-function customConnectorAgentName(agent: TeamComposeItem): string {
-  return agent.displayName ?? "Unnamed";
+function customConnectorAgentName(
+  agent: TeamComposeItem,
+  unnamed: string,
+): string {
+  return agent.displayName ?? unnamed;
 }
 
 function truncateCustomConnectorAgentName(name: string): string {
@@ -68,6 +73,10 @@ function CustomConnectorAgentUsage({
   readonly agents: readonly TeamComposeItem[];
   readonly loading: boolean;
 }) {
+  const { t } = useTranslation();
+  const unnamed = t(($) => {
+    return $.connectors.catalog.unnamedAgent;
+  });
   if (loading) {
     return <span className="block h-3 w-20 animate-pulse rounded bg-muted" />;
   }
@@ -77,7 +86,9 @@ function CustomConnectorAgentUsage({
         className="truncate text-xs text-muted-foreground"
         data-testid="custom-connector-card-agent-usage"
       >
-        Not used by any agents
+        {t(($) => {
+          return $.connectors.custom.agentUsage.none;
+        })}
       </span>
     );
   }
@@ -85,17 +96,39 @@ function CustomConnectorAgentUsage({
   const visibleNames = agents
     .slice(0, CUSTOM_CONNECTOR_AGENT_NAME_LIMIT)
     .map((agent) => {
-      return truncateCustomConnectorAgentName(customConnectorAgentName(agent));
+      return truncateCustomConnectorAgentName(
+        customConnectorAgentName(agent, unnamed),
+      );
     });
   const overflowCount = agents.length - visibleNames.length;
+  const agentNames = visibleNames.join(", ");
   return (
     <span
       className="min-w-0 truncate text-xs text-muted-foreground"
       data-testid="custom-connector-card-agent-usage"
-      title={agents.map(customConnectorAgentName).join(", ")}
+      title={agents
+        .map((agent) => {
+          return customConnectorAgentName(agent, unnamed);
+        })
+        .join(", ")}
     >
-      Used by {visibleNames.join(", ")}
-      {overflowCount > 0 ? ` +${overflowCount}` : ""}
+      {overflowCount > 0
+        ? t(
+            ($) => {
+              return $.connectors.custom.agentUsage.usedByOverflow;
+            },
+            {
+              agents: agentNames,
+              count: overflowCount,
+              value: formatLocalizedNumber(overflowCount),
+            },
+          )
+        : t(
+            ($) => {
+              return $.connectors.custom.agentUsage.usedBy;
+            },
+            { agents: agentNames },
+          )}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -1,11 +1,11 @@
 import {
   MODEL_PROVIDER_TYPES,
   getVm0ModelPriceTier,
-  getVm0ModelPriceTierLabel,
   type ModelProviderType,
   type SupportedRunModel,
   type Vm0ModelPriceTier,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { i18n } from "../../../../i18n/index.ts";
 
 /**
  * UI-only display overrides for provider labels. These do not modify the core
@@ -28,9 +28,6 @@ const PROVIDER_UI_OVERRIDES = Object.freeze<
   "azure-foundry": {
     label: "Azure foundry portal",
   },
-  vm0: {
-    label: "Built-in model",
-  },
 });
 
 function getOverrides(
@@ -43,7 +40,37 @@ function getOverrides(
  * Get the display label for a provider type (UI override or core fallback)
  */
 export function getUILabel(type: ModelProviderType): string {
+  if (type === "vm0") {
+    return i18n.t(($) => {
+      return $.settings.models.picker.builtInModel;
+    });
+  }
   return getOverrides(type)?.label ?? MODEL_PROVIDER_TYPES[type].label;
+}
+
+export function getVm0ModelPriceTierLabel(tier: Vm0ModelPriceTier): string {
+  switch (tier) {
+    case "$": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.priceTiers.economy;
+      });
+    }
+    case "$$": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.priceTiers.balanced;
+      });
+    }
+    case "$$$": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.priceTiers.frontier;
+      });
+    }
+    case "$$$$": {
+      return i18n.t(($) => {
+        return $.settings.models.picker.priceTiers.premium;
+      });
+    }
+  }
 }
 
 const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
@@ -74,8 +101,4 @@ export function getModelBrandIconType(
 ): ModelProviderType {
   return MODEL_BRAND_ICON[model];
 }
-export {
-  getVm0ModelPriceTier,
-  getVm0ModelPriceTierLabel,
-  type Vm0ModelPriceTier,
-};
+export { getVm0ModelPriceTier, type Vm0ModelPriceTier };

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -366,11 +366,14 @@ function FeishuAppCredentialFields({
   saving: boolean;
   readOnly: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       <FeishuCredentialInput
         field="appId"
-        label="App ID"
+        label={t(($) => {
+          return $.connectors.providerSettings.feishu.credentials.appId;
+        })}
         form={form}
         saving={saving}
         readOnly={readOnly}
@@ -378,7 +381,9 @@ function FeishuAppCredentialFields({
       />
       <FeishuCredentialInput
         field="appSecret"
-        label="App Secret"
+        label={t(($) => {
+          return $.connectors.providerSettings.feishu.credentials.appSecret;
+        })}
         form={form}
         saving={saving}
         readOnly={readOnly}
@@ -396,18 +401,23 @@ function FeishuEventCredentialFields({
   saving: boolean;
   readOnly: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       <FeishuCredentialInput
         field="encryptKey"
-        label="Encrypt Key"
+        label={t(($) => {
+          return $.connectors.providerSettings.feishu.tokens.encryptKey;
+        })}
         form={form}
         saving={saving}
         readOnly={readOnly}
       />
       <FeishuCredentialInput
         field="verificationToken"
-        label="Verification Token"
+        label={t(($) => {
+          return $.connectors.providerSettings.feishu.tokens.verificationToken;
+        })}
         form={form}
         saving={saving}
         readOnly={readOnly}
@@ -508,7 +518,9 @@ function FeishuCreateStep() {
             rel="noreferrer"
             className="font-medium text-foreground underline underline-offset-4"
           >
-            Feishu developer console
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.developerConsole;
+            })}
           </a>
           {t(
             ($) => {
@@ -641,7 +653,9 @@ function FeishuTokensStep({
             rel="noreferrer"
             className="font-medium text-foreground underline underline-offset-4"
           >
-            Feishu developer console
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.developerConsole;
+            })}
           </a>
           {t(($) => {
             return $.connectors.providerSettings.feishu.tokens.descriptionAfter;
@@ -771,7 +785,9 @@ function FeishuRedirectStep({ data }: { data: FeishuDialogData | null }) {
             rel="noreferrer"
             className="font-medium text-foreground underline underline-offset-4"
           >
-            Feishu developer console
+            {t(($) => {
+              return $.connectors.providerSettings.feishu.developerConsole;
+            })}
           </a>
           {t(
             ($) => {
@@ -1829,6 +1845,9 @@ function FeishuSetupDialog({
     >
       <DialogContent
         className="max-h-[90vh] max-w-2xl overflow-y-auto"
+        closeLabel={t(($) => {
+          return $.connectors.actions.close;
+        })}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
         }}
@@ -1874,7 +1893,11 @@ function FeishuUninstallDialog({ bot }: { bot: FeishuBotInstallation | null }) {
         }
       }}
     >
-      <DialogContent>
+      <DialogContent
+        closeLabel={t(($) => {
+          return $.connectors.actions.close;
+        })}
+      >
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
@@ -26,7 +26,10 @@ import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
 
+import { resolvedAppLocale } from "../../i18n/format.ts";
+import { i18n } from "../../i18n/index.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -48,7 +51,14 @@ function copyValue(value: string, label: string): void {
   detach(
     (async () => {
       if (await writeToClipboard(value)) {
-        toast.success(`${label} copied`);
+        toast.success(
+          i18n.t(
+            ($) => {
+              return $.connectors.providerSettings.strapi.copied;
+            },
+            { label },
+          ),
+        );
       }
     })(),
     Reason.DomCallback,
@@ -62,6 +72,7 @@ function CopyField({
   readonly label: string;
   readonly value: string;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-2">
       <div className="text-xs font-medium text-muted-foreground">{label}</div>
@@ -78,7 +89,9 @@ function CopyField({
           }}
         >
           <IconCopy size={14} />
-          Copy
+          {t(($) => {
+            return $.connectors.providerSettings.strapi.actions.copy;
+          })}
         </Button>
       </div>
     </div>
@@ -86,7 +99,11 @@ function CopyField({
 }
 
 function formatTimestamp(value: string | null): string {
-  return value ? new Date(value).toLocaleString() : "Not received";
+  return value
+    ? new Date(value).toLocaleString(resolvedAppLocale())
+    : i18n.t(($) => {
+        return $.connectors.providerSettings.strapi.notReceived;
+      });
 }
 
 function StrapiIntegrationHeader({
@@ -94,6 +111,7 @@ function StrapiIntegrationHeader({
 }: {
   readonly integration: StrapiIntegration;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="flex items-start gap-4 p-4">
       <div className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#4945ff]/10 text-[#4945ff]">
@@ -108,9 +126,102 @@ function StrapiIntegrationHeader({
       {integration.lastTestedAt ? (
         <span className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-border px-2 py-1 text-xs font-medium">
           <IconCircleCheck size={14} className="text-green-600" />
-          Webhook tested
+          {t(($) => {
+            return $.connectors.providerSettings.strapi.tested;
+          })}
         </span>
       ) : null}
+    </div>
+  );
+}
+
+function StrapiAdminActions({
+  integrationId,
+}: {
+  readonly integrationId: string;
+}) {
+  const { t } = useTranslation();
+  const pageSignal = useGet(pageSignal$);
+  const [checkLoadable, checkTest] = useLoadableSet(
+    checkStrapiIntegrationTest$,
+  );
+  const [removeLoadable, remove] = useLoadableSet(removeStrapiIntegration$);
+  const checking = checkLoadable.state === "loading";
+  const removing = removeLoadable.state === "loading";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={checking}
+        onClick={() => {
+          return detach(
+            checkTest(integrationId, pageSignal),
+            Reason.DomCallback,
+          );
+        }}
+      >
+        {checking ? <IconLoader2 size={14} className="animate-spin" /> : null}
+        {t(($) => {
+          return $.connectors.providerSettings.strapi.actions.checkTest;
+        })}
+      </Button>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button type="button" variant="ghost" size="sm">
+            <IconTrash size={14} />
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.actions.remove;
+            })}
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          closeLabel={t(($) => {
+            return $.connectors.actions.close;
+          })}
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {t(($) => {
+                return $.connectors.providerSettings.strapi.removeTitle;
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t(($) => {
+                return $.connectors.providerSettings.strapi.removeDescription;
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                {t(($) => {
+                  return $.connectors.providerSettings.strapi.actions.cancel;
+                })}
+              </Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={removing}
+                onClick={() => {
+                  return detach(
+                    remove(integrationId, pageSignal),
+                    Reason.DomCallback,
+                  );
+                }}
+              >
+                {t(($) => {
+                  return $.connectors.providerSettings.strapi.actions.remove;
+                })}
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -122,29 +233,31 @@ function StrapiIntegrationCard({
   readonly integration: StrapiIntegration;
   readonly isAdmin: boolean;
 }) {
+  const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const revealed = useGet(strapiRevealedSecret$);
   const [revealLoadable, reveal] = useLoadableSet(
     revealStrapiIntegrationSecret$,
   );
-  const [checkLoadable, checkTest] = useLoadableSet(
-    checkStrapiIntegrationTest$,
-  );
-  const [removeLoadable, remove] = useLoadableSet(removeStrapiIntegration$);
   const showingSecret = revealed?.integrationId === integration.id;
   const revealing = revealLoadable.state === "loading";
-  const checking = checkLoadable.state === "loading";
-  const removing = removeLoadable.state === "loading";
 
   return (
     <div className="zero-card overflow-hidden">
       <StrapiIntegrationHeader integration={integration} />
 
       <div className="space-y-4 border-t border-border/60 p-4">
-        <CopyField label="Webhook URL" value={integration.webhookUrl} />
+        <CopyField
+          label={t(($) => {
+            return $.connectors.providerSettings.strapi.webhookUrl;
+          })}
+          value={integration.webhookUrl}
+        />
         {showingSecret && revealed ? (
           <CopyField
-            label="Authorization header"
+            label={t(($) => {
+              return $.connectors.providerSettings.strapi.authorizationHeader;
+            })}
             value={revealed.authorizationHeader}
           />
         ) : isAdmin ? (
@@ -163,84 +276,40 @@ function StrapiIntegrationCard({
             {revealing ? (
               <IconLoader2 size={14} className="animate-spin" />
             ) : null}
-            Reveal authorization header
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.actions
+                .revealAuthorization;
+            })}
           </Button>
         ) : null}
 
         <div className="rounded-lg border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
-          In Strapi, open{" "}
-          <strong className="text-foreground">Settings → Webhooks</strong>, add
-          this URL and Authorization header, select <code>entry.publish</code>,
-          then click <strong className="text-foreground">Trigger</strong> to
-          send a Strapi test webhook.
+          {t(($) => {
+            return $.connectors.providerSettings.strapi.instructions;
+          })}
         </div>
 
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-0.5 text-xs text-muted-foreground">
-            <div>Last test: {formatTimestamp(integration.lastTestedAt)}</div>
             <div>
-              Last publish: {formatTimestamp(integration.lastReceivedAt)}
+              {t(
+                ($) => {
+                  return $.connectors.providerSettings.strapi.lastTest;
+                },
+                { date: formatTimestamp(integration.lastTestedAt) },
+              )}
+            </div>
+            <div>
+              {t(
+                ($) => {
+                  return $.connectors.providerSettings.strapi.lastPublish;
+                },
+                { date: formatTimestamp(integration.lastReceivedAt) },
+              )}
             </div>
           </div>
           {isAdmin ? (
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={checking}
-                onClick={() => {
-                  return detach(
-                    checkTest(integration.id, pageSignal),
-                    Reason.DomCallback,
-                  );
-                }}
-              >
-                {checking ? (
-                  <IconLoader2 size={14} className="animate-spin" />
-                ) : null}
-                Check test
-              </Button>
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button type="button" variant="ghost" size="sm">
-                    <IconTrash size={14} />
-                    Remove
-                  </Button>
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>Remove Strapi integration?</DialogTitle>
-                    <DialogDescription>
-                      Remove its workflow automations first. Strapi webhook
-                      requests to this URL will stop working.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <DialogClose asChild>
-                      <Button type="button" variant="outline">
-                        Cancel
-                      </Button>
-                    </DialogClose>
-                    <DialogClose asChild>
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        disabled={removing}
-                        onClick={() => {
-                          return detach(
-                            remove(integration.id, pageSignal),
-                            Reason.DomCallback,
-                          );
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </DialogClose>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
+            <StrapiAdminActions integrationId={integration.id} />
           ) : null}
         </div>
       </div>
@@ -249,6 +318,7 @@ function StrapiIntegrationCard({
 }
 
 function StrapiIntegrationForm() {
+  const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const form = useGet(strapiIntegrationForm$);
   const updateForm = useSet(updateStrapiIntegrationForm$);
@@ -262,23 +332,31 @@ function StrapiIntegrationForm() {
     <form className="zero-card space-y-4 p-4" onSubmit={submit}>
       <div>
         <h2 className="text-sm font-medium text-foreground">
-          Add Strapi instance
+          {t(($) => {
+            return $.connectors.providerSettings.strapi.addTitle;
+          })}
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          One integration can serve multiple workflow automations.
+          {t(($) => {
+            return $.connectors.providerSettings.strapi.addDescription;
+          })}
         </p>
       </div>
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
           <label htmlFor="strapi-name" className="text-sm font-medium">
-            Name
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.form.name;
+            })}
           </label>
           <Input
             id="strapi-name"
             value={form.name}
             required
             maxLength={128}
-            placeholder="Company CMS"
+            placeholder={t(($) => {
+              return $.connectors.providerSettings.strapi.form.namePlaceholder;
+            })}
             disabled={creating}
             onChange={(event) => {
               updateForm({ name: event.target.value });
@@ -287,7 +365,9 @@ function StrapiIntegrationForm() {
         </div>
         <div className="space-y-2">
           <label htmlFor="strapi-url" className="text-sm font-medium">
-            Strapi URL
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.form.url;
+            })}
           </label>
           <Input
             id="strapi-url"
@@ -308,13 +388,16 @@ function StrapiIntegrationForm() {
         ) : (
           <IconPlus size={16} />
         )}
-        Create integration
+        {t(($) => {
+          return $.connectors.providerSettings.strapi.actions.create;
+        })}
       </Button>
     </form>
   );
 }
 
 export function ZeroStrapiSettingsPage() {
+  const { t } = useTranslation();
   const integrationsLoadable = useLastLoadable(strapiIntegrations$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin =
@@ -331,12 +414,19 @@ export function ZeroStrapiSettingsPage() {
             className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <IconArrowLeft size={16} />
-            Where Zero works
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.whereZeroWorks;
+            })}
           </Link>
-          <h1 className="text-lg font-semibold tracking-tight">Strapi</h1>
+          <h1 className="text-lg font-semibold tracking-tight">
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.title;
+            })}
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Let Zero react to published Strapi entries and automate downstream
-            work.
+            {t(($) => {
+              return $.connectors.providerSettings.strapi.description;
+            })}
           </p>
         </div>
       </header>
@@ -346,7 +436,9 @@ export function ZeroStrapiSettingsPage() {
             <StrapiIntegrationForm />
           ) : (
             <div className="zero-card p-4 text-sm text-muted-foreground">
-              Ask an organization admin to add or update Strapi integrations.
+              {t(($) => {
+                return $.connectors.providerSettings.strapi.adminRequired;
+              })}
             </div>
           )}
           {integrations === null ? (
@@ -357,7 +449,9 @@ export function ZeroStrapiSettingsPage() {
             </div>
           ) : integrations.length === 0 ? (
             <div className="zero-card p-6 text-center text-sm text-muted-foreground">
-              No Strapi instances connected yet.
+              {t(($) => {
+                return $.connectors.providerSettings.strapi.empty;
+              })}
             </div>
           ) : (
             integrations.map((integration) => {

--- a/turbo/apps/platform/src/views/zero-page/subscription-usage-format.ts
+++ b/turbo/apps/platform/src/views/zero-page/subscription-usage-format.ts
@@ -1,5 +1,6 @@
 import { now } from "../../lib/time.ts";
 import { i18n } from "../../i18n/index.ts";
+import { formatLocalizedNumber, resolvedAppLocale } from "../../i18n/format.ts";
 
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
@@ -23,7 +24,6 @@ type SubscriptionUsageResetDisplay =
 
 export function formatSubscriptionUsageReset(
   resetAt: string | null,
-  localized = false,
 ): SubscriptionUsageResetDisplay | null {
   const text = resetAt?.trim();
   if (!text) {
@@ -33,39 +33,32 @@ export function formatSubscriptionUsageReset(
   const date = new Date(text);
   if (Number.isNaN(date.getTime())) {
     return {
-      fallbackText: localized
-        ? i18n.t(
-            ($) => {
-              return $.settings.models.usage.resetsRaw;
-            },
-            { value: text },
-          )
-        : `resets ${text}`,
+      fallbackText: i18n.t(
+        ($) => {
+          return $.settings.models.usage.resetsRaw;
+        },
+        { value: text },
+      ),
     };
   }
 
-  const absoluteText = formatAbsoluteResetDate(date, localized);
-  const relativeText = formatRelativeResetTime(
-    date.getTime() - now(),
-    localized,
-  );
+  const absoluteText = formatAbsoluteResetDate(date);
+  const relativeText = formatRelativeResetTime(date.getTime() - now());
 
   return {
-    absoluteResetText: localized
-      ? i18n.t(
-          ($) => {
-            return $.settings.models.usage.resetsAt;
-          },
-          { date: absoluteText },
-        )
-      : `resets ${absoluteText}`,
+    absoluteResetText: i18n.t(
+      ($) => {
+        return $.settings.models.usage.resetsAt;
+      },
+      { date: absoluteText },
+    ),
     absoluteText,
     relativeText,
-    tooltipTitle: formatResetTooltipTitle(relativeText, localized),
+    tooltipTitle: formatResetTooltipTitle(relativeText),
   };
 }
 
-function formatAbsoluteResetDate(date: Date, localized: boolean): string {
+function formatAbsoluteResetDate(date: Date): string {
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
@@ -78,30 +71,17 @@ function formatAbsoluteResetDate(date: Date, localized: boolean): string {
   if (browserTimeZone) {
     options.timeZone = browserTimeZone;
   }
-  return date.toLocaleDateString(
-    localized ? (i18n.resolvedLanguage ?? i18n.language) : "en-US",
-    options,
-  );
+  return date.toLocaleDateString(resolvedAppLocale(), options);
 }
 
-function resetTimePassed(localized: boolean): string {
-  return localized
-    ? i18n.t(($) => {
-        return $.settings.models.usage.resetTimePassed;
-      })
-    : "reset time passed";
+function resetTimePassed(): string {
+  return i18n.t(($) => {
+    return $.settings.models.usage.resetTimePassed;
+  });
 }
 
-function formatResetTooltipTitle(
-  relativeText: string,
-  localized: boolean,
-): string {
-  if (!localized) {
-    return relativeText === "reset time passed"
-      ? "Reset time passed"
-      : `Resets ${relativeText}`;
-  }
-  if (relativeText === resetTimePassed(true)) {
+function formatResetTooltipTitle(relativeText: string): string {
+  if (relativeText === resetTimePassed()) {
     return i18n.t(($) => {
       return $.settings.models.usage.resetTimePassedTitle;
     });
@@ -114,77 +94,68 @@ function formatResetTooltipTitle(
   );
 }
 
-function formatRelativeResetTime(
-  remainingMs: number,
-  localized: boolean,
-): string {
+function formatRelativeResetTime(remainingMs: number): string {
   if (remainingMs <= 0) {
-    return resetTimePassed(localized);
+    return resetTimePassed();
   }
   if (remainingMs < MINUTE_MS) {
-    return localized
-      ? i18n.t(($) => {
-          return $.settings.models.usage.inLessThanMinute;
-        })
-      : "in <1m";
+    return i18n.t(($) => {
+      return $.settings.models.usage.inLessThanMinute;
+    });
   }
 
   const totalMinutes = Math.floor(remainingMs / MINUTE_MS);
   if (remainingMs < HOUR_MS) {
-    return localized
-      ? i18n.t(
-          ($) => {
-            return $.settings.models.usage.inMinutes;
-          },
-          { minutes: totalMinutes },
-        )
-      : `in ${totalMinutes}m`;
+    return i18n.t(
+      ($) => {
+        return $.settings.models.usage.inMinutes;
+      },
+      { minutes: formatLocalizedNumber(totalMinutes) },
+    );
   }
 
   const totalHours = Math.floor(remainingMs / HOUR_MS);
   if (remainingMs < DAY_MS) {
     const minutes = Math.floor((remainingMs % HOUR_MS) / MINUTE_MS);
     if (minutes > 0) {
-      return localized
-        ? i18n.t(
-            ($) => {
-              return $.settings.models.usage.inHoursMinutes;
-            },
-            { hours: totalHours, minutes },
-          )
-        : `in ${totalHours}h ${minutes}m`;
+      return i18n.t(
+        ($) => {
+          return $.settings.models.usage.inHoursMinutes;
+        },
+        {
+          hours: formatLocalizedNumber(totalHours),
+          minutes: formatLocalizedNumber(minutes),
+        },
+      );
     }
-    return localized
-      ? i18n.t(
-          ($) => {
-            return $.settings.models.usage.inHours;
-          },
-          { hours: totalHours },
-        )
-      : `in ${totalHours}h`;
+    return i18n.t(
+      ($) => {
+        return $.settings.models.usage.inHours;
+      },
+      { hours: formatLocalizedNumber(totalHours) },
+    );
   }
 
   const totalDays = Math.floor(remainingMs / DAY_MS);
   if (remainingMs < WEEK_MS) {
     const hours = Math.floor((remainingMs % DAY_MS) / HOUR_MS);
     if (hours > 0) {
-      return localized
-        ? i18n.t(
-            ($) => {
-              return $.settings.models.usage.inDaysHours;
-            },
-            { days: totalDays, hours },
-          )
-        : `in ${totalDays}d ${hours}h`;
+      return i18n.t(
+        ($) => {
+          return $.settings.models.usage.inDaysHours;
+        },
+        {
+          days: formatLocalizedNumber(totalDays),
+          hours: formatLocalizedNumber(hours),
+        },
+      );
     }
   }
 
-  return localized
-    ? i18n.t(
-        ($) => {
-          return $.settings.models.usage.inDays;
-        },
-        { days: totalDays },
-      )
-    : `in ${totalDays}d`;
+  return i18n.t(
+    ($) => {
+      return $.settings.models.usage.inDays;
+    },
+    { days: formatLocalizedNumber(totalDays) },
+  );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -17,6 +17,7 @@ import { equalArrays } from "../../lib/equality.ts";
 import { now } from "../../lib/time.ts";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
+import { resolvedAppLocale } from "../../i18n/format.ts";
 import { i18n } from "../../i18n/index.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
@@ -403,7 +404,7 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
 // automation.
 export function AutomationMenuButton({
   thread,
-  ariaLabel = "Automations",
+  ariaLabel,
 }: {
   thread: ChatThreadSignals;
   ariaLabel?: string;
@@ -928,7 +929,7 @@ function ChatThreadEmojiGrid({
 }
 
 function formatChatTimestamp(value: string): string {
-  return new Date(value).toLocaleString("en-US", {
+  return new Date(value).toLocaleString(resolvedAppLocale(), {
     month: "short",
     day: "numeric",
     hour: "numeric",

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -65,6 +65,8 @@ import {
   useSubscriptionUsageRows,
 } from "./zero-sidebar-subscriptions.tsx";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
+import { formatLocalizedNumber } from "../../i18n/format.ts";
+import { i18n } from "../../i18n/index.ts";
 
 interface SessionAccount {
   sessionId: string;
@@ -73,6 +75,18 @@ interface SessionAccount {
   initial: string;
   imageUrl: string | undefined;
   isActive: boolean;
+}
+
+function formatCreditBalance(credits: number): string {
+  return i18n.t(
+    ($) => {
+      return $.settings.accountMenu.creditBalance;
+    },
+    {
+      count: credits,
+      value: formatLocalizedNumber(credits),
+    },
+  );
 }
 
 function AccountAvatar({
@@ -286,10 +300,7 @@ function AccountCreditBalanceGroup({
   const credits =
     billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
   const loading = billingLoadable.state === "loading" && credits === null;
-  const creditLabel =
-    credits !== null
-      ? `${credits.toLocaleString("en-US")} ${credits === 1 ? "credit" : "credits"}`
-      : null;
+  const creditLabel = credits !== null ? formatCreditBalance(credits) : null;
 
   if (!loading && creditLabel === null) {
     return null;
@@ -325,10 +336,7 @@ function AccountUsageGroupWithCredit({
   const credits =
     billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
   const creditLoading = billingLoadable.state === "loading" && credits === null;
-  const creditLabel =
-    credits !== null
-      ? `${credits.toLocaleString("en-US")} ${credits === 1 ? "credit" : "credits"}`
-      : null;
+  const creditLabel = credits !== null ? formatCreditBalance(credits) : null;
   const showCredit = creditLoading || creditLabel !== null;
   const showSubscriptions = subscriptionsLoading || rows.length > 0;
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -5,6 +5,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
+import { useTranslation } from "react-i18next";
 
 import {
   ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS,
@@ -19,6 +20,7 @@ import {
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
 import { formatCodexResetCredits } from "./components/preferences/codex-reset-usage-dialog.tsx";
 import { formatSubscriptionUsageReset } from "./subscription-usage-format.ts";
+import { formatLocalizedNumber } from "../../i18n/format.ts";
 
 type SubscriptionUsage = AccountMenuSubscriptionUsage;
 type SubscriptionUsageWindow = AccountMenuSubscriptionUsageWindow;
@@ -124,6 +126,7 @@ function AccountMenuSubscriptionProviderSection({
   readonly resetPending: boolean;
   readonly onResetCodexUsage?: (resetCredits: number | null) => void;
 }) {
+  const { t } = useTranslation();
   const windows = accountMenuSubscriptionUsageWindows(usage);
   const canResetCodex =
     type === "codex-oauth-token" &&
@@ -133,7 +136,15 @@ function AccountMenuSubscriptionProviderSection({
     resetCredits > 0;
 
   return (
-    <section className="flex flex-col gap-1.5" aria-label={`${label} usage`}>
+    <section
+      className="flex flex-col gap-1.5"
+      aria-label={t(
+        ($) => {
+          return $.settings.accountMenu.subscriptions.usage;
+        },
+        { provider: label },
+      )}
+    >
       {divided && <div className="-mx-3 h-px bg-border" />}
       <h3 className="truncate text-xs font-medium leading-4 text-foreground">
         {label}
@@ -161,7 +172,11 @@ function AccountMenuSubscriptionProviderSection({
           <span className="min-w-0 flex-1 truncate text-muted-foreground">
             {formatCodexResetCredits(resetCredits)}
           </span>
-          <span className="shrink-0 font-medium text-foreground">Reset</span>
+          <span className="shrink-0 font-medium text-foreground">
+            {t(($) => {
+              return $.settings.accountMenu.subscriptions.reset;
+            })}
+          </span>
         </DropdownMenuModalItem>
       ) : null}
     </section>
@@ -177,6 +192,7 @@ function AccountMenuSubscriptionUsageBar({
   readonly windowLabel: string;
   readonly window: SubscriptionUsageWindow;
 }) {
+  const { t } = useTranslation();
   const rawRemainingPercent =
     window.remainingPercent ??
     (window.usedPercent === null ? null : 100 - window.usedPercent);
@@ -202,7 +218,12 @@ function AccountMenuSubscriptionUsageBar({
           <span
             tabIndex={0}
             role="progressbar"
-            aria-label={`${providerLabel} ${windowLabel} remaining`}
+            aria-label={t(
+              ($) => {
+                return $.settings.accountMenu.subscriptions.usageRemaining;
+              },
+              { provider: providerLabel, window: windowLabel },
+            )}
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={remainingPercent ?? undefined}
@@ -216,7 +237,12 @@ function AccountMenuSubscriptionUsageBar({
         </TooltipTrigger>
         <TooltipContent side="right" align="center" className="max-w-56">
           {reset === null ? (
-            <p className="text-xs">Reset time unavailable</p>
+            <p className="text-xs">
+              {t(($) => {
+                return $.settings.accountMenu.subscriptions
+                  .resetTimeUnavailable;
+              })}
+            </p>
           ) : "fallbackText" in reset ? (
             <p className="text-xs">{reset.fallbackText}</p>
           ) : (
@@ -243,7 +269,10 @@ function formatUsagePercent(value: number | null): string | null {
     return null;
   }
   const rounded = Math.round(value * 10) / 10;
-  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+  return formatLocalizedNumber(rounded / 100, {
+    style: "percent",
+    maximumFractionDigits: 1,
+  });
 }
 
 function usageTone(remainingPercent: number | null): {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -19,7 +19,6 @@ import {
   getVm0ConcreteProviderType,
   getVm0Vendor,
   getVm0ModelPriceTier,
-  getVm0ModelPriceTierLabel,
   isModelSupportedByProvider,
   isCodexFastModeModel,
   isSupportedRunModel,
@@ -660,16 +659,6 @@ describe("model-first canonical catalog", () => {
     expect(getVm0ModelPriceTier("gpt-5.4")).toBeUndefined();
     expect(getVm0ModelPriceTier("gpt-5.4-mini")).toBeUndefined();
     expect(getVm0ModelPriceTier("custom/model")).toBeUndefined();
-    expect(getVm0ModelPriceTierLabel("$")).toBe(
-      "Economy tier for everyday simple tasks",
-    );
-    expect(getVm0ModelPriceTierLabel("$$")).toBe(
-      "Balanced cost and performance",
-    );
-    expect(getVm0ModelPriceTierLabel("$$$")).toBe("Frontier flagship model");
-    expect(getVm0ModelPriceTierLabel("$$$$")).toBe(
-      "Premium frontier model for the hardest tasks",
-    );
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -533,7 +533,6 @@ export {
   MODEL_PROVIDER_TYPES,
   SUPPORTED_RUN_MODELS,
   VM0_MODEL_PRICE_TIER,
-  VM0_MODEL_PRICE_TIER_LABEL,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
@@ -556,7 +555,6 @@ export {
   isSupportedRunModel,
   normalizeRunModelId,
   getVm0ModelPriceTier,
-  getVm0ModelPriceTierLabel,
   // Selectable provider filtering
   getSelectableProviderTypes,
   // Multi-auth provider support

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -58,12 +58,3 @@ export const VM0_MODEL_PRICE_TIER = Object.freeze<
   "mimo-v2.5": "$",
   "hy3-preview": "$",
 });
-
-export const VM0_MODEL_PRICE_TIER_LABEL = Object.freeze<
-  Record<Vm0ModelPriceTier, string>
->({
-  $: "Economy tier for everyday simple tasks",
-  $$: "Balanced cost and performance",
-  $$$: "Frontier flagship model",
-  $$$$: "Premium frontier model for the hardest tasks",
-});

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   SUPPORTED_RUN_MODELS,
   VM0_MODEL_PRICE_TIER,
-  VM0_MODEL_PRICE_TIER_LABEL,
   type SupportedRunModel,
   type Vm0ModelPriceTier,
 } from "./model-price-tiers";
@@ -25,7 +24,6 @@ export type {
 export {
   SUPPORTED_RUN_MODELS,
   VM0_MODEL_PRICE_TIER,
-  VM0_MODEL_PRICE_TIER_LABEL,
   type SupportedRunModel,
   type Vm0ModelPriceTier,
 };
@@ -224,10 +222,6 @@ export function getVm0ModelPriceTier(
   model: string,
 ): Vm0ModelPriceTier | undefined {
   return isSupportedRunModel(model) ? VM0_MODEL_PRICE_TIER[model] : undefined;
-}
-
-export function getVm0ModelPriceTierLabel(tier: Vm0ModelPriceTier): string {
-  return VM0_MODEL_PRICE_TIER_LABEL[tier];
 }
 
 export function getCanonicalModelDisplayName(model: string): string {


### PR DESCRIPTION
## Summary
- localize the remaining pt-BR gaps across custom connectors, model/provider settings, billing, chat timestamps, Strapi diagnostics, and Feishu surfaces
- use the selected app locale for user-facing dates and numbers while preserving provider, user, and technical content verbatim
- add a scoped hardcoded UI-copy guard and entry-point integration coverage for the affected flows
- move UI-only model price descriptions out of the shared API contracts package

## Testing
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app --workspace @vm0/api-contracts`
- targeted platform Vitest suite: 14 files, 239 tests
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run` (23 files, 497 tests)

Closes #23890
