### PR TITLE
feat(platform): let admins self-serve the github app install

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4792,6 +4792,7 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
   });
 
   it("keeps GitHub no-install read and upload-init surfaces visible through APIs", async () => {
+    integrations.configureGithubAppInstallProvider();
     const actor = integrations.user();
 
     const installation = await integrations.readGithubInstallation(actor);
@@ -4802,6 +4803,33 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
         code: "NOT_FOUND",
       },
     });
+    const adminInstallUrl =
+      "installUrl" in installation.body ? installation.body.installUrl : null;
+    if (!adminInstallUrl) {
+      throw new Error("Expected an install URL for organization admins");
+    }
+    expect(adminInstallUrl).toContain(
+      "https://github.com/apps/bdd-github-app/installations/new",
+    );
+    expect(
+      new URL(adminInstallUrl).searchParams
+        .get("redirect_uri")
+        ?.endsWith("/api/github/app/setup/callback"),
+    ).toBeTruthy();
+
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected GitHub admin test user to have an org");
+    }
+    const member = integrations.user({ orgId, orgRole: "org:member" });
+    const memberInstallation =
+      await integrations.readGithubInstallation(member);
+    expect(memberInstallation.status).toBe(404);
+    expect(
+      "installUrl" in memberInstallation.body
+        ? memberInstallation.body.installUrl
+        : "unset",
+    ).toBeNull();
 
     const upload = await integrations.requestGithubUploadInit(
       actor,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -29,7 +29,7 @@ import {
   type ResolvedConnectorActionMethod,
 } from "../services/connector-action-resolver.service";
 import {
-  buildGithubOauthState,
+  buildGithubAppInstallUrl,
   buildGithubUserConnectAuthorizationUrl,
   createOrActivateGithubInstallation,
   findGithubInstallationByInstallationId,
@@ -58,7 +58,6 @@ import {
 
 const REDIRECT_STATUS = 307;
 const GITHUB_CONNECTOR_SLUG = "github";
-const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
 const L = logger("GithubOAuthRoute");
 
 function redirectResponse(url: string): Response {
@@ -84,10 +83,6 @@ function jsonErrorResponse(error: string, status: number): Response {
 
 function appUrl(path: string): string {
   return `${env("APP_URL").replace(/\/$/u, "")}${path}`;
-}
-
-function githubAppSetupCallbackRedirectUri(origin: string): string {
-  return `${origin}${GITHUB_APP_SETUP_CALLBACK_PATH}`;
 }
 
 function githubUserOauthClient(
@@ -608,26 +603,17 @@ const installGithubOauth$ = command(
       }
     }
 
-    const state = await buildGithubOauthState({
+    const installUrl = await buildGithubAppInstallUrl({
+      appSlug,
       vm0UserId: query.vm0UserId,
       orgId: query.orgId,
       composeId: query.composeId,
+      origin,
       secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
     });
     signal.throwIfAborted();
 
-    const installUrl = new URL(
-      `https://github.com/apps/${appSlug}/installations/new`,
-    );
-    if (state) {
-      installUrl.searchParams.set("state", state);
-    }
-    installUrl.searchParams.set(
-      "redirect_uri",
-      githubAppSetupCallbackRedirectUri(origin),
-    );
-
-    return noStoreRedirect(installUrl.toString());
+    return noStoreRedirect(installUrl);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -322,7 +322,7 @@ export function verifyGithubConnectSignature(args: {
   return signaturesMatch(args.signature, expected);
 }
 
-export async function buildGithubOauthState(args: {
+async function buildGithubOauthState(args: {
   readonly vm0UserId?: string;
   readonly orgId?: string;
   readonly composeId?: string;
@@ -357,6 +357,38 @@ export async function buildGithubOauthState(args: {
 
 export function githubUserConnectCallbackRedirectUri(origin: string): string {
   return `${origin}/api/zero/github/oauth/connect/callback`;
+}
+
+function githubAppSetupCallbackRedirectUri(origin: string): string {
+  return `${origin}/api/github/app/setup/callback`;
+}
+
+export async function buildGithubAppInstallUrl(args: {
+  readonly appSlug: string;
+  readonly vm0UserId?: string;
+  readonly orgId?: string;
+  readonly composeId?: string;
+  readonly origin: string;
+  readonly secretsEncryptionKey: string;
+}): Promise<string> {
+  const state = await buildGithubOauthState({
+    vm0UserId: args.vm0UserId,
+    orgId: args.orgId,
+    composeId: args.composeId,
+    secretsEncryptionKey: args.secretsEncryptionKey,
+  });
+  const url = new URL(
+    `https://github.com/apps/${args.appSlug}/installations/new`,
+  );
+  if (state) {
+    url.searchParams.set("state", state);
+  }
+  url.searchParams.set(
+    "redirect_uri",
+    githubAppSetupCallbackRedirectUri(args.origin),
+  );
+
+  return url.toString();
 }
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -6,6 +6,7 @@ import type {
 import { connectors } from "@vm0/db/schema/connector";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { and, eq } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -15,6 +16,7 @@ import { publishUserSignal } from "../external/realtime";
 import { env, optionalEnv } from "../../lib/env";
 import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
 import {
+  buildGithubOauthState,
   buildGithubUserConnectAuthorizationUrl,
   findGithubInstallationByInstallationId,
   getGithubOAuthAuthMethod,
@@ -29,6 +31,34 @@ function errorResponse(status: 400 | 404 | 409, message: string, code: string) {
 
 function githubConnectStartUrl(origin: string): string {
   return `${origin}/api/zero/github/oauth/connect`;
+}
+
+async function githubInstallUrl(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly composeId: string | null;
+  readonly origin: string;
+}): Promise<string | null> {
+  const appSlug = optionalEnv("GITHUB_APP_SLUG");
+  if (!appSlug) {
+    return null;
+  }
+
+  const state = await buildGithubOauthState({
+    vm0UserId: args.userId,
+    orgId: args.orgId,
+    composeId: args.composeId ?? undefined,
+    secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
+  });
+  const url = new URL(`https://github.com/apps/${appSlug}/installations/new`);
+  if (state) {
+    url.searchParams.set("state", state);
+  }
+  url.searchParams.set(
+    "redirect_uri",
+    `${args.origin}/api/github/app/setup/callback`,
+  );
+  return url.toString();
 }
 
 async function publishGithubChanged(userIds: readonly string[]): Promise<void> {
@@ -50,6 +80,19 @@ function canManageInstallation(args: {
   readonly orgRole: string | undefined;
 }): boolean {
   return args.orgRole === "admin";
+}
+
+async function loadOrgDefaultComposeId(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<string | null> {
+  const [orgRow] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  return orgRow?.defaultAgentId ?? null;
 }
 
 async function loadOrgGithubInstallation(
@@ -185,6 +228,18 @@ export const getGithubInstallation$ = command(
     signal.throwIfAborted();
 
     if (!installation) {
+      const composeId = await loadOrgDefaultComposeId(db, auth.orgId);
+      signal.throwIfAborted();
+      const installUrl = canManageInstallation({ orgRole: auth.orgRole })
+        ? await githubInstallUrl({
+            userId: auth.userId,
+            orgId: auth.orgId,
+            composeId,
+            origin,
+          })
+        : null;
+      signal.throwIfAborted();
+
       return {
         status: 404 as const,
         body: {
@@ -192,6 +247,7 @@ export const getGithubInstallation$ = command(
             message: "No GitHub installation found",
             code: "NOT_FOUND",
           },
+          installUrl,
         },
       };
     }

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -16,7 +16,7 @@ import { publishUserSignal } from "../external/realtime";
 import { env, optionalEnv } from "../../lib/env";
 import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
 import {
-  buildGithubOauthState,
+  buildGithubAppInstallUrl,
   buildGithubUserConnectAuthorizationUrl,
   findGithubInstallationByInstallationId,
   getGithubOAuthAuthMethod,
@@ -34,31 +34,28 @@ function githubConnectStartUrl(origin: string): string {
 }
 
 async function githubInstallUrl(args: {
+  readonly db: ReadonlyDb;
   readonly userId: string;
   readonly orgId: string;
-  readonly composeId: string | null;
   readonly origin: string;
+  readonly signal: AbortSignal;
 }): Promise<string | null> {
   const appSlug = optionalEnv("GITHUB_APP_SLUG");
   if (!appSlug) {
     return null;
   }
 
-  const state = await buildGithubOauthState({
+  const composeId = await loadOrgDefaultComposeId(args.db, args.orgId);
+  args.signal.throwIfAborted();
+
+  return await buildGithubAppInstallUrl({
+    appSlug,
     vm0UserId: args.userId,
     orgId: args.orgId,
-    composeId: args.composeId ?? undefined,
+    composeId: composeId ?? undefined,
+    origin: args.origin,
     secretsEncryptionKey: env("SECRETS_ENCRYPTION_KEY"),
   });
-  const url = new URL(`https://github.com/apps/${appSlug}/installations/new`);
-  if (state) {
-    url.searchParams.set("state", state);
-  }
-  url.searchParams.set(
-    "redirect_uri",
-    `${args.origin}/api/github/app/setup/callback`,
-  );
-  return url.toString();
 }
 
 async function publishGithubChanged(userIds: readonly string[]): Promise<void> {
@@ -228,14 +225,13 @@ export const getGithubInstallation$ = command(
     signal.throwIfAborted();
 
     if (!installation) {
-      const composeId = await loadOrgDefaultComposeId(db, auth.orgId);
-      signal.throwIfAborted();
       const installUrl = canManageInstallation({ orgRole: auth.orgRole })
         ? await githubInstallUrl({
+            db,
             userId: auth.userId,
             orgId: auth.orgId,
-            composeId,
             origin,
+            signal,
           })
         : null;
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4378,6 +4378,8 @@
         "events": "Triggering events",
         "filterHelp": "Leave a filter empty to match any value. Separate multiple values with commas.",
         "headBranches": "Head branches",
+        "installAdminRequired": "Ask an organization admin to install it.",
+        "installApp": "Install GitHub App",
         "installedRequired": "GitHub is not installed for this workspace.",
         "issueCommentDescription": "Run when a matching issue or PR comment is created.",
         "issueCommentRule": "When a matching GitHub issue or pull request comment is created",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4452,6 +4452,8 @@
         "events": "Eventos de acionamento",
         "filterHelp": "Deixe um filtro vazio para corresponder a qualquer valor. Separe vários valores com vírgulas.",
         "headBranches": "Branches de origem",
+        "installAdminRequired": "Peça a um administrador da organização para instalá-lo.",
+        "installApp": "Instalar o GitHub App",
         "installedRequired": "O GitHub não está instalado neste espaço de trabalho.",
         "issueCommentDescription": "Execute quando um comentário correspondente em issue ou PR for criado.",
         "issueCommentRule": "Quando um comentário correspondente em issue ou pull request for criado no GitHub",

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-github.ts
@@ -7,6 +7,7 @@ import { mockApi } from "../msw-contract.ts";
 
 const defaultMissingGithubIntegration: GithubInstallationNotFoundResponse = {
   error: { message: "GitHub installation not found", code: "NOT_FOUND" },
+  installUrl: "https://github.com/apps/vm0-test/installations/new?state=abc",
 };
 
 const defaultGithubInstallation: GithubInstallationResponse = {

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -19,7 +19,7 @@ interface GithubIntegrationMissingData extends GithubInstallationNotFoundRespons
   readonly connectUrl: string;
 }
 
-type GithubIntegrationData =
+export type GithubIntegrationData =
   | (GithubInstallationResponse & { readonly isInstalled: true })
   | GithubIntegrationMissingData;
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2534,6 +2534,32 @@ describe("workflow detail page", () => {
     });
   });
 
+  it("offers a GitHub App install link when GitHub is not installed", async () => {
+    mockWorkflowApis([salesResearch()]);
+    setMockGithubIntegration(null);
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"));
+
+    await waitFor(() => {
+      expect(buttonByText("Add automation")).toBeInTheDocument();
+    });
+    click(buttonByText("Add automation"));
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    pickAutomation("Integrations", /^GitHub workflow completed/);
+
+    const form = await screen.findByRole("form", {
+      name: "Add GitHub workflow automation",
+    });
+    await waitFor(() => {
+      expect(linkByText("Install GitHub App", form)).toHaveAttribute(
+        "href",
+        "https://github.com/apps/vm0-test/installations/new?state=abc",
+      );
+    });
+  });
+
   it("hides new GitHub webhook creation entries when the feature is disabled", async () => {
     mockWorkflowApis([salesResearch()]);
     detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -16,6 +16,7 @@ import {
   type ZeroWorkflowAutomationSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 import { zeroStrapiIntegrationsContract } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -2558,6 +2559,43 @@ describe("workflow detail page", () => {
         "https://github.com/apps/vm0-test/installations/new?state=abc",
       );
     });
+  });
+
+  it("asks for an org admin when the API omits the install URL", async () => {
+    mockWorkflowApis([salesResearch()]);
+    setMockGithubIntegration(null);
+    context.mocks.api(
+      integrationsGithubContract.getInstallation,
+      ({ respond }) => {
+        return respond(404, {
+          error: {
+            message: "GitHub installation not found",
+            code: "NOT_FOUND",
+          },
+        });
+      },
+    );
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"));
+
+    await waitFor(() => {
+      expect(buttonByText("Add automation")).toBeInTheDocument();
+    });
+    click(buttonByText("Add automation"));
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    pickAutomation("Integrations", /^GitHub workflow completed/);
+
+    const form = await screen.findByRole("form", {
+      name: "Add GitHub workflow automation",
+    });
+    await waitFor(() => {
+      expect(
+        within(form).getByText("Ask an organization admin to install it."),
+      ).toBeInTheDocument();
+    });
+    expect(queryAllByRoleFast("link", form)).toHaveLength(0);
   });
 
   it("hides new GitHub webhook creation entries when the feature is disabled", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -208,6 +208,7 @@ import { strapiIntegrations$ } from "../../signals/zero-page/zero-strapi.ts";
 import {
   connectGithubInstallation$,
   githubIntegrationData$,
+  type GithubIntegrationData,
 } from "../../signals/zero-page/zero-github.ts";
 import {
   atTimeInTimezone,
@@ -7891,14 +7892,14 @@ function GithubWebhookAutomationFields({
 
 function GithubLabelAutomationAvailabilityMessages({
   githubLoaded,
-  isInstalled,
+  githubData,
   needsConnection,
   githubLoadError,
   connecting,
   onConnect,
 }: {
   readonly githubLoaded: boolean;
-  readonly isInstalled: boolean;
+  readonly githubData: GithubIntegrationData | null;
   readonly needsConnection: boolean;
   readonly githubLoadError: boolean;
   readonly connecting: boolean;
@@ -7906,7 +7907,9 @@ function GithubLabelAutomationAvailabilityMessages({
 }) {
   return (
     <>
-      {githubLoaded && !isInstalled ? <GithubNotInstalledNotice /> : null}
+      {githubLoaded && !githubData?.isInstalled ? (
+        <GithubNotInstalledNotice githubData={githubData} />
+      ) : null}
       {needsConnection ? (
         <GithubAccountConnectionNotice
           connecting={connecting}
@@ -7918,12 +7921,39 @@ function GithubLabelAutomationAvailabilityMessages({
   );
 }
 
-function GithubNotInstalledNotice() {
+function GithubNotInstalledNotice({
+  githubData,
+}: {
+  readonly githubData: GithubIntegrationData | null;
+}) {
+  const installUrl =
+    githubData && !githubData.isInstalled ? githubData.installUrl : null;
+
   return (
     <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
       {i18n.t(($) => {
         return $.workflows.automations.github.installedRequired;
       })}
+      {installUrl ? (
+        <Button
+          asChild
+          type="button"
+          variant="link"
+          className="ml-1 h-auto p-0 text-xs"
+        >
+          <a href={installUrl} target="_blank" rel="noreferrer">
+            {i18n.t(($) => {
+              return $.workflows.automations.github.installApp;
+            })}
+          </a>
+        </Button>
+      ) : (
+        <span className="ml-1">
+          {i18n.t(($) => {
+            return $.workflows.automations.github.installAdminRequired;
+          })}
+        </span>
+      )}
     </div>
   );
 }
@@ -8070,7 +8100,7 @@ function CreateGithubLabelAppliedAutomationDialog({
           />
           <GithubLabelAutomationAvailabilityMessages
             githubLoaded={githubLoadable.state === "hasData"}
-            isInstalled={isInstalled}
+            githubData={githubData}
             needsConnection={needsConnection}
             githubLoadError={githubLoadError}
             connecting={connecting}
@@ -8164,7 +8194,7 @@ function CreateGithubWorkflowRunCompletedAutomationDialog({
             disabled={creating || loadingGithub || githubLoadError}
           />
           {githubLoadable.state === "hasData" && !isInstalled ? (
-            <GithubNotInstalledNotice />
+            <GithubNotInstalledNotice githubData={githubData} />
           ) : null}
           {githubLoadError ? <GithubLoadErrorNotice /> : null}
           <DialogFooter>
@@ -8331,7 +8361,7 @@ function CreateGithubWebhookAutomationDialog({
             disabled={creating || loadingGithub || githubLoadError}
           />
           {githubLoadable.state === "hasData" && !isInstalled ? (
-            <GithubNotInstalledNotice />
+            <GithubNotInstalledNotice githubData={githubData} />
           ) : null}
           {githubLoadError ? <GithubLoadErrorNotice /> : null}
           <DialogFooter>
@@ -9857,7 +9887,7 @@ function UpdateGithubLabelAppliedAutomationForm({
       />
       <GithubLabelAutomationAvailabilityMessages
         githubLoaded={githubLoadable.state === "hasData"}
-        isInstalled={isInstalled}
+        githubData={githubData}
         needsConnection={needsConnection}
         githubLoadError={githubLoadError}
         connecting={connecting}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -7927,19 +7927,21 @@ function GithubNotInstalledNotice({
   readonly githubData: GithubIntegrationData | null;
 }) {
   const installUrl =
-    githubData && !githubData.isInstalled ? githubData.installUrl : null;
+    githubData && !githubData.isInstalled
+      ? (githubData.installUrl ?? null)
+      : null;
 
   return (
     <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
       {i18n.t(($) => {
         return $.workflows.automations.github.installedRequired;
-      })}
+      })}{" "}
       {installUrl ? (
         <Button
           asChild
           type="button"
           variant="link"
-          className="ml-1 h-auto p-0 text-xs"
+          className="h-auto p-0 text-xs"
         >
           <a href={installUrl} target="_blank" rel="noreferrer">
             {i18n.t(($) => {
@@ -7948,7 +7950,7 @@ function GithubNotInstalledNotice({
           </a>
         </Button>
       ) : (
-        <span className="ml-1">
+        <span>
           {i18n.t(($) => {
             return $.workflows.automations.github.installAdminRequired;
           })}

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -23,7 +23,9 @@ export type GithubInstallationResponse = z.infer<
   typeof githubInstallationResponseSchema
 >;
 
-export const githubInstallationNotFoundResponseSchema = apiErrorSchema;
+export const githubInstallationNotFoundResponseSchema = apiErrorSchema.extend({
+  installUrl: z.string().nullable(),
+});
 
 export type GithubInstallationNotFoundResponse = z.infer<
   typeof githubInstallationNotFoundResponseSchema

--- a/turbo/packages/api-contracts/src/contracts/integrations-github.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-github.ts
@@ -23,8 +23,11 @@ export type GithubInstallationResponse = z.infer<
   typeof githubInstallationResponseSchema
 >;
 
+// `installUrl` is optional so a new frontend paired with the previous API
+// deployment can still parse this body during a rollout. Make it required once
+// no API version without the field is serving traffic.
 export const githubInstallationNotFoundResponseSchema = apiErrorSchema.extend({
-  installUrl: z.string().nullable(),
+  installUrl: z.string().nullish(),
 });
 
 export type GithubInstallationNotFoundResponse = z.infer<


### PR DESCRIPTION
## Summary

#19516 removed the Works-page GitHub card as part of dropping the legacy label listener. That card was the only surface exposing the GitHub App install URL, so a workspace without an installation currently has no self-serve way to install the app:

- no client links to `/api/github/oauth/install` anymore, and `zero github` only keeps `upload-file` / `download-file`
- installing straight from `github.com/apps/<slug>` fails: the setup callback requires a signed `state`, so it redirects to `/works?error=Invalid OAuth state. Please try installing again from the Platform.`
- the GitHub automation dialogs render `GitHub is not installed for this workspace.` and #19516 also removed the only link out of that notice

Existing installations (including ours) are unaffected, which is why this was not visible internally. New workspaces cannot enable any GitHub automation event.

This PR restores the install entry point at the place where it is needed, without bringing back the label listener.

- `GET /api/integrations/github` returns `installUrl` in its 404 (not-installed) body for org admins, built the same way as before: `https://github.com/apps/<slug>/installations/new` with the signed OAuth state (org default agent as `composeId`) and the app setup callback as `redirect_uri`
- `installUrl` is `null` for non-admins and when `GITHUB_APP_SLUG` is unset, matching the install endpoint's own admin check
- the GitHub automation notice now renders an `Install GitHub App` action when the URL is present, and an "ask an organization admin" hint otherwise
- covers all four notice call sites: create label-applied, create workflow-run, create webhook automation, and edit label-applied

## Verification

- `npx prettier@3.8.1 --check` on all changed files
- new API BDD coverage in `integrations.bdd.test.ts`: admin read returns an install URL with the setup-callback `redirect_uri`, member read returns `null`
- new platform coverage in `workflows-page.test.tsx`: the install link renders in the GitHub workflow automation dialog when the workspace has no installation
- local `pnpm` type-check and vitest are not runnable in this sandbox (`apps/api` `tsc` OOMs), so CI is the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
