### PR TITLE
ci: keep the release pull request refresh from failing the run

### DIFF
--- a/.github/workflows/release-please-refresh.yml
+++ b/.github/workflows/release-please-refresh.yml
@@ -30,12 +30,26 @@ jobs:
         with:
           ref: main
 
-      - uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
+      # Refreshing the release pull request is best effort. release-please force
+      # updates the release branch, and GitHub rejects that update while the
+      # release pull request is held by the merge queue. release-please also
+      # recomputes the pull request from scratch on every run, so a rejected
+      # refresh self-heals on the next push to main or on the release-please.yml
+      # refresh that follows the merge. Failing the job would only produce red
+      # runs that nobody acts on.
+      - id: release-please
+        continue-on-error: true
+        uses: vm0-ai/release-please-action@3971df459631cdcf704dcbf86231cb26b790a7c8 # vm0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+
+      - name: Report a refresh that did not land
+        if: ${{ steps.release-please.outcome == 'failure' }}
+        run: |
+          echo "::warning::release-please could not refresh the release pull request; the next push to main rebuilds it from scratch."
 
       - name: Pass ci-gate checks for release PR
         env:


### PR DESCRIPTION
## Problem

`release-please-refresh` goes red whenever the release PR is sitting in the merge queue:

```
✔ Successfully created commit ... 74775d69
✔ Updating reference heads/release-please--branches--main to 74775d69
##[error]release-please failed: Error updating ref heads/release-please--branches--main to 74775d69
```

release-please refreshes the release PR by force updating `release-please--branches--main`. GitHub locks the head ref of a queued PR, so the update is rejected and the action exits non-zero.

Example: [run 30521530264](https://github.com/vm0-ai/vm0/actions/runs/30521530264/job/90802819685). #23964 was enqueued at 07:01:10Z; the refresh triggered by the next push to main failed at 07:04:15Z.

## Why this does not need a fix beyond the red X

The refresh is already best effort by design. release-please recomputes the release PR from scratch on every run, so whatever a rejected refresh could not write is written by the next push to main, or by the `refresh-release-pull-request` job in `release-please.yml` once the release PR merges. The same reasoning is already documented on that job.

## Change

Mark the release-please step `continue-on-error` and emit a warning annotation when it does not land. The `Pass ci-gate checks for release PR` step still runs and still fails loudly, so the DB/API release coupling gate keeps its signal.

Deliberately not added: a pre-flight `isInMergeQueue` check that skips the step. It still loses the race when the PR is enqueued between the check and the ref update, and it adds a code path that can hide real failures.
