### PR TITLE
refactor(api): acquire both chat queue admission locks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -38,6 +38,7 @@ import {
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
   completeRunWithoutCallbacksFixture,
+  holdChatEventQueueAdmissionLockFixture,
   holdOrgAdmissionLockFixture,
   readChatInputQueueParamsFixture,
   setQueuedUserMessageCreatedAtFixture,
@@ -772,6 +773,45 @@ describe("workflow queue", () => {
     await expect(
       workflowRunIds(webhookAutomation.threadId),
     ).resolves.toHaveLength(2);
+  });
+
+  it("serializes concurrent workflow admissions for the same thread", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdChatEventQueueAdmissionLockFixture({
+      threadId: automation.threadId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const firstRequest = postWorkflowWebhook(automation, "first concurrent");
+    await expect.poll(admissionLock.directWaiterCount).toBe(1);
+
+    const secondRequest = postWorkflowWebhook(automation, "second concurrent");
+    // The first admission holds the legacy key while waiting on the canonical
+    // key; the second admission must wait behind it on that same legacy key.
+    await expect.poll(admissionLock.transitiveWaiterCount).toBe(2);
+    await expect.poll(admissionLock.directWaiterCount).toBe(1);
+    await expect(
+      pendingWorkflowEvents(automation.threadId),
+    ).resolves.toStrictEqual([]);
+
+    admissionLock.release();
+    const results = await Promise.all([firstRequest, secondRequest]);
+    await admissionLock.done;
+
+    expect(
+      results.map((result) => {
+        return result.status;
+      }),
+    ).toStrictEqual([200, 200]);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(1);
+    await expect(
+      pendingWorkflowEvents(automation.threadId),
+    ).resolves.toHaveLength(1);
   });
 
   it("propagates queue encryption failure while persistence remains necessary", async () => {

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -40,6 +40,10 @@ import { createUserMessageDocument } from "./zero-chat-user-message.service";
 const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
 const automationEventRevoker = alias(chatEvents, "automation_event_revoker");
 
+export type WorkflowQueueAdmissionTransaction = Parameters<
+  Parameters<Db["transaction"]>[0]
+>[0];
+
 const workflowQueueEventParamsWireSchema = z.object({
   version: z.literal(1),
   prompt: z.string().optional(),
@@ -101,11 +105,22 @@ export async function decryptWorkflowQueueEventParams(
   return workflowQueueEventParamsWireSchema.parse(JSON.parse(raw));
 }
 
-function chatEventQueueAdmissionLock(chatThreadId: string) {
-  // Keep the advisory namespace stable while API revisions overlap. This is
-  // only a lock identifier; the contracted queue table is never accessed.
+async function chatEventQueueAdmissionLock(
+  tx: WorkflowQueueAdmissionTransaction,
+  chatThreadId: string,
+): Promise<void> {
+  // Release 1 of the two-phase namespace migration: every admission acquires
+  // the legacy key before the canonical key while API revisions overlap.
+  // Release 2 may drop the legacy key only after Release 1 is fully rolled out
+  // and its rollback target has drained.
   const compatibilityKey = `chat_message_queue:${chatThreadId}`;
-  return sql`SELECT pg_advisory_xact_lock(hashtext(${compatibilityKey}))`;
+  const canonicalKey = `chat_event_queue:${chatThreadId}`;
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${compatibilityKey}))`,
+  );
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${canonicalKey}))`,
+  );
 }
 
 /** Any active thread-bound run preserves strict per-thread serialization. */
@@ -158,10 +173,6 @@ type WorkflowQueueAdmissionAttempt =
   | WorkflowQueueAdmission
   | { readonly kind: "payload-required" };
 
-export type WorkflowQueueAdmissionTransaction = Parameters<
-  Parameters<Db["transaction"]>[0]
->[0];
-
 export type PersistWorkflowQueueSourceTransition = (
   tx: WorkflowQueueAdmissionTransaction,
 ) => Promise<void>;
@@ -187,7 +198,7 @@ async function attemptWorkflowQueueAdmission(
 ): Promise<WorkflowQueueAdmissionAttempt> {
   const { automation } = args;
   return await db.transaction(async (tx) => {
-    await tx.execute(chatEventQueueAdmissionLock(args.chatThreadId));
+    await chatEventQueueAdmissionLock(tx, args.chatThreadId);
 
     if (
       args.coalescePendingScheduleRun &&
@@ -287,7 +298,7 @@ export async function loadNextWorkflowQueueEvent(
   queueItemCreatedBefore?: Date,
 ): Promise<PendingWorkflowQueueEvent | null> {
   return await db.transaction(async (tx) => {
-    await tx.execute(chatEventQueueAdmissionLock(chatThreadId));
+    await chatEventQueueAdmissionLock(tx, chatThreadId);
     if (await hasPendingUserChatQueueEvent(tx, chatThreadId)) {
       return null;
     }

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -404,6 +404,58 @@ export async function holdOrgAdmissionLockFixture(args: {
 }
 
 /**
+ * Holds the canonical workflow queue admission key so tests can observe the
+ * Release 1 lock chain: the first request holds the legacy key while waiting
+ * here, and a concurrent request for the same thread waits behind it.
+ */
+export async function holdChatEventQueueAdmissionLockFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly directWaiterCount: () => Promise<number>;
+  readonly transitiveWaiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const lockKey = `chat_event_queue:${args.threadId}`;
+    const rows = await executeRawRows(
+      tx,
+      sql`
+        SELECT
+          pg_backend_pid() AS "pid",
+          pg_advisory_xact_lock(hashtext(${lockKey}))
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the queue admission lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    directWaiterCount: async () => {
+      return await directBlockedWaiterCount(holderPid);
+    },
+    transitiveWaiterCount: async () => {
+      return await transitiveBlockedWaiterCount(holderPid);
+    },
+  };
+}
+
+/**
  * Stages the canonical conversation clear inside an open transaction so a
  * concurrent run still resolves the pre-clear snapshot, then blocks on this
  * transaction when its launch commit re-reads the session row `FOR UPDATE`.


### PR DESCRIPTION
## Summary

- acquire `chat_message_queue:<threadId>` before `chat_event_queue:<threadId>` in every workflow chat queue admission/claim transaction
- document the two-phase namespace migration and its contract gate
- add an integration regression that proves concurrent admissions for one thread remain serialized through the Release 1 lock chain

## Why

The advisory lock id is derived from `hashtext(key)`. Renaming the key in one release would let old and new API revisions take different locks during a rolling deployment, temporarily breaking per-thread serial admission.

## Release plan

This PR is **Release 1 (expand)**. Both keys are always acquired in the fixed old-then-new order so old×old, old×new, and new×new revisions remain mutually exclusive without introducing a lock-order deadlock.

**Release 2 is out of scope.** It may remove the legacy key only after this Release 1 API revision is fully rolled out and the rollback target has drained; that contraction will be submitted separately.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/workflow-chat-event-queue.service.ts apps/api/src/test-fixtures/chat-events.ts apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts -t "serializes concurrent workflow admissions for the same thread" --maxWorkers=1 --silent=passed-only`

Refs #23925