### PR TITLE
chore(api): detect reducible sql composition

### DIFF
--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -139,7 +139,7 @@ function modelStatModelExpression() {
       return sql`WHEN ${eq(modelColumn, alias)} THEN ${model}`;
     }),
     sql` `,
-  )} ELSE ${sql`${modelColumn}`} END`.mapWith(pgTextDecoder);
+  )} ELSE ${modelColumn} END`.mapWith(pgTextDecoder);
 }
 
 function modelStatWindowSum(

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -6,7 +6,17 @@ import {
 } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { eq, isNotNull, isNull, not, notExists, or, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  isNotNull,
+  isNull,
+  not,
+  notExists,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { env } from "../../lib/env";
@@ -110,7 +120,9 @@ export async function touchChatThreadLastMessageAt(
   });
 }
 
-export function visibleChatEventCondition(db: Pick<Db, "select">) {
+export function visibleChatEventCondition(
+  db: Pick<Db, "select">,
+): SQL | undefined {
   const isCompatibilityUserEvent = chatEventTypeIn([
     "input.prompt",
     "input.automation",
@@ -118,29 +130,26 @@ export function visibleChatEventCondition(db: Pick<Db, "select">) {
     "control.interrupt",
     "control.revoke",
   ]);
-  return sql.join(
-    [
-      not(chatEventTypeIn(["input.goal"])),
-      notExists(
-        db
-          .select({ id: revoker.id })
-          .from(revoker)
-          .where(eq(revoker.revokesEventId, chatEvents.id)),
-      ),
-      or(
-        not(isCompatibilityUserEvent),
-        isNotNull(chatEvents.runId),
-        isNull(chatEvents.revokesEventId),
-        isNotNull(chatEvents.content),
-        isNotNull(chatEvents.error),
-      ),
-      or(
-        not(isCompatibilityUserEvent),
-        isNotNull(chatEvents.runId),
-        isNull(chatEvents.interruptsRunId),
-      ),
-    ],
-    sql` AND `,
+  return and(
+    not(chatEventTypeIn(["input.goal"])),
+    notExists(
+      db
+        .select({ id: revoker.id })
+        .from(revoker)
+        .where(eq(revoker.revokesEventId, chatEvents.id)),
+    ),
+    or(
+      not(isCompatibilityUserEvent),
+      isNotNull(chatEvents.runId),
+      isNull(chatEvents.revokesEventId),
+      isNotNull(chatEvents.content),
+      isNotNull(chatEvents.error),
+    ),
+    or(
+      not(isCompatibilityUserEvent),
+      isNotNull(chatEvents.runId),
+      isNull(chatEvents.interruptsRunId),
+    ),
   );
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1431,7 +1431,7 @@ export function zeroChatThreadArtifacts(args: {
 function artifactCallerVisibilityConditions(args: {
   readonly userId: string;
   readonly orgId: string;
-}): SQL[] {
+}): readonly [SQL, SQL, SQL] {
   return [
     eq(agentRuns.orgId, args.orgId),
     eq(chatThreads.userId, args.userId),
@@ -1662,7 +1662,6 @@ async function listChangedArtifacts(args: {
         effectiveUpdatedAt,
         sql`(${args.updatedAfter}::timestamptz AT TIME ZONE 'UTC') - (${ARTIFACT_SYNC_REPLAY_WINDOW_MINUTES} * interval '1 minute')`,
       );
-  const callerConditions = artifactCallerVisibilityConditions(args.query);
   const fileConditions = artifactFileVisibilityConditions(args.db);
   const rows = await executeRawRows(
     args.db,
@@ -1684,7 +1683,7 @@ async function listChangedArtifacts(args: {
           ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
         INNER JOIN ${zeroAgents}
           ON ${eq(zeroAgents.id, agentComposes.id)}
-        WHERE ${sql.join(callerConditions, sql` AND `)}
+        WHERE ${and(...artifactCallerVisibilityConditions(args.query))}
       ),
       changed_artifact_ids AS MATERIALIZED (
         SELECT

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
@@ -95,9 +95,21 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         import * as drizzle from "drizzle-orm";
         declare const optionalCondition: SQL | undefined;
         declare const optionalConditions: readonly (SQL | undefined)[];
+        const fixedConditions = [
+          eq(users.id, 1),
+          optionalCondition,
+        ] as const;
+        declare const fixedUnion:
+          | readonly [SQL]
+          | readonly [SQL, SQL | undefined];
+        declare const fixedHead:
+          readonly [SQL, ...(SQL | undefined)[]];
         sql\`\${and(eq(users.id, 1), optionalCondition)}\`;
         sql\`\${or(eq(users.id, 1), ...optionalConditions)}\`;
         sql\`\${drizzle.and(drizzle.eq(users.id, 1), undefined)}\`;
+        sql\`\${and(...fixedConditions)}\`;
+        sql\`\${or(...fixedUnion)}\`;
+        sql\`\${and(...fixedHead)}\`;
       `,
     },
     {
@@ -177,16 +189,28 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         import { and, sql, type SQL } from "drizzle-orm";
         declare const optionalCondition: SQL | undefined;
         declare const optionalConditions: readonly (SQL | undefined)[];
+        declare const optionalTuple:
+          readonly [SQL | undefined, SQL | undefined];
+        declare const maybeEmptyTuple:
+          | readonly []
+          | readonly [SQL];
+        declare const restOnlyTuple: readonly [...SQL[]];
         declare const unsafeCondition: unknown;
         declare const unsafeConditions: readonly unknown[];
         declare function localAnd(condition: SQL): SQL | undefined;
         sql\`\${and(optionalCondition)}\`;
         sql\`\${and(...optionalConditions)}\`;
+        sql\`\${and(...optionalTuple)}\`;
+        sql\`\${and(...maybeEmptyTuple)}\`;
+        sql\`\${and(...restOnlyTuple)}\`;
         sql\`\${and(sql\`true\`, unsafeCondition)}\`;
         sql\`\${and(sql\`true\`, ...unsafeConditions)}\`;
         sql\`\${localAnd(sql\`true\`)}\`;
       `,
       errors: [
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
@@ -107,6 +107,7 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         sql\`\${and(eq(users.id, 1), optionalCondition)}\`;
         sql\`\${or(eq(users.id, 1), ...optionalConditions)}\`;
         sql\`\${drizzle.and(drizzle.eq(users.id, 1), undefined)}\`;
+        sql\`\${and(or(eq(users.id, 1), optionalCondition), optionalCondition)}\`;
         sql\`\${and(...fixedConditions)}\`;
         sql\`\${or(...fixedUnion)}\`;
         sql\`\${and(...fixedHead)}\`;
@@ -186,7 +187,7 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
     },
     {
       code: `${drizzlePreamble}
-        import { and, sql, type SQL } from "drizzle-orm";
+        import { and, or, sql, type SQL } from "drizzle-orm";
         declare const optionalCondition: SQL | undefined;
         declare const optionalConditions: readonly (SQL | undefined)[];
         declare const optionalTuple:
@@ -203,11 +204,13 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         sql\`\${and(...optionalTuple)}\`;
         sql\`\${and(...maybeEmptyTuple)}\`;
         sql\`\${and(...restOnlyTuple)}\`;
+        sql\`\${and(or(optionalCondition), optionalCondition)}\`;
         sql\`\${and(sql\`true\`, unsafeCondition)}\`;
         sql\`\${and(sql\`true\`, ...unsafeConditions)}\`;
         sql\`\${localAnd(sql\`true\`)}\`;
       `,
       errors: [
+        { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },
         { messageId: "undefinedInterpolation" },

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -616,7 +616,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select({
           qualified: sql\`CASE
             WHEN \${eq(users.id, 1)} THEN \${"one"}
-            ELSE \${sql\`\${users.name}\`}
+            ELSE \${sql\`\${users.name}\`.mapWith(users.name)}
           END\`.mapWith(users.name),
           distinctAlias: sql\`\${users.name}\`
             .mapWith(users.name)
@@ -639,6 +639,63 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         export function exportedColumnSql() {
           return sql\`\${users.name}\`;
         }
+      `,
+    },
+    {
+      name: "concrete and optional-element conjunction contracts stay raw",
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        declare const optionalCondition: SQL | undefined;
+        declare const optionalSeparator: SQL | undefined;
+        function concreteCondition(): SQL {
+          return sql.join(
+            [eq(users.id, 1), eq(users.name, "name")],
+            sql\` AND \`,
+          );
+        }
+        function dynamicConditions(): SQL[] {
+          const conditions = [
+            eq(users.id, 1),
+            eq(users.name, "name"),
+          ];
+          return conditions;
+        }
+        function optionalConditions(): (SQL | undefined)[] {
+          return [eq(users.id, 1), optionalCondition];
+        }
+        db.select()
+          .from(users)
+          .where(
+            sql.join(
+              [eq(users.id, 1), optionalCondition],
+              sql\` AND \`,
+            ),
+          );
+        db.select()
+          .from(users)
+          .where(
+            sql.join(
+              [eq(users.id, 1), eq(users.name, "name")],
+              optionalSeparator,
+            ),
+          );
+        db.select()
+          .from(users)
+          .where(sql.join(dynamicConditions(), sql\` AND \`));
+        db.select()
+          .from(users)
+          .where(sql.join(optionalConditions(), sql\` AND \`));
+        const castIdentity = sql\`CASE
+          WHEN \${eq(users.id, 1)} THEN \${"one"}
+          ELSE \${sql\`\${users.name}\` as SQL}
+        END\`;
+        const aliasedIdentity = sql\`CASE
+          WHEN \${eq(users.id, 1)} THEN \${"one"}
+          ELSE \${sql\`\${users.name}\`.as("nested_name")}
+        END\`;
+        void concreteCondition();
+        void castIdentity;
+        void aliasedIdentity;
       `,
     },
     {
@@ -847,6 +904,72 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
   ],
   invalid: [
+    {
+      name: "directly nested identity column wrapper",
+      code: `${drizzlePreamble}
+        import { eq, sql } from "drizzle-orm";
+        const expression = sql\`CASE
+          WHEN \${eq(users.id, 1)} THEN \${"one"}
+          ELSE \${sql\`\${users.name}\`}
+        END\`.mapWith(users.name);
+        void expression;
+      `,
+      errors: [{ messageId: "directColumn", line: 22 }],
+    },
+    {
+      name: "fixed conjunction under explicit optional SQL return",
+      code: `${drizzlePreamble}
+        import { eq, or, sql, type SQL } from "drizzle-orm";
+        declare const optionalCondition: SQL | undefined;
+        function visibleCondition(): SQL | undefined {
+          return sql.join(
+            [
+              eq(users.id, 1),
+              or(eq(users.name, "name"), optionalCondition),
+            ],
+            sql\` AND \`,
+          );
+        }
+        void visibleCondition();
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 22,
+        },
+      ],
+    },
+    {
+      name: "fixed conjunction from local array factory",
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        function callerConditions(id: number, name: string): SQL[] {
+          return [eq(users.id, id), eq(users.name, name)];
+        }
+        const conditions = callerConditions(1, "name");
+        db.select()
+          .from(users)
+          .where(sql.join(conditions, sql\` AND \`));
+        db.select()
+          .from(users)
+          .where(
+            sql.join(callerConditions(2, "other"), sql\` AND \`),
+          );
+      `,
+      errors: [
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 26,
+        },
+        {
+          messageId: "typedApi",
+          data: { helper: "and" },
+          line: 30,
+        },
+      ],
+    },
     {
       name: "repeated selected grouping expression",
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -4,6 +4,8 @@ import {
   type TSESTree,
 } from "@typescript-eslint/utils";
 import {
+  ElementFlags,
+  IndexKind,
   isAsExpression,
   isCallExpression,
   isIdentifier,
@@ -25,6 +27,7 @@ import {
   type Symbol as TypeScriptSymbol,
   type Type,
   type TypeChecker,
+  type TupleTypeReference,
 } from "typescript";
 
 function drizzleDeclarationSourcePath(node: Declaration): string {
@@ -270,6 +273,150 @@ export function isDrizzleWrapperType(
       return isDrizzleWrapperType(checker, member);
     })
   );
+}
+
+function collectConstrainedTypeMembers(
+  checker: TypeChecker,
+  type: Type,
+  visited: Set<Type>,
+): Type[] | null {
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    if (visited.has(type)) {
+      return null;
+    }
+    visited.add(type);
+    const constraint = checker.getBaseConstraintOfType(type);
+    const members =
+      constraint === undefined
+        ? null
+        : collectConstrainedTypeMembers(checker, constraint, visited);
+    visited.delete(type);
+    return members;
+  }
+  if (!type.isUnion()) {
+    return [type];
+  }
+  const members: Type[] = [];
+  for (const member of type.types) {
+    const constrainedMembers = collectConstrainedTypeMembers(
+      checker,
+      member,
+      visited,
+    );
+    if (constrainedMembers === null) {
+      return null;
+    }
+    members.push(...constrainedMembers);
+  }
+  return members;
+}
+
+export function constrainedTypeMembers(
+  checker: TypeChecker,
+  type: Type,
+): Type[] | null {
+  return collectConstrainedTypeMembers(checker, type, new Set<Type>());
+}
+
+function isOptionalDrizzleWrapperType(
+  checker: TypeChecker,
+  type: Type,
+): boolean {
+  const members = constrainedTypeMembers(checker, type);
+  return (
+    members !== null &&
+    members.every((member) => {
+      return (
+        (member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0 ||
+        isDrizzleWrapperType(checker, member)
+      );
+    })
+  );
+}
+
+function isTupleTypeReference(
+  checker: TypeChecker,
+  type: Type,
+): type is TupleTypeReference {
+  return checker.isTupleType(type);
+}
+
+function definitelyPresentSpreadCondition(
+  checker: TypeChecker,
+  type: Type,
+): boolean | null {
+  const members = constrainedTypeMembers(checker, type);
+  if (members === null) {
+    return null;
+  }
+  let everyMemberIsPresent = true;
+  for (const member of members) {
+    const elementType = checker.getIndexTypeOfType(member, IndexKind.Number);
+    if (
+      elementType === undefined ||
+      !isOptionalDrizzleWrapperType(checker, elementType)
+    ) {
+      return null;
+    }
+    everyMemberIsPresent &&=
+      isTupleTypeReference(checker, member) &&
+      checker.getTypeArguments(member).some((element, index) => {
+        return (
+          ((member.target.elementFlags[index] ?? 0) & ElementFlags.Required) !==
+            0 && isDrizzleWrapperType(checker, element)
+        );
+      });
+  }
+  return everyMemberIsPresent;
+}
+
+export function isDefinitelyPresentDrizzleBooleanHelper(
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  expression: TSESTree.Expression,
+): boolean {
+  if (expression.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+  const tsExpression = services.esTreeNodeToTSNodeMap.get(expression);
+  if (!isCallExpression(tsExpression)) {
+    return false;
+  }
+  const signature = checker.getResolvedSignature(tsExpression);
+  if (
+    signature === undefined ||
+    (!isNamedDrizzleSignature(signature, "and") &&
+      !isNamedDrizzleSignature(signature, "or"))
+  ) {
+    return false;
+  }
+  let hasPresentCondition = false;
+  for (const argument of expression.arguments) {
+    if (argument.type === AST_NODE_TYPES.SpreadElement) {
+      const tsArgument = services.esTreeNodeToTSNodeMap.get(argument.argument);
+      const spreadPresence = definitelyPresentSpreadCondition(
+        checker,
+        checker.getTypeAtLocation(tsArgument),
+      );
+      if (spreadPresence === null) {
+        return false;
+      }
+      hasPresentCondition ||= spreadPresence;
+      continue;
+    }
+    const tsArgument = services.esTreeNodeToTSNodeMap.get(argument);
+    const type = checker.getTypeAtLocation(tsArgument);
+    if (!isOptionalDrizzleWrapperType(checker, type)) {
+      return false;
+    }
+    if (
+      isDrizzleWrapperType(checker, type) ||
+      isDefinitelyPresentDrizzleBooleanHelper(checker, services, argument)
+    ) {
+      hasPresentCondition = true;
+    }
+  }
+  return hasPresentCondition;
 }
 
 function propertyType(

--- a/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
@@ -1,20 +1,11 @@
-import {
-  ESLintUtils,
-  type ParserServicesWithTypeInformation,
-  type TSESTree,
-} from "@typescript-eslint/utils";
-import {
-  IndexKind,
-  isCallExpression,
-  TypeFlags,
-  type Type,
-  type TypeChecker,
-} from "typescript";
+import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import { TypeFlags, type Type, type TypeChecker } from "typescript";
 
 import {
+  constrainedTypeMembers,
+  isDefinitelyPresentDrizzleBooleanHelper,
   isDrizzleSqlTag,
   isDrizzleWrapperType,
-  isNamedDrizzleSignature,
 } from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
@@ -25,45 +16,11 @@ type MessageId =
   | "undefinedInterpolation"
   | "unknownInterpolation";
 
-function constrainedTypeMembers(
-  checker: TypeChecker,
-  type: Type,
-  visited: Set<Type>,
-): Type[] | null {
-  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
-    if (visited.has(type)) {
-      return null;
-    }
-    visited.add(type);
-    const constraint = checker.getBaseConstraintOfType(type);
-    const members =
-      constraint === undefined
-        ? null
-        : constrainedTypeMembers(checker, constraint, visited);
-    visited.delete(type);
-    return members;
-  }
-
-  if (!type.isUnion()) {
-    return [type];
-  }
-
-  const members: Type[] = [];
-  for (const member of type.types) {
-    const constrainedMembers = constrainedTypeMembers(checker, member, visited);
-    if (constrainedMembers === null) {
-      return null;
-    }
-    members.push(...constrainedMembers);
-  }
-  return members;
-}
-
 function interpolationProblem(
   checker: TypeChecker,
   type: Type,
 ): MessageId | null {
-  const members = constrainedTypeMembers(checker, type, new Set<Type>());
+  const members = constrainedTypeMembers(checker, type);
   if (members === null) {
     return "unknownInterpolation";
   }
@@ -109,70 +66,6 @@ function interpolationProblem(
   return null;
 }
 
-function isDefinitelyPresentBooleanHelper(
-  checker: TypeChecker,
-  services: ParserServicesWithTypeInformation,
-  expression: TSESTree.Expression,
-): boolean {
-  if (expression.type !== "CallExpression") {
-    return false;
-  }
-  const tsExpression = services.esTreeNodeToTSNodeMap.get(expression);
-  if (!isCallExpression(tsExpression)) {
-    return false;
-  }
-  const signature = checker.getResolvedSignature(tsExpression);
-  if (
-    signature === undefined ||
-    (!isNamedDrizzleSignature(signature, "and") &&
-      !isNamedDrizzleSignature(signature, "or"))
-  ) {
-    return false;
-  }
-  let hasPresentCondition = false;
-  for (const argument of expression.arguments) {
-    if (argument.type === "SpreadElement") {
-      const tsArgument = services.esTreeNodeToTSNodeMap.get(argument.argument);
-      const elementType = checker.getIndexTypeOfType(
-        checker.getTypeAtLocation(tsArgument),
-        IndexKind.Number,
-      );
-      if (
-        elementType === undefined ||
-        !isOptionalDrizzleWrapperType(checker, elementType)
-      ) {
-        return false;
-      }
-      continue;
-    }
-    const tsArgument = services.esTreeNodeToTSNodeMap.get(argument);
-    const type = checker.getTypeAtLocation(tsArgument);
-    if (!isOptionalDrizzleWrapperType(checker, type)) {
-      return false;
-    }
-    if (isDrizzleWrapperType(checker, type)) {
-      hasPresentCondition = true;
-    }
-  }
-  return hasPresentCondition;
-}
-
-function isOptionalDrizzleWrapperType(
-  checker: TypeChecker,
-  type: Type,
-): boolean {
-  const members = constrainedTypeMembers(checker, type, new Set<Type>());
-  return (
-    members !== null &&
-    members.every((member) => {
-      return (
-        (member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0 ||
-        isDrizzleWrapperType(checker, member)
-      );
-    })
-  );
-}
-
 export const noUnsafeSqlInterpolation = createRule({
   name: "no-unsafe-sql-interpolation",
   defaultOptions: [],
@@ -215,7 +108,11 @@ export const noUnsafeSqlInterpolation = createRule({
           if (
             messageId !== null &&
             (messageId !== "undefinedInterpolation" ||
-              !isDefinitelyPresentBooleanHelper(checker, services, expression))
+              !isDefinitelyPresentDrizzleBooleanHelper(
+                checker,
+                services,
+                expression,
+              ))
           ) {
             context.report({ node: expression, messageId });
           }

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -20,6 +20,7 @@ import {
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
+  TypeFlags,
   type Expression as TypeScriptExpression,
   type Node,
   type Signature,
@@ -233,6 +234,9 @@ export const preferDrizzleApis = createRule({
       if (isRelationalWhereCallbackResult(node)) {
         return true;
       }
+      if (hasExplicitOptionalSqlReturnContract(node)) {
+        return true;
+      }
       const parent = node.parent;
       if (
         parent.type === AST_NODE_TYPES.TemplateLiteral &&
@@ -264,6 +268,62 @@ export const preferDrizzleApis = createRule({
         predicateIndex !== undefined &&
         parent.arguments[predicateIndex] === node &&
         isDrizzleMethodCall(parent, method)
+      );
+    }
+
+    function isOptionalDrizzleSqlType(type: Type, location: Node): boolean {
+      const members = type.isUnion() ? type.types : [type];
+      let hasOptional = false;
+      let hasSql = false;
+      for (const member of members) {
+        if ((member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0) {
+          hasOptional = true;
+          continue;
+        }
+        if (
+          (member.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0 ||
+          !isDrizzleSqlType(checker, member, location)
+        ) {
+          return false;
+        }
+        hasSql = true;
+      }
+      return hasOptional && hasSql;
+    }
+
+    function hasExplicitOptionalSqlReturnContract(
+      node: TSESTree.Expression,
+    ): boolean {
+      const result = outerTransparentNode(node);
+      const returnStatement = result.parent;
+      if (
+        returnStatement?.type !== AST_NODE_TYPES.ReturnStatement ||
+        returnStatement.argument !== result ||
+        returnStatement.parent.type !== AST_NODE_TYPES.BlockStatement
+      ) {
+        return false;
+      }
+      const declaration = returnStatement.parent.parent;
+      if (
+        declaration.type !== AST_NODE_TYPES.FunctionDeclaration ||
+        declaration.body !== returnStatement.parent
+      ) {
+        return false;
+      }
+      const tsDeclaration = services.esTreeNodeToTSNodeMap.get(declaration);
+      if (
+        !isFunctionDeclaration(tsDeclaration) ||
+        tsDeclaration.type === undefined
+      ) {
+        return false;
+      }
+      const signature = checker.getSignatureFromDeclaration(tsDeclaration);
+      return (
+        signature !== undefined &&
+        isOptionalDrizzleSqlType(
+          checker.getReturnTypeOfSignature(signature),
+          tsDeclaration,
+        )
       );
     }
 
@@ -608,6 +668,20 @@ export const preferDrizzleApis = createRule({
         if (method === "innerJoin" && isTrueJoinPredicate) {
           context.report({ node, messageId: "crossJoin" });
         }
+      });
+    }
+
+    function inspectSqlJoinCall(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "join" ||
+        !acceptsOptionalSql(node) ||
+        !sqlSourceComposer.couldCompose(node)
+      ) {
+        return;
+      }
+      structuralCallInspections.push(() => {
+        reportAnalysis(node, "predicate");
       });
     }
 
@@ -1309,6 +1383,32 @@ export const preferDrizzleApis = createRule({
         }
         current = current.callee.object;
       }
+    }
+
+    function inspectNestedDirectColumn(
+      node: TSESTree.TaggedTemplateExpression,
+    ): void {
+      const template = node.parent;
+      const outer =
+        template.type === AST_NODE_TYPES.TemplateLiteral
+          ? template.parent
+          : undefined;
+      const expression = node.quasi.expressions[0];
+      if (
+        outer?.type !== AST_NODE_TYPES.TaggedTemplateExpression ||
+        outer.quasi !== template ||
+        !template.expressions.includes(node) ||
+        expression === undefined ||
+        !isDrizzleSqlTag(checker, services, node.tag) ||
+        !isDrizzleSqlTag(checker, services, outer.tag) ||
+        !isConventionalColumnExpression(expression) ||
+        columnMetadata(expression) === undefined ||
+        reportedDirectColumnSelections.has(node)
+      ) {
+        return;
+      }
+      reportedDirectColumnSelections.add(node);
+      context.report({ node, messageId: "directColumn" });
     }
 
     function inspectDirectColumnSelection(node: TSESTree.Expression): void {
@@ -2146,6 +2246,7 @@ export const preferDrizzleApis = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         inspectRawQueryCall(node);
         inspectPredicateCall(node);
+        inspectSqlJoinCall(node);
         inspectUnstableGroupingCall(node);
         inspectAdditionalContextCall(node);
         inspectConflictUpdateCall(node);
@@ -2234,6 +2335,9 @@ export const preferDrizzleApis = createRule({
         reportSourceLocal(sourceLocalCandidates);
         for (const inspect of structuralCallInspections) {
           inspect();
+        }
+        for (const node of directColumnCandidates) {
+          inspectNestedDirectColumn(node);
         }
         inspectStructuredSelections();
         reportSourceLocal(deferredSourceLocalCandidates);

--- a/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
+++ b/turbo/packages/eslint-rules/src/api/sql-analysis/sql-source.ts
@@ -22,13 +22,16 @@ import {
   isVariableDeclarationList,
   isVariableStatement,
   NodeFlags,
+  TypeFlags,
   type Node,
   type Symbol as TypeScriptSymbol,
+  type Type,
   type TypeChecker,
   type VariableDeclaration,
 } from "typescript";
 
 import {
+  isDefinitelyPresentDrizzleBooleanHelper,
   isDrizzleSqlType,
   isDrizzleSqlTag,
   isDrizzleSymbol,
@@ -92,6 +95,11 @@ interface LocalFunction {
   readonly declaration: Node;
   readonly parameters: readonly TypeScriptSymbol[];
   readonly returned: TSESTree.Expression;
+}
+
+interface StaticArray {
+  readonly declarations: ReadonlySet<Node>;
+  readonly node: TSESTree.ArrayExpression;
 }
 
 function quasiText(node: TSESTree.TemplateElement): string {
@@ -543,6 +551,56 @@ export function createSqlSourceComposer(
     };
   }
 
+  function localStaticArrayFactory(node: TSESTree.CallExpression): {
+    readonly declaration: Node;
+    readonly returned: TSESTree.ArrayExpression;
+  } | null {
+    if (
+      node.callee.type !== AST_NODE_TYPES.Identifier ||
+      node.arguments.some((argument) => {
+        return argument.type === AST_NODE_TYPES.SpreadElement;
+      })
+    ) {
+      return null;
+    }
+    const tsCallee = services.esTreeNodeToTSNodeMap.get(node.callee);
+    const declaration = symbolAt(node.callee)?.valueDeclaration;
+    if (
+      declaration === undefined ||
+      !isFunctionDeclaration(declaration) ||
+      declaration.getSourceFile() !== tsCallee.getSourceFile() ||
+      declaration.body === undefined ||
+      declaration.body.statements.length !== 1 ||
+      declaration.parameters.length !== node.arguments.length ||
+      declaration.parameters.some((parameter) => {
+        return (
+          parameter.dotDotDotToken !== undefined ||
+          parameter.initializer !== undefined ||
+          !isIdentifier(parameter.name)
+        );
+      })
+    ) {
+      return null;
+    }
+    const statement = declaration.body.statements[0];
+    if (
+      statement === undefined ||
+      !isReturnStatement(statement) ||
+      statement.expression === undefined
+    ) {
+      return null;
+    }
+    let returned = services.tsNodeToESTreeNodeMap.get(statement.expression);
+    let transparent = transparentExpression(returned);
+    while (transparent !== null) {
+      returned = transparent;
+      transparent = transparentExpression(returned);
+    }
+    return returned.type === AST_NODE_TYPES.ArrayExpression
+      ? { declaration, returned }
+      : null;
+  }
+
   function localConstInitializer(node: TSESTree.Identifier): {
     readonly declaration: Node;
     readonly initializer: TSESTree.Expression;
@@ -592,6 +650,42 @@ export function createSqlSourceComposer(
       expression = substitution.expression;
     }
     return { expression, origins };
+  }
+
+  function typeMayBeUndefined(type: Type): boolean {
+    if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
+      return true;
+    }
+    if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+      const constraint = checker.getBaseConstraintOfType(type);
+      return constraint === undefined || typeMayBeUndefined(constraint);
+    }
+    if (type.isUnion()) {
+      return type.types.some(typeMayBeUndefined);
+    }
+    return (type.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0;
+  }
+
+  function expressionIsDefinitelyPresent(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+  ): boolean {
+    const resolved = resolvedExpression(node, state);
+    let expression = resolved.expression;
+    let transparent = transparentExpression(expression);
+    while (transparent !== null) {
+      expression = transparent;
+      transparent = transparentExpression(expression);
+    }
+    const tsNode = services.esTreeNodeToTSNodeMap.get(expression);
+    if (!typeMayBeUndefined(checker.getTypeAtLocation(tsNode))) {
+      return true;
+    }
+    return isDefinitelyPresentDrizzleBooleanHelper(
+      checker,
+      services,
+      expression,
+    );
   }
 
   function composeInterpolation(
@@ -683,10 +777,14 @@ export function createSqlSourceComposer(
     );
   }
 
-  function staticArray(node: TSESTree.Expression): {
-    readonly declaration: Node | undefined;
-    readonly node: TSESTree.ArrayExpression;
-  } | null {
+  function staticArray(
+    node: TSESTree.Expression,
+    state: MutableCompositionState,
+    visited: ReadonlySet<Node> = new Set(),
+  ): StaticArray | null {
+    if (!consumeStep(state)) {
+      return null;
+    }
     let current = node;
     let transparent = transparentExpression(current);
     while (transparent !== null) {
@@ -694,24 +792,38 @@ export function createSqlSourceComposer(
       transparent = transparentExpression(current);
     }
     if (current.type === AST_NODE_TYPES.ArrayExpression) {
-      return { declaration: undefined, node: current };
+      return { declarations: new Set(), node: current };
     }
-    if (current.type !== AST_NODE_TYPES.Identifier) {
+    if (current.type === AST_NODE_TYPES.Identifier) {
+      const initializer = localConstInitializer(current);
+      if (initializer === null || visited.has(initializer.declaration)) {
+        return null;
+      }
+      const nested = staticArray(
+        initializer.initializer,
+        state,
+        new Set([...visited, initializer.declaration]),
+      );
+      return nested === null
+        ? null
+        : {
+            declarations: new Set([
+              initializer.declaration,
+              ...nested.declarations,
+            ]),
+            node: nested.node,
+          };
+    }
+    if (current.type !== AST_NODE_TYPES.CallExpression) {
       return null;
     }
-    const initializer = localConstInitializer(current);
-    if (initializer === null) {
-      return null;
-    }
-    let value = initializer.initializer;
-    let wrapper = transparentExpression(value);
-    while (wrapper !== null) {
-      value = wrapper;
-      wrapper = transparentExpression(value);
-    }
-    return value.type === AST_NODE_TYPES.ArrayExpression
-      ? { declaration: initializer.declaration, node: value }
-      : null;
+    const factory = localStaticArrayFactory(current);
+    return factory === null || visited.has(factory.declaration)
+      ? null
+      : {
+          declarations: new Set([factory.declaration]),
+          node: factory.returned,
+        };
   }
 
   function composeJoin(
@@ -734,80 +846,75 @@ export function createSqlSourceComposer(
     ) {
       return null;
     }
-    const array = staticArray(itemsArgument);
+    const array = staticArray(itemsArgument, state);
+    if (array === null) {
+      return null;
+    }
+    const elements = array.node.elements;
     if (
-      array === null ||
-      array.node.elements.some((element) => {
+      elements.some((element) => {
         return (
-          element === null || element.type === AST_NODE_TYPES.SpreadElement
+          element === null ||
+          element.type === AST_NODE_TYPES.SpreadElement ||
+          !expressionIsDefinitelyPresent(element, state)
         );
       }) ||
-      (array.declaration !== undefined &&
-        state.activeDeclarations.has(array.declaration))
+      [...array.declarations].some((declaration) => {
+        return state.activeDeclarations.has(declaration);
+      })
     ) {
       return null;
     }
-
-    if (array.declaration !== undefined) {
-      state.activeDeclarations.add(array.declaration);
-    }
     const separatorArgument = node.arguments[1];
-    if (separatorArgument?.type === AST_NODE_TYPES.SpreadElement) {
-      if (array.declaration !== undefined) {
-        state.activeDeclarations.delete(array.declaration);
-      }
+    if (
+      separatorArgument?.type === AST_NODE_TYPES.SpreadElement ||
+      (separatorArgument !== undefined &&
+        !expressionIsDefinitelyPresent(separatorArgument, state))
+    ) {
       return null;
     }
-    const separator =
-      separatorArgument === undefined
-        ? emptySource()
-        : composeJoinedChunk(separatorArgument, state);
-    if (separator === null) {
-      if (array.declaration !== undefined) {
-        state.activeDeclarations.delete(array.declaration);
-      }
-      return null;
+    for (const declaration of array.declarations) {
+      state.activeDeclarations.add(declaration);
     }
 
-    let result = emptySource();
-    for (let index = 0; index < array.node.elements.length; index += 1) {
-      const element = array.node.elements[index];
-      if (element === null || element.type === AST_NODE_TYPES.SpreadElement) {
-        if (array.declaration !== undefined) {
-          state.activeDeclarations.delete(array.declaration);
-        }
+    try {
+      const separator =
+        separatorArgument === undefined
+          ? emptySource()
+          : composeJoinedChunk(separatorArgument, state);
+      if (separator === null) {
         return null;
       }
-      if (index > 0) {
-        const withSeparator = concatenateSources(result, separator);
-        if (withSeparator === null) {
-          if (array.declaration !== undefined) {
-            state.activeDeclarations.delete(array.declaration);
-          }
+
+      let result = emptySource();
+      for (let index = 0; index < elements.length; index += 1) {
+        const element = elements[index];
+        if (element === null || element.type === AST_NODE_TYPES.SpreadElement) {
           return null;
         }
-        result = withSeparator;
-      }
-      const item = composeJoinedChunk(element, state);
-      if (item === null) {
-        if (array.declaration !== undefined) {
-          state.activeDeclarations.delete(array.declaration);
+        if (index > 0) {
+          const withSeparator = concatenateSources(result, separator);
+          if (withSeparator === null) {
+            return null;
+          }
+          result = withSeparator;
         }
-        return null;
-      }
-      const withItem = concatenateSources(result, item);
-      if (withItem === null) {
-        if (array.declaration !== undefined) {
-          state.activeDeclarations.delete(array.declaration);
+        const item = composeJoinedChunk(element, state);
+        if (item === null) {
+          return null;
         }
-        return null;
+        const withItem = concatenateSources(result, item);
+        if (withItem === null) {
+          return null;
+        }
+        result = withItem;
       }
-      result = withItem;
+      return withLocalExpansion(prependOrigin(result, node));
+    } finally {
+      for (const declaration of array.declarations) {
+        state.activeDeclarations.delete(declaration);
+      }
     }
-    if (array.declaration !== undefined) {
-      state.activeDeclarations.delete(array.declaration);
-    }
-    return withLocalExpansion(prependOrigin(result, node));
   }
 
   function composeFactory(


### PR DESCRIPTION
## Summary

- replace the three proven reducible Drizzle SQL tags with direct column or
  `and(...)` composition
- extend `api/prefer-drizzle-apis` to detect directly nested column identities,
  fixed conjunctions under explicit optional-SQL contracts, and conventional
  same-file fixed-array factories
- share the real-Drizzle Boolean presence proof with
  `api/no-unsafe-sql-interpolation` and accept only tuple spreads that prove at
  least one required concrete SQL wrapper

The runner-affinity concrete-`SQL` conjunction, dynamic or optional joined
lists, mapped/aliased/cast identities, and the two space-separated `CASE WHEN`
joins remain intentionally valid.

This changes no schema, persisted data, statement or round-trip count, API,
protocol, feature switch, or deployment-compatibility contract.

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/eslint-rules test -- --silent=passed-only` — 973 tests across
  47 files
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts src/signals/routes/__tests__/artifacts.bdd.test.ts src/signals/routes/__tests__/chat-files.bdd.test.ts --maxWorkers=4 --silent=passed-only`
  — 37 tests across 3 files
- Drizzle serialization and PostgreSQL 17 AST equivalence probe, including an
  optional-element non-equivalence boundary
- `pnpm format`
- `pnpm knip`
- repository pre-commit hook, including all selected Turbo type checks
- `git diff --check`

After rebasing onto `4e8d4268e0`, the exact candidate `24d8a2fd0a` passed five
alternating API ESLint resource pairs at +2.20% median wall time and +0.21%
median process-tree peak RSS, within the +5% and +10% gates.

Closes #23893

Parent delivery issue: #23047  
Follow-up retained-SQL audit: #22901
