### PR TITLE
refactor(cli): remove unnecessary resource candidate groups

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -193,19 +193,6 @@ describe("zero generate source-backed artifact commands", () => {
     expect(presentationSelection.candidates.templates).toHaveLength(0);
   });
 
-  it("attributes every vm0 image style to the vm0-skills repo", () => {
-    const selection = selectResourceCandidates();
-    const vm0ImageStyles = selection.candidates.imageStyles.filter((entry) => {
-      return entry.id.startsWith("image-style:");
-    });
-
-    expect(vm0ImageStyles.length).toBeGreaterThan(0);
-    for (const entry of vm0ImageStyles) {
-      expect(entry.source.repo).toBe("vm0-ai/vm0-skills");
-      expect(entry.source.ref).toBe("main");
-    }
-  });
-
   it("annotates every template entry with at least one target", () => {
     const selection = selectResourceCandidates();
     for (const template of selection.candidates.templates) {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -155,6 +155,15 @@ describe("zero generate source-backed artifact commands", () => {
     );
   });
 
+  it("omits unnecessary candidate groups", () => {
+    const selection = selectResourceCandidates();
+
+    expect(selection.candidates).not.toHaveProperty("imageStyles");
+    expect(selection.candidates).not.toHaveProperty("audioStyles");
+    expect(selection.candidates).not.toHaveProperty("videoTemplates");
+    expect(selection.candidates).not.toHaveProperty("bundleTemplates");
+  });
+
   it("filters template candidates by target when requested", () => {
     const websiteSelection = selectResourceCandidates("website");
     const presentationSelection = selectResourceCandidates("presentation");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -155,13 +155,26 @@ describe("zero generate source-backed artifact commands", () => {
     );
   });
 
-  it("omits unnecessary candidate groups", () => {
-    const selection = selectResourceCandidates();
+  it("omits unnecessary candidate groups from the generated packet", async () => {
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "report",
+      "--prompt",
+      "Q2 generation usage report",
+      "--site-slug",
+      "report-demo",
+    ]);
 
-    expect(selection.candidates).not.toHaveProperty("imageStyles");
-    expect(selection.candidates).not.toHaveProperty("audioStyles");
-    expect(selection.candidates).not.toHaveProperty("videoTemplates");
-    expect(selection.candidates).not.toHaveProperty("bundleTemplates");
+    const stdout = output();
+    expect(stdout).not.toContain('"imageStyles"');
+    expect(stdout).not.toContain('"audioStyles"');
+    expect(stdout).not.toContain('"videoTemplates"');
+    expect(stdout).not.toContain('"bundleTemplates"');
+    expect(stdout).not.toContain('"imageStyle"');
+    expect(stdout).not.toContain('"audioStyle"');
+    expect(stdout).not.toContain('"videoTemplate"');
+    expect(stdout).not.toContain('"bundleTemplate"');
   });
 
   it("filters template candidates by target when requested", () => {

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -155,7 +155,7 @@ export function createHtmlArtifactAuthoringPacket(
     "",
     "## Stage 1: Resource Selection",
     "- Choose generation resources from the bundled federated registry slice below.",
-    "- Select one template, one or more skills, zero or one design system, and optional media/style resources when relevant.",
+    "- Select one template, one or more skills, and zero or one design system.",
     "- Choose only IDs present in this packet; do not invent registry IDs.",
     "- Prefer compatible resources, but the user prompt is the highest-priority signal.",
     "- Treat the selection JSON as internal working state, then continue to authoring.",

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -41,10 +41,6 @@ interface HtmlArtifactAuthoringPacket {
       readonly skills: "string[]";
       readonly template: "string";
       readonly designSystem: "string | null";
-      readonly imageStyle: "string | null";
-      readonly audioStyle: "string | null";
-      readonly videoTemplate: "string | null";
-      readonly bundleTemplate: "string | null";
       readonly rationale: "string";
     };
   };
@@ -115,10 +111,6 @@ export function createHtmlArtifactAuthoringPacket(
     skills: "string[]",
     template: "string",
     designSystem: "string | null",
-    imageStyle: "string | null",
-    audioStyle: "string | null",
-    videoTemplate: "string | null",
-    bundleTemplate: "string | null",
     rationale: "string",
   } as const;
   const artifact = {

--- a/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
@@ -1,8 +1,7 @@
 import {
   type GenerationOutputKind,
-  type ResourceCandidateSlice,
   type VideoTemplateRegistryEntry,
-  selectResourceCandidates,
+  RESOURCE_REGISTRY_VERSION,
 } from "./resource-registry";
 
 interface VideoTemplateAuthoringOptions {
@@ -31,7 +30,9 @@ interface VideoTemplateAuthoringPacket {
     readonly outputDir: string;
   };
   readonly selection: {
-    readonly candidates: ResourceCandidateSlice["candidates"];
+    readonly candidates: {
+      readonly videoTemplates: readonly VideoTemplateRegistryEntry[];
+    };
     readonly outputSchema: {
       readonly videoTemplate: "string";
       readonly rationale: "string";
@@ -43,15 +44,6 @@ interface VideoTemplateAuthoringPacket {
   };
   readonly outputDir: string;
   readonly instructions: string;
-}
-
-function formatCandidateSource(
-  source: ResourceCandidateSlice["sources"][number],
-): string {
-  if ("repo" in source) {
-    return `- \`${source.repo}@${source.ref}\``;
-  }
-  return `- ${source.description}`;
 }
 
 const outputDir = "./generated/videos";
@@ -67,28 +59,8 @@ const artifactRules = [
 export function createVideoTemplateAuthoringPacket(
   options: VideoTemplateAuthoringOptions,
 ): VideoTemplateAuthoringPacket {
-  const baseSlice = selectResourceCandidates();
-  const candidateSlice: ResourceCandidateSlice = {
-    registryVersion: baseSlice.registryVersion,
-    source: {
-      repo: options.template.source.repo,
-      ref: options.template.source.ref,
-    },
-    sources: [
-      {
-        repo: options.template.source.repo,
-        ref: options.template.source.ref,
-      },
-    ],
-    candidates: {
-      skills: [],
-      templates: [],
-      designSystems: [],
-      imageStyles: [],
-      audioStyles: [],
-      videoTemplates: [options.template],
-      bundleTemplates: [],
-    },
+  const candidates = {
+    videoTemplates: [options.template],
   };
   const selectionSchema = {
     videoTemplate: "string",
@@ -133,12 +105,11 @@ export function createVideoTemplateAuthoringPacket(
     "```",
     "",
     "## Locked Template Source",
-    `Registry: \`${candidateSlice.registryVersion}\``,
-    "Sources:",
-    ...candidateSlice.sources.map(formatCandidateSource),
+    `Registry: \`${RESOURCE_REGISTRY_VERSION}\``,
+    `Git source: \`${options.template.source.repo}@${options.template.source.ref}\``,
     "",
     "```json",
-    JSON.stringify(candidateSlice.candidates, null, 2),
+    JSON.stringify(candidates, null, 2),
     "```",
     "",
     "## Stage 2: Resolve Selected Resources",
@@ -177,10 +148,10 @@ export function createVideoTemplateAuthoringPacket(
     type: "generation-source-selection",
     kind: "video",
     prompt: options.prompt,
-    registryVersion: candidateSlice.registryVersion,
+    registryVersion: RESOURCE_REGISTRY_VERSION,
     artifact,
     selection: {
-      candidates: candidateSlice.candidates,
+      candidates,
       outputSchema: selectionSchema,
     },
     authoring: {

--- a/turbo/packages/core/src/__tests__/video-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/video-template-items.spec.ts
@@ -3,10 +3,7 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   findVideoTemplateItem,
 } from "../video-template-items";
-import {
-  findVideoTemplate,
-  selectResourceCandidates,
-} from "../resource-registry";
+import { findVideoTemplate } from "../resource-registry";
 
 describe("video template items", () => {
   const expectedOrder = [
@@ -53,25 +50,6 @@ describe("video template items", () => {
       expect(template).not.toHaveProperty("previewImage");
       expect(template).not.toHaveProperty("previewVideo");
     }
-  });
-
-  it("exposes video templates through the candidate slice", () => {
-    const { videoTemplates } = selectResourceCandidates().candidates;
-
-    expect(
-      videoTemplates.map((template) => {
-        return template.id;
-      }),
-    ).toEqual(expectedOrder);
-    expect(videoTemplates).toContainEqual(
-      expect.objectContaining({
-        id: "video-template:epic-grandeur",
-        kind: "video-template",
-        source: expect.objectContaining({
-          path: "video-template/epic-grandeur",
-        }),
-      }),
-    );
   });
 
   it("resolves historical video template ids", () => {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -97,10 +97,6 @@ export interface ResourceCandidateSlice {
     readonly skills: readonly RegistryEntry[];
     readonly templates: readonly RegistryEntry[];
     readonly designSystems: readonly RegistryEntry[];
-    readonly imageStyles: readonly RegistryEntry[];
-    readonly audioStyles: readonly RegistryEntry[];
-    readonly videoTemplates: readonly VideoTemplateRegistryEntry[];
-    readonly bundleTemplates: readonly RegistryEntry[];
   };
 }
 
@@ -113,7 +109,7 @@ const VIDEO_TEMPLATE_REGISTRY_SOURCE = {
   ref: VM0_SKILLS_REF,
 } as const;
 
-const RESOURCE_REGISTRY_VERSION = "v1";
+export const RESOURCE_REGISTRY_VERSION = "v1";
 
 function privateR2ArchiveSource(
   path: string,
@@ -3985,10 +3981,6 @@ export function selectResourceCandidates(
       skills: listSkills(),
       templates: listTemplates(target),
       designSystems: filterByKind("design-system"),
-      imageStyles: filterByKind("image-style"),
-      audioStyles: filterByKind("audio-style"),
-      videoTemplates: listVideoTemplates(),
-      bundleTemplates: filterByKind("bundle-template"),
     },
   };
 }


### PR DESCRIPTION
## Summary

- remove `imageStyles` from the shared candidate slice; standalone Image generation continues to use the existing image-style registry APIs
- remove `videoTemplates` from the shared candidate slice; Video authoring only used `selectResourceCandidates()` to read the registry version and already constructs its locked template from `options.template`
- remove `audioStyles` and `bundleTemplates`: neither has registry entries or an independent consumer, so both were always serialized as empty arrays
- export `RESOURCE_REGISTRY_VERSION` for the dedicated Video authoring path, which continues to emit its selected Video Template
- remove the corresponding `imageStyle`, `audioStyle`, `videoTemplate`, and `bundleTemplate` fields from the shared HTML selection schema

## Scope

`selectResourceCandidates` now returns only Skills, Templates, and Design Systems. Its name, source metadata, entry shape, and existing target filtering remain unchanged.

## Verification

- added a regression test confirming the four unnecessary candidate groups are absent
- retained the Video command assertion that its dedicated packet includes the selected Video Template
- formatted the five touched files with Prettier 3.8.1
- linted the touched Core and CLI files with Oxlint 1.75.0
- ran a standalone TypeScript 6.0.3 strict check for the affected registry and authoring modules
- ran a runtime smoke check confirming the shared slice contains only Skills, Templates, and Design Systems while the Video packet still contains its selected template and registry version
- ran `git diff --check`

The fresh checkout has no installed `node_modules`, so the prescribed `pnpm format` stopped with `prettier: not found`; package checks and Vitest are deferred to the PR pipeline.
