### PR TITLE
feat(cli): send full user message documents from zero chat send

### DIFF
--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,14 +28,24 @@ describe("zero chat send command", () => {
     throw new Error("process.exit called");
   }) as never);
 
+  let tempDir: string;
+
+  function writeUserMessageFile(document: unknown): string {
+    const filePath = path.join(tempDir, "user-message.json");
+    writeFileSync(filePath, JSON.stringify(document), "utf8");
+    return filePath;
+  }
+
   beforeEach(() => {
     chalk.level = 0;
+    tempDir = mkdtempSync(path.join(tmpdir(), "zero-chat-send-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-zero-token");
     vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true });
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     mockExit.mockClear();
@@ -180,6 +194,162 @@ describe("zero chat send command", () => {
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
     expect(stderr).toContain("Chat message text is required");
     expect(stderr).toContain('Pass --text "message"');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("sends a multi-part document from --user-message-file as written", async () => {
+    const document = {
+      version: 1,
+      parts: [
+        { type: "text", text: "Review this deck" },
+        {
+          type: "file",
+          fileId: "file_abc",
+          filenameSnapshot: "deck.pdf",
+          contentType: "application/pdf",
+        },
+        {
+          type: "chat_thread",
+          threadId: OTHER_THREAD_ID,
+          titleSnapshot: "Launch plan",
+        },
+      ],
+    };
+    server.use(
+      http.get(metadataUrl(THREAD_ID), () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Launch plan",
+          selectedModel: null,
+        });
+      }),
+      http.post(SEND_URL, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          agentId: AGENT_ID,
+          threadId: THREAD_ID,
+          prompt: "Review this deck",
+          hasTextContent: true,
+          userMessage: document,
+        });
+        return HttpResponse.json(
+          {
+            runId: RUN_ID,
+            threadId: THREAD_ID,
+            status: "pending",
+            createdAt: "2026-07-30T10:00:00.000Z",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "send",
+      "--user-message-file",
+      writeUserMessageFile(document),
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Chat message dispatched");
+    expect(output).toContain(`Run:    ${RUN_ID}`);
+  });
+
+  it("reports a file-only document as having no text content", async () => {
+    const document = {
+      version: 1,
+      parts: [
+        {
+          type: "file",
+          fileId: "file_abc",
+          filenameSnapshot: "deck.pdf",
+          contentType: "application/pdf",
+        },
+      ],
+    };
+    server.use(
+      http.get(metadataUrl(THREAD_ID), () => {
+        return HttpResponse.json({
+          id: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Launch plan",
+          selectedModel: null,
+        });
+      }),
+      http.post(SEND_URL, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          prompt: "(see attached files)",
+          hasTextContent: false,
+          userMessage: document,
+        });
+        return HttpResponse.json(
+          { runId: null, threadId: THREAD_ID },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "send",
+      "--user-message-file",
+      writeUserMessageFile(document),
+    ]);
+
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      "Chat message queued",
+    );
+  });
+
+  it("reports document validation issues before calling the API", async () => {
+    const filePath = writeUserMessageFile({
+      version: 1,
+      parts: [{ type: "file", fileId: "file_abc" }],
+    });
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "send",
+        "--user-message-file",
+        filePath,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("is not a valid UserMessageDocument");
+    expect(stderr).toContain("parts.0.filenameSnapshot");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects --text together with --user-message-file", async () => {
+    const filePath = writeUserMessageFile({
+      version: 1,
+      parts: [{ type: "text", text: "Continue" }],
+    });
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "send",
+        "--text",
+        "Continue",
+        "--user-message-file",
+        filePath,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain(
+      "Pass either --text or --user-message-file, not both",
+    );
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/chat/send.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/send.ts
@@ -3,16 +3,50 @@ import { readFileSync } from "node:fs";
 
 import chalk from "chalk";
 import { Command } from "commander";
-import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  type UserMessageDocument,
+  userMessageDocumentSchema,
+} from "@vm0/api-contracts/contracts/chat-threads";
 
 import { getZeroChatThreadAgentId, sendZeroChatEvent } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { printChatUsageError, resolveChatThreadId } from "./shared";
 
+// Non-authoritative plain-text views of a document that carries no text part.
+// The API re-derives the agent prompt from the document itself; the web app
+// sends the same file placeholder for attachment-only messages.
+const ATTACHED_FILES_PROMPT = "(see attached files)";
+const MESSAGE_PARTS_PROMPT = "(see message parts)";
+
+const USER_MESSAGE_JSON_HELP = `
+User message JSON (--user-message-file), one version 1 document:
+  { "version": 1, "parts": [ <part>, ... ] }            at least one part
+
+  text         { "type": "text", "text": "..." }
+  chat_thread  { "type": "chat_thread", "threadId": "<uuid>",
+                 "titleSnapshot": "..." }
+  template     { "type": "template", "titleSnapshot": "...",
+                 "template": { "type": "presentation" | "video" |
+                   "illustration" | "workflow" | "website",
+                   "selection": { ... } } }
+  file         { "type": "file", "fileId": "...",
+                 "filenameSnapshot": "...", "contentType": "..." }
+  feedback     { "type": "feedback", "quote": "...",
+                 "note": [ text | chat_thread | template parts ],
+                 "source": { "type": "mail", "id": "...",
+                   "status": "draft" | "sent", "sentId": "..." } }`;
+
 interface SendOptions {
   readonly json?: boolean;
   readonly text?: string;
   readonly threadId?: string;
+  readonly userMessageFile?: string;
+}
+
+interface ResolvedUserMessage {
+  readonly userMessage: UserMessageDocument;
+  readonly prompt: string;
+  readonly hasTextContent: boolean;
 }
 
 function readMessageText(optionText: string | undefined): string {
@@ -30,10 +64,96 @@ function readMessageText(optionText: string | undefined): string {
   if (!trimmed) {
     printChatUsageError(
       "Chat message text is required",
-      'Pass --text "message" or pipe the message on stdin.',
+      'Pass --text "message", pipe the message on stdin, or pass --user-message-file <path>.',
     );
   }
   return trimmed;
+}
+
+function documentText(document: UserMessageDocument): string {
+  return document.parts
+    .map((part) => {
+      return part.type === "text" ? part.text : "";
+    })
+    .join("")
+    .trim();
+}
+
+function promptForDocument(document: UserMessageDocument): string {
+  const text = documentText(document);
+  if (text) {
+    return text;
+  }
+  const hasFilePart = document.parts.some((part) => {
+    return part.type === "file";
+  });
+  return hasFilePart ? ATTACHED_FILES_PROMPT : MESSAGE_PARTS_PROMPT;
+}
+
+function readUserMessageDocument(path: string): UserMessageDocument {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printChatUsageError(
+      `Failed to read user message file "${path}": ${message}`,
+      "Pass a readable JSON file. Run: zero chat send --help",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printChatUsageError(
+      `User message file "${path}" is not valid JSON: ${message}`,
+      "Run: zero chat send --help",
+    );
+  }
+
+  const result = userMessageDocumentSchema.safeParse(parsed);
+  if (!result.success) {
+    printChatUsageError(
+      `User message file "${path}" is not a valid UserMessageDocument`,
+      result.error.issues
+        .map((issue) => {
+          const issuePath = issue.path.join(".");
+          return `${issuePath === "" ? "(root)" : issuePath}: ${issue.message}`;
+        })
+        .join("\n  "),
+    );
+  }
+  return result.data;
+}
+
+function resolveUserMessage(options: SendOptions): ResolvedUserMessage {
+  if (options.userMessageFile === undefined) {
+    const text = readMessageText(options.text);
+    return {
+      userMessage: {
+        version: 1,
+        parts: [{ type: "text", text }],
+      },
+      prompt: text,
+      hasTextContent: true,
+    };
+  }
+
+  if (options.text !== undefined) {
+    printChatUsageError(
+      "Pass either --text or --user-message-file, not both",
+      "Use --text for a plain message and --user-message-file for a full document.",
+    );
+  }
+
+  const userMessage = readUserMessageDocument(options.userMessageFile);
+  return {
+    userMessage,
+    prompt: promptForDocument(userMessage),
+    hasTextContent: documentText(userMessage).length > 0,
+  };
 }
 
 export const sendCommand = new Command()
@@ -44,6 +164,10 @@ export const sendCommand = new Command()
     "Chat thread ID (defaults to ZERO_CHAT_THREAD_ID)",
   )
   .option("-t, --text <message>", "Message text (or read it from stdin)")
+  .option(
+    "--user-message-file <path>",
+    "JSON file holding one full UserMessageDocument (excludes --text)",
+  )
   .option("--json", "Print machine-readable JSON")
   .addHelpText(
     "after",
@@ -52,32 +176,33 @@ Examples:
   Send to this chat:  zero chat send --text "Continue the analysis"
   Send to a thread:   zero chat send --thread-id <thread-id> --text "Continue"
   Pipe a message:     printf "Continue" | zero chat send --thread-id <thread-id>
+  Send a document:    zero chat send --user-message-file ./message.json
   Print JSON:         zero chat send --text "Continue" --json
+${USER_MESSAGE_JSON_HELP}
 
 Notes:
-  - Constructs a version 1 UserMessageDocument with one text part
+  - --text wraps the message in a version 1 UserMessageDocument with one text part
+  - --user-message-file sends the document as written, validated before the request
+  - file parts reference an uploaded web file id (zero web upload-file)
+  - The API derives the agent prompt and title state from the document itself
   - Every normal message enters the thread queue first; an idle queue may dispatch it immediately
   - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-message:write capabilities)`,
   )
   .action(
     withErrorHandler(async (options: SendOptions) => {
       const threadId = resolveChatThreadId(options.threadId);
-      const text = readMessageText(options.text);
+      const message = resolveUserMessage(options);
       const agentId = await getZeroChatThreadAgentId({ threadId });
       const eventId = randomUUID();
-      const userMessage = {
-        version: 1,
-        parts: [{ type: "text", text }],
-      } satisfies UserMessageDocument;
 
       const result = await sendZeroChatEvent({
         agentId,
         threadId,
-        prompt: text,
-        hasTextContent: true,
+        prompt: message.prompt,
+        hasTextContent: message.hasTextContent,
         clientEventId: eventId,
         chatThreadSortEventId: randomUUID(),
-        userMessage,
+        userMessage: message.userMessage,
       });
       const queued = result.runId === null;
 


### PR DESCRIPTION
## Why

The send API has always accepted the full user message document — `userMessage` on `POST /api/zero/chat/events` is `userMessageDocumentSchema`, and the server re-derives `agentPrompt`, `displayText`, `generationTemplates`, and `hasTextContent` from it (`zero-chat-user-message.service.ts:182`). Only the CLI was narrow: `zero chat send` hardcoded `{ version: 1, parts: [{ type: "text", text }] }`, so a run could not attach a file, mention another thread, pick a generation template, or quote feedback.

No API change is needed — this is the missing CLI entry point.

## What

`zero chat send --user-message-file <path>` sends one version 1 `UserMessageDocument` as written. It is mutually exclusive with `--text`, which stays the shortcut that wraps plain text (or stdin) in a single text part.

- The document is validated against the contract's own `userMessageDocumentSchema` before the request, so a malformed file reports zod field paths (`parts.0.filenameSnapshot: …`) locally instead of coming back as a 400.
- `--help` documents every part shape:

```
User message JSON (--user-message-file), one version 1 document:
  { "version": 1, "parts": [ <part>, ... ] }            at least one part

  text         { "type": "text", "text": "..." }
  chat_thread  { "type": "chat_thread", "threadId": "<uuid>", "titleSnapshot": "..." }
  template     { "type": "template", "titleSnapshot": "...",
                 "template": { "type": "presentation" | "video" | "illustration" |
                   "workflow" | "website", "selection": { ... } } }
  file         { "type": "file", "fileId": "...", "filenameSnapshot": "...",
                 "contentType": "..." }
  feedback     { "type": "feedback", "quote": "...",
                 "note": [ text | chat_thread | template parts ],
                 "source": { "type": "mail", "id": "...",
                   "status": "draft" | "sent", "sentId": "..." } }
```

- `prompt` and `hasTextContent` are derived from the document's text parts. Both are non-authoritative (the server overwrites them from its own projection), so a document with no text part sends the same `(see attached files)` placeholder the web app uses for attachment-only messages, keeping the contract's `prompt: min(1)` satisfied.
- `file` parts reference an uploaded web file id (`zero web upload-file`); the `[Web file] … [ID] …` block the agent needs comes from the part itself, so `zero web download-file` keeps working. Artifact card metadata still comes from the separate `attachFiles` body field, which this PR does not touch.

## Verification

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/chat/__tests__/send.test.ts` — 7 tests pass: the 3 existing text cases plus a multi-part document (text + file + chat_thread), a file-only document (`hasTextContent: false`), local schema rejection before any HTTP call, and `--text` + `--user-message-file` rejection.
- `pnpm -F @vm0/cli check-types` clean.

Stacked independently of #23915 (that PR does not touch `send.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
