### PR TITLE
feat: enable codex session pruning globally

### DIFF
--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -15,7 +15,6 @@ use std::borrow::Cow;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const CLAUDE_SESSION_PRUNING_FEATURE_FLAG: &str = "claudeSessionPruning";
-const CODEX_SESSION_PRUNING_FEATURE_FLAG: &str = "codexSessionPruning";
 
 #[derive(Clone, Copy)]
 enum CheckpointMode {
@@ -73,7 +72,6 @@ struct CheckpointInputs<'a> {
     run_id: &'a str,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
-    codex_session_pruning_enabled: bool,
     home_dir: &'a str,
     artifact_entries: &'a [env::ArtifactEnv],
     session_id_file: Cow<'a, str>,
@@ -90,12 +88,6 @@ impl<'a> CheckpointInputs<'a> {
                 .config
                 .feature_flags
                 .get(CLAUDE_SESSION_PRUNING_FEATURE_FLAG)
-                .copied()
-                .unwrap_or(false),
-            codex_session_pruning_enabled: runtime
-                .config
-                .feature_flags
-                .get(CODEX_SESSION_PRUNING_FEATURE_FLAG)
                 .copied()
                 .unwrap_or(false),
             home_dir: &runtime.config.home_dir,
@@ -354,7 +346,6 @@ mod tests {
             run_id: "checkpoint-missing-mount",
             framework: env::Framework::ClaudeCode,
             claude_session_pruning_enabled: false,
-            codex_session_pruning_enabled: false,
             home_dir: &home_dir,
             artifact_entries: &entries,
             session_id_file: guest_paths.session_id_file().into(),
@@ -378,7 +369,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkpoint_reuses_codex_zstd_session_history_when_pruning_enabled() {
+    async fn checkpoint_reuses_codex_zstd_session_history() {
         let server = MockServer::start();
         let dir = tempfile::tempdir().unwrap();
         let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
@@ -449,7 +440,6 @@ mod tests {
             run_id: "checkpoint-codex-zstd-reuse",
             framework: env::Framework::Codex,
             claude_session_pruning_enabled: false,
-            codex_session_pruning_enabled: true,
             home_dir: &home_dir,
             artifact_entries: &[],
             session_id_file: guest_paths.session_id_file().into(),

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -199,7 +199,6 @@ pub(super) struct CheckpointSessionHistoryInputs {
     mode: CheckpointMode,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
-    codex_session_pruning_enabled: bool,
     home_dir: String,
     session_id_file: String,
     session_history_path_file: String,
@@ -211,7 +210,6 @@ impl CheckpointSessionHistoryInputs {
             mode,
             framework: inputs.framework,
             claude_session_pruning_enabled: inputs.claude_session_pruning_enabled,
-            codex_session_pruning_enabled: inputs.codex_session_pruning_enabled,
             home_dir: inputs.home_dir.to_string(),
             session_id_file: inputs.session_id_file.to_string(),
             session_history_path_file: inputs.session_history_path_file.to_string(),
@@ -359,7 +357,6 @@ fn prepare_session_history(
     mode: CheckpointMode,
     framework: env::Framework,
     claude_session_pruning_enabled: bool,
-    codex_session_pruning_enabled: bool,
     cli_agent_session_id: &str,
     history_marker_payload: &str,
     history_read_start: std::time::Instant,
@@ -418,8 +415,7 @@ fn prepare_session_history(
     }
 
     let mut resolved_codex_history = None;
-    if codex_session_pruning_enabled
-        && mode.can_prune_history()
+    if mode.can_prune_history()
         && framework == env::Framework::Codex
         && history::is_codex_marker(history_marker_payload)
     {
@@ -774,7 +770,6 @@ fn prepare_checkpoint_session_history(
         mode,
         framework,
         claude_session_pruning_enabled,
-        codex_session_pruning_enabled,
         home_dir,
         session_id_file,
         session_history_path_file,
@@ -838,7 +833,6 @@ fn prepare_checkpoint_session_history(
         mode,
         framework,
         claude_session_pruning_enabled,
-        codex_session_pruning_enabled,
         &cli_agent_session_id,
         &history_marker_payload,
         history_read_start,

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -31,14 +31,6 @@ fn set_claude_session_pruning(runtime: &mut guest_agent::run_context::GuestRunti
         .insert("claudeSessionPruning".to_string(), enabled);
 }
 
-fn set_codex_session_pruning(runtime: &mut guest_agent::run_context::GuestRuntime, enabled: bool) {
-    runtime.config.framework = guest_agent::env::Framework::Codex;
-    runtime
-        .config
-        .feature_flags
-        .insert("codexSessionPruning".to_string(), enabled);
-}
-
 fn session_file_paths() -> (String, String) {
     let paths = shared_guest_paths();
     (
@@ -502,51 +494,12 @@ async fn success_checkpoint_preserves_oversized_claude_history_when_pruning_disa
 }
 
 #[tokio::test]
-async fn success_checkpoint_preserves_oversized_codex_history_when_pruning_disabled() {
+async fn success_checkpoint_preserves_small_codex_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
     let mut runtime = runtime_from_process_env().unwrap();
-    set_codex_session_pruning(&mut runtime, false);
-    let _files_guard = SessionCheckpointFilesGuard::new();
-    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    let (history_dir, history_path, _) = write_prunable_codex_history(session_id).unwrap();
-    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
-    let source_size = std::fs::metadata(&history_path).unwrap().len();
-
-    let prepare_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/checkpoints/prepare-history");
-        then.status(200);
-    });
-    let checkpoint_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/checkpoints");
-        then.status(200);
-    });
-
-    let error = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime)
-        .await
-        .unwrap_err();
-
-    assert!(
-        error
-            .to_string()
-            .contains("Session history exceeds maximum size"),
-        "disabled Codex pruning must retain the original hard-limit behavior: {error}"
-    );
-    assert_eq!(std::fs::metadata(&history_path).unwrap().len(), source_size);
-    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
-    prepare_mock.assert_calls_async(0).await;
-    checkpoint_mock.assert_calls_async(0).await;
-}
-
-#[tokio::test]
-async fn success_checkpoint_preserves_small_codex_history_when_pruning_enabled() {
-    let api = SharedApiMock::new().await;
-    let server = api.server();
-
-    let mut runtime = runtime_from_process_env().unwrap();
-    set_codex_session_pruning(&mut runtime, true);
+    runtime.config.framework = guest_agent::env::Framework::Codex;
     let _files_guard = SessionCheckpointFilesGuard::new();
     let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
@@ -679,7 +632,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
     let server = api.server();
 
     let mut runtime = runtime_from_process_env().unwrap();
-    set_codex_session_pruning(&mut runtime, true);
+    runtime.config.framework = guest_agent::env::Framework::Codex;
     let _files_guard = SessionCheckpointFilesGuard::new();
     let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     let (history_dir, history_path, candidate) = write_prunable_codex_history(session_id).unwrap();
@@ -1628,7 +1581,7 @@ async fn recovery_checkpoint_does_not_prune_eligible_codex_history() {
     let server = api.server();
 
     let mut runtime = runtime_from_process_env().unwrap();
-    set_codex_session_pruning(&mut runtime, true);
+    runtime.config.framework = guest_agent::env::Framework::Codex;
     let _files_guard = SessionCheckpointFilesGuard::new();
     let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     let (history_dir, history_path, _) = write_prunable_codex_history(session_id).unwrap();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9123,7 +9123,6 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
 
     expect(claim.featureFlags).toMatchObject({
       [FeatureSwitchKey.ZeroChatMessaging]: false,
-      [FeatureSwitchKey.CodexSessionPruning]: false,
       [FeatureSwitchKey.ClaudeSessionPruning]: false,
     });
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -130,7 +130,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );
-    expect(staffOrgStates[FeatureSwitchKey.CodexSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadSidebarAutoOpen]).toBe(
@@ -164,7 +163,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.BrazilianPortugueseLocale]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.CodexSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ClaudeSessionPruning]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -58,7 +58,6 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "codexFastMode",
-  CodexSessionPruning = "codexSessionPruning",
   ClaudeSessionPruning = "claudeSessionPruning",
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -320,13 +320,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.CodexSessionPruning]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Prune oversized Codex checkpoint histories to the latest native compact generation.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ClaudeSessionPruning]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- enable native Codex session pruning for every successful checkpoint without a feature switch
- remove `codexSessionPruning` from the guest checkpoint inputs, core registry, and runner claim payload
- keep the 64 MiB pruning guard and existing compact-generation validation and reconciliation behavior

## Scope

- Claude session pruning remains feature-gated
- recovery checkpoints continue to preserve the original session history
- no database migration is required; persisted overrides for the retired key are ignored as unknown

## Deployment compatibility

- new guest versions ignore the legacy feature flag sent by an older API
- old guest versions receiving a claim from the new API temporarily retain the previous non-pruning behavior
- mixed versions do not change checkpoint or persisted session formats

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/core --workspace api`
- repository pre-commit checks
