### PR TITLE
feat(connectors): add custom connector permissions and skills

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2541,6 +2541,81 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     ).resolves.toStrictEqual([]);
   });
 
+  it("persists permission bundles and skill markdown with security-sensitive revisions", async () => {
+    const bdd = createBddApi(context);
+    const admin = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.CustomConnectorOAuth2]: true,
+      [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
+    });
+    const slug = uniqueSlug("bdd-permission-skill");
+
+    const created = await connectorsApi.createCustomConnector(admin, {
+      ...customConnectorBody(slug),
+      permissionBundleRef: "builtin:slack@1",
+      skillMarkdown: "Use this connector to coordinate Slack conversations.",
+    });
+    expect(created).toMatchObject({
+      permissionBundleRef: "builtin:slack@1",
+      skillMarkdown: "Use this connector to coordinate Slack conversations.",
+      revision: 1,
+    });
+
+    const skillUpdated = await connectorsApi.updateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: created.displayName,
+        prefixTemplates: created.prefixTemplates,
+        fields: created.fields,
+        headerInjections: created.headerInjections,
+        queryInjections: created.queryInjections,
+        authMode: created.authMode,
+        skillMarkdown: "Updated Slack operating instructions.",
+      },
+    );
+    expect(skillUpdated).toMatchObject({
+      permissionBundleRef: "builtin:slack@1",
+      skillMarkdown: "Updated Slack operating instructions.",
+      revision: 1,
+    });
+
+    const permissionBundleCleared = await connectorsApi.updateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: skillUpdated.displayName,
+        prefixTemplates: skillUpdated.prefixTemplates,
+        fields: skillUpdated.fields,
+        headerInjections: skillUpdated.headerInjections,
+        queryInjections: skillUpdated.queryInjections,
+        authMode: skillUpdated.authMode,
+        permissionBundleRef: null,
+      },
+    );
+    expect(permissionBundleCleared).toMatchObject({
+      permissionBundleRef: null,
+      skillMarkdown: "Updated Slack operating instructions.",
+      revision: 2,
+    });
+
+    const unknownBundle = await connectorsApi.requestCreateCustomConnector(
+      admin,
+      {
+        ...customConnectorBody(uniqueSlug("bdd-unknown-bundle")),
+        permissionBundleRef: "builtin:not-a-connector@1",
+      },
+      [400],
+    );
+    expectApiError(unknownBundle.body);
+    expect(unknownBundle.body.error.message).toContain(
+      "Unknown custom connector permission bundle",
+    );
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
   it("rejects prefix collisions introduced by edits", async () => {
     const admin = createBddApi(context).user();
     await connectorsApi.updateFeatureSwitches(admin, {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2547,7 +2547,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     bdd.acceptAgentStorageWrites();
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorOAuth2]: true,
-      [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
     });
     const slug = uniqueSlug("bdd-permission-skill");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -21,7 +21,10 @@ import {
   integrationsGithubContract,
   type GithubInstallationResponse,
 } from "@vm0/api-contracts/contracts/integrations-github";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorOAuth2Contract,
@@ -1883,6 +1886,19 @@ export function createConnectorBddApi(context: TestContext) {
       return response.body.enabledIds;
     },
 
+    async readAgentCustomConnectorGrants(
+      actor: ApiTestUser,
+      agentId: string,
+    ): Promise<readonly AgentCustomConnectorGrant[]> {
+      const response = await api.requestAgentCustomConnectors(
+        actor,
+        agentId,
+        [200],
+      );
+      expectStatus(response, 200);
+      return response.body.grants ?? [];
+    },
+
     async requestUpdateAgentCustomConnectors(
       actor: ApiTestUser | null,
       agentId: string,
@@ -1920,6 +1936,28 @@ export function createConnectorBddApi(context: TestContext) {
       );
       expectStatus(response, 200);
       return response.body.enabledIds;
+    },
+
+    async requestUpdateAgentCustomConnectorGrants(
+      actor: ApiTestUser | null,
+      agentId: string,
+      grants: readonly AgentCustomConnectorGrant[],
+      statuses: readonly (200 | 400 | 401 | 403 | 404)[],
+      operation?: "replace" | "add" | "remove",
+    ) {
+      const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+      const body =
+        operation === undefined
+          ? { grants: [...grants] }
+          : { grants: [...grants], operation };
+      return await accept(
+        client.update({
+          params: { id: agentId },
+          headers: authenticate(actor),
+          body,
+        }),
+        statuses,
+      );
     },
   };
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7267,9 +7267,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     createBddApi(context).acceptAgentStorageWrites();
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
-    });
     const slug = `_bdd-permission-skill-${randomUUID().slice(0, 8)}`;
     const custom = await connectors.createCustomConnector(actor, {
       slug,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14,7 +14,10 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { Job as RunnerJob } from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { getCustomSkillStorageName } from "@vm0/core/storage-names";
+import {
+  getCustomConnectorSkillStorageName,
+  getCustomSkillStorageName,
+} from "@vm0/core/storage-names";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type ExecutionFirewallEntry,
@@ -7257,6 +7260,78 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("enforces custom connector permission grants and mounts its generated skill", async () => {
+    const api = createRunsApi(context);
+    createBddApi(context).acceptAgentStorageWrites();
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
+    });
+    const slug = `_bdd-permission-skill-${randomUUID().slice(0, 8)}`;
+    const custom = await connectors.createCustomConnector(actor, {
+      slug,
+      displayName: "BDD Permissioned API",
+      prefixes: ["https://permissioned.example.test/api/"],
+      headerName: "Authorization",
+      headerTemplate: "Bearer {{secret}}",
+      permissionBundleRef: "builtin:slack@1",
+      skillMarkdown: "Use the selected Slack-compatible operations only.",
+    });
+    await connectors.setCustomConnectorSecret(
+      actor,
+      custom.id,
+      "permissioned-custom-secret",
+    );
+    const grant = {
+      customConnectorId: custom.id,
+      permissionNames: ["chat:write"],
+    };
+    const grantResponse =
+      await connectors.requestUpdateAgentCustomConnectorGrants(
+        actor,
+        agentId,
+        [grant],
+        [200],
+      );
+    if (grantResponse.status !== 200) {
+      throw new Error("Expected custom connector permission grant to succeed");
+    }
+    expect(grantResponse.body.grants).toStrictEqual([grant]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use only the authorized custom connector operation",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const internalName = `custom_connector_${custom.id.replaceAll("-", "")}`;
+    const customApis = inlineFirewallApis(claim.firewalls, internalName);
+    expect(customApis[0]?.permissions).toStrictEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "chat:write" })]),
+    );
+    expect(claim.networkPolicies?.[internalName]?.allow).toContain(
+      "chat:write",
+    );
+    expect(claim.networkPolicies?.[internalName]?.deny.length).toBeGreaterThan(
+      0,
+    );
+    expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("deny");
+
+    const skillMount = expectCanonicalStorageManifest(
+      claim.storageManifest,
+    )?.storageMounts.find((storage) => {
+      return storage.name === getCustomConnectorSkillStorageName(custom.id);
+    });
+    expect(skillMount?.mountPath).toBe(
+      `/home/user/.claude/skills/custom-${slug.slice(1, 49)}-${custom.id.replaceAll("-", "").slice(0, 8)}`,
+    );
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
   });
 
   it("serializes and injects custom connector OAuth 2.0 refreshes", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -78,6 +79,29 @@ async function createUnconfiguredCustomConnector(
 
 async function createCustomConnector(actor: ApiTestUser, slug: string) {
   const connector = await createUnconfiguredCustomConnector(actor, slug);
+  await connectors.setCustomConnectorSecret(
+    actor,
+    connector.id,
+    `${slug}-secret`,
+  );
+  return connector;
+}
+
+async function createPermissionedCustomConnector(
+  actor: ApiTestUser,
+  slug: string,
+) {
+  await connectors.updateFeatureSwitches(actor, {
+    [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
+  });
+  const connector = await connectors.createCustomConnector(actor, {
+    displayName: `Connector ${slug}`,
+    slug: `_${slug}`,
+    prefixes: [`https://${slug}.example.test`],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{secret}}",
+    permissionBundleRef: "builtin:slack@1",
+  });
   await connectors.setCustomConnectorSecret(
     actor,
     connector.id,
@@ -198,7 +222,7 @@ describe("GET /api/zero/agents/:id/custom-connectors", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ enabledIds: [] });
+    expect(response.body).toStrictEqual({ enabledIds: [], grants: [] });
   });
 
   it("returns 404 for a non-existent agent", async () => {
@@ -316,6 +340,81 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
       agent.agentId,
     );
     expect([...readBack].sort()).toStrictEqual([...response].sort());
+  });
+
+  it("requires explicit permission selection for connectors with a bundle", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, {
+      displayName: "Permissioned Agent",
+    });
+    const connector = await createPermissionedCustomConnector(
+      actor,
+      "permission-required",
+    );
+
+    const response = await connectors.requestUpdateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [connector.id],
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Permission selection is required for custom connector ids: ${connector.id}`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
+  it("persists selected permission names and rejects unknown permissions atomically", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, {
+      displayName: "Permission Grant Agent",
+    });
+    const connector = await createPermissionedCustomConnector(
+      actor,
+      "permission-roundtrip",
+    );
+    const grant = {
+      customConnectorId: connector.id,
+      permissionNames: ["chat:write"],
+    };
+
+    const updated = await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      [grant],
+      [200],
+    );
+    expect(updated.body).toStrictEqual({
+      enabledIds: [connector.id],
+      grants: [grant],
+    });
+    await expect(
+      connectors.readAgentCustomConnectorGrants(actor, agent.agentId),
+    ).resolves.toStrictEqual([grant]);
+
+    const rejected = await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      [
+        {
+          customConnectorId: connector.id,
+          permissionNames: ["unknown:permission"],
+        },
+      ],
+      [400],
+    );
+    expect(rejected.body).toStrictEqual({
+      error: {
+        message: `Unknown permission names for custom connector ${connector.id}: unknown:permission`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+    await expect(
+      connectors.readAgentCustomConnectorGrants(actor, agent.agentId),
+    ).resolves.toStrictEqual([grant]);
   });
 
   it("rejects enabling custom connectors without required user values", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -91,9 +90,6 @@ async function createPermissionedCustomConnector(
   actor: ApiTestUser,
   slug: string,
 ) {
-  await connectors.updateFeatureSwitches(actor, {
-    [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: true,
-  });
   const connector = await connectors.createCustomConnector(actor, {
     displayName: `Connector ${slug}`,
     slug: `_${slug}`,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -11,6 +11,8 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -33,7 +35,7 @@ import {
   defaultAgentResponse,
   zeroAgentDetail,
   zeroAgentEnabledConnectorSlugs,
-  zeroAgentEnabledCustomConnectorIds,
+  zeroAgentCustomConnectorGrants,
   zeroAgentExists,
   zeroAgentList,
   visibleJoinedZeroAgentCondition,
@@ -43,6 +45,7 @@ import {
   updateUserConnectors,
   updateUserCustomConnectors,
 } from "../services/user-connectors.service";
+import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUBLIC_AGENT_LIMIT = 7;
@@ -520,14 +523,22 @@ const getAgentCustomConnectorsInner$ = computed(async (get) => {
     return agentNotFound(params.id);
   }
 
-  const enabledIds = await get(
-    zeroAgentEnabledCustomConnectorIds({
+  const grants = await get(
+    zeroAgentCustomConnectorGrants({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
     }),
   );
-  return { status: 200 as const, body: { enabledIds: [...enabledIds] } };
+  return {
+    status: 200 as const,
+    body: {
+      enabledIds: grants.map((grant) => {
+        return grant.customConnectorId;
+      }),
+      grants: [...grants],
+    },
+  };
 });
 
 const updateAgentCustomConnectorsBody$ = bodyResultOf(
@@ -743,8 +754,31 @@ const updateAgentCustomConnectorsInner$ = command(
       return agentNotFound(params.id);
     }
 
+    if ("grants" in body.data) {
+      const featureContext = await get(
+        userFeatureSwitchContext(auth.orgId, auth.userId),
+      );
+      signal.throwIfAborted();
+      if (
+        !isFeatureEnabled(
+          FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
+          featureContext,
+        )
+      ) {
+        return forbidden(
+          "Custom connector permissions and skills are not enabled",
+        );
+      }
+    }
+
     const writeDb = set(writeDb$);
-    const enabledIds = Array.from(new Set(body.data.enabledIds));
+    const grants = "grants" in body.data ? body.data.grants : undefined;
+    const enabledIds =
+      "enabledIds" in body.data
+        ? Array.from(new Set(body.data.enabledIds))
+        : body.data.grants.map((grant) => {
+            return grant.customConnectorId;
+          });
     const operation = body.data.operation ?? "replace";
 
     const updated = await updateUserCustomConnectors(writeDb, {
@@ -752,6 +786,7 @@ const updateAgentCustomConnectorsInner$ = command(
       userId: auth.userId,
       agentId: params.id,
       enabledIds,
+      ...(grants !== undefined ? { grants } : {}),
       operation,
     });
     signal.throwIfAborted();
@@ -774,10 +809,21 @@ const updateAgentCustomConnectorsInner$ = command(
         `Custom connector ids are not configured for this user: ${updated.unconfiguredIds.join(", ")}`,
       );
     }
+    if (updated.status === "customConnectorPermissionSelectionRequired") {
+      return validationError(
+        `Permission selection is required for custom connector ids: ${updated.connectorIds.join(", ")}`,
+      );
+    }
+    if (updated.status === "invalidCustomConnectorPermissions") {
+      return validationError(updated.message);
+    }
 
     return {
       status: 200 as const,
-      body: { enabledIds: [...updated.enabledIds] },
+      body: {
+        enabledIds: [...updated.enabledIds],
+        grants: [...updated.grants],
+      },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -11,8 +11,6 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -45,7 +43,6 @@ import {
   updateUserConnectors,
   updateUserCustomConnectors,
 } from "../services/user-connectors.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUBLIC_AGENT_LIMIT = 7;
@@ -752,23 +749,6 @@ const updateAgentCustomConnectorsInner$ = command(
     signal.throwIfAborted();
     if (!exists) {
       return agentNotFound(params.id);
-    }
-
-    if ("grants" in body.data) {
-      const featureContext = await get(
-        userFeatureSwitchContext(auth.orgId, auth.userId),
-      );
-      signal.throwIfAborted();
-      if (
-        !isFeatureEnabled(
-          FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
-          featureContext,
-        )
-      ) {
-        return forbidden(
-          "Custom connector permissions and skills are not enabled",
-        );
-      }
     }
 
     const writeDb = set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
@@ -56,6 +56,31 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       };
     }
   }
+  if (
+    bodyResult.data.permissionBundleRef !== undefined ||
+    bodyResult.data.skillMarkdown !== undefined
+  ) {
+    const featureContext = await get(
+      userFeatureSwitchContext(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    if (
+      !isFeatureEnabled(
+        FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
+        featureContext,
+      )
+    ) {
+      return {
+        status: 403 as const,
+        body: {
+          error: {
+            message: "Custom connector permissions and skills are not enabled",
+            code: "FORBIDDEN" as const,
+          },
+        },
+      };
+    }
+  }
 
   const result = await set(
     createCustomConnector$,

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
@@ -56,32 +56,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       };
     }
   }
-  if (
-    bodyResult.data.permissionBundleRef !== undefined ||
-    bodyResult.data.skillMarkdown !== undefined
-  ) {
-    const featureContext = await get(
-      userFeatureSwitchContext(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(
-        FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
-        featureContext,
-      )
-    ) {
-      return {
-        status: 403 as const,
-        body: {
-          error: {
-            message: "Custom connector permissions and skills are not enabled",
-            code: "FORBIDDEN" as const,
-          },
-        },
-      };
-    }
-  }
-
   const result = await set(
     createCustomConnector$,
     { orgId: auth.orgId, userId: auth.userId, input: bodyResult.data },

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-update.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-update.ts
@@ -55,25 +55,6 @@ const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
     };
   }
-  if (
-    (bodyResult.data.permissionBundleRef !== undefined ||
-      bodyResult.data.skillMarkdown !== undefined) &&
-    !isFeatureEnabled(
-      FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
-      featureContext,
-    )
-  ) {
-    return {
-      status: 403 as const,
-      body: {
-        error: {
-          message: "Custom connector permissions and skills are not enabled",
-          code: "FORBIDDEN" as const,
-        },
-      },
-    };
-  }
-
   const result = await set(
     updateCustomConnectorDefinition$,
     {

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-update.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-update.ts
@@ -55,6 +55,24 @@ const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
     };
   }
+  if (
+    (bodyResult.data.permissionBundleRef !== undefined ||
+      bodyResult.data.skillMarkdown !== undefined) &&
+    !isFeatureEnabled(
+      FeatureSwitchKey.CustomConnectorPermissionsAndSkills,
+      featureContext,
+    )
+  ) {
+    return {
+      status: 403 as const,
+      body: {
+        error: {
+          message: "Custom connector permissions and skills are not enabled",
+          code: "FORBIDDEN" as const,
+        },
+      },
+    };
+  }
 
   const result = await set(
     updateCustomConnectorDefinition$,

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -2,6 +2,7 @@ import {
   connectorSlugSchema,
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -16,6 +17,7 @@ import type { ReadonlyDb } from "../external/db";
 export interface AgentConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants: readonly AgentCustomConnectorGrant[];
 }
 
 export interface AgentConnectorSlugRow {
@@ -24,6 +26,7 @@ export interface AgentConnectorSlugRow {
 
 export interface AgentCustomConnectorRow {
   readonly customConnectorId: string;
+  readonly permissionNames: readonly string[];
 }
 
 interface ZeroBackedComposeAgent {
@@ -60,7 +63,10 @@ async function loadAgentAllowedCustomConnectorRows(
   },
 ): Promise<readonly AgentCustomConnectorRow[]> {
   return await db
-    .select({ customConnectorId: userCustomConnectors.customConnectorId })
+    .select({
+      customConnectorId: userCustomConnectors.customConnectorId,
+      permissionNames: userCustomConnectors.permissionNames,
+    })
     .from(userCustomConnectors)
     .innerJoin(
       orgCustomConnectors,
@@ -94,7 +100,17 @@ export function agentConnectorScopeFromRows(args: {
   const allowedCustomConnectorIds = args.customConnectorRows.map((row) => {
     return row.customConnectorId;
   });
-  return { allowedConnectorSlugs, allowedCustomConnectorIds };
+  const customConnectorGrants = args.customConnectorRows.map((row) => {
+    return {
+      customConnectorId: row.customConnectorId,
+      permissionNames: [...row.permissionNames],
+    };
+  });
+  return {
+    allowedConnectorSlugs,
+    allowedCustomConnectorIds,
+    customConnectorGrants,
+  };
 }
 
 export async function loadAgentConnectorScope(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -10,6 +10,7 @@ import {
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import type {
   ConnectorAuthMethodId,
   ConnectorSlug,
@@ -69,6 +70,8 @@ import {
 } from "@vm0/core/feature-switch";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
+  getCustomConnectorSkillName,
+  getCustomConnectorSkillStorageName,
   getCustomSkillStorageName,
   getSkillStorageName,
   MEMORY_ARTIFACT_NAME,
@@ -153,6 +156,10 @@ import {
   renderTemplateForRuntime,
 } from "./zero-custom-connector.service";
 import { refreshCustomConnectorOAuth2ValuesIfNeeded } from "./custom-connector-oauth2.service";
+import {
+  loadCustomConnectorPermissionBundle,
+  type CustomConnectorPermissionBundle,
+} from "./custom-connector-permission-bundle.service";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
 import {
   prepareAgentRunStorage,
@@ -395,12 +402,16 @@ type ConnectorScopeSource = "explicit" | "zero_agent" | "legacy_all" | "empty";
 interface EffectiveConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
   readonly allowedCustomConnectorIds: readonly string[] | undefined;
+  readonly customConnectorGrants:
+    | readonly AgentCustomConnectorGrant[]
+    | undefined;
   readonly source: ConnectorScopeSource;
 }
 
 interface ExplicitConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants?: readonly AgentCustomConnectorGrant[];
   readonly source?: Exclude<ConnectorScopeSource, "legacy_all" | "empty">;
 }
 
@@ -763,6 +774,11 @@ interface CustomConnectorRuntimeContext {
   readonly firewalls: readonly ExpandedFirewallConfig[];
   readonly reservedSecretAliases: Record<string, true> | undefined;
   readonly authRefs: readonly CustomConnectorAuthRef[];
+  readonly permissionPolicies: FirewallPolicies | undefined;
+  readonly skills: readonly {
+    readonly connectorId: string;
+    readonly connectorSlug: string;
+  }[];
 }
 
 function customConnectorAuthRefsForApis(args: {
@@ -942,6 +958,24 @@ function buildWorkflowSkillVolumes(
         mountPath: skillMountPath(framework, workflow.name),
       };
     });
+}
+
+function buildCustomConnectorSkillVolumes(
+  skills: CustomConnectorRuntimeContext["skills"],
+  framework: SupportedFramework,
+): readonly PreparedAdditionalVolume[] {
+  return skills.map((skill) => {
+    return {
+      volume: {
+        name: getCustomConnectorSkillStorageName(skill.connectorId),
+        mountPath: skillMountPath(
+          framework,
+          getCustomConnectorSkillName(skill.connectorSlug, skill.connectorId),
+        ),
+      },
+      source: "custom_connector_skill",
+    };
+  });
 }
 
 function buildInjectedSkillVolumes(
@@ -3473,14 +3507,80 @@ function customConnectorRuntimeAuth(args: {
   };
 }
 
-async function buildCustomConnectorRuntimeContext(args: {
+async function buildCustomConnectorRuntimeApis(args: {
+  readonly row: CustomConnectorRuntimeDataRows[number];
+  readonly headers: Record<string, string>;
+  readonly query: Record<string, string>;
+  readonly permissionBundle: CustomConnectorPermissionBundle | null;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly stats: CustomConnectorRuntimeBuildStats;
+}): Promise<ExpandedFirewallConfig["apis"]> {
+  const prefixVariableKeys = customConnectorPrefixTemplateVariableKeys(
+    args.row.connector.prefixTemplates,
+  );
+  const prefixValues = args.row.values.filter((value) => {
+    return value.kind === "variable" && prefixVariableKeys.has(value.key);
+  });
+  const decryptStartedAt = now();
+  const decryptedValues =
+    prefixValues.length === 0
+      ? {}
+      : await decryptCustomConnectorValues({
+          values: prefixValues,
+          featureSwitchContext: args.featureSwitchContext,
+        });
+  args.stats.recordPhaseDuration("decryptValues", decryptStartedAt);
+  args.stats.recordDecryptedValues(prefixValues.length);
+
+  const apis: ExpandedFirewallConfig["apis"] = [];
+  const prefixStartedAt = now();
+  for (const prefixTemplate of args.row.connector.prefixTemplates) {
+    const renderedPrefix = renderCustomConnectorRuntimePrefix({
+      template: prefixTemplate,
+      values: decryptedValues,
+      connectorName: args.row.connector.displayName,
+    });
+    if (!renderedPrefix) {
+      args.stats.recordInvalidPrefix();
+      continue;
+    }
+    args.stats.recordRenderedApi();
+    apis.push({
+      base: renderedPrefix,
+      auth: { headers: args.headers, query: args.query },
+      ...(args.permissionBundle
+        ? { permissions: [...args.permissionBundle.permissions] }
+        : {}),
+    });
+  }
+  args.stats.recordPhaseDuration("renderPrefixes", prefixStartedAt);
+  return apis;
+}
+
+interface BuildCustomConnectorRuntimeContextArgs {
   readonly rows: CustomConnectorRuntimeDataRows;
   readonly featureSwitchContext: FeatureSwitchContext;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly grants: readonly AgentCustomConnectorGrant[] | undefined;
   readonly timing?: ApiDispatchTimingCollector;
-}): Promise<CustomConnectorRuntimeContext> {
+}
+
+async function buildCustomConnectorRuntimeContext(
+  args: BuildCustomConnectorRuntimeContextArgs,
+): Promise<CustomConnectorRuntimeContext> {
   const firewalls: ExpandedFirewallConfig[] = [];
   const reservedSecretAliases: Record<string, true> = {};
   const authRefs: CustomConnectorAuthRef[] = [];
+  const permissionPolicies: FirewallPolicies = {};
+  const skills: {
+    connectorId: string;
+    connectorSlug: string;
+  }[] = [];
+  const grantByConnectorId = new Map(
+    (args.grants ?? []).map((grant) => {
+      return [grant.customConnectorId, grant.permissionNames] as const;
+    }),
+  );
   const stats = new CustomConnectorRuntimeBuildStats(args.rows);
   for (const row of args.rows) {
     const missingRequiredStartedAt = now();
@@ -3508,7 +3608,6 @@ async function buildCustomConnectorRuntimeContext(args: {
       stats.recordMissingRequiredConnector();
       continue;
     }
-    const apis: ExpandedFirewallConfig["apis"] = [];
     const authTemplateStartedAt = now();
     const { headers, query } = customConnectorRuntimeAuth({
       connector: row.connector,
@@ -3519,43 +3618,23 @@ async function buildCustomConnectorRuntimeContext(args: {
       stats.recordNoAuthInjectionConnector();
       continue;
     }
-    const prefixVariableKeys = customConnectorPrefixTemplateVariableKeys(
-      row.connector.prefixTemplates,
-    );
-    const prefixValues = row.values.filter((value) => {
-      return value.kind === "variable" && prefixVariableKeys.has(value.key);
-    });
-    const decryptStartedAt = now();
-    const decryptedValues =
-      prefixValues.length === 0
-        ? {}
-        : await decryptCustomConnectorValues({
-            values: prefixValues,
-            featureSwitchContext: args.featureSwitchContext,
-          });
-    stats.recordPhaseDuration("decryptValues", decryptStartedAt);
-    stats.recordDecryptedValues(prefixValues.length);
-    const prefixStartedAt = now();
-    for (const prefixTemplate of row.connector.prefixTemplates) {
-      const renderedPrefix = renderCustomConnectorRuntimePrefix({
-        template: prefixTemplate,
-        values: decryptedValues,
-        connectorName: row.connector.displayName,
-      });
-      if (!renderedPrefix) {
-        stats.recordInvalidPrefix();
-        continue;
-      }
-      stats.recordRenderedApi();
-      apis.push({
-        base: renderedPrefix,
-        auth: {
-          headers,
-          query,
-        },
-      });
+    const permissionBundle = row.connector.permissionBundleRef
+      ? await loadCustomConnectorPermissionBundle({
+          snapshot: args.connectorCatalogSnapshot,
+          ref: row.connector.permissionBundleRef,
+        })
+      : null;
+    if (row.connector.permissionBundleRef && !permissionBundle) {
+      continue;
     }
-    stats.recordPhaseDuration("renderPrefixes", prefixStartedAt);
+    const apis = await buildCustomConnectorRuntimeApis({
+      row,
+      headers,
+      query,
+      permissionBundle,
+      featureSwitchContext: args.featureSwitchContext,
+      stats,
+    });
     const assemblyStartedAt = now();
     if (apis.length === 0) {
       stats.recordPhaseDuration("assembleFirewalls", assemblyStartedAt);
@@ -3566,6 +3645,28 @@ async function buildCustomConnectorRuntimeContext(args: {
       description: row.connector.displayName,
       apis,
     });
+    if (permissionBundle) {
+      const selectedPermissionNames = new Set(
+        grantByConnectorId.get(row.connector.id) ?? [],
+      );
+      permissionPolicies[customConnectorInternalName(row.connector.id)] = {
+        policies: Object.fromEntries(
+          [...permissionBundle.permissionNames].map((permissionName) => {
+            return [
+              permissionName,
+              selectedPermissionNames.has(permissionName) ? "allow" : "deny",
+            ];
+          }),
+        ),
+        unknownPolicy: "deny",
+      };
+    }
+    if (row.connector.skillMarkdown !== null) {
+      skills.push({
+        connectorId: row.connector.id,
+        connectorSlug: row.connector.slug,
+      });
+    }
     const rowAuthRefs = customConnectorAuthRefsForApis({
       connectorId: row.connector.id,
       connectorRevision: row.connector.revision,
@@ -3584,6 +3685,8 @@ async function buildCustomConnectorRuntimeContext(args: {
     firewalls,
     reservedSecretAliases: compactRecord(reservedSecretAliases),
     authRefs,
+    permissionPolicies: compactRecord(permissionPolicies),
+    skills,
   };
   stats.recordPhaseDuration("assembleFirewalls", finalAssemblyStartedAt);
   stats.flush(args.timing);
@@ -3596,13 +3699,23 @@ async function loadCustomConnectorContext(
     readonly orgId: string;
     readonly userId: string;
     readonly allowedCustomConnectorIds: readonly string[] | undefined;
+    readonly customConnectorGrants:
+      | readonly AgentCustomConnectorGrant[]
+      | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   signal: AbortSignal,
   timing?: ApiDispatchTimingCollector,
 ): Promise<CustomConnectorRuntimeContext> {
   if (args.allowedCustomConnectorIds?.length === 0) {
-    return { firewalls: [], reservedSecretAliases: undefined, authRefs: [] };
+    return {
+      firewalls: [],
+      reservedSecretAliases: undefined,
+      authRefs: [],
+      permissionPolicies: undefined,
+      skills: [],
+    };
   }
 
   const rows = await loadCustomConnectorRuntimeData(db, {
@@ -3623,7 +3736,13 @@ async function loadCustomConnectorContext(
     },
   });
   if (rows.length === 0) {
-    return { firewalls: [], reservedSecretAliases: undefined, authRefs: [] };
+    return {
+      firewalls: [],
+      reservedSecretAliases: undefined,
+      authRefs: [],
+      permissionPolicies: undefined,
+      skills: [],
+    };
   }
   const refreshedRows: CustomConnectorRuntimeDataRows[number][] = [];
   for (const row of rows) {
@@ -3650,6 +3769,8 @@ async function loadCustomConnectorContext(
       return await buildCustomConnectorRuntimeContext({
         rows: refreshedRows,
         featureSwitchContext: args.featureSwitchContext,
+        connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+        grants: args.customConnectorGrants,
         timing,
       });
     },
@@ -4051,7 +4172,7 @@ function applyBuiltinConnectorMetadataPolicies(
   };
 }
 
-async function buildPermissionManifest(args: {
+interface BuildPermissionManifestArgs {
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly permissionPolicies: FirewallPolicies | undefined;
@@ -4059,8 +4180,13 @@ async function buildPermissionManifest(args: {
   readonly connectorVars?: Record<string, string>;
   readonly connectorSlugs?: readonly ConnectorSlug[];
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
+  readonly customConnectorPermissionPolicies?: FirewallPolicies;
   readonly timing?: ApiDispatchTimingCollector;
-}): Promise<PermissionManifest | undefined> {
+}
+
+async function buildPermissionManifest(
+  args: BuildPermissionManifestArgs,
+): Promise<PermissionManifest | undefined> {
   const connectorSlugs =
     args.connectorSlugs ??
     Object.keys(args.permissionPolicies ?? {}).filter((connectorSlug) => {
@@ -4124,7 +4250,10 @@ async function buildPermissionManifest(args: {
       return Promise.resolve(
         applyConnectorPolicies(
           customConnectorFirewalls,
-          args.permissionPolicies,
+          mergeRecords(
+            args.permissionPolicies,
+            args.customConnectorPermissionPolicies,
+          ),
           inlineFirewallEntry,
           (_firewall, permissionNames) => {
             return allAllowPolicyForPermissions(permissionNames);
@@ -6360,7 +6489,9 @@ async function loadRunConnectorContexts(
             userId: args.userId,
             allowedCustomConnectorIds:
               args.connectorScope.allowedCustomConnectorIds,
+            customConnectorGrants: args.connectorScope.customConnectorGrants,
             featureSwitchContext,
+            connectorCatalogSnapshot,
           },
           args.signal,
           timing,
@@ -6462,6 +6593,8 @@ async function buildPreparedPermissionManifest(args: {
       connectorVars: args.storedConnectorMetadataContext.vars,
       connectorSlugs: args.storedConnectorMetadataContext.connectorSlugs,
       customConnectorFirewalls: args.customConnectorContext.firewalls,
+      customConnectorPermissionPolicies:
+        args.customConnectorContext.permissionPolicies,
       timing: args.timing,
     }),
   );
@@ -6478,21 +6611,29 @@ function preparedRunAdditionalVolumes(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
   readonly resolved: ResolvedCompose;
 }): PreparedAdditionalVolumes {
   const bodyAdditionalVolumes = args.body.additionalVolumes;
+  const injectedSkillVolumes = buildInjectedSkillVolumes(
+    {
+      injectSkillVolumes: args.createArgs.injectSkillVolumes,
+      allowedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
+      connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+    },
+    args.framework,
+  );
   return mergeAdditionalVolumes({
-    prepend: buildInjectedSkillVolumes(
-      {
-        injectSkillVolumes: args.createArgs.injectSkillVolumes,
-        allowedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
-        connectorCatalogSnapshot: args.connectorCatalogSnapshot,
-      },
-      args.framework,
-    ),
+    prepend: [
+      ...buildCustomConnectorSkillVolumes(
+        args.customConnectorContext.skills,
+        args.framework,
+      ),
+      ...(injectedSkillVolumes ?? []),
+    ],
     base: prepareAdditionalVolumesWithSource(
       bodyAdditionalVolumes ?? args.resolved.additionalVolumes,
       bodyAdditionalVolumes ? "request_additional_volume" : "unknown",
@@ -6559,6 +6700,7 @@ function connectorScopeFromCreateArgs(
   return {
     allowedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
     allowedCustomConnectorIds: args.connectorScope.allowedCustomConnectorIds,
+    customConnectorGrants: args.connectorScope.customConnectorGrants,
     source,
   };
 }
@@ -6603,6 +6745,7 @@ async function resolveEffectiveConnectorScope(args: {
   return {
     allowedConnectorSlugs: undefined,
     allowedCustomConnectorIds: undefined,
+    customConnectorGrants: undefined,
     source: "legacy_all",
   };
 }
@@ -6919,6 +7062,7 @@ function prepareRunOutputMetadata(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
@@ -6932,6 +7076,7 @@ function prepareRunOutputMetadata(args: {
     createArgs: args.createArgs,
     connectorScope: args.connectorScope,
     connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+    customConnectorContext: args.customConnectorContext,
     framework: args.framework,
     featureSwitchContext: args.featureSwitchContext,
     body: args.body,
@@ -7047,6 +7192,7 @@ function prepareRunContext(input: {
               createArgs: args,
               connectorScope: runtimeContext.connectorScope,
               connectorCatalogSnapshot: runtimeContext.connectorCatalogSnapshot,
+              customConnectorContext: runtimeContext.customConnectorContext,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
               body,

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -53,6 +53,7 @@ type StorageManifestEntryKind = "compose" | "additional" | "artifact";
 export type StorageManifestSource =
   | "system_skill"
   | "connector_skill"
+  | "custom_connector_skill"
   | "workflow_skill"
   | "request_additional_volume"
   | "compose_additional_volume"
@@ -312,6 +313,7 @@ const STORAGE_MANIFEST_COUNT_BUCKET_DIMENSIONS = [
 const STORAGE_MANIFEST_SOURCES = [
   "system_skill",
   "connector_skill",
+  "custom_connector_skill",
   "workflow_skill",
   "request_additional_volume",
   "compose_additional_volume",
@@ -358,6 +360,7 @@ function emptyStorageManifestSourceCounts(): StorageManifestSourceCounts {
   return {
     system_skill: 0,
     connector_skill: 0,
+    custom_connector_skill: 0,
     workflow_skill: 0,
     request_additional_volume: 0,
     compose_additional_volume: 0,

--- a/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
@@ -1,0 +1,80 @@
+import {
+  connectorSlugSchema,
+  type ConnectorSlug,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import type { CustomConnectorPermissionBundleRef } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { ExpandedFirewallConfig } from "@vm0/connectors/firewall-types";
+
+import type { ConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+
+const PERMISSION_BUNDLE_REF_PATTERN = /^builtin:([^@]+)@1$/u;
+
+type FirewallPermissions = NonNullable<
+  ExpandedFirewallConfig["apis"][number]["permissions"]
+>;
+
+export interface CustomConnectorPermissionBundle {
+  readonly ref: CustomConnectorPermissionBundleRef;
+  readonly connectorSlug: ConnectorSlug;
+  readonly permissionNames: ReadonlySet<string>;
+  readonly permissions: FirewallPermissions;
+}
+
+function customConnectorPermissionBundleSlug(
+  ref: string,
+): ConnectorSlug | null {
+  const match = PERMISSION_BUNDLE_REF_PATTERN.exec(ref);
+  const parsed = connectorSlugSchema.safeParse(match?.[1]);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function loadCustomConnectorPermissionBundle(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly ref: CustomConnectorPermissionBundleRef;
+}): Promise<CustomConnectorPermissionBundle | null> {
+  const connectorSlug = customConnectorPermissionBundleSlug(args.ref);
+  if (!connectorSlug || !args.snapshot.serverFirewalls.has(connectorSlug)) {
+    return null;
+  }
+
+  const [permissionIndex, routingMetadata] = await Promise.all([
+    args.snapshot.serverFirewalls.loadPermissionIndex(connectorSlug),
+    args.snapshot.serverFirewalls.loadRoutingMetadata(connectorSlug),
+  ]);
+  if (!permissionIndex || !routingMetadata) {
+    return null;
+  }
+
+  const rulesByPermission = new Map<string, Set<string>>(
+    [...permissionIndex.permissionNames].map((permissionName) => {
+      return [permissionName, new Set<string>()];
+    }),
+  );
+  for (const api of routingMetadata.apis) {
+    for (const route of api.routes) {
+      rulesByPermission.get(route.permissionName)?.add(route.rule);
+    }
+  }
+
+  const permissionNames = new Set(
+    [...permissionIndex.permissionNames].sort((left, right) => {
+      return left.localeCompare(right);
+    }),
+  );
+  const permissions: FirewallPermissions = [...permissionNames].map((name) => {
+    const description = permissionIndex.permissionDescription(name);
+    return {
+      name,
+      ...(description ? { description } : {}),
+      rules: [...(rulesByPermission.get(name) ?? [])].sort((left, right) => {
+        return left.localeCompare(right);
+      }),
+    };
+  });
+  return {
+    ref: args.ref,
+    connectorSlug,
+    permissionNames,
+    permissions,
+  };
+}

--- a/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
@@ -1,0 +1,87 @@
+import { command } from "ccstate";
+import {
+  getCustomConnectorSkillName,
+  getCustomConnectorSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { synthesizeSkillMd } from "@vm0/core/zero-workflow-skill";
+import { storages } from "@vm0/db/schema/storage";
+import { and, eq } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { writeDb$ } from "../external/db";
+import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
+import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
+import { SKILL_FILENAME } from "./zero-workflow-volume.service";
+
+export const syncCustomConnectorSkillVolume$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly connectorId: string;
+      readonly connectorSlug: string;
+      readonly displayName: string;
+      readonly skillMarkdown: string | null;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const storageName = getCustomConnectorSkillStorageName(args.connectorId);
+    if (args.skillMarkdown !== null) {
+      await set(
+        uploadVolumeServerSide$,
+        {
+          orgId: args.orgId,
+          storageName,
+          files: [
+            {
+              path: SKILL_FILENAME,
+              content: synthesizeSkillMd({
+                name: getCustomConnectorSkillName(
+                  args.connectorSlug,
+                  args.connectorId,
+                ),
+                description: args.displayName,
+                instruction: args.skillMarkdown,
+              }),
+            },
+          ],
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      return;
+    }
+
+    const writeDb = set(writeDb$);
+    const [storage] = await writeDb
+      .delete(storages)
+      .where(
+        and(
+          eq(storages.orgId, args.orgId),
+          eq(storages.userId, VOLUME_ORG_USER_ID),
+          eq(storages.name, storageName),
+        ),
+      )
+      .returning({ s3Prefix: storages.s3Prefix });
+    signal.throwIfAborted();
+    if (!storage) {
+      return;
+    }
+
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const objects = await get(
+      listS3ObjectsUnderPrefix(bucket, storage.s3Prefix),
+    );
+    signal.throwIfAborted();
+    await get(
+      deleteS3Objects(
+        bucket,
+        objects.map((object) => {
+          return object.key;
+        }),
+      ),
+    );
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { connectorSlugCanonicalInsertUserConnectors } from "@vm0/db/compat/connector-slug-canonical-insert";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import {
@@ -18,6 +19,11 @@ import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import type { Db } from "../external/db";
+import {
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 
 type UpdateUserConnectorsResult =
   | {
@@ -32,6 +38,7 @@ type UpdateUserCustomConnectorsResult =
   | {
       readonly status: "updated";
       readonly enabledIds: readonly string[];
+      readonly grants: readonly AgentCustomConnectorGrant[];
     }
   | { readonly status: "agentNotFound" }
   | {
@@ -41,9 +48,18 @@ type UpdateUserCustomConnectorsResult =
   | {
       readonly status: "customConnectorsNotConfigured";
       readonly unconfiguredIds: readonly string[];
+    }
+  | {
+      readonly status: "customConnectorPermissionSelectionRequired";
+      readonly connectorIds: readonly string[];
+    }
+  | {
+      readonly status: "invalidCustomConnectorPermissions";
+      readonly message: string;
     };
 
 type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 type AddUserCustomConnectorResult =
   | { readonly status: "added" }
@@ -55,6 +71,14 @@ type AddUserCustomConnectorResult =
   | {
       readonly status: "customConnectorsNotConfigured";
       readonly unconfiguredIds: readonly string[];
+    }
+  | {
+      readonly status: "customConnectorPermissionSelectionRequired";
+      readonly connectorIds: readonly string[];
+    }
+  | {
+      readonly status: "invalidCustomConnectorPermissions";
+      readonly message: string;
     };
 
 const LEGACY_SECRET_KEY = "secret";
@@ -346,7 +370,15 @@ interface LockedCustomConnectorRow {
   readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
   readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
   readonly authMode: OrgCustomConnectorAuthMode;
+  readonly permissionBundleRef: string | null;
   readonly revision: number;
+}
+
+interface LockedCustomConnectorValidation {
+  readonly missingIds: readonly string[];
+  readonly unconfiguredIds: readonly string[];
+  readonly revisions: ReadonlyMap<string, number>;
+  readonly permissionBundleRefs: ReadonlyMap<string, string | null>;
 }
 
 async function loadCustomConnectorOAuthConnectionIds(
@@ -438,13 +470,14 @@ async function lockCustomConnectorsForReplace(
     readonly userId: string;
     readonly enabledIds: readonly string[];
   },
-): Promise<{
-  readonly missingIds: readonly string[];
-  readonly unconfiguredIds: readonly string[];
-  readonly revisions: ReadonlyMap<string, number>;
-}> {
+): Promise<LockedCustomConnectorValidation> {
   if (args.enabledIds.length === 0) {
-    return { missingIds: [], unconfiguredIds: [], revisions: new Map() };
+    return {
+      missingIds: [],
+      unconfiguredIds: [],
+      revisions: new Map(),
+      permissionBundleRefs: new Map(),
+    };
   }
 
   const sortedIds = [...args.enabledIds].sort();
@@ -460,6 +493,7 @@ async function lockCustomConnectorsForReplace(
         headerInjections: orgCustomConnectors.headerInjections,
         queryInjections: orgCustomConnectors.queryInjections,
         authMode: orgCustomConnectors.authMode,
+        permissionBundleRef: orgCustomConnectors.permissionBundleRef,
         revision: orgCustomConnectors.revision,
       })
       .from(orgCustomConnectors)
@@ -486,7 +520,12 @@ async function lockCustomConnectorsForReplace(
     return !lockedIds.has(id);
   });
   if (missingIds.length > 0) {
-    return { missingIds, unconfiguredIds: [], revisions: new Map() };
+    return {
+      missingIds,
+      unconfiguredIds: [],
+      revisions: new Map(),
+      permissionBundleRefs: new Map(),
+    };
   }
 
   const connectorIds = lockedRows.map((row) => {
@@ -519,6 +558,11 @@ async function lockCustomConnectorsForReplace(
     revisions: new Map(
       lockedRows.map((row) => {
         return [row.id, row.revision] as const;
+      }),
+    ),
+    permissionBundleRefs: new Map(
+      lockedRows.map((row) => {
+        return [row.id, row.permissionBundleRef] as const;
       }),
     ),
   };
@@ -605,6 +649,278 @@ export async function updateUserConnectors(
   });
 }
 
+interface NormalizedCustomConnectorGrantRequest {
+  readonly enabledIds: readonly string[];
+  readonly grantByConnectorId: ReadonlyMap<string, readonly string[]>;
+}
+
+type InvalidCustomConnectorPermissionsResult = Extract<
+  UpdateUserCustomConnectorsResult,
+  { readonly status: "invalidCustomConnectorPermissions" }
+>;
+
+type PermissionSelectionError = Extract<
+  UpdateUserCustomConnectorsResult,
+  {
+    readonly status:
+      | "invalidCustomConnectorPermissions"
+      | "customConnectorPermissionSelectionRequired";
+  }
+>;
+
+function normalizeCustomConnectorGrantRequest(args: {
+  readonly enabledIds: readonly string[];
+  readonly grants?: readonly AgentCustomConnectorGrant[];
+}):
+  | NormalizedCustomConnectorGrantRequest
+  | InvalidCustomConnectorPermissionsResult {
+  const grantByConnectorId = new Map<string, readonly string[]>();
+  for (const grant of args.grants ?? []) {
+    if (grantByConnectorId.has(grant.customConnectorId)) {
+      return {
+        status: "invalidCustomConnectorPermissions",
+        message: `Duplicate custom connector grant: ${grant.customConnectorId}`,
+      };
+    }
+    const uniquePermissionNames = new Set(grant.permissionNames);
+    if (uniquePermissionNames.size !== grant.permissionNames.length) {
+      return {
+        status: "invalidCustomConnectorPermissions",
+        message: `Duplicate permission names for custom connector ${grant.customConnectorId}`,
+      };
+    }
+    grantByConnectorId.set(grant.customConnectorId, [...uniquePermissionNames]);
+  }
+  const enabledIds =
+    args.grants !== undefined
+      ? [...grantByConnectorId.keys()]
+      : Array.from(new Set(args.enabledIds));
+  return { enabledIds, grantByConnectorId };
+}
+
+async function validateExplicitPermissionNames(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorId: string;
+  readonly permissionNames: readonly string[];
+  readonly permissionBundleRef: string | null;
+}): Promise<
+  | { readonly ok: true; readonly permissionNames: readonly string[] }
+  | {
+      readonly ok: false;
+      readonly error: InvalidCustomConnectorPermissionsResult;
+    }
+> {
+  if (args.permissionBundleRef === null) {
+    return args.permissionNames.length === 0
+      ? { ok: true, permissionNames: [] }
+      : {
+          ok: false,
+          error: {
+            status: "invalidCustomConnectorPermissions",
+            message: `Custom connector ${args.connectorId} has no permission bundle`,
+          },
+        };
+  }
+
+  const bundle = await loadCustomConnectorPermissionBundle({
+    snapshot: args.snapshot,
+    ref: args.permissionBundleRef,
+  });
+  if (!bundle) {
+    return {
+      ok: false,
+      error: {
+        status: "invalidCustomConnectorPermissions",
+        message: `Permission bundle is unavailable for custom connector ${args.connectorId}`,
+      },
+    };
+  }
+  const invalidPermissionNames = args.permissionNames.filter(
+    (permissionName) => {
+      return !bundle.permissionNames.has(permissionName);
+    },
+  );
+  return invalidPermissionNames.length === 0
+    ? { ok: true, permissionNames: [...args.permissionNames] }
+    : {
+        ok: false,
+        error: {
+          status: "invalidCustomConnectorPermissions",
+          message: `Unknown permission names for custom connector ${args.connectorId}: ${invalidPermissionNames.join(", ")}`,
+        },
+      };
+}
+
+async function validateCustomConnectorPermissionSelection(args: {
+  readonly enabledIds: readonly string[];
+  readonly explicitGrants: boolean;
+  readonly grantByConnectorId: ReadonlyMap<string, readonly string[]>;
+  readonly permissionBundleRefs: ReadonlyMap<string, string | null>;
+  readonly snapshot: ConnectorRuntimeSnapshot | null;
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly permissionNamesByConnectorId: ReadonlyMap<
+        string,
+        readonly string[]
+      >;
+    }
+  | { readonly ok: false; readonly error: PermissionSelectionError }
+> {
+  if (!args.explicitGrants) {
+    const connectorIds = args.enabledIds.filter((connectorId) => {
+      return (args.permissionBundleRefs.get(connectorId) ?? null) !== null;
+    });
+    return connectorIds.length === 0
+      ? {
+          ok: true,
+          permissionNamesByConnectorId: new Map(
+            args.enabledIds.map((connectorId) => {
+              return [connectorId, []] as const;
+            }),
+          ),
+        }
+      : {
+          ok: false,
+          error: {
+            status: "customConnectorPermissionSelectionRequired",
+            connectorIds,
+          },
+        };
+  }
+  if (!args.snapshot) {
+    throw new Error("Expected connector catalog snapshot");
+  }
+
+  const permissionNamesByConnectorId = new Map<string, readonly string[]>();
+  for (const connectorId of args.enabledIds) {
+    const result = await validateExplicitPermissionNames({
+      snapshot: args.snapshot,
+      connectorId,
+      permissionNames: args.grantByConnectorId.get(connectorId) ?? [],
+      permissionBundleRef: args.permissionBundleRefs.get(connectorId) ?? null,
+    });
+    if (!result.ok) {
+      return result;
+    }
+    permissionNamesByConnectorId.set(connectorId, result.permissionNames);
+  }
+  return { ok: true, permissionNamesByConnectorId };
+}
+
+async function persistUserCustomConnectorUpdate(
+  tx: DbTransaction,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentId: string;
+    readonly enabledIds: readonly string[];
+    readonly operation: UserCustomConnectorUpdateOperation;
+    readonly connectorRevisions: ReadonlyMap<string, number>;
+    readonly permissionNamesByConnectorId: ReadonlyMap<
+      string,
+      readonly string[]
+    >;
+  },
+): Promise<Extract<UpdateUserCustomConnectorsResult, { status: "updated" }>> {
+  const connectorScope = and(
+    eq(userCustomConnectors.orgId, args.orgId),
+    eq(userCustomConnectors.userId, args.userId),
+    eq(userCustomConnectors.agentId, args.agentId),
+  );
+  if (args.operation === "replace") {
+    await tx.delete(userCustomConnectors).where(connectorScope);
+  } else if (args.operation === "remove" && args.enabledIds.length > 0) {
+    await tx
+      .delete(userCustomConnectors)
+      .where(
+        and(
+          connectorScope,
+          inArray(userCustomConnectors.customConnectorId, args.enabledIds),
+        ),
+      );
+  }
+
+  if (args.operation !== "remove" && args.enabledIds.length > 0) {
+    await tx
+      .insert(userCustomConnectors)
+      .values(
+        args.enabledIds.map((customConnectorId) => {
+          return {
+            orgId: args.orgId,
+            userId: args.userId,
+            agentId: args.agentId,
+            customConnectorId,
+            connectorRevision:
+              args.connectorRevisions.get(customConnectorId) ?? 1,
+            permissionNames: [
+              ...(args.permissionNamesByConnectorId.get(customConnectorId) ??
+                []),
+            ],
+          };
+        }),
+      )
+      .onConflictDoUpdate({
+        target: [
+          userCustomConnectors.orgId,
+          userCustomConnectors.userId,
+          userCustomConnectors.agentId,
+          userCustomConnectors.customConnectorId,
+        ],
+        set: {
+          connectorRevision: sql`excluded.connector_revision`,
+          permissionNames: sql`excluded.permission_names`,
+        },
+      });
+  }
+
+  if (args.operation === "replace") {
+    return {
+      status: "updated",
+      enabledIds: args.enabledIds,
+      grants: args.enabledIds.map((customConnectorId) => {
+        return {
+          customConnectorId,
+          permissionNames: [
+            ...(args.permissionNamesByConnectorId.get(customConnectorId) ?? []),
+          ],
+        };
+      }),
+    };
+  }
+  const rows = await tx
+    .select({
+      customConnectorId: userCustomConnectors.customConnectorId,
+      permissionNames: userCustomConnectors.permissionNames,
+    })
+    .from(userCustomConnectors)
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, userCustomConnectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, userCustomConnectors.orgId),
+        eq(
+          orgCustomConnectors.revision,
+          userCustomConnectors.connectorRevision,
+        ),
+      ),
+    )
+    .where(and(connectorScope, eq(orgCustomConnectors.enabled, true)))
+    .orderBy(userCustomConnectors.customConnectorId);
+  return {
+    status: "updated",
+    enabledIds: rows.map((row) => {
+      return row.customConnectorId;
+    }),
+    grants: rows.map((row) => {
+      return {
+        customConnectorId: row.customConnectorId,
+        permissionNames: [...row.permissionNames],
+      };
+    }),
+  };
+}
+
 export async function updateUserCustomConnectors(
   db: Db,
   args: {
@@ -612,11 +928,20 @@ export async function updateUserCustomConnectors(
     readonly userId: string;
     readonly agentId: string;
     readonly enabledIds: readonly string[];
+    readonly grants?: readonly AgentCustomConnectorGrant[];
     readonly operation?: UserCustomConnectorUpdateOperation;
   },
 ): Promise<UpdateUserCustomConnectorsResult> {
-  const enabledIds = Array.from(new Set(args.enabledIds));
+  const normalized = normalizeCustomConnectorGrantRequest(args);
+  if ("status" in normalized) {
+    return normalized;
+  }
+  const { enabledIds, grantByConnectorId } = normalized;
   const operation = args.operation ?? "replace";
+  const connectorCatalogSnapshot =
+    args.grants !== undefined && operation !== "remove"
+      ? await loadConnectorRuntimeSnapshot(db)
+      : null;
 
   return await db.transaction(async (tx) => {
     const composeLocked = await lockAgentComposeForConnectorReplace(tx, args);
@@ -629,88 +954,51 @@ export async function updateUserCustomConnectors(
       return { status: "agentNotFound" };
     }
 
-    let connectorRevisions: ReadonlyMap<string, number> = new Map();
-    if (operation !== "remove") {
-      const validation = await lockCustomConnectorsForReplace(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
+    if (operation === "remove") {
+      return await persistUserCustomConnectorUpdate(tx, {
+        ...args,
         enabledIds,
+        operation,
+        connectorRevisions: new Map(),
+        permissionNamesByConnectorId: new Map(),
       });
-      if (validation.missingIds.length > 0) {
-        return {
-          status: "customConnectorsNotFound",
-          missingIds: validation.missingIds,
-        };
-      }
-      if (validation.unconfiguredIds.length > 0) {
-        return {
-          status: "customConnectorsNotConfigured",
-          unconfiguredIds: validation.unconfiguredIds,
-        };
-      }
-      connectorRevisions = validation.revisions;
     }
-
-    const connectorScope = and(
-      eq(userCustomConnectors.orgId, args.orgId),
-      eq(userCustomConnectors.userId, args.userId),
-      eq(userCustomConnectors.agentId, args.agentId),
-    );
-
-    if (operation === "replace") {
-      await tx.delete(userCustomConnectors).where(connectorScope);
-    } else if (operation === "remove" && enabledIds.length > 0) {
-      await tx
-        .delete(userCustomConnectors)
-        .where(
-          and(
-            connectorScope,
-            inArray(userCustomConnectors.customConnectorId, enabledIds),
-          ),
-        );
+    const validation = await lockCustomConnectorsForReplace(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      enabledIds,
+    });
+    if (validation.missingIds.length > 0) {
+      return {
+        status: "customConnectorsNotFound",
+        missingIds: validation.missingIds,
+      };
     }
-
-    if (operation !== "remove" && enabledIds.length > 0) {
-      await tx
-        .insert(userCustomConnectors)
-        .values(
-          enabledIds.map((customConnectorId) => {
-            return {
-              orgId: args.orgId,
-              userId: args.userId,
-              agentId: args.agentId,
-              customConnectorId,
-              connectorRevision: connectorRevisions.get(customConnectorId) ?? 1,
-            };
-          }),
-        )
-        .onConflictDoUpdate({
-          target: [
-            userCustomConnectors.orgId,
-            userCustomConnectors.userId,
-            userCustomConnectors.agentId,
-            userCustomConnectors.customConnectorId,
-          ],
-          set: {
-            connectorRevision: sql`excluded.connector_revision`,
-          },
-        });
+    if (validation.unconfiguredIds.length > 0) {
+      return {
+        status: "customConnectorsNotConfigured",
+        unconfiguredIds: validation.unconfiguredIds,
+      };
     }
-
-    if (operation === "replace") {
-      return { status: "updated", enabledIds };
+    const permissionSelection =
+      await validateCustomConnectorPermissionSelection({
+        enabledIds,
+        explicitGrants: args.grants !== undefined,
+        grantByConnectorId,
+        permissionBundleRefs: validation.permissionBundleRefs,
+        snapshot: connectorCatalogSnapshot,
+      });
+    if (!permissionSelection.ok) {
+      return permissionSelection.error;
     }
-
-    const rows = await tx
-      .select({ customConnectorId: userCustomConnectors.customConnectorId })
-      .from(userCustomConnectors)
-      .where(connectorScope);
-    return {
-      status: "updated",
-      enabledIds: rows.map((row) => {
-        return row.customConnectorId;
-      }),
-    };
+    return await persistUserCustomConnectorUpdate(tx, {
+      ...args,
+      enabledIds,
+      operation,
+      connectorRevisions: validation.revisions,
+      permissionNamesByConnectorId:
+        permissionSelection.permissionNamesByConnectorId,
+    });
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -5,6 +5,7 @@ import {
   connectorSlugSchema,
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
@@ -187,39 +188,48 @@ export function zeroAgentEnabledConnectorSlugs(args: {
   });
 }
 
-export function zeroAgentEnabledCustomConnectorIds(args: {
+export function zeroAgentCustomConnectorGrants(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
-}): Computed<Promise<readonly string[]>> {
-  return computed(async (get): Promise<readonly string[]> => {
-    const rows = await get(db$)
-      .select({ customConnectorId: userCustomConnectors.customConnectorId })
-      .from(userCustomConnectors)
-      .innerJoin(
-        orgCustomConnectors,
-        and(
-          eq(orgCustomConnectors.id, userCustomConnectors.customConnectorId),
-          eq(orgCustomConnectors.orgId, userCustomConnectors.orgId),
-          eq(
-            orgCustomConnectors.revision,
-            userCustomConnectors.connectorRevision,
+}): Computed<Promise<readonly AgentCustomConnectorGrant[]>> {
+  return computed(
+    async (get): Promise<readonly AgentCustomConnectorGrant[]> => {
+      const rows = await get(db$)
+        .select({
+          customConnectorId: userCustomConnectors.customConnectorId,
+          permissionNames: userCustomConnectors.permissionNames,
+        })
+        .from(userCustomConnectors)
+        .innerJoin(
+          orgCustomConnectors,
+          and(
+            eq(orgCustomConnectors.id, userCustomConnectors.customConnectorId),
+            eq(orgCustomConnectors.orgId, userCustomConnectors.orgId),
+            eq(
+              orgCustomConnectors.revision,
+              userCustomConnectors.connectorRevision,
+            ),
           ),
-        ),
-      )
-      .where(
-        and(
-          eq(userCustomConnectors.orgId, args.orgId),
-          eq(userCustomConnectors.userId, args.userId),
-          eq(userCustomConnectors.agentId, args.agentId),
-          eq(orgCustomConnectors.enabled, true),
-        ),
-      );
+        )
+        .where(
+          and(
+            eq(userCustomConnectors.orgId, args.orgId),
+            eq(userCustomConnectors.userId, args.userId),
+            eq(userCustomConnectors.agentId, args.agentId),
+            eq(orgCustomConnectors.enabled, true),
+          ),
+        )
+        .orderBy(asc(userCustomConnectors.customConnectorId));
 
-    return rows.map((row) => {
-      return row.customConnectorId;
-    });
-  });
+      return rows.map((row) => {
+        return {
+          customConnectorId: row.customConnectorId,
+          permissionNames: [...row.permissionNames],
+        };
+      });
+    },
+  );
 }
 
 export function zeroTeam(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1,5 +1,6 @@
 import { command, computed, type Computed } from "ccstate";
 import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type {
   CreateCustomConnectorBody,
@@ -9,6 +10,7 @@ import type {
   CustomConnectorHeaderInjection,
   CustomConnectorOAuthConfig,
   CustomConnectorOAuthConfigInput,
+  CustomConnectorPermissionBundleRef,
   CustomConnectorProposal,
   CustomConnectorQueryInjection,
   CustomConnectorResponse,
@@ -42,6 +44,9 @@ import {
 } from "./crypto.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
+import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
 
 const L = logger("CustomConnectorService");
 
@@ -96,6 +101,8 @@ export interface CustomConnectorRow {
   readonly queryInjections: readonly CustomConnectorQueryInjection[];
   readonly authMode: CustomConnectorAuthMode;
   readonly oauthConfig: CustomConnectorOAuthConfigRow | null;
+  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
+  readonly skillMarkdown: string | null;
   readonly revision: number;
   readonly createdBy: string;
   readonly createdAt: Date;
@@ -109,6 +116,8 @@ interface DefinitionInput {
   readonly headerInjections: readonly CustomConnectorHeaderInjection[];
   readonly queryInjections: readonly CustomConnectorQueryInjection[];
   readonly authMode?: CustomConnectorAuthMode;
+  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
+  readonly skillMarkdown: string | null;
   readonly slug?: string;
 }
 
@@ -119,6 +128,8 @@ interface ValidatedDefinition {
   readonly headerInjections: readonly CustomConnectorHeaderInjection[];
   readonly queryInjections: readonly CustomConnectorQueryInjection[];
   readonly authMode: CustomConnectorAuthMode;
+  readonly permissionBundleRef: CustomConnectorPermissionBundleRef | null;
+  readonly skillMarkdown: string | null;
   readonly slug: string | undefined;
 }
 
@@ -331,7 +342,7 @@ function oauthConfigsEqual(
 }
 
 function jsonValuesEqual(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+  return isDeepStrictEqual(left, right);
 }
 
 function grantConfigurationChanged(args: {
@@ -354,6 +365,7 @@ function grantConfigurationChanged(args: {
       args.existing.queryInjections,
       args.definition.queryInjections,
     ) ||
+    args.existing.permissionBundleRef !== args.definition.permissionBundleRef ||
     !oauthConfigsEqual(args.existing.oauthConfig, args.nextOAuthConfig)
   );
 }
@@ -464,6 +476,8 @@ export function serialiseCustomConnector(args: {
     ...(args.row.oauthConfig
       ? { oauthConfig: serialiseOAuthConfig(args.row.oauthConfig) }
       : {}),
+    permissionBundleRef: args.row.permissionBundleRef,
+    skillMarkdown: args.row.skillMarkdown,
     revision: args.row.revision,
     connected,
     missingRequiredFields: [...responseMissingRequiredFields],
@@ -1050,8 +1064,29 @@ function validateDefinition(
     headerInjections,
     queryInjections,
     authMode,
+    permissionBundleRef: input.permissionBundleRef,
+    skillMarkdown: input.skillMarkdown,
     slug,
   };
+}
+
+async function validatePermissionBundleRef(
+  db: ReadonlyDb,
+  permissionBundleRef: CustomConnectorPermissionBundleRef | null,
+): Promise<BadRequestResponse | null> {
+  if (permissionBundleRef === null) {
+    return null;
+  }
+  const snapshot = await loadConnectorRuntimeSnapshot(db);
+  const bundle = await loadCustomConnectorPermissionBundle({
+    snapshot,
+    ref: permissionBundleRef,
+  });
+  return bundle
+    ? null
+    : badRequestMessage(
+        `Unknown custom connector permission bundle: ${permissionBundleRef}`,
+      );
 }
 
 function definitionFromCreateInput(
@@ -1072,6 +1107,8 @@ function definitionFromCreateInput(
       headerInjections: input.headerInjections ?? [],
       queryInjections: input.queryInjections ?? [],
       authMode: input.authMode,
+      permissionBundleRef: input.permissionBundleRef ?? null,
+      skillMarkdown: input.skillMarkdown ?? null,
       slug: input.slug,
     };
   }
@@ -1097,13 +1134,15 @@ function definitionFromCreateInput(
     ],
     queryInjections: [],
     authMode: "manual",
+    permissionBundleRef: input.permissionBundleRef ?? null,
+    skillMarkdown: input.skillMarkdown ?? null,
     slug: input.slug,
   };
 }
 
 function definitionFromUpdateInput(
   input: UpdateCustomConnectorBody,
-  authMode: CustomConnectorAuthMode = "manual",
+  existing?: CustomConnectorRow,
 ): DefinitionInput {
   return {
     displayName: input.displayName,
@@ -1111,7 +1150,15 @@ function definitionFromUpdateInput(
     fields: input.fields,
     headerInjections: input.headerInjections,
     queryInjections: input.queryInjections,
-    authMode: input.authMode ?? authMode,
+    authMode: input.authMode ?? existing?.authMode ?? "manual",
+    permissionBundleRef:
+      input.permissionBundleRef !== undefined
+        ? input.permissionBundleRef
+        : (existing?.permissionBundleRef ?? null),
+    skillMarkdown:
+      input.skillMarkdown !== undefined
+        ? input.skillMarkdown
+        : (existing?.skillMarkdown ?? null),
   };
 }
 
@@ -1305,6 +1352,14 @@ export const createCustomConnector$ = command(
     if (isBadRequest(v)) {
       return v;
     }
+    const invalidPermissionBundle = await validatePermissionBundleRef(
+      writeDb,
+      v.permissionBundleRef,
+    );
+    signal.throwIfAborted();
+    if (invalidPermissionBundle) {
+      return invalidPermissionBundle;
+    }
     const oauthConfigUpdate = validateOAuthConfigUpdate({
       authMode: v.authMode,
       input: args.input.oauthConfig,
@@ -1356,6 +1411,8 @@ export const createCustomConnector$ = command(
           headerInjections: [...v.headerInjections],
           queryInjections: [...v.queryInjections],
           authMode: v.authMode,
+          permissionBundleRef: v.permissionBundleRef,
+          skillMarkdown: v.skillMarkdown,
           createdBy: args.userId,
         })
         .returning();
@@ -1384,7 +1441,25 @@ export const createCustomConnector$ = command(
       return created;
     }
 
-    return normaliseCustomConnectorRow(created.row, created.oauthConfig);
+    const result = normaliseCustomConnectorRow(
+      created.row,
+      created.oauthConfig,
+    );
+    if (result.skillMarkdown !== null) {
+      await set(
+        syncCustomConnectorSkillVolume$,
+        {
+          orgId: result.orgId,
+          connectorId: result.id,
+          connectorSlug: result.slug,
+          displayName: result.displayName,
+          skillMarkdown: result.skillMarkdown,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+    return result;
   },
 );
 
@@ -1484,6 +1559,8 @@ async function persistCustomConnectorUpdate(
         headerInjections: [...args.definition.headerInjections],
         queryInjections: [...args.definition.queryInjections],
         authMode: args.definition.authMode,
+        permissionBundleRef: args.definition.permissionBundleRef,
+        skillMarkdown: args.definition.skillMarkdown,
         revision: args.grantConfigurationChanged
           ? args.existing.revision + 1
           : args.existing.revision,
@@ -1566,10 +1643,18 @@ export const updateCustomConnectorDefinition$ = command(
       return notFound("Custom connector not found");
     }
     const v = validateDefinition(
-      definitionFromUpdateInput(args.input, existingConnector.authMode),
+      definitionFromUpdateInput(args.input, existingConnector),
     );
     if (isBadRequest(v)) {
       return v;
+    }
+    const invalidPermissionBundle = await validatePermissionBundleRef(
+      writeDb,
+      v.permissionBundleRef,
+    );
+    signal.throwIfAborted();
+    if (invalidPermissionBundle) {
+      return invalidPermissionBundle;
     }
     const oauthConfigUpdate = validateOAuthConfigUpdate({
       authMode: v.authMode,
@@ -1625,7 +1710,28 @@ export const updateCustomConnectorDefinition$ = command(
     if (!result) {
       return notFound("Custom connector not found");
     }
-    return normaliseCustomConnectorRow(result.row, result.oauthConfig);
+    const normalized = normaliseCustomConnectorRow(
+      result.row,
+      result.oauthConfig,
+    );
+    if (
+      normalized.skillMarkdown !== null ||
+      args.input.skillMarkdown !== undefined
+    ) {
+      await set(
+        syncCustomConnectorSkillVolume$,
+        {
+          orgId: normalized.orgId,
+          connectorId: normalized.id,
+          connectorSlug: normalized.slug,
+          displayName: normalized.displayName,
+          skillMarkdown: normalized.skillMarkdown,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+    return normalized;
   },
 );
 
@@ -1670,6 +1776,18 @@ export const deleteCustomConnector$ = command(
     if (!deleted) {
       return notFound("Custom connector not found");
     }
+    await set(
+      syncCustomConnectorSkillVolume$,
+      {
+        orgId: args.orgId,
+        connectorId: args.id,
+        connectorSlug: "_deleted",
+        displayName: "Deleted custom connector",
+        skillMarkdown: null,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
     L.debug("custom connector deleted", { orgId: args.orgId, id: args.id });
     return undefined;
   },
@@ -2443,7 +2561,11 @@ const authorizeProposalAgent$ = command(
     if (added.status === "customConnectorsNotFound") {
       return notFound("Custom connector not found");
     }
-    if (added.status === "customConnectorsNotConfigured") {
+    if (
+      added.status === "customConnectorsNotConfigured" ||
+      added.status === "customConnectorPermissionSelectionRequired" ||
+      added.status === "invalidCustomConnectorPermissions"
+    ) {
       return undefined;
     }
     return args.agentId;

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -58,6 +58,9 @@ const bootstrapMetadataRowKindDecoder = zodEnumDriverValueDecoder(
 const bootstrapMetadataSwitchesDecoder = zodDriverValueDecoder(
   z.record(z.string(), z.boolean()),
 );
+const customConnectorPermissionNamesDecoder = zodDriverValueDecoder(
+  z.array(z.string()),
+);
 const permissionGrantActionDecoder = zodEnumDriverValueDecoder(
   userPermissionGrantActionSchema,
 );
@@ -68,6 +71,8 @@ const nullableBootstrapMetadataSwitchesDecoder = nullableDriverValueDecoder(
 const nullablePermissionGrantActionDecoder = nullableDriverValueDecoder(
   permissionGrantActionDecoder,
 );
+const nullableCustomConnectorPermissionNamesDecoder =
+  nullableDriverValueDecoder(customConnectorPermissionNamesDecoder);
 
 interface BootstrapMetadataQueryRow {
   readonly kind: BootstrapMetadataRowKind;
@@ -79,6 +84,7 @@ interface BootstrapMetadataQueryRow {
   readonly switches: Record<string, boolean> | null;
   readonly detail: string | null;
   readonly action: FirewallPermissionGrantAction | null;
+  readonly permissionNames: readonly string[] | null;
 }
 
 export interface UserInfo {
@@ -136,6 +142,9 @@ function emptyBootstrapMetadataFields() {
     action: sql`NULL::text`
       .mapWith(nullablePermissionGrantActionDecoder)
       .as("action"),
+    permissionNames: sql`NULL::text[]`
+      .mapWith(nullableCustomConnectorPermissionNamesDecoder)
+      .as("permission_names"),
   };
 }
 
@@ -171,6 +180,9 @@ function zeroRunCustomConnectorMetadataQuery(
       id: sql`${userCustomConnectors.customConnectorId}::text`
         .mapWith(nullableTextDecoder)
         .as("id"),
+      permissionNames: sql`${userCustomConnectors.permissionNames}`
+        .mapWith(nullableCustomConnectorPermissionNamesDecoder)
+        .as("permission_names"),
     })
     .from(userCustomConnectors)
     .innerJoin(
@@ -381,12 +393,15 @@ export function materializeZeroRunBootstrapContext(
         break;
       }
       case "custom_connector": {
-        if (row.id === null) {
+        if (row.id === null || row.permissionNames === null) {
           throw new Error(
             "Invalid Zero bootstrap metadata custom connector row",
           );
         }
-        customConnectorRows.push({ customConnectorId: row.id });
+        customConnectorRows.push({
+          customConnectorId: row.id,
+          permissionNames: row.permissionNames,
+        });
         break;
       }
       case "permission_grant": {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -5,6 +5,7 @@ import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunCreateBodySchema } from "@vm0/api-contracts/contracts/zero-runs";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
@@ -898,6 +899,7 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants: readonly AgentCustomConnectorGrant[];
   readonly timing: ApiDispatchTimingCollector;
   readonly threadSessionResolution?: ChatThreadSessionResolution;
   readonly cloudBrowserEnabled: boolean | undefined;
@@ -946,6 +948,7 @@ function buildZeroCreateAgentRunArgs(args: {
     connectorScope: {
       allowedConnectorSlugs: args.allowedConnectorSlugs,
       allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+      customConnectorGrants: args.customConnectorGrants,
       source: "zero_agent",
     },
     validateEnvironmentReferences: false,
@@ -979,6 +982,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants: readonly AgentCustomConnectorGrant[];
   readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
   const command = args.command;
@@ -1011,6 +1015,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
     connectorScope: {
       allowedConnectorSlugs: args.allowedConnectorSlugs,
       allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+      customConnectorGrants: args.customConnectorGrants,
       source: "zero_agent",
     },
     validateEnvironmentReferences: false,
@@ -1029,6 +1034,7 @@ interface ZeroRunAfterPreCreateBase {
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants: readonly AgentCustomConnectorGrant[];
   readonly timing: ApiDispatchTimingCollector;
   readonly cloudBrowserEnabled: boolean | undefined;
 }
@@ -1179,6 +1185,7 @@ export const createZeroIntegrationRun$ = command(
       featureSwitchContext,
       allowedConnectorSlugs,
       allowedCustomConnectorIds,
+      customConnectorGrants,
       workflows,
       runPermissionPolicies,
       connectorCatalogSnapshot,
@@ -1208,6 +1215,7 @@ export const createZeroIntegrationRun$ = command(
         workflows,
         allowedConnectorSlugs,
         allowedCustomConnectorIds,
+        customConnectorGrants,
         timing,
         cloudBrowserEnabled: undefined,
       },
@@ -1269,6 +1277,7 @@ const createZeroRunInternal$ = command(
       featureSwitchContext,
       allowedConnectorSlugs,
       allowedCustomConnectorIds,
+      customConnectorGrants,
       workflows,
       runPermissionPolicies,
       connectorCatalogSnapshot,
@@ -1306,6 +1315,7 @@ const createZeroRunInternal$ = command(
         workflows,
         allowedConnectorSlugs,
         allowedCustomConnectorIds,
+        customConnectorGrants,
         timing,
         cloudBrowserEnabled,
       },

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -134,9 +134,15 @@ export const apiAgentsHandlers = [
   mockApi(
     zeroAgentCustomConnectorsContract.update,
     ({ body, params, respond }) => {
+      const requestedIds =
+        "enabledIds" in body
+          ? body.enabledIds
+          : body.grants.map((grant) => {
+              return grant.customConnectorId;
+            });
       const enabledIds = mockConnectorUpdateResponse(
         mockEnabledCustomConnectorIdsByAgent.get(params.id) ?? [],
-        body.enabledIds,
+        requestedIds,
         body.operation,
       );
       mockEnabledCustomConnectorIdsByAgent.set(params.id, enabledIds);

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -13,7 +13,10 @@ import {
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorUpdate,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
@@ -81,20 +84,23 @@ function applyUserConnectorUpdate(
 
 function applyCustomConnectorUpdate(
   current: readonly string[],
-  body: {
-    readonly enabledIds: readonly string[];
-    readonly operation?: "replace" | "add" | "remove";
-  },
+  body: AgentCustomConnectorUpdate,
 ): string[] {
+  const enabledIds =
+    "enabledIds" in body
+      ? body.enabledIds
+      : body.grants.map((grant) => {
+          return grant.customConnectorId;
+        });
   if (body.operation === "add") {
-    return Array.from(new Set([...current, ...body.enabledIds]));
+    return Array.from(new Set([...current, ...enabledIds]));
   }
   if (body.operation === "remove") {
     return current.filter((id) => {
-      return !body.enabledIds.includes(id);
+      return !enabledIds.includes(id);
     });
   }
-  return [...body.enabledIds];
+  return [...enabledIds];
 }
 
 function createAgent(id: string, displayName: string): TeamComposeItem {

--- a/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
@@ -16,10 +16,47 @@ export type AgentCustomConnectorEnabledIds = z.infer<
   typeof agentCustomConnectorEnabledIdsSchema
 >;
 
-export const agentCustomConnectorUpdateSchema =
+export const agentCustomConnectorGrantSchema = z.object({
+  customConnectorId: z.string().uuid(),
+  permissionNames: z.array(z.string().min(1).max(128)).max(500),
+});
+export type AgentCustomConnectorGrant = z.infer<
+  typeof agentCustomConnectorGrantSchema
+>;
+
+export const agentCustomConnectorGrantsSchema = z.object({
+  grants: z.array(agentCustomConnectorGrantSchema),
+});
+export type AgentCustomConnectorGrants = z.infer<
+  typeof agentCustomConnectorGrantsSchema
+>;
+
+export const agentCustomConnectorResponseSchema =
   agentCustomConnectorEnabledIdsSchema.extend({
-    operation: z.enum(["replace", "add", "remove"]).optional(),
+    grants: z.array(agentCustomConnectorGrantSchema).optional(),
   });
+export type AgentCustomConnectorResponse = z.infer<
+  typeof agentCustomConnectorResponseSchema
+>;
+
+const legacyAgentCustomConnectorUpdateSchema =
+  agentCustomConnectorEnabledIdsSchema
+    .extend({
+      operation: z.enum(["replace", "add", "remove"]).optional(),
+    })
+    .strict();
+
+const permissionedAgentCustomConnectorUpdateSchema =
+  agentCustomConnectorGrantsSchema
+    .extend({
+      operation: z.enum(["replace", "add", "remove"]).optional(),
+    })
+    .strict();
+
+export const agentCustomConnectorUpdateSchema = z.union([
+  legacyAgentCustomConnectorUpdateSchema,
+  permissionedAgentCustomConnectorUpdateSchema,
+]);
 export type AgentCustomConnectorUpdate = z.infer<
   typeof agentCustomConnectorUpdateSchema
 >;
@@ -39,7 +76,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
     headers: authHeadersSchema,
     pathParams: z.object({ id: z.string().uuid() }),
     responses: {
-      200: agentCustomConnectorEnabledIdsSchema,
+      200: agentCustomConnectorResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
@@ -53,7 +90,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
     pathParams: z.object({ id: z.string().uuid() }),
     body: agentCustomConnectorUpdateSchema,
     responses: {
-      200: agentCustomConnectorEnabledIdsSchema,
+      200: agentCustomConnectorResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -72,6 +72,21 @@ export type CustomConnectorOAuthConfigInput = z.infer<
   typeof customConnectorOAuthConfigInputSchema
 >;
 
+export const customConnectorPermissionBundleRefSchema = z
+  .string()
+  .max(128)
+  .regex(/^builtin:[a-z0-9][a-z0-9-]*@1$/u);
+export type CustomConnectorPermissionBundleRef = z.infer<
+  typeof customConnectorPermissionBundleRefSchema
+>;
+
+export const customConnectorSkillMarkdownSchema = z.string().refine(
+  (value) => {
+    return new TextEncoder().encode(value).byteLength <= 65_536;
+  },
+  { message: "Custom connector skill markdown must not exceed 64 KiB" },
+);
+
 /**
  * Custom connector response — safe to return to any org member.
  * Never includes any secret material.
@@ -89,6 +104,10 @@ export const customConnectorResponseSchema = z.object({
   queryInjections: z.array(customConnectorQueryInjectionSchema),
   authMode: customConnectorAuthModeSchema.optional(),
   oauthConfig: customConnectorOAuthConfigSchema.optional(),
+  permissionBundleRef: customConnectorPermissionBundleRefSchema
+    .nullable()
+    .optional(),
+  skillMarkdown: customConnectorSkillMarkdownSchema.nullable().optional(),
   revision: z.number().int().positive().optional(),
   connected: z.boolean(),
   missingRequiredFields: z.array(z.string()),
@@ -116,6 +135,10 @@ export const createCustomConnectorBodySchema = z.object({
   queryInjections: z.array(customConnectorQueryInjectionSchema).optional(),
   authMode: customConnectorAuthModeSchema.optional(),
   oauthConfig: customConnectorOAuthConfigInputSchema.optional(),
+  permissionBundleRef: customConnectorPermissionBundleRefSchema
+    .nullable()
+    .optional(),
+  skillMarkdown: customConnectorSkillMarkdownSchema.nullable().optional(),
   slug: z.string().optional(),
 });
 export type CreateCustomConnectorBody = z.infer<
@@ -130,6 +153,10 @@ export const updateCustomConnectorBodySchema = z.object({
   queryInjections: z.array(customConnectorQueryInjectionSchema),
   authMode: customConnectorAuthModeSchema.optional(),
   oauthConfig: customConnectorOAuthConfigInputSchema.optional(),
+  permissionBundleRef: customConnectorPermissionBundleRefSchema
+    .nullable()
+    .optional(),
+  skillMarkdown: customConnectorSkillMarkdownSchema.nullable().optional(),
 });
 export type UpdateCustomConnectorBody = z.infer<
   typeof updateCustomConnectorBodySchema

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -81,4 +81,5 @@ export enum FeatureSwitchKey {
   ThreeColumnNav = "threeColumnNav",
   ChatThreadSidebarAutoOpen = "chatThreadSidebarAutoOpen",
   CustomConnectorOAuth2 = "customConnectorOAuth2",
+  CustomConnectorPermissionsAndSkills = "customConnectorPermissionsAndSkills",
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -81,5 +81,4 @@ export enum FeatureSwitchKey {
   ThreeColumnNav = "threeColumnNav",
   ChatThreadSidebarAutoOpen = "chatThreadSidebarAutoOpen",
   CustomConnectorOAuth2 = "customConnectorOAuth2",
-  CustomConnectorPermissionsAndSkills = "customConnectorPermissionsAndSkills",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -494,13 +494,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: {
-    maintainer: "yuma@vm0.ai",
-    description:
-      "Allow custom connectors to use builtin permission bundles and generated skills.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
 };
 
 interface ResolvedHashes {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -494,6 +494,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.CustomConnectorPermissionsAndSkills]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Allow custom connectors to use builtin permission bundles and generated skills.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -725,6 +725,8 @@ export {
   getInstructionsStorageName,
   getSkillStorageName,
   getCustomSkillStorageName,
+  getCustomConnectorSkillStorageName,
+  getCustomConnectorSkillName,
   VOLUME_ORG_USER_ID,
   SYSTEM_ORG_ID,
 } from "./storage-names";

--- a/turbo/packages/core/src/storage-names.ts
+++ b/turbo/packages/core/src/storage-names.ts
@@ -51,6 +51,30 @@ export function getCustomSkillStorageName(skillName: string): string {
 }
 
 /**
+ * Generate the storage name for a custom connector skill.
+ * The connector id is used so renaming the connector does not orphan storage.
+ */
+export function getCustomConnectorSkillStorageName(
+  connectorId: string,
+): string {
+  return `custom-connector-skill@${connectorId}`;
+}
+
+/**
+ * Generate the framework-visible name for a custom connector skill.
+ * Includes connector identity so it cannot collide with builtin/workflow skills.
+ */
+export function getCustomConnectorSkillName(
+  connectorSlug: string,
+  connectorId: string,
+): string {
+  const base = connectorSlug.startsWith("_")
+    ? connectorSlug.slice(1)
+    : connectorSlug;
+  return `custom-${base.slice(0, 48)}-${connectorId.replaceAll("-", "").slice(0, 8)}`;
+}
+
+/**
  * Reserved name of the per-user memory storage that Zero auto-injects into
  * every agent run. It is owned by the user and mounted into the sandbox at a
  * framework-specific path.

--- a/turbo/packages/core/src/zero-workflow-skill.ts
+++ b/turbo/packages/core/src/zero-workflow-skill.ts
@@ -1,14 +1,12 @@
 import { stringify as stringifyYaml } from "yaml";
 
 /**
- * Synthesize the SKILL.md written to a workflow's volume.
+ * Synthesize the SKILL.md written to a server-managed skill volume.
  *
- * The DB is the single source of truth for a workflow: its (name, description,
- * instruction) are composed into a SKILL.md whose frontmatter is generated, not
- * user-authored. Users never see or edit the frontmatter — they edit only the
- * instruction body and the supplementary files.
+ * The DB is the single source of truth: name, description, and instruction are
+ * composed into generated frontmatter plus the user-authored instruction body.
  */
-export function synthesizeWorkflowSkillMd(args: {
+export function synthesizeSkillMd(args: {
   readonly name: string;
   readonly description: string | null;
   readonly instruction: string | null;
@@ -22,6 +20,14 @@ export function synthesizeWorkflowSkillMd(args: {
   return body.length > 0
     ? `---\n${frontmatter}\n---\n\n${body}\n`
     : `---\n${frontmatter}\n---\n`;
+}
+
+export function synthesizeWorkflowSkillMd(args: {
+  readonly name: string;
+  readonly description: string | null;
+  readonly instruction: string | null;
+}): string {
+  return synthesizeSkillMd(args);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add feature-gated backend contracts for versioned builtin permission bundles, custom connector skill markdown, and per-agent permission selection
- validate grants against the authoritative connector catalog and compile selected permissions into fail-closed runtime firewall policies
- synthesize server-managed `SKILL.md` volumes and mount them only for authorized custom connectors
- preserve legacy custom connector behavior and invalidate grants through connector revisions when security-sensitive definitions change
- intentionally leave UI unchanged; the required database columns already exist

Design: https://app.notion.com/p/Custom-Connector-Token-OAuth-3ab0e96f013481fca24ae5080c94cdf2

## Testing

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts` (22 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts` (41 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "enforces custom connector permission grants and mounts its generated skill"`