### PR TITLE
refactor(api): rename residual chat-message identifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -135,7 +135,7 @@ describe("cron monitor chat event queue", () => {
     expect(
       context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
     ).toMatchObject({
-      name: "OrphanedQueuedChatMessagesError",
+      name: "OrphanedQueuedChatEventsError",
       code: "ORPHANED_QUEUED_CHAT_MESSAGES",
       orphanedMessages: 1,
     });
@@ -146,7 +146,7 @@ describe("cron monitor chat event queue", () => {
       method: "GET",
       errorCode: "ORPHANED_QUEUED_CHAT_MESSAGES",
       error: {
-        name: "OrphanedQueuedChatMessagesError",
+        name: "OrphanedQueuedChatEventsError",
         code: "ORPHANED_QUEUED_CHAT_MESSAGES",
         orphanedMessages: 1,
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1701,7 +1701,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       payload: {
         channelId,
         threadTs,
-        chatMessageId: expect.any(String),
+        chatEventId: expect.any(String),
       },
     });
     const run1 = await runs.readRun(actor, run1Id);

--- a/turbo/apps/api/src/signals/services/agentphone-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-chat-callback-payload.ts
@@ -20,5 +20,5 @@ export type AgentPhoneDeliveryTarget = z.infer<
 
 export const agentphoneChatCallbackPayloadSchema =
   agentphoneDeliveryTargetSchema.extend({
-    chatMessageId: z.string().uuid(),
+    chatEventId: z.string().uuid(),
   });

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -14,7 +14,7 @@ class OrphanedQueuedChatEventsError extends Error {
 
   constructor(readonly orphanedMessages: number) {
     super("Orphaned queued chat messages detected");
-    this.name = "OrphanedQueuedChatMessagesError";
+    this.name = "OrphanedQueuedChatEventsError";
   }
 }
 

--- a/turbo/apps/api/src/signals/services/feishu-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/feishu-chat-callback-payload.ts
@@ -17,5 +17,5 @@ export type FeishuDeliveryTarget = z.infer<typeof feishuDeliveryTargetSchema>;
 
 export const feishuChatCallbackPayloadSchema =
   feishuDeliveryTargetSchema.extend({
-    chatMessageId: z.string(),
+    chatEventId: z.string(),
   });

--- a/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
@@ -176,7 +176,7 @@ async function loadAgentPhoneChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, run.chatThreadId),
         chatEventTypeIn([
@@ -407,7 +407,7 @@ interface AgentPhoneChatAdmissionFailureArgs {
   readonly orgId: string;
   readonly agentId: string;
   readonly target: AgentPhoneDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
   readonly signal: AbortSignal;
 }
 
@@ -419,7 +419,7 @@ export async function deliverAgentPhoneChatAdmissionFailure(
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, args.chatMessageId),
+        eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
         isNotNull(chatEvents.content),

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -487,7 +487,7 @@ interface ChatCallbackDependencies {
       readonly channelId: string;
       readonly threadTs: string;
       readonly routeThreadTs?: string;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     },
     signal: AbortSignal,
   ) => Promise<void>;
@@ -510,7 +510,7 @@ interface ChatCallbackDependencies {
       readonly orgId: string;
       readonly agentId: string;
       readonly target: TeamsDeliveryTarget;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     },
     signal: AbortSignal,
   ) => Promise<void>;
@@ -526,7 +526,7 @@ interface ChatCallbackDependencies {
       readonly orgId: string;
       readonly agentId: string;
       readonly target: TelegramDeliveryTarget;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     },
     signal: AbortSignal,
   ) => Promise<void>;
@@ -542,7 +542,7 @@ interface ChatCallbackDependencies {
       readonly orgId: string;
       readonly agentId: string;
       readonly target: AgentPhoneDeliveryTarget;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     },
     signal: AbortSignal,
   ) => Promise<void>;
@@ -1146,7 +1146,7 @@ async function insertSlackChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: SlackDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1175,7 +1175,7 @@ async function insertSlackChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1190,7 +1190,7 @@ async function insertFeishuChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: FeishuDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1219,7 +1219,7 @@ async function insertFeishuChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1234,7 +1234,7 @@ async function insertTeamsChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: TeamsDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1263,7 +1263,7 @@ async function insertTeamsChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1278,7 +1278,7 @@ async function insertTelegramChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: TelegramDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1307,7 +1307,7 @@ async function insertTelegramChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1322,7 +1322,7 @@ async function insertAgentPhoneChatDeliveryCallback(args: {
   readonly runId: string;
   readonly sourceCallbackId?: string;
   readonly target: AgentPhoneDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
 }): Promise<string> {
   const callbackCondition = args.sourceCallbackId
     ? and(
@@ -1351,7 +1351,7 @@ async function insertAgentPhoneChatDeliveryCallback(args: {
       encryptedSecret: sourceCallback.encryptedSecret,
       payload: {
         ...args.target,
-        chatMessageId: args.chatMessageId,
+        chatEventId: args.chatEventId,
       },
     })
     .returning({ id: agentRunCallbacks.id });
@@ -1400,7 +1400,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.slackDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     const feishuDeliveryCallbackId = args.feishuDelivery
@@ -1409,7 +1409,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.feishuDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     const teamsDeliveryCallbackId = args.teamsDelivery
@@ -1418,7 +1418,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.teamsDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     const telegramDeliveryCallbackId = args.telegramDelivery
@@ -1427,7 +1427,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.telegramDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     const agentphoneDeliveryCallbackId = args.agentphoneDelivery
@@ -1436,7 +1436,7 @@ async function insertAssistantErrorEvent(args: {
           runId: args.runId,
           sourceCallbackId: args.sourceCallbackId,
           target: args.agentphoneDelivery,
-          chatMessageId: event.id,
+          chatEventId: event.id,
         })
       : undefined;
     await touchChatThreadLastMessageAt(tx, args.threadId, event.createdAt);
@@ -1646,7 +1646,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.slackDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   const feishuDeliveryCallbackId =
@@ -1656,7 +1656,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.feishuDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   const teamsDeliveryCallbackId =
@@ -1666,7 +1666,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.teamsDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   const telegramDeliveryCallbackId =
@@ -1676,7 +1676,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.telegramDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   const agentphoneDeliveryCallbackId =
@@ -1686,7 +1686,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
           runId: input.runId,
           sourceCallbackId: input.sourceCallbackId,
           target: input.agentphoneDelivery,
-          chatMessageId: deliveryEvent.id,
+          chatEventId: deliveryEvent.id,
         })
       : undefined;
   await touchChatThreadLastMessageAt(
@@ -3138,7 +3138,7 @@ async function handleSlackQueuedMessageAdmissionFailure(args: {
         ...(args.failure.slackDelivery.routeThreadTs
           ? { routeThreadTs: args.failure.slackDelivery.routeThreadTs }
           : {}),
-        chatMessageId: failed.assistantEventId,
+        chatEventId: failed.assistantEventId,
       },
       args.signal,
     ),
@@ -3194,7 +3194,7 @@ async function handleTeamsQueuedMessageAdmissionFailure(args: {
         orgId: args.failure.orgId,
         agentId: args.failure.agentId,
         target: args.failure.teamsDelivery,
-        chatMessageId: failed.assistantEventId,
+        chatEventId: failed.assistantEventId,
       },
       args.signal,
     ),
@@ -3250,7 +3250,7 @@ async function handleTelegramQueuedMessageAdmissionFailure(args: {
         orgId: args.failure.orgId,
         agentId: args.failure.agentId,
         target: args.failure.telegramDelivery,
-        chatMessageId: failed.assistantEventId,
+        chatEventId: failed.assistantEventId,
       },
       args.signal,
     ),
@@ -3306,7 +3306,7 @@ async function handleAgentPhoneQueuedMessageAdmissionFailure(args: {
         orgId: args.failure.orgId,
         agentId: args.failure.agentId,
         target: args.failure.agentphoneDelivery,
-        chatMessageId: failed.assistantEventId,
+        chatEventId: failed.assistantEventId,
       },
       args.signal,
     ),

--- a/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
@@ -123,7 +123,7 @@ async function loadFeishuChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, run.chatThreadId),
         chatEventTypeIn([

--- a/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
@@ -125,7 +125,7 @@ async function loadSlackChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, run.chatThreadId),
         chatEventTypeIn([
@@ -324,7 +324,7 @@ export async function deliverSlackChatAdmissionFailure(args: {
   readonly channelId: string;
   readonly threadTs: string;
   readonly routeThreadTs?: string;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
   readonly signal: AbortSignal;
 }): Promise<void> {
   const [eventRows, bindingRows] = await Promise.all([
@@ -333,7 +333,7 @@ export async function deliverSlackChatAdmissionFailure(args: {
       .from(chatEvents)
       .where(
         and(
-          eq(chatEvents.id, args.chatMessageId),
+          eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["output.error"]),
           isNotNull(chatEvents.content),

--- a/turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts
@@ -127,7 +127,7 @@ async function loadTeamsChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, run.chatThreadId),
         chatEventTypeIn([
@@ -387,7 +387,7 @@ interface TeamsChatAdmissionFailureArgs {
   readonly orgId: string;
   readonly agentId: string;
   readonly target: TeamsDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
   readonly signal: AbortSignal;
 }
 
@@ -405,7 +405,7 @@ async function loadTeamsAdmissionFailureContext(
       .from(chatEvents)
       .where(
         and(
-          eq(chatEvents.id, args.chatMessageId),
+          eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["output.error"]),
           isNotNull(chatEvents.content),

--- a/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
@@ -262,7 +262,7 @@ async function loadTelegramChatDeliveryContext(args: {
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, payload.chatMessageId),
+        eq(chatEvents.id, payload.chatEventId),
         eq(chatEvents.runId, args.callback.runId),
         eq(chatEvents.chatThreadId, run.chatThreadId),
         chatEventTypeIn([
@@ -603,7 +603,7 @@ interface TelegramChatAdmissionFailureArgs {
   readonly userId: string;
   readonly orgId: string;
   readonly target: TelegramDeliveryTarget;
-  readonly chatMessageId: string;
+  readonly chatEventId: string;
   readonly signal: AbortSignal;
 }
 
@@ -615,7 +615,7 @@ export async function deliverTelegramChatAdmissionFailure(
     .from(chatEvents)
     .where(
       and(
-        eq(chatEvents.id, args.chatMessageId),
+        eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
         isNotNull(chatEvents.content),

--- a/turbo/apps/api/src/signals/services/slack-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/slack-chat-callback-payload.ts
@@ -4,5 +4,5 @@ export const slackChatCallbackPayloadSchema = z.object({
   channelId: z.string(),
   threadTs: z.string(),
   routeThreadTs: z.string().optional(),
-  chatMessageId: z.string(),
+  chatEventId: z.string(),
 });

--- a/turbo/apps/api/src/signals/services/teams-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/teams-chat-callback-payload.ts
@@ -29,5 +29,5 @@ export const teamsDeliveryTargetSchema = z.object({
 export type TeamsDeliveryTarget = z.infer<typeof teamsDeliveryTargetSchema>;
 
 export const teamsChatCallbackPayloadSchema = teamsDeliveryTargetSchema.extend({
-  chatMessageId: z.string().uuid(),
+  chatEventId: z.string().uuid(),
 });

--- a/turbo/apps/api/src/signals/services/telegram-chat-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/telegram-chat-callback-payload.ts
@@ -19,5 +19,5 @@ export type TelegramDeliveryTarget = z.infer<
 
 export const telegramChatCallbackPayloadSchema =
   telegramDeliveryTargetSchema.extend({
-    chatMessageId: z.string().uuid(),
+    chatEventId: z.string().uuid(),
   });

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1572,7 +1572,7 @@ async function persistAgentPhoneChatMessage(args: {
   | {
       readonly inserted: true;
       readonly chatThreadId: string;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     }
   | { readonly inserted: false }
 > {
@@ -1616,7 +1616,7 @@ async function persistAgentPhoneChatMessage(args: {
   );
   args.signal.throwIfAborted();
 
-  const chatMessageId = agentPhoneChatMessageId({
+  const chatEventId = agentPhoneChatMessageId({
     event: args.event,
     userLinkId: args.userLink.id,
     rootMessageId: args.rootMessageId,
@@ -1625,7 +1625,7 @@ async function persistAgentPhoneChatMessage(args: {
     const event = await insertChatEvent(
       tx,
       {
-        id: chatMessageId,
+        id: chatEventId,
         chatThreadId: route.chatThreadId,
         eventType: "input.prompt",
         userMessage: createUserMessageDocument({ text: args.prompt }),
@@ -1644,7 +1644,7 @@ async function persistAgentPhoneChatMessage(args: {
       tx,
       route.chatThreadId,
       currentTime,
-      chatMessageId,
+      chatEventId,
     );
     return true;
   });
@@ -1653,7 +1653,7 @@ async function persistAgentPhoneChatMessage(args: {
     ? {
         inserted: true,
         chatThreadId: route.chatThreadId,
-        chatMessageId,
+        chatEventId,
       }
     : { inserted: false };
 }
@@ -1662,7 +1662,7 @@ async function agentPhoneMessageDispatchState(
   db: Db,
   args: {
     readonly chatThreadId: string;
-    readonly chatMessageId: string;
+    readonly chatEventId: string;
   },
 ): Promise<AgentPhoneMessageDispatchResult> {
   const [[run], [queued]] = await Promise.all([
@@ -1674,8 +1674,8 @@ async function agentPhoneMessageDispatchState(
         and(
           eq(chatEvents.chatThreadId, args.chatThreadId),
           or(
-            eq(chatEvents.id, args.chatMessageId),
-            eq(chatEvents.revokesEventId, args.chatMessageId),
+            eq(chatEvents.id, args.chatEventId),
+            eq(chatEvents.revokesEventId, args.chatEventId),
           ),
         ),
       )
@@ -1685,7 +1685,7 @@ async function agentPhoneMessageDispatchState(
       .from(chatEvents)
       .where(
         and(
-          eq(chatEvents.id, args.chatMessageId),
+          eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["input.prompt"]),
           isNull(chatEvents.runId),

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -1617,7 +1617,7 @@ async function persistTeamsChatMessage(args: {
   | {
       readonly inserted: true;
       readonly chatThreadId: string;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     }
   | { readonly inserted: false }
 > {
@@ -1672,12 +1672,12 @@ async function persistTeamsChatMessage(args: {
   );
   args.signal.throwIfAborted();
 
-  const chatMessageId = teamsChatMessageId(args.activity, args.connection.id);
+  const chatEventId = teamsChatMessageId(args.activity, args.connection.id);
   const inserted = await args.db.transaction(async (tx) => {
     const event = await insertChatEvent(
       tx,
       {
-        id: chatMessageId,
+        id: chatEventId,
         chatThreadId: route.chatThreadId,
         eventType: "input.prompt",
         userMessage: createUserMessageDocument({
@@ -1705,13 +1705,13 @@ async function persistTeamsChatMessage(args: {
       tx,
       route.chatThreadId,
       currentTime,
-      chatMessageId,
+      chatEventId,
     );
     return true;
   });
   args.signal.throwIfAborted();
   return inserted
-    ? { inserted: true, chatThreadId: route.chatThreadId, chatMessageId }
+    ? { inserted: true, chatThreadId: route.chatThreadId, chatEventId }
     : { inserted: false };
 }
 
@@ -1719,7 +1719,7 @@ async function teamsMessageDispatchState(
   db: Db,
   args: {
     readonly chatThreadId: string;
-    readonly chatMessageId: string;
+    readonly chatEventId: string;
   },
 ): Promise<TeamsMessageDispatchResult> {
   const [[run], [queued]] = await Promise.all([
@@ -1731,8 +1731,8 @@ async function teamsMessageDispatchState(
         and(
           eq(chatEvents.chatThreadId, args.chatThreadId),
           or(
-            eq(chatEvents.id, args.chatMessageId),
-            eq(chatEvents.revokesEventId, args.chatMessageId),
+            eq(chatEvents.id, args.chatEventId),
+            eq(chatEvents.revokesEventId, args.chatEventId),
           ),
         ),
       )
@@ -1742,7 +1742,7 @@ async function teamsMessageDispatchState(
       .from(chatEvents)
       .where(
         and(
-          eq(chatEvents.id, args.chatMessageId),
+          eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["input.prompt"]),
           isNull(chatEvents.runId),

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1788,16 +1788,16 @@ async function persistTelegramChatMessage(args: {
   | {
       readonly inserted: true;
       readonly chatThreadId: string;
-      readonly chatMessageId: string;
+      readonly chatEventId: string;
     }
   | { readonly inserted: false }
 > {
   const currentTime = new Date(args.source.apiStartTime);
-  const chatMessageId = telegramChatMessageId(args);
+  const chatEventId = telegramChatMessageId(args);
   const [existingMessage] = await args.source.db
     .select({ id: chatEvents.id })
     .from(chatEvents)
-    .where(eq(chatEvents.id, chatMessageId))
+    .where(eq(chatEvents.id, chatEventId))
     .limit(1);
   args.signal.throwIfAborted();
   if (existingMessage) {
@@ -1854,7 +1854,7 @@ async function persistTelegramChatMessage(args: {
     const event = await insertChatEvent(
       tx,
       {
-        id: chatMessageId,
+        id: chatEventId,
         chatThreadId: binding.chatThreadId,
         eventType: "input.prompt",
         content: null,
@@ -1874,7 +1874,7 @@ async function persistTelegramChatMessage(args: {
       tx,
       binding.chatThreadId,
       currentTime,
-      chatMessageId,
+      chatEventId,
     );
     return true;
   });
@@ -1883,7 +1883,7 @@ async function persistTelegramChatMessage(args: {
     ? {
         inserted: true,
         chatThreadId: binding.chatThreadId,
-        chatMessageId,
+        chatEventId,
       }
     : { inserted: false };
 }
@@ -1892,7 +1892,7 @@ async function telegramMessageDispatchState(
   db: Db,
   args: {
     readonly chatThreadId: string;
-    readonly chatMessageId: string;
+    readonly chatEventId: string;
   },
 ): Promise<TelegramMessageDispatchResult> {
   const [[run], [queued]] = await Promise.all([
@@ -1904,8 +1904,8 @@ async function telegramMessageDispatchState(
         and(
           eq(chatEvents.chatThreadId, args.chatThreadId),
           or(
-            eq(chatEvents.id, args.chatMessageId),
-            eq(chatEvents.revokesEventId, args.chatMessageId),
+            eq(chatEvents.id, args.chatEventId),
+            eq(chatEvents.revokesEventId, args.chatEventId),
           ),
         ),
       )
@@ -1915,7 +1915,7 @@ async function telegramMessageDispatchState(
       .from(chatEvents)
       .where(
         and(
-          eq(chatEvents.id, args.chatMessageId),
+          eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["input.prompt"]),
           isNull(chatEvents.runId),


### PR DESCRIPTION
## Summary

- rename API-side identifiers that carry `chatEvents.id` values from `chatMessageId` to `chatEventId`, including internal delivery callback payloads and admission-failure arguments
- update the orphaned queue error `name` to `OrphanedQueuedChatEventsError` and adjust name-only test expectations
- apply the same rule to the AgentPhone paths added to `main` after the issue's 26-occurrence snapshot

## Keep vs. rename split

The dividing rule is the value's domain, not the transport that happens to carry it:

- **Renamed:** locals, return fields, callback payload fields, and arguments used directly as `chatEvents.id` / `chatEvents.revokesEventId`, or populated from `event.id`, `deliveryEvent.id`, or `assistantEventId`.
- **Kept for Teams:** `fetchTeamsPersonalChatMessages`, `persistTeamsChatMessage`, `teamsChatMessageId`, Teams activity/message types, and fields such as `activityId` remain in the Teams external-message vocabulary.
- **Kept for Slack, Telegram, Feishu, and AgentPhone:** platform message clients and platform identifiers (`messageId`, thread/root ids, timestamps, and the platform-specific deterministic message-id helpers) remain message-domain names. `listFeishuChatMessages` and the analogous external-message persistence helpers are unchanged.
- **Kept elsewhere:** Morning Brief `chatMessage` values are user-visible `userMessage` text; the local LLM `{ role, content }` `ChatMessage` types, `chat_message_queue:<threadId>` advisory-lock key, SQL aliases tracked by #23922, and historical migrations remain untouched.

This is a pure vocabulary refactor with no behavior, external contract, database schema, or event-storage semantic changes.

## Validation

- targeted Prettier write/check for all changed TypeScript files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- focused Vitest selection across the cron monitor, chat callbacks, Slack, Feishu, Teams, Telegram, and AgentPhone paths: 145 tests covered; one cold-start timeout in the serial batch passed on isolated rerun without changing the timeout

Closes #23917