### PR TITLE
refactor(api): rename chat-message sql aliases to chat events

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -374,7 +374,7 @@ const sendEventBody$ = bodyResultOf(chatEventsContract.send);
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
-const replacementChatEvent = alias(chatEvents, "replacement_chat_message");
+const replacementChatEvent = alias(chatEvents, "replacement_chat_event");
 const replacementAgentRun = alias(agentRuns, "replacement_agent_run");
 
 function forbidden(message: string) {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -112,8 +112,8 @@ type QueuedUserMessageRunParams = z.infer<
   typeof queuedUserMessageRunParamsSchema
 >;
 
-const queuedChatEvent = alias(chatEvents, "queued_chat_message");
-const queuedChatEventRevoker = alias(chatEvents, "queued_chat_message_revoker");
+const queuedChatEvent = alias(chatEvents, "queued_chat_event");
+const queuedChatEventRevoker = alias(chatEvents, "queued_chat_event_revoker");
 const queuedEncryptedParams = sql`COALESCE(
   ${chatInputQueueParams.encryptedParams},
   ${chatEvents.encryptedParams}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -127,8 +127,8 @@ const nullableTriggerSourceDecoder = nullableDriverValueDecoder(
   zodEnumDriverValueDecoder(triggerSourceSchema),
 );
 const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
-const matchedChatEvent = alias(chatEvents, "matched_chat_message");
-const revokedChatEvent = alias(chatEvents, "revoked_chat_message");
+const matchedChatEvent = alias(chatEvents, "matched_chat_event");
+const revokedChatEvent = alias(chatEvents, "revoked_chat_event");
 const hostedRunUploadedFiles = alias(runUploadedFiles, "hosted_files");
 const HOSTED_ARTIFACT_KINDS = ["hosted-site", "presentation-html"] as const;
 
@@ -409,7 +409,7 @@ function chatEventMetadataSubquery(db: Pick<Db, "select">) {
     )
     .where(eq(zeroRuns.id, chatEvents.runId))
     .limit(1)
-    .as("chat_message_metadata");
+    .as("chat_event_metadata");
 }
 
 function selectChatEventsWithMetadata(db: Pick<Db, "select">) {


### PR DESCRIPTION
## Summary

- rename the six query-local `chat_message` SQL aliases listed in #23922 to the canonical chat event vocabulary
- re-scan the chat API paths and confirm no additional `chat_message` SQL aliases or dependent raw SQL/result mappings need updates
- preserve the affected query structure and behavior exactly; this PR has no migration or contract changes

## Validation

- `pnpm prettier --write --ignore-unknown apps/api/src/signals/routes/zero-chat-events.ts apps/api/src/signals/services/zero-chat-queued-event.service.ts apps/api/src/signals/services/zero-chat-thread.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types` (12/12 workspaces passed)
- `pnpm knip --workspace apps/api`
- focused Vitest coverage for replacement resolution, queued-event revocation, event metadata listing, and chat search (4 passed)

Closes #23922