### PR TITLE
fix: title ingress chat threads when their run is created

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1429,9 +1429,13 @@ describe("CHAT-02: completed chat callback", () => {
       `chatThreadMessageCreated:${first.threadId}`,
       { syncThroughSeqId: followupEvent.seqId },
     );
+    // The auto-sent queued message titles the thread as soon as its run is
+    // created, with the completed round supplying prior context.
     expect(titlePrompts).toHaveLength(1);
+    expect(titlePrompts[0]).toContain(
+      "Most recent user message:\nqueued while side effects wait",
+    );
     expect(titlePrompts[0]).toContain("finish the current turn");
-    expect(titlePrompts[0]).not.toContain("queued while side effects wait");
 
     await flushWaitUntilForTest();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2280,6 +2280,81 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
   });
 
+  it("titles canonical Slack threads when their run is created", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    integrations.configureSlackAppMocks();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+
+    const titlePrompts: string[] = [];
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const systemContent = body.messages[0]?.content ?? "";
+      if (systemContent.includes("Generate a short, descriptive title")) {
+        titlePrompts.push(body.messages[1]?.content ?? "");
+        return "Canonical Slack Title";
+      }
+      return "Generated summary";
+    });
+
+    const slackUserId = uniqueSlackUserId();
+    const { teamId } = await integrations.installSlackWorkspace(actor, {
+      installerSlackUserId: slackUserId,
+    });
+    const channelId = "C_BDD_EAGER_TITLE";
+    const threadTs = "2960.000100";
+    const prompt = "title this canonical Slack thread";
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: prompt,
+      ts: threadTs,
+      channel: channelId,
+      channel_type: "channel",
+    });
+    const runId = await pollSlackRun(runnerGroup);
+    const claim = await runs.claimRunnerJob(runId);
+    await flushWaitUntilForTest();
+
+    const state = await integrations.readSlackTestState(teamId);
+    const chatThreadId = state.chat_thread_routes.find((route) => {
+      return route.channelId === channelId && route.threadTs === threadTs;
+    })?.chatThreadId;
+    if (!chatThreadId) {
+      throw new Error("Expected the Slack event to create a canonical thread");
+    }
+    const beforeComplete = await chat.requestThreadEvents(actor, {}, [200]);
+    if (beforeComplete.status !== 200) {
+      throw new Error("Expected canonical Slack thread events to load");
+    }
+    // The title lands while the run is still in flight, so Slack threads no
+    // longer wait for the terminal callback to be named.
+    expect(beforeComplete.body.events).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "renamed",
+          chatThreadId,
+          title: "Canonical Slack Title",
+        }),
+      ]),
+    );
+    expect(titlePrompts).toHaveLength(1);
+    expect(titlePrompts[0]).toContain(prompt);
+
+    await completeSlackTriggeredRun({
+      runId,
+      sandboxToken: claim.sandboxToken,
+      cliAgentType: claim.cliAgentType,
+      assistantText: "Canonical Slack titled answer",
+    });
+    await flushWaitUntilForTest();
+
+    expect(titlePrompts).toHaveLength(1);
+  });
+
   it("binds agent and model choices when canonical Slack threads are created", async () => {
     const actor = bdd.user();
     runs.acceptStorageDownloads();

--- a/turbo/apps/api/src/signals/routes/zero-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-events.ts
@@ -82,10 +82,7 @@ import {
   dispatchCancelSideEffects$,
   type CancelRunResult,
 } from "../services/zero-run-cancel.service";
-import {
-  generateAndPersistChatThreadTitle,
-  isChatTitleGenerationConfigured,
-} from "../services/zero-chat-title.service";
+import { scheduleChatThreadTitleGeneration } from "../services/zero-chat-title.service";
 import { generateAndPersistInitialThinkingMessage } from "../services/zero-chat-initial-thinking.service";
 import {
   isCodexFastServiceTierSupported,
@@ -2514,23 +2511,18 @@ function scheduleChatTitleGeneration(params: {
   readonly userId: string;
   readonly orgId: string;
 }): void {
-  if (
-    params.body.hasTextContent === false ||
-    !isChatTitleGenerationConfigured()
-  ) {
+  if (params.body.hasTextContent === false) {
     return;
   }
 
-  waitUntil(
-    generateAndPersistChatThreadTitle({
-      db: params.db,
-      threadId: params.thread.threadId,
-      userId: params.userId,
-      orgId: params.orgId,
-      prompt: params.body.agentPrompt,
-      includePriorRounds: !params.thread.isNewThread,
-    }),
-  );
+  scheduleChatThreadTitleGeneration({
+    db: params.db,
+    threadId: params.thread.threadId,
+    userId: params.userId,
+    orgId: params.orgId,
+    prompt: params.body.agentPrompt,
+    includePriorRounds: !params.thread.isNewThread,
+  });
 }
 
 function scheduleAssociatedUserMessage(params: {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -137,10 +137,10 @@ import { handleMorningBriefEmailInternalCallback } from "./internal-morning-brie
 import { sendUserPushNotifications } from "./zero-push-notifications.service";
 import {
   type ChatCompletionContextMessage,
-  generateAndPersistChatThreadTitleFromCallback,
   generateChatThreadRecommendedFollowupsFromContext,
   generateChatNotificationSummary,
   loadChatThreadRecommendedFollowupContext,
+  scheduleChatThreadTitleGeneration,
 } from "./zero-chat-title.service";
 import { createQueueFirstZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
@@ -2012,16 +2012,6 @@ async function runCompletedChatCallbackSideEffects(args: {
     args.signal,
   );
 
-  const titleStep = generateAndPersistChatThreadTitleFromCallback({
-    db: args.db,
-    threadId: args.chatThread.chatThreadId,
-    userId: args.chatThread.userId,
-    orgId: args.chatThread.orgId,
-    runId: args.runId,
-    prompt: args.run.prompt,
-    currentAssistantReply: args.lastResultText ?? undefined,
-  });
-
   const followupsStep = (async () => {
     const recommendedFollowups =
       await generateRecommendedFollowupsForCompletedRun({
@@ -2073,7 +2063,6 @@ async function runCompletedChatCallbackSideEffects(args: {
   const results = await Promise.allSettled([
     saveSummaryStep,
     chatRunFinishedStep,
-    titleStep,
     followupsStep,
     pushStep,
   ]);
@@ -3542,6 +3531,16 @@ async function autoSendQueuedMessageForThread(
     }),
   );
   if (run) {
+    // Ingress channels never touch the web send route, so this is where their
+    // threads get an eager title instead of waiting for the run to finish.
+    scheduleChatThreadTitleGeneration({
+      db: args.db,
+      threadId,
+      userId,
+      orgId: runInput.orgId,
+      prompt: runInput.prompt,
+      includePriorRounds: true,
+    });
     args.timing.flush(run.runId, runInput.triggerSource);
   }
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -18,7 +18,6 @@ import {
   inArray,
   isNotNull,
   isNull,
-  ne,
   not,
   or,
   type SQL,
@@ -26,6 +25,7 @@ import {
 
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { waitUntil } from "../context/wait-until";
 import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
 import { nowDate } from "../external/time";
@@ -66,7 +66,6 @@ export interface ChatCompletionContextMessage {
 
 interface ChatTitleInput {
   readonly currentUserMessage: string;
-  readonly currentAssistantReply?: string;
   readonly priorRounds?: readonly ChatCompletionContextMessage[];
 }
 
@@ -91,7 +90,7 @@ interface ChatCompletionContextRow {
 
 type SelectDb = Pick<Db, "select">;
 
-export function isChatTitleGenerationConfigured(): boolean {
+function isChatTitleGenerationConfigured(): boolean {
   return Boolean(optionalEnv("OPENROUTER_API_KEY"));
 }
 
@@ -222,11 +221,6 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
   sections.push(
     `Most recent user message:\n${input.currentUserMessage.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
   );
-  if (input.currentAssistantReply) {
-    sections.push(
-      `Most recent assistant reply:\n${input.currentAssistantReply.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
-    );
-  }
 
   return generateText([
     {
@@ -244,26 +238,7 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
 async function getLatestTitleContextMessages(
   db: Db,
   threadId: string,
-  options?: { readonly excludeRunId?: string },
 ): Promise<ChatCompletionContextMessage[]> {
-  const filters = [
-    eq(chatEvents.chatThreadId, threadId),
-    contextMessageContentCondition(),
-    chatEventTypeIn(CHAT_EVENT_TYPES),
-    visibleChatEventCondition(db),
-    completedConversationContextMessageCondition(db),
-  ];
-  if (options?.excludeRunId !== undefined) {
-    filters.push(
-      // Keep prior context free of the current exchange. User rows have the run
-      // id too, so this excludes both sides of the just-completed round.
-      or(
-        isNull(chatEvents.runId),
-        ne(chatEvents.runId, options.excludeRunId),
-      ) as SQL,
-    );
-  }
-
   const rows = await db
     .select({
       eventType: chatEvents.eventType,
@@ -274,7 +249,15 @@ async function getLatestTitleContextMessages(
     })
     .from(chatEvents)
     .leftJoin(agentRuns, eq(agentRuns.id, chatEvents.runId))
-    .where(and(...filters))
+    .where(
+      and(
+        eq(chatEvents.chatThreadId, threadId),
+        contextMessageContentCondition(),
+        chatEventTypeIn(CHAT_EVENT_TYPES),
+        visibleChatEventCondition(db),
+        completedConversationContextMessageCondition(db),
+      ),
+    )
     .orderBy(desc(chatEvents.seqId))
     .limit(TITLE_PRIOR_MESSAGE_CAP);
 
@@ -339,7 +322,7 @@ async function shouldGenerateChatThreadTitle(
   return Boolean(thread && thread.title === null && thread.renamedAt === null);
 }
 
-export async function generateAndPersistChatThreadTitle(args: {
+async function generateAndPersistChatThreadTitle(args: {
   readonly db: Db;
   readonly threadId: string;
   readonly userId: string;
@@ -379,48 +362,24 @@ export async function generateAndPersistChatThreadTitle(args: {
   );
 }
 
-export async function generateAndPersistChatThreadTitleFromCallback(args: {
+/**
+ * Fire-and-forget eager title generation, shared by the inline web send route
+ * and the queue drain. Every chat-thread-bound run passes through one of the
+ * two, so the trigger source no longer decides whether a thread is titled
+ * before its run finishes.
+ */
+export function scheduleChatThreadTitleGeneration(args: {
   readonly db: Db;
   readonly threadId: string;
   readonly userId: string;
   readonly orgId: string | null;
-  readonly runId: string;
   readonly prompt: string;
-  readonly currentAssistantReply: string | undefined;
-}): Promise<void> {
-  await tapError(
-    (async () => {
-      if (!(await shouldGenerateChatThreadTitle(args.db, args.threadId))) {
-        return;
-      }
-
-      const priorRounds = await getLatestTitleContextMessages(
-        args.db,
-        args.threadId,
-        { excludeRunId: args.runId },
-      );
-      const title = await generateChatTitle({
-        currentUserMessage: args.prompt,
-        currentAssistantReply: args.currentAssistantReply,
-        priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
-      });
-      if (title) {
-        await updateChatThreadTitle(
-          args.db,
-          args.threadId,
-          args.userId,
-          args.orgId,
-          title,
-        );
-      }
-    })(),
-    (err) => {
-      log.warn("Chat title generation failed", {
-        threadId: args.threadId,
-        err,
-      });
-    },
-  );
+  readonly includePriorRounds: boolean;
+}): void {
+  if (!isChatTitleGenerationConfigured() || args.prompt.trim().length === 0) {
+    return;
+  }
+  waitUntil(generateAndPersistChatThreadTitle(args));
 }
 
 export function generateChatNotificationSummary(


### PR DESCRIPTION
## Problem

Chat threads created from Slack (and Feishu, Teams, Telegram) stayed untitled until their run finished, while web chat threads are titled the moment the message is sent.

The eager title call only existed inside the web send route (`routes/zero-chat-events.ts`), bound to `RuntimeNormalSendBody` / `ResolvedThread`. Ingress channels never reach that route: they insert the user message directly and dispatch through `drainChatThreadQueueForThread$`, so the only remaining trigger was `generateAndPersistChatThreadTitleFromCallback` in the terminal run callback. The same gap hit web sends that queued behind an active run.

## Change

- Move the scheduling (config gate + `waitUntil`) into `scheduleChatThreadTitleGeneration` in `zero-chat-title.service.ts`; the web route now delegates to it.
- Call it from `autoSendQueuedMessageForThread` after a queued message's run is created. That is the single place every non-inline chat-thread-bound run is born: Slack, Feishu, Teams, Telegram, queued web sends, workflow-schedule messages, and Morning Brief.
- Delete `generateAndPersistChatThreadTitleFromCallback` and the code only it used: the `excludeRunId` filter in `getLatestTitleContextMessages` and the `currentAssistantReply` title input.

## Why deleting the callback variant is safe

Thread-bound runs come from four `createQueueFirstZeroRun$` call sites:

| Call site | Title source |
| --- | --- |
| `routes/zero-chat-events.ts` inline web send | existing eager call |
| `internal-chat-run-callback.service.ts` queue drain | new eager call |
| `zero-goal-queue-drain.service.ts` | thread created with `title: objective` |
| `zero-workflow-automation-launch.service.ts` | thread created with an explicit title |

`createZeroRun$` (runs API, AgentPhone, GitHub webhook) and `createZeroIntegrationRun$` (Telegram dispatch) do not bind a chat thread. So every thread that can have `title IS NULL` now gets its title at run creation, and the callback pass could only ever re-check an already-titled thread. `chat-callbacks.bdd.test.ts` already asserted this: completing a run added no title prompt.

## Behavior notes

- Titles no longer include the assistant reply. Slack titles now match web quality, and the `title IS NULL AND renamed_at IS NULL` guard keeps manual renames intact.
- Failed runs now get a title. The callback path only ran on completion.
- Repeat scheduling stays idempotent: `shouldGenerateChatThreadTitle` pre-checks and the guarded `UPDATE` only appends a `renamed` thread event when it actually wins.
- The retry that the callback provided is gone. A dropped eager call is retried by the next message in the thread; a thread with exactly one message whose OpenRouter call fails stays untitled.

## Tests

- New: `integrations.bdd.test.ts` asserts a canonical Slack thread is renamed while its run is still in flight, and that completing the run issues no second title prompt.
- Existing title assertions in `chat-events.bdd.test.ts` and `chat-callbacks.bdd.test.ts` cover the web path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
