### PR TITLE
fix(ci): trigger the release path from the push to main

### DIFF
--- a/.github/scripts/pass-release-pr-ci-gates.sh
+++ b/.github/scripts/pass-release-pr-ci-gates.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create ci-gate check runs on the release PR head commit. GITHUB_TOKEN pushes
+# don't trigger pull_request events, so the CI workflows never run on the new
+# commit. The Checks API with GITHUB_TOKEN produces check runs with
+# integration_id 15368 (GitHub Actions), satisfying the required_status_checks
+# ruleset.
+
+require_env() {
+  local name=$1
+  if [ -z "${!name:-}" ]; then
+    echo "missing required env: ${name}" >&2
+    exit 2
+  fi
+}
+
+require_env GH_TOKEN
+require_env GITHUB_REPOSITORY
+
+PR_JSON=$(gh pr view release-please--branches--main --repo "$GITHUB_REPOSITORY" --json number,headRefOid 2>/dev/null || echo "")
+if [ -z "$PR_JSON" ]; then
+  echo "No release PR found, skipping"
+  exit 0
+fi
+
+PR_NUMBER=$(jq -r .number <<<"$PR_JSON")
+PR_HEAD=$(jq -r .headRefOid <<<"$PR_JSON")
+CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only)
+
+create_gate_check() {
+  local gate="$1"
+  local conclusion="$2"
+  local title="$3"
+  local summary="$4"
+
+  gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+    -f name="$gate" \
+    -f head_sha="$PR_HEAD" \
+    -f status="completed" \
+    -f conclusion="$conclusion" \
+    -f "output[title]=$title" \
+    -f "output[summary]=$summary"
+  echo "✅ Created $gate check run on $PR_HEAD with conclusion $conclusion"
+}
+
+db_release_in_pr=false
+api_release_in_pr=false
+if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/packages/db/package.json"; then
+  db_release_in_pr=true
+fi
+if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/apps/api/package.json"; then
+  api_release_in_pr=true
+fi
+
+if [ "$db_release_in_pr" = "true" ] && [ "$api_release_in_pr" != "true" ]; then
+  create_gate_check \
+    ci-gate-turbo \
+    failure \
+    "DB release requires API release" \
+    "Release PRs that bump turbo/packages/db must also bump turbo/apps/api because production migrations are owned by the API release lifecycle."
+  create_gate_check ci-gate-crates success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+  create_gate_check ci-gate-security success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+  echo "::error::turbo/packages/db release PR changes must ship with turbo/apps/api."
+  exit 1
+fi
+
+for gate in ci-gate-turbo ci-gate-crates ci-gate-security; do
+  create_gate_check "$gate" success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
+done

--- a/.github/workflows/release-please-refresh.yml
+++ b/.github/workflows/release-please-refresh.yml
@@ -1,0 +1,43 @@
+name: release-please-refresh
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: write
+
+# Only the newest main state is worth publishing to the release pull request, so
+# an in-flight refresh is cancelled by a newer push.
+concurrency:
+  group: release-please-pull-request
+  cancel-in-progress: true
+
+jobs:
+  refresh-release-pull-request:
+    # Release commits are refreshed by release-please.yml instead, because that
+    # workflow creates the tags before it regenerates the pull request. Doing it
+    # here first would rebuild the pull request from a baseline whose releases do
+    # not exist yet and bump every just-released component a second time.
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+
+      - uses: vm0-ai/release-please-action@vm0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
+      - name: Pass ci-gate checks for release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/pass-release-pr-ci-gates.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,11 +1,15 @@
 name: release-please
 
+# Releases run straight off the push to main. Waiting for the Turbo run on main
+# bought nothing: the merge queue is fast-forwarded, so the merge-group Turbo run
+# already validated this exact commit SHA and already built and uploaded the
+# canonical app artifact that promote-app-production consumes. On a release
+# commit the Turbo run on main skips 27 of its 30 jobs, and the app build and
+# upload steps skip too because the artifact is already present. Its only unique
+# effect is repointing the staging-app Pages alias.
 on:
-  workflow_run:
-    workflows: ["Turbo"]
+  push:
     branches: ["main"]
-    types:
-      - completed
 
 permissions:
   actions: read
@@ -16,8 +20,42 @@ permissions:
   checks: write
 
 jobs:
+  # A push to main can carry several merge-queue entries at once, so look at every
+  # commit subject in the push rather than only the head commit. Without this the
+  # release path would run on every main push and each no-op run would still take
+  # a turn in the production deploy queue.
+  detect-release-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release: ${{ steps.detect.outputs.release }}
+    steps:
+      - name: Detect a release commit in this push
+        id: detect
+        env:
+          COMMIT_MESSAGES: ${{ toJSON(github.event.commits.*.message) }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          subjects=$(jq -r 'if length == 0 then empty else .[] | split("\n")[0] end' <<<"$COMMIT_MESSAGES")
+          if [ -z "$subjects" ]; then
+            subjects=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1)
+          fi
+
+          release=false
+          while IFS= read -r subject; do
+            case "$subject" in
+            'chore: release'*) release=true ;;
+            esac
+          done <<<"$subjects"
+
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          echo "release commit in this push: $release"
+
   queue-production-deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: detect-release-commit
+    if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
@@ -33,9 +71,9 @@ jobs:
         run: bash .github/scripts/wait-production-deploy-queue.sh
 
   release-please:
-    needs: queue-production-deploy
+    needs: [detect-release-commit, queue-production-deploy]
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.detect-release-commit.outputs.release == 'true' }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       release_target: ${{ steps.release-target.outputs.sha }}
@@ -1797,7 +1835,7 @@ jobs:
         with:
           workspaces: crates -> target
           shared-key: ${{ steps.target-metadata.outputs.cache_suffix }}-release
-          save-if: ${{ github.event.workflow_run.head_branch == 'main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Notify Slack - Starting
         id: slack-start

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
 
       - name: Resolve release target
         id: release-target
@@ -99,66 +100,30 @@ jobs:
 
           echo "sha=$release_target" >> "$GITHUB_OUTPUT"
 
-      # Create ci-gate check runs on release PR head commit.
-      # GITHUB_TOKEN pushes don't trigger pull_request events, so the CI
-      # workflows never run on the new commit. The Checks API with GITHUB_TOKEN
-      # produces check runs with integration_id 15368 (GitHub Actions),
-      # satisfying the required_status_checks ruleset.
+  # Refreshing the release pull request is a separate job so that a failure here
+  # cannot skip the release and deployment jobs above. release-please recomputes
+  # the pull request from scratch on every run, so a failed refresh self-heals on
+  # the next push to main.
+  refresh-release-pull-request:
+    needs: release-please
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+
+      - uses: vm0-ai/release-please-action@vm0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
       - name: Pass ci-gate checks for release PR
-        if: ${{ steps.release.outputs.releases_created != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_JSON=$(gh pr view release-please--branches--main --repo "${{ github.repository }}" --json number,headRefOid 2>/dev/null || echo "")
-          if [ -z "$PR_JSON" ]; then
-            echo "No release PR found, skipping"
-            exit 0
-          fi
-
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r .number)
-          PR_HEAD=$(echo "$PR_JSON" | jq -r .headRefOid)
-          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" --name-only)
-
-          create_gate_check() {
-            local gate="$1"
-            local conclusion="$2"
-            local title="$3"
-            local summary="$4"
-
-            gh api repos/${{ github.repository }}/check-runs -X POST \
-              -f name="$gate" \
-              -f head_sha="$PR_HEAD" \
-              -f status="completed" \
-              -f conclusion="$conclusion" \
-              -f "output[title]=$title" \
-              -f "output[summary]=$summary"
-            echo "✅ Created $gate check run on $PR_HEAD with conclusion $conclusion"
-          }
-
-          db_release_in_pr=false
-          api_release_in_pr=false
-          if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/packages/db/package.json"; then
-            db_release_in_pr=true
-          fi
-          if printf '%s\n' "$CHANGED_FILES" | grep -qx "turbo/apps/api/package.json"; then
-            api_release_in_pr=true
-          fi
-
-          if [ "$db_release_in_pr" = "true" ] && [ "$api_release_in_pr" != "true" ]; then
-            create_gate_check \
-              ci-gate-turbo \
-              failure \
-              "DB release requires API release" \
-              "Release PRs that bump turbo/packages/db must also bump turbo/apps/api because production migrations are owned by the API release lifecycle."
-            create_gate_check ci-gate-crates success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-            create_gate_check ci-gate-security success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-            echo "::error::turbo/packages/db release PR changes must ship with turbo/apps/api."
-            exit 1
-          fi
-
-          for gate in ci-gate-turbo ci-gate-crates ci-gate-security; do
-            create_gate_check "$gate" success "Release PR — CI skipped" "Release-please PRs only contain version bumps and changelogs."
-          done
+        run: bash .github/scripts/pass-release-pr-ci-gates.sh
 
   validate-db-release-coupling:
     needs: release-please

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -223,6 +223,7 @@ jobs:
             .github/scripts/check-release-please-component-releases.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/cloudflare-ssh-preconnect.sh \
+            .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/tests/ansible-ssh-control-path-test.sh \


### PR DESCRIPTION
## Summary

- trigger `release-please.yml` from the `push` to `main` instead of from `workflow_run` of Turbo on `main`
- gate the release path on the push actually containing a `chore: release` commit, checking every commit subject in the push rather than only the head commit
- point the Rust cache `save-if` at `github.ref`, which no longer has a `workflow_run` payload to read

> Stacked on #23935. That PR moves the pull-request refresh into its own push-triggered workflow, which is what keeps the release pull request fresh once this PR stops running release-please on non-release pushes. Review and merge #23935 first; the base here is `fix/release-pr-fast-refresh`.

## Why the Turbo dependency was not buying anything

The merge queue fast-forwards `main`, so the merge-group head SHA is the commit that lands. Verified on two commits: `871ac17d` (release commit for #23901) and `402ce7e1` (an ordinary feature commit) each have one merge_group Turbo run and one push Turbo run with the same `head_sha`.

**The canonical app artifact comes from the merge-group run, not from the run on `main`.** `deploy-app` resolves `okou-app/<sha>`, checks for `ready.json`, and skips building when it already exists. For `871ac17d`:

| step | merge_group run 30514251206 | push run 30514356763 |
|---|---|---|
| Check for existing artifact | success | success |
| Build canonical app artifact | success | **skipped** |
| Upload canonical app artifact | success | **skipped** |

So `promote-app-production`, which downloads `okou-app/<release_target>/` and polls `ready.json` for up to 10 minutes, is already satisfied before `main` receives the commit.

**The rest of that run is a duplicate.** For `402ce7e1` the merge_group run and the push run have the same 30 jobs with identical per-job conclusions (280s vs 274s). On a release commit the push run skips 27 of 30 jobs and finishes in about 1.4 minutes. Its only unique effect is `resolve-okou-pages-branch.sh` returning `staging-app` instead of `pr-<N>-app`.

## What this fixes beyond latency

A release commit's Turbo run on `main` can only fail through `deploy-app`. Today that failure means release-please never runs, so the runner, API, desktop and host-worker releases stall too, even though they build from the release commit and never touch that artifact. After this change an app build failure only affects the app: `promote-app-production` fails on its own artifact wait, and the other components still ship.

## Behavior

- `detect-release-commit` runs on every push to `main` and costs a few seconds. Everything else skips unless the push contains a release commit.
- production deploy ordering is unchanged: `queue-production-deploy` still runs before `release-please` and still waits for older release-please and rollback runs.
- release, build, promotion and tagging order are unchanged. `createReleases()` still runs before any production build, exactly as today.
- all 18 checkouts in this workflow already pin an explicit `ref`, so switching the event does not change what any job checks out. The two that use `${{ github.ref }}` resolve to `refs/heads/main` under both events.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow
- the detection step's shell logic was exercised against five payload shapes: a single release commit, a batch where the release commit is not last, an ordinary push, an empty `commits` array falling back to `head_commit`, and a body line mentioning `chore: release` that must not match
- `actionlint`, Workflow Lint and the workflow script tests run in this pipeline

## Not in this PR

Turbo on `main` is itself a proven duplicate for Turbo specifically, so the test suite there could be skipped when the same SHA already has a green merge_group run. That needs its own PR and its own guard for commits that reach `main` without passing the queue. The Crates, Runner Image and Security Scanning workflows show different durations on `main` (Security 77s vs 381s), so they are not assumed to be duplicates and were not investigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
