### PR TITLE
refactor(agentphone): remove legacy thread session runtime access

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -877,6 +877,46 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
         (send.body?.includes("Only the linked sender") ?? false)
       );
     });
+
+    // Resetting the canonical route makes prior message history insufficient
+    // to resolve the group owner.
+    const beforeSessionReset = sends.messages.length;
+    await ap.postAgentPhoneInboundMessage({
+      channel: "imessage",
+      from: phone,
+      body: "/new_session @Zero",
+      conversationId,
+      isGroup: true,
+    });
+    await waitForSendMatching(sends, beforeSessionReset, (send) => {
+      return (
+        send.conversationId === conversationId &&
+        send.body === "New session started."
+      );
+    });
+
+    const beforeColdCutoverPrompt = sends.messages.length;
+    await ap.postAgentPhoneInboundMessage({
+      channel: "imessage",
+      from: stranger,
+      body: "@Zero resume the old group",
+      conversationId,
+      isGroup: true,
+    });
+    const coldCutoverPrompt = await waitForSendMatching(
+      sends,
+      beforeColdCutoverPrompt,
+      (send) => {
+        return (
+          send.conversationId === conversationId &&
+          (send.body?.includes("message Zero directly") ?? false)
+        );
+      },
+    );
+    expect(coldCutoverPrompt.body).not.toContain("/agentphone/connect?");
+    await runs.heartbeatRunner(runnerGroup);
+    const coldCutoverIdle = await runs.pollRunner(runnerGroup);
+    expect(coldCutoverIdle.body.job).toBeNull();
   });
 
   it("skips completion delivery for runs whose phone link was disconnected mid-flight", async () => {

--- a/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
@@ -2,11 +2,10 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentphoneMessages } from "@vm0/db/schema/agentphone-message";
-import { agentphoneThreadSessions } from "@vm0/db/schema/agentphone-thread-session";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
@@ -131,134 +130,6 @@ export async function storeOutboundAgentPhoneMessage(
       body: params.body ?? null,
       mediaUrl: params.mediaUrl ?? null,
       isBot: true,
-    })
-    .onConflictDoNothing();
-}
-
-export async function saveAgentPhoneThreadSession(
-  db: Db,
-  opts: {
-    readonly userLinkId: string;
-    readonly conversationId: string | null;
-    readonly rootMessageId: string;
-    readonly existingSessionId: string | undefined;
-    readonly newSessionId: string | undefined;
-    readonly messageId: string;
-    readonly runStatus: string;
-  },
-): Promise<void> {
-  if (!opts.existingSessionId && opts.newSessionId) {
-    const updated = await db
-      .update(agentphoneThreadSessions)
-      .set({
-        agentSessionId: opts.newSessionId,
-        conversationId: opts.conversationId,
-        lastProcessedMessageId: opts.messageId,
-        updatedAt: nowDate(),
-      })
-      .where(
-        and(
-          eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-          eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
-        ),
-      )
-      .returning({ id: agentphoneThreadSessions.id });
-
-    if (updated.length > 0) {
-      return;
-    }
-
-    await db
-      .insert(agentphoneThreadSessions)
-      .values({
-        agentphoneUserLinkId: opts.userLinkId,
-        conversationId: opts.conversationId,
-        rootMessageId: opts.rootMessageId,
-        agentSessionId: opts.newSessionId,
-        lastProcessedMessageId: opts.messageId,
-      })
-      .onConflictDoNothing();
-    return;
-  }
-
-  if (
-    opts.existingSessionId &&
-    (opts.runStatus === "completed" || opts.runStatus === "timeout")
-  ) {
-    await db
-      .update(agentphoneThreadSessions)
-      .set({
-        conversationId: opts.conversationId,
-        lastProcessedMessageId: opts.messageId,
-        updatedAt: nowDate(),
-      })
-      .where(
-        and(
-          eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-          eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
-        ),
-      );
-  }
-}
-
-/**
- * Dual-write a canonical AgentPhone thread binding into the legacy session
- * table so rollback-eligible API versions continue from the canonical session.
- */
-export async function saveCanonicalAgentPhoneThreadSession(
-  db: Db,
-  opts: {
-    readonly userLinkId: string;
-    readonly conversationId: string | null;
-    readonly rootMessageId: string;
-    readonly agentSessionId: string;
-    readonly messageId: string;
-    readonly runStatus: "completed" | "failed";
-  },
-): Promise<void> {
-  const [existing] = await db
-    .select({ agentSessionId: agentphoneThreadSessions.agentSessionId })
-    .from(agentphoneThreadSessions)
-    .where(
-      and(
-        eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-        eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
-      ),
-    )
-    .limit(1);
-
-  const updateLastProcessed =
-    opts.runStatus === "completed" ||
-    existing?.agentSessionId !== opts.agentSessionId;
-  const updated = await db
-    .update(agentphoneThreadSessions)
-    .set({
-      agentSessionId: opts.agentSessionId,
-      conversationId: opts.conversationId,
-      ...(updateLastProcessed
-        ? { lastProcessedMessageId: opts.messageId }
-        : {}),
-      updatedAt: nowDate(),
-    })
-    .where(
-      and(
-        eq(agentphoneThreadSessions.agentphoneUserLinkId, opts.userLinkId),
-        eq(agentphoneThreadSessions.rootMessageId, opts.rootMessageId),
-      ),
-    )
-    .returning({ id: agentphoneThreadSessions.id });
-  if (updated.length > 0) {
-    return;
-  }
-
-  await db
-    .insert(agentphoneThreadSessions)
-    .values({
-      agentphoneUserLinkId: opts.userLinkId,
-      conversationId: opts.conversationId,
-      rootMessageId: opts.rootMessageId,
-      agentSessionId: opts.agentSessionId,
-      lastProcessedMessageId: opts.messageId,
     })
     .onConflictDoNothing();
 }

--- a/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
@@ -22,7 +22,6 @@ import {
   markdownToImessagePlain,
   resolveAgentPhoneAuditLogsUrl,
   resolveAgentPhoneReplyFooterText,
-  saveCanonicalAgentPhoneThreadSession,
   storeOutboundAgentPhoneMessage,
 } from "./agentphone-shared.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -39,7 +38,6 @@ interface ClaimedAgentPhoneChatDelivery {
 interface AgentPhoneChatRunContext {
   readonly userId: string;
   readonly orgId: string;
-  readonly sessionId: string;
   readonly chatThreadId: string;
   readonly agentId: string;
 }
@@ -145,7 +143,6 @@ async function loadAgentPhoneChatDeliveryContext(args: {
     .select({
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
-      sessionId: agentRuns.sessionId,
       chatThreadId: zeroRuns.chatThreadId,
       agentId: chatThreads.agentComposeId,
     })
@@ -166,7 +163,6 @@ async function loadAgentPhoneChatDeliveryContext(args: {
   const runContext: AgentPhoneChatRunContext = {
     userId: run.userId,
     orgId: run.orgId,
-    sessionId: run.sessionId,
     chatThreadId: run.chatThreadId,
     agentId: run.agentId,
   };
@@ -284,10 +280,8 @@ async function resolveAgentPhonePresentation(args: {
 async function recordAgentPhoneChatDelivery(args: {
   readonly db: Db;
   readonly target: AgentPhoneDeliveryTarget;
-  readonly run: AgentPhoneChatRunContext;
   readonly sent: AgentPhoneSendResult;
   readonly body: string;
-  readonly status: "completed" | "failed";
 }): Promise<void> {
   await storeOutboundAgentPhoneMessage(args.db, {
     agentphoneMessageId: args.sent.id,
@@ -300,14 +294,6 @@ async function recordAgentPhoneChatDelivery(args: {
     body: args.body,
     channel: args.sent.channel,
     userChannel: args.target.channel,
-  });
-  await saveCanonicalAgentPhoneThreadSession(args.db, {
-    userLinkId: args.target.userLinkId,
-    conversationId: args.target.conversationId,
-    rootMessageId: args.target.rootMessageId,
-    agentSessionId: args.run.sessionId,
-    messageId: args.target.messageId,
-    runStatus: args.status,
   });
 }
 
@@ -342,10 +328,8 @@ async function deliverClaimedAgentPhoneChatCallback(args: {
   await recordAgentPhoneChatDelivery({
     db: args.db,
     target: payload,
-    run,
     sent,
     body,
-    status: args.status,
   });
   return "delivered";
 }
@@ -437,7 +421,6 @@ export async function deliverAgentPhoneChatAdmissionFailure(
     run: {
       userId: args.userId,
       orgId: args.orgId,
-      sessionId: "",
       chatThreadId: args.chatThreadId,
       agentId: args.agentId,
     },

--- a/turbo/apps/api/src/signals/services/internal-agentphone-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-run-callback.service.ts
@@ -27,7 +27,6 @@ import {
   resolveAgentPhoneAuditLogsUrl,
   resolveAgentPhoneReplyFooterText,
   resolveAgentPhoneUserLink,
-  saveAgentPhoneThreadSession,
   storeOutboundAgentPhoneMessage,
   type AgentPhoneChannel,
 } from "./agentphone-shared.service";
@@ -59,7 +58,6 @@ type AgentPhoneCallbackPayload = z.infer<
 interface RunContext {
   readonly userId: string;
   readonly orgId: string;
-  readonly sessionId: string;
   readonly lastEventSequence: number | null;
   readonly chatThreadId: string | null;
 }
@@ -154,7 +152,6 @@ async function loadRunContext(args: {
     .select({
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
-      sessionId: agentRuns.sessionId,
       lastEventSequence: agentRuns.lastEventSequence,
       chatThreadId: zeroRuns.chatThreadId,
     })
@@ -230,17 +227,6 @@ async function staleLinkDisconnected(args: {
   return currentUserLink?.id !== args.payload.userLinkId;
 }
 
-function agentPhoneCallbackRootMessageId(
-  payload: AgentPhoneCallbackPayload,
-): string {
-  return (
-    payload.rootMessageId ??
-    (payload.isGroup && payload.conversationId
-      ? `group:${payload.conversationId}`
-      : "dm")
-  );
-}
-
 async function sendAgentPhoneCompletionMessage(args: {
   readonly payload: AgentPhoneCallbackPayload;
   readonly body: string;
@@ -289,8 +275,6 @@ async function sendAgentPhoneCompletionMessage(args: {
 async function recordAgentPhoneCompletion(args: {
   readonly db: Db;
   readonly payload: AgentPhoneCallbackPayload;
-  readonly run: RunContext | undefined;
-  readonly status: "completed" | "failed";
   readonly body: string;
   readonly sent: SentAgentPhoneMessage;
   readonly userChannel: AgentPhoneChannel;
@@ -307,23 +291,6 @@ async function recordAgentPhoneCompletion(args: {
     body: args.body,
     channel: args.sent.channel,
     userChannel: args.userChannel,
-  });
-  args.signal.throwIfAborted();
-
-  if (!args.run) {
-    return;
-  }
-
-  await saveAgentPhoneThreadSession(args.db, {
-    userLinkId: args.payload.userLinkId,
-    conversationId: args.payload.conversationId,
-    rootMessageId: agentPhoneCallbackRootMessageId(args.payload),
-    existingSessionId: args.payload.existingSessionId ?? undefined,
-    newSessionId: args.payload.existingSessionId
-      ? undefined
-      : args.run.sessionId,
-    messageId: args.payload.messageId,
-    runStatus: args.status,
   });
   args.signal.throwIfAborted();
 }
@@ -419,8 +386,6 @@ async function handleCompletion(args: {
   await recordAgentPhoneCompletion({
     db: args.db,
     payload: args.payload,
-    run,
-    status: args.status,
     body,
     sent: sendResult.sent,
     userChannel,

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -14,11 +14,10 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { agentphoneChatThreadRoutes } from "@vm0/db/schema/agentphone-chat-thread-route";
 import { agentphoneMessages } from "@vm0/db/schema/agentphone-message";
-import { agentphoneThreadSessions } from "@vm0/db/schema/agentphone-thread-session";
 import { agentphoneUserAgentPreferences } from "@vm0/db/schema/agentphone-user-agent-preference";
 import { agentphoneUserLinks } from "@vm0/db/schema/agentphone-user-link";
 import { chatEvents } from "@vm0/db/schema/chat-event";
-import { and, desc, eq, isNotNull, isNull, notExists, or } from "drizzle-orm";
+import { and, desc, eq, isNull, notExists, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -416,34 +415,7 @@ async function resolveAgentPhoneConversationUserLink(
     .where(eq(agentphoneChatThreadRoutes.conversationId, conversationId))
     .orderBy(desc(agentphoneChatThreadRoutes.createdAt))
     .limit(1);
-  if (route) {
-    return resolveAgentPhoneUserLinkById(db, route.userLinkId);
-  }
-
-  const [session] = await db
-    .select({ userLinkId: agentphoneThreadSessions.agentphoneUserLinkId })
-    .from(agentphoneThreadSessions)
-    .where(eq(agentphoneThreadSessions.conversationId, conversationId))
-    .orderBy(desc(agentphoneThreadSessions.updatedAt))
-    .limit(1);
-  if (session) {
-    return resolveAgentPhoneUserLinkById(db, session.userLinkId);
-  }
-
-  const [message] = await db
-    .select({ userLinkId: agentphoneMessages.agentphoneUserLinkId })
-    .from(agentphoneMessages)
-    .where(
-      and(
-        eq(agentphoneMessages.conversationId, conversationId),
-        isNotNull(agentphoneMessages.agentphoneUserLinkId),
-      ),
-    )
-    .orderBy(desc(agentphoneMessages.createdAt))
-    .limit(1);
-  return message?.userLinkId
-    ? resolveAgentPhoneUserLinkById(db, message.userLinkId)
-    : null;
+  return route ? resolveAgentPhoneUserLinkById(db, route.userLinkId) : null;
 }
 
 export async function resolveAgentPhoneUserLinkForEvent(
@@ -1209,24 +1181,14 @@ async function handleNewSessionCommand(args: {
 
   const rootMessageId = agentPhoneThreadRootMessageId(args.event);
   const userLinkId = args.userLink.id;
-  await args.db.transaction(async (tx) => {
-    await tx
-      .delete(agentphoneChatThreadRoutes)
-      .where(
-        and(
-          eq(agentphoneChatThreadRoutes.agentphoneUserLinkId, userLinkId),
-          eq(agentphoneChatThreadRoutes.rootMessageId, rootMessageId),
-        ),
-      );
-    await tx
-      .delete(agentphoneThreadSessions)
-      .where(
-        and(
-          eq(agentphoneThreadSessions.agentphoneUserLinkId, userLinkId),
-          eq(agentphoneThreadSessions.rootMessageId, rootMessageId),
-        ),
-      );
-  });
+  await args.db
+    .delete(agentphoneChatThreadRoutes)
+    .where(
+      and(
+        eq(agentphoneChatThreadRoutes.agentphoneUserLinkId, userLinkId),
+        eq(agentphoneChatThreadRoutes.rootMessageId, rootMessageId),
+      ),
+    );
   args.signal.throwIfAborted();
 
   await sendAgentPhoneSlashCommandText(


### PR DESCRIPTION
## Summary

- remove every AgentPhone runtime read, dual-write, cursor update, and reset cleanup against `agentphone_thread_sessions`
- make iMessage group-owner resolution depend only on `agentphone_chat_thread_routes`, while keeping canonical session binding, queue ordering, deduplication, typing, channel selection, group replies, and callback idempotency unchanged
- retain `agentphone-thread-session.ts`, the DB index export, and immutable migration history for the separate physical-drop PR; this PR adds no migration and does not drop the table

## User-visible impact

Active canonical AgentPhone conversations keep the same DM/SMS and mentioned-group behavior. The accepted cold-cutover consequence is explicit: an historical iMessage group conversation that exists only in legacy state no longer resolves an owner from old session or message history and is treated as a new conversation. Group-owner resolution now comes exclusively from `agentphone_chat_thread_routes`, consistent with #23900.

## Key implementation choices

- remove both legacy persistence helpers and their legacy/canonical callback call sites instead of leaving dead rollback writes
- stop selecting callback session IDs that existed only to populate the legacy table
- resolve group owners from canonical routes alone; the BDD coverage resets the route and proves prior message history cannot restore the owner or dispatch a run
- make `/new_session` delete only the canonical AgentPhone route
- preserve callback payload compatibility fields and all canonical admission/delivery logic

## Active verification before removal

I fetched `origin/main` and ran the issue-specified suite on an unmodified, clean `main@03b65547cc9fb4a9aed89df615d1a49d075d4e2f` before changing source:

```sh
pnpm -F api exec vitest run \
  src/signals/routes/__tests__/agentphone.bdd.test.ts \
  --maxWorkers=1 --silent=passed-only
```

Baseline result: **1 file, 11 tests passed** in 6.59s. This actively exercised canonical DM and group identity, session continuity, FIFO queueing, deduplication, typing, channel selection, group reply targeting, and callback idempotency before legacy removal.

## Verification after removal

- the same focused command after rebasing onto the latest `main`: **1 file, 11 tests passed** in 6.35s
- focused Prettier formatting for all 5 changed files
- `git diff --check`
- active-code grep for `agentphoneThreadSessions` / `agentphone-thread-session` / `agentphone_thread_sessions`: only `turbo/packages/db/src/schema/agentphone-thread-session.ts` and its `turbo/packages/db/src/index.ts` import remain; immutable migration history is unchanged
- no DB schema, DB index, or migration files changed

## Follow-up

PR 2 still needs to add the dedicated `DROP TABLE agentphone_thread_sessions` migration, delete the retained schema/export, add migration-consistency contraction coverage, and verify zero remaining active references after the physical contraction.

Part of #23967