### PR TITLE
refactor(platform): rename chat message dom identifiers

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx
@@ -118,7 +118,7 @@ describe("chat history backfill loading", () => {
       }
       expect(skeleton.parentElement).toBe(messageContainer);
       expect(
-        skeleton.querySelectorAll("[data-chat-message-skeleton]"),
+        skeleton.querySelectorAll("[data-chat-event-skeleton]"),
       ).toHaveLength(2);
       expect(
         skeleton.compareDocumentPosition(firstMessage) &

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -83,7 +83,7 @@ describe("chat lifecycle", () => {
     const credit = await waitFor(() => {
       return buttonByLabel("Credit usage 24,734");
     });
-    const actions = credit.closest('[data-testid="chat-message-actions"]');
+    const actions = credit.closest('[data-testid="chat-event-actions"]');
     expect(actions).not.toBeNull();
     const copy = within(actions as HTMLElement).getByLabelText("Copy message");
     expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4325,7 +4325,7 @@ function ChatEventSkeletonPair({ compact = false }: { compact?: boolean }) {
     <>
       {/* User bubble skeleton */}
       <div
-        data-chat-message-skeleton="user"
+        data-chat-event-skeleton="user"
         aria-hidden
         className="flex justify-end"
       >
@@ -4335,7 +4335,7 @@ function ChatEventSkeletonPair({ compact = false }: { compact?: boolean }) {
       </div>
       {/* Assistant bubble skeleton */}
       <div
-        data-chat-message-skeleton="assistant"
+        data-chat-event-skeleton="assistant"
         aria-hidden
         className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start"
       >
@@ -7628,7 +7628,7 @@ function PagedAssistantGroup({
     return null;
   }
 
-  const groupElementId = `chat-message-group-${group.beginEventId}`;
+  const groupElementId = `chat-event-group-${group.beginEventId}`;
   const fullContent = group.events
     .map((m) => {
       return m.content;
@@ -7918,7 +7918,7 @@ function PagedGroupPrimaryActions({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="flex items-center gap-1" data-testid="chat-message-actions">
+    <div className="flex items-center gap-1" data-testid="chat-event-actions">
       {firstRunId && (
         <TooltipProvider delayDuration={300}>
           <Tooltip>


### PR DESCRIPTION
## Summary

- rename the chat skeleton DOM attribute to `data-chat-event-skeleton`
- rename assistant group element IDs to the `chat-event-group-*` prefix
- rename the primary action test ID to `chat-event-actions`
- update the two platform tests that consume these selectors

## Scope verification

A repository-wide search before the rename found the old selectors only in the four implementation locations and the two platform test references described in the issue. No e2e tests, screenshot tooling, analytics, or code outside `apps/platform` depended on them.

This is a selector-only rename with no rendering, styling, or behavioral changes. Persisted IndexedDB store/key names, `createChatMessagesStore`, and the clipboard message vocabulary remain unchanged.

## Validation

- `pnpm exec prettier --write --ignore-unknown apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-history-backfill-progress.test.tsx src/views/zero-page/__tests__/chat-run-results.test.tsx --silent=passed-only`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace apps/platform`

Closes #23923