### PR TITLE
refactor(api): remove synthetic catalog ref validation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -5954,6 +5954,38 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
+      name: "duplicate connector slug",
+      expected: "invalid-artifact",
+      release: () => {
+        return buildRelease({
+          version: "duplicate-connector-slug",
+          mutateCatalog: (artifact) => {
+            const connectors = arrayValue(artifact.connectors, "connectors");
+            connectors.push(
+              structuredClone(firstRecord(connectors, "connectors")),
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "unknown category group",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "unknown-category-group",
+          mutateCatalog: (artifact) => {
+            const categoryMetadata = recordValue(
+              artifact.categoryMetadata,
+              "categoryMetadata",
+            );
+            firstRecord(categoryMetadata.categories, "categories").groupId =
+              "unknown";
+          },
+        });
+      },
+    },
+    {
       name: "duplicate auth method id",
       expected: "invalid-artifact",
       release: () => {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -185,8 +185,6 @@ export const firewallCategoriesSchema = z
 
 const firewallGeneratorResultSchema = z
   .object({
-    // TODO(#23619): Rename only with the external generator artifact version.
-    connectorRef: connectorSlugSchema,
     firewall: firewallConfigSchema,
     categories: firewallCategoriesSchema.nullable(),
     defaultAllowed: z.array(z.string().min(1)).nullable(),
@@ -370,23 +368,19 @@ function validateHostPolicy(connectorSlug: string, api: FirewallApi): void {
 export function validateFirewallGeneratorResult(
   result: FirewallGeneratorResult,
 ): void {
-  if (result.connectorRef !== result.firewall.name) {
-    throw new Error(
-      `Firewall result ref mismatch: ${result.connectorRef} != ${result.firewall.name}`,
-    );
-  }
+  const connectorSlug = result.firewall.name;
   const permissionNames = firewallPermissionNames(result.firewall);
   for (const api of result.firewall.apis) {
-    parseFirewallBaseUrl(api.base, result.connectorRef);
+    parseFirewallBaseUrl(api.base, connectorSlug);
     validateBaseUrlHostPolicy({
       base: api.base,
-      serviceName: result.connectorRef,
+      serviceName: connectorSlug,
       hostPolicy: api.hostPolicy,
     });
     if (api.auth.base !== undefined) {
-      validateAuthBaseUrl(api.auth.base, result.connectorRef);
+      validateAuthBaseUrl(api.auth.base, connectorSlug);
     }
-    validateHostPolicy(result.connectorRef, api);
+    validateHostPolicy(connectorSlug, api);
   }
 
   if (result.categories !== null) {
@@ -399,7 +393,7 @@ export function validateFirewallGeneratorResult(
     });
     if (missing.length > 0 || unknown.length > 0) {
       throw new Error(
-        `Firewall categories do not match permissions for ${result.connectorRef}`,
+        `Firewall categories do not match permissions for ${connectorSlug}`,
       );
     }
     const categoryNames = new Set(
@@ -416,7 +410,7 @@ export function validateFirewallGeneratorResult(
       })
     ) {
       throw new Error(
-        `Firewall category order does not match categories for ${result.connectorRef}`,
+        `Firewall category order does not match categories for ${connectorSlug}`,
       );
     }
   }
@@ -428,7 +422,7 @@ export function validateFirewallGeneratorResult(
     });
     if (duplicates.length > 0 || unknown.length > 0) {
       throw new Error(
-        `Firewall default allowlist is invalid for ${result.connectorRef}`,
+        `Firewall default allowlist is invalid for ${connectorSlug}`,
       );
     }
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -116,9 +116,6 @@ function sourceGrant(method: ConnectorCatalogAuthMethod): ConnectorGrantSource {
 function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
   const catalogSource = catalogSourceSchema.parse({
     catalogVersion: artifact.catalogVersion,
-    connectorRefs: artifact.connectors.map((connector) => {
-      return connector.slug;
-    }),
     categoryMetadata: artifact.categoryMetadata,
   });
   validateCatalogSourceSemantics(catalogSource);
@@ -143,7 +140,6 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
       throw new Error(`Unknown category for connector ${connector.slug}`);
     }
     const source = connectorSourceSchema.parse({
-      ref: connector.slug,
       label: connector.label,
       description: connector.description,
       category: connector.category,
@@ -166,7 +162,10 @@ function validateConnectorSemantics(artifact: ConnectorCatalogArtifact): void {
         };
       }),
     });
-    validateConnectorSourceSemantics(source);
+    validateConnectorSourceSemantics({
+      connectorSlug: connector.slug,
+      source,
+    });
 
     if (connector.skill.kind === "bundled") {
       const storageOwner = skillStorageOwners.get(connector.skill.storageName);
@@ -347,7 +346,6 @@ function validateFirewallSemantics(artifact: ConnectorCatalogArtifact): void {
       throw new Error("Generated connector firewall is unavailable");
     }
     validateFirewallGeneratorResult({
-      connectorRef: connector.slug,
       firewall,
       categories: connector.firewall.categories,
       defaultAllowed: connector.firewall.defaultAllowed,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -1,10 +1,6 @@
 import { connectorAuthMethodIdSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
-import {
-  connectorSlugSchema,
-  connectorCatalogVersionSchema,
-  privateNameSchema,
-} from "./common";
+import { connectorCatalogVersionSchema, privateNameSchema } from "./common";
 
 export const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/u);
 export const connectorFeatureSwitchKeySchema = z
@@ -53,8 +49,6 @@ const categorySourceSchema = z
 export const catalogSourceSchema = z
   .object({
     catalogVersion: connectorCatalogVersionSchema,
-    // TODO(#23619): Rename only with the external catalog source format.
-    connectorRefs: z.array(connectorSlugSchema).min(1),
     categoryMetadata: z
       .object({
         categories: z.array(categorySourceSchema).min(1),
@@ -262,8 +256,6 @@ const connectorAuthMethodSourceSchema = z
 
 export const connectorSourceSchema = z
   .object({
-    // TODO(#23619): Rename only with the external connector source format.
-    ref: connectorSlugSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: connectorCategoryIdSchema,
@@ -517,25 +509,25 @@ function validateAuthMethodSemantics(args: {
   validateRefreshableSecrets(methodRef, args.authMethod, storage);
 }
 
-export function validateConnectorSourceSemantics(
-  source: ConnectorSource,
-): void {
+export function validateConnectorSourceSemantics(args: {
+  readonly connectorSlug: string;
+  readonly source: ConnectorSource;
+}): void {
   assertUnique({
-    values: source.authMethods.map((authMethod) => {
+    values: args.source.authMethods.map((authMethod) => {
       return authMethod.id;
     }),
-    label: `${source.ref} auth method id`,
+    label: `${args.connectorSlug} auth method id`,
   });
-  for (const authMethod of source.authMethods) {
-    validateAuthMethodSemantics({ connectorSlug: source.ref, authMethod });
+  for (const authMethod of args.source.authMethods) {
+    validateAuthMethodSemantics({
+      connectorSlug: args.connectorSlug,
+      authMethod,
+    });
   }
 }
 
 export function validateCatalogSourceSemantics(source: CatalogSource): void {
-  assertUnique({
-    values: source.connectorRefs,
-    label: "catalog connector ref",
-  });
   const groupIds = source.categoryMetadata.groups.map((group) => {
     return group.id;
   });


### PR DESCRIPTION
## Summary

- remove validator-only `ref`, `connectorRef`, and `connectorRefs` fields reconstructed from canonical connector slugs
- use the canonical connector slug and derived firewall name directly for semantic validation and diagnostics
- remove the unreachable firewall ref equality check and rely on the artifact schema's connector slug uniqueness validation
- add catalog sync integration coverage for duplicate connector slugs and unknown category groups

## Compatibility

- no connector catalog artifact, R2 path, database schema, API, or runner protocol changes
- preserve the public compatibility output that still exposes `connectorRef`; its removal is owned by #23821

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --silent=passed-only`
- `pnpm knip`
- pre-commit hooks, including repository-wide TypeScript checks

Closes #23945

Parent: #23619
