### PR TITLE
refactor: rename chat message capability and cron identifiers

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -102,6 +102,26 @@ describe("auth tokens", () => {
     });
   });
 
+  it("normalizes legacy chat message capabilities to chat event capabilities", () => {
+    const nowSeconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: "user_zero",
+      orgId: "org_zero",
+      runId: "run_zero",
+      capabilities: ["chat-message:read", "chat-message:write"],
+      iat: nowSeconds,
+      exp: nowSeconds + 60,
+    });
+
+    expect(verifyZeroToken(token)).toStrictEqual({
+      userId: "user_zero",
+      orgId: "org_zero",
+      runId: "run_zero",
+      capabilities: ["chat-event:read", "chat-event:write"],
+    });
+  });
+
   it("rejects expired tokens and mismatched scopes", () => {
     const nowSeconds = currentSecond();
     const expiredToken = signPatJwtForTests({
@@ -147,15 +167,25 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(token)?.capabilities).toContain("chat-thread:write");
   });
 
-  it("grants chat message read and write independently of prompt discovery", () => {
+  it("grants chat event read and write independently of prompt discovery", () => {
     const token = generateZeroToken("user_zero", "run_zero", "org_zero", {
       [FeatureSwitchKey.ZeroChatMessaging]: false,
     });
 
-    expect(verifyZeroToken(token)?.capabilities).toContain("chat-message:read");
-    expect(verifyZeroToken(token)?.capabilities).toContain(
-      "chat-message:write",
-    );
+    expect(decodeZeroTokenPayloadForTest(token)).toMatchObject({
+      capabilities: expect.arrayContaining([
+        "chat-event:read",
+        "chat-event:write",
+      ]),
+    });
+    expect(decodeZeroTokenPayloadForTest(token)).not.toMatchObject({
+      capabilities: expect.arrayContaining(["chat-message:read"]),
+    });
+    expect(decodeZeroTokenPayloadForTest(token)).not.toMatchObject({
+      capabilities: expect.arrayContaining(["chat-message:write"]),
+    });
+    expect(verifyZeroToken(token)?.capabilities).toContain("chat-event:read");
+    expect(verifyZeroToken(token)?.capabilities).toContain("chat-event:write");
   });
 
   it("gates banking capability behind the banking feature switch", () => {

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -58,13 +58,30 @@ function isZeroCapability(value: string): value is ZeroCapability {
   });
 }
 
+function normalizeZeroCapability(capability: string): string {
+  switch (capability) {
+    case "chat-message:read": {
+      return "chat-event:read";
+    }
+    case "chat-message:write": {
+      return "chat-event:write";
+    }
+    default: {
+      return capability;
+    }
+  }
+}
+
 // Capability names are open-ended at the token boundary so tokens issued by a
 // newer API remain valid on an older API. The validated output remains closed
 // to known capabilities so unknown names cannot grant permissions.
 const zeroCapabilitiesSchema = z
   .array(z.string().min(1))
   .transform((capabilities) => {
-    return capabilities.filter(isZeroCapability);
+    return capabilities.flatMap((capability) => {
+      const normalized = normalizeZeroCapability(capability);
+      return isZeroCapability(normalized) ? [normalized] : [];
+    });
   })
   .readonly();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2219,7 +2219,7 @@ describe("CHAT-03 run usage events", () => {
 });
 
 describe("CHAT-01 chat search", () => {
-  it("rejects search without an org session or the chat-message:read capability", async () => {
+  it("rejects search without an org session or the chat-event:read capability", async () => {
     const unauthenticated = await chat.requestSearchChat(
       null,
       "hello",
@@ -2246,7 +2246,7 @@ describe("CHAT-01 chat search", () => {
     );
     expectApiError(forbidden.body);
     expect(forbidden.body.error.code).toBe("FORBIDDEN");
-    expect(forbidden.body.error.message).toContain("chat-message:read");
+    expect(forbidden.body.error.message).toContain("chat-event:read");
   });
 
   it("searches own messages with filters, context, and like-escaping", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -14,7 +14,7 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
 
 const context = testContext();
 const CRON_SECRET = "test-cron-secret";
-const STATE_ROUTE = "/api/test/cron-monitor-chat-message-queue-state/action";
+const STATE_ROUTE = "/api/test/cron-monitor-chat-event-queue-state/action";
 
 interface MonitorFixture {
   readonly composeId: string;
@@ -32,7 +32,7 @@ async function rawCronRequest(
   headers: Record<string, string> = {},
 ): Promise<Response> {
   const app = createApp({ signal: context.signal });
-  return await app.request("/api/cron/monitor-chat-message-queue", {
+  return await app.request("/api/cron/monitor-chat-event-queue", {
     method: "GET",
     headers,
   });
@@ -142,7 +142,7 @@ describe("cron monitor chat event queue", () => {
     const [, fields] = context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(fields).toMatchObject({
       type: "unhandled_request_error",
-      route: "/api/cron/monitor-chat-message-queue",
+      route: "/api/cron/monitor-chat-event-queue",
       method: "GET",
       errorCode: "ORPHANED_QUEUED_CHAT_MESSAGES",
       error: {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-events-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-events-auth.test.ts
@@ -14,7 +14,7 @@ function client() {
 }
 
 describe("POST /api/zero/chat/events authorization", () => {
-  it("rejects a zero token without chat-message:write", async () => {
+  it("rejects a zero token without chat-event:write", async () => {
     const seconds = Math.floor(now() / 1000);
     const token = signSandboxJwtForTests({
       scope: "zero",
@@ -44,7 +44,7 @@ describe("POST /api/zero/chat/events authorization", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Missing required capability: chat-message:write",
+        message: "Missing required capability: chat-event:write",
         code: "FORBIDDEN",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-get.test.ts
@@ -136,12 +136,12 @@ describe("GET /api/zero/chat-threads/:id/metadata", () => {
 });
 
 describe("GET /api/zero/chat-threads/:threadId/events", () => {
-  it("lists events with ZERO_TOKEN chat-message:read capability", async () => {
+  it("lists events with ZERO_TOKEN chat-event:read capability", async () => {
     const fixture = await seedChatThread("Launch plan");
     const token = zeroToken({
       userId: fixture.userId,
       orgId: fixture.orgId,
-      capabilities: ["chat-message:read"],
+      capabilities: ["chat-event:read"],
     });
 
     const response = await accept(
@@ -159,7 +159,35 @@ describe("GET /api/zero/chat-threads/:threadId/events", () => {
     });
   });
 
-  it("rejects ZERO_TOKEN without chat-message:read capability", async () => {
+  it("lists events with the legacy chat-message:read capability", async () => {
+    const fixture = await seedChatThread("Launch plan");
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["chat-message:read"],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const response = await accept(
+      eventsClient().list({
+        headers: { authorization: `Bearer ${token}` },
+        params: { threadId: fixture.threadId },
+        query: {},
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      events: [],
+      hasHistoryBefore: false,
+    });
+  });
+
+  it("rejects ZERO_TOKEN without chat-event:read capability", async () => {
     const fixture = await seedChatThread("Launch plan");
     const token = zeroToken({
       userId: fixture.userId,
@@ -179,7 +207,7 @@ describe("GET /api/zero/chat-threads/:threadId/events", () => {
     expect(response.body).toStrictEqual({
       error: {
         code: "FORBIDDEN",
-        message: "Missing required capability: chat-message:read",
+        message: "Missing required capability: chat-event:read",
       },
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
@@ -130,7 +130,7 @@ describe("POST /api/zero/chat-threads/:id/rename", () => {
     const token = zeroToken({
       userId: fixture.userId,
       orgId: fixture.orgId,
-      capabilities: ["chat-message:read"],
+      capabilities: ["chat-event:read"],
     });
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/zero-artifact-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifact-catalog.ts
@@ -68,7 +68,7 @@ export const zeroArtifactCatalogRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       listArtifactCatalogInner$,
     ),
@@ -79,7 +79,7 @@ export const zeroArtifactCatalogRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       getArtifactCatalogEntryInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -313,7 +313,7 @@ export const zeroArtifactsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       listArtifactsInner$,
     ),
@@ -324,7 +324,7 @@ export const zeroArtifactsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       getImageEditSnapshotInner$,
     ),
@@ -335,7 +335,7 @@ export const zeroArtifactsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       upsertImageEditSnapshotInner$,
     ),
@@ -346,7 +346,7 @@ export const zeroArtifactsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       deleteImageEditSnapshotInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -3438,7 +3438,7 @@ export const zeroChatEventsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:write",
+        requiredCapability: "chat-event:write",
       },
       sendChatEventInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -331,7 +331,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadEventsContract.list,
     handler: authRoute(
-      { requiredCapability: "chat-message:read" },
+      { requiredCapability: "chat-event:read" },
       listChatEventsInner$,
     ),
   },
@@ -345,7 +345,7 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "chat-message:read",
+        requiredCapability: "chat-event:read",
       },
       searchChatInner$,
     ),

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -9,7 +9,7 @@
       "schedule": "* * * * *"
     },
     {
-      "path": "/api/cron/monitor-chat-message-queue",
+      "path": "/api/cron/monitor-chat-event-queue",
       "schedule": "* * * * *"
     },
     {

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -115,6 +115,23 @@ describe("decodeZeroTokenPayload", () => {
     });
   });
 
+  it("should normalize legacy chat message capabilities", () => {
+    const token = buildZeroToken({
+      userId: "user-1",
+      runId: "run-1",
+      orgId: "org-1",
+      scope: "zero",
+      capabilities: ["chat-message:read", "chat-message:write"],
+      iat: 1000,
+      exp: 2000,
+    });
+
+    expect(decodeZeroTokenPayload(token)?.capabilities).toStrictEqual([
+      "chat-event:read",
+      "chat-event:write",
+    ]);
+  });
+
   it("should return undefined for token without vm0_sandbox_ prefix", () => {
     expect(decodeZeroTokenPayload("some-other-token")).toBeUndefined();
   });
@@ -407,10 +424,10 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
-  it("should show chat when chat-message:read capability is present", () => {
+  it("should show chat when chat-event:read capability is present", () => {
     const token = buildZeroToken({
       scope: "zero",
-      capabilities: ["chat-message:read"],
+      capabilities: ["chat-event:read"],
     });
     vi.stubEnv("ZERO_TOKEN", token);
 
@@ -420,10 +437,10 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
-  it("should show chat when chat-message:write capability is present", () => {
+  it("should show chat when chat-event:write capability is present", () => {
     const token = buildZeroToken({
       scope: "zero",
-      capabilities: ["chat-message:write"],
+      capabilities: ["chat-event:write"],
     });
     vi.stubEnv("ZERO_TOKEN", token);
 

--- a/turbo/apps/cli/src/commands/zero/chat/cancel.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/cancel.ts
@@ -73,7 +73,7 @@ Examples:
 
 Notes:
   - --run-id and --event-id are mutually exclusive
-  - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-message:write capabilities)`,
+  - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-event:write capabilities)`,
   )
   .action(
     withErrorHandler(async (options: CancelOptions) => {

--- a/turbo/apps/cli/src/commands/zero/chat/queued.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/queued.ts
@@ -95,7 +95,7 @@ Examples:
 Notes:
   - Lists the same unassociated user and automation events shown as queued by Platform
   - Event IDs can be passed to zero chat cancel --event-id
-  - Authenticates via ZERO_TOKEN (requires chat-message:read capability)`,
+  - Authenticates via ZERO_TOKEN (requires chat-event:read capability)`,
   )
   .action(
     withErrorHandler(async (options: QueuedOptions) => {

--- a/turbo/apps/cli/src/commands/zero/chat/send.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/send.ts
@@ -57,7 +57,7 @@ Examples:
 Notes:
   - Constructs a version 1 UserMessageDocument with one text part
   - Every normal message enters the thread queue first; an idle queue may dispatch it immediately
-  - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-message:write capabilities)`,
+  - Authenticates via ZERO_TOKEN (requires chat-thread:read and chat-event:write capabilities)`,
   )
   .action(
     withErrorHandler(async (options: SendOptions) => {

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -11,6 +11,20 @@ export interface ZeroTokenPayload {
   exp: number;
 }
 
+function normalizeZeroCapability(capability: string): string {
+  switch (capability) {
+    case "chat-message:read": {
+      return "chat-event:read";
+    }
+    case "chat-message:write": {
+      return "chat-event:write";
+    }
+    default: {
+      return capability;
+    }
+  }
+}
+
 /**
  * Decode a ZERO_TOKEN JWT payload.
  * Only decodes — does NOT verify signature (server does that).
@@ -35,7 +49,10 @@ export function decodeZeroTokenPayload(
       Buffer.from(parts[1]!, "base64url").toString(),
     ) as ZeroTokenPayload;
     if (payload.scope === "zero" && Array.isArray(payload.capabilities)) {
-      return payload;
+      return {
+        ...payload,
+        capabilities: payload.capabilities.map(normalizeZeroCapability),
+      };
     }
   } catch {
     // Malformed token — fall through

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -38,10 +38,10 @@ const COMMAND_CAPABILITY_MAP: Record<
   model: null,
   "model-provider": null,
   logs: "agent-run:read",
-  search: "chat-message:read",
+  search: "chat-event:read",
   chat: [
-    "chat-message:read",
-    "chat-message:write",
+    "chat-event:read",
+    "chat-event:write",
     "chat-thread:read",
     "chat-thread:write",
   ],

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -139,9 +139,11 @@ describe("ZERO_CAPABILITIES", () => {
     expect(ZERO_CAPABILITIES).toContain("chat-thread:write");
   });
 
-  it("should include chat message read and write capabilities", () => {
-    expect(ZERO_CAPABILITIES).toContain("chat-message:read");
-    expect(ZERO_CAPABILITIES).toContain("chat-message:write");
+  it("should include chat event read and write capabilities", () => {
+    expect(ZERO_CAPABILITIES).toContain("chat-event:read");
+    expect(ZERO_CAPABILITIES).toContain("chat-event:write");
+    expect(ZERO_CAPABILITIES).not.toContain("chat-message:read");
+    expect(ZERO_CAPABILITIES).not.toContain("chat-message:write");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -55,8 +55,8 @@ export const ZERO_CAPABILITIES = [
   "phone:write",
   "telegram:read",
   "telegram:write",
-  "chat-message:read",
-  "chat-message:write",
+  "chat-event:read",
+  "chat-event:write",
   "chat-thread:read",
   "chat-thread:write",
   "connector:read",
@@ -141,11 +141,11 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
       group: "Integrations",
       label: "Send Telegram messages and files",
     },
-    "chat-message:read": {
+    "chat-event:read": {
       group: "Integrations",
       label: "Read chat messages",
     },
-    "chat-message:write": {
+    "chat-event:write": {
       group: "Integrations",
       label: "Send & cancel chat messages",
     },

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -267,7 +267,7 @@ export const cronCompactUsageEventsContract = c.router({
 export const cronMonitorChatEventQueueContract = c.router({
   monitor: {
     method: "GET",
-    path: "/api/cron/monitor-chat-message-queue",
+    path: "/api/cron/monitor-chat-event-queue",
     headers: authHeadersSchema,
     responses: {
       200: cronMonitorChatEventQueueResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
@@ -35,7 +35,7 @@ export const testCronMonitorChatEventQueueStateActionResponseSchema = z
 export const testCronMonitorChatEventQueueStateContract = c.router({
   action: {
     method: "POST",
-    path: "/api/test/cron-monitor-chat-message-queue-state/action",
+    path: "/api/test/cron-monitor-chat-event-queue-state/action",
     body: testCronMonitorChatEventQueueStateActionBodySchema,
     responses: {
       200: testCronMonitorChatEventQueueStateActionResponseSchema,


### PR DESCRIPTION
## Summary

- rename Zero capability identifiers from `chat-message:read` / `chat-message:write` to `chat-event:read` / `chat-event:write`
- keep Release 1 backward compatibility by normalizing legacy claims at the API verification boundary and in the CLI token decoder, while issuers, CLI gates, and route declarations use only the new names
- rename the cron and test-state URLs to the chat-event vocabulary and update `apps/api/vercel.json` in the same release

## Release 1 compatibility

Already-issued Zero run tokens can contain the legacy capability claims. The API verifier maps each legacy claim to its new equivalent before filtering/authorization, so both legacy and new tokens authorize the new route declarations. The CLI decoder applies the same normalization so a newer CLI does not hide chat commands when an in-flight token still carries a legacy claim.

Newly issued tokens contain only `chat-event:read` and `chat-event:write`; tests inspect the raw JWT payload as well as the verified authorization result.

### Release 2 gate (out of scope)

Do not remove the legacy aliases until Release 1 is fully deployed across API/CLI issuers, issuance of legacy claims has stopped, and more than **2 hours** have elapsed. `generateZeroToken()` sets `exp = iat + 2 hours`, matching the maximum two-hour run/job window, so after that bound no pre-Release-1 Zero token can remain valid. Before deleting the aliases, also confirm that no pre-Release-1 runs remain active.

## Persistence audit

Performed before implementation:

- **Database:** no exact legacy capability string appears in `packages/db/src/schema`, migrations, or API persistence services. Zero capability claims are carried in signed JWTs and checked per request; they are not stored in a DB column.
- **Compose manifests:** no checked-in YAML/JSON/TOML compose manifest contains either legacy string. The compose schema strips the old experimental capability field, so the capability registry in `contracts/composes.ts` is not persisted compose content.
- **Cached authorization:** no cache/grant record persists these capability strings. The membership cache stores membership/role data; Zero capabilities come from the verified token on each request.
- **Published documentation:** the only public-text matches are historical release entries in `apps/cli/CHANGELOG.md` and `packages/core/CHANGELOG.md`. They are retained unchanged as historical records. No current product documentation advertises the legacy names.

## User-visible labels

The labels remain **“Read chat messages”** and **“Send & cancel chat messages.”** This is intentional: they describe user actions in product language rather than the capability contract identifier. Keeping them avoids an unrelated user-facing copy change while the keys move to the canonical chat-event vocabulary.

## Cron deployment window

The old cron path is not kept as an alias. Vercel schedules this monitor every minute and the route only detects/reports orphaned queue state; a stale invocation that reaches the new deployment at the old URL can return 404, delaying monitoring by at most one schedule interval. The next invocation uses `/api/cron/monitor-chat-event-queue`. This bounded alerting gap is acceptable and avoids carrying a second cron path into another release.

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- API focused integration suite: 7 files, 59 tests passed
- API contracts focused suite: 38 tests passed
- CLI capability compatibility selection: 3 tests passed
- full test matrix and `lint-knip` remain required PR pipeline gates before merge

Refs #23921