### PR TITLE
feat(cli): add zero chat create and full user message sends

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
@@ -85,7 +85,9 @@ function zeroToken(args: {
     scope: "zero",
     userId: args.userId,
     orgId: args.orgId,
-    runId: args.runId ?? `run_${randomUUID()}`,
+    // Run tokens always carry a real run id, and thread creation reads that
+    // run's model, so an unrelated id still has to be a uuid.
+    runId: args.runId ?? randomUUID(),
     capabilities: [...args.capabilities],
     iat: seconds,
     exp: seconds + 600,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  chatThreadMetadataContract,
+  chatThreadsContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { createStore } from "ccstate";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createBddApi } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { seedOrgMembership$ } from "./helpers/zero-org-membership";
+import { seedRun$ } from "./helpers/zero-usage-insight";
+
+const context = testContext();
+const store = createStore();
+const bdd = createBddApi(context);
+const api = createRunsApi(context);
+
+const WORKSPACE_DEFAULT_MODEL = "claude-sonnet-4-6";
+const OTHER_WORKSPACE_MODEL = "claude-sonnet-5";
+
+interface AgentFixture {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+}
+
+/** Creates an agent whose workspace allows both policy models. */
+async function seedAgent(): Promise<AgentFixture> {
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  const { providerId } = await api.ensureOrgModelProvider(actor);
+  await api.updateOrgModelPolicies(actor, [
+    {
+      model: WORKSPACE_DEFAULT_MODEL,
+      isDefault: true,
+      defaultProviderType: "anthropic-api-key",
+      credentialScope: "org",
+      modelProviderId: providerId,
+    },
+    {
+      model: OTHER_WORKSPACE_MODEL,
+      isDefault: false,
+      defaultProviderType: "anthropic-api-key",
+      credentialScope: "org",
+      modelProviderId: providerId,
+    },
+  ]);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Chat thread create agent",
+    visibility: "private",
+  });
+  if (!actor.orgId) {
+    throw new Error("Expected the seeded actor to belong to an org");
+  }
+  await store.set(
+    seedOrgMembership$,
+    { orgId: actor.orgId, userId: actor.userId },
+    context.signal,
+  );
+  return {
+    userId: actor.userId,
+    orgId: actor.orgId,
+    agentId: agent.agentId,
+  };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly capabilities: readonly ZeroCapability[];
+  readonly runId?: string;
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId ?? `run_${randomUUID()}`,
+    capabilities: [...args.capabilities],
+    iat: seconds,
+    exp: seconds + 600,
+  });
+}
+
+function threadsClient() {
+  return setupApp({ context })(chatThreadsContract);
+}
+
+function metadataClient() {
+  return setupApp({ context })(chatThreadMetadataContract);
+}
+
+describe("POST /api/zero/chat-threads", () => {
+  it("creates a titled thread with ZERO_TOKEN chat-thread:write capability", async () => {
+    const fixture = await seedAgent();
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+
+    const response = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          title: "Deep dive on P2",
+          model: OTHER_WORKSPACE_MODEL,
+        },
+      }),
+      [201],
+    );
+    expect(response.body).toMatchObject({
+      title: "Deep dive on P2",
+      selectedModel: OTHER_WORKSPACE_MODEL,
+    });
+
+    const metadataResponse = await accept(
+      metadataClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: response.body.id },
+      }),
+      [200],
+    );
+    expect(metadataResponse.body).toStrictEqual({
+      id: response.body.id,
+      agentId: fixture.agentId,
+      title: "Deep dive on P2",
+      selectedModel: OTHER_WORKSPACE_MODEL,
+    });
+  });
+
+  it("inherits the model of the run that owns the token when model is omitted", async () => {
+    const fixture = await seedAgent();
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.agentId,
+        triggerSource: "web",
+        selectedModel: OTHER_WORKSPACE_MODEL,
+      },
+      context.signal,
+    );
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+      runId,
+    });
+
+    const response = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: { agentId: fixture.agentId, title: "Inherited model" },
+      }),
+      [201],
+    );
+    expect(response.body.selectedModel).toBe(OTHER_WORKSPACE_MODEL);
+
+    const metadataResponse = await accept(
+      metadataClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: response.body.id },
+      }),
+      [200],
+    );
+    expect(metadataResponse.body.selectedModel).toBe(OTHER_WORKSPACE_MODEL);
+  });
+
+  it("rejects an omitted model when the token has no run model to inherit", async () => {
+    const fixture = await seedAgent();
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:write"],
+    });
+
+    const response = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: { agentId: fixture.agentId, title: "No model anywhere" },
+      }),
+      [400],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "A model selection is required",
+      },
+    });
+  });
+
+  it("rejects ZERO_TOKEN without chat-thread:write capability", async () => {
+    const fixture = await seedAgent();
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read"],
+    });
+
+    const response = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          title: "Unauthorized thread",
+          model: WORKSPACE_DEFAULT_MODEL,
+        },
+      }),
+      [403],
+    );
+    expect(response.body).toStrictEqual({
+      error: {
+        code: "FORBIDDEN",
+        message: "Missing required capability: chat-thread:write",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
@@ -1,15 +1,17 @@
 import { command } from "ccstate";
+import { eq } from "drizzle-orm";
 import {
   chatThreadsContract,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { writeDb$ } from "../external/db";
+import { type Db, writeDb$ } from "../external/db";
 import { publishThreadListChanged } from "../external/realtime";
-import { notFound } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { createChatThread$ } from "../services/zero-chat-thread.service";
 import { zeroComposeExists } from "../services/zero-compose-data.service";
 import { resolveModelSelectionPin } from "../services/zero-model-selection.service";
@@ -23,6 +25,26 @@ function modelFirstSelection(selectedModel: string) {
     modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
     selectedModel,
   };
+}
+
+/**
+ * Model a caller inherits when it omits `model`: the model of the run that owns
+ * its token. Session and PAT callers have no run, so they must send a model.
+ */
+async function inheritedRunModel(
+  db: Db,
+  runId: string | undefined,
+): Promise<string | null> {
+  if (!runId) {
+    return null;
+  }
+
+  const [run] = await db
+    .select({ selectedModel: zeroRuns.selectedModel })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return run?.selectedModel ?? null;
 }
 
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -44,11 +66,23 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Agent not found");
   }
 
+  const writeDb = set(writeDb$);
+  const callerRunId =
+    auth.tokenType === "sandbox" || auth.tokenType === "zero"
+      ? auth.runId
+      : undefined;
+  const selectedModel =
+    body.data.model ?? (await inheritedRunModel(writeDb, callerRunId));
+  signal.throwIfAborted();
+  if (!selectedModel) {
+    return badRequestMessage("A model selection is required");
+  }
+
   const pin = await resolveModelSelectionPin({
-    db: set(writeDb$),
+    db: writeDb,
     orgId: auth.orgId,
     userId: auth.userId,
-    modelSelection: modelFirstSelection(body.data.model),
+    modelSelection: modelFirstSelection(selectedModel),
   });
   signal.throwIfAborted();
   if ("status" in pin) {
@@ -79,6 +113,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       id: thread.id,
       title: body.data.title ?? null,
       createdAt: thread.createdAt.toISOString(),
+      selectedModel,
     },
   };
 });
@@ -87,7 +122,11 @@ export const zeroChatThreadCreateRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadsContract.create,
     handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
+      {
+        requiredCapability: "chat-thread:write",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
       createInner$,
     ),
   },

--- a/turbo/apps/api/src/signals/services/zero-chat-messaging-tool-prompt.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-messaging-tool-prompt.ts
@@ -7,6 +7,7 @@ export function buildZeroChatMessagingToolPrompt(
 
   return [
     '- Web chat messaging: use `zero chat send --thread-id <thread-id> --text "<message>"` to send a user message to a chat thread. Use `zero chat cancel --thread-id <thread-id> --run-id <run-id>` to cancel a run or `--event-id <event-id>` to cancel a queued message.',
+    '- New web chat threads: use `zero chat create "<title>"` to open a separate chat thread. The title is required, and the command only creates the thread; send its first message with `zero chat send --thread-id <thread-id>`. The new thread never inherits the current thread\'s history, so that first message must be a self-contained handoff prompt.',
     "- Chat run finished automations: a workflow can trigger whenever a run in a specific chat thread finishes. Use the `workflow-setup` skill with a `chat-run-finished` automation naming the watched chat thread ID; optionally filter by finish status (completed, failed, cancelled) and a `*`-wildcard pattern matched against the finished run's final assistant text.",
   ];
 }

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/create.test.ts
@@ -1,0 +1,151 @@
+import chalk from "chalk";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroChatCommand } from "../index";
+
+const CURRENT_THREAD_ID = "00000000-0000-4000-8000-000000000001";
+const NEW_THREAD_ID = "00000000-0000-4000-8000-000000000002";
+const AGENT_ID = "00000000-0000-4000-8000-000000000010";
+const OTHER_AGENT_ID = "00000000-0000-4000-8000-000000000011";
+const CREATE_URL = "http://localhost:3000/api/zero/chat-threads";
+
+function metadataUrl(threadId: string): string {
+  return `http://localhost:3000/api/zero/chat-threads/${threadId}/metadata`;
+}
+
+describe("zero chat create command", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", CURRENT_THREAD_ID);
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockExit.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("creates a thread under this chat's agent and inherits the run model", async () => {
+    server.use(
+      http.get(metadataUrl(CURRENT_THREAD_ID), () => {
+        return HttpResponse.json({
+          id: CURRENT_THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Current chat",
+          selectedModel: "claude-sonnet-5",
+        });
+      }),
+      http.post(CREATE_URL, async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer test-zero-token",
+        );
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toStrictEqual({
+          agentId: AGENT_ID,
+          title: "Deep dive on P2",
+        });
+        return HttpResponse.json(
+          {
+            id: NEW_THREAD_ID,
+            title: "Deep dive on P2",
+            createdAt: "2026-07-30T10:00:00.000Z",
+            selectedModel: "claude-sonnet-5",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "create",
+      "Deep dive",
+      "on P2",
+      "--json",
+    ]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        threadId: NEW_THREAD_ID,
+        title: "Deep dive on P2",
+        selectedModel: "claude-sonnet-5",
+        agentId: AGENT_ID,
+      },
+    );
+  });
+
+  it("guides to the first send with an explicit agent and model", async () => {
+    server.use(
+      http.post(CREATE_URL, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toStrictEqual({
+          agentId: OTHER_AGENT_ID,
+          title: "Launch plan",
+          model: "claude-sonnet-5",
+        });
+        return HttpResponse.json(
+          {
+            id: NEW_THREAD_ID,
+            title: "Launch plan",
+            createdAt: "2026-07-30T10:00:00.000Z",
+            selectedModel: "claude-sonnet-5",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "create",
+      "Launch plan",
+      "--agent",
+      OTHER_AGENT_ID,
+      "--model",
+      "claude-sonnet-5",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Chat thread created");
+    expect(output).toContain(`Thread: ${NEW_THREAD_ID}`);
+    expect(output).toContain("Title:  Launch plan");
+    expect(output).toContain("Model:  claude-sonnet-5");
+    expect(output).toContain(`Agent:  ${OTHER_AGENT_ID}`);
+    expect(output).toContain(
+      `zero chat send --thread-id ${NEW_THREAD_ID} --text "<message>"`,
+    );
+  });
+
+  it("requires an agent when it runs outside a web chat thread", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "create",
+        "Launch plan",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("ZERO_CHAT_THREAD_ID is not set");
+    expect(stderr).toContain("Pass --agent <agent-id>");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,14 +28,24 @@ describe("zero chat send command", () => {
     throw new Error("process.exit called");
   }) as never);
 
+  let tempDir: string;
+
+  function writeUserMessageFile(document: unknown): string {
+    const filePath = path.join(tempDir, "user-message.json");
+    writeFileSync(filePath, JSON.stringify(document), "utf8");
+    return filePath;
+  }
+
   beforeEach(() => {
     chalk.level = 0;
+    tempDir = mkdtempSync(path.join(tmpdir(), "zero-chat-send-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-zero-token");
     vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true });
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     mockExit.mockClear();
@@ -180,6 +194,162 @@ describe("zero chat send command", () => {
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
     expect(stderr).toContain("Chat message text is required");
     expect(stderr).toContain('Pass --text "message"');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("sends a multi-part document from --user-message-file as written", async () => {
+    const document = {
+      version: 1,
+      parts: [
+        { type: "text", text: "Review this deck" },
+        {
+          type: "file",
+          fileId: "file_abc",
+          filenameSnapshot: "deck.pdf",
+          contentType: "application/pdf",
+        },
+        {
+          type: "chat_thread",
+          threadId: OTHER_THREAD_ID,
+          titleSnapshot: "Launch plan",
+        },
+      ],
+    };
+    server.use(
+      http.get(metadataUrl(THREAD_ID), () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Launch plan",
+          selectedModel: null,
+        });
+      }),
+      http.post(SEND_URL, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          agentId: AGENT_ID,
+          threadId: THREAD_ID,
+          prompt: "Review this deck",
+          hasTextContent: true,
+          userMessage: document,
+        });
+        return HttpResponse.json(
+          {
+            runId: RUN_ID,
+            threadId: THREAD_ID,
+            status: "pending",
+            createdAt: "2026-07-30T10:00:00.000Z",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "send",
+      "--user-message-file",
+      writeUserMessageFile(document),
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Chat message dispatched");
+    expect(output).toContain(`Run:    ${RUN_ID}`);
+  });
+
+  it("reports a file-only document as having no text content", async () => {
+    const document = {
+      version: 1,
+      parts: [
+        {
+          type: "file",
+          fileId: "file_abc",
+          filenameSnapshot: "deck.pdf",
+          contentType: "application/pdf",
+        },
+      ],
+    };
+    server.use(
+      http.get(metadataUrl(THREAD_ID), () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Launch plan",
+          selectedModel: null,
+        });
+      }),
+      http.post(SEND_URL, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          prompt: "(see attached files)",
+          hasTextContent: false,
+          userMessage: document,
+        });
+        return HttpResponse.json(
+          { runId: null, threadId: THREAD_ID },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "send",
+      "--user-message-file",
+      writeUserMessageFile(document),
+    ]);
+
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      "Chat message queued",
+    );
+  });
+
+  it("reports document validation issues before calling the API", async () => {
+    const filePath = writeUserMessageFile({
+      version: 1,
+      parts: [{ type: "file", fileId: "file_abc" }],
+    });
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "send",
+        "--user-message-file",
+        filePath,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("is not a valid UserMessageDocument");
+    expect(stderr).toContain("parts.0.filenameSnapshot");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects --text together with --user-message-file", async () => {
+    const filePath = writeUserMessageFile({
+      version: 1,
+      parts: [{ type: "text", text: "Continue" }],
+    });
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "send",
+        "--text",
+        "Continue",
+        "--user-message-file",
+        filePath,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain(
+      "Pass either --text or --user-message-file, not both",
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/chat/create.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/create.ts
@@ -1,0 +1,120 @@
+import chalk from "chalk";
+import { Command } from "commander";
+
+import {
+  createZeroChatThread,
+  getZeroChatThreadAgentId,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+import { isUuid } from "../../../lib/utils/uuid";
+import { printChatUsageError } from "./shared";
+
+interface CreateOptions {
+  readonly agent?: string;
+  readonly json?: boolean;
+  readonly model?: string;
+}
+
+/**
+ * Agent that owns the new thread: an explicit `--agent`, otherwise the agent of
+ * the chat the command runs in.
+ */
+async function resolveAgentId(
+  flagAgentId: string | undefined,
+): Promise<string> {
+  const agentId = flagAgentId?.trim();
+  if (agentId) {
+    return agentId;
+  }
+
+  const currentThreadId = process.env.ZERO_CHAT_THREAD_ID?.trim();
+  if (!currentThreadId) {
+    printChatUsageError(
+      "ZERO_CHAT_THREAD_ID is not set",
+      "Pass --agent <agent-id> or run inside a Zero web chat thread.",
+    );
+  }
+  if (!isUuid(currentThreadId)) {
+    printChatUsageError(
+      `Invalid thread ID "${currentThreadId}" — expected a UUID`,
+      "Pass --agent <agent-id> to choose the agent explicitly.",
+    );
+  }
+
+  return await getZeroChatThreadAgentId({ threadId: currentThreadId });
+}
+
+export const createCommand = new Command()
+  .name("create")
+  .description("Create a new web chat thread")
+  .argument("<title...>", "Chat title")
+  .option(
+    "--agent <id>",
+    "Agent ID that owns the thread (defaults to this chat's agent)",
+  )
+  .option(
+    "--model <id>",
+    "Model for the thread (defaults to the current run's model)",
+  )
+  .option("--json", "Print machine-readable JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create a chat:     zero chat create "Launch plan"
+  Pick the model:    zero chat create "Launch plan" --model claude-sonnet-5
+  Pick the agent:    zero chat create "Launch plan" --agent <agent-id>
+  Print JSON:        zero chat create "Launch plan" --json
+
+Notes:
+  - Creates an empty thread; send its first message with zero chat send
+  - Defaults --agent to the agent of ZERO_CHAT_THREAD_ID
+  - Defaults --model to the model of the run that owns ZERO_TOKEN
+  - The new thread never inherits this chat's history, so the first message must be self-contained
+  - Authenticates via ZERO_TOKEN (requires chat-thread:write, and chat-thread:read to default --agent)`,
+  )
+  .action(
+    withErrorHandler(async (titleParts: string[], options: CreateOptions) => {
+      const title = titleParts.join(" ").trim();
+      if (!title) {
+        printChatUsageError(
+          "Chat title is required",
+          'Run: zero chat create "New title"',
+        );
+      }
+
+      const agentId = await resolveAgentId(options.agent);
+      const thread = await createZeroChatThread({
+        agentId,
+        title,
+        ...(options.model === undefined ? {} : { model: options.model }),
+      });
+
+      if (options.json) {
+        console.log(
+          JSON.stringify({
+            threadId: thread.threadId,
+            title: thread.title,
+            selectedModel: thread.selectedModel,
+            agentId,
+          }),
+        );
+        return;
+      }
+
+      console.log(chalk.green("✓ Chat thread created"));
+      console.log(chalk.dim(`  Thread: ${thread.threadId}`));
+      console.log(chalk.dim(`  Title:  ${title}`));
+      console.log(
+        chalk.dim(`  Model:  ${thread.selectedModel ?? "(default)"}`),
+      );
+      console.log(chalk.dim(`  Agent:  ${agentId}`));
+      console.log();
+      console.log("Send the first message:");
+      console.log(
+        chalk.cyan(
+          `  zero chat send --thread-id ${thread.threadId} --text "<message>"`,
+        ),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 
 import { cancelCommand } from "./cancel";
+import { createCommand } from "./create";
 import { getCommand } from "./get";
 import { listCommand } from "./list";
 import { modelCommand } from "./model";
@@ -11,6 +12,7 @@ import { sendCommand } from "./send";
 export const zeroChatCommand = new Command()
   .name("chat")
   .description("Manage web chat threads")
+  .addCommand(createCommand)
   .addCommand(sendCommand)
   .addCommand(queuedCommand)
   .addCommand(cancelCommand)
@@ -22,6 +24,7 @@ export const zeroChatCommand = new Command()
     "after",
     `
 Examples:
+  Create a chat:     zero chat create "Launch plan"
   Send a message:    zero chat send --text "Continue"
   Show queued:       zero chat queued --thread-id <thread-id>
   Cancel a run:      zero chat cancel --thread-id <thread-id> --run-id <run-id>

--- a/turbo/apps/cli/src/commands/zero/chat/send.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/send.ts
@@ -3,16 +3,50 @@ import { readFileSync } from "node:fs";
 
 import chalk from "chalk";
 import { Command } from "commander";
-import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  type UserMessageDocument,
+  userMessageDocumentSchema,
+} from "@vm0/api-contracts/contracts/chat-threads";
 
 import { getZeroChatThreadAgentId, sendZeroChatEvent } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { printChatUsageError, resolveChatThreadId } from "./shared";
 
+// Non-authoritative plain-text views of a document that carries no text part.
+// The API re-derives the agent prompt from the document itself; the web app
+// sends the same file placeholder for attachment-only messages.
+const ATTACHED_FILES_PROMPT = "(see attached files)";
+const MESSAGE_PARTS_PROMPT = "(see message parts)";
+
+const USER_MESSAGE_JSON_HELP = `
+User message JSON (--user-message-file), one version 1 document:
+  { "version": 1, "parts": [ <part>, ... ] }            at least one part
+
+  text         { "type": "text", "text": "..." }
+  chat_thread  { "type": "chat_thread", "threadId": "<uuid>",
+                 "titleSnapshot": "..." }
+  template     { "type": "template", "titleSnapshot": "...",
+                 "template": { "type": "presentation" | "video" |
+                   "illustration" | "workflow" | "website",
+                   "selection": { ... } } }
+  file         { "type": "file", "fileId": "...",
+                 "filenameSnapshot": "...", "contentType": "..." }
+  feedback     { "type": "feedback", "quote": "...",
+                 "note": [ text | chat_thread | template parts ],
+                 "source": { "type": "mail", "id": "...",
+                   "status": "draft" | "sent", "sentId": "..." } }`;
+
 interface SendOptions {
   readonly json?: boolean;
   readonly text?: string;
   readonly threadId?: string;
+  readonly userMessageFile?: string;
+}
+
+interface ResolvedUserMessage {
+  readonly userMessage: UserMessageDocument;
+  readonly prompt: string;
+  readonly hasTextContent: boolean;
 }
 
 function readMessageText(optionText: string | undefined): string {
@@ -30,10 +64,96 @@ function readMessageText(optionText: string | undefined): string {
   if (!trimmed) {
     printChatUsageError(
       "Chat message text is required",
-      'Pass --text "message" or pipe the message on stdin.',
+      'Pass --text "message", pipe the message on stdin, or pass --user-message-file <path>.',
     );
   }
   return trimmed;
+}
+
+function documentText(document: UserMessageDocument): string {
+  return document.parts
+    .map((part) => {
+      return part.type === "text" ? part.text : "";
+    })
+    .join("")
+    .trim();
+}
+
+function promptForDocument(document: UserMessageDocument): string {
+  const text = documentText(document);
+  if (text) {
+    return text;
+  }
+  const hasFilePart = document.parts.some((part) => {
+    return part.type === "file";
+  });
+  return hasFilePart ? ATTACHED_FILES_PROMPT : MESSAGE_PARTS_PROMPT;
+}
+
+function readUserMessageDocument(path: string): UserMessageDocument {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printChatUsageError(
+      `Failed to read user message file "${path}": ${message}`,
+      "Pass a readable JSON file. Run: zero chat send --help",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printChatUsageError(
+      `User message file "${path}" is not valid JSON: ${message}`,
+      "Run: zero chat send --help",
+    );
+  }
+
+  const result = userMessageDocumentSchema.safeParse(parsed);
+  if (!result.success) {
+    printChatUsageError(
+      `User message file "${path}" is not a valid UserMessageDocument`,
+      result.error.issues
+        .map((issue) => {
+          const issuePath = issue.path.join(".");
+          return `${issuePath === "" ? "(root)" : issuePath}: ${issue.message}`;
+        })
+        .join("\n  "),
+    );
+  }
+  return result.data;
+}
+
+function resolveUserMessage(options: SendOptions): ResolvedUserMessage {
+  if (options.userMessageFile === undefined) {
+    const text = readMessageText(options.text);
+    return {
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text }],
+      },
+      prompt: text,
+      hasTextContent: true,
+    };
+  }
+
+  if (options.text !== undefined) {
+    printChatUsageError(
+      "Pass either --text or --user-message-file, not both",
+      "Use --text for a plain message and --user-message-file for a full document.",
+    );
+  }
+
+  const userMessage = readUserMessageDocument(options.userMessageFile);
+  return {
+    userMessage,
+    prompt: promptForDocument(userMessage),
+    hasTextContent: documentText(userMessage).length > 0,
+  };
 }
 
 export const sendCommand = new Command()
@@ -44,6 +164,10 @@ export const sendCommand = new Command()
     "Chat thread ID (defaults to ZERO_CHAT_THREAD_ID)",
   )
   .option("-t, --text <message>", "Message text (or read it from stdin)")
+  .option(
+    "--user-message-file <path>",
+    "JSON file holding one full UserMessageDocument (excludes --text)",
+  )
   .option("--json", "Print machine-readable JSON")
   .addHelpText(
     "after",
@@ -52,32 +176,33 @@ Examples:
   Send to this chat:  zero chat send --text "Continue the analysis"
   Send to a thread:   zero chat send --thread-id <thread-id> --text "Continue"
   Pipe a message:     printf "Continue" | zero chat send --thread-id <thread-id>
+  Send a document:    zero chat send --user-message-file ./message.json
   Print JSON:         zero chat send --text "Continue" --json
+${USER_MESSAGE_JSON_HELP}
 
 Notes:
-  - Constructs a version 1 UserMessageDocument with one text part
+  - --text wraps the message in a version 1 UserMessageDocument with one text part
+  - --user-message-file sends the document as written, validated before the request
+  - file parts reference an uploaded web file id (zero web upload-file)
+  - The API derives the agent prompt and title state from the document itself
   - Every normal message enters the thread queue first; an idle queue may dispatch it immediately
   - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-message:write capabilities)`,
   )
   .action(
     withErrorHandler(async (options: SendOptions) => {
       const threadId = resolveChatThreadId(options.threadId);
-      const text = readMessageText(options.text);
+      const message = resolveUserMessage(options);
       const agentId = await getZeroChatThreadAgentId({ threadId });
       const eventId = randomUUID();
-      const userMessage = {
-        version: 1,
-        parts: [{ type: "text", text }],
-      } satisfies UserMessageDocument;
 
       const result = await sendZeroChatEvent({
         agentId,
         threadId,
-        prompt: text,
-        hasTextContent: true,
+        prompt: message.prompt,
+        hasTextContent: message.hasTextContent,
         clientEventId: eventId,
         chatThreadSortEventId: randomUUID(),
-        userMessage,
+        userMessage: message.userMessage,
       });
       const queued = result.runId === null;
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
@@ -32,6 +32,12 @@ interface ZeroChatEventsPage {
   readonly hasHistoryBefore: boolean;
 }
 
+interface ZeroChatThreadCreateResult {
+  readonly threadId: string;
+  readonly title: string | null;
+  readonly selectedModel: string | null;
+}
+
 interface ZeroChatEventSendResult {
   readonly runId: string | null;
   readonly threadId: string;
@@ -110,6 +116,32 @@ export async function listZeroChatThreadEvents(options: {
     return { kind: "expired" };
   }
   handleError(result, "Failed to list chat thread events");
+}
+
+export async function createZeroChatThread(options: {
+  agentId: string;
+  title: string;
+  model?: string;
+}): Promise<ZeroChatThreadCreateResult> {
+  const config = await getClientConfig();
+  const client = initClient(chatThreadsContract, config);
+  const result = await client.create({
+    body: {
+      agentId: options.agentId,
+      title: options.title,
+      ...(options.model === undefined ? {} : { model: options.model }),
+    },
+  });
+  if (result.status === 201) {
+    return {
+      threadId: result.body.id,
+      title: result.body.title,
+      // An API that predates the echoed pin leaves the CLI with only the
+      // model the caller asked for.
+      selectedModel: result.body.selectedModel ?? options.model ?? null,
+    };
+  }
+  handleError(result, "Failed to create chat thread");
 }
 
 export async function renameZeroChatThread(options: {

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -193,6 +193,7 @@ export { listZeroLogs, searchZeroLogs } from "./domains/zero-logs";
 
 // Domain modules - Zero Chat
 export {
+  createZeroChatThread,
   getZeroChatThreadAgentId,
   getZeroChatThreadSnapshot,
   getZeroChatThread,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -733,9 +733,10 @@ const chatThreadCreateBodySchema = z.preprocess(
     eventId: chatThreadEventIdSchema.optional(),
     /**
      * Selected model id. The API resolves the effective model provider from org
-     * policy and available credentials.
+     * policy and available credentials. Omit it to inherit the model of the run
+     * that owns the calling token; callers without a run must send it.
      */
-    model: selectedModelRequestSchema,
+    model: selectedModelRequestSchema.optional(),
     title: z.string().optional(),
   }),
 );
@@ -877,10 +878,15 @@ export const chatThreadsContract = c.router({
         id: z.string(),
         title: z.string().nullable(),
         createdAt: z.string(),
+        // The model the thread was pinned to, echoed so a caller that omitted
+        // `model` learns what it inherited. Remove optionality only after
+        // pre-echo APIs cannot serve a newly released CLI during rollout.
+        selectedModel: z.string().optional(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,
       402: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Create a new chat thread",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -483,7 +483,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ZeroChatMessaging]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Advertise zero chat send and cancel in the agent system prompt without gating the CLI commands or API.",
+      "Advertise zero chat create, send, and cancel in the agent system prompt without gating the CLI commands or API.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Why

Two gaps in how a run reaches web chat threads from the CLI:

1. It could not open a new thread. `POST /api/zero/chat-threads` had no capability gate, so run-scoped tokens fell through to `This endpoint is not available for sandbox tokens`, and delegating work to a separate thread required the Web UI.
2. It could only send plain text. The send API has always accepted the full document (`userMessage` is `userMessageDocumentSchema`, and the server re-derives `agentPrompt`, `displayText`, `generationTemplates`, and `hasTextContent` from it in `zero-chat-user-message.service.ts:182`), but `zero chat send` hardcoded a single text part.

## What

### `zero chat create "<title>"`

- Creates the thread and nothing else. Messaging stays in `zero chat send`, so each command remains one operation an agent can compose.
- Title is required (positional). An empty thread has no first message to generate a title from, so untitled threads would all read as "New chat".
- `--agent` defaults to the agent of `ZERO_CHAT_THREAD_ID`; `--model` defaults to the model of the run that owns `ZERO_TOKEN`.
- The new thread never inherits the current thread's history, so its first message has to be a self-contained handoff prompt.
- Output guides the next step with the ready-to-run `zero chat send --thread-id …` line; `--json` returns `threadId`, `title`, `selectedModel`, and `agentId`.

API for create:

- Gated on `chat-thread:write` — the same capability `zero chat rename` and `zero chat model` already use, and one every agent run token carries. No new capability, no permission-grant plumbing.
- `model` became optional. A run-scoped caller inherits `zero_runs.selected_model` for its own `runId`; the inherited model still goes through `resolveModelSelectionPin`, so workspace model policy and plan restrictions are unchanged. Callers without a run (sessions, PATs) still must send a model and otherwise get `400 A model selection is required`.
- The 201 response echoes `selectedModel` so a caller that omitted `model` learns what it inherited.

### `zero chat send --user-message-file <path>`

- Sends one version 1 `UserMessageDocument` as written; mutually exclusive with `--text`, which stays the shortcut that wraps plain text (or stdin) in a single text part.
- Validated against the contract's own `userMessageDocumentSchema` before the request, so a malformed file reports zod field paths (`parts.0.filenameSnapshot: …`) locally instead of coming back as a 400.
- `--help` documents every part shape:

```
User message JSON (--user-message-file), one version 1 document:
  { "version": 1, "parts": [ <part>, ... ] }            at least one part

  text         { "type": "text", "text": "..." }
  chat_thread  { "type": "chat_thread", "threadId": "<uuid>", "titleSnapshot": "..." }
  template     { "type": "template", "titleSnapshot": "...",
                 "template": { "type": "presentation" | "video" | "illustration" |
                   "workflow" | "website", "selection": { ... } } }
  file         { "type": "file", "fileId": "...", "filenameSnapshot": "...",
                 "contentType": "..." }
  feedback     { "type": "feedback", "quote": "...",
                 "note": [ text | chat_thread | template parts ],
                 "source": { "type": "mail", "id": "...",
                   "status": "draft" | "sent", "sentId": "..." } }
```

- `prompt` and `hasTextContent` are derived from the document's text parts. Both are non-authoritative (the server overwrites them from its own projection), so a document with no text part sends the same `(see attached files)` placeholder the web app uses for attachment-only messages, keeping the contract's `prompt: min(1)` satisfied.
- `file` parts reference an uploaded web file id (`zero web upload-file`); the `[Web file] … [ID] …` block the agent needs comes from the part itself, so `zero web download-file` keeps working. Artifact card metadata still comes from the separate `attachFiles` body field, which this PR does not touch.

The agent system prompt advertises `create` behind the existing `zeroChatMessaging` feature switch, which already covers `send`/`cancel` and gates only the prompt, not the CLI or API.

## Compatibility

- `selectedModel` is optional on the create response, and the CLI falls back to the model it requested, so a newer CLI keeps working against an API that predates the echo. Omitting `--model` against such an API surfaces the API's own 400.
- Session callers are unaffected: the capability gate only applies to sandbox and run-scoped tokens, and the web client already always sends `model`.
- Creating a thread grants no new run-spawning power — `chat-message:write` already lets a run dispatch runs in existing threads.
- `zero chat send` needs no API change at all.

## Verification

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/chat` — 8 files, 34 tests pass: 3 new `create` cases and 4 new `send` document cases (multi-part text+file+chat_thread, file-only with `hasTextContent: false`, local schema rejection before any HTTP call, `--text` + `--user-message-file` rejection).
- `pnpm -F @vm0/api-contracts exec vitest run` — 23 files, 497 tests pass.
- `check-types` clean for `@vm0/cli`, `@vm0/api-contracts`, `@vm0/core`; `lint` and `knip` clean for the same scope, plus oxlint/eslint on the touched `apps/api` files.
- New API tests cover the capability grant, model inheritance from the run, the missing-model 400, and the missing-capability 403. `apps/api` type-check and DB-backed tests run in the PR pipeline (the sandbox has neither the memory nor Postgres for them).

Supersedes #23933, whose commit is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
