### PR TITLE
fix(ci): decouple release-please from main turbo

### DIFF
--- a/.github/scripts/pass-release-pr-ci-gates.sh
+++ b/.github/scripts/pass-release-pr-ci-gates.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create ci-gate check runs on the release PR head commit. GITHUB_TOKEN pushes
+# don't trigger pull_request events, so the CI workflows never run on the new
+# commit. The Checks API with GITHUB_TOKEN produces check runs with
+# integration_id 15368 (GitHub Actions), satisfying the required_status_checks
+# ruleset.
+
+require_env() {
+  local name=$1
+  if [ -z "${!name:-}" ]; then
+    echo "missing required env: ${name}" >&2
+    exit 2
+  fi
+}
+
+require_env GH_TOKEN
+require_env GITHUB_REPOSITORY
+
+PR_JSON=$(gh pr view release-please--branches--main --repo "$GITHUB_REPOSITORY" --json number,headRefOid 2>/dev/null || echo "")
+if [ -z "$PR_JSON" ]; then
+  echo "No release PR found, skipping"
+  exit 0
+fi
+
+PR_NUMBER=$(jq -r .number <<<"$PR_JSON")
+PR_HEAD=$(jq -r .headRefOid <<<"$PR_JSON")
+CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only)
+
+create_gate_check() {
+  local gate="$1"
+  local conclusion="$2"
+  local title="$3"
+  local summary="$4"
+
+  gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+    -f name="$gate" \
+    -f head_sha="$PR_HEAD" \
+    -f status="completed" \
+    -f conclusion="$conclusion" \
+    -f "output[title]=$title" \
+    -f "output[summary]=$summary"
+  echo "✅ Created $gate check run on $PR_HEAD with conclusion $conclusion"
+}
+
+db_release_in_pr=false
+api_release_in_pr=false
+if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/packages/db/package.json"; then
+  db_release_in_pr=true
+fi
+if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/apps/api/package.json"; then
+  api_release_in_pr=true
+fi
+
+if [ "$db_release_in_pr" = "true" ] && [ "$api_release_in_pr" != "true" ]; then
+  create_gate_check \
+    ci-gate-turbo \
+    failure \
+    "DB release requires API release" \
+    "Release PRs that bump turbo/packages/db must also bump turbo/apps/api because production migrations are owned by the API release lifecycle."
+  create_gate_check ci-gate-crates success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+  create_gate_check ci-gate-security success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+  echo "::error::turbo/packages/db release PR changes must ship with turbo/apps/api."
+  exit 1
+fi
+
+for gate in ci-gate-turbo ci-gate-crates ci-gate-security; do
+  create_gate_check "$gate" success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+done

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -256,7 +256,11 @@ ruby -e '
   raise "Runner must wait for resolver" unless rollback.fetch("rollback-runner").fetch("needs") == "resolve-target"
   raise "API must wait for resolver" unless rollback.fetch("rollback-api").fetch("needs") == "resolve-target"
   release_job = release.fetch("release-please")
-  raise "release must wait for production queue" unless release_job.fetch("needs") == "queue-production-deploy"
+  release_needs = Array(release_job.fetch("needs"))
+  raise "release must wait for production queue" unless release_needs.include?("queue-production-deploy")
+  raise "release must wait for release detection" unless release_needs.include?("detect-release-commit")
+  queue_needs = Array(release.fetch("queue-production-deploy").fetch("needs"))
+  raise "production queue must wait for release detection" unless queue_needs.include?("detect-release-commit")
   release_target_output = "$" + "{{ steps.release-target.outputs.sha }}"
   raise "release job must expose the resolved release target" unless release_job.fetch("outputs").fetch("release_target") == release_target_output
   raise "release workflow must not use the triggering workflow SHA as a release target" if File.read(ARGV[1]).include?("github.event.workflow_run.head_sha")
@@ -265,6 +269,7 @@ ruby -e '
   desktop_target = "desktop-v" + "$" + "{{ needs.release-please.outputs.desktop_version }}"
   checkout_ref_exceptions = {
     "queue-production-deploy" => "main",
+    "refresh-release-pull-request" => "main",
     "build-desktop-release" => desktop_target,
     "publish-desktop-update-manifest" => desktop_target,
     "update-rollback-dashboard" => "main",

--- a/.github/workflows/release-please-refresh.yml
+++ b/.github/workflows/release-please-refresh.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: main
 
-      - uses: vm0-ai/release-please-action@vm0
+      - uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/release-please-refresh.yml
+++ b/.github/workflows/release-please-refresh.yml
@@ -1,0 +1,43 @@
+name: release-please-refresh
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: write
+
+# Only the newest main state is worth publishing to the release pull request, so
+# an in-flight refresh is cancelled by a newer push.
+concurrency:
+  group: release-please-pull-request
+  cancel-in-progress: true
+
+jobs:
+  refresh-release-pull-request:
+    # Release commits are refreshed by release-please.yml instead, because that
+    # workflow creates the tags before it regenerates the pull request. Doing it
+    # here first would rebuild the pull request from a baseline whose releases do
+    # not exist yet and bump every just-released component a second time.
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+
+      - uses: vm0-ai/release-please-action@vm0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
+      - name: Pass ci-gate checks for release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/pass-release-pr-ci-gates.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,11 +1,13 @@
 name: release-please
 
+# Releases run straight off the push to main. Waiting for the Turbo run on main
+# adds no artifact dependency: each queued pull request's merge-group Turbo run
+# uploads the canonical app artifact under its merged commit SHA, and
+# release-please deploys that same SHA as release_target. The Turbo push run
+# reuses the artifact and only repoints the staging-app Pages alias.
 on:
-  workflow_run:
-    workflows: ["Turbo"]
+  push:
     branches: ["main"]
-    types:
-      - completed
 
 permissions:
   actions: read
@@ -16,8 +18,42 @@ permissions:
   checks: write
 
 jobs:
+  # A push to main can carry several merge-queue entries at once, so look at every
+  # commit subject in the push rather than only the head commit. Without this the
+  # release path would run on every main push and each no-op run would still take
+  # a turn in the production deploy queue.
+  detect-release-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release: ${{ steps.detect.outputs.release }}
+    steps:
+      - name: Detect a release commit in this push
+        id: detect
+        env:
+          COMMIT_MESSAGES: ${{ toJSON(github.event.commits.*.message) }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          subjects=$(jq -r 'if length == 0 then empty else .[] | split("\n")[0] end' <<<"$COMMIT_MESSAGES")
+          if [ -z "$subjects" ]; then
+            subjects=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1)
+          fi
+
+          release=false
+          while IFS= read -r subject; do
+            case "$subject" in
+            'chore: release'*) release=true ;;
+            esac
+          done <<<"$subjects"
+
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          echo "release commit in this push: $release"
+
   queue-production-deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: detect-release-commit
+    if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
@@ -33,9 +69,9 @@ jobs:
         run: bash .github/scripts/wait-production-deploy-queue.sh
 
   release-please:
-    needs: queue-production-deploy
+    needs: [detect-release-commit, queue-production-deploy]
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       release_target: ${{ steps.release-target.outputs.sha }}
@@ -1797,7 +1833,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: ${{ steps.target-metadata.outputs.cache_suffix }}-release
-          save-if: ${{ github.event.workflow_run.head_branch == 'main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Notify Slack - Starting
         id: slack-start

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,7 +93,7 @@ jobs:
       desktop_version: ${{ steps.release.outputs['turbo/apps/desktop--version'] }}
       cli_version: ${{ steps.release.outputs['turbo/apps/cli--version'] }}
     steps:
-      - uses: vm0-ai/release-please-action@vm0
+      - uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
         with:
           ref: main
 
-      - uses: vm0-ai/release-please-action@vm0
+      - uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
 
       - name: Resolve release target
         id: release-target
@@ -99,66 +100,30 @@ jobs:
 
           echo "sha=$release_target" >> "$GITHUB_OUTPUT"
 
-      # Create ci-gate check runs on release PR head commit.
-      # GITHUB_TOKEN pushes don't trigger pull_request events, so the CI
-      # workflows never run on the new commit. The Checks API with GITHUB_TOKEN
-      # produces check runs with integration_id 15368 (GitHub Actions),
-      # satisfying the required_status_checks ruleset.
+  # Refreshing the release pull request is a separate job so that a failure here
+  # cannot skip the release and deployment jobs above. release-please recomputes
+  # the pull request from scratch on every run, so a failed refresh self-heals on
+  # the next push to main.
+  refresh-release-pull-request:
+    needs: release-please
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+
+      - uses: vm0-ai/release-please-action@vm0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
       - name: Pass ci-gate checks for release PR
-        if: ${{ steps.release.outputs.releases_created != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_JSON=$(gh pr view release-please--branches--main --repo "${{ github.repository }}" --json number,headRefOid 2>/dev/null || echo "")
-          if [ -z "$PR_JSON" ]; then
-            echo "No release PR found, skipping"
-            exit 0
-          fi
-
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r .number)
-          PR_HEAD=$(echo "$PR_JSON" | jq -r .headRefOid)
-          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" --name-only)
-
-          create_gate_check() {
-            local gate="$1"
-            local conclusion="$2"
-            local title="$3"
-            local summary="$4"
-
-            gh api repos/${{ github.repository }}/check-runs -X POST \
-              -f name="$gate" \
-              -f head_sha="$PR_HEAD" \
-              -f status="completed" \
-              -f conclusion="$conclusion" \
-              -f "output[title]=$title" \
-              -f "output[summary]=$summary"
-            echo "✅ Created $gate check run on $PR_HEAD with conclusion $conclusion"
-          }
-
-          db_release_in_pr=false
-          api_release_in_pr=false
-          if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/packages/db/package.json"; then
-            db_release_in_pr=true
-          fi
-          if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/apps/api/package.json"; then
-            api_release_in_pr=true
-          fi
-
-          if [ "$db_release_in_pr" = "true" ] && [ "$api_release_in_pr" != "true" ]; then
-            create_gate_check \
-              ci-gate-turbo \
-              failure \
-              "DB release requires API release" \
-              "Release PRs that bump turbo/packages/db must also bump turbo/apps/api because production migrations are owned by the API release lifecycle."
-            create_gate_check ci-gate-crates success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-            create_gate_check ci-gate-security success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-            echo "::error::turbo/packages/db release PR changes must ship with turbo/apps/api."
-            exit 1
-          fi
-
-          for gate in ci-gate-turbo ci-gate-crates ci-gate-security; do
-            create_gate_check "$gate" success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-          done
+        run: bash .github/scripts/pass-release-pr-ci-gates.sh
 
   validate-db-release-coupling:
     needs: release-please

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -223,6 +223,7 @@ jobs:
             .github/scripts/check-release-please-component-releases.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/cloudflare-ssh-preconnect.sh \
+            .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/tests/ansible-ssh-control-path-test.sh \


### PR DESCRIPTION
## Summary

- refresh the release-please pull request from a dedicated `push` workflow, without waiting for Turbo on `main` or the production deployment queue
- start the release path directly from the push containing `chore: release`, while keeping release creation and production deployment serialized behind `queue-production-deploy`
- split GitHub Release creation from pull-request refresh so a failed branch update cannot skip builds and deployments after tags already exist
- share release-PR ci-gate check creation between both refresh paths

## Why

`Validate release presence` rejects a release pull request when release-managed component changes merge ahead of the pull request's generation base. The intended recovery is to regenerate the release pull request, but the previous workflow made that slow and fragile:

- refresh waited 1.5 to 8 minutes for Turbo on `main`, and a failed Turbo run produced no refresh
- refresh also waited behind the production deployment queue even though only release creation and deployment need serialization
- `createReleases()` ran before `createPullRequests()`, so a release-PR ref update failure marked the whole job failed after tags and GitHub Releases existed, skipping every dependent build and deploy job

On 2026-07-30, release pull request #23901 remained stale for 34 minutes and was rejected by five merge-group runs before a refresh landed during a queue gap.

## Behavior

### Pull-request refresh

`release-please-refresh.yml` runs on every non-release push to `main` with `skip-github-release: true`. A newer push cancels an older in-flight refresh because only the newest `main` state is useful.

Release commits remain on the release path, which creates tags first and then regenerates the next release pull request. This prevents just-released components from being bumped twice.

### Release creation

`release-please.yml` now starts from `push` instead of waiting for `workflow_run` of Turbo on `main`. A small detection job checks every commit subject in the push, so a release commit is not missed when it is not the final commit in a merge-queue push batch. Non-release pushes skip the production deployment queue and the rest of this workflow.

Production ordering is unchanged: `queue-production-deploy` still completes before release creation, builds, and promotion.

### App artifact identity

Release-please returns the merged release pull request commit as `release_target`. Production jobs checkout that SHA, and `promote-app-production` reads `okou-app/<release_target>/` from R2.

Each queued pull request receives a Turbo merge-group run at its merged commit SHA, which builds that same immutable R2 artifact. For #23901:

- release pull request branch head: `8d4048ba`
- merged commit and `release_target`: `871ac17d`
- merge-group upload and production download: `okou-app/871ac17d/`

If a push contains later commits after the release commit, production still deploys the release PR's `release_target`, not the push's final `github.sha`.

## Validation

Local targeted checks:

- Bash syntax validation for the changed scripts
- ShellCheck for the extracted ci-gate script and workflow structure test
- `resolve-production-rollback-target-test.sh`
- workflow shell-compatibility validation
- actionlint 1.7.12
- release-commit detection against five payload shapes, including a batch where the release commit is not last

The full repository checks run in the PR pipeline.

## Follow-up

Widening the release-presence gate's `<component>/**/src/**` pathspec is deliberately left out. That change can increase queue rejection frequency and should land after this workflow change is stable.

Closes #22879.
